### PR TITLE
[FEATURE] Afficher le message de certification terminée par le surveillant sur la page de fin de test (PIX-4110)

### DIFF
--- a/mon-pix/app/controllers/certifications/results.js
+++ b/mon-pix/app/controllers/certifications/results.js
@@ -3,4 +3,8 @@ import { inject as service } from '@ember/service';
 
 export default class CertificationResultsController extends Controller {
   @service featureToggles;
+
+  get isEndedBySupervisor() {
+    return this.model.assessment.get('state') === 'endedBySupervisor';
+  }
 }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -59,7 +59,7 @@ Router.map(function () {
     this.route('join', { path: '/' });
     this.route('start', { path: '/candidat/:certification_candidate_id' });
     this.route('resume', { path: '/:certification_course_id' });
-    this.route('results', { path: '/:certification_number/results' });
+    this.route('results', { path: '/:certification_id/results' });
   });
   this.route('shared-certification', { path: '/partage-certificat/:id' });
   this.route('user-certifications', { path: 'mes-certifications' }, function () {

--- a/mon-pix/app/routes/certifications/results.js
+++ b/mon-pix/app/routes/certifications/results.js
@@ -2,8 +2,9 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
-  model(params) {
-    // FIXME certification number is a domain attribute and should not be queried as a technical id
-    return params.certification_number;
+  async model(params) {
+    const certificationCourse = await this.store.findRecord('certification-course', params.certification_id);
+    await certificationCourse.assessment.reload();
+    return certificationCourse;
   }
 }

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,7 +1,10 @@
 {{page-title (t "pages.certification-results.title")}}
 
 {{#if this.featureToggles.featureToggles.isEndTestScreenRemovalEnabled}}
-  <Certifications::CertificationEnder @certificationNumber={{@model}} />
+  <Certifications::CertificationEnder
+    @certificationNumber={{@model.id}}
+    @isEndedBySupervisor={{this.isEndedBySupervisor}}
+  />
 {{else}}
-  <CertificationResultsPage @certificationNumber={{@model}} />
+  <CertificationResultsPage @certificationNumber={{@model.id}} />
 {{/if}}

--- a/mon-pix/app/templates/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/templates/components/certifications/certification-ender.hbs
@@ -15,6 +15,11 @@
         {{this.currentUser.user.fullName}}
       </div>
       <div class="certification-ender__candidate-title">{{t "pages.certification-ender.candidate.title"}}</div>
+      {{#if @isEndedBySupervisor}}
+        <div class="certification-ender__candidate-message">
+          {{t "pages.certification-ender.candidate.ended-by-supervisor"}}
+        </div>
+      {{/if}}
       <PixButtonLink @route="logout" @backgroundColor="blue" class="certification-ender__candidate-action-disconnect">
         {{t "pages.certification-ender.candidate.disconnect"}}
       </PixButtonLink>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -115,4 +115,6 @@ export default function () {
     const certificationCandidateId = request.params.id;
     return schema.certificationCandidateSubscriptions.find(certificationCandidateId);
   });
+
+  this.get('/certification-courses/:id');
 }

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -375,6 +375,30 @@ describe('Acceptance | Certification | Certification Course', function () {
           expect(contains('Test terminé !')).to.exist;
         });
       });
+
+      context('when test was ended by supervisor', function () {
+        it('should display "Votre surveillant a mis fin…"', async function () {
+          // given
+          server.create('feature-toggle', { id: 0, isEndTestScreenRemovalEnabled: true });
+          const user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
+          const certificationCourse = this.server.create('certification-course');
+          this.server.create('assessment', {
+            certificationCourseId: certificationCourse.id,
+            state: 'endedBySupervisor',
+          });
+
+          // when
+          await authenticateByEmail(user);
+          await visit(`/certifications/${certificationCourse.id}/results`);
+
+          // then
+          expect(
+            contains(
+              'Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.'
+            )
+          ).to.exist;
+        });
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/certifications/certification-ender_test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender_test.js
@@ -49,4 +49,44 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
     // then
     expect(contains('Jim Halpert')).to.exist;
   });
+
+  context('when the assessment status is not ended by supervisor', function () {
+    it('should not display the ended by supervisor text', async function () {
+      // given
+      class currentUser extends Service {
+        user = {
+          fullName: 'Jim Halpert',
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+
+      // when
+      await render(hbs`
+      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedBySupervisor={{false}} />
+    `);
+
+      // then
+      expect(contains(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).not.to.exist;
+    });
+  });
+
+  context('when the assessment status is ended by supervisor', function () {
+    it('should display the ended by supervisor text', async function () {
+      // given
+      class currentUser extends Service {
+        user = {
+          fullName: 'Jim Halpert',
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+
+      // when
+      await render(hbs`
+      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedBySupervisor={{true}} />
+    `);
+
+      // then
+      expect(contains(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).to.exist;
+    });
+  });
 });

--- a/mon-pix/tests/unit/routes/certifications/results_test.js
+++ b/mon-pix/tests/unit/routes/certifications/results_test.js
@@ -26,9 +26,7 @@ describe('Unit | Route | Certifications | Results', function () {
       const model = await route.model({ certification_id: 1 });
 
       // then
-      expect(model).to.equal(certificationCourse);
-      sinon.assert.calledWith(findRecordStub, 'certification-course', 1);
-      sinon.assert.called(reloadStub);
+      expect(model).to.deep.equal(certificationCourse);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/certifications/results_test.js
+++ b/mon-pix/tests/unit/routes/certifications/results_test.js
@@ -1,22 +1,34 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
 
 describe('Unit | Route | Certifications | Results', function () {
   setupTest();
 
   describe('model', function () {
-    it('should find logged user details', function () {
-      // Given
-      const route = this.owner.lookup('route:certifications.results');
-
-      // When
-      const model = route.model({
-        certification_number: 'certification_number',
+    it('should retrieve certification course', async function () {
+      // given
+      const reloadStub = sinon.stub().resolves();
+      const assessment = EmberObject.create({ reload: reloadStub });
+      const certificationCourse = EmberObject.create({
+        id: 1,
+        assessment,
       });
+      const findRecordStub = sinon.stub().resolves(certificationCourse);
+      const storeStub = Service.create({ findRecord: findRecordStub });
+      const route = this.owner.lookup('route:certifications.results');
+      route.set('store', storeStub);
 
-      // Then
-      expect(model).to.equal('certification_number');
+      // when
+      const model = await route.model({ certification_id: 1 });
+
+      // then
+      expect(model).to.equal(certificationCourse);
+      sinon.assert.calledWith(findRecordStub, 'certification-course', 1);
+      sinon.assert.called(reloadStub);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de la refonte de la page de fin de test, lorsqu'un test de certification a été terminé par le surveillant, nous voulons en informer le candidat.

## :gift: Solution
Ajouter la phrase "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions." sur l'écran de fin de test si l'assessment a un statut endedBySupervisor.

## 🍣  Remarques

Hérite de #3888 et doit être mergée après.

## :santa: Pour tester
- Terminer la certification d'un candidat depuis l'espace surveillant.
- En tant que candidat, tenter de répondre à une question, ce qui redirigera à la page de fin de test.
- Constater la présence du message concernant le test terminé par le surveillant.