### PR TITLE
[A11Y] Changer la couleur du graphique ayant un contraste insuffisant pour l'accessibilité (PIX-4052)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-status.js
+++ b/orga/app/components/campaign/charts/participants-by-status.js
@@ -93,7 +93,7 @@ const LABELS_ASSESSMENT = {
     legend: 'charts.participants-by-status.labels-legend.started',
     legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#ffbe00',
+    color: '#da7601',
     shape: 'diamond-box',
   },
   completed: {
@@ -120,7 +120,7 @@ const LABELS_PROFILE_COLLECTIONS = {
     legend: 'charts.participants-by-status.labels-legend.started',
     legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#ffbe00',
+    color: '#da7601',
     shape: 'diamond-box',
   },
   completed: {


### PR DESCRIPTION
## :christmas_tree: Problème
Le contraste du Graphique en donut pour les participants ayant commencé leur parcours n'est pas suffisant pour atteindre un score correct WCAGG

## :gift: Solution
Changer la couleur en question pour une teinte plus foncé afin d'avoir le contraste suffisant

## :star2: Remarques
Les tags dans la liste des participants sont aussi impacté. Nous devons d'abord mettre à jour Pix-UI pour prendre un compte cette nouvelle couleur

## :santa: Pour tester
Se connecter sur Pix Orga pro.admin@example.net, vérifier que sur une campagne avec des particpations en cour la couleur soit bien devenu Orange au lieu du jaune.