### PR TITLE
[FEATURE][A11Y] Indiquer que la saisie des champs est obligatoire sur Pix Orga (PIX-3891).

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -18,10 +18,8 @@
     </div>
   {{/if}}
 
-  <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
-
   <form {{on "submit" this.authenticate}}>
-
+    <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
     <div class="input-container">
       <label for="login-email" class="label">{{t "pages.login-form.email"}}</label>
       <Input

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -20,43 +20,34 @@
 
   <form {{on "submit" this.authenticate}}>
     <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
+
     <div class="input-container">
-      <label for="login-email" class="label">{{t "pages.login-form.email"}}</label>
-      <Input
-        id="login-email"
+      <PixInput
+        @id="login-email"
+        @label={{t "pages.login-form.email"}}
+        name="login"
         @type="email"
         @value={{this.email}}
-        name="login"
-        class="input"
-        autocomplete="username"
+        {{on "focusout" this.validateEmail}}
+        @errorMessage={{this.emailValidationMessage}}
         required={{true}}
+        aria-required={{true}}
+        autocomplete="email"
       />
     </div>
 
     <div class="input-container">
-      <label for="login-password" class="label">{{t "pages.login-form.password"}}</label>
-      <div class="input-password">
-        <Input
-          id="login-password"
-          @type={{this.passwordInputType}}
-          @value={{this.password}}
-          name="password"
-          class="input"
-          autocomplete="current-password"
-          required={{true}}
-        />
-        <PixIconButton
-          @icon="{{if this.isPasswordVisible "eye" "eye-slash"}}"
-          aria-label={{if
-            this.isPasswordVisible
-            (t "pages.login-form.hide-password")
-            (t "pages.login-form.show-password")
-          }}
-          @triggerAction={{this.togglePasswordVisibility}}
-          @withBackground={{false}}
-          @color="dark-grey"
-        />
-      </div>
+      <PixInputPassword
+        @id="login-password"
+        name="password"
+        @label={{t "pages.login-form.password"}}
+        autocomplete="current-password"
+        required={{true}}
+        aria-required={{true}}
+        {{on "focusout" this.validatePassword}}
+        {{on "input" this.validatePassword}}
+        @errorMessage={{this.passwordValidationMessage}}
+      />
     </div>
 
     <div class="input-container">

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -19,7 +19,7 @@
   {{/if}}
 
   <form {{on "submit" this.authenticate}}>
-    <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
+    <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
 
     <div class="input-container">
       <PixInput

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -1,8 +1,10 @@
 import { action } from '@ember/object';
