### PR TITLE
[TECH] Remplacer la librairie de date MomentJS par DayJs sur l'API.

### DIFF
--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -3,7 +3,7 @@ const events = require('../../domain/events');
 const privateCertificateSerializer = require('../../infrastructure/serializers/jsonapi/private-certificate-serializer');
 const shareableCertificateSerializer = require('../../infrastructure/serializers/jsonapi/shareable-certificate-serializer');
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
-const moment = require('moment');
+const dayjs = require('dayjs');
 
 module.exports = {
   async findUserCertifications(request) {
@@ -43,7 +43,7 @@ module.exports = {
       certificates: [attestation],
     });
 
-    const fileName = `attestation-pix-${moment(attestation.deliveredAt).format('YYYYMMDD')}.pdf`;
+    const fileName = `attestation-pix-${dayjs(attestation.deliveredAt).format('YYYYMMDD')}.pdf`;
     return h
       .response(buffer)
       .header('Content-Disposition', `attachment; filename=${fileName}`)

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -18,7 +18,7 @@ const {
   extractLocaleFromRequest,
   extractUserIdFromRequest,
 } = require('../../infrastructure/utils/request-response-utils');
-const moment = require('moment');
+const dayjs = require('dayjs');
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
 
@@ -127,7 +127,7 @@ module.exports = {
       certificates: attestations,
     });
 
-    const now = moment();
+    const now = dayjs();
     const fileName = `${now.format('YYYYMMDD')}_attestations_${division}.pdf`;
 
     return h
@@ -144,7 +144,7 @@ module.exports = {
 
     const csvResult = await certificationResultUtils.getDivisionCertificationResultsCsv({ certificationResults });
 
-    const now = moment();
+    const now = dayjs();
     const fileName = `${now.format('YYYYMMDD')}_resultats_${division}.csv`;
 
     return h

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
 const { BadRequestError, SessionPublicationBatchError } = require('../http-errors');
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
@@ -148,7 +148,7 @@ module.exports = {
       certificationResults,
     });
 
-    const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+    const dateWithTime = dayjs(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
     const fileName = `${dateWithTime.format('YYYYMMDD_HHmm')}_resultats_session_${sessionId}.csv`;
 
     return h
@@ -169,7 +169,7 @@ module.exports = {
       certificationResults,
     });
 
