### PR TITLE
[FEATURE] Mise à jour des RT dans Pix-Admin (PIX-3960).

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -13,19 +13,71 @@
       <div class="badge-data__image">
         <img src={{@badge.imageUrl}} alt="" role="presentation" width="90px" /><br />
       </div>
-      <div class="page-section__details">
-        ID :
-        {{@badge.id}}<br />
-        Titre :
-        {{@badge.title}}<br />
-        Clé :
-        {{@badge.key}}<br />
-        Message :
-        {{@badge.message}}<br />
-        Message alternatif :
-        {{@badge.altMessage}}<br />
-        <PixTag @color={{this.isCertifiableColor}} class="badge-data__tags">{{this.isCertifiableText}}</PixTag><br />
-      </div>
+      {{#if this.editMode}}
+        <div class="badge-edit-form">
+          <form class="form" {{on "submit" this.updateBadge}}>
+            <div class="badge-edit-form__field">
+              <label for="title" class="badge-edit-form-field__label">
+                Titre :
+              </label>
+              <Input id="title" @type="text" class="form-control" @value={{this.form.title}} required={{true}} />
+            </div>
+            <div class="badge-edit-form__field">
+              <label for="key" class="badge-edit-form-field__label">
+                Clé :
+              </label>
+              <Input id="key" @type="text" class="form-control" @value={{this.form.key}} required={{true}} />
+            </div>
+            <div class="badge-edit-form__field">
+              <label for="message" class="badge-edit-form-field__label">
+                Message :
+              </label>
+              <Input id="message" @type="text" class="form-control" @value={{this.form.message}} required={{true}} />
+            </div>
+            <div class="badge-edit-form__field">
+              <label for="altMessage" class="badge-edit-form-field__label">
+                Message Alternatif :
+              </label>
+              <Input
+                id="altMessage"
+                @type="text"
+                class="form-control"
+                @value={{this.form.altMessage}}
+                required={{true}}
+              />
+            </div>
+            <div class="badge-edit-form__actions">
+              <PixButton
+                @size="small"
+                @backgroundColor="transparent-light"
+                @isBorderVisible={{true}}
+                @triggerAction={{this.cancel}}
+              >Annuler</PixButton>
+              <PixButton @type="submit" @size="small" @backgroundColor="green">Enregistrer</PixButton>
+            </div>
+          </form>
+        </div>
+      {{else}}
+        <div class="page-section__details">
+          ID :
+          {{@badge.id}}<br />
+          Titre :
+          {{@badge.title}}<br />
+          Clé :
+          {{@badge.key}}<br />
+          Message :
+          {{@badge.message}}<br />
+          Message alternatif :
+          {{@badge.altMessage}}<br />
+          <PixTag @color={{this.isCertifiableColor}} class="badge-data__tags">{{this.isCertifiableText}}</PixTag><br />
+          <PixButton
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @size="small"
+            @triggerAction={{this.toggleEditMode}}
+          >Editer</PixButton>
+        </div>
+      {{/if}}
     </div>
   </section>
 

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -14,6 +14,28 @@
   list-style-type: none;
 }
 
+.badge-edit-form {
+  width: 50%;
+
+  &__field {
+    margin-bottom: 12px;
+  }
+
+  &__actions {
+    display: flex;
+    max-width: 220px;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+}
+
+.badge-edit-form-field {
+
+  &__label {
+    width: 100%;
+  }
+}
+
 .skill-sets-table {
   margin: 20px 0;
 }

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find } from '@ember/test-helpers';
+import { render, find, fillIn, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import sinon from 'sinon';
 
 module('Integration | Component | Badges::Badge', function (hooks) {
   let badge;
@@ -62,5 +63,31 @@ module('Integration | Component | Badges::Badge', function (hooks) {
     assert.contains('Competence');
     assert.contains('@skill2');
     assert.contains('Mon tube');
+  });
+
+  module('#updateBadge', function () {
+    test('should send badge update request to api', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const findRecordStub = sinon.stub();
+      const saveStub = sinon.stub().resolves();
+      findRecordStub.returns({ save: saveStub });
+      store.findRecord = findRecordStub;
+
+      await render(hbs`<Badges::Badge @badge={{this.badge}} />`);
+
+      // when
+      await click('button[type="button"]');
+      await fillIn('input#title', 'mon titre mis à jour');
+      await fillIn('input#key', 'ma clef mise à jour');
+      await fillIn('input#message', 'mon message mis à jour');
+      await fillIn('input#altMessage', 'mon message alternatif mis à jour');
+      await click('button[type="submit"]');
+
+      // then
+      sinon.assert.calledWith(findRecordStub, 'badge', badge.id);
+      sinon.assert.calledOnce(saveStub);
+      assert.ok(true);
+    });
   });
 });

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -1,10 +1,20 @@
 const usecases = require('../../domain/usecases');
 const badgeWithLearningContentSerializer = require('../../infrastructure/serializers/jsonapi/badge-with-learning-content-serializer');
+const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
 
 module.exports = {
   async getBadge(request) {
     const badgeId = request.params.id;
     const badgeWithLearningContent = await usecases.getBadgeDetails({ badgeId });
     return badgeWithLearningContentSerializer.serialize(badgeWithLearningContent);
+  },
+
+  async updateBadge(request, h) {
+    const badgeId = request.params.id;
+    const badge = badgeSerializer.deserialize(request.payload);
+
+    const updatedBadge = await usecases.updateBadge({ badgeId, badge });
+
+    return h.response(badgeSerializer.serialize(updatedBadge)).code(204);
   },
 };

--- a/api/lib/application/badges/index.js
+++ b/api/lib/application/badges/index.js
@@ -28,6 +28,49 @@ exports.register = async function (server) {
         ],
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/admin/badges/{id}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRolePixMaster,
+            assign: 'hasRolePixMaster',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.badgeId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              id: Joi.string().required(),
+              attributes: Joi.object({
+                key: Joi.string().required(),
+                'alt-message': Joi.string().required(),
+                'image-url': Joi.string().required(),
+                message: Joi.string().required().allow('').allow(null),
+                title: Joi.string().required().allow('').allow(null),
+                'is-certifiable': Joi.boolean().required(),
+                'is-always-visible': Joi.boolean().required(),
+                'campaign-threshold': Joi.number().allow(null),
+                'skill-set-threshold': Joi.number().allow(null),
+                'skill-set-name': Joi.string().allow(null).allow(''),
+                'skill-set-skills-ids': Joi.array().items(Joi.string()).allow(null),
+              }).required(),
+              type: Joi.string().required(),
+              relationships: Joi.object(),
+            }).required(),
+          }).required(),
+        },
+        handler: badgesController.updateBadge,
+        tags: ['api', 'badges'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+            '- Elle permet de modifier un résultat thématique.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -348,6 +348,7 @@ module.exports = injectDependencies(
     superviseSession: require('./supervise-session'),
     unarchiveCampaign: require('./unarchive-campaign'),
     unpublishSession: require('./unpublish-session'),
+    updateBadge: require('./update-badge'),
     updateCampaign: require('./update-campaign'),
     updateCampaignDetailsManagement: require('./update-campaign-details-management'),
     updateCertificationCenter: require('./update-certification-center'),

--- a/api/lib/domain/usecases/update-badge.js
+++ b/api/lib/domain/usecases/update-badge.js
@@ -1,0 +1,10 @@
+module.exports = async function updateBadge({ badgeId, badge, badgeRepository }) {
+  const existingBadge = await badgeRepository.get(badgeId);
+
+  if (badge.message) existingBadge.message = badge.message;
+  if (badge.altMessage) existingBadge.altMessage = badge.altMessage;
+  if (badge.key) existingBadge.key = badge.key;
+  if (badge.title) existingBadge.title = badge.title;
+
+  return badgeRepository.update(existingBadge);
+};

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -72,6 +72,11 @@ module.exports = {
     }
   },
 
