### PR TITLE
[FEATURE] Afficher les résultats de la certification Pix+ Edu dans le csv des résultats (PIX-4080).

### DIFF
--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -1,8 +1,17 @@
 const _ = require('lodash');
 const CompetenceMark = require('./CompetenceMark');
 const PartnerCertification = require('./PartnerCertification');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('./Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('./Badge').keys;
 
 const status = {
   REJECTED: 'rejected',
@@ -138,6 +147,36 @@ class CertificationResult {
       (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_EXPERT_CERTIF
     );
     return pixPlusDroitExpertPartnerCertification && pixPlusDroitExpertPartnerCertification.acquired;
+  }
+
+  hasAcquiredPixPlusEduAutonome() {
+    const pixPlusEduAutonomePartnerCertification = this.partnerCertifications.find(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
+    );
+    return pixPlusEduAutonomePartnerCertification && pixPlusEduAutonomePartnerCertification.acquired;
+  }
+
+  hasAcquiredPixPlusEduAvance() {
+    const pixPlusEduAvancePartnerCertification = this.partnerCertifications.find((partnerCertification) =>
+      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE].includes(
+        partnerCertification.partnerKey
+      )
+    );
+    return pixPlusEduAvancePartnerCertification && pixPlusEduAvancePartnerCertification.acquired;
+  }
+
+  hasAcquiredPixPlusEduExpert() {
+    const pixPlusEduExpertPartnerCertification = this.partnerCertifications.find(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+    );
+    return pixPlusEduExpertPartnerCertification && pixPlusEduExpertPartnerCertification.acquired;
+  }
+
+  hasAcquiredPixPlusEduFormateur() {
+    const pixPlusEduFormateurPartnerCertification = this.partnerCertifications.find(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
+    );
+    return pixPlusEduFormateurPartnerCertification && pixPlusEduFormateurPartnerCertification.acquired;
   }
 }
 

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -149,11 +149,25 @@ class CertificationResult {
     return pixPlusDroitExpertPartnerCertification && pixPlusDroitExpertPartnerCertification.acquired;
   }
 
