### PR TITLE
[TECH] Algo flash : Réutiliser le niveau estimé enregistré pour trouver le prochain challenge

### DIFF
--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const { DEFAULT_ESTIMATED_LEVEL } = require('./flash');
 
 async function fetchForCampaigns({
   assessment,
@@ -74,15 +75,23 @@ async function fetchForCompetenceEvaluations({
   };
 }
 
-async function fetchForFlashCampaigns({ assessment, answerRepository, challengeRepository, locale }) {
-  const [allAnswers, challenges] = await Promise.all([
+async function fetchForFlashCampaigns({
+  assessment,
+  answerRepository,
+  challengeRepository,
+  flashAssessmentResultRepository,
+  locale,
+}) {
+  const [allAnswers, challenges, { estimatedLevel = DEFAULT_ESTIMATED_LEVEL } = {}] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
     challengeRepository.findFlashCompatible(locale),
+    flashAssessmentResultRepository.getByAssessmentId(assessment.id),
   ]);
 
   return {
     allAnswers,
     challenges,
+    estimatedLevel,
   };
 }
 

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -24,12 +24,10 @@ function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
     return {
       hasAssessmentEnded: true,
       possibleChallenges: [],
-      estimatedLevel: DEFAULT_ESTIMATED_LEVEL,
-      errorRate: DEFAULT_ERROR_RATE,
     };
   }
 
-  const { estimatedLevel, errorRate } = getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+  const { estimatedLevel } = getEstimatedLevelAndErrorRate({ allAnswers, challenges });
 
   const challengesWithReward = nonAnsweredChallenges.map((challenge) => {
     return {
@@ -52,8 +50,6 @@ function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
   return {
     hasAssessmentEnded: false,
     possibleChallenges,
-    estimatedLevel,
-    errorRate,
   };
 }
 

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -15,9 +15,10 @@ module.exports = {
   getPossibleNextChallenges,
   getEstimatedLevelAndErrorRate,
   getNonAnsweredChallenges,
+  DEFAULT_ESTIMATED_LEVEL,
 };
 
-function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
+function getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel } = {}) {
   const nonAnsweredChallenges = getNonAnsweredChallenges({ allAnswers, challenges });
 
   if (nonAnsweredChallenges?.length === 0 || allAnswers.length >= config.features.numberOfChallengesForFlashMethod) {
@@ -26,8 +27,6 @@ function getPossibleNextChallenges({ allAnswers, challenges } = {}) {
       possibleChallenges: [],
     };
   }
-
-  const { estimatedLevel } = getEstimatedLevelAndErrorRate({ allAnswers, challenges });
 
   const challengesWithReward = nonAnsweredChallenges.map((challenge) => {
     return {

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -6,11 +6,9 @@ const dataFetcher = require('../services/algorithm-methods/data-fetcher');
 const hashInt = require('hash-int');
 
 module.exports = async function getNextChallengeForCampaignAssessment({
-  knowledgeElementRepository,
-  targetProfileRepository,
   challengeRepository,
   answerRepository,
-  improvementService,
+  flashAssessmentResultRepository,
   assessment,
   pickChallengeService,
   locale,
@@ -22,6 +20,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
       assessment,
       answerRepository,
       challengeRepository,
+      flashAssessmentResultRepository,
       locale,
     });
     algoResult = flash.getPossibleNextChallenges({ ...inputValues });

--- a/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
@@ -21,4 +21,8 @@ module.exports = {
     if (knexTransaction) query.transacting(knexTransaction);
     return query;
   },
+
+  async getByAssessmentId(assessmentId) {
+    return knex(TABLE_NAME).select().where({ assessmentId }).first();
+  },
 };

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -12,7 +12,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [];
 
         // when
-        const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
+        const result = flash.getPossibleNextChallenges({ challenges, allAnswers, estimatedLevel: 0 });
 
         // then
         expect(result).to.deep.equal({
@@ -22,7 +22,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       });
     });
 
-    context('when there is challenge', function () {
+    context('when there is a challenge', function () {
       it('should return hasAssessmentEnded as false and possibleChallenges not empty', function () {
         // given
         const challenge = domainBuilder.buildChallenge();
@@ -30,7 +30,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [];
 
         // when
-        const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
+        const result = flash.getPossibleNextChallenges({ challenges, allAnswers, estimatedLevel: 0 });
 
         // then
         expect(result).to.deep.equal({
@@ -54,7 +54,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           const allAnswers = [];
 
           // when
-          const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
+          const result = flash.getPossibleNextChallenges({ challenges, allAnswers, estimatedLevel: 0 });
 
           // then
           expect(result).to.deep.equal({
@@ -86,7 +86,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           const allAnswers = [];
 
           // when
-          const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
+          const result = flash.getPossibleNextChallenges({ challenges, allAnswers, estimatedLevel: 0 });
 
           // then
           expect(result).to.deep.equal({
@@ -125,7 +125,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           ];
 
           // when
-          const result = flash.getPossibleNextChallenges({ challenges, allAnswers });
+          const result = flash.getPossibleNextChallenges({ challenges, allAnswers, estimatedLevel: 1.450557193743759 });
 
           // then
           expect(result).to.deep.equal({
@@ -315,13 +315,28 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           }),
         ];
 
-        const answers = [
-          domainBuilder.buildAnswer({ challengeId: 'recL', result: AnswerStatus.KO }),
-          domainBuilder.buildAnswer({ challengeId: 'recC', result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: 'recT', result: AnswerStatus.KO }),
-          domainBuilder.buildAnswer({ challengeId: 'recE', result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: 'recA', result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: 'recQ', result: AnswerStatus.OK }),
+        const inputs = [
+          { answer: domainBuilder.buildAnswer({ challengeId: 'recL', result: AnswerStatus.KO }), estimatedLevel: 0 },
+          {
+            answer: domainBuilder.buildAnswer({ challengeId: 'recC', result: AnswerStatus.OK }),
+            estimatedLevel: -0.6086049191210775,
+          },
+          {
+            answer: domainBuilder.buildAnswer({ challengeId: 'recT', result: AnswerStatus.KO }),
+            estimatedLevel: -0.6653800198379971,
+          },
+          {
+            answer: domainBuilder.buildAnswer({ challengeId: 'recE', result: AnswerStatus.OK }),
+            estimatedLevel: -1.7794873733366134,
+          },
+          {
+            answer: domainBuilder.buildAnswer({ challengeId: 'recA', result: AnswerStatus.OK }),
+            estimatedLevel: -1.8036203882448785,
+          },
+          {
+            answer: domainBuilder.buildAnswer({ challengeId: 'recQ', result: AnswerStatus.OK }),
+            estimatedLevel: -1.557864373635504,
+          },
         ];
 
         const expectedChallengeIds = ['recL', 'recC', 'recT', 'recE', 'recA', 'recQ'];
@@ -329,13 +344,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [];
         let result;
 
-        for (let i = 0; i < answers.length; i++) {
-          result = flash.getPossibleNextChallenges({ challenges: listChallenges, allAnswers });
+        for (let i = 0; i < inputs.length; i++) {
+          const { answer, estimatedLevel } = inputs[i];
+          result = flash.getPossibleNextChallenges({ challenges: listChallenges, allAnswers, estimatedLevel });
 
           // then
           expect(result.possibleChallenges[0].id).to.equal(expectedChallengeIds[i]);
 
-          allAnswers.push(answers[i]);
+          allAnswers.push(answer);
         }
       });
     });

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -18,8 +18,6 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         expect(result).to.deep.equal({
           hasAssessmentEnded: true,
           possibleChallenges: [],
-          estimatedLevel: 0,
-          errorRate: 5,
         });
       });
     });
@@ -38,8 +36,6 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         expect(result).to.deep.equal({
           hasAssessmentEnded: false,
           possibleChallenges: [challenge],
-          estimatedLevel: 0,
-          errorRate: 5,
         });
       });
 
@@ -64,8 +60,6 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           expect(result).to.deep.equal({
             hasAssessmentEnded: false,
             possibleChallenges: [bestNextChallenge],
-            estimatedLevel: 0,
-            errorRate: 5,
           });
         });
 
@@ -98,8 +92,6 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           expect(result).to.deep.equal({
             hasAssessmentEnded: false,
             possibleChallenges: [bestNextChallenge, anotherBestNextChallenge],
-            estimatedLevel: 0,
-            errorRate: 5,
           });
         });
       });