-    const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+    const dateWithTime = dayjs(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
     const fileName = `${dateWithTime.format('YYYYMMDD_HHmm')}_resultats_session_${sessionId}.csv`;
 
     return h

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -1,5 +1,8 @@
 const _ = require('lodash');
-const moment = require('moment');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
+
 const bluebird = require('bluebird');
 
 const constants = require('../../infrastructure/constants');
@@ -116,7 +119,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream({
   const fileName = translate('campaign-export.common.file-name', {
     name: campaign.name,
     id: campaign.id,
-    date: moment.utc().format('YYYY-MM-DD-hhmm'),
+    date: dayjs.utc().format('YYYY-MM-DD-hhmm'),
   });
   return { fileName };
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2175,6 +2175,11 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
     },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -31,6 +31,7 @@
     "bookshelf-json-columns": "^3.0.0",
     "bookshelf-validate": "^2.0.3",
     "boom": "^7.3.0",
+    "dayjs": "^1.10.7",
     "dotenv": "^10.0.0",
     "fast-levenshtein": "^3.0.0",
     "file-type": "^16.5.3",

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -189,14 +189,11 @@ describe('Unit | Controller | certifications-controller', function () {
   });
 
   describe('#getCertificationAttestation', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const attestationPDF = 'binary string';
-    const fileName = 'attestation-pix-20181003.pdf';
-    const userId = 1;
-
     it('should return binary attestation', async function () {
       // given
+      const attestationPDF = 'binary string';
+      const fileName = 'attestation-pix-20181003.pdf';
+      const userId = 1;
       const deliveredAt = new Date('2018-12-04T02:02:02Z');
       const certification = domainBuilder.buildPrivateCertificateWithCompetenceTree({ deliveredAt });
       const request = {

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -191,28 +191,22 @@ describe('Unit | Controller | certifications-controller', function () {
   describe('#getCertificationAttestation', function () {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line mocha/no-setup-in-describe
-    const certification = domainBuilder.buildPrivateCertificateWithCompetenceTree();
     const attestationPDF = 'binary string';
     const fileName = 'attestation-pix-20181003.pdf';
     const userId = 1;
 
-    const request = {
-      auth: { credentials: { userId } },
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      params: { id: certification.id },
-    };
-
-    beforeEach(function () {
-      sinon.stub(usecases, 'getCertificationAttestation');
-    });
-
     it('should return binary attestation', async function () {
       // given
+      const deliveredAt = new Date('2018-12-04T02:02:02Z');
+      const certification = domainBuilder.buildPrivateCertificateWithCompetenceTree({ deliveredAt });
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: certification.id },
+      };
+      sinon.stub(usecases, 'getCertificationAttestation').resolves(certification);
       sinon
         .stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer')
         .resolves({ buffer: attestationPDF, fileName });
-      usecases.getCertificationAttestation.resolves(certification);
 
       // when
       const response = await certificationController.getPDFAttestation(request, hFake);
@@ -223,7 +217,7 @@ describe('Unit | Controller | certifications-controller', function () {
         certificationId: certification.id,
       });
       expect(response.source).to.deep.equal(attestationPDF);
-      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=attestation-pix-20181003.pdf');
+      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=attestation-pix-20181204.pdf');
     });
   });
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1,4 +1,3 @@
-const { fn: momentProto } = require('moment');
 const {
   domainBuilder,
   expect,
@@ -930,6 +929,15 @@ describe('Unit | Application | Organizations | organization-controller', functio
   });
 
   describe('#downloadCertificationResults', function () {
+    let clock;
+    const fakedDate = new Date('2019-12-01T05:06:07Z');
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(fakedDate);
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
     it('should return a response with CSV results', async function () {
       // given
       const request = {
@@ -947,9 +955,6 @@ describe('Unit | Application | Organizations | organization-controller', functio
         domainBuilder.buildCertificationResult({ isPublished: true }),
       ];
 
-      sinon.stub(momentProto, 'format');
-      momentProto.format.withArgs('YYYYMMDD').returns('20210101');
-
       sinon
         .stub(usecases, 'getScoCertificationResultsByDivision')
         .withArgs({ organizationId: 1, division: '3èmeA' })
@@ -966,11 +971,20 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(response.source).to.equal('csv-string');
       expect(response.headers['Content-Type']).to.equal('text/csv;charset=utf-8');
-      expect(response.headers['Content-Disposition']).to.equal('attachment; filename=20210101_resultats_3èmeA.csv');
+      expect(response.headers['Content-Disposition']).to.equal('attachment; filename=20191201_resultats_3èmeA.csv');
     });
   });
 
   describe('#downloadCertificationAttestationsForDivision', function () {
+    let clock;
+    const fakedDate = new Date('2019-12-01T05:06:07Z');
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(fakedDate);
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
     it('should return binary attestations', async function () {
       // given
       const certifications = [
@@ -980,9 +994,6 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const organizationId = domainBuilder.buildOrganization().id;
       const division = '3b';
       const attestationsPDF = 'binary string';
-
-      sinon.stub(momentProto, 'format');
-      momentProto.format.withArgs('YYYYMMDD').returns('20210101');
 
       const fileName = '20210101_attestations_3b.pdf';
       const userId = 1;
@@ -1008,7 +1019,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
       });
       expect(response.source).to.deep.equal(attestationsPDF);
-      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=20210101_attestations_3b.pdf');
+      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=20191201_attestations_3b.pdf');
     });
   });
 });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -4,6 +4,7 @@ const startWritingCampaignAssessmentResultsToStream = require('../../../../lib/d
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../../../../lib/domain/errors');
 const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 const { getI18n } = require('../../../tooling/i18n/i18n');
+const moment = require('moment');
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   const campaignRepository = { get: () => undefined };
@@ -112,7 +113,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"'${skill2_1_1.name}"\n`;
 
     // when
-    startWritingCampaignAssessmentResultsToStream({
+    const { fileName } = await startWritingCampaignAssessmentResultsToStream({
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
@@ -128,7 +129,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     const csv = await csvPromise;
 
     // then
-    expect(csv).to.equal(csvExpected);
+    const expectedFilename = `Resultats-name-${campaign.id}-${moment.utc().format('YYYY-MM-DD-hhmm')}.csv`;
+    expect(fileName).to.equals(expectedFilename);
+    expect(csv).to.deep.equal(csvExpected);
   });
 
   it('should contains idPixLabel in header if any setup in campaign', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Suite de #1965 

## :gift: Solution
Utiliser la doc dayjs
Utiliser le plugin utc https://day.js.org/docs/en/plugin/utc

## :star2: Remarques
Ajout de tests manquants

## :santa: Pour tester
Vérifier que la CI passe
