### PR TITLE
[FEATURE] Ajout de l'url de documentation lors de la création d'une orga (Pix-3975).

### DIFF
--- a/admin/app/components/organizations/form.hbs
+++ b/admin/app/components/organizations/form.hbs
@@ -24,7 +24,7 @@
       <label class="form-field__label" for="organizationType">Type : </label>
       <div
         id="organizationTypeSelector"
-        class="form-field__select {{if @organization.errors.type "is-invalid" ""}} organization-form__select-type"
+        class="form-field__select {{if @organization.errors.type " is-invalid" ""}} organization-form__select-type"
       >
         <PowerSelect
           @options={{this.organizationTypes}}
@@ -41,6 +41,24 @@
           {{error.message}}
         </div>
       {{/each}}
+    </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="documentationUrl">Lien vers la documentation : </label>
+      <Input
+        class={{if
+          @organization.errors.documentationUrl
+          "form-field__text form-control is-invalid"
+          "form-field__text form-control"
+        }}
+        id="documentationUrl"
+        @value={{@organization.documentationUrl}}
+      />
+      {{#if @organization.errors.documentationUrl}}
+        <div class="form-field__error">
+          {{@organization.errors.documentationUrl.0.message}}
+        </div>
+      {{/if}}
     </div>
   </section>
 

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -37,12 +37,21 @@ module.exports = {
       'external-id': externalId,
       'province-code': provinceCode,
       'logo-url': logoUrl,
+      'documentation-url': documentationUrl,
     } = request.payload.data.attributes;
 
     const pixMasterUserId = extractUserIdFromRequest(request);
-
     return usecases
-      .createOrganization({ createdBy: pixMasterUserId, name, type, externalId, provinceCode, logoUrl, email })
+      .createOrganization({
+        createdBy: pixMasterUserId,
+        name,
+        type,
+        externalId,
+        provinceCode,
+        logoUrl,
+        email,
+        documentationUrl,
+      })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/create-organization.js
+++ b/api/lib/domain/usecases/create-organization.js
@@ -8,9 +8,10 @@ module.exports = async function createOrganization({
   name,
   type,
   provinceCode,
+  documentationUrl,
   organizationRepository,
 }) {
-  organizationCreationValidator.validate({ name, type });
-  const organization = new Organization({ createdBy, name, type, logoUrl, externalId, provinceCode });
+  organizationCreationValidator.validate({ name, type, documentationUrl });
+  const organization = new Organization({ createdBy, name, type, logoUrl, externalId, provinceCode, documentationUrl });
   return organizationRepository.create(organization);
 };

--- a/api/lib/domain/validators/organization-creation-validator.js
+++ b/api/lib/domain/validators/organization-creation-validator.js
@@ -12,6 +12,10 @@ const organizationValidationJoiSchema = Joi.object({
     'string.empty': 'Le type n’est pas renseigné.',
     'any.only': 'Le type de l’organisation doit avoir l’une des valeurs suivantes: SCO, SUP, PRO.',
   }),
+
+  documentationUrl: Joi.string().uri().allow(null).messages({
+    'string.uri': 'Le lien vers la documentation n’est pas valide.',
+  }),
 });
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -62,6 +62,7 @@ module.exports = {
       'isManagingStudents',
       'canCollectProfiles',
       'createdBy',
+      'documentationUrl',
     ]);
 
     return knex('organizations')

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -37,6 +37,7 @@ describe('Acceptance | Application | organization-controller', function () {
           attributes: {
             name: 'The name of the organization',
             type: 'PRO',
+            'documentation-url': 'https://kingArthur.com',
           },
         },
       };