+import isEmpty from 'lodash/isEmpty';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
+import isEmailValid from '../../utils/email-validator';
 
 export default class LoginForm extends Component {
   @service intl;
@@ -13,16 +15,12 @@ export default class LoginForm extends Component {
   @tracked errorMessage = null;
   @tracked isErrorMessagePresent = false;
   @tracked isLoading = false;
-  @tracked isPasswordVisible = false;
-
-  email = null;
-  password = null;
+  @tracked password = null;
+  @tracked email = null;
+  @tracked passwordValidationMessage = null;
+  @tracked emailValidationMessage = null;
 
   ERROR_MESSAGES;
-
-  get passwordInputType() {
-    return this.isPasswordVisible ? 'text' : 'password';
-  }
 
   get displayRecoveryLink() {
     if (this.intl.t('current-lang') === 'en' || !this.url.isFrenchDomainExtension) {
@@ -59,8 +57,26 @@ export default class LoginForm extends Component {
   }
 
   @action
-  togglePasswordVisibility() {
-    this.isPasswordVisible = !this.isPasswordVisible;
+  validatePassword(event) {
+    this.password = event.target.value;
+    const isInvalidInput = isEmpty(this.password);
+    this.passwordValidationMessage = null;
+
+    if (isInvalidInput) {
+      this.passwordValidationMessage = this.intl.t('pages.login-form.errors.empty-password');
+    }
+  }
+
+  @action
+  validateEmail() {
+    this.email = this.email.trim();
+    const isInvalidInput = !isEmailValid(this.email);
+
+    this.emailValidationMessage = null;
+
+    if (isInvalidInput) {
+      this.emailValidationMessage = this.intl.t('pages.login-form.errors.invalid-email');
+    }
   }
 
   async _authenticate(password, email) {

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -37,6 +37,11 @@ export default class LoginForm extends Component {
     const email = this.email ? this.email.trim() : '';
     const password = this.password;
 
+    if (!this.isFormValid) {
+      this.isLoading = false;
+      return;
+    }
+
     if (this.args.isWithInvitation) {
       try {
         await this._acceptOrganizationInvitation(
@@ -79,6 +84,10 @@ export default class LoginForm extends Component {
     }
   }
 
+  get isFormValid() {
+    return isEmailValid(this.email) && !isEmpty(this.password);
+  }
+
   async _authenticate(password, email) {
     const scope = 'pix-orga';
 
@@ -86,7 +95,6 @@ export default class LoginForm extends Component {
     this.errorMessage = '';
 
     this._initErrorMessages();
-
     try {
       await this.session.authenticate('authenticator:oauth2', email, password, scope);
     } catch (errorResponse) {

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -1,99 +1,62 @@
 <div class="register-form">
   <form {{on "submit" this.register}}>
     <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
-    <div id="register-firstName-container" class="input-container">
-      <label for="register-firstName" class="label">{{t
-          "pages.login-or-register.register-form.fields.first-name.label"
-        }}</label>
-      <Input
-        id="register-firstName"
+    <div class="input-container">
+      <PixInput
+        @id="register-firstName"
+        @label={{t "pages.login-or-register.register-form.fields.first-name.label"}}
         name="firstName"
         @type="firstName"
-        class="input {{if this.validation.firstName.hasError "input--error"}}"
         @value={{this.user.firstName}}
-        required={{true}}
-        autocomplete="given-name"
         {{on "focusout" (fn this.validateInput "firstName" this.user.firstName)}}
+        @errorMessage={{if this.validation.firstName.hasError this.validation.firstName.message}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="given-name"
       />
-      {{#if this.validation.firstName.hasError}}
-        <div
-          class="alert-input alert-input--error alert-input--left"
-          role="alert"
-        >{{this.validation.firstName.message}}</div>
-      {{/if}}
     </div>
 
-    <div id="register-lastName-container" class="input-container">
-      <label for="register-lastName" class="label">{{t
-          "pages.login-or-register.register-form.fields.last-name.label"
-        }}</label>
-      <Input
-        id="register-lastName"
+    <div class="input-container">
+      <PixInput
+        @id="register-lastName"
+        @label={{t "pages.login-or-register.register-form.fields.last-name.label"}}
         name="lastName"
         @type="lastName"
-        class="input {{if this.validation.lastName.hasError "input--error"}}"
         @value={{this.user.lastName}}
-        autocomplete="family-name"
-        required={{true}}
         {{on "focusout" (fn this.validateInput "lastName" this.user.lastName)}}
+        @errorMessage={{if this.validation.lastName.hasError this.validation.lastName.message}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="family-name"
       />
-      {{#if this.validation.lastName.hasError}}
-        <div
-          class="alert-input alert-input--error alert-input--left"
-          role="alert"
-        >{{this.validation.lastName.message}}</div>
-      {{/if}}
     </div>
 
-    <div id="register-email-container" class="input-container">
-      <label for="register-email" class="label">{{t "pages.login-or-register.register-form.fields.email.label"}}</label>
-      <Input
-        id="register-email"
+    <div class="input-container">
+      <PixInput
+        @id="register-email"
+        @label={{t "pages.login-or-register.register-form.fields.email.label"}}
         name="email"
         @type="email"
-        class="input {{if this.validation.email.hasError "input--error"}}"
         @value={{this.user.email}}
-        autocomplete="email"
-        required={{true}}
         {{on "focusout" (fn this.validateInput "email" this.user.email)}}
+        @errorMessage={{if this.validation.email.hasError this.validation.email.message}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="email"
       />
-      {{#if this.validation.email.hasError}}
-        <div
-          class="alert-input alert-input--error alert-input--left"
-          role="alert"
-        >{{this.validation.email.message}}</div>
-      {{/if}}
     </div>
 
-    <div id="register-password-container" class="input-container">
-      <label for="register-password" class="label">{{t
-          "pages.login-or-register.register-form.fields.password.label"
-        }}</label>
-      <div class="input-password {{if this.validation.password.hasError "input-password--error"}}">
-        <Input
-          id="register-password"
-          name="password"
-          @type={{this.passwordInputType}}
-          class="input"
-          @value={{this.user.password}}
-          autocomplete="current-password"
-          required={{true}}
-          {{on "focusout" (fn this.validateInput "password" this.user.password)}}
-        />
-        <PixIconButton
-          @icon="{{if this.isPasswordVisible "eye" "eye-slash"}}"
-          aria-label="rendre le mot de passe lisible"
-          @triggerAction={{this.togglePasswordVisibility}}
-          @withBackground={{false}}
-          @color="dark-grey"
-        />
-      </div>
-      {{#if this.validation.password.hasError}}
-        <div
-          class="alert-input alert-input--error alert-input--left"
-          role="alert"
-        >{{this.validation.password.message}}</div>
-      {{/if}}
+    <div class="input-container">
+      <PixInputPassword
+        @id="register-password"
+        name="password"
+        @label={{t "pages.login-or-register.register-form.fields.password.label"}}
+        autocomplete="current-password"
+        required={{true}}
+        aria-required={{true}}
+        {{on "focusout" (fn this.validateInput "password")}}
+        @errorMessage={{if this.validation.password.hasError this.validation.password.message}}
+      />
     </div>
 
     <div id="register-cgu-container" class="input-container">
@@ -103,6 +66,7 @@
           @type="checkbox"
           @checked={{this.user.cgu}}
           required={{true}}
+          aria-required={{true}}
           aria-label="{{t "pages.login-or-register.register-form.fields.cgu.aria-label"}}"
           {{on "focusout" (fn this.validateInput "cgu" this.user.cgu)}}
         />

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -1,6 +1,6 @@
 <div class="register-form">
   <form {{on "submit" this.register}}>
-    <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
+    <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
     <div class="input-container">
       <PixInput
         @id="register-firstName"

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -7,9 +7,9 @@
         @label={{t "pages.login-or-register.register-form.fields.first-name.label"}}
         name="firstName"
         @type="firstName"
-        @value={{this.user.firstName}}
-        {{on "focusout" (fn this.validateInput "firstName" this.user.firstName)}}
-        @errorMessage={{if this.validation.firstName.hasError this.validation.firstName.message}}
+        @value={{this.firstName}}
+        {{on "focusout" this.validateFirstName}}
+        @errorMessage={{this.firstNameValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
@@ -22,9 +22,9 @@
         @label={{t "pages.login-or-register.register-form.fields.last-name.label"}}
         name="lastName"
         @type="lastName"
-        @value={{this.user.lastName}}
-        {{on "focusout" (fn this.validateInput "lastName" this.user.lastName)}}
-        @errorMessage={{if this.validation.lastName.hasError this.validation.lastName.message}}
+        @value={{this.lastName}}
+        {{on "focusout" this.validateLastName}}
+        @errorMessage={{this.lastNameValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"
@@ -37,9 +37,9 @@
         @label={{t "pages.login-or-register.register-form.fields.email.label"}}
         name="email"
         @type="email"
-        @value={{this.user.email}}
-        {{on "focusout" (fn this.validateInput "email" this.user.email)}}
-        @errorMessage={{if this.validation.email.hasError this.validation.email.message}}
+        @value={{this.email}}
+        {{on "focusout" this.validateEmail}}
+        @errorMessage={{this.emailValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
@@ -54,8 +54,9 @@
         autocomplete="current-password"
         required={{true}}
         aria-required={{true}}
-        {{on "focusout" (fn this.validateInput "password")}}
-        @errorMessage={{if this.validation.password.hasError this.validation.password.message}}
+        {{on "input" this.validatePassword}}
+        {{on "focusout" this.validatePassword}}
+        @errorMessage={{this.passwordValidationMessage}}
       />
     </div>
 
@@ -64,11 +65,11 @@
         <Input
           id="register-cgu"
           @type="checkbox"
-          @checked={{this.user.cgu}}
+          @checked={{this.cgu}}
           required={{true}}
           aria-required={{true}}
           aria-label="{{t "pages.login-or-register.register-form.fields.cgu.aria-label"}}"
-          {{on "focusout" (fn this.validateInput "cgu" this.user.cgu)}}
+          {{on "focusout" this.validateCgu}}
         />
         <span class="register-form__cgu">
           {{t "pages.login-or-register.register-form.fields.cgu.accept"}}
@@ -82,10 +83,16 @@
           </a>
         </span>
       </label>
-      {{#if this.validation.cgu.hasError}}
-        <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.cgu.message}}</div>
+      {{#if this.cguValidationMessage}}
+        <div class="register-form__cgu-error" role="alert">{{this.cguValidationMessage}}</div>
       {{/if}}
     </div>
+
+    {{#if this.errorMessage}}
+      <PixMessage @type="alert">
+        {{this.errorMessage}}
+      </PixMessage>
+    {{/if}}
 
     <div class="input-container">
       <PixButton @type="submit" @isLoading={{this.isLoading}}>

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -1,6 +1,6 @@
 <div class="register-form">
   <form {{on "submit" this.register}}>
-
+    <p class="login-form__information">{{t "pages.login-form.mandatory-all-fields"}}</p>
     <div id="register-firstName-container" class="input-container">
       <label for="register-firstName" class="label">{{t
           "pages.login-or-register.register-form.fields.first-name.label"
@@ -11,6 +11,7 @@
         @type="firstName"
         class="input {{if this.validation.firstName.hasError "input--error"}}"
         @value={{this.user.firstName}}
+        required={{true}}
         autocomplete="given-name"
         {{on "focusout" (fn this.validateInput "firstName" this.user.firstName)}}
       />
@@ -33,6 +34,7 @@
         class="input {{if this.validation.lastName.hasError "input--error"}}"
         @value={{this.user.lastName}}
         autocomplete="family-name"
+        required={{true}}
         {{on "focusout" (fn this.validateInput "lastName" this.user.lastName)}}
       />
       {{#if this.validation.lastName.hasError}}
@@ -52,6 +54,7 @@
         class="input {{if this.validation.email.hasError "input--error"}}"
         @value={{this.user.email}}
         autocomplete="email"
+        required={{true}}
         {{on "focusout" (fn this.validateInput "email" this.user.email)}}
       />
       {{#if this.validation.email.hasError}}
@@ -74,6 +77,7 @@
           class="input"
           @value={{this.user.password}}
           autocomplete="current-password"
+          required={{true}}
           {{on "focusout" (fn this.validateInput "password" this.user.password)}}
         />
         <PixIconButton
@@ -98,6 +102,7 @@
           id="register-cgu"
           @type="checkbox"
           @checked={{this.user.cgu}}
+          required={{true}}
           aria-label="{{t "pages.login-or-register.register-form.fields.cgu.aria-label"}}"
           {{on "focusout" (fn this.validateInput "cgu" this.user.cgu)}}
         />

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -31,13 +31,8 @@ export default class RegisterForm extends Component {
     cgu: new InputValidator(Boolean, this.intl.t('pages.login-or-register.register-form.fields.cgu.error')),
   };
 
-  user = null;
+  @tracked user = null;
   @tracked isLoading = false;
-  @tracked isPasswordVisible = false;
-
-  get passwordInputType() {
-    return this.isPasswordVisible ? 'text' : 'password';
-  }
 
   constructor() {
     super(...arguments);
@@ -76,12 +71,11 @@ export default class RegisterForm extends Component {
   }
 
   @action
-  togglePasswordVisibility() {
-    this.isPasswordVisible = !this.isPasswordVisible;
-  }
-
-  @action
   validateInput(key, value) {
+    if (key === 'password') {
+      value = value.target.value;
+      this.user.password = value;
+    }
     this.validation[key].validate({ value, resetServerMessage: true });
   }
 

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -2,100 +2,130 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import InputValidator from '../../utils/input-validator';
-
+import isEmpty from 'lodash/isEmpty';
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
-
-const isStringValid = (value) => Boolean(value.trim());
+import get from 'lodash/get';
 
 export default class RegisterForm extends Component {
   @service session;
   @service store;
   @service intl;
 
-  validation = {
-    firstName: new InputValidator(
-      isStringValid,
-      this.intl.t('pages.login-or-register.register-form.fields.first-name.error')
-    ),
-    lastName: new InputValidator(
-      isStringValid,
-      this.intl.t('pages.login-or-register.register-form.fields.last-name.error')
-    ),
-    email: new InputValidator(isEmailValid, this.intl.t('pages.login-or-register.register-form.fields.email.error')),
-    password: new InputValidator(
-      isPasswordValid,
-      this.intl.t('pages.login-or-register.register-form.fields.password.error')
-    ),
-    cgu: new InputValidator(Boolean, this.intl.t('pages.login-or-register.register-form.fields.cgu.error')),
-  };
-
-  @tracked user = null;
   @tracked isLoading = false;
-
-  constructor() {
-    super(...arguments);
-    this.user = this.store.createRecord('user', {
-      lastName: '',
-      firstName: '',
-      email: '',
-      password: '',
-      cgu: false,
-    });
-  }
+  @tracked firstName = null;
+  @tracked lastName = null;
+  @tracked email = null;
+  @tracked password = null;
+  @tracked passwordValidationMessage = null;
+  @tracked emailValidationMessage = null;
+  @tracked firstNameValidationMessage = null;
+  @tracked lastNameValidationMessage = null;
+  @tracked cguValidationMessage = null;
+  @tracked errorMessage = null;
 
   @action
   async register(event) {
     event.preventDefault();
-    if (this._isFormInvalid()) {
+    this.errorMessage = null;
+    if (!this._isFormValid()) {
       return;
     }
     this.isLoading = true;
     try {
-      await this.user.save();
-    } catch (e) {
+      await this.store
+        .createRecord('user', {
+          lastName: this.lastName,
+          firstName: this.firstName,
+          email: this.email,
+          password: this.password,
+          cgu: true,
+        })
+        .save();
+
+      await this._acceptOrganizationInvitation(
+        this.args.organizationInvitationId,
+        this.args.organizationInvitationCode,
+        this.email
+      );
+      await this._authenticate(this.email, this.password);
+
+      this.password = null;
+    } catch (response) {
+      const status = get(response, 'errors[0].status');
+
+      if (status === '422') {
+        this.errorMessage = this.intl.t('pages.login-or-register.register-form.errors.email-already-exists');
+      } else {
+        this.errorMessage = this.intl.t('pages.login-or-register.register-form.errors.default');
+      }
+    } finally {
       this.isLoading = false;
-      return this._updateInputsStatus();
     }
-
-    await this._acceptOrganizationInvitation(
-      this.args.organizationInvitationId,
-      this.args.organizationInvitationCode,
-      this.user.email
-    );
-    await this._authenticate(this.user.email, this.user.password);
-
-    this.user.password = null;
-    this.isLoading = false;
   }
 
   @action
-  validateInput(key, value) {
-    if (key === 'password') {
-      value = value.target.value;
-      this.user.password = value;
+  validatePassword(event) {
+    this.passwordValidationMessage = null;
+    this.password = event.target.value;
+    const isInvalidInput = !isPasswordValid(this.password);
+
+    if (isInvalidInput) {
+      this.passwordValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.password.error');
     }
-    this.validation[key].validate({ value, resetServerMessage: true });
   }
 
-  _updateInputsStatus() {
-    const errors = this.user.errors;
-    errors.forEach(({ attribute, message }) => this._setError(attribute, message));
+  @action
+  validateEmail() {
+    this.emailValidationMessage = null;
+    this.email = this.email.trim();
+    const isInvalidInput = !isEmailValid(this.email);
+
+    if (isInvalidInput) {
+      this.emailValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.email.error');
+    }
   }
 
-  _isFormInvalid() {
-    this._processFromValidation();
-    return Object.values(this.validation).some((value) => value.hasError);
+  @action
+  validateFirstName() {
+    this.firstNameValidationMessage = null;
+    this.firstName = this.firstName.trim();
+    const isInvalidInput = isEmpty(this.firstName);
+
+    if (isInvalidInput) {
+      this.firstNameValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.first-name.error');
+    }
   }
 
-  _setError(attribute, message) {
-    this.validation[attribute].hasError = true;
-    this.validation[attribute].serverMessage = message;
+  @action
+  validateLastName() {
+    this.lastNameValidationMessage = null;
+    this.lastName = this.lastName.trim();
+    const isInvalidInput = isEmpty(this.lastName);
+
+    if (isInvalidInput) {
+      this.lastNameValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.last-name.error');
+    }
   }
 
-  _processFromValidation() {
-    Object.keys(this.validation).forEach((input) => this.validation[input].validate({ value: this.user[input] }));
+  @action
+  validateCgu() {
+    this.cguValidationMessage = null;
+    const isInputChecked = Boolean(this.cgu);
+
+    if (!isInputChecked) {
+      this.cguValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.cgu.error');
+    }
+  }
+
+  _isFormValid() {
+    return (
+      !isEmpty(this.lastName) &&
+      !isEmpty(this.firstName) &&
+      isEmailValid(this.email) &&
+      isPasswordValid(this.password) &&
+      Boolean(this.cgu)
+    );
   }
 
   _acceptOrganizationInvitation(organizationInvitationId, organizationInvitationCode, createdUserEmail) {
@@ -111,10 +141,5 @@ export default class RegisterForm extends Component {
   _authenticate(email, password) {
     const scope = 'pix-orga';
     return this.session.authenticate('authenticator:oauth2', email, password, scope);
-  }
-
-  willDestroy() {
-    this.user.unloadRecord();
-    super.willDestroy(...arguments);
   }
 }

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -1,10 +1,16 @@
 <form {{on "submit" this.onSubmit}} class="form">
-  <p class="form__mandatory-fields-information">{{t "pages.campaign-creation.mandatory-fields" htmlSafe=true}}</p>
+  <p class="form__mandatory-fields-information" aria-hidden="true">
+    <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark">*</abbr>
+    {{t "common.form.mandatory-fields"}}
+  </p>
 
   <div class="form__field">
+    <label class="label" for="campaign-name">
+      <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{t "pages.campaign-creation.name.label"}}
+    </label>
     <PixInput
       @id="campaign-name"
-      @label={{t "pages.campaign-creation.name.label" htmlSafe=true}}
       @name="campaign-name"
       @type="text"
       class="input"
@@ -24,7 +30,10 @@
   {{#if this.currentUser.organization.canCollectProfiles}}
     <div class="form__field-with-info">
       <div class="form__field" role="radiogroup" aria-labelledby="collect-profiles-label">
-        <p id="collect-profiles-label" class="label">{{t "pages.campaign-creation.purpose.label" htmlSafe=true}}</p>
+        <p id="collect-profiles-label" class="label">
+          <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+          {{t "pages.campaign-creation.purpose.label"}}
+        </p>
         <div class="form__radio-button">
           <input
             type="radio"
@@ -80,7 +89,8 @@
     <div class="form__field-with-info form__field-with-info--small">
       <div class="form__field form__field--wide">
         <label class="label" for="campaign-target-profile">
-          {{t "pages.campaign-creation.target-profiles-list-label" htmlSafe=true}}
+          <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+          {{t "pages.campaign-creation.target-profiles-list-label"}}
         </label>
         <PixSelect
           @id="campaign-target-profile"
@@ -123,7 +133,8 @@
     <div class="form__field-with-info">
       <div class="form__field" aria-labelledby="multiple-sendings-label" role="radiogroup">
         <p id="multiple-sendings-label" class="label">
-          {{t "pages.campaign-creation.multiple-sendings.question-label" htmlSafe=true}}
+          <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+          {{t "pages.campaign-creation.multiple-sendings.question-label"}}
         </p>
         <div class="form__radio-button">
           <input
@@ -161,7 +172,8 @@
 
   <div class="form__field" aria-labelledby="external-ids-label" role="radiogroup">
     <p id="external-ids-label" class="label">
-      {{t "pages.campaign-creation.external-id-label.question-label" htmlSafe=true}}
+      <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{t "pages.campaign-creation.external-id-label.question-label"}}
     </p>
     <div class="form__radio-button">
       <input

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -192,6 +192,7 @@
       <PixInput
         @id="external-id-label"
         @name="external-id-label"
+        @information={{t "pages.campaign-creation.external-id-label.suggestion"}}
         @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
         @value={{this.campaign.idPixLabel}}
@@ -201,9 +202,6 @@
           {{display-campaign-errors @errors.idPixLabel}}
         </div>
       {{/if}}
-      <div class="form__information help-text">
-        {{t "pages.campaign-creation.external-id-label.suggestion"}}
-      </div>
     </div>
   {{/if}}
 

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -1,14 +1,17 @@
 <form {{on "submit" this.onSubmit}} class="form">
+  <p class="form__mandatory-fields-information">{{t "pages.campaign-creation.mandatory-fields" htmlSafe=true}}</p>
 
   <div class="form__field">
     <PixInput
       @id="campaign-name"
-      @label={{t "pages.campaign-creation.name.label"}}
+      @label={{t "pages.campaign-creation.name.label" htmlSafe=true}}
       @name="campaign-name"
       @type="text"
       class="input"
       maxlength="255"
       @value={{this.campaign.name}}
+      required={{true}}
+      aria-required={{true}}
     />
 
     {{#if @errors.name}}
@@ -21,7 +24,7 @@
   {{#if this.currentUser.organization.canCollectProfiles}}
     <div class="form__field-with-info">
       <div class="form__field" role="radiogroup" aria-labelledby="collect-profiles-label">
-        <p id="collect-profiles-label" class="label">{{t "pages.campaign-creation.purpose.label"}}</p>
+        <p id="collect-profiles-label" class="label">{{t "pages.campaign-creation.purpose.label" htmlSafe=true}}</p>
         <div class="form__radio-button">
           <input
             type="radio"
@@ -30,6 +33,8 @@
             value="assess-participants"
             aria-describedby="campaign-goal-assessment-info"
             {{on "change" this.setCampaignGoal}}
+            required={{true}}
+            aria-required={{true}}
           />
           <label for="assess-participants">{{t "pages.campaign-creation.purpose.assessment"}}</label>
         </div>
@@ -74,15 +79,19 @@
   {{#if this.isCampaignGoalAssessment}}
     <div class="form__field-with-info form__field-with-info--small">
       <div class="form__field form__field--wide">
+        <label class="label" for="campaign-target-profile">
+          {{t "pages.campaign-creation.target-profiles-list-label" htmlSafe=true}}
+        </label>
         <PixSelect
           @id="campaign-target-profile"
-          @label={{t "pages.campaign-creation.target-profiles-list-label"}}
           @onChange={{this.selectTargetProfile}}
           @options={{this.targetProfilesOptions}}
           @emptyOptionLabel=""
           aria-describedby="target-profile-info"
           placeholder={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
           @isSearchable={{true}}
+          required={{true}}
+          aria-required={{true}}
         />
         {{#if @errors.targetProfile}}
           <div class="form__error error-message">
@@ -114,7 +123,7 @@
     <div class="form__field-with-info">
       <div class="form__field" aria-labelledby="multiple-sendings-label" role="radiogroup">
         <p id="multiple-sendings-label" class="label">
-          {{t "pages.campaign-creation.multiple-sendings.question-label"}}
+          {{t "pages.campaign-creation.multiple-sendings.question-label" htmlSafe=true}}
         </p>
         <div class="form__radio-button">
           <input
@@ -151,7 +160,9 @@
   {{/if}}
 
   <div class="form__field" aria-labelledby="external-ids-label" role="radiogroup">
-    <p id="external-ids-label" class="label">{{t "pages.campaign-creation.external-id-label.question-label"}}</p>
+    <p id="external-ids-label" class="label">
+      {{t "pages.campaign-creation.external-id-label.question-label" htmlSafe=true}}
+    </p>
     <div class="form__radio-button">
       <input
         type="radio"
@@ -159,6 +170,8 @@
         id="no-external-id"
         name="external-id-label"
         {{on "change" this.doNotAskLabelIdPix}}
+        required={{true}}
+        aria-required={{true}}
       />
       <label for="no-external-id">{{t "pages.campaign-creation.no"}}</label>
     </div>
@@ -181,7 +194,6 @@
         @name="external-id-label"
         @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
-        aria-required="true"
         @value={{this.campaign.idPixLabel}}
       />
       {{#if @errors.idPixLabel}}

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -1,11 +1,14 @@
 <form class="form" {{on "submit" @onSubmit}}>
+  <p class="form__mandatory-fields-information">{{t "pages.campaign-modification.mandatory-fields" htmlSafe=true}}</p>
   <div class="form__field">
     <PixInput
       @id="campaign-name"
       @name="campaign-name"
-      @label={{t "pages.campaign-modification.campaign-name"}}
+      @label={{t "pages.campaign-modification.campaign-name" htmlSafe=true}}
       maxlength="255"
       @value={{@campaign.name}}
+      required={{true}}
+      aria-required={{true}}
     />
   </div>
 

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -1,10 +1,16 @@
 <form class="form" {{on "submit" @onSubmit}}>
-  <p class="form__mandatory-fields-information">{{t "pages.campaign-modification.mandatory-fields" htmlSafe=true}}</p>
+  <p class="form__mandatory-fields-information" aria-hidden="true">
+    <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark">*</abbr>
+    {{t "common.form.mandatory-fields"}}
+  </p>
   <div class="form__field">
+    <label class="label" for="campaign-name">
+      <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{t "pages.campaign-modification.campaign-name"}}
+    </label>
     <PixInput
       @id="campaign-name"
       @name="campaign-name"
-      @label={{t "pages.campaign-modification.campaign-name" htmlSafe=true}}
       maxlength="255"
       @value={{@campaign.name}}
       required={{true}}

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -3,7 +3,7 @@
 
   &__information {
     text-align: center;
-    margin-bottom: 32px;
+    margin-bottom: 25px;
     color: $grey-90;
     font-family: $roboto;
     font-size: 0.875rem;

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -34,11 +34,6 @@
     text-align: left;
   }
 
-  &__button {
-    font-weight: 600;
-    margin-top: 8px;
-  }
-
   &__invitation-error {
     border-radius: 3px;
     color: $error;
@@ -49,7 +44,7 @@
   }
 
   .input-container {
-    margin: 16px 2px;
+    margin: 16px 2px 25px 2px;
   }
 
   form {

--- a/orga/app/styles/components/register-form.scss
+++ b/orga/app/styles/components/register-form.scss
@@ -12,6 +12,14 @@
   }
 
   .input-container {
-    margin: 16px 2px;
+    margin: 16px 2px 25px 2px;
+
+    &:nth-child(6){
+      padding-top: 20px;
+    }
+  }
+
+  .pix-input-password > .pix-input__error-message {
+    bottom: calc(-18px - 1px - 0.75rem);
   }
 }

--- a/orga/app/styles/components/register-form.scss
+++ b/orga/app/styles/components/register-form.scss
@@ -4,11 +4,20 @@
   &__cgu {
     font-family: $roboto;
     font-size: 0.875rem;
-    font-weight: 300;
   }
 
-  &__cgu-label input[type=checkbox] {
-    margin: 2px 6px 0 0;
+  &__cgu-label {
+    display: flex;
+    align-items: center;
+
+    input[type=checkbox] {
+      margin: 0 6px 0 0;
+    }
+  }
+
+  &__cgu-error {
+    color: $red;
+    font-size: 0.75em;
   }
 
   .input-container {

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -59,6 +59,8 @@ $information-dark: #f24645;
 $information-light: #F1A141;
 $security-dark: #AC008D;
 $security-light: #FF3F94;
+$pink-alert-dark: #A71E1A;
+
 // status
 $error: #FF4B00;
 $success: #57C884;

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -6,7 +6,7 @@
   &__field {
     display: flex;
     flex-direction: column;
-    margin-bottom: 16px;
+    margin: 16px 0;
 
     @include device-is('desktop') {
       width: 500px;
@@ -43,15 +43,13 @@
     border-radius: 8px;
     background: $grey-15;
     height: max-content;
-    margin-bottom: 16px;
     padding: 16px;
     color: $grey-60;
     font-size: 0.875rem;
 
     @include device-is('desktop') {
       position: absolute;
-      margin-left: 16px;
-      margin-bottom: 0;
+      margin: 16px 0 0 16px;
       left: 100%;
       width: calc(100vw - 100% - #{$app-sidebar-width} - 32px);
     }
@@ -103,15 +101,21 @@
     input[type=radio] {
       margin-right: 16px;
     }
+    label {
+      font-size: 0.875rem;
+    }
   }
 }
 
 .label {
   display: inline-block;
   color: $grey-70;
-  font-size: 0.94rem;
-  font-weight: 500;
+  font-size: 0.875rem;
   padding-bottom: 5px;
+}
+
+p.label {
+  margin: 0 0 16px;
 }
 
 .input-container {
@@ -143,17 +147,6 @@
   color: red;
   font-family: $roboto;
   font-size: 0.75rem;
-}
-
-.pix-select > select, .pix-select > input, .pix-textarea > textarea {
-  border-radius: 4px;
-  border: 1px solid $grey-40;
-
-  &:focus {
-    border: 1px solid $blue;
-    box-shadow: none;
-    outline: none;
-  }
 }
 
 input[type=radio]::before,

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -105,6 +105,19 @@
       font-size: 0.875rem;
     }
   }
+
+  &__mandatory-fields-information {
+    font-size: 0.875rem;
+    margin: 0 0 35px 0;
+    color: $grey-70;
+  }
+
+  abbr.mandatory-mark {
+    cursor: help;
+    color: $pink-alert-dark;
+    text-decoration: none;
+    border: none;
+  }
 }
 
 .label {

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -139,42 +139,6 @@
   }
 }
 
-.input-password {
-  display: flex;
-  height: 42px;
-  border-radius: 3px;
-  align-items: center;
-  background-color: $white;
-  border: 1px solid $grey-40;
-
-  &--error {
-    border: 1px solid $error;
-  }
-
-  &:focus-within {
-    border: 1px solid $blue;
-  }
-
-  .input {
-    height: 40px;
-    flex-grow: 1;
-    border: none;
-    border-radius: 3px;
-    outline: none;
-    padding: 0 10px;
-    font-size: 1rem;
-
-    &:focus {
-      outline: 0;
-      border: none;
-    }
-
-    &::-ms-clear, &::-ms-reveal {
-      display: none;
-    }
-  }
-}
-
 .error-message {
   color: red;
   font-family: $roboto;

--- a/orga/app/styles/globals/pages.scss
+++ b/orga/app/styles/globals/pages.scss
@@ -1,5 +1,9 @@
 .page {
-  padding: 24px 35px;
+  padding: 0 10px;
+
+  @include device-is('tablet') {
+    padding: 24px 35px;
+  }
 
   &__title {
     margin-bottom: 18px;
@@ -8,10 +12,4 @@
 
 .navigation {
   margin: 24px 0;
-}
-
-@include device-is('mobile') {
-  .page {
-    padding: 0;
-  }
 }

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -60,7 +60,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       const expectedTargetProfileId = availableTargetProfiles[1].id;
       const expectedTargetProfileName = availableTargetProfiles[1].name;
 
-      await fillByLabel('Nom de la campagne', 'Ma Campagne');
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
       await selectByLabelAndOption('Que souhaitez-vous tester ?', expectedTargetProfileName);
       await selectOptionInRadioGroup('Souhaitez-vous demander un identifiant externe ?', 'Oui');
       await fillByLabel('Libellé de l’identifiant', 'Mail Pro');
@@ -82,9 +82,13 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should display error on global form when error 500 is returned from backend', async function (assert) {
       // given
+      const expectedTargetProfileName = availableTargetProfiles[1].name;
       server.post('/campaigns', {}, 500);
 
       // when
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
+      await selectByLabelAndOption('Que souhaitez-vous tester ?', expectedTargetProfileName);
+      await selectOptionInRadioGroup('Souhaitez-vous demander un identifiant externe ?', 'Non');
       await clickByName('Créer la campagne');
 
       // then
@@ -108,8 +112,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
       const expectedTargetProfileName = availableTargetProfiles[1].name;
 
       await clickByName('Évaluer les participants');
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
       await selectByLabelAndOption('Que souhaitez-vous tester ?', expectedTargetProfileName);
-      await fillByLabel('Nom de la campagne', 'Ma Campagne');
       await selectOptionInRadioGroup('Souhaitez-vous demander un identifiant externe ?', 'Non');
 
       // when
@@ -125,7 +129,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
     test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function (assert) {
       // given
       await clickByName('Collecter les profils Pix des participants');
-      await fillByLabel('Nom de la campagne', 'Ma Campagne');
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
       await selectOptionInRadioGroup('Souhaitez-vous demander un identifiant externe ?', 'Non');
 
       // when
@@ -142,7 +146,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
       await clickByName('Évaluer les participants');
       await selectByLabelAndOption('Que souhaitez-vous tester ?', expectedTargetProfileName);
-      await fillByLabel('Nom de la campagne', 'Ma Campagne');
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
       await fillByLabel('Titre du parcours', 'Savoir rechercher');
       await clickByName('Non');
 

--- a/orga/tests/acceptance/campaign-update_test.js
+++ b/orga/tests/acceptance/campaign-update_test.js
@@ -25,7 +25,7 @@ module('Acceptance | Campaign Update', function (hooks) {
     const newText = 'New text';
 
     await visit(`/campagnes/${campaign.id}/modification`);
-    await fillByLabel('Nom de la campagne', newName);
+    await fillByLabel('* Nom de la campagne', newName);
     await fillByLabel("Texte de la page d'accueil", newText);
 
     // when

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -40,6 +40,14 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
     assert.dom('#login-password').exists();
   });
 
+  test('[a11y] it should display a message that all inputs are required', async function (assert) {
+    // when
+    await render(hbs`<Auth::LoginForm/>`);
+
+    // then
+    assert.contains('Tous les champs sont obligatoires.');
+  });
+
   test('it should not display error message', async function (assert) {
     // when
     await render(hbs`<Auth::LoginForm/>`);

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -1,13 +1,10 @@
 import { reject, resolve } from 'rsvp';
 import hbs from 'htmlbars-inline-precompile';
-
 import { module, test } from 'qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
-
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { triggerEvent } from '@ember/test-helpers';
+import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -33,7 +30,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
   test('it should ask for email and password', async function (assert) {
     // when
-    await render(hbs`<Auth::LoginForm/>`);
+    await renderScreen(hbs`<Auth::LoginForm/>`);
 
     // then
     assert.dom('#login-email').exists();
@@ -42,15 +39,15 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
   test('[a11y] it should display a message that all inputs are required', async function (assert) {
     // when
-    await render(hbs`<Auth::LoginForm/>`);
+    const screen = await renderScreen(hbs`<Auth::LoginForm/>`);
 
     // then
-    assert.contains('Tous les champs sont obligatoires.');
+    assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
   });
 
   test('it should not display error message', async function (assert) {
     // when
-    await render(hbs`<Auth::LoginForm/>`);
+    await renderScreen(hbs`<Auth::LoginForm/>`);
 
     // then
     assert.dom('#login-form-error-message').doesNotExist();
@@ -70,7 +67,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
     test('it should call authentication service with appropriate parameters', async function (assert) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
-      await render(hbs`<Auth::LoginForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
+      await renderScreen(hbs`<Auth::LoginForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
       await fillByLabel(emailInputLabel, 'pix@example.net');
       await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
 
@@ -106,7 +103,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
     test('it should be ok and call authentication service with appropriate parameters', async function (assert) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
-      await render(
+      await renderScreen(
         hbs`<Auth::LoginForm @isWithInvitation=true @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`
       );
       await fillByLabel(emailInputLabel, 'pix@example.net');
@@ -134,7 +131,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
     SessionStub.prototype.authenticate = () => reject(errorResponse);
 
-    await render(hbs`<Auth::LoginForm/>`);
+    await renderScreen(hbs`<Auth::LoginForm/>`);
     await fillByLabel(emailInputLabel, 'pix@example.net');
     await fillByLabel(passwordInputLabel, 'Mauvais mot de passe');
 
@@ -157,7 +154,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
     SessionStub.prototype.authenticate = () => reject(errorResponse);
 
-    await render(hbs`<Auth::LoginForm/>`);
+    await renderScreen(hbs`<Auth::LoginForm/>`);
     await fillByLabel(emailInputLabel, 'pix@example.net');
     await fillByLabel(passwordInputLabel, 'pix123');
 
@@ -184,7 +181,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       this.owner.register('service:url', UrlStub);
 
       // when
-      await render(hbs`<Auth::LoginForm/>`);
+      await renderScreen(hbs`<Auth::LoginForm/>`);
 
       // then
       assert.dom('.login-form__recover-access-link').doesNotExist();
@@ -202,7 +199,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       this.owner.register('service:url', UrlStub);
 
       // when
-      await render(hbs`<Auth::LoginForm/>`);
+      await renderScreen(hbs`<Auth::LoginForm/>`);
 
       // then
       assert.dom('.login-form__recover-access-link').exists();
@@ -213,26 +210,26 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
     test('should display an invalid email error message when focus-out', async function (assert) {
       //given
       const invalidEmail = 'invalidEmail';
-      await render(hbs`<Auth::LoginForm/>`);
+      const screen = await renderScreen(hbs`<Auth::LoginForm/>`);
 
       // when
       await fillByLabel(emailInputLabel, invalidEmail);
       await triggerEvent('#login-email', 'focusout');
 
       // then
-      assert.contains(this.intl.t('pages.login-form.errors.invalid-email'));
+      assert.dom(screen.getByText(this.intl.t('pages.login-form.errors.invalid-email'))).exists();
     });
 
     test('should display an empty password error message when focus-out', async function (assert) {
       //given
-      await render(hbs`<Auth::LoginForm/>`);
+      const screen = await renderScreen(hbs`<Auth::LoginForm/>`);
 
       // when
       await fillByLabel(passwordInputLabel, '');
       await triggerEvent('#login-password', 'focusout');
 
       // then
-      assert.contains(this.intl.t('pages.login-form.errors.empty-password'));
+      assert.dom(screen.getByText(this.intl.t('pages.login-form.errors.empty-password'))).exists();
     });
   });
 });

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { resolve } from 'rsvp';
-import { render } from '@ember/test-helpers';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';
@@ -41,7 +40,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
   test('it renders', async function (assert) {
     // when
-    await render(hbs`<Auth::RegisterForm/>`);
+    await renderScreen(hbs`<Auth::RegisterForm/>`);
 
     //then
     assert.dom('.register-form').exists();
@@ -49,10 +48,10 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
   test('[a11y] it should display a message that all inputs are required', async function (assert) {
     // when
-    await render(hbs`<Auth::RegisterForm/>`);
+    const screen = await renderScreen(hbs`<Auth::RegisterForm/>`);
 
     // then
-    assert.contains('Tous les champs sont obligatoires.');
+    assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
   });
 
   module('successful cases', function (hooks) {
@@ -81,7 +80,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     test('it should call authentication service with appropriate parameters, when all things are ok and form is submitted', async function (assert) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
-      await render(hbs`<Auth::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
+      await renderScreen(hbs`<Auth::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
       await fillByLabel(firstNameInputLabel, 'pix');
       await fillByLabel(lastNameInputLabel, 'pix');
       await fillByLabel(emailInputLabel, 'shi@fu.me');
@@ -101,7 +100,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
   });
 
   module('errors management', function (hooks) {
-    let spy;
+    let spy, screen;
 
     hooks.beforeEach(async function () {
       spy = sinon.spy();
@@ -114,7 +113,9 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         },
       });
 
-      await render(hbs`<Auth::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
+      screen = await renderScreen(
+        hbs`<Auth::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`
+      );
     });
 
     module('When first name is not valid', () => {
@@ -127,7 +128,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
         // then
         assert.equal(spy.callCount, 0);
-        assert.contains(this.intl.t(EMPTY_FIRSTNAME_ERROR_MESSAGE));
+        assert.dom(screen.getByText(this.intl.t(EMPTY_FIRSTNAME_ERROR_MESSAGE))).exists();
       });
     });
 
@@ -141,7 +142,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
         // then
         assert.equal(spy.callCount, 0);
-        assert.contains(this.intl.t(EMPTY_LASTNAME_ERROR_MESSAGE));
+        assert.dom(screen.getByText(this.intl.t(EMPTY_LASTNAME_ERROR_MESSAGE))).exists();
       });
     });
 
@@ -155,7 +156,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
         // then
         assert.equal(spy.callCount, 0);
-        assert.contains(this.intl.t(EMPTY_EMAIL_ERROR_MESSAGE));
+        assert.dom(screen.getByText(this.intl.t(EMPTY_EMAIL_ERROR_MESSAGE))).exists();
       });
     });
 
@@ -169,7 +170,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
         // then
         assert.equal(spy.callCount, 0);
-        assert.contains(this.intl.t(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE));
+        assert.dom(screen.getByText(this.intl.t(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE))).exists();
       });
     });
 

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -47,6 +47,14 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     assert.dom('.register-form').exists();
   });
 
+  test('[a11y] it should display a message that all inputs are required', async function (assert) {
+    // when
+    await render(hbs`<Auth::RegisterForm/>`);
+
+    // then
+    assert.contains('Tous les champs sont obligatoires.');
+  });
+
   module('successful cases', function (hooks) {
     hooks.beforeEach(function () {
       this.owner.unregister('service:store');

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import sinon from 'sinon';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -26,7 +25,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   test('it should contain inputs, attributes and validation button', async function (assert) {
     // when
-    await render(
+    await renderScreen(
       hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
     );
 
@@ -39,18 +38,18 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   test('[a11y] it should display a message that some inputs are required', async function (assert) {
     // when
-    await render(
+    const screen = await renderScreen(
       hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
     );
 
     // then
-    assert.contains(t('pages.campaign-creation.mandatory-fields'));
+    assert.dom(screen.getByText(t('pages.campaign-creation.mandatory-fields'))).exists();
   });
 
   module('when user cannot create campaign of type PROFILES_COLLECTION', function () {
     test('it should display fields for campaign title and target profile by default', async function (assert) {
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
 
@@ -61,7 +60,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     test('it should not contain field to select campaign type', async function (assert) {
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
 
@@ -79,7 +78,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       }
       this.owner.register('service:current-user', CurrentUserStub);
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -98,7 +97,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       this.campaign = EmberObject.create({});
 
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -110,7 +109,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     test('it should not display multiple sendings field', async function (assert) {
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
 
@@ -145,7 +144,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           }),
         ];
         // when
-        await render(
+        await renderScreen(
           hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -181,7 +180,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           }),
         ];
         // when
-        await render(
+        await renderScreen(
           hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -201,7 +200,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       }
       this.owner.register('service:current-user', CurrentUserStub);
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
@@ -218,7 +217,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       }
       this.owner.register('service:current-user', CurrentUserStub);
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
@@ -236,7 +235,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       this.campaign = EmberObject.create({});
 
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
@@ -250,7 +249,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   module('when user has not chosen yet to ask or not an external user ID', function () {
     test('it should not display gdpr footnote', async function (assert) {
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
 
@@ -262,7 +261,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   module('when user choose not to ask an external user ID', function () {
     test('it should not display gdpr footnote either', async function (assert) {
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.no'));
@@ -275,7 +274,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   module('when user choose to ask an external user ID', function () {
     test('it should display gdpr footnote', async function (assert) {
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.yes'));
@@ -290,7 +289,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     this.targetProfiles = [{ name: 'targetProfile1' }];
     this.createCampaignSpy = sinon.stub();
 
-    await render(
+    await renderScreen(
       hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}} @targetProfiles={{this.targetProfiles}}/>`
     );
     await fillByLabel(t('pages.campaign-creation.name.label'), 'Ma campagne');
@@ -334,7 +333,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       this.errors = campaign.errors;
 
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
       await clickByName(t('pages.campaign-creation.yes'));
@@ -359,7 +358,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       this.errors = campaign.errors;
 
       // when
-      await render(
+      await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
       );
 

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -37,6 +37,16 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.dom('textarea').hasAttribute('maxLength', '5000');
   });
 
+  test('[a11y] it should display a message that some inputs are required', async function (assert) {
+    // when
+    await render(
+      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
+    );
+
+    // then
+    assert.contains(t('pages.campaign-creation.mandatory-fields'));
+  });
+
   module('when user cannot create campaign of type PROFILES_COLLECTION', function () {
     test('it should display fields for campaign title and target profile by default', async function (assert) {
       // when
@@ -276,12 +286,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   });
 
   test('it should send campaign creation action when submitted', async function (assert) {
+    // given
+    this.targetProfiles = [{ name: 'targetProfile1' }];
     this.createCampaignSpy = sinon.stub();
 
     await render(
-      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}} @targetProfiles={{this.targetProfiles}}/>`
     );
     await fillByLabel(t('pages.campaign-creation.name.label'), 'Ma campagne');
+    await fillByLabel(t('pages.campaign-creation.target-profiles-list-label'), this.targetProfiles[0].name);
 
     // when
     await clickByName(t('pages.campaign-creation.actions.create'));

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -1,6 +1,11 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import {
+  fillByLabel,
+  clickByName,
+  render as renderScreen,
+  selectByLabelAndOption,
+} from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -43,7 +48,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     );
 
     // then
-    assert.dom(screen.getByText(t('pages.campaign-creation.mandatory-fields'))).exists();
+    assert.dom(screen.getByText(t('common.form.mandatory-fields'))).exists();
   });
 
   module('when user cannot create campaign of type PROFILES_COLLECTION', function () {
@@ -148,7 +153,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
-        await fillByLabel(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
+        await selectByLabelAndOption(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
+
         // then
         assert.contains('description1');
         assert.contains(t('common.target-profile-details.subjects', { value: 11 }));
@@ -184,7 +190,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
-        await fillByLabel(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
+        await selectByLabelAndOption(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
 
         // then
         assert.contains(t('common.target-profile-details.results.common'));
@@ -292,8 +298,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     await renderScreen(
       hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}} @targetProfiles={{this.targetProfiles}}/>`
     );
-    await fillByLabel(t('pages.campaign-creation.name.label'), 'Ma campagne');
-    await fillByLabel(t('pages.campaign-creation.target-profiles-list-label'), this.targetProfiles[0].name);
+    await fillByLabel(`* ${t('pages.campaign-creation.name.label')}`, 'Ma campagne');
+    await selectByLabelAndOption(t('pages.campaign-creation.target-profiles-list-label'), this.targetProfiles[0].name);
 
     // when
     await clickByName(t('pages.campaign-creation.actions.create'));

--- a/orga/tests/integration/components/campaign/update-form_test.js
+++ b/orga/tests/integration/components/campaign/update-form_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -16,7 +15,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
 
   test('it should contain inputs, attributes and validation button', async function (assert) {
     // when
-    await render(
+    await renderScreen(
       hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`
     );
 
@@ -26,9 +25,19 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
     assert.dom('#campaign-custom-landing-page-text').hasAttribute('maxLength', '5000');
   });
 
+  test('[a11y] it should display a message that some inputs are required', async function (assert) {
+    // when
+    const screen = await renderScreen(
+      hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`
+    );
+
+    // then
+    assert.dom(screen.getByText('indique un champ obligatoire')).exists();
+  });
+
   test('it should send campaign update action when submitted', async function (assert) {
     // when
-    await render(
+    await renderScreen(
       hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`
     );
 
@@ -43,7 +52,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
     test('it should display campaign title input', async function (assert) {
       this.campaign = EmberObject.create({ isTypeAssessment: true });
 
-      await render(
+      await renderScreen(
         hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`
       );
 
@@ -56,7 +65,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
     test('it should not display campaign title input', async function (assert) {
       this.campaign = EmberObject.create({ isTypeAssessment: false });
 
-      await render(
+      await renderScreen(
         hbs`<Campaign::UpdateForm @campaign={{this.campaign}} @onSubmit={{this.updateCampaignSpy}} @onCancel={{this.cancelSpy}} />`
       );
 

--- a/orga/tests/unit/components/auth/login-form_test.js
+++ b/orga/tests/unit/components/auth/login-form_test.js
@@ -11,6 +11,12 @@ module('Unit | Component | Routes | login-form', (hooks) => {
 
   hooks.beforeEach(function () {
     component = createGlimmerComponent('component:auth/login-form');
+    component.session = {
+      authenticate: sinon.stub(),
+    };
+    component.store = {
+      createRecord: sinon.stub(),
+    };
   });
 
   module('#authenticate', () => {
@@ -29,6 +35,66 @@ module('Unit | Component | Routes | login-form', (hooks) => {
 
       // then
       assert.ok(_authenticateStub.calledWith(sinon.match.any, expectedEmail));
+    });
+
+    module('When there is no invitation', () => {
+      test('should not accept organization invitation when parameters are invalid', function (assert) {
+        // given
+        component.email = '';
+        component.password = 'pix123';
+        component.args.isWithInvitation = true;
+
+        component._acceptOrganizationInvitation = sinon.stub().resolves();
+
+        // when
+        component.authenticate(new Event('stub'));
+
+        // then
+        assert.ok(component._acceptOrganizationInvitation.notCalled);
+      });
+
+      test('should accept organization invitation when parameters are valid', function (assert) {
+        // given
+        component.email = 'sco.admin@example.net';
+        component.password = 'pix123';
+        component.args.isWithInvitation = true;
+
+        component._acceptOrganizationInvitation = sinon.stub().resolves();
+
+        // when
+        component.authenticate(new Event('stub'));
+
+        // then
+        assert.ok(component._acceptOrganizationInvitation.called);
+      });
+    });
+
+    module('When there is an invitation', () => {
+      test('should not call authenticate session when parameters are invalid', function (assert) {
+        // given
+        component.email = '';
+        component.password = 'pix123';
+        component.args.isWithInvitation = false;
+
+        // when
+        component.authenticate(new Event('stub'));
+
+        // then
+        assert.ok(component.session.authenticate.notCalled);
+      });
+
+      test('should call authenticate session when parameters are valid', function (assert) {
+        // given
+        component.email = 'sco.admin@example.net';
+        component.password = 'pix123';
+        component.args.isWithInvitation = false;
+
+        // when
+        component.authenticate(new Event('stub'));
+
+        // then
+        assert.ok(component.session.authenticate.called);
+      });
     });
   });
 });

--- a/orga/tests/unit/components/auth/login-form_test.js
+++ b/orga/tests/unit/components/auth/login-form_test.js
@@ -24,6 +24,7 @@ module('Unit | Component | Routes | login-form', (hooks) => {
       // given
       const emailWithSpaces = '    user@example.net  ';
       component.email = emailWithSpaces;
+      component.password = 'pix123';
 
       const _authenticateStub = sinon.stub().resolves();
       component._authenticate = _authenticateStub;
@@ -37,8 +38,8 @@ module('Unit | Component | Routes | login-form', (hooks) => {
       assert.ok(_authenticateStub.calledWith(sinon.match.any, expectedEmail));
     });
 
-    module('When there is no invitation', () => {
-      test('should not accept organization invitation when parameters are invalid', function (assert) {
+    module('When there is an invitation', () => {
+      test('should not accept organization invitation when form is invalid', function (assert) {
         // given
         component.email = '';
         component.password = 'pix123';
@@ -53,7 +54,7 @@ module('Unit | Component | Routes | login-form', (hooks) => {
         assert.ok(component._acceptOrganizationInvitation.notCalled);
       });
 
-      test('should accept organization invitation when parameters are valid', function (assert) {
+      test('should accept organization invitation when form is valid', function (assert) {
         // given
         component.email = 'sco.admin@example.net';
         component.password = 'pix123';
@@ -65,12 +66,12 @@ module('Unit | Component | Routes | login-form', (hooks) => {
         component.authenticate(new Event('stub'));
 
         // then
-        assert.ok(component._acceptOrganizationInvitation.called);
+        assert.ok(component._acceptOrganizationInvitation.calledOnce);
       });
     });
 
-    module('When there is an invitation', () => {
-      test('should not call authenticate session when parameters are invalid', function (assert) {
+    module('When there is no invitation', () => {
+      test('should not call authenticate session when form is invalid', function (assert) {
         // given
         component.email = '';
         component.password = 'pix123';
@@ -83,7 +84,7 @@ module('Unit | Component | Routes | login-form', (hooks) => {
         assert.ok(component.session.authenticate.notCalled);
       });
 
-      test('should call authenticate session when parameters are valid', function (assert) {
+      test('should call authenticate session when form is valid', function (assert) {
         // given
         component.email = 'sco.admin@example.net';
         component.password = 'pix123';
@@ -93,7 +94,7 @@ module('Unit | Component | Routes | login-form', (hooks) => {
         component.authenticate(new Event('stub'));
 
         // then
-        assert.ok(component.session.authenticate.called);
+        assert.ok(component.session.authenticate.calledOnce);
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -569,7 +569,11 @@
             "label": "Password"
           }
         },
-        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
+        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr.",
+        "errors": {
+          "default": "The service is temporarily unavailable. Please try again later.",
+          "email-already-exists": "This email address is already registered, please login."
+        }
       }
     },
     "preselect-target-profile": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -275,7 +275,7 @@
       }
     },
     "campaign-creation": {
-      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a mandatory field",
+      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a required field",
       "title": "Create a campaign",
       "actions": {
         "create": "Create a campaign"
@@ -352,7 +352,7 @@
       "title": "Review for {firstName} {lastName}"
     },
     "campaign-modification": {
-      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a mandatory field",
+      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a required field",
       "title": "Edit a campaign",
       "actions": {
         "edit": "Edit"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -275,13 +275,14 @@
       }
     },
     "campaign-creation": {
+      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a mandatory field",
       "title": "Create a campaign",
       "actions": {
         "create": "Create a campaign"
       },
       "external-id-label": {
         "label": "external user ID label",
-        "question-label": "Do you need an external user ID?",
+        "question-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Do you need an external user ID?",
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },
       "landing-page-text": {
@@ -289,22 +290,22 @@
       },
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
-        "question-label": "Do you want to allow participants to submit their profile more than once?",
+        "question-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Do you want to allow participants to submit their profile more than once?",
         "info": "If you choose to allow multiple submissions, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile.",
         "info-title": "Multiple submissions"
       },
       "name": {
-        "label": "Name of the campaign"
+        "label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Name of the campaign"
       },
       "no": "No",
       "purpose": {
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
-        "label": "What is the purpose of your campaign?",
+        "label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score."
       },
-      "target-profiles-list-label": "What would you like to test?",
+      "target-profiles-list-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {
         "label": "Title of the customised test"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -149,6 +149,11 @@
         "empty": "No class"
       }
     },
+    "form": {
+      "mandatory-all-fields": "All fields are required.",
+      "mandatory-fields": " indicates a required field",
+      "mandatory-fields-title": "required"
+    },
     "help-form": "https://pix.org/en-gb/contact-form",
     "home-page": "Pix Orga home page",
     "loading": "Loading",
@@ -275,14 +280,13 @@
       }
     },
     "campaign-creation": {
-      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a required field",
       "title": "Create a campaign",
       "actions": {
         "create": "Create a campaign"
       },
       "external-id-label": {
         "label": "external user ID label",
-        "question-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Do you need an external user ID?",
+        "question-label": "Do you need an external user ID?",
         "suggestion": "Example : \"Student Number\" or \"Email address\" *"
       },
       "landing-page-text": {
@@ -290,22 +294,22 @@
       },
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
-        "question-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Do you want to allow participants to submit their profile more than once?",
+        "question-label": "Do you want to allow participants to submit their profile more than once?",
         "info": "If you choose to allow multiple submissions, the participants will be able to submit their profile several times by re-entering the campaign code. Within Pix Orga you will find the latest submitted profile.",
         "info-title": "Multiple submissions"
       },
       "name": {
-        "label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Name of the campaign"
+        "label": "Name of the campaign"
       },
       "no": "No",
       "purpose": {
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
-        "label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> What is the purpose of your campaign?",
+        "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score."
       },
-      "target-profiles-list-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> What would you like to test?",
+      "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {
         "label": "Title of the customised test"
@@ -352,12 +356,11 @@
       "title": "Review for {firstName} {lastName}"
     },
     "campaign-modification": {
-      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a required field",
       "title": "Edit a campaign",
       "actions": {
         "edit": "Edit"
       },
-      "campaign-name": "<abbr title=\"required\" class=\"mandatory-mark\", aria-hidden=true>*</abbr> Name of the campaign",
+      "campaign-name": "Name of the campaign",
       "landing-page-text": "Text to display on the starting page",
       "personalised-test-title": "Title of the personalised test"
     },
@@ -527,10 +530,7 @@
       "is-only-accessible": "Pix Orga is only accessible to invited members. Please contact your Pix Orga administrator in order to be invited.",
       "login": "Log in",
       "only-for-admin": "only for school administrations",
-      "password": "Password",
-      "show-password": "Show password",
-      "hide-password": "Hide password",
-      "mandatory-all-fields": "All fields are required."
+      "password": "Password"
     },
     "login-or-register": {
       "title": "You have been invited to join the organisation {organizationName}",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -304,14 +304,7 @@
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score."
       },
-      "target-profiles-list": {
-        "label": "What would you like to test?",
-        "percentage": "percentage",
-        "star": "star",
-        "tube": "Topics: {count}",
-        "thematic-results": "Thematic results: {count}",
-        "result": "Success rate in "
-      },
+      "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {
         "label": "Title of the customised test"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -352,11 +352,12 @@
       "title": "Review for {firstName} {lastName}"
     },
     "campaign-modification": {
+      "mandatory-fields": "'<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' indicates a mandatory field",
       "title": "Edit a campaign",
       "actions": {
         "edit": "Edit"
       },
-      "campaign-name": "Name of the campaign",
+      "campaign-name": "<abbr title=\"required\" class=\"mandatory-mark\", aria-hidden=true>*</abbr> Name of the campaign",
       "landing-page-text": "Text to display on the starting page",
       "personalised-test-title": "Title of the personalised test"
     },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -517,6 +517,8 @@
       "active-or-retrieve": "Activate or retrieve your Pix Orga space",
       "email": "Email address",
       "errors": {
+        "invalid-email": "Your email address is invalid.",
+        "empty-password": "Your password can't be empty.",
         "status": {
           "401": "Missing or invalid credentials",
           "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -149,6 +149,11 @@
         "empty": "Aucune classe"
       }
     },
+    "form": {
+      "mandatory-all-fields": "Tous les champs sont obligatoires.",
+      "mandatory-fields": " indique un champ obligatoire",
+      "mandatory-fields-title": "obligatoire"
+    },
     "help-form": "https://support.pix.fr/support/tickets/new",
     "home-page": "Page d'accueil de Pix Orga",
     "loading": "Chargement en cours",
@@ -275,14 +280,13 @@
       }
     },
     "campaign-creation": {
-      "mandatory-fields": "'<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' indique un champ obligatoire",
       "title": "Création d'une campagne",
       "actions": {
         "create": "Créer la campagne"
       },
       "external-id-label": {
         "label": "Libellé de l’identifiant",
-        "question-label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Souhaitez-vous demander un identifiant externe ?",
+        "question-label": "Souhaitez-vous demander un identifiant externe ?",
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },
       "landing-page-text": {
@@ -290,22 +294,22 @@
       },
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
       "multiple-sendings": {
-        "question-label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
+        "question-label": "Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
         "info": "Si vous choisissez l’envoi multiple, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.",
         "info-title": "Envoi multiple"
       },
       "name": {
-        "label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Nom de la campagne"
+        "label": "Nom de la campagne"
       },
       "no": "Non",
       "purpose": {
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
-        "label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Quel est l'objectif de votre campagne ?",
+        "label": "Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
       },
-      "target-profiles-list-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Que souhaitez-vous tester ?",
+      "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {
         "label": "Titre du parcours"
@@ -352,12 +356,11 @@
       "title": "Analyse pour {firstName} {lastName}"
     },
     "campaign-modification": {
-      "mandatory-fields": "'<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' indique un champ obligatoire",
       "title": "Modification d'une campagne",
       "actions": {
         "edit": "Modifier"
       },
-      "campaign-name": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Nom de la campagne",
+      "campaign-name": "Nom de la campagne",
       "landing-page-text": "Texte de la page d'accueil",
       "personalised-test-title": "Titre du parcours"
     },
@@ -527,10 +530,7 @@
       "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",
       "login": "Je me connecte",
       "only-for-admin": "Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
-      "password": "Mot de passe",
-      "show-password": "Afficher le mot de passe",
-      "hide-password": "Masquer le mot de passe",
-      "mandatory-all-fields": "Tous les champs sont obligatoires."
+      "password": "Mot de passe"
     },
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre l'organisation {organizationName}",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -352,11 +352,12 @@
       "title": "Analyse pour {firstName} {lastName}"
     },
     "campaign-modification": {
+      "mandatory-fields": "'<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' indique un champ obligatoire",
       "title": "Modification d'une campagne",
       "actions": {
         "edit": "Modifier"
       },
-      "campaign-name": "Nom de la campagne",
+      "campaign-name": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Nom de la campagne",
       "landing-page-text": "Texte de la page d'accueil",
       "personalised-test-title": "Titre du parcours"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -275,13 +275,14 @@
       }
     },
     "campaign-creation": {
+      "mandatory-fields": "'<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' indique un champ obligatoire",
       "title": "Création d'une campagne",
       "actions": {
         "create": "Créer la campagne"
       },
       "external-id-label": {
         "label": "Libellé de l’identifiant",
-        "question-label": "Souhaitez-vous demander un identifiant externe ?",
+        "question-label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Souhaitez-vous demander un identifiant externe ?",
         "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
       },
       "landing-page-text": {
@@ -289,22 +290,22 @@
       },
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
       "multiple-sendings": {
-        "question-label": "Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
+        "question-label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Souhaitez-vous permettre aux participants d'envoyer plusieurs fois leur profil ?",
         "info": "Si vous choisissez l’envoi multiple, le participant pourra envoyer plusieurs fois son profil en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez le dernier profil envoyé.",
         "info-title": "Envoi multiple"
       },
       "name": {
-        "label": "Nom de la campagne"
+        "label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Nom de la campagne"
       },
       "no": "Non",
       "purpose": {
         "assessment": "Évaluer les participants",
         "assessment-info": "Une campagne d’évaluation permet de tester les participants sur des sujets précis.",
-        "label": "Quel est l'objectif de votre campagne ?",
+        "label": "<abbr title=\"obligatoire\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Quel est l'objectif de votre campagne ?",
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
       },
-      "target-profiles-list-label": "Que souhaitez-vous tester ?",
+      "target-profiles-list-label": "<abbr title=\"required\" class=\"mandatory-mark\" aria-hidden=true>*</abbr> Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {
         "label": "Titre du parcours"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -510,6 +510,8 @@
       "active-or-retrieve": "Activez ou récupérez votre espace Pix Orga",
       "email": "Adresse e-mail",
       "errors": {
+        "invalid-email": "Votre adresse e-mail n’est pas valide.",
+        "empty-password": "Le champ mot de passe est obligatoire.",
         "status": {
           "401": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
           "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -569,7 +569,11 @@
             "label": "Mot de passe"
           }
         },
-        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr."
+        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr.",
+        "errors": {
+          "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
+          "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous."
+        }
       }
     },
     "preselect-target-profile": {


### PR DESCRIPTION
## :christmas_tree: Problème
Pour des besoins d'accessibilité, les champs obligatoires devraient avoir une indication visible située dans l'étiquette (mention "obligatoire" ou * explicitée). Ce qui n'est actuellement pas le cas sur Pix Orga sur les pages suivantes : 
- page de connexion
- page de création de compte
- page de création de campagne
- page de modification d'une campagne

## :gift: Solution
Indiquer pour la page de connexion et de création de compte (dans la double mire de la page invitation ) que tous les champs sont obligatoires.
Indiquer pour la page de création et modification de campagne que certains champs sont obligatoires, indiqués par un *

## :star2: Remarques

On remplace ici les champs existants avec des composants pix-UI.

---

Ajout de l'attribut `aria-required` en plus du `required`, utiles pour les utilisateurs de technologies d'assistance. https://www.w3.org/TR/WCAG20-TECHS/ARIA2.html

_"HTML5 a introduit l’attribut `required`, mais `aria-required` est toujours utile pour les agents utilisateurs qui ne prennent pas encore en charge HTML5."_ [lien doc](https://developer.mozilla.org/fr/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute)

---
Concernant les `radiogroup`, le `required` est appliqué à un seul `input`: 

_Dans le cas d'un groupe de boutons radio de même nom, si un seul bouton radio dans le groupe a l'attribut `required`, un bouton radio dans ce groupe doit être vérifié, bien que ce ne soit pas nécessairement celui où l'attribut est appliqué._ [lien doc](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/required)

---

un `aria-hidden=true` est ajouté aux astérisques des champs pour éviter que le lecteur d'écran ne lise par exemple "étoiles Nom de la campagne". Comme le champ est en `required`, l'information que ce champ est obligatoire est transmise de cette façon.


## :santa: Pour tester

Sur la page de connexion : 
- Vérifier la présence du message suivant : "Tous les champs sont obligatoires."
- Les champs ont étés remplacés par des composants Pix-UI
- Vérifier qu'un message d'erreur apparaît si l'adresse entrée n'est pas valide
- Vérifier qu'un message d'erreur apparaît si le mot de passe est laissé vide
- Si vous tentez de valider le formulaire sans rien remplir, un message d'erreur venant du navigateur vous indique de remplir le champ requis.

Sur la page de création de compte:
Pour s'y rendre, se connecter avec `sco.admin@example.net` et s'inviter, accepter l'invitation par mail pour accéder à la double mire.

- Vérifier la présence du message suivant : "Tous les champs sont obligatoires."
- Les champs ont étés remplacés par des composants Pix-UI
- Vérifier qu'un message d'erreur apparaît si le nom, prénom reste vide, l'email et le mot de passe non valide. (existant, mais vérifier qu'ils apparaissent toujours malgré le changement de composant)
- Si vous tentez de valider le formulaire sans rien remplir, un message d'erreur venant du navigateur vous indique de remplir le champ requis.

Sur la page de création de campagne : 
- Vérifier la présence du message suivant : "* indique un champ obligatoire"
- Vérifier la présence des astérisques devant les champs concernés.
- Si vous tentez de valider le formulaire sans rien remplir, un message d'erreur venant du navigateur vous indique de remplir le champ requis.

Sur la page de modification de campagne : 
- Vérifier la présence du message suivant : "* indique un champ obligatoire"
- Vérifier la présence des astérisques devant le champ nom de la campagne.
- Si vous tentez de valider le formulaire sans rien remplir, un message d'erreur venant du navigateur vous indique de remplir le champ requis.

Vérifier la version en anglais.
Vérifier le format mobile sur la page de création de compte, le padding était inexistant et le formulaire était collé à l'écran.

Des clés de traduction étaient présentes dans le fichier en.json, mais inexistantes en version fr. Un commit les supprime
<img width="701" alt="Capture d’écran 2022-01-07 à 16 00 11" src="https://user-images.githubusercontent.com/58915422/148562370-1cfb7c48-ebc8-41b1-8a08-c3579dd01d64.png">