+  hasTakenPixPlusEduAutonome() {
+    return this.partnerCertifications.some(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
+    );
+  }
+
   hasAcquiredPixPlusEduAutonome() {
     const pixPlusEduAutonomePartnerCertification = this.partnerCertifications.find(
       (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
     );
     return pixPlusEduAutonomePartnerCertification && pixPlusEduAutonomePartnerCertification.acquired;
+  }
+
+  hasTakenPixPlusEduAvance() {
+    return this.partnerCertifications.some((partnerCertification) =>
+      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE].includes(
+        partnerCertification.partnerKey
+      )
+    );
   }
 
   hasAcquiredPixPlusEduAvance() {
@@ -165,11 +179,23 @@ class CertificationResult {
     return pixPlusEduAvancePartnerCertification && pixPlusEduAvancePartnerCertification.acquired;
   }
 
+  hasTakenPixPlusEduExpert() {
+    return this.partnerCertifications.some(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+    );
+  }
+
   hasAcquiredPixPlusEduExpert() {
     const pixPlusEduExpertPartnerCertification = this.partnerCertifications.find(
       (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
     );
     return pixPlusEduExpertPartnerCertification && pixPlusEduExpertPartnerCertification.acquired;
+  }
+
+  hasTakenPixPlusEduFormateur() {
+    return this.partnerCertifications.some(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
+    );
   }
 
   hasAcquiredPixPlusEduFormateur() {

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -69,7 +69,7 @@ class CertificationResult {
           competence_code: competenceMarkDTO.competence_code.toString(),
         })
     );
-    const partnerCertifications = certificationResultDTO.partnerCertifications.map(
+    const partnerCertifications = _.compact(certificationResultDTO.partnerCertifications).map(
       (partnerCertification) => new PartnerCertification(partnerCertification)
     );
 
@@ -111,98 +111,90 @@ class CertificationResult {
   }
 
   hasTakenClea() {
-    return this.partnerCertifications.some((partnerCertification) =>
-      [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerCertification.partnerKey)
+    return this.partnerCertifications.some(({ partnerKey }) =>
+      [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerKey)
     );
   }
 
   hasAcquiredClea() {
-    const cleaPartnerCertification = this.partnerCertifications.find((partnerCertification) =>
-      [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerCertification.partnerKey)
+    const cleaPartnerCertification = this.partnerCertifications.find(({ partnerKey }) =>
+      [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerKey)
     );
-    return cleaPartnerCertification && cleaPartnerCertification.acquired;
+    return Boolean(cleaPartnerCertification?.acquired);
   }
 
   hasTakenPixPlusDroitMaitre() {
-    return this.partnerCertifications.some(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_MAITRE_CERTIF
-    );
+    return this.partnerCertifications.some(({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF);
   }
 
   hasAcquiredPixPlusDroitMaitre() {
     const pixPlusDroitMaitrePartnerCertification = this.partnerCertifications.find(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_MAITRE_CERTIF
+      ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF
     );
-    return pixPlusDroitMaitrePartnerCertification && pixPlusDroitMaitrePartnerCertification.acquired;
+    return Boolean(pixPlusDroitMaitrePartnerCertification?.acquired);
   }
 
   hasTakenPixPlusDroitExpert() {
-    return this.partnerCertifications.some(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_EXPERT_CERTIF
-    );
+    return this.partnerCertifications.some(({ partnerKey }) => partnerKey === PIX_DROIT_EXPERT_CERTIF);
   }
 
   hasAcquiredPixPlusDroitExpert() {
     const pixPlusDroitExpertPartnerCertification = this.partnerCertifications.find(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_EXPERT_CERTIF
+      ({ partnerKey }) => partnerKey === PIX_DROIT_EXPERT_CERTIF
     );
-    return pixPlusDroitExpertPartnerCertification && pixPlusDroitExpertPartnerCertification.acquired;
+    return Boolean(pixPlusDroitExpertPartnerCertification?.acquired);
   }
 
   hasTakenPixPlusEduAutonome() {
     return this.partnerCertifications.some(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
     );
   }
 
   hasAcquiredPixPlusEduAutonome() {
     const pixPlusEduAutonomePartnerCertification = this.partnerCertifications.find(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME
     );
-    return pixPlusEduAutonomePartnerCertification && pixPlusEduAutonomePartnerCertification.acquired;
+    return Boolean(pixPlusEduAutonomePartnerCertification?.acquired);
   }
 
   hasTakenPixPlusEduAvance() {
-    return this.partnerCertifications.some((partnerCertification) =>
-      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE].includes(
-        partnerCertification.partnerKey
-      )
+    return this.partnerCertifications.some(({ partnerKey }) =>
+      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE].includes(partnerKey)
     );
   }
 
   hasAcquiredPixPlusEduAvance() {
-    const pixPlusEduAvancePartnerCertification = this.partnerCertifications.find((partnerCertification) =>
-      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE].includes(
-        partnerCertification.partnerKey
-      )
+    const pixPlusEduAvancePartnerCertification = this.partnerCertifications.find(({ partnerKey }) =>
+      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE].includes(partnerKey)
     );
-    return pixPlusEduAvancePartnerCertification && pixPlusEduAvancePartnerCertification.acquired;
+    return Boolean(pixPlusEduAvancePartnerCertification?.acquired);
   }
 
   hasTakenPixPlusEduExpert() {
     return this.partnerCertifications.some(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
     );
   }
 
   hasAcquiredPixPlusEduExpert() {
     const pixPlusEduExpertPartnerCertification = this.partnerCertifications.find(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
     );
-    return pixPlusEduExpertPartnerCertification && pixPlusEduExpertPartnerCertification.acquired;
+    return Boolean(pixPlusEduExpertPartnerCertification?.acquired);
   }
 
   hasTakenPixPlusEduFormateur() {
     return this.partnerCertifications.some(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
     );
   }
 
   hasAcquiredPixPlusEduFormateur() {
     const pixPlusEduFormateurPartnerCertification = this.partnerCertifications.find(
-      (partnerCertification) => partnerCertification.partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR
     );
-    return pixPlusEduFormateurPartnerCertification && pixPlusEduFormateurPartnerCertification.acquired;
+    return Boolean(pixPlusEduFormateurPartnerCertification?.acquired);
   }
 }
 

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -1,5 +1,8 @@
 const _ = require('lodash');
 const CompetenceMark = require('./CompetenceMark');
+const PartnerCertification = require('./PartnerCertification');
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('./Badge').keys;
 
 const status = {
   REJECTED: 'rejected',
@@ -23,9 +26,7 @@ class CertificationResult {
     pixScore,
     commentForOrganization,
     competencesWithMark,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
+    partnerCertifications,
   }) {
     this.id = id;
     this.firstName = firstName;
@@ -39,17 +40,10 @@ class CertificationResult {
     this.pixScore = pixScore;
     this.commentForOrganization = commentForOrganization;
     this.competencesWithMark = competencesWithMark;
-    this.cleaCertificationResult = cleaCertificationResult;
-    this.pixPlusDroitMaitreCertificationResult = pixPlusDroitMaitreCertificationResult;
-    this.pixPlusDroitExpertCertificationResult = pixPlusDroitExpertCertificationResult;
+    this.partnerCertifications = partnerCertifications;
   }
 
-  static from({
-    certificationResultDTO,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
-  }) {
+  static from({ certificationResultDTO }) {
     let certificationStatus;
     if (certificationResultDTO.isCancelled) {
       certificationStatus = status.CANCELLED;
@@ -66,6 +60,9 @@ class CertificationResult {
           competence_code: competenceMarkDTO.competence_code.toString(),
         })
     );
+    const partnerCertifications = certificationResultDTO.partnerCertifications.map(
+      (partnerCertification) => new PartnerCertification(partnerCertification)
+    );
 
     return new CertificationResult({
       id: certificationResultDTO.id,
@@ -80,9 +77,7 @@ class CertificationResult {
       pixScore: certificationResultDTO.pixScore,
       commentForOrganization: certificationResultDTO.commentForOrganization,
       competencesWithMark,
-      cleaCertificationResult,
-      pixPlusDroitMaitreCertificationResult,
-      pixPlusDroitExpertCertificationResult,
+      partnerCertifications,
     });
   }
 
@@ -107,27 +102,42 @@ class CertificationResult {
   }
 
   hasTakenClea() {
-    return this.cleaCertificationResult.isTaken();
+    return this.partnerCertifications.some((partnerCertification) =>
+      [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerCertification.partnerKey)
+    );
   }
 
   hasAcquiredClea() {
-    return this.cleaCertificationResult.isAcquired();
+    const cleaPartnerCertification = this.partnerCertifications.find((partnerCertification) =>
+      [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerCertification.partnerKey)
+    );
+    return cleaPartnerCertification && cleaPartnerCertification.acquired;
   }
 
   hasTakenPixPlusDroitMaitre() {
-    return this.pixPlusDroitMaitreCertificationResult.isTaken();
+    return this.partnerCertifications.some(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_MAITRE_CERTIF
+    );
   }
 
   hasAcquiredPixPlusDroitMaitre() {
-    return this.pixPlusDroitMaitreCertificationResult.isAcquired();
+    const pixPlusDroitMaitrePartnerCertification = this.partnerCertifications.find(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_MAITRE_CERTIF
+    );
+    return pixPlusDroitMaitrePartnerCertification && pixPlusDroitMaitrePartnerCertification.acquired;
   }
 
   hasTakenPixPlusDroitExpert() {
-    return this.pixPlusDroitExpertCertificationResult.isTaken();
+    return this.partnerCertifications.some(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_EXPERT_CERTIF
+    );
   }
 
   hasAcquiredPixPlusDroitExpert() {
-    return this.pixPlusDroitExpertCertificationResult.isAcquired();
+    const pixPlusDroitExpertPartnerCertification = this.partnerCertifications.find(
+      (partnerCertification) => partnerCertification.partnerKey === PIX_DROIT_EXPERT_CERTIF
+    );
+    return pixPlusDroitExpertPartnerCertification && pixPlusDroitExpertPartnerCertification.acquired;
   }
 }
 

--- a/api/lib/domain/models/CleaCertificationResult.js
+++ b/api/lib/domain/models/CleaCertificationResult.js
@@ -1,12 +1,8 @@
-const { keys } = require('./Badge');
-
 const cleaStatuses = {
   ACQUIRED: 'acquired',
   REJECTED: 'rejected',
   NOT_TAKEN: 'not_taken',
 };
-const badgeKeyV1 = keys.PIX_EMPLOI_CLEA;
-const badgeKeyV2 = keys.PIX_EMPLOI_CLEA_V2;
 
 class CleaCertificationResult {
   constructor({ status } = {}) {
@@ -35,6 +31,4 @@ class CleaCertificationResult {
 }
 
 CleaCertificationResult.cleaStatuses = cleaStatuses;
-CleaCertificationResult.badgeKeyV1 = badgeKeyV1;
-CleaCertificationResult.badgeKeyV2 = badgeKeyV2;
 module.exports = CleaCertificationResult;

--- a/api/lib/domain/models/PartnerCertification.js
+++ b/api/lib/domain/models/PartnerCertification.js
@@ -1,0 +1,9 @@
+class PartnerCertification {
+  constructor({ certificationCourseId, partnerKey, acquired } = {}) {
+    this.certificationCourseId = certificationCourseId;
+    this.partnerKey = partnerKey;
+    this.acquired = acquired;
+  }
+}
+
+module.exports = PartnerCertification;

--- a/api/lib/domain/models/PixPlusDroitExpertCertificationResult.js
+++ b/api/lib/domain/models/PixPlusDroitExpertCertificationResult.js
@@ -4,8 +4,6 @@ const statuses = {
   NOT_TAKEN: 'not_taken',
 };
 
-const badgeKey = 'PIX_DROIT_EXPERT_CERTIF';
-
 class PixPlusDroitExpertCertificationResult {
   constructor({ status } = {}) {
     this.status = status;
@@ -33,5 +31,4 @@ class PixPlusDroitExpertCertificationResult {
 }
 
 PixPlusDroitExpertCertificationResult.statuses = statuses;
-PixPlusDroitExpertCertificationResult.badgeKey = badgeKey;
 module.exports = PixPlusDroitExpertCertificationResult;

--- a/api/lib/domain/models/PixPlusDroitMaitreCertificationResult.js
+++ b/api/lib/domain/models/PixPlusDroitMaitreCertificationResult.js
@@ -4,8 +4,6 @@ const statuses = {
   NOT_TAKEN: 'not_taken',
 };
 
-const badgeKey = 'PIX_DROIT_MAITRE_CERTIF';
-
 class PixPlusDroitMaitreCertificationResult {
   constructor({ status } = {}) {
     this.status = status;
@@ -33,5 +31,4 @@ class PixPlusDroitMaitreCertificationResult {
 }
 
 PixPlusDroitMaitreCertificationResult.statuses = statuses;
-PixPlusDroitMaitreCertificationResult.badgeKey = badgeKey;
 module.exports = PixPlusDroitMaitreCertificationResult;

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -2,9 +2,7 @@ const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-const {
+  PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -27,7 +25,7 @@ class CertifiedBadgeImage {
       });
     }
 
-    if (partnerKey === pixPlusDroitExpertBadgeKey) {
+    if (partnerKey === PIX_DROIT_EXPERT_CERTIF) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
         isTemporaryBadge: false,

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -1,7 +1,5 @@
 const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
+  PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
@@ -18,7 +16,7 @@ class CertifiedBadgeImage {
   }
 
   static fromPartnerKey(partnerKey) {
-    if (partnerKey === pixPlusDroitMaitreBadgeKey) {
+    if (partnerKey === PIX_DROIT_MAITRE_CERTIF) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
         isTemporaryBadge: false,

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -3,12 +3,10 @@ const { knex } = require('../../../db/knex-database-connection');
 const CertificationAttestation = require('../../domain/models/CertificationAttestation');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
+  PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -143,7 +141,7 @@ async function _getAcquiredPartnerCertificationKeys(certificationCourseId) {
   const handledBadgeKeys = [
     CleaCertificationResult.badgeKeyV1,
     CleaCertificationResult.badgeKeyV2,
-    pixPlusDroitExpertBadgeKey,
+    PIX_DROIT_EXPERT_CERTIF,
     pixPlusDroitMaitreBadgeKey,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
 const { knex } = require('../../../db/knex-database-connection');
 const CertificationAttestation = require('../../domain/models/CertificationAttestation');
-const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
   PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
@@ -137,8 +138,8 @@ function _filterMostRecentCertificationCoursePerSchoolingRegistration(DTOs) {
 
 async function _getAcquiredPartnerCertificationKeys(certificationCourseId) {
   const handledBadgeKeys = [
-    CleaCertificationResult.badgeKeyV1,
-    CleaCertificationResult.badgeKeyV2,
+    PIX_EMPLOI_CLEA,
+    PIX_EMPLOI_CLEA_V2,
     PIX_DROIT_EXPERT_CERTIF,
     PIX_DROIT_MAITRE_CERTIF,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -3,9 +3,7 @@ const { knex } = require('../../../db/knex-database-connection');
 const CertificationAttestation = require('../../domain/models/CertificationAttestation');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
+  PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
@@ -142,7 +140,7 @@ async function _getAcquiredPartnerCertificationKeys(certificationCourseId) {
     CleaCertificationResult.badgeKeyV1,
     CleaCertificationResult.badgeKeyV2,
     PIX_DROIT_EXPERT_CERTIF,
-    pixPlusDroitMaitreBadgeKey,
+    PIX_DROIT_MAITRE_CERTIF,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,

--- a/api/lib/infrastructure/repositories/certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/certification-result-repository.js
@@ -1,7 +1,16 @@
 const { knex } = require('../../../db/knex-database-connection');
 const CertificationResult = require('../../domain/models/CertificationResult');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../domain/models/Badge').keys;
 
 module.exports = {
   async findBySessionId({ sessionId }) {
@@ -60,7 +69,17 @@ function _selectCertificationResults() {
     .leftJoin('partner-certifications', function () {
       this.on('partner-certifications.certificationCourseId', '=', 'certification-courses.id').onIn(
         'partner-certifications.partnerKey',
-        [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF]
+        [
+          PIX_EMPLOI_CLEA,
+          PIX_EMPLOI_CLEA_V2,
+          PIX_DROIT_MAITRE_CERTIF,
+          PIX_DROIT_EXPERT_CERTIF,
+          PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+          PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+          PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+        ]
       );
     })
     .groupBy('certification-courses.id', 'assessments.id', 'assessment-results.id')

--- a/api/lib/infrastructure/repositories/certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/certification-result-repository.js
@@ -19,7 +19,7 @@ module.exports = {
       .orderBy('certification-courses.lastName', 'ASC')
       .orderBy('certification-courses.firstName', 'ASC');
 
-    return certificationResultDTOs.map((certificationResultDTO) => _toDomain({ certificationResultDTO }));
+    return certificationResultDTOs.map(_toDomain);
   },
 
   async findByCertificationCandidateIds({ certificationCandidateIds }) {
@@ -33,7 +33,7 @@ module.exports = {
       .orderBy('certification-courses.lastName', 'ASC')
       .orderBy('certification-courses.firstName', 'ASC');
 
-    return certificationResultDTOs.map((certificationResultDTO) => _toDomain({ certificationResultDTO }));
+    return certificationResultDTOs.map(_toDomain);
   },
 };
 
@@ -59,7 +59,7 @@ function _selectCertificationResults() {
     )
     .select(
       knex.raw(`
-        COALESCE(json_agg("partner-certifications".*) filter (where "partner-certifications"."partnerKey" is not null), '[]') as "partnerCertifications"`)
+        json_agg("partner-certifications".*) as "partnerCertifications"`)
     )
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
@@ -96,7 +96,7 @@ function _filterMostRecentAssessmentResult(qb) {
   );
 }
 
-function _toDomain({ certificationResultDTO }) {
+function _toDomain(certificationResultDTO) {
   return CertificationResult.from({
     certificationResultDTO,
   });

--- a/api/lib/infrastructure/repositories/clea-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/clea-certification-result-repository.js
@@ -1,5 +1,6 @@
 const { knex } = require('../bookshelf');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2 } = require('../../domain/models/Badge').keys;
 
 module.exports = {
   async get({ certificationCourseId }) {
@@ -7,7 +8,7 @@ module.exports = {
       .select('acquired')
       .from('partner-certifications')
       .where({ certificationCourseId })
-      .whereIn('partnerKey', [CleaCertificationResult.badgeKeyV1, CleaCertificationResult.badgeKeyV2])
+      .whereIn('partnerKey', [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2])
       .first();
 
     if (!result) {

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -6,6 +6,7 @@ const CleaCertificationResult = require('../../domain/models/CleaCertificationRe
 const PixPlusDroitMaitreCertificationResult = require('../../domain/models/PixPlusDroitMaitreCertificationResult');
 const PixPlusDroitExpertCertificationResult = require('../../domain/models/PixPlusDroitExpertCertificationResult');
 const Assessment = require('../../domain/models/Assessment');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../domain/models/Badge').keys;
 
 module.exports = {
   async findBySessionId(sessionId) {
@@ -105,7 +106,7 @@ function _getPartnerCertificationsResult(partnerCertificationsSource) {
     partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
   });
   const pixPlusDroitExpertCertification = _.find(partnerCertifications, {
-    partnerKey: PixPlusDroitExpertCertificationResult.badgeKey,
+    partnerKey: PIX_DROIT_EXPERT_CERTIF,
   });
 
   return {

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -6,7 +6,8 @@ const CleaCertificationResult = require('../../domain/models/CleaCertificationRe
 const PixPlusDroitMaitreCertificationResult = require('../../domain/models/PixPlusDroitMaitreCertificationResult');
 const PixPlusDroitExpertCertificationResult = require('../../domain/models/PixPlusDroitExpertCertificationResult');
 const Assessment = require('../../domain/models/Assessment');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../domain/models/Badge').keys;
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../domain/models/Badge').keys;
 
 module.exports = {
   async findBySessionId(sessionId) {
@@ -100,8 +101,8 @@ function _toDomain(juryCertificationSummaryDTO) {
 function _getPartnerCertificationsResult(partnerCertificationsSource) {
   const partnerCertifications = _.compact(partnerCertificationsSource);
   const cleaCertificationCertification =
-    _.find(partnerCertifications, { partnerKey: CleaCertificationResult.badgeKeyV1 }) ||
-    _.find(partnerCertifications, { partnerKey: CleaCertificationResult.badgeKeyV2 });
+    _.find(partnerCertifications, { partnerKey: PIX_EMPLOI_CLEA }) ||
+    _.find(partnerCertifications, { partnerKey: PIX_EMPLOI_CLEA_V2 });
   const pixPlusDroitMaitreCertification = _.find(partnerCertifications, {
     partnerKey: PIX_DROIT_MAITRE_CERTIF,
   });

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -6,7 +6,7 @@ const CleaCertificationResult = require('../../domain/models/CleaCertificationRe
 const PixPlusDroitMaitreCertificationResult = require('../../domain/models/PixPlusDroitMaitreCertificationResult');
 const PixPlusDroitExpertCertificationResult = require('../../domain/models/PixPlusDroitExpertCertificationResult');
 const Assessment = require('../../domain/models/Assessment');
-const { PIX_DROIT_EXPERT_CERTIF } = require('../../domain/models/Badge').keys;
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../domain/models/Badge').keys;
 
 module.exports = {
   async findBySessionId(sessionId) {
@@ -103,7 +103,7 @@ function _getPartnerCertificationsResult(partnerCertificationsSource) {
     _.find(partnerCertifications, { partnerKey: CleaCertificationResult.badgeKeyV1 }) ||
     _.find(partnerCertifications, { partnerKey: CleaCertificationResult.badgeKeyV2 });
   const pixPlusDroitMaitreCertification = _.find(partnerCertifications, {
-    partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
+    partnerKey: PIX_DROIT_MAITRE_CERTIF,
   });
   const pixPlusDroitExpertCertification = _.find(partnerCertifications, {
     partnerKey: PIX_DROIT_EXPERT_CERTIF,

--- a/api/lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository.js
@@ -1,12 +1,13 @@
 const { knex } = require('../bookshelf');
 const PixPlusDroitExpertCertificationResult = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../lib/domain/models/Badge').keys;
 
 module.exports = {
   async get({ certificationCourseId }) {
     const result = await knex
       .select('acquired')
       .from('partner-certifications')
-      .where({ certificationCourseId, partnerKey: PixPlusDroitExpertCertificationResult.badgeKey })
+      .where({ certificationCourseId, partnerKey: PIX_DROIT_EXPERT_CERTIF })
       .first();
 
     if (!result) {

--- a/api/lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository.js
@@ -1,12 +1,13 @@
 const { knex } = require('../bookshelf');
 const PixPlusDroitMaitreCertificationResult = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+const { PIX_DROIT_MAITRE_CERTIF } = require('../../../lib/domain/models/Badge').keys;
 
 module.exports = {
   async get({ certificationCourseId }) {
     const result = await knex
       .select('acquired')
       .from('partner-certifications')
-      .where({ certificationCourseId, partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey })
+      .where({ certificationCourseId, partnerKey: PIX_DROIT_MAITRE_CERTIF })
       .first();
 
     if (!result) {

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -4,12 +4,10 @@ const PrivateCertificate = require('../../domain/models/PrivateCertificate');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
+  PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -126,7 +124,7 @@ async function _getCleaCertificationResult(certificationCourseId) {
 
 async function _getCertifiedBadgeImages(certificationCourseId) {
   const handledBadgeKeys = [
-    pixPlusDroitExpertBadgeKey,
+    PIX_DROIT_EXPERT_CERTIF,
     pixPlusDroitMaitreBadgeKey,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -4,6 +4,8 @@ const PrivateCertificate = require('../../domain/models/PrivateCertificate');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
   PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
@@ -111,7 +113,7 @@ async function _getCleaCertificationResult(certificationCourseId) {
     .select('acquired')
     .from('partner-certifications')
     .where({ certificationCourseId })
-    .whereIn('partnerKey', [CleaCertificationResult.badgeKeyV1, CleaCertificationResult.badgeKeyV2])
+    .whereIn('partnerKey', [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2])
     .first();
 
   if (!result) {

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -4,9 +4,7 @@ const PrivateCertificate = require('../../domain/models/PrivateCertificate');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
+  PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
@@ -125,7 +123,7 @@ async function _getCleaCertificationResult(certificationCourseId) {
 async function _getCertifiedBadgeImages(certificationCourseId) {
   const handledBadgeKeys = [
     PIX_DROIT_EXPERT_CERTIF,
-    pixPlusDroitMaitreBadgeKey,
+    PIX_DROIT_MAITRE_CERTIF,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -5,9 +5,7 @@ const AssessmentResult = require('../../domain/models/AssessmentResult');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
+  PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
@@ -101,7 +99,7 @@ async function _getCleaCertificationResult(certificationCourseId) {
 async function _getCertifiedBadgeImages(certificationCourseId) {
   const handledBadgeKeys = [
     PIX_DROIT_EXPERT_CERTIF,
-    pixPlusDroitMaitreBadgeKey,
+    PIX_DROIT_MAITRE_CERTIF,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -5,12 +5,10 @@ const AssessmentResult = require('../../domain/models/AssessmentResult');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
+  PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -102,7 +100,7 @@ async function _getCleaCertificationResult(certificationCourseId) {
 
 async function _getCertifiedBadgeImages(certificationCourseId) {
   const handledBadgeKeys = [
-    pixPlusDroitExpertBadgeKey,
+    PIX_DROIT_EXPERT_CERTIF,
     pixPlusDroitMaitreBadgeKey,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
     PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -5,6 +5,8 @@ const AssessmentResult = require('../../domain/models/AssessmentResult');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
   PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
@@ -87,7 +89,7 @@ async function _getCleaCertificationResult(certificationCourseId) {
     .select('acquired')
     .from('partner-certifications')
     .where({ certificationCourseId })
-    .whereIn('partnerKey', [CleaCertificationResult.badgeKeyV1, CleaCertificationResult.badgeKeyV2])
+    .whereIn('partnerKey', [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2])
     .first();
 
   if (!result) {

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -76,10 +76,28 @@ function _buildFileHeaders(certificationResults) {
   const shouldIncludePixPlusDroitExpertHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusDroitExpert()
   );
+  const shouldIncludePixPlusEduAutonomeHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEduAutonome()
+  );
+  const shouldIncludePixPlusEduAvanceHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEduAvance()
+  );
+  const shouldIncludePixPlusEduExpertHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEduExpert()
+  );
+  const shouldIncludePixPlusEduFormateurHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEduFormateur()
+  );
 
   const cleaHeader = shouldIncludeCleaHeader ? [_headers.CLEA_STATUS] : [];
   const pixPlusDroitMaitreHeader = shouldIncludePixPlusDroitMaitreHeader ? [_headers.PIX_PLUS_DROIT_MAITRE_STATUS] : [];
   const pixPlusDroitExpertHeader = shouldIncludePixPlusDroitExpertHeader ? [_headers.PIX_PLUS_DROIT_EXPERT_STATUS] : [];
+  const pixPlusEduAutonomeHeader = shouldIncludePixPlusEduAutonomeHeader ? [_headers.PIX_PLUS_EDU_AUTONOME_HEADER] : [];
+  const pixPlusEduAvanceHeader = shouldIncludePixPlusEduAvanceHeader ? [_headers.PIX_PLUS_EDU_AVANCE_HEADER] : [];
+  const pixPlusEduExpertHeader = shouldIncludePixPlusEduExpertHeader ? [_headers.PIX_PLUS_EDU_EXPERT_HEADER] : [];
+  const pixPlusEduFormateurHeader = shouldIncludePixPlusEduFormateurHeader
+    ? [_headers.PIX_PLUS_EDU_FORMATEUR_HEADER]
+    : [];
 
   return _.concat(
     [
@@ -94,6 +112,10 @@ function _buildFileHeaders(certificationResults) {
     pixPlusDroitMaitreHeader,
     pixPlusDroitExpertHeader,
     cleaHeader,
+    pixPlusEduAutonomeHeader,
+    pixPlusEduAvanceHeader,
+    pixPlusEduExpertHeader,
+    pixPlusEduFormateurHeader,
     [_headers.PIX_SCORE],
     _competenceIndexes,
     [
@@ -117,6 +139,10 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
     [_headers.CLEA_STATUS]: _formatCleaCertificationResult(certificationResult),
     [_headers.PIX_PLUS_DROIT_MAITRE_STATUS]: _formatPixPlusDroitMaitreCertificationResult(certificationResult),
     [_headers.PIX_PLUS_DROIT_EXPERT_STATUS]: _formatPixPlusDroitExpertCertificationResult(certificationResult),
+    [_headers.PIX_PLUS_EDU_AUTONOME_HEADER]: _formatPixPlusEduAutonomeCertificationResult(certificationResult),
+    [_headers.PIX_PLUS_EDU_AVANCE_HEADER]: _formatPixPlusEduAvanceCertificationResult(certificationResult),
+    [_headers.PIX_PLUS_EDU_EXPERT_HEADER]: _formatPixPlusEduExpertCertificationResult(certificationResult),
+    [_headers.PIX_PLUS_EDU_FORMATEUR_HEADER]: _formatPixPlusEduFormateurCertificationResult(certificationResult),
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
     [_headers.JURY_COMMENT_FOR_ORGANIZATION]: certificationResult.commentForOrganization,
     [_headers.SESSION_ID]: session.id,
@@ -144,6 +170,27 @@ function _formatPixPlusDroitExpertCertificationResult(certificationResult) {
   if (!certificationResult.hasTakenPixPlusDroitExpert()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
   return certificationResult.hasAcquiredPixPlusDroitExpert() ? 'Validée' : 'Rejetée';
+}
+
+function _formatPixPlusEduAutonomeCertificationResult(certificationResult) {
+  if (!certificationResult.hasTakenPixPlusEduAutonome()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
+  return certificationResult.hasAcquiredPixPlusEduAutonome() ? 'Validée' : 'Rejetée';
+}
+function _formatPixPlusEduAvanceCertificationResult(certificationResult) {
+  if (!certificationResult.hasTakenPixPlusEduAvance()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
+  return certificationResult.hasAcquiredPixPlusEduAvance() ? 'Validée' : 'Rejetée';
+}
+function _formatPixPlusEduExpertCertificationResult(certificationResult) {
+  if (!certificationResult.hasTakenPixPlusEduExpert()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
+  return certificationResult.hasAcquiredPixPlusEduExpert() ? 'Validée' : 'Rejetée';
+}
+function _formatPixPlusEduFormateurCertificationResult(certificationResult) {
+  if (!certificationResult.hasTakenPixPlusEduFormateur()) return 'Non passée';
+  if (certificationResult.isCancelled()) return 'Annulée';
+  return certificationResult.hasAcquiredPixPlusEduFormateur() ? 'Validée' : 'Rejetée';
 }
 
 function _formatPixScore(certificationResult) {
@@ -232,6 +279,10 @@ const _headers = {
   CLEA_STATUS: 'Certification CléA numérique',
   PIX_PLUS_DROIT_MAITRE_STATUS: 'Certification Pix+ Droit Maître',
   PIX_PLUS_DROIT_EXPERT_STATUS: 'Certification Pix+ Droit Expert',
+  PIX_PLUS_EDU_AUTONOME_HEADER: 'Certification Pix+ Édu Autonome',
+  PIX_PLUS_EDU_AVANCE_HEADER: 'Certification Pix+ Édu Avancé',
+  PIX_PLUS_EDU_EXPERT_HEADER: 'Certification Pix+ Édu Expert',
+  PIX_PLUS_EDU_FORMATEUR_HEADER: 'Certification Pix+ Édu Formateur',
   PIX_SCORE: 'Nombre de Pix',
   SESSION_ID: 'Session',
   CERTIFICATION_CENTER: 'Centre de certification',

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -8,12 +8,10 @@ const {
 } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const CertificationAttestation = require('../../../../lib/domain/models/CertificationAttestation');
-const {
-  badgeKeyV1: cleaBadgeKeyV1,
-  badgeKeyV2: cleaBadgeKeyV2,
-} = require('../../../../lib/domain/models/CleaCertificationResult');
 const _ = require('lodash');
 const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
   PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
@@ -315,8 +313,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
     context('acquired certifiable badges', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
-        cleaBadgeKeyV1,
-        cleaBadgeKeyV2,
+        PIX_EMPLOI_CLEA,
+        PIX_EMPLOI_CLEA_V2,
         PIX_DROIT_EXPERT_CERTIF,
         PIX_DROIT_MAITRE_CERTIF,
         PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
@@ -397,7 +395,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
-      await _buildCleaResult({ certificationCourseId: 123, acquired: false, cleaBadgeKey: cleaBadgeKeyV1 });
+      await _buildCleaResult({ certificationCourseId: 123, acquired: false, cleaBadgeKey: PIX_EMPLOI_CLEA });
       await _buildPixPlusDroitMaitreResult({ certificationCourseId: 123, acquired: true });
 
       // when

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -17,9 +17,7 @@ const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-const {
+  PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -321,7 +319,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       [
         cleaBadgeKeyV1,
         cleaBadgeKeyV2,
-        pixPlusDroitExpertBadgeKey,
+        PIX_DROIT_EXPERT_CERTIF,
         pixPlusDroitMaitreBadgeKey,
         PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
         PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -14,9 +14,7 @@ const {
 } = require('../../../../lib/domain/models/CleaCertificationResult');
 const _ = require('lodash');
 const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
+  PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
@@ -320,7 +318,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         cleaBadgeKeyV1,
         cleaBadgeKeyV2,
         PIX_DROIT_EXPERT_CERTIF,
-        pixPlusDroitMaitreBadgeKey,
+        PIX_DROIT_MAITRE_CERTIF,
         PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
         PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
         PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -395,7 +393,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [pixPlusDroitMaitreBadgeKey],
+        acquiredPartnerCertificationKeys: [PIX_DROIT_MAITRE_CERTIF],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
@@ -1114,11 +1112,11 @@ async function _buildCleaResult({ certificationCourseId, acquired, cleaBadgeKey 
 }
 
 async function _buildPixPlusDroitMaitreResult({ certificationCourseId, acquired }) {
-  databaseBuilder.factory.buildBadge({ key: pixPlusDroitMaitreBadgeKey });
+  databaseBuilder.factory.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });
   databaseBuilder.factory.buildBadge({ key: 'some-other-badge-m' });
   databaseBuilder.factory.buildPartnerCertification({
     certificationCourseId,
-    partnerKey: pixPlusDroitMaitreBadgeKey,
+    partnerKey: PIX_DROIT_MAITRE_CERTIF,
     acquired,
   });
   databaseBuilder.factory.buildPartnerCertification({

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -5,10 +5,7 @@ const {
   badgeKeyV1: cleaBadgeKeyV1,
   badgeKeyV2: cleaBadgeKeyV2,
 } = require('../../../../lib/domain/models/CleaCertificationResult');
-const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Certification Result', function () {
   describe('#findBySessionId', function () {
@@ -203,7 +200,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
       { complementaryCertificationName: 'CléA V2', badgeKey: cleaBadgeKeyV2, validationFunction: 'hasAcquiredClea' },
       {
         complementaryCertificationName: 'PixPlus Droit Maître',
-        badgeKey: pixPlusDroitMaitreBadgeKey,
+        badgeKey: PIX_DROIT_MAITRE_CERTIF,
         validationFunction: 'hasAcquiredPixPlusDroitMaitre',
       },
       {
@@ -457,7 +454,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
       { complementaryCertificationName: 'CléA V2', badgeKey: cleaBadgeKeyV2, validationFunction: 'hasAcquiredClea' },
       {
         complementaryCertificationName: 'PixPlus Droit Maître',
-        badgeKey: pixPlusDroitMaitreBadgeKey,
+        badgeKey: PIX_DROIT_MAITRE_CERTIF,
         validationFunction: 'hasAcquiredPixPlusDroitMaitre',
       },
       {

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -1,11 +1,8 @@
 const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const certificationResultRepository = require('../../../../lib/infrastructure/repositories/certification-result-repository');
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
-const {
-  badgeKeyV1: cleaBadgeKeyV1,
-  badgeKeyV2: cleaBadgeKeyV2,
-} = require('../../../../lib/domain/models/CleaCertificationResult');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Certification Result', function () {
   describe('#findBySessionId', function () {
@@ -196,8 +193,12 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { complementaryCertificationName: 'CléA V1', badgeKey: cleaBadgeKeyV1, validationFunction: 'hasAcquiredClea' },
-      { complementaryCertificationName: 'CléA V2', badgeKey: cleaBadgeKeyV2, validationFunction: 'hasAcquiredClea' },
+      { complementaryCertificationName: 'CléA V1', badgeKey: PIX_EMPLOI_CLEA, validationFunction: 'hasAcquiredClea' },
+      {
+        complementaryCertificationName: 'CléA V2',
+        badgeKey: PIX_EMPLOI_CLEA_V2,
+        validationFunction: 'hasAcquiredClea',
+      },
       {
         complementaryCertificationName: 'PixPlus Droit Maître',
         badgeKey: PIX_DROIT_MAITRE_CERTIF,
@@ -450,8 +451,12 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      { complementaryCertificationName: 'CléA V1', badgeKey: cleaBadgeKeyV1, validationFunction: 'hasAcquiredClea' },
-      { complementaryCertificationName: 'CléA V2', badgeKey: cleaBadgeKeyV2, validationFunction: 'hasAcquiredClea' },
+      { complementaryCertificationName: 'CléA V1', badgeKey: PIX_EMPLOI_CLEA, validationFunction: 'hasAcquiredClea' },
+      {
+        complementaryCertificationName: 'CléA V2',
+        badgeKey: PIX_EMPLOI_CLEA_V2,
+        validationFunction: 'hasAcquiredClea',
+      },
       {
         complementaryCertificationName: 'PixPlus Droit Maître',
         badgeKey: PIX_DROIT_MAITRE_CERTIF,

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -1,8 +1,17 @@
 const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const certificationResultRepository = require('../../../../lib/infrastructure/repositories/certification-result-repository');
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Certification Result', function () {
   describe('#findBySessionId', function () {
@@ -202,6 +211,31 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         complementaryCertificationName: 'PixPlus Droit Expert',
         badgeKey: PIX_DROIT_EXPERT_CERTIF,
         validationFunction: 'hasAcquiredPixPlusDroitExpert',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Autonome',
+        badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+        validationFunction: 'hasAcquiredPixPlusEduAutonome',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Avancé',
+        badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+        validationFunction: 'hasAcquiredPixPlusEduAvance',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Avancé',
+        badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        validationFunction: 'hasAcquiredPixPlusEduAvance',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Expert',
+        badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        validationFunction: 'hasAcquiredPixPlusEduExpert',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Formateur',
+        badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+        validationFunction: 'hasAcquiredPixPlusEduFormateur',
       },
     ].forEach(function (testCase) {
       it(`should get the ${testCase.complementaryCertificationName} result if this complementary certification was taken`, async function () {
@@ -454,6 +488,31 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         complementaryCertificationName: 'PixPlus Droit Expert',
         badgeKey: PIX_DROIT_EXPERT_CERTIF,
         validationFunction: 'hasAcquiredPixPlusDroitExpert',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Autonome',
+        badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+        validationFunction: 'hasAcquiredPixPlusEduAutonome',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Avancé',
+        badgeKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+        validationFunction: 'hasAcquiredPixPlusEduAvance',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Avancé',
+        badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        validationFunction: 'hasAcquiredPixPlusEduAvance',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Expert',
+        badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        validationFunction: 'hasAcquiredPixPlusEduExpert',
+      },
+      {
+        complementaryCertificationName: 'PixPlus Édu Formateur',
+        badgeKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+        validationFunction: 'hasAcquiredPixPlusEduFormateur',
       },
     ].forEach(function (testCase) {
       it(`should get the ${testCase.complementaryCertificationName} result if this complementary certification was taken`, async function () {

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -91,13 +91,11 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         externalId: 'RIPPER',
         createdAt: new Date('2021-06-06'),
         sessionId,
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         status: CertificationResult.status.REJECTED,
         pixScore: 0,
         commentForOrganization: 'Un commentaire orga 2',
         competencesWithMark: [],
+        partnerCertifications: [],
       });
       const expectedSecondCertificationResult = domainBuilder.buildCertificationResult({
         id: certificationCourseId3,
@@ -108,13 +106,11 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         externalId: 'WITCH',
         createdAt: new Date('2020-10-10'),
         sessionId,
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         status: CertificationResult.status.CANCELLED,
         pixScore: null,
         commentForOrganization: null,
         competencesWithMark: [],
+        partnerCertifications: [],
       });
       const expectedThirdCertificationResult = domainBuilder.buildCertificationResult({
         id: certificationCourseId1,
@@ -125,9 +121,6 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         externalId: 'VAMPIRES_SUCK',
         createdAt: new Date('2020-01-01'),
         sessionId,
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         status: CertificationResult.status.VALIDATED,
         pixScore: 123,
         commentForOrganization: 'Un commentaire orga 1',
@@ -142,6 +135,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
             assessmentResultId: assessmentResultId1,
           }),
         ],
+        partnerCertifications: [],
       });
       expect(certificationResults).to.deepEqualArray([
         expectedFirstCertificationResult,
@@ -344,13 +338,11 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         externalId: 'RIPPER',
         createdAt: new Date('2021-06-06'),
         sessionId,
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         status: CertificationResult.status.REJECTED,
         pixScore: 0,
         commentForOrganization: 'Un commentaire orga 2',
         competencesWithMark: [],
+        partnerCertifications: [],
       });
       const expectedSecondCertificationResult = domainBuilder.buildCertificationResult({
         id: certificationCourseId3,
@@ -361,13 +353,11 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         externalId: 'WITCH',
         createdAt: new Date('2020-10-10'),
         sessionId,
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         status: CertificationResult.status.CANCELLED,
         pixScore: null,
         commentForOrganization: null,
         competencesWithMark: [],
+        partnerCertifications: [],
       });
       const expectedThirdCertificationResult = domainBuilder.buildCertificationResult({
         id: certificationCourseId1,
@@ -378,9 +368,6 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         externalId: 'VAMPIRES_SUCK',
         createdAt: new Date('2020-01-01'),
         sessionId,
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         status: CertificationResult.status.VALIDATED,
         pixScore: 123,
         commentForOrganization: 'Un commentaire orga 1',
@@ -395,6 +382,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
             assessmentResultId: assessmentResultId1,
           }),
         ],
+        partnerCertifications: [],
       });
       expect(certificationResults).to.deepEqualArray([
         expectedFirstCertificationResult,

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -8,9 +8,7 @@ const {
 const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Certification Result', function () {
   describe('#findBySessionId', function () {
@@ -210,7 +208,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
       },
       {
         complementaryCertificationName: 'PixPlus Droit Expert',
-        badgeKey: pixPlusDroitExpertBadgeKey,
+        badgeKey: PIX_DROIT_EXPERT_CERTIF,
         validationFunction: 'hasAcquiredPixPlusDroitExpert',
       },
     ].forEach(function (testCase) {
@@ -464,7 +462,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
       },
       {
         complementaryCertificationName: 'PixPlus Droit Expert',
-        badgeKey: pixPlusDroitExpertBadgeKey,
+        badgeKey: PIX_DROIT_EXPERT_CERTIF,
         validationFunction: 'hasAcquiredPixPlusDroitExpert',
       },
     ].forEach(function (testCase) {

--- a/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certification-result-repository_test.js
@@ -1,6 +1,7 @@
 const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const cleaCertificationResultRepository = require('../../../../lib/infrastructure/repositories/clea-certification-result-repository');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2 } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repositories | clea-certification-result-repository', function () {
   describe('#get', function () {
@@ -24,11 +25,11 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
       context('V1', function () {
         it('should return a acquired result', async function () {
           // given
-          databaseBuilder.factory.buildBadge({ key: CleaCertificationResult.badgeKeyV1 });
+          databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
           databaseBuilder.factory.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: CleaCertificationResult.badgeKeyV1,
+            partnerKey: PIX_EMPLOI_CLEA,
             acquired: true,
           });
           await databaseBuilder.commit();
@@ -45,11 +46,11 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
         context('when there is a rejected clea certification result for a given certification id', function () {
           it('should return a rejected result', async function () {
             // given
-            databaseBuilder.factory.buildBadge({ key: CleaCertificationResult.badgeKeyV1 });
+            databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA });
             const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
             databaseBuilder.factory.buildPartnerCertification({
               certificationCourseId,
-              partnerKey: CleaCertificationResult.badgeKeyV1,
+              partnerKey: PIX_EMPLOI_CLEA,
               acquired: false,
             });
             await databaseBuilder.commit();
@@ -68,11 +69,11 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
       context('V2', function () {
         it('should return a acquired result', async function () {
           // given
-          databaseBuilder.factory.buildBadge({ key: CleaCertificationResult.badgeKeyV2 });
+          databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA_V2 });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
           databaseBuilder.factory.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: CleaCertificationResult.badgeKeyV2,
+            partnerKey: PIX_EMPLOI_CLEA_V2,
             acquired: true,
           });
           await databaseBuilder.commit();
@@ -89,11 +90,11 @@ describe('Integration | Infrastructure | Repositories | clea-certification-resul
         context('when there is a rejected clea certification result for a given certification id', function () {
           it('should return a rejected result', async function () {
             // given
-            databaseBuilder.factory.buildBadge({ key: CleaCertificationResult.badgeKeyV2 });
+            databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA_V2 });
             const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
             databaseBuilder.factory.buildPartnerCertification({
               certificationCourseId,
-              partnerKey: CleaCertificationResult.badgeKeyV2,
+              partnerKey: PIX_EMPLOI_CLEA_V2,
               acquired: false,
             });
             await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -5,10 +5,7 @@ const {
   badgeKeyV1: cleaBadgeKeyV1,
   badgeKeyV2: cleaBadgeKeyV2,
 } = require('../../../../lib/domain/models/CleaCertificationResult');
-const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Jury Certification', function () {
   describe('#get', function () {
@@ -169,7 +166,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       },
       {
         complementaryCertificationName: 'PixPlus Droit Maître',
-        badgeKey: pixPlusDroitMaitreBadgeKey,
+        badgeKey: PIX_DROIT_MAITRE_CERTIF,
         complementaryCertificationResult: 'pixPlusDroitMaitreCertificationResult',
       },
       {

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -8,9 +8,7 @@ const {
 const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Jury Certification', function () {
   describe('#get', function () {
@@ -176,7 +174,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       },
       {
         complementaryCertificationName: 'PixPlus Droit Expert',
-        badgeKey: pixPlusDroitExpertBadgeKey,
+        badgeKey: PIX_DROIT_EXPERT_CERTIF,
         complementaryCertificationResult: 'pixPlusDroitExpertCertificationResult',
       },
     ].forEach(function (testCase) {

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -1,11 +1,8 @@
 const { expect, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const juryCertificationRepository = require('../../../../lib/infrastructure/repositories/jury-certification-repository');
-const {
-  badgeKeyV1: cleaBadgeKeyV1,
-  badgeKeyV2: cleaBadgeKeyV2,
-} = require('../../../../lib/domain/models/CleaCertificationResult');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Jury Certification', function () {
   describe('#get', function () {
@@ -156,12 +153,12 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
     [
       {
         complementaryCertificationName: 'CléA V1',
-        badgeKey: cleaBadgeKeyV1,
+        badgeKey: PIX_EMPLOI_CLEA,
         complementaryCertificationResult: 'cleaCertificationResult',
       },
       {
         complementaryCertificationName: 'CléA V2',
-        badgeKey: cleaBadgeKeyV2,
+        badgeKey: PIX_EMPLOI_CLEA_V2,
         complementaryCertificationResult: 'cleaCertificationResult',
       },
       {

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -3,13 +3,13 @@ const JuryCertificationSummary = require('../../../../lib/domain/read-models/Jur
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
 const PixPlusDroitMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const PixPlusDroitExpertCertificationResult = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
 const {
   CertificationIssueReportCategories,
 } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 const juryCertificationSummaryRepository = require('../../../../lib/infrastructure/repositories/jury-certification-summary-repository');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Repository | JuryCertificationSummary', function () {
   describe('#findBySessionId', function () {
@@ -435,10 +435,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
         const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-        dbf.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        dbf.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: PixPlusDroitExpertCertificationResult.badgeKey,
+          partnerKey: PIX_DROIT_EXPERT_CERTIF,
           acquired: true,
         });
         await databaseBuilder.commit();
@@ -459,10 +459,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
         const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-        dbf.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        dbf.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: PixPlusDroitExpertCertificationResult.badgeKey,
+          partnerKey: PIX_DROIT_EXPERT_CERTIF,
           acquired: false,
         });
         await databaseBuilder.commit();
@@ -517,10 +517,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
           acquired: false,
         });
-        dbf.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+        dbf.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: PixPlusDroitExpertCertificationResult.badgeKey,
+          partnerKey: PIX_DROIT_EXPERT_CERTIF,
           acquired: true,
         });
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -2,14 +2,13 @@ const { databaseBuilder, expect, domainBuilder } = require('../../../test-helper
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
-const PixPlusDroitMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
   CertificationIssueReportCategories,
 } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 const juryCertificationSummaryRepository = require('../../../../lib/infrastructure/repositories/jury-certification-summary-repository');
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Repository | JuryCertificationSummary', function () {
   describe('#findBySessionId', function () {
@@ -365,10 +364,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
         const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-        dbf.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        dbf.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
+          partnerKey: PIX_DROIT_MAITRE_CERTIF,
           acquired: true,
         });
         await databaseBuilder.commit();
@@ -389,10 +388,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
         const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-        dbf.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        dbf.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
+          partnerKey: PIX_DROIT_MAITRE_CERTIF,
           acquired: false,
         });
         await databaseBuilder.commit();
@@ -511,10 +510,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           partnerKey: CleaCertificationResult.badgeKeyV1,
           acquired: true,
         });
-        dbf.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+        dbf.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
+          partnerKey: PIX_DROIT_MAITRE_CERTIF,
           acquired: false,
         });
         dbf.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -1,14 +1,14 @@
 const { databaseBuilder, expect, domainBuilder } = require('../../../test-helper');
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
-const CleaCertificationResult = require('../../../../lib/domain/models/CleaCertificationResult');
 const {
   CertificationIssueReportCategories,
 } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 const juryCertificationSummaryRepository = require('../../../../lib/infrastructure/repositories/jury-certification-summary-repository');
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Repository | JuryCertificationSummary', function () {
   describe('#findBySessionId', function () {
@@ -253,10 +253,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           const dbf = databaseBuilder.factory;
           const sessionId = dbf.buildSession().id;
           const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-          dbf.buildBadge({ key: CleaCertificationResult.badgeKeyV1 });
+          dbf.buildBadge({ key: PIX_EMPLOI_CLEA });
           dbf.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: CleaCertificationResult.badgeKeyV1,
+            partnerKey: PIX_EMPLOI_CLEA,
             acquired: true,
           });
           await databaseBuilder.commit();
@@ -275,10 +275,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           const dbf = databaseBuilder.factory;
           const sessionId = dbf.buildSession().id;
           const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-          dbf.buildBadge({ key: CleaCertificationResult.badgeKeyV1 });
+          dbf.buildBadge({ key: PIX_EMPLOI_CLEA });
           dbf.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: CleaCertificationResult.badgeKeyV1,
+            partnerKey: PIX_EMPLOI_CLEA,
             acquired: false,
           });
           await databaseBuilder.commit();
@@ -299,10 +299,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           const dbf = databaseBuilder.factory;
           const sessionId = dbf.buildSession().id;
           const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-          dbf.buildBadge({ key: CleaCertificationResult.badgeKeyV2 });
+          dbf.buildBadge({ key: PIX_EMPLOI_CLEA_V2 });
           dbf.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: CleaCertificationResult.badgeKeyV2,
+            partnerKey: PIX_EMPLOI_CLEA_V2,
             acquired: true,
           });
           await databaseBuilder.commit();
@@ -321,10 +321,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           const dbf = databaseBuilder.factory;
           const sessionId = dbf.buildSession().id;
           const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-          dbf.buildBadge({ key: CleaCertificationResult.badgeKeyV2 });
+          dbf.buildBadge({ key: PIX_EMPLOI_CLEA_V2 });
           dbf.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: CleaCertificationResult.badgeKeyV2,
+            partnerKey: PIX_EMPLOI_CLEA_V2,
             acquired: false,
           });
           await databaseBuilder.commit();
@@ -504,10 +504,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
         const certificationCourseId = dbf.buildCertificationCourse({ sessionId }).id;
-        dbf.buildBadge({ key: CleaCertificationResult.badgeKeyV1 });
+        dbf.buildBadge({ key: PIX_EMPLOI_CLEA });
         dbf.buildPartnerCertification({
           certificationCourseId,
-          partnerKey: CleaCertificationResult.badgeKeyV1,
+          partnerKey: PIX_EMPLOI_CLEA,
           acquired: true,
         });
         dbf.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository_test.js
@@ -1,6 +1,6 @@
 const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const pixPlusDroitExpertCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-expert-certification-result-repository');
-const PixPlusDroitExpertCertificationResult = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-certification-result-repository', function () {
   describe('#get', function () {
@@ -26,11 +26,11 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-ce
       function () {
         it('should return a acquired result', async function () {
           // given
-          databaseBuilder.factory.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+          databaseBuilder.factory.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
           databaseBuilder.factory.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: PixPlusDroitExpertCertificationResult.badgeKey,
+            partnerKey: PIX_DROIT_EXPERT_CERTIF,
             acquired: true,
           });
           await databaseBuilder.commit();
@@ -53,11 +53,11 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-expert-ce
       function () {
         it('should return a rejected result', async function () {
           // given
-          databaseBuilder.factory.buildBadge({ key: PixPlusDroitExpertCertificationResult.badgeKey });
+          databaseBuilder.factory.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
           databaseBuilder.factory.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: PixPlusDroitExpertCertificationResult.badgeKey,
+            partnerKey: PIX_DROIT_EXPERT_CERTIF,
             acquired: false,
           });
           await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository_test.js
@@ -1,6 +1,6 @@
 const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const pixPlusDroitMaitreCertificationResultRepository = require('../../../../lib/infrastructure/repositories/pix-plus-droit-maitre-certification-result-repository');
-const PixPlusDroitMaitreCertificationResult = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+const { PIX_DROIT_MAITRE_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-certification-result-repository', function () {
   describe('#get', function () {
@@ -26,11 +26,11 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-ce
       function () {
         it('should return a acquired result', async function () {
           // given
-          databaseBuilder.factory.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+          databaseBuilder.factory.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
           databaseBuilder.factory.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
+            partnerKey: PIX_DROIT_MAITRE_CERTIF,
             acquired: true,
           });
           await databaseBuilder.commit();
@@ -53,11 +53,11 @@ describe('Integration | Infrastructure | Repositories | pix-plus-droit-maitre-ce
       function () {
         it('should return a rejected result', async function () {
           // given
-          databaseBuilder.factory.buildBadge({ key: PixPlusDroitMaitreCertificationResult.badgeKey });
+          databaseBuilder.factory.buildBadge({ key: PIX_DROIT_MAITRE_CERTIF });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
           databaseBuilder.factory.buildPartnerCertification({
             certificationCourseId,
-            partnerKey: PixPlusDroitMaitreCertificationResult.badgeKey,
+            partnerKey: PIX_DROIT_MAITRE_CERTIF,
             acquired: false,
           });
           await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -9,11 +9,8 @@ const {
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const privateCertificateRepository = require('../../../../lib/infrastructure/repositories/private-certificate-repository');
 const PrivateCertificate = require('../../../../lib/domain/models/PrivateCertificate');
-const {
-  badgeKeyV1: cleaBadgeKeyV1,
-  badgeKeyV2: cleaBadgeKeyV2,
-} = require('../../../../lib/domain/models/CleaCertificationResult');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../../../lib/domain/models/Badge').keys;
 const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | Private Certificate', function () {
@@ -301,10 +298,10 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         userId,
       }).id;
       databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId });
-      databaseBuilder.factory.buildBadge({ key: cleaBadgeKeyV1 });
+      databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA });
       databaseBuilder.factory.buildPartnerCertification({
         certificationCourseId: certificateId,
-        partnerKey: cleaBadgeKeyV1,
+        partnerKey: PIX_EMPLOI_CLEA,
         acquired: true,
       });
       await databaseBuilder.commit();
@@ -346,10 +343,10 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
       const { certificateId } = await _buildValidPrivateCertificate(privateCertificateData);
 
-      databaseBuilder.factory.buildBadge({ key: cleaBadgeKeyV2 });
+      databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA_V2 });
       databaseBuilder.factory.buildPartnerCertification({
         certificationCourseId: certificateId,
-        partnerKey: cleaBadgeKeyV2,
+        partnerKey: PIX_EMPLOI_CLEA_V2,
         acquired: true,
       });
       await databaseBuilder.commit();
@@ -667,10 +664,10 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         userId,
       }).id;
       databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId });
-      databaseBuilder.factory.buildBadge({ key: cleaBadgeKeyV1 });
+      databaseBuilder.factory.buildBadge({ key: PIX_EMPLOI_CLEA });
       databaseBuilder.factory.buildPartnerCertification({
         certificationCourseId: certificateId,
-        partnerKey: cleaBadgeKeyV1,
+        partnerKey: PIX_EMPLOI_CLEA,
         acquired: true,
       });
       await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -13,10 +13,7 @@ const {
   badgeKeyV1: cleaBadgeKeyV1,
   badgeKeyV2: cleaBadgeKeyV2,
 } = require('../../../../lib/domain/models/CleaCertificationResult');
-const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | Private Certificate', function () {
@@ -402,7 +399,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
           acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
-          notAcquiredBadges: [pixPlusDroitMaitreBadgeKey],
+          notAcquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
         });
 
         // when
@@ -450,7 +447,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
           acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
-          notAcquiredBadges: [pixPlusDroitMaitreBadgeKey],
+          notAcquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
         });
 
         // when

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -16,10 +16,7 @@ const {
 const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | Private Certificate', function () {
@@ -404,7 +401,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
-          acquiredBadges: [pixPlusDroitExpertBadgeKey],
+          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
           notAcquiredBadges: [pixPlusDroitMaitreBadgeKey],
         });
 
@@ -452,7 +449,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
-          acquiredBadges: [pixPlusDroitExpertBadgeKey],
+          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
           notAcquiredBadges: [pixPlusDroitMaitreBadgeKey],
         });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -8,11 +8,8 @@ const {
 } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const shareableCertificateRepository = require('../../../../lib/infrastructure/repositories/shareable-certificate-repository');
-const {
-  badgeKeyV1: cleaBadgeKeyV1,
-  badgeKeyV2: cleaBadgeKeyV2,
-} = require('../../../../lib/domain/models/CleaCertificationResult');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Shareable Certificate', function () {
   const minimalLearningContent = [
@@ -353,7 +350,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
       const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
         shareableCertificateData,
-        acquiredBadges: [cleaBadgeKeyV1],
+        acquiredBadges: [PIX_EMPLOI_CLEA],
         notAcquiredBadges: [],
       });
 
@@ -393,7 +390,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
       const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
         shareableCertificateData,
-        acquiredBadges: [cleaBadgeKeyV2],
+        acquiredBadges: [PIX_EMPLOI_CLEA_V2],
         notAcquiredBadges: [],
       });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -15,9 +15,7 @@ const {
 const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
+const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Shareable Certificate', function () {
   const minimalLearningContent = [
@@ -446,7 +444,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
         const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
           shareableCertificateData,
-          acquiredBadges: [pixPlusDroitExpertBadgeKey, pixPlusDroitMaitreBadgeKey],
+          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, pixPlusDroitMaitreBadgeKey],
           notAcquiredBadges: [],
         });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -12,10 +12,7 @@ const {
   badgeKeyV1: cleaBadgeKeyV1,
   badgeKeyV2: cleaBadgeKeyV2,
 } = require('../../../../lib/domain/models/CleaCertificationResult');
-const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const { PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Shareable Certificate', function () {
   const minimalLearningContent = [
@@ -444,7 +441,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
         const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
           shareableCertificateData,
-          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, pixPlusDroitMaitreBadgeKey],
+          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF],
           notAcquiredBadges: [],
         });
 
@@ -490,7 +487,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
         const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
           shareableCertificateData,
-          acquiredBadges: [pixPlusDroitExpertBadgeKey],
+          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
           notAcquiredBadges: [],
         });
 

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -3,8 +3,15 @@ const {
   getSessionCertificationResultsCsv,
   getDivisionCertificationResultsCsv,
 } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
-const { PIX_EMPLOI_CLEA, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', function () {
   context('#getSessionCertificationResultsCsv', function () {
@@ -137,225 +144,87 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
       });
     });
 
-    context('when at least one candidate has passed CleA certification', function () {
-      it('should return correct csvContent with the CleA information', async function () {
-        // given
-        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
-        const competencesWithMark = [
-          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
-          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
-        ];
-        const certifResult = domainBuilder.buildCertificationResult.validated({
-          id: 123,
-          lastName: 'Oxford',
-          firstName: 'Lili',
-          birthdate: '1990-01-04',
-          birthplace: 'Torreilles',
-          externalId: 'LOLORD',
-          createdAt: new Date('2020-01-01'),
-          pixScore: 55,
-          commentForOrganization: 'RAS',
-          competencesWithMark: competencesWithMark,
-          partnerCertifications: [
-            domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
-          ],
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      { partnerKey: PIX_EMPLOI_CLEA, expectedHeader: 'Certification CléA numérique' },
+      { partnerKey: PIX_DROIT_MAITRE_CERTIF, expectedHeader: 'Certification Pix+ Droit Maître' },
+      { partnerKey: PIX_DROIT_EXPERT_CERTIF, expectedHeader: 'Certification Pix+ Droit Expert' },
+      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME, expectedHeader: 'Certification Pix+ Édu Autonome' },
+      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, expectedHeader: 'Certification Pix+ Édu Avancé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, expectedHeader: 'Certification Pix+ Édu Expert' },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+        expectedHeader: 'Certification Pix+ Édu Formateur',
+      },
+    ].forEach(({ partnerKey, expectedHeader }) => {
+      context(`when at least one candidate has passed ${partnerKey} certification`, function () {
+        it(`should return correct csvContent with the ${partnerKey} information`, async function () {
+          // given
+          const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
+          const competencesWithMark = [
+            domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
+            domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
+          ];
+          const certifResult = domainBuilder.buildCertificationResult.validated({
+            id: 123,
+            lastName: 'Oxford',
+            firstName: 'Lili',
+            birthdate: '1990-01-04',
+            birthplace: 'Torreilles',
+            externalId: 'LOLORD',
+            createdAt: new Date('2020-01-01'),
+            pixScore: 55,
+            commentForOrganization: 'RAS',
+            competencesWithMark: competencesWithMark,
+            partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey, acquired: true })],
+          });
+
+          const certificationResults = [certifResult];
+
+          // when
+          const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+          // then
+          const expectedResult =
+            '\uFEFF' +
+            `"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"${expectedHeader}";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n` +
+            '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Validée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
+          expect(result).to.equal(expectedResult);
         });
 
-        const certificationResults = [certifResult];
+        it(`should return a cancelled ${partnerKey} certification when certification pix is cancelled`, async function () {
+          // given
+          const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
+          const competencesWithMark = [
+            domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
+            domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
+          ];
+          const certifResult = domainBuilder.buildCertificationResult.cancelled({
+            id: 123,
+            lastName: 'Oxford',
+            firstName: 'Lili',
+            birthdate: '1990-01-04',
+            birthplace: 'Torreilles',
+            externalId: 'LOLORD',
+            createdAt: new Date('2020-01-01'),
+            pixScore: 55,
+            commentForOrganization: 'RAS',
+            competencesWithMark: competencesWithMark,
+            partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey, acquired: true })],
+          });
 
-        // when
-        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+          const certificationResults = [certifResult];
 
-        // then
-        const expectedResult =
-          '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Validée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
-        expect(result).to.equal(expectedResult);
-      });
+          // when
+          const result = await getSessionCertificationResultsCsv({ session, certificationResults });
 
-      it('should return a cancelled clea certification when certification pix is cancelled', async function () {
-        // given
-        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
-        const competencesWithMark = [
-          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
-          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
-        ];
-        const certifResult = domainBuilder.buildCertificationResult.cancelled({
-          id: 123,
-          lastName: 'Oxford',
-          firstName: 'Lili',
-          birthdate: '1990-01-04',
-          birthplace: 'Torreilles',
-          externalId: 'LOLORD',
-          createdAt: new Date('2020-01-01'),
-          pixScore: 55,
-          commentForOrganization: 'RAS',
-          competencesWithMark: competencesWithMark,
-          partnerCertifications: [
-            domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
-          ],
+          // then
+          const expectedResult =
+            '\uFEFF' +
+            `"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"${expectedHeader}";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n` +
+            '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
+          expect(result).to.equal(expectedResult);
         });
-
-        const certificationResults = [certifResult];
-
-        // when
-        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
-
-        // then
-        const expectedResult =
-          '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
-        expect(result).to.equal(expectedResult);
-      });
-    });
-
-    context('when at least one candidate has passed Pix plus maitre certification', function () {
-      it('should return correct csvContent with the Pix plus maitre information', async function () {
-        // given
-        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
-        const competencesWithMark = [
-          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
-          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
-        ];
-        const certifResult = domainBuilder.buildCertificationResult.validated({
-          id: 123,
-          lastName: 'Oxford',
-          firstName: 'Lili',
-          birthdate: '1990-01-04',
-          birthplace: 'Torreilles',
-          externalId: 'LOLORD',
-          createdAt: new Date('2020-01-01'),
-          pixScore: 55,
-          commentForOrganization: 'RAS',
-          competencesWithMark: competencesWithMark,
-          partnerCertifications: [
-            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
-          ],
-        });
-
-        const certificationResults = [certifResult];
-
-        // when
-        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
-
-        // then
-        const expectedResult =
-          '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
-        expect(result).to.equal(expectedResult);
-      });
-
-      it('should return a cancelled Pix plus maitre certification when certification pix is cancelled', async function () {
-        // given
-        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
-        const competencesWithMark = [
-          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
-          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
-        ];
-        const certifResult = domainBuilder.buildCertificationResult.cancelled({
-          id: 123,
-          lastName: 'Oxford',
-          firstName: 'Lili',
-          birthdate: '1990-01-04',
-          birthplace: 'Torreilles',
-          externalId: 'LOLORD',
-          createdAt: new Date('2020-01-01'),
-          pixScore: 55,
-          commentForOrganization: 'RAS',
-          competencesWithMark: competencesWithMark,
-          partnerCertifications: [
-            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
-          ],
-        });
-
-        const certificationResults = [certifResult];
-
-        // when
-        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
-
-        // then
-        const expectedResult =
-          '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
-        expect(result).to.equal(expectedResult);
-      });
-    });
-
-    context('when at least one candidate has passed Pix plus expert certification', function () {
-      it('should return correct csvContent with the Pix plus expert information', async function () {
-        // given
-        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
-        const competencesWithMark = [
-          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
-          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
-        ];
-        const certifResult = domainBuilder.buildCertificationResult.validated({
-          id: 123,
-          lastName: 'Oxford',
-          firstName: 'Lili',
-          birthdate: '1990-01-04',
-          birthplace: 'Torreilles',
-          externalId: 'LOLORD',
-          createdAt: new Date('2020-01-01'),
-          pixScore: 55,
-          commentForOrganization: 'RAS',
-          competencesWithMark: competencesWithMark,
-          partnerCertifications: [
-            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
-          ],
-        });
-
-        const certificationResults = [certifResult];
-
-        // when
-        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
-
-        // then
-        const expectedResult =
-          '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Validée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
-        expect(result).to.equal(expectedResult);
-      });
-
-      it('should return a cancelled Pix plus expert certification when certification pix is cancelled', async function () {
-        // given
-        const session = domainBuilder.buildSession({ id: 777, certificationCenter: 'CentreCertif' });
-        const competencesWithMark = [
-          domainBuilder.buildCompetenceMark({ competence_code: '5.1', level: 3 }),
-          domainBuilder.buildCompetenceMark({ competence_code: '5.2', level: -1 }),
-        ];
-        const certifResult = domainBuilder.buildCertificationResult.cancelled({
-          id: 123,
-          lastName: 'Oxford',
-          firstName: 'Lili',
-          birthdate: '1990-01-04',
-          birthplace: 'Torreilles',
-          externalId: 'LOLORD',
-          createdAt: new Date('2020-01-01'),
-          pixScore: 55,
-          commentForOrganization: 'RAS',
-          competencesWithMark: competencesWithMark,
-          partnerCertifications: [
-            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
-          ],
-        });
-
-        const certificationResults = [certifResult];
-
-        // when
-        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
-
-        // then
-        const expectedResult =
-          '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Annulée";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"RAS";777;"CentreCertif";"01/01/2020"';
-        expect(result).to.equal(expectedResult);
       });
     });
 
@@ -382,6 +251,22 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
             domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
             domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
             domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
+            domainBuilder.buildPartnerCertification({
+              partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+              acquired: true,
+            }),
+            domainBuilder.buildPartnerCertification({
+              partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+              acquired: false,
+            }),
+            domainBuilder.buildPartnerCertification({
+              partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+              acquired: true,
+            }),
+            domainBuilder.buildPartnerCertification({
+              partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+              acquired: false,
+            }),
           ],
         });
 
@@ -393,8 +278,8 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         // then
         const expectedResult =
           '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";"Validée";"Validée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Certification Pix+ Édu Autonome";"Certification Pix+ Édu Avancé";"Certification Pix+ Édu Expert";"Certification Pix+ Édu Formateur";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";"Validée";"Validée";"Validée";"Rejetée";"Validée";"Rejetée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });
     });

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -3,6 +3,8 @@ const {
   getSessionCertificationResultsCsv,
   getDivisionCertificationResultsCsv,
 } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
+const { PIX_EMPLOI_CLEA, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', function () {
   context('#getSessionCertificationResultsCsv', function () {
@@ -33,9 +35,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark1,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [],
         });
         const certifResult2 = domainBuilder.buildCertificationResult.rejected({
           id: 456,
@@ -48,9 +48,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 66,
           commentForOrganization: null,
           competencesWithMark: competencesWithMark2,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
+          partnerCertifications: [],
         });
         const certificationResults = [certifResult1, certifResult2];
 
@@ -86,9 +84,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [],
         });
 
         const certificationResults = [certifResult];
@@ -124,9 +120,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [],
         });
 
         const certificationResults = [certifResult];
@@ -162,9 +156,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -198,9 +192,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -236,9 +230,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.rejected(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -272,9 +266,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.rejected(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -310,9 +304,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -346,9 +340,9 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -384,9 +378,11 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           pixScore: 55,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.rejected(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.acquired(),
+          partnerCertifications: [
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
+            domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
+          ],
         });
 
         const certificationResults = [certifResult];
@@ -432,9 +428,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark1,
           sessionId: 777,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [],
         });
         const certifResult2 = domainBuilder.buildCertificationResult.rejected({
           id: 456,
@@ -448,9 +442,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           sessionId: 777,
           commentForOrganization: null,
           competencesWithMark: competencesWithMark2,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
+          partnerCertifications: [],
         });
         const certificationResults = [certifResult1, certifResult2];
 
@@ -486,9 +478,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           sessionId: 777,
           commentForOrganization: 'RAS',
           competencesWithMark: competencesWithMark,
-          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitMaitreCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-          pixPlusDroitExpertCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          partnerCertifications: [],
         });
 
         const certificationResults = [certifResult];

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -1,6 +1,4 @@
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
-const buildCleaCertificationResult = require('./build-clea-certification-result');
-const buildPixPlusDroitCertificationResult = require('./build-pix-plus-droit-certification-result');
 
 const buildCertificationResult = function ({
   id = 123,
@@ -15,9 +13,7 @@ const buildCertificationResult = function ({
   pixScore = 0,
   commentForOrganization = 'comment organization',
   competencesWithMark = [],
-  cleaCertificationResult = buildCleaCertificationResult.notTaken(),
-  pixPlusDroitMaitreCertificationResult = buildPixPlusDroitCertificationResult.maitre.notTaken(),
-  pixPlusDroitExpertCertificationResult = buildPixPlusDroitCertificationResult.expert.notTaken(),
+  partnerCertifications = [],
 } = {}) {
   return new CertificationResult({
     id,
@@ -32,9 +28,7 @@ const buildCertificationResult = function ({
     pixScore,
     commentForOrganization,
     competencesWithMark,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
+    partnerCertifications,
   });
 };
 
@@ -50,9 +44,7 @@ buildCertificationResult.validated = function ({
   pixScore,
   commentForOrganization,
   competencesWithMark,
-  cleaCertificationResult,
-  pixPlusDroitMaitreCertificationResult,
-  pixPlusDroitExpertCertificationResult,
+  partnerCertifications,
 }) {
   return buildCertificationResult({
     id,
@@ -67,9 +59,7 @@ buildCertificationResult.validated = function ({
     pixScore,
     commentForOrganization,
     competencesWithMark,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
+    partnerCertifications,
   });
 };
 
@@ -85,9 +75,7 @@ buildCertificationResult.rejected = function ({
   pixScore,
   commentForOrganization,
   competencesWithMark,
-  cleaCertificationResult,
-  pixPlusDroitMaitreCertificationResult,
-  pixPlusDroitExpertCertificationResult,
+  partnerCertifications,
 }) {
   return buildCertificationResult({
     id,
@@ -102,9 +90,7 @@ buildCertificationResult.rejected = function ({
     pixScore,
     commentForOrganization,
     competencesWithMark,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
+    partnerCertifications,
   });
 };
 
@@ -120,9 +106,7 @@ buildCertificationResult.cancelled = function ({
   pixScore,
   commentForOrganization,
   competencesWithMark,
-  cleaCertificationResult,
-  pixPlusDroitMaitreCertificationResult,
-  pixPlusDroitExpertCertificationResult,
+  partnerCertifications,
 }) {
   return buildCertificationResult({
     id,
@@ -137,9 +121,7 @@ buildCertificationResult.cancelled = function ({
     pixScore,
     commentForOrganization,
     competencesWithMark,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
+    partnerCertifications,
   });
 };
 
@@ -155,9 +137,7 @@ buildCertificationResult.error = function ({
   pixScore,
   commentForOrganization,
   competencesWithMark,
-  cleaCertificationResult,
-  pixPlusDroitMaitreCertificationResult,
-  pixPlusDroitExpertCertificationResult,
+  partnerCertifications,
 }) {
   return buildCertificationResult({
     id,
@@ -172,9 +152,7 @@ buildCertificationResult.error = function ({
     pixScore,
     commentForOrganization,
     competencesWithMark,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
+    partnerCertifications,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-partner-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-partner-certification.js
@@ -1,0 +1,13 @@
+const PartnerCertification = require('./../../../../lib/domain/models/PartnerCertification');
+
+module.exports = function buildPartnerCertification({
+  certificationCourseId = 1,
+  partnerKey = 'PARTNER_KEY',
+  acquired = false,
+} = {}) {
+  return new PartnerCertification({
+    certificationCourseId,
+    partnerKey,
+    acquired,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -73,6 +73,7 @@ module.exports = {
   buildOrganization: require('./build-organization'),
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationTag: require('./build-organization-tag'),
+  buildPartnerCertification: require('./build-partner-certification'),
   buildPixPlusDroitCertificationResult: require('./build-pix-plus-droit-certification-result'),
   buildPixPlusCertificationScoring: require('./build-pix-plus-certification-scoring'),
   buildPixRole: require('./build-pix-role'),

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -1,7 +1,16 @@
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
 const { expect, domainBuilder } = require('../../../test-helper');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Models | CertificationResult', function () {
   context('#static from', function () {
@@ -389,6 +398,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     { method: 'hasAcquiredClea', partnerKeys: [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2] },
     { method: 'hasAcquiredPixPlusDroitMaitre', partnerKeys: [PIX_DROIT_MAITRE_CERTIF] },
     { method: 'hasAcquiredPixPlusDroitExpert', partnerKeys: [PIX_DROIT_EXPERT_CERTIF] },
+    { method: 'hasAcquiredPixPlusEduAutonome', partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME] },
+    {
+      method: 'hasAcquiredPixPlusEduAvance',
+      partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE],
+    },
+    { method: 'hasAcquiredPixPlusEduExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
+    { method: 'hasAcquiredPixPlusEduFormateur', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR] },
   ].forEach(({ method, partnerKeys }) => {
     context(`#${method}`, function () {
       // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -346,181 +346,78 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     });
   });
 
-  context('#hasTakenClea', function () {
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].forEach((partnerKey) => {
-      it(`returns true when ${partnerKey} certification has been taken in the certification`, async function () {
-        // given
-        const certificationResult = domainBuilder.buildCertificationResult({
-          partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey })],
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  [
+    { method: 'hasTakenClea', partnerKeys: [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2] },
+    { method: 'hasTakenPixPlusDroitMaitre', partnerKeys: [PIX_DROIT_MAITRE_CERTIF] },
+    { method: 'hasTakenPixPlusDroitExpert', partnerKeys: [PIX_DROIT_EXPERT_CERTIF] },
+  ].forEach(({ method, partnerKeys }) => {
+    context(`#${method}`, function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      partnerKeys.forEach((partnerKey) => {
+        it(`returns true when ${partnerKey} certification has been taken in the certification`, async function () {
+          // given
+          const certificationResult = domainBuilder.buildCertificationResult({
+            partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey })],
+          });
+
+          // when
+          const hasTaken = certificationResult[method]();
+
+          // then
+          expect(hasTaken).to.be.true;
         });
 
-        // when
-        const hasTakenClea = certificationResult.hasTakenClea();
+        it(`returns false when ${partnerKey} certification has not been taken in the certification`, async function () {
+          // given
+          const certificationResult = domainBuilder.buildCertificationResult({
+            partnerCertifications: [],
+          });
 
-        // then
-        expect(hasTakenClea).to.be.true;
+          // when
+          const hasTaken = certificationResult[method]();
+
+          // then
+          expect(hasTaken).to.be.false;
+        });
       });
-    });
-
-    it('returns false when Clea certification has not been taken in the certification', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [],
-      });
-
-      // when
-      const hasTakenClea = certificationResult.hasTakenClea();
-
-      // then
-      expect(hasTakenClea).to.be.false;
     });
   });
 
-  context('#hasAcquiredClea', function () {
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].forEach((partnerKey) => {
-      it(`returns true when ${partnerKey} certification has been acquired`, async function () {
-        // given
-        const certificationResult = domainBuilder.buildCertificationResult({
-          partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey, acquired: true })],
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  [
+    { method: 'hasAcquiredClea', partnerKeys: [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2] },
+    { method: 'hasAcquiredPixPlusDroitMaitre', partnerKeys: [PIX_DROIT_MAITRE_CERTIF] },
+    { method: 'hasAcquiredPixPlusDroitExpert', partnerKeys: [PIX_DROIT_EXPERT_CERTIF] },
+  ].forEach(({ method, partnerKeys }) => {
+    context(`#${method}`, function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      partnerKeys.forEach((partnerKey) => {
+        it(`returns true when ${partnerKey} certification has been acquired`, async function () {
+          // given
+          const certificationResult = domainBuilder.buildCertificationResult({
+            partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey, acquired: true })],
+          });
+
+          // when
+          const hasAcquired = certificationResult[method]();
+
+          // then
+          expect(hasAcquired).to.be.true;
         });
 
-        // when
-        const hasAcquiredClea = certificationResult.hasAcquiredClea();
+        it(`returns false when ${partnerKey} certification has not been acquired`, async function () {
+          // given
+          const certificationResult = domainBuilder.buildCertificationResult({
+            partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey, acquired: false })],
+          });
+          // when
+          const hasAcquired = certificationResult[method]();
 
-        // then
-        expect(hasAcquiredClea).to.be.true;
-      });
-
-      it(`returns false when ${partnerKey} certification has not been acquired`, async function () {
-        // given
-        const certificationResult = domainBuilder.buildCertificationResult({
-          partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey, acquired: false })],
+          // then
+          expect(hasAcquired).to.be.false;
         });
-        // when
-        const hasAcquiredClea = certificationResult.hasAcquiredClea();
-
-        // then
-        expect(hasAcquiredClea).to.be.false;
       });
-    });
-  });
-
-  context('#hasTakenPixPlusDroitMaitre', function () {
-    it('returns true when PIX_DROIT_MAITRE_CERTIF certification has been taken in the certification', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF })],
-      });
-      // when
-      const hasTakenPixPlusDroitMaitre = certificationResult.hasTakenPixPlusDroitMaitre();
-
-      // then
-      expect(hasTakenPixPlusDroitMaitre).to.be.true;
-    });
-
-    it('returns false when PIX_DROIT_MAITRE_CERTIF certification has not been taken in the certification', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [],
-      });
-
-      // when
-      const hasTakenPixPlusDroitMaitre = certificationResult.hasTakenPixPlusDroitMaitre();
-
-      // then
-      expect(hasTakenPixPlusDroitMaitre).to.be.false;
-    });
-  });
-
-  context('#hasAcquiredPixPlusDroitMaitre', function () {
-    it('returns true when PIX_DROIT_MAITRE_CERTIF certification has been acquired', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [
-          domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: true }),
-        ],
-      });
-
-      // when
-      const hasAcquiredPixPlusDroitMaitre = certificationResult.hasAcquiredPixPlusDroitMaitre();
-
-      // then
-      expect(hasAcquiredPixPlusDroitMaitre).to.be.true;
-    });
-
-    it('returns false when PIX_DROIT_MAITRE_CERTIF certification has not been acquired', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [
-          domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: false }),
-        ],
-      });
-      // when
-      const hasAcquiredPixPlusDroitMaitre = certificationResult.hasAcquiredPixPlusDroitMaitre();
-
-      // then
-      expect(hasAcquiredPixPlusDroitMaitre).to.be.false;
-    });
-  });
-
-  context('#hasTakenPixPlusDroitExpert', function () {
-    it('returns true when PIX_DROIT_EXPERT_CERTIF certification has been taken in the certification', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF })],
-      });
-
-      // when
-      const hasTakenPixPlusDroitExpert = certificationResult.hasTakenPixPlusDroitExpert();
-
-      // then
-      expect(hasTakenPixPlusDroitExpert).to.be.true;
-    });
-
-    it('returns false when PIX_DROIT_EXPERT_CERTIF certification has not been taken in the certification', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [],
-      });
-      // when
-      const hasTakenPixPlusDroitExpert = certificationResult.hasTakenPixPlusDroitExpert();
-
-      // then
-      expect(hasTakenPixPlusDroitExpert).to.be.false;
-    });
-  });
-
-  context('#hasAcquiredPixPlusDroitExpert', function () {
-    it('returns true when PIX_DROIT_EXPERT_CERTIF certification has been acquired', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [
-          domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: true }),
-        ],
-      });
-
-      // when
-      const hasAcquiredPixPlusDroitExpert = certificationResult.hasAcquiredPixPlusDroitExpert();
-
-      // then
-      expect(hasAcquiredPixPlusDroitExpert).to.be.true;
-    });
-
-    it('returns false when PIX_DROIT_EXPERT_CERTIF certification has not been acquired', async function () {
-      // given
-      const certificationResult = domainBuilder.buildCertificationResult({
-        partnerCertifications: [
-          domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: false }),
-        ],
-      });
-
-      // when
-      const hasAcquiredPixPlusDroitExpert = certificationResult.hasAcquiredPixPlusDroitExpert();
-
-      // then
-      expect(hasAcquiredPixPlusDroitExpert).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -360,6 +360,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     { method: 'hasTakenClea', partnerKeys: [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2] },
     { method: 'hasTakenPixPlusDroitMaitre', partnerKeys: [PIX_DROIT_MAITRE_CERTIF] },
     { method: 'hasTakenPixPlusDroitExpert', partnerKeys: [PIX_DROIT_EXPERT_CERTIF] },