+  async update(badge) {
+    const [updatedBadge] = await knex(TABLE_NAME).update(_adaptModelToDb(badge)).where({ id: badge.id }).returning('*');
+    return new Badge({ ...badge, ...updatedBadge });
+  },
+
   async isKeyAvailable(key, { knexTransaction } = DomainTransaction.emptyTransaction()) {
     const result = await (knexTransaction ?? knex)(TABLE_NAME).select('key').where('key', key);
     if (result.length) {

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -7,4 +7,13 @@ module.exports = {
       attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'isAlwaysVisible'],
     }).serialize(badge);
   },
+
+  deserialize(json) {
+    return {
+      key: json.data.attributes['key'],
+      altMessage: json.data.attributes['alt-message'],
+      message: json.data.attributes['message'],
+      title: json.data.attributes['title'],
+    };
+  },
 };

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -6,6 +6,7 @@ const {
   insertUserWithRolePixMaster,
   learningContentBuilder,
   mockLearningContent,
+  knex,
 } = require('../../../test-helper');
 
 describe('Acceptance | API | Badges', function () {
@@ -219,6 +220,73 @@ describe('Acceptance | API | Badges', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal(expectedBadge);
+    });
+  });
+
+  describe('PATCH /api/admin/badges/{id}', function () {
+    beforeEach(async function () {
+      userId = (await insertUserWithRolePixMaster()).id;
+
+      badge = databaseBuilder.factory.buildBadge({
+        id: 1,
+        altMessage: 'Message alternatif',
+        imageUrl: 'url_image',
+        message: 'Bravo',
+        title: 'titre du badge',
+        key: 'clef du badge',
+        isCertifiable: false,
+        isAlwaysVisible: true,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('badges').delete();
+    });
+
+    it('should update the existing badge', async function () {
+      // given
+      const badgeWithUpdatedInfo = {
+        key: '1',
+        title: 'titre du badge modifié',
+        message: 'Message modifié',
+        'alt-message': 'Message alternatif modifié',
+        'image-url': 'url_image_modifiée',
+        'is-certifiable': true,
+        'is-always-visible': true,
+        'campaign-threshold': null,
+        'skill-set-threshold': null,
+        'skill-set-name': '',
+        'skill-set-skills-ids': null,
+      };
+
+      options = {
+        method: 'PATCH',
+        url: `/api/admin/badges/${badge.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            id: '1',
+            type: 'badges',
+            attributes: badgeWithUpdatedInfo,
+            relationships: {
+              'target-profile': {
+                data: {
+                  id: badge.targetProfileId,
+                  type: 'target-profiles',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -444,6 +444,51 @@ describe('Integration | Repository | Badge', function () {
     });
   });
 
+  describe('#update', function () {
+    it('should update the badge', async function () {
+      // given
+      const targetProfileId = targetProfileWithSeveralBadges.id;
+      const badge = databaseBuilder.factory.buildBadge({
+        id: 1,
+        altMessage: 'You won the Toto badge!',
+        imageUrl: 'data:,',
+        message: 'Congrats, you won the Toto badge!',
+        key: 'TOTO2',
+        targetProfileId,
+      });
+      databaseBuilder.factory.buildBadgeCriterion({ badgeId: badge.id });
+      await databaseBuilder.commit();
+
+      const updatedData = {
+        id: 1,
+        altMessage: 'You won the Updated badge!',
+        imageUrl: 'Updated URL',
+        message: 'Congrats, you won the Updated badge!',
+        key: 'TOTO_UPDATED',
+      };
+
+      const expectedBadge = {
+        id: 1,
+        altMessage: 'You won the Updated badge!',
+        imageUrl: 'Updated URL',
+        message: 'Congrats, you won the Updated badge!',
+        title: 'title',
+        key: 'TOTO_UPDATED',
+        isCertifiable: false,
+        badgeCriteria: [],
+        skillSets: [],
+        targetProfileId,
+        isAlwaysVisible: false,
+      };
+
+      // when
+      const updatedBadge = await badgeRepository.update(updatedData);
+
+      // then
+      expect(updatedBadge).to.deep.equal(expectedBadge);
+    });
+  });
+
   describe('#isKeyAvailable', function () {
     it('should return true', async function () {
       // given

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -124,4 +124,40 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
       expect(json).to.deep.equal(expectedSerializedBadge);
     });
   });
+
+  describe('#deserialize', function () {
+    it('should convert JSON API data into a Badge model object', async function () {
+      // given
+      const jsonBadge = {
+        data: {
+          type: 'badge-update',
+          attributes: {
+            key: 'BADGE_KEY',
+            'alt-message': 'alt-message',
+            'image-url': 'https://example.net/image.svg',
+            message: 'message',
+            title: 'title',
+            'is-certifiable': false,
+            'is-always-visible': true,
+            'campaign-threshold': 99,
+            'skill-set-threshold': 66,
+            'skill-set-name': "le nom du lot d'acquis",
+            'skill-set-skills-ids': ['skillId1', 'skillId2', 'skillId4'],
+          },
+        },
+      };
+
+      // when
+      const badge = await serializer.deserialize(jsonBadge);
+
+      // then
+      const expectedBadge = {
+        key: 'BADGE_KEY',
+        altMessage: 'alt-message',
+        message: 'message',
+        title: 'title',
+      };
+      expect(badge).to.deep.equal(expectedBadge);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Une fois un RT dans Pix-Admin créé, il n'est pas possible de le modifier en cas d'erreur de saisie.

## :gift: Solution

Création d'une nouvelle route à cet effet.
Modification de l'UI de Pix-Admin afin de pouvoir modifier un RT existant.

## :star2: Remarques

Pas convaincu par le test d'update front qui ne teste que les appels ont été réalisés, je n'ai pas de meilleure solution. Preneur de suggestions sur le sujet (et sur tout le reste évidemment 😄 )

## :santa: Pour tester

Dans Pix-Admin, créer un RT
Dans le listing des RT, voir les détails d'un RT
Modifier un ou plusieurs champs dans le mode d'édition
Enregistrer et constater des modifs sur le modèle Ember et en DB.