@@ -139,8 +131,6 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           expect(result).to.deep.equal({
             hasAssessmentEnded: false,
             possibleChallenges: [nonAnsweredBestNextChallenge],
-            estimatedLevel: 1.450557193743759,
-            errorRate: 0.7615694867853122,
           });
         });
       });
@@ -184,14 +174,271 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         expect(result).to.deep.equal({
           hasAssessmentEnded: true,
           possibleChallenges: [],
-          estimatedLevel: 0,
-          errorRate: 5,
         });
       });
     });
 
     context('when the user answers a lot of challenges', function () {
-      it('should choose the correct challenge with the correct estimatedLevel', function () {
+      it('should choose the correct challenge', function () {
+        const listSkills = {
+          url5: domainBuilder.buildSkill({ id: 'url5' }),
+          web3: domainBuilder.buildSkill({ id: 'web3' }),
+          sourceinfo5: domainBuilder.buildSkill({ id: 'sourceinfo5' }),
+          installogiciel2: domainBuilder.buildSkill({ id: 'installogiciel2' }),
+          fichier4: domainBuilder.buildSkill({ id: 'fichier4' }),
+          sauvegarde5: domainBuilder.buildSkill({ id: 'sauvegarde5' }),
+          langbalise6: domainBuilder.buildSkill({ id: 'langbalise6' }),
+          pratiquesinternet4: domainBuilder.buildSkill({ id: 'pratiquesinternet4' }),
+          langbalise7: domainBuilder.buildSkill({ id: 'langbalise7' }),
+        };
+
+        const listChallenges = [
+          domainBuilder.buildChallenge({
+            id: 'recA',
+            skills: [listSkills.url5],
+            difficulty: -0.917927344545694,
+            discriminant: 1.02282430250024,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recB',
+            skills: [listSkills.web3],
+            difficulty: 0.301604780272093,
+            discriminant: 0.815896135600247,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recC',
+            skills: [listSkills.sourceinfo5],
+            difficulty: -1.69218011589622,
+            discriminant: 1.38594509996278,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recD',
+            skills: [listSkills.installogiciel2],
+            difficulty: -5.4464574841729,
+            discriminant: 0.427255285029657,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recE',
+            skills: [listSkills.fichier4],
+            difficulty: -1.5526216455839,
+            discriminant: 1.21015304225808,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recF',
+            skills: [listSkills.fichier4],
+            difficulty: -1.36561917255237,
+            discriminant: 1.09320650236677,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recG',
+            skills: [listSkills.fichier4],
+            difficulty: -4.20230915443229,
+            discriminant: 0.562929008226957,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recH',
+            skills: [listSkills.fichier4],
+            difficulty: 0.262904155422314,
+            discriminant: 0.901542609459213,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recI',
+            skills: [listSkills.fichier4],
+            difficulty: -0.754355900389256,
+            discriminant: 0.834990152043718,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recJ',
+            skills: [listSkills.sauvegarde5],
+            difficulty: 3.174339929941,
+            discriminant: 0.827526706077148,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recK',
+            skills: [listSkills.sauvegarde5],
+            difficulty: -1.16967416012961,
+            discriminant: 1.17433370794629,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recL',
+            skills: [listSkills.sauvegarde5],
+            difficulty: -0.030736508016524,
+            discriminant: 1.06665273005823,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recM',
+            skills: [listSkills.sauvegarde5],
+            difficulty: -2.37249657419562,
+            discriminant: 0.656224379307742,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recN',
+            skills: [listSkills.langbalise6],
+            difficulty: 1.62670103354638,
+            discriminant: 1.50948587856458,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recO',
+            skills: [listSkills.langbalise6],
+            difficulty: 2.811956480867,
+            discriminant: 1.04445171700575,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recP',
+            skills: [listSkills.langbalise6],
+            difficulty: 0.026713944730478,
+            discriminant: 0.703441785686095,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recQ',
+            skills: [listSkills.pratiquesinternet4],
+            difficulty: -1.83253533603,
+            discriminant: 0.711777117426424,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recR',
+            skills: [listSkills.pratiquesinternet4],
+            difficulty: 0.251708600387063,
+            discriminant: 0.369707224301943,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recS',
+            skills: [listSkills.pratiquesinternet4],
+            difficulty: 1.90647729810166,
+            discriminant: 0.950709518595358,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'recT',
+            skills: [listSkills.langbalise6],
+            difficulty: -1.82670103354638,
+            discriminant: 2.50948587856458,
+          }),
+        ];
+
+        const answers = [
+          domainBuilder.buildAnswer({ challengeId: 'recL', result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: 'recC', result: AnswerStatus.OK }),
+          domainBuilder.buildAnswer({ challengeId: 'recT', result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: 'recE', result: AnswerStatus.OK }),
+          domainBuilder.buildAnswer({ challengeId: 'recA', result: AnswerStatus.OK }),
+          domainBuilder.buildAnswer({ challengeId: 'recQ', result: AnswerStatus.OK }),
+        ];
+
+        const expectedChallengeIds = ['recL', 'recC', 'recT', 'recE', 'recA', 'recQ'];
+
+        const allAnswers = [];
+        let result;
+
+        for (let i = 0; i < answers.length; i++) {
+          result = flash.getPossibleNextChallenges({ challenges: listChallenges, allAnswers });
+
+          // then
+          expect(result.possibleChallenges[0].id).to.equal(expectedChallengeIds[i]);
+
+          allAnswers.push(answers[i]);
+        }
+      });
+    });
+  });
+
+  describe('#getEstimatedLevelAndErrorRate', function () {
+    it('should return 0 when there is no answers', function () {
+      // given
+      const allAnswers = [];
+
+      // when
+      const result = flash.getEstimatedLevelAndErrorRate({ allAnswers });
+
+      // then
+      expect(result).to.deep.equal({
+        estimatedLevel: 0,
+        errorRate: 5,
+      });
+    });
+
+    it('should return the correct estimatedLevel when there is one answer', function () {
+      // given
+      const challenges = [
+        domainBuilder.buildChallenge({
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+        }),
+      ];
+
+      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+      // when
+      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+
+      // then
+      expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+      expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
+    });
+
+    it('should return the correct estimatedLevel when there is two answers', function () {
+      // given
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'ChallengeFirstAnswers',
+          discriminant: 1.86350005965093,
+          difficulty: 0.194712138508747,
+        }),
+        domainBuilder.buildChallenge({
+          id: 'ChallengeSecondAnswers',
+          discriminant: 2.25422414740233,
+          difficulty: 0.823376599163319,
+        }),
+      ];
+
+      const allAnswers = [
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+      ];
+
+      // when
+      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+
+      // then
+      expect(estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
+      expect(errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
+    });
+
+    it('should return the correct estimatedLevel when there is three answers', function () {
+      // given
+      const challenges = [
+        domainBuilder.buildChallenge({
+          id: 'ChallengeFirstAnswers',
+          discriminant: 1.06665273005823,
+          difficulty: -0.030736508016524,
+        }),
+        domainBuilder.buildChallenge({
+          id: 'ChallengeSecondAnswers',
+          discriminant: 1.50948587856458,
+          difficulty: 1.62670103354638,
+        }),
+        domainBuilder.buildChallenge({
+          id: 'ChallengeThirdAnswers',
+          discriminant: 0.950709518595358,
+          difficulty: 1.90647729810166,
+        }),
+      ];
+
+      const allAnswers = [
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
+      ];
+
+      // when
+      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+
+      // then
+      expect(estimatedLevel).to.be.closeTo(2.851063556136754, 0.00000000001);
+      expect(errorRate).to.be.closeTo(0.9271693210547304, 0.00000000001);
+    });
+
+    context('when the user answers a lot of challenges', function () {
+      it('should return the correct estimatedLevel and errorRate', function () {
         const listSkills = {
           url5: domainBuilder.buildSkill({ id: 'url5' }),
           web3: domainBuilder.buildSkill({ id: 'web3' }),
@@ -345,119 +592,19 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           0.5880298028515323,
         ];
 
-        const expectedChallengeIds = ['recL', 'recC', 'recT', 'recE', 'recA', 'recQ'];
-
         const allAnswers = [];
         let result;
 
-        for (let i = 0; i < expectedChallengeIds.length; i++) {
-          result = flash.getPossibleNextChallenges({ challenges: listChallenges, allAnswers });
+        for (let i = 0; i < answers.length; i++) {
+          result = flash.getEstimatedLevelAndErrorRate({ challenges: listChallenges, allAnswers });
 
           // then
-          expect(result.possibleChallenges[0].id).to.equal(expectedChallengeIds[i]);
           expect(result.estimatedLevel).to.be.closeTo(expectedEstimatedLevel[i], 0.000000001);
           expect(result.errorRate).to.be.closeTo(expectedErrorRate[i], 0.000000001);
 
           allAnswers.push(answers[i]);
         }
       });
-    });
-  });
-
-  describe('#getEstimatedLevelAndErrorRate', function () {
-    it('should return 0 when there is no answers', function () {
-      // given
-      const allAnswers = [];
-
-      // when
-      const result = flash.getEstimatedLevelAndErrorRate({ allAnswers });
-
-      // then
-      expect(result).to.deep.equal({
-        estimatedLevel: 0,
-        errorRate: 5,
-      });
-    });
-
-    it('should return the correct estimatedLevel when there is one answer', function () {
-      // given
-      const challenges = [
-        domainBuilder.buildChallenge({
-          discriminant: 1.86350005965093,
-          difficulty: 0.194712138508747,
-        }),
-      ];
-
-      const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
-
-      // when
-      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
-
-      // then
-      expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
-      expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
-    });
-
-    it('should return the correct estimatedLevel when there is two answers', function () {
-      // given
-      const challenges = [
-        domainBuilder.buildChallenge({
-          id: 'ChallengeFirstAnswers',
-          discriminant: 1.86350005965093,
-          difficulty: 0.194712138508747,
-        }),
-        domainBuilder.buildChallenge({
-          id: 'ChallengeSecondAnswers',
-          discriminant: 2.25422414740233,
-          difficulty: 0.823376599163319,
-        }),
-      ];
-
-      const allAnswers = [
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
-      ];
-
-      // when
-      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
-
-      // then
-      expect(estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
-      expect(errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
-    });
-
-    it('should return the correct estimatedLevel when there is three answers', function () {
-      // given
-      const challenges = [
-        domainBuilder.buildChallenge({
-          id: 'ChallengeFirstAnswers',
-          discriminant: 1.06665273005823,
-          difficulty: -0.030736508016524,
-        }),
-        domainBuilder.buildChallenge({
-          id: 'ChallengeSecondAnswers',
-          discriminant: 1.50948587856458,
-          difficulty: 1.62670103354638,
-        }),
-        domainBuilder.buildChallenge({
-          id: 'ChallengeThirdAnswers',
-          discriminant: 0.950709518595358,
-          difficulty: 1.90647729810166,
-        }),
-      ];
-
-      const allAnswers = [
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
-        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[2].id }),
-      ];
-
-      // when
-      const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
-
-      // then
-      expect(estimatedLevel).to.be.closeTo(2.851063556136754, 0.00000000001);
-      expect(errorRate).to.be.closeTo(0.9271693210547304, 0.00000000001);
     });
   });
 

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -160,12 +160,14 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       challengeRepository,
       challenges,
       campaignParticipationRepository,
