### PR TITLE
[TECH] Assurer que l'utilisateur créateur de la campagne est bien renseigné.

### DIFF
--- a/api/db/migrations/20220105132942_alter-creatorId-from-campaigns-to-be-not-nullable.js
+++ b/api/db/migrations/20220105132942_alter-creatorId-from-campaigns-to-be-not-nullable.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'campaigns';
+const COLUMN_NAME = 'creatorId';
+
+exports.up = function (knex) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};


### PR DESCRIPTION
## :christmas_tree: Problème
La colonne `creatorId` peut être `null` cependant ça n'a pas de sens : cet id d'utilisateur est mis automatiquement lorsque l'utilisateur créé une campagne sur Pix Orga.

## :gift: Solution
Rendre non nullable la colonne creatorId.

## :star2: Remarques
Ceci avait posé soucis lors de la migration en recette [du ticket 3982](https://github.com/1024pix/pix/pull/3858) car il existait sur cet environnement une campagne sans `creatorId` : 
<img width="980" alt="image" src="https://user-images.githubusercontent.com/38167520/148242819-27a3ea0e-3a7c-4e9e-9d0c-515ca0b54132.png">

Il n'existe à ce jour aucune campagne avec un `creatorId` à `null` en production (et la recette avait été corrigée).


## :santa: Pour tester
Sur API :
- npm run db:migrate
- Vérifier qu'il n'y a pas d'erreur et qu'en BDD la colonne est bien non nullable
- npm run db:reset
- Vérifier qu'il n'y a pas d'erreur et qu'en BDD la colonne est bien non nullable