### PR TITLE
[FEATURE] Supprime le feature toggle du Net Promoter Score (PIX-4096)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -165,7 +165,6 @@ module.exports = (function () {
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),
-      isNetPromoterScoreEnabled: isFeatureEnabled(process.env.FT_NET_PROMOTER_SCORE_ENABLED),
     },
 
     infra: {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -31,7 +31,6 @@ const schema = Joi.object({
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_END_TEST_SCREEN_REMOVAL_ENABLED: Joi.string().optional().valid('true', 'false'),
-  FT_NET_PROMOTER_SCORE_ENABLED: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -36,13 +36,6 @@ FT_VALIDATE_EMAIL=false
 # default: false
 FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=false
 
-# Enable Net Promoter Score in Pix App
-#
-# type: boolean
-# presence: optionnal
-# default: false
-FT_NET_PROMOTER_SCORE_ENABLED=false
-
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -25,7 +25,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,
             'is-complementary-certification-subscription-enabled': false,
-            'is-net-promoter-score-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -12,7 +12,6 @@ export default class SkillReview extends Component {
   @service currentUser;
   @service url;
   @service store;
-  @service featureToggles;
 
   @tracked displayErrorMessage = false;
 
@@ -123,11 +122,7 @@ export default class SkillReview extends Component {
   }
 
   get showNPS() {
-    return (
-      this.featureToggles.featureToggles.isNetPromoterScoreEnabled &&
-      this.args.model.campaign.organizationShowNPS &&
-      this.isShared
-    );
+    return this.args.model.campaign.organizationShowNPS && this.isShared;
   }
 
   _buildUrl(baseUrl, params) {

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -2,5 +2,4 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isEmailValidationEnabled;
-  @attr('boolean') isNetPromoterScoreEnabled;
 }

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -6,17 +6,11 @@ import hbs from 'htmlbars-inline-precompile';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
-import Service from '@ember/service';
-
-class MockFeatureTogglesService extends Service {
-  featureToggles = { isNetPromoterScoreEnabled: true };
-}
 
 describe('Integration | Component | routes/campaigns/assessment/skill-review', function () {
   let campaign;
   setupIntlRenderingTest();
   beforeEach(function () {
-    this.owner.register('service:feature-toggles', MockFeatureTogglesService);
     campaign = {
       organizationShowNPS: false,
     };


### PR DESCRIPTION
## :christmas_tree: Problème
Le feature toggle du Net Promoter Score est devenu inutile suite à l'ajout d'une colonne `showNPS` sur les orgas.

## :gift: Solution
Supprimer le FT :fire: 

## :star2: Remarques
N/A

## :santa: Pour tester
Vérifier que le NPS fonctionne tjrs correctement en fin de campagne.