+      flashAssessmentResultRepository,
       actualNextChallenge,
       improvementService,
       challengeWeb21,
       challengeWeb22,
       possibleChallenges,
-      locale;
+      locale,
+      estimatedLevel;
 
     beforeEach(async function () {
       userId = 'dummyUserId';
@@ -185,6 +187,11 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
         isImproving: false,
         method: 'FLASH',
       });
+
+      estimatedLevel = Symbol('estimatedLevel');
+      flashAssessmentResultRepository = {
+        getByAssessmentId: sinon.stub().withArgs(assessmentId).resolves({ estimatedLevel }),
+      };
 
       const web2 = domainBuilder.buildSkill({ name: '@web2' });
       challengeWeb21 = domainBuilder.buildChallenge({ id: 'challenge_web2_1' });
@@ -214,6 +221,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
         answerRepository,
         challengeRepository,
         campaignParticipationRepository,
+        flashAssessmentResultRepository,
         improvementService,
         locale,
       });
@@ -232,6 +240,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       expect(flash.getPossibleNextChallenges).to.have.been.calledWithExactly({
         allAnswers,
         challenges,
+        estimatedLevel,
       });
     });
 

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -153,6 +153,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
   describe('#fetchForFlashCampaigns', function () {
     let answerRepository;
     let challengeRepository;
+    let flashAssessmentResultRepository;
 
     beforeEach(function () {
       answerRepository = {
@@ -160,6 +161,9 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       };
       challengeRepository = {
         findFlashCompatible: sinon.stub(),
+      };
+      flashAssessmentResultRepository = {
+        getByAssessmentId: sinon.stub(),
       };
     });
 
@@ -173,20 +177,24 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       });
       const answer = Symbol('answer');
       const challenges = Symbol('challenge');
