### PR TITLE
[FEATURE] Ajouter la date de validation des cgu lors de la création de compte pix  (PIX-1763)

### DIFF
--- a/api/lib/domain/usecases/create-user-from-pole-emploi.js
+++ b/api/lib/domain/usecases/create-user-from-pole-emploi.js
@@ -39,6 +39,7 @@ module.exports = async function createUserFromPoleEmploi({
     firstName: userInfo.firstName,
     lastName: userInfo.lastName,
     cgu: true,
+    lastTermsOfServiceValidatedAt: new Date(),
   });
 
   let createdUserId = null;

--- a/api/lib/domain/usecases/create-user.js
+++ b/api/lib/domain/usecases/create-user.js
@@ -73,6 +73,11 @@ module.exports = async function createUser({
     userRepository,
   });
 
+  const userHasValidatedPixTermsOfService = user.cgu === true;
+  if (userHasValidatedPixTermsOfService) {
+    user.lastTermsOfServiceValidatedAt = new Date();
+  }
+
   if (isValid) {
     const hashedPassword = await encryptionService.hashPassword(password);
 

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -76,7 +76,7 @@ describe('Acceptance | Controller | users-controller', function () {
         expect(response.statusCode).to.equal(201);
         expect(response.result.data.type).to.equal('users');
         expect(response.result.data.attributes['recaptcha-token']).to.be.undefined;
-
+        expect(response.result.data.attributes['last-terms-of-service-validated-at']).to.be.instanceOf(Date);
         const userAttributes = pick(response.result.data.attributes, pickedUserAttributes);
         expect(userAttributes).to.deep.equal(expectedAttributes);
       });

--- a/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-pole-emploi_test.js
@@ -27,8 +27,10 @@ describe('Unit | UseCase | create-user-from-pole-emploi', function () {
   let userRepository;
   let authenticationService;
 
+  const now = new Date('2021-01-02');
+
   beforeEach(function () {
-    clock = sinon.useFakeTimers(Date.now());
+    clock = sinon.useFakeTimers(now);
 
     DomainTransaction.execute = (lambda) => {
       return lambda(domainTransaction);
@@ -110,6 +112,7 @@ describe('Unit | UseCase | create-user-from-pole-emploi', function () {
         firstName: decodedUserInfo.firstName,
         lastName: decodedUserInfo.lastName,
         cgu: true,
+        lastTermsOfServiceValidatedAt: now,
       });
 
       const expectedAuthenticationMethod = new AuthenticationMethod({

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -235,6 +235,60 @@ describe('Unit | UseCase | create-user', function () {
         expect(error.invalidAttributes).to.have.lengthOf(3);
       });
     });
+
+    context('when user has accepted terms of service', function () {
+      it('should update the validation date', async function () {
+        // given
+        const user = new User({
+          email: userEmail,
+          cgu: true,
+        });
+
+        // when
+        await createUser({
+          user,
+          password,
+          campaignCode,
+          locale,
+          authenticationMethodRepository,
+          campaignRepository,
+          userRepository,
+          encryptionService,
+          mailService,
+          userService,
+        });
+
+        // then
+        expect(user.lastTermsOfServiceValidatedAt).to.be.an.instanceOf(Date);
+      });
+    });
+
+    context('when user has not accepted terms of service', function () {
+      it('should not update the validation date', async function () {
+        // given
+        const user = new User({
+          email: userEmail,
+          cgu: false,
+        });
+
+        // when
+        await createUser({
+          user,
+          password,
+          campaignCode,
+          locale,
+          authenticationMethodRepository,
+          campaignRepository,
+          userRepository,
+          encryptionService,
+          mailService,
+          userService,
+        });
+
+        // then
+        expect(user.lastTermsOfServiceValidatedAt).not.to.be.an.instanceOf(Date);
+      });
+    });
   });
 
   context("when user's email is not defined", function () {

--- a/mon-pix/tests/acceptance/terms-of-service_test.js
+++ b/mon-pix/tests/acceptance/terms-of-service_test.js
@@ -11,20 +11,18 @@ describe('Acceptance | terms-of-service', function () {
   setupApplicationTest();
   setupMirage();
   setupIntl();
-  let user;
-
-  beforeEach(function () {
-    user = server.create('user', {
-      email: 'with-email',
-      password: 'pix123',
-      cgu: true,
-      mustValidateTermsOfService: true,
-      lastTermsOfServiceValidatedAt: new Date(),
-    });
-  });
 
   describe('When user log in and must validate Pix latest terms of service', async function () {
     it('should be redirected to terms-of-services page', async function () {
+      // given
+      const user = server.create('user', {
+        email: 'with-email',
+        password: 'pix123',
+        cgu: true,
+        mustValidateTermsOfService: true,
+        lastTermsOfServiceValidatedAt: new Date(),
+      });
+
       // when
       await authenticateByEmail(user);
 
@@ -36,6 +34,13 @@ describe('Acceptance | terms-of-service', function () {
   describe('when the user has validated terms of service', async function () {
     it('should redirect to default page when user validate the terms of service', async function () {
       // given
+      const user = server.create('user', {
+        email: 'with-email',
+        password: 'pix123',
+        cgu: true,
+        mustValidateTermsOfService: true,
+        lastTermsOfServiceValidatedAt: new Date(),
+      });
       await authenticateByEmail(user);
 
       // when

--- a/mon-pix/tests/acceptance/terms-of-service_test.js
+++ b/mon-pix/tests/acceptance/terms-of-service_test.js
@@ -17,8 +17,9 @@ describe('Acceptance | terms-of-service', function () {
     user = server.create('user', {
       email: 'with-email',
       password: 'pix123',
+      cgu: true,
       mustValidateTermsOfService: true,
-      lastTermsOfServiceValidatedAt: null,
+      lastTermsOfServiceValidatedAt: new Date(),
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de la création d'un nouvel utilisateur qui doit valider les CGU de Pix App, on ne sauvegardait pas en base la date de validation dans la colonne `LastTermsOfServiceValidatedAt` de la table `Users`.

## :gift: Solution
La date est mise à jour dans le usecase utilisé pour la création d'un compte pix avec email et mot de passe.

## :star2: Remarques
Certain(e)s utilisateurs(rices) peuvent créer un compte sans avoir à valider les cgu de PIX, cela concerne notamment les accès qui se font via le GAR. 

## :santa: Pour tester
- l'envoi d'email est actif sur scalingo ^^
- COMPTE PIX : Se créer un compte sur mon pix : https://app-pr3895.review.pix.fr et vérifier en base de données que dans la table `users` pour l'utilisateur que vous venez de créer, la colonne `lastTermsOfServiceValidatedAt` est remplie avec la date et l'heure  de création de l'utilisateur 
- COMPTE ORGA : Aller sur Pix admin https://admin-pr3895.review.pix.fr et inviter un membre avec une adresse email. Choisir l'option se créer un compte après avoir cliqué sur  `Accepter l’invitation` dans l'email reçu, comme précédemment, vérifier en base de données
- COMPTE POLE EMPLOI : 

-->  VIA CONNEXION : Se connecter en local avec l'utilisateur Pole Emploi de PROD (attention, aller sur `http://localhost.fr:8080/connexion` pour que le bouton `se connecter avec pole emploi` s'affiche

 `http://localhost.fr:8080` est également  paramètré côté store pole emploi  comme url de redirection après authentification PE) 
--> VIA INVITATION A REJOINDRE UNE CAMPAGNE : Se rendre sur http://localhost.fr:8080/campagnes/QWERTY789 puis se connecter via pole emploi
Dans les deux cas, la date de LastTermsOfServiceValidatedAt est mise à jour à la création de l'utilisateur dans la base de données