### PR TITLE
[FEATURE] Supprime le commentaire spécifique aux organisations SCO (PIX-3871)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -89,11 +89,6 @@
             {{display-campaign-errors @errors.targetProfile}}
           </div>
         {{/if}}
-        {{#if this.currentUser.isSCOManagingStudents}}
-          <p class="form__comment">
-            {{t "pages.campaign-creation.target-profile-informations" htmlSafe=true}}
-          </p>
-        {{/if}}
       </div>
       {{#if this.targetProfile}}
         <div class="form__field-info" id="target-profile-info">

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -237,48 +237,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     });
   });
 
-  module(
-    'when user‘s organization is SCO and is managing student and user is creating an assessment campaign',
-    function () {
-      test('it should display comment for target profile selection', async function (assert) {
-        // given
-        class CurrentUserStub extends Service {
-          organization = EmberObject.create({ canCollectProfiles: false });
-          isSCOManagingStudents = true;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-        // when
-        await render(
-          hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
-        );
-
-        // then
-        assert.contains(t('pages.campaign-creation.target-profile-informations'));
-      });
-    }
-  );
-
-  module(
-    'when user‘s organization is not (SCO and managing student) user is creating an assessment campaign',
-    function () {
-      test('it should not display comment for target profile selection', async function (assert) {
-        // given
-        class CurrentUserStub extends Service {
-          organization = EmberObject.create({ canCollectProfiles: false });
-          isSCOManagingStudents = false;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-        // when
-        await render(
-          hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
-        );
-
-        // then
-        assert.notContains(t('pages.campaign-creation.target-profile-informations'));
-      });
-    }
-  );
-
   module('when user has not chosen yet to ask or not an external user ID', function () {
     test('it should not display gdpr footnote', async function (assert) {
       // when

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -311,7 +311,6 @@
         "thematic-results": "Thematic results: {count}",
         "result": "Success rate in "
       },
-      "target-profile-informations": "If you want more information, see <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> the corresponding documentation</a>.",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {
         "label": "Title of the customised test"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -304,7 +304,6 @@
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
       },
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
-      "target-profile-informations": "Si vous souhaitez avoir plus d'information, consulter <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> la documentation correspondante</a>.",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {
         "label": "Titre du parcours"


### PR DESCRIPTION
## :christmas_tree: Problème
Il y a un commentaire spécifique aux organisations SCO qui est afficher lors de la création de campagne d'évaluation. Il n'est plus d'actualité.

## :gift: Solution
On supprime ce commentaire spécifique.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter sur Pix Orga avec le compte admin Sco
- Aller sur la page de création d'une campagne
- Sélectionner le type campagne d'évaluation
- Constater que le bloc de texte avec le lien n'est plus présent sous la sélection du type de campagne