+      const estimatedLevel = Symbol('estimatedLevel');
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       challengeRepository.findFlashCompatible.withArgs().resolves(challenges);
+      flashAssessmentResultRepository.getByAssessmentId.withArgs(assessment.id).resolves({ estimatedLevel });
 
       // when
       const data = await dataFetcher.fetchForFlashCampaigns({
         assessment,
         answerRepository,
         challengeRepository,
+        flashAssessmentResultRepository,
       });
 
       // then
       expect(data.allAnswers).to.deep.equal([answer]);
       expect(data.challenges).to.deep.equal(challenges);
+      expect(data.estimatedLevel).to.equal(estimatedLevel);
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -11,6 +11,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
     let targetProfileRepository;
     let challengeRepository;
     let answerRepository;
+    let flashAssessmentResultRepository;
     let pickChallengeService;
 
     let assessment;
@@ -26,6 +27,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
       challengeRepository = { get: sinon.stub() };
       challengeRepository.get.withArgs('first_challenge').resolves(firstChallenge);
       challengeRepository.get.withArgs('second_challenge').resolves(secondChallenge);
+      flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
       pickChallengeService = { pickChallenge: sinon.stub() };
     });
 
@@ -42,6 +44,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
         targetProfileRepository,
         challengeRepository,
         answerRepository,
