### PR TITLE
[BUGFIX] [A11Y] Ajouter un titre au champ de filtrage sur la page d'ajout d'élèves à une session de certification (PIX-3906)

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -2,9 +2,9 @@
 
 <div class="add-student-list">
   <div class="add-student-list__filters">
-    <label for="add-student-list__multi-select">Filtrer</label>
+    <span>Filtrer</span>
     <PixMultiSelect
-      @title={{'Classes'}}
+      @title="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
       @emptyMessage={{this.emptyMessage}}
       @id={{'add-student-list__multi-select'}}
       @onSelect={{this.selectDivision}}

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -14,6 +14,7 @@
 
     .pix-multi-select {
       min-width: 200px;
+      width: auto;
 
       &__list-button {
         display: flex;

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | add-student-list', function(hooks) {
   setupRenderingTest(hooks);
@@ -33,14 +34,13 @@ module('Integration | Component | add-student-list', function(hooks) {
 
   module('when there are students', () => {
 
-    test('it shows students divisons in the multiSelect', async function(assert) {
+    test('it shows students divisions in the multiSelect', async function(assert) {
       // given
       const birthdate = new Date('2018-01-12T09:29:16Z');
       const firstStudent = _buildUnselectedStudent('first', 'last', '3A', birthdate);
       const secondStudent = _buildUnselectedStudent('second', 'lastName', '2B', birthdate);
       const thirdStudent = _buildUnselectedStudent('third', 'lastName', '3A', birthdate);
 
-      const pixMultiSelect = '.pix-multi-select ul li';
       this.set('students', [
         firstStudent,
         secondStudent,
@@ -50,13 +50,17 @@ module('Integration | Component | add-student-list', function(hooks) {
       this.set('divisions', divisions);
 
       // when
-      await render(hbs`<AddStudentList @studentList={{this.students}} @certificationCenterDivisions={{this.divisions}}></AddStudentList>`);
-      const multiSelectItemsList = document.querySelectorAll(pixMultiSelect);
+      const screen = await render(hbs`
+        <AddStudentList
+          @studentList={{this.students}}
+          @certificationCenterDivisions={{this.divisions}}
+        />
+      `);
+      await click(screen.getByRole('textbox', { name: 'Filtrer Classes' }));
 
       // then
-      assert.dom(pixMultiSelect + ' label[for=add-student-list__multi-select-3A]').includesText(firstStudent.division);
-      assert.dom(pixMultiSelect + ' label[for=add-student-list__multi-select-2B]').includesText(secondStudent.division);
-      assert.equal(multiSelectItemsList.length, divisions.length);
+      assert.dom(screen.getByRole('checkbox', { name: '3A' })).exists();
+      assert.dom(screen.getByRole('checkbox', { name: '2B' })).exists();
     });
 
     test('it shows student information in the table', async function(assert) {

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -56,7 +56,7 @@ module('Integration | Component | add-student-list', function(hooks) {
           @certificationCenterDivisions={{this.divisions}}
         />
       `);
-      await click(screen.getByRole('textbox', { name: 'Filtrer Classes' }));
+      await click(screen.getByRole('textbox', { name: 'Filtrer la liste des élèves en cochant la ou les classes souhaitées' }));
 
       // then
       assert.dom(screen.getByRole('checkbox', { name: '3A' })).exists();


### PR DESCRIPTION
## :christmas_tree: Problème

Suite à l’audit accessibilité de Pix Certif dans le cadre duquel l’app a obtenu le score de 40%, nous cherchons à améliorer notre % de conformité à 50%. 
Or dans PixCertif, le champ de filtrage par classe de la liste d'élève par n'a pas un bon libellé. 

## :gift: Solution

Corriger le libellé du champ en mettant "Filtrer la liste des élèves en cochant la ou les classes souhaitées". 

## :star2: Remarques

À noter que le problème est en partie dû à une confusion autour des paramètres `@label` et `@title` du `PixMultiSelect` (le second étant parfois utilisé comme un aria-label masqué, parfois non). En attendant que le problème soit corrigé côté `PixMultiSelect`, le champ `@title` a été utilisé pour faire office d'`aria-label` et l'élément `label` avec le mot "Filtrer" qui précédait le champ a été transformé en `div`, sans quoi l'élément `input` avait deux `label` ce qui était signalé comme une erreur par Wave.

La solution idéal serait de pouvoir faire : 

```hbs
    <PixMultiSelect
      @label="Filtrer"
      aria-label="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
      …
    />
    </PixMultiSelect>
```

Mais vu la manière dont fonctionne le `PixMultiSelect`, ce n'est pas possible aujourd'hui.

## :santa: Pour tester

1. Se connecter à Pix Certif avec un compte sco (e.g. certifsco@example.net)
2. Se rendre dans une session avec des candidats
3. Activer le lecteur d'écran (<kbd>Cmd</kbd> + <kbd>F5</kbd> sur Mac) et se positionner sur le champ de filtrage par classe
4. Constater que le lecteur d'écran annonce "Filtrer la liste des élèves en cochant la ou les classes souhaitées"
