### PR TITLE
[FEATURE] Enlever le dégradé du menu dans pix Orga (PIX-4053).

### DIFF
--- a/orga/app/styles/components/layout/sidebar.scss
+++ b/orga/app/styles/components/layout/sidebar.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: $app-sidebar-width;
   min-width: 100px;
-  background: $pix-orga-old-gradient;
+  background-color: $dark-blue-orga;
 
   &__logo {
     padding: 24px;

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -9,6 +9,7 @@ $white: #ffffff;
 // secondary
 $blue-hover: #3257D9;
 $dark-blue-pro: #1A38A0;
+$dark-blue-orga: #213371;
 $dark-green-certif: #1A8C89;
 $dark-green-certif-light: adjust-color($dark-green-certif, $alpha: -0.9);
 $dark-orga: #0095C0;


### PR DESCRIPTION
## :christmas_tree: Problème
Le dégradé appliqué en fond du menu de gauche sur Pix Orga nuit à l'accessibilité.

## :gift: Solution
On applique en fond du menu la couleur la plus foncé du dégradé.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Orga avec n'importe quel compte
- Constater que le fond du menu est maintenant d'une couleur unie et foncé