+        flashAssessmentResultRepository,
         pickChallengeService,
         assessment,
       });
@@ -63,6 +66,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           targetProfileRepository,
           challengeRepository,
           answerRepository,
+          flashAssessmentResultRepository,
           pickChallengeService,
           assessment,
           locale,
@@ -74,6 +78,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           assessment,
           answerRepository,
           challengeRepository,
+          flashAssessmentResultRepository,
           locale,
         });
       });


### PR DESCRIPTION
## :christmas_tree: Problème
Le niveau de l'utilisateur est réestimé à la volée quand on cherche un nouveau challenge alors qu'il est déjà enregistré dans la table `flash-assessment-result`.

## :gift: Solution
Utiliser le niveau enregistré de l'utilisateur quand on cherche un nouveau challenge.

## :star2: Remarques
Il serait intéresssant de sortir l'appel à `getNonAnsweredChallenges()` de `getPossibleNextChallenges()` (voire même de sortir la fonction `getNonAnsweredChallenges()` de `flash.js`, ce n'est pas de l'algo...).

Ça permettrait de ne plus avoir que les variables `challenges` (en fait `nonAnsweredChallenges`) et `estimatedLevel` en paramètre de `getPossibleNextChallenges()`.

À faire dans une autre PR ? Ça n'a pas l'air si simple.

## :santa: Pour tester
Vérifier que la campagne `FLASH1234` fonctionne toujours.