@@ -69,6 +70,7 @@ describe('Acceptance | Application | organization-controller', function () {
         const createdOrganization = response.result.data.attributes;
         expect(createdOrganization.name).to.equal('The name of the organization');
         expect(createdOrganization.type).to.equal('PRO');
+        expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
       });
 
       it('should save the Pix Master userId creating the Organization', async function () {

--- a/api/tests/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/integration/domain/usecases/create-organization_test.js
@@ -19,11 +19,13 @@ describe('Integration | UseCases | create-organization', function () {
     const name = 'ACME';
     const provinceCode = 'provinceCode';
     const type = 'PRO';
+    const documentationUrl = 'https://pix.fr';
 
     // when
     const result = await createOrganization({
       createdBy: pixMasterUserId,
       externalId,
+      documentationUrl,
       name,
       provinceCode,
       type,
@@ -37,5 +39,6 @@ describe('Integration | UseCases | create-organization', function () {
     expect(result.name).to.be.equal(name);
     expect(result.provinceCode).to.be.equal(provinceCode);
     expect(result.type).to.be.equal(type);
+    expect(result.documentationUrl).to.be.equal(documentationUrl);
   });
 });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -51,6 +51,7 @@ describe('Integration | Repository | Organization', function () {
       expect(organizationSaved.externalId).to.equal(organization.externalId);
       expect(organizationSaved.provinceCode).to.equal(organization.provinceCode);
       expect(organizationSaved.createdBy).to.equal(organization.createdBy);
+      expect(organizationSaved.documentationUrl).to.equal(organization.documentationUrl);
     });
 
     it('should insert default value for canCollectProfiles (false), credit (0) when not defined', async function () {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1,7 +1,6 @@
 const { catchErr, expect, knex, domainBuilder, databaseBuilder } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const Organization = require('../../../../lib/domain/models/Organization');
-const BookshelfOrganization = require('../../../../lib/infrastructure/orm-models/Organization');
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const _ = require('lodash');
 
@@ -24,13 +23,13 @@ describe('Integration | Repository | Organization', function () {
 
     it('should add a row in the table "organizations"', async function () {
       // given
-      const nbOrganizationsBeforeCreation = await BookshelfOrganization.count();
+      const { count: nbOrganizationsBeforeCreation } = await knex('organizations').count('*').first();
 
       // when
       await organizationRepository.create(domainBuilder.buildOrganization());
 
       // then
-      const nbOrganizationsAfterCreation = await BookshelfOrganization.count();
+      const { count: nbOrganizationsAfterCreation } = await knex('organizations').count('*').first();
       expect(nbOrganizationsAfterCreation).to.equal(nbOrganizationsBeforeCreation + 1);
     });
 
@@ -75,13 +74,12 @@ describe('Integration | Repository | Organization', function () {
   describe('#update', function () {
     it('should return an Organization domain object with related tags', async function () {
       // given
-      const bookshelfOrganization = databaseBuilder.factory.buildOrganization({ id: 1 });
+      const organization = databaseBuilder.factory.buildOrganization({ id: 1 });
       const tagId = databaseBuilder.factory.buildTag().id;
       databaseBuilder.factory.buildOrganizationTag({ organizationId: 1, tagId });
       await databaseBuilder.commit();
 
       // when
-      const organization = domainBuilder.buildOrganization(bookshelfOrganization);
       const organizationSaved = await organizationRepository.update(organization);
 
       // then
@@ -91,27 +89,25 @@ describe('Integration | Repository | Organization', function () {
 
     it('should not add row in table "organizations"', async function () {
       // given
-      const bookshelfOrganization = databaseBuilder.factory.buildOrganization({ id: 1 });
+      const organization = databaseBuilder.factory.buildOrganization({ id: 1 });
       await databaseBuilder.commit();
-      const nbOrganizationsBeforeUpdate = await BookshelfOrganization.count();
-
-      const organization = domainBuilder.buildOrganization(bookshelfOrganization);
+      const { count: nbOrganizationsBeforeUpdate } = await knex('organizations').count('*').first();
 
       // when
       await organizationRepository.update(organization);
 
       // then
-      const nbOrganizationsAfterUpdate = await BookshelfOrganization.count();
+      const { count: nbOrganizationsAfterUpdate } = await knex('organizations').count('*').first();
       expect(nbOrganizationsAfterUpdate).to.equal(nbOrganizationsBeforeUpdate);
     });
 
     it('should update model in database', async function () {
       // given
-      const bookshelfOrganization = databaseBuilder.factory.buildOrganization({ id: 1 });
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
       await databaseBuilder.commit();
 
       const organization = domainBuilder.buildOrganization({
-        id: bookshelfOrganization.id,
+        id: organizationId,
         name: 'New name',
         type: 'SCO',
         logoUrl: 'http://new.logo.url',

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -80,6 +80,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
                 'external-id': organizationToCreate.externalId,
                 'logo-url': organizationToCreate.logoUrl,
                 'province-code': organizationToCreate.provinceCode,
+                'documentation-url': organizationToCreate.documentationUrl,
               },
             },
           },
@@ -97,6 +98,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
           externalId: organizationToCreate.externalId,
           logoUrl: organizationToCreate.logoUrl,
           provinceCode: organizationToCreate.provinceCode,
+          documentationUrl: organizationToCreate.documentationUrl,
         });
       });
 

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -10,32 +10,45 @@ describe('Unit | UseCase | create-organization', function () {
   });
 
   context('Green cases', function () {
-    const name = 'ACME';
-    const type = 'PRO';
-    const externalId = 'externalId';
-    const provinceCode = 'provinceCode';
+    let name;
+    let type;
+    let externalId;
+    let provinceCode;
+    let documentationUrl;
     let organizationRepository;
 
     beforeEach(function () {
+      name = 'ACME';
+      type = 'PRO';
+      externalId = 'externalId';
+      provinceCode = 'provinceCode';
+      documentationUrl = 'https://pix.fr';
       organizationCreationValidator.validate.returns();
 
       organizationRepository = { create: sinon.stub() };
       organizationRepository.create.resolves();
     });
 
-    it('should validate params (name + type)', async function () {
+    it('should validate params (name + type + documentationUrl)', async function () {
       // when
-      await createOrganization({ name, type, externalId, provinceCode, organizationRepository });
+      await createOrganization({ name, type, documentationUrl, externalId, provinceCode, organizationRepository });
 
       // then
-      expect(organizationCreationValidator.validate).to.have.been.calledWithExactly({ name, type });
+      expect(organizationCreationValidator.validate).to.have.been.calledWithExactly({ name, type, documentationUrl });
     });
 
     it('should create a new Organization Entity with Pix Master userId', async function () {
       // given
       const pixMasterUserId = 10;
       const createdBy = pixMasterUserId;
-      const expectedOrganization = new Organization({ createdBy, name, type, externalId, provinceCode });
+      const expectedOrganization = new Organization({
+        createdBy,
+        name,
+        documentationUrl,
+        type,
+        externalId,
+        provinceCode,
+      });
 
       // when
       await createOrganization({
@@ -44,6 +57,7 @@ describe('Unit | UseCase | create-organization', function () {
         name,
         provinceCode,
         type,
+        documentationUrl,
         organizationRepository,
       });
 

--- a/api/tests/unit/domain/validators/organization-creation-validator_test.js
+++ b/api/tests/unit/domain/validators/organization-creation-validator_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, catchErr } = require('../../../test-helper');
 const organizationCreationValidator = require('../../../../lib/domain/validators/organization-creation-validator');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
 
@@ -15,7 +15,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
     context('when validation is successful', function () {
       it('should not throw any error', function () {
         // given
-        const organizationCreationParams = { name: 'ACME', type: 'PRO' };
+        const organizationCreationParams = { name: 'ACME', type: 'PRO', documentationUrl: 'https://kingArthur.com' };
 
         // when/then
         expect(organizationCreationValidator.validate(organizationCreationParams)).to.not.throw;
@@ -97,6 +97,18 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             // when/then
             return expect(organizationCreationValidator.validate(organizationCreationParams)).to.not.throw;
           });
+        });
+      });
+
+      context('on documentationUrl attribute', function () {
+        it('should reject with error when documentationUrl is invalide', async function () {
+          // given
+          const organizationCreationParams = { name: 'ACME', type: 'PRO', documentationUrl: 'invalidUrl' };
+          const error = await catchErr(organizationCreationValidator.validate)(organizationCreationParams);
+
+          // then
+          expect(error.invalidAttributes[0].attribute).to.equal('documentationUrl');
+          expect(error.invalidAttributes[0].message).to.equal('Le lien vers la documentation n’est pas valide.');
         });
       });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à l'ajout du champs documentationUrl dans la BDD #3807 puis afficher le URL de documentation depuis pix admin dans la page de détail d'une orga #3810 , puis le modifier dans #3831, Maintenant l'on veut ajouter la possibilité de ajouter le line ver la documentation lors de la creation d'une Orga dans pix Admin

## :gift: Solution
Rajouter un input dans pix admin lors de la création de une organisation.


## :star2: Remarques
Nous pouvons créer une organisation sans le line vers sa documentation.

## :santa: Pour tester
- Se connectez à Pix Admin
- allez dans organisations puis cliquez sur le bouton 'Nouvelle Organisation'
- Constatez que le champ ' lien vers la documentation ' exist 
- Remplissez le champ avec une url invalide et observez le message d'erreur qui s'affiche avec le message  '_Le lien vers la documentation n’est pas valide._'