### PR TITLE
[BUGFIX] Corriger le test flaky sur l'api remontant les données de resultat d'une campagne (PIX-4102)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -143,7 +143,7 @@ describe('Integration | Repository | Campaign-Report', function () {
 
       // then
       expect(result).to.be.instanceOf(Array);
-      expect(result).to.deep.equal([0.1, 0.3]);
+      expect(result).to.have.members([0.1, 0.3]);
     });
 
     it('should only take into account participations not improved', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Tests pas forcément valide à chaque execution de la CI

## :gift: Solution
au lieu du deep.equal utiliser have.members qui ne vérifie pas l'ordre remonté

## :star2: Remarques
RAS

## :santa: Pour tester
la CI doit passer