### PR TITLE
[BUGFIX] Accepter les fichiers SIECLE csv avec le mime type `text/plain` (PIX-4111)

### DIFF
--- a/orga/app/adapters/students-import.js
+++ b/orga/app/adapters/students-import.js
@@ -16,16 +16,20 @@ export default class StudentImportsAdapter extends ApplicationAdapter {
     return this.ajax(url, 'POST', { data: files[0] });
   }
 
-  importStudentsSiecle(organizationId, files, acceptedFormat) {
+  importStudentsSiecle(organizationId, files, acceptedFormatName, acceptedFormatMimeTypes) {
     if (!files || files.length === 0) return;
 
     const fileToUpload = files[0];
     const fileToUploadMimeType = fileToUpload.type;
-    if (!fileToUploadMimeType?.includes(acceptedFormat)) {
+    const isFormatSupported =
+      acceptedFormatMimeTypes.find((acceptedFormatMimeType) =>
+        fileToUploadMimeType?.includes(acceptedFormatMimeType)
+      ) !== undefined;
+    if (!isFormatSupported) {
       throw new Error(ENV.APP.ERRORS.FILE_UPLOAD.FORMAT_NOT_SUPPORTED_ERROR);
     }
 
-    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/schooling-registrations/import-siecle?format=${acceptedFormat}`;
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/schooling-registrations/import-siecle?format=${acceptedFormatName}`;
     return this.ajax(url, 'POST', { data: fileToUpload });
   }
 }

--- a/orga/tests/unit/adapters/students-import_test.js
+++ b/orga/tests/unit/adapters/students-import_test.js
@@ -40,17 +40,37 @@ module('Unit | Adapters | Students import', function (hooks) {
   module('#importStudentsSiecle', function () {
     const zipFile = new File([''], 'archive.zip', { type: 'application/zip' });
     const csvFile = new File([''], 'file.csv', { type: 'text/csv' });
-    const acceptedFormat = 'csv';
+    const csvTextFile = new File([''], 'file.csv', { type: 'text/plain' });
+    const acceptedFormatName = 'csv';
+    const acceptedFormatMimeTypes = ['text/plain', 'csv'];
 
     test('should throw an error if format is not handled', async function (assert) {
-      const error = await catchErr(adapter.importStudentsSiecle)(1, [zipFile], acceptedFormat);
+      const error = await catchErr(adapter.importStudentsSiecle)(
+        1,
+        [zipFile],
+        acceptedFormatName,
+        acceptedFormatMimeTypes
+      );
       sinon.assert.notCalled(adapter.ajax);
       assert.equal(error.message, ENV.APP.ERRORS.FILE_UPLOAD.FORMAT_NOT_SUPPORTED_ERROR);
     });
 
-    test('should build importStudentsSiecle url from organizationId and format', async function (assert) {
+    test('should build importStudentsSiecle url from organizationId and mime type containing "csv"', async function (assert) {
       // when
-      await adapter.importStudentsSiecle(1, [csvFile], acceptedFormat);
+      await adapter.importStudentsSiecle(1, [csvFile], acceptedFormatName, acceptedFormatMimeTypes);
+
+      // then
+      assert.ok(
+        adapter.ajax.calledWith(
+          'http://localhost:3000/api/organizations/1/schooling-registrations/import-siecle?format=csv',
+          'POST'
+        )
+      );
+    });
+
+    test('should build importStudentsSiecle url from organizationId and "text/plain" mime type', async function (assert) {
+      // when
+      await adapter.importStudentsSiecle(1, [csvTextFile], acceptedFormatName, acceptedFormatMimeTypes);
 
       // then
       assert.ok(

--- a/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
@@ -9,6 +9,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
   let importStudentStub;
   const filesWithXmlMimeType = [{ type: 'text/xml' }];
   const filesWithCsvMimeType = [{ type: 'text/csv' }];
+  const filesWithTextPlainMimeType = [{ type: 'text/plain' }];
 
   hooks.beforeEach(function () {
     this.owner.lookup('service:intl').setLocale('fr');
@@ -28,7 +29,17 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
 
         await controller.importStudents(filesWithCsvMimeType);
 
-        assert.ok(importStudentStub.calledWith(1, filesWithCsvMimeType, 'csv'));
+        assert.ok(importStudentStub.calledWith(1, filesWithCsvMimeType, 'csv', ['text/plain', 'csv']));
+      });
+    });
+
+    module('when file is text/plain', function () {
+      test('it sends the chosen csv file to the API', async function (assert) {
+        currentUser.isAgriculture = true;
+
+        await controller.importStudents(filesWithTextPlainMimeType);
+
+        assert.ok(importStudentStub.calledWith(1, filesWithTextPlainMimeType, 'csv', ['text/plain', 'csv']));
       });
     });
 
@@ -38,7 +49,7 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
 
         await controller.importStudents(filesWithXmlMimeType);
 
-        assert.ok(importStudentStub.calledWith(1, filesWithXmlMimeType, 'xml'));
+        assert.ok(importStudentStub.calledWith(1, filesWithXmlMimeType, 'xml', ['xml']));
       });
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Contexte : import fichiers SIECLE Agri.
L'export de fichiers csv depuis Fregata leur donne le mime-type `text/plain`. On ne gère pour l'instant que les mime-types contenant `csv`.

## :gift: Solution
Accepter temporairement les fichiers csv avec le mime-type `text/plain` le temps qu'un correctif soit développé côté Fregata.

## :star2: Remarques
On a mis au courant les devs côté Fregata pour gérer le problème à la source, il ne faudra pas oublier de supprimer ce patch une fois qu'ils auront fait un correctif de leur côté.

## :santa: Pour tester
Un fichier csv avec le mime-type `text/plain` ne doit pas renvoyer d'erreur lors de l'import.
Les messages d'erreurs doivent rester les mêmes.