### PR TITLE
[BUGFIX] Corriger les repositories effectuant des opérations hors transaction à tort

### DIFF
--- a/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
+++ b/api/lib/infrastructure/repositories/account-recovery-demand-repository.js
@@ -44,10 +44,11 @@ module.exports = {
     return _toDomain(result[0]);
   },
 
-  async markAsBeingUsed(temporaryKey, domainTransaction = DomainTransaction.emptyTransaction()) {
-    return knex('account-recovery-demands')
-      .transacting(domainTransaction)
+  async markAsBeingUsed(temporaryKey, { knexTransaction } = DomainTransaction.emptyTransaction()) {
+    const query = knex('account-recovery-demands')
       .where({ temporaryKey })
       .update({ used: true, updatedAt: knex.fn.now() });
+    if (knexTransaction) query.transacting(knexTransaction);
+    return query;
   },
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -183,8 +183,14 @@ module.exports = {
       .then((bookshelfUser) => _toDomain(bookshelfUser));
   },
 
-  updateWithEmailConfirmed({ id, userAttributes, domainTransaction = DomainTransaction.emptyTransaction() }) {
-    return knex('users').transacting(domainTransaction).where({ id }).update(userAttributes);
+  updateWithEmailConfirmed({
+    id,
+    userAttributes,
+    domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
+  }) {
+    const query = knex('users').where({ id }).update(userAttributes);
+    if (knexTransaction) query.transacting(knexTransaction);
+    return query;
   },
 
   checkIfEmailIsAvailable(email) {


### PR DESCRIPTION
## :christmas_tree: Problème
Certains repositories donnaient la domainTransaction à `knex.transacting()`, ça ne plante pas mais ça ne fonctionne pas !
Les opérations sont donc hors transaction.

## :gift: Solution
Donner la transaction knex à `knex.transacting()`, si il y en a une.

## :star2: Remarques
Le comportement de `transacting()` est un peu étrange, voir https://github.com/knex/knex/blob/bfdece3cdc9a029589cee1c8907d1930edace2cc/lib/builder-interface-augmenter.js#L70

Ça donne :
```js
transacting(null); // lève une erreur
transacting({}); // lève une erreur
transacting({ foo: 'foo' }); // ne lève pas d'erreur, mais ne fait rien !

transacting(domainTransaction); // ne lève pas d'erreur non plus, mais ne fait rien ! 😬
```

## :santa: Pour tester
Les tests sont OK.
Tester la non régression mais je ne sais pas exactement quels sont les use cases.