+    { method: 'hasTakenPixPlusEduAutonome', partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME] },
+    {
+      method: 'hasTakenPixPlusEduAvance',
+      partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE],
+    },
+    { method: 'hasTakenPixPlusEduExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
+    { method: 'hasTakenPixPlusEduFormateur', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR] },
   ].forEach(({ method, partnerKeys }) => {
     context(`#${method}`, function () {
       // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -4,9 +4,7 @@ const {
   badgeKey: pixPlusDroitMaitreBadgeKey,
 } = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
 const {
-  badgeKey: pixPlusDroitExpertBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
-const {
+  PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
@@ -19,7 +17,7 @@ const badgeInfos = {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
     isTemporaryBadge: false,
   },
-  [pixPlusDroitExpertBadgeKey]: {
+  [PIX_DROIT_EXPERT_CERTIF]: {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
     isTemporaryBadge: false,
   },

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -1,9 +1,7 @@
 const { expect } = require('../../../test-helper');
 const CertifiedBadgeImage = require('../../../../lib/domain/read-models/CertifiedBadgeImage');
 const {
-  badgeKey: pixPlusDroitMaitreBadgeKey,
-} = require('../../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const {
+  PIX_DROIT_MAITRE_CERTIF,
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
@@ -13,7 +11,7 @@ const {
 } = require('../../../../lib/domain/models/Badge').keys;
 
 const badgeInfos = {
-  [pixPlusDroitMaitreBadgeKey]: {
+  [PIX_DROIT_MAITRE_CERTIF]: {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
     isTemporaryBadge: false,
   },


### PR DESCRIPTION
## :christmas_tree: Problème
La certification Pix+ Edu va être rendue possible, nous avons déjà permis à un candidat ayant obtenu sa certification Pix+ Edu de visualiser son macaron depuis son certificat, son attestation et sur le certificat partagé, il s’agit maintenant de permettre au prescripteur de la certification d’avoir également cette information.

## :gift: Solution
- Ajouter le résultat des certifications Pix+ Édu dans le csv des résultats.

## :star2: Remarques
Plusieurs refacto ont été effectués dans cette PR, notamment le remplacement des constantes présentes dans des modèles de résultats par les constantes présentes dans le model Badge. 

## :santa: Pour tester
- Aller sur Pix Admin,
- Se rendre sur la session de certification 20000.
- Cliquer sur le bouton "Lien de téléchargement des résultats"
- Vérifier que le candidat "Certif Initiale" a bien validé la certification Pix+ Édu Avancé.
- Vérifier que le candidat "Certif Continue" a bien validé la certification Pix+ Édu Formateur.