### PR TITLE
[FEATURE]  Afficher le flag permettant d'afficher ou non les acquis dans l'export de résultats d'une campagne (Pix 4104). 

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -195,6 +195,8 @@
                   "Oui"
                   "Non"
                 }}</span><br />
+              Affichage des acquis dans l'export de résultats :
+              <span class="organization__showSkills">{{if @organization.showSkills "Oui" "Non"}}</span><br />
               Affichage du Net Promoter Score :
               <span>{{if @organization.showNPS "Oui" "Non"}}</span><br />
               Lien vers le formulaire du Net Promoter Score :

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -18,6 +18,7 @@ export default class Organization extends Model {
   @attr() email;
   @attr() createdBy;
   @attr('string') documentationUrl;
+  @attr('boolean') showSkills;
 
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -43,6 +43,32 @@ module('Integration | Component | organizations/information-section', function (
     assert.dom('.organization__canCollectProfiles').hasText('Oui');
   });
 
+  module('Displaying whether or not the items of this campaign will be exported in results', function () {
+    test("it should display 'Oui' when showskills set to true", async function (assert) {
+      // given
+      const organization = EmberObject.create({ type: 'SUP', showSkills: true });
+      this.set('organization', organization);
+
+      // when
+      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+
+      // then
+      assert.dom('.organization__showSkills').hasText('Oui');
+    });
+
+    test("it should display 'Non' when showskills set to false", async function (assert) {
+      // given
+      const organization = EmberObject.create({ type: 'SCO', showSkills: false });
+      this.set('organization', organization);
+
+      // when
+      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+
+      // then
+      assert.dom('.organization__showSkills').hasText('Non');
+    });
+  });
+
   test('it should display documentation url', async function (assert) {
     // given
     const organization = EmberObject.create({ documentationUrl: 'https://pix.fr' });

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -17,6 +17,7 @@ const buildOrganization = function buildOrganization({
   createdBy,
   showNPS = false,
   formNPSUrl = null,
+  showSkills = false,
 } = {}) {
   const values = {
     id,
@@ -35,6 +36,7 @@ const buildOrganization = function buildOrganization({
     updatedAt,
     showNPS,
     formNPSUrl,
+    showSkills,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20220106130955_add-showskills-to-organizations.js
+++ b/api/db/migrations/20220106130955_add-showskills-to-organizations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'showSkills';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+  await knex(TABLE_NAME).whereIn('type', ['SUP', 'PRO']).update({ showSkills: true });
+};
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -31,6 +31,7 @@ class Organization {
     createdBy,
     showNPS,
     formNPSUrl,
+    showSkills,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -50,6 +51,7 @@ class Organization {
     this.createdBy = createdBy;
     this.showNPS = showNPS;
     this.formNPSUrl = formNPSUrl;
+    this.showSkills = showSkills;
   }
 
   get isSup() {

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -26,6 +26,7 @@ function _toDomain(rawOrganization) {
     createdBy: rawOrganization.createdBy,
     showNPS: rawOrganization.showNPS,
     formNPSUrl: rawOrganization.formNPSUrl,
+    showSkills: rawOrganization.showSkills,
   });
 
   organization.targetProfileShares = rawOrganization.targetProfileShares || [];

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -23,6 +23,7 @@ module.exports = {
         'documentationUrl',
         'showNPS',
         'formNPSUrl',
+        'showSkills',
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -648,6 +648,7 @@ describe('Acceptance | Application | organization-controller', function () {
               'documentation-url': organization.documentationUrl,
               'show-nps': organization.showNPS,
               'form-nps-url': organization.formNPSUrl,
+              'show-skills': false,
             },
             id: organization.id.toString(),
             relationships: {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -159,6 +159,7 @@ describe('Integration | Repository | Organization', function () {
           createdBy: pixMasterUserId,
           showNPS: true,
           formNPSUrl: 'https://pix.fr/',
+          showSkills: false,
         });
 
         const expectedAttributes = {
@@ -180,6 +181,7 @@ describe('Integration | Repository | Organization', function () {
           createdBy: insertedOrganization.createdBy,
           showNPS: true,
           formNPSUrl: 'https://pix.fr/',
+          showSkills: false,
         };
 
         await databaseBuilder.commit();

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -29,6 +29,7 @@ function buildOrganization({
   documentationUrl = 'https://pix.fr',
   showNPS = false,
   formNPSUrl = 'https://pix.fr',
+  showSkills = false,
 } = {}) {
   return new Organization({
     id,
@@ -48,6 +49,7 @@ function buildOrganization({
     documentationUrl,
     showNPS,
     formNPSUrl,
+    showSkills,
   });
 }
 

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -11,6 +11,7 @@ describe('Unit | Domain | Models | Organization', function () {
         name: 'Lycée Jean Rostand',
         type: 'SCO',
         email: 'jr@lycee.fr',
+        showSkills: false,
       };
 
       // when
@@ -20,6 +21,7 @@ describe('Unit | Domain | Models | Organization', function () {
       expect(organization.id).to.equal(1);
       expect(organization.type).to.equal('SCO');
       expect(organization.name).to.equal('Lycée Jean Rostand');
+      expect(organization.showSkills).to.equal(false);
     });
 
     it('should build an Organization with targetProfile related', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -41,6 +41,7 @@ describe('Unit | Serializer | organization-serializer', function () {
             'documentation-url': organization.documentationUrl,
             'show-nps': organization.showNPS,
             'form-nps-url': organization.formNPSUrl,
+            'show-skills': organization.showSkills,
           },
           relationships: {
             memberships: {


### PR DESCRIPTION
## :christmas_tree: Problème
Pix souhaite a terme supprimer complètement les acquis des exports de résultats d’une campagne d'évaluation dans pix orga. Cependant afin d’accompagner ce changement en douceur nous avons décidé de mettre en place un feature toggle pour décider quelle organisation à le droit de voir les acquis ou non dans son export de résultats 

## :gift: Solution
Créer le boolean “showSkills” dans la table 'organizations' pour savoir si l'organisation a le droit de voir les acquis ou non lors de son export de résultat. Ce champs dans la BDD doit être false par défaut quand une organisation est créée.

## :star2: Remarques
Le boolean doit être FALSE pour les organisation de type SCO
Le boolean doit être TREU pour les organisation de type SUPE et PRO

## :santa: Pour tester
- Se Connectez à Pix Admin, puis allez dans le menu Organisations
- Sélectionnez une organisation de type SCO et constatez que la ligne 'Affichage des acquis dans l'export de résultats ' Existe dans l'information d'une organisation avec une valeur 'Non'.
- Sélectionnez une organisation de type SUP ou PRO et constatez que la ligne 'Affichage des acquis dans l'export de résultats ' Existe dans l'information d'une organisation avec une valeur 'Oui'.