### PR TITLE
[A11Y] Ajouter un role "columnheader" a tous les tableaux dans Pix Orga (Pix-4115)

### DIFF
--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -15,12 +15,12 @@
     <table class="table content-text content-text--small">
       <thead>
         <tr>
-          <th>{{t "pages.campaign-activity.table.column.last-name"}}</th>
-          <th>{{t "pages.campaign-activity.table.column.first-name"}}</th>
+          <Table::Header @size="wide">{{t "pages.campaign-activity.table.column.last-name"}}</Table::Header>
+          <Table::Header @size="wide">{{t "pages.campaign-activity.table.column.first-name"}}</Table::Header>
           {{#if @campaign.idPixLabel}}
-            <th>{{@campaign.idPixLabel}}</th>
+            <Table::Header @size="wide">{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
-          <th>{{t "pages.campaign-activity.table.column.status"}}</th>
+          <Table::Header @size="wide">{{t "pages.campaign-activity.table.column.status"}}</Table::Header>
         </tr>
       </thead>
 

--- a/orga/app/components/campaign/charts/participants-by-day.hbs
+++ b/orga/app/components/campaign/charts/participants-by-day.hbs
@@ -14,8 +14,8 @@
       <table class="sr-only">
         <thead>
           <tr>
-            <th>{{t "charts.participants-by-day.labels-a11y.date"}}</th>
-            <th>{{t dataset.countLabel}}</th>
+            <Table::Header>{{t "charts.participants-by-day.labels-a11y.date"}}</Table::Header>
+            <Table::Header>{{t dataset.countLabel}}</Table::Header>
           </tr>
         </thead>
         <tbody>

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -17,14 +17,14 @@
     <table class="table content-text content-text--small">
       <thead>
         <tr>
-          <th>{{t "pages.campaign-results.table.column.last-name"}}</th>
-          <th>{{t "pages.campaign-results.table.column.first-name"}}</th>
+          <Table::Header>{{t "pages.campaign-results.table.column.last-name"}}</Table::Header>
+          <Table::Header>{{t "pages.campaign-results.table.column.first-name"}}</Table::Header>
           {{#if @campaign.idPixLabel}}
-            <th>{{@campaign.idPixLabel}}</th>
+            <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
-          <th>{{t "pages.campaign-results.table.column.results.label"}}</th>
+          <Table::Header>{{t "pages.campaign-results.table.column.results.label"}}</Table::Header>
           {{#if @campaign.hasBadges}}
-            <th>{{t "pages.campaign-results.table.column.badges"}}</th>
+            <Table::Header>{{t "pages.campaign-results.table.column.badges"}}</Table::Header>
           {{/if}}
         </tr>
       </thead>

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -15,17 +15,19 @@
     <table class="table content-text content-text--small">
       <thead>
         <tr>
-          <th>{{t "pages.profiles-list.table.column.last-name"}}</th>
-          <th>{{t "pages.profiles-list.table.column.first-name"}}</th>
+          <Table::Header>{{t "pages.profiles-list.table.column.last-name"}}</Table::Header>
+          <Table::Header>{{t "pages.profiles-list.table.column.first-name"}}</Table::Header>
           {{#if @campaign.idPixLabel}}
-            <th>{{@campaign.idPixLabel}}</th>
+            <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
-          <th class="table__column--center">{{t "pages.profiles-list.table.column.sending-date.label"}}</th>
-          <th class="table__column--center">{{t "pages.profiles-list.table.column.pix-score.label"}}</th>
-          <th class="table__column--center hide-on-mobile">{{t "pages.profiles-list.table.column.certifiable"}}</th>
-          <th class="table__column--center hide-on-mobile">{{t
+          <Table::Header @align="center">{{t "pages.profiles-list.table.column.sending-date.label"}}</Table::Header>
+          <Table::Header @align="center">{{t "pages.profiles-list.table.column.pix-score.label"}}</Table::Header>
+          <Table::Header @align="center" class="hide-on-mobile">{{t
+              "pages.profiles-list.table.column.certifiable"
+            }}</Table::Header>
+          <Table::Header @align="center" class="hide-on-mobile">{{t
               "pages.profiles-list.table.column.competences-certifiables"
-            }}</th>
+            }}</Table::Header>
         </tr>
       </thead>
 

--- a/orga/app/components/participant/assessment/results.hbs
+++ b/orga/app/components/participant/assessment/results.hbs
@@ -4,11 +4,13 @@
   <table class="content-text content-text--small">
     <thead>
       <tr>
-        <th class="table__column--wide">{{t
+        <Table::Header @size="wide">{{t
             "pages.assessment-individual-results.table.column.competences"
             count=@results.sortedCompetenceResults.length
-          }}</th>
-        <th class="table__column--wide">{{t "pages.assessment-individual-results.table.column.results.label"}}</th>
+          }}</Table::Header>
+        <Table::Header @size="wide">{{t
+            "pages.assessment-individual-results.table.column.results.label"
+          }}</Table::Header>
       </tr>
     </thead>
 

--- a/orga/app/components/participant/profile/table.hbs
+++ b/orga/app/components/participant/profile/table.hbs
@@ -3,15 +3,15 @@
   <table>
     <thead>
       <tr>
-        <th>
+        <Table::Header @size="wide">
           {{t "pages.profiles-individual-results.table.column.skill"}}
-        </th>
-        <th class="table__column table__column--center">
-          {{t "pages.profiles-individual-results.table.column.level"}}
-        </th>
-        <th class="table__column table__column--center">
-          {{t "pages.profiles-individual-results.table.column.pix-score"}}
-        </th>
+        </Table::Header>
+        <Table::Header @size="small" @align="center">{{t
+            "pages.profiles-individual-results.table.column.level"
+          }}</Table::Header>
+        <Table::Header @size="small" @align="center">{{t
+            "pages.profiles-individual-results.table.column.pix-score"
+          }}</Table::Header>
       </tr>
     </thead>
     <tbody>

--- a/orga/app/components/table/header.hbs
+++ b/orga/app/components/table/header.hbs
@@ -1,3 +1,7 @@
-<th class="{{if @size (concat "table__column--" @size)}} {{if @align (concat "table__column--" @align)}}" ...attributes>
+<th
+  class="{{if @size (concat "table__column--" @size)}}{{if @align (concat " table__column--" @align)}}"
+  role="columnheader"
+  ...attributes
+>
   {{yield}}
 </th>

--- a/orga/app/components/team/invitations-list.hbs
+++ b/orga/app/components/team/invitations-list.hbs
@@ -2,15 +2,20 @@
   <table>
     <thead>
       <tr>
-        <th>{{t "pages.team-invitations.table.column.email-address"}}</th>
-        <th class="hide-on-mobile">{{t "pages.team-invitations.table.column.pending-invitation"}}</th>
+        <Table::Header @size="wide">{{t "pages.team-invitations.table.column.email-address"}}</Table::Header>
+        <Table::Header @size="x-wide" class="hide-on-mobile">{{t
+            "pages.team-invitations.table.column.pending-invitation"
+          }}</Table::Header>
+        <Table::Header @size="wide" class="hide-on-mobile">
+          <span class="sr-only">{{t "common.actions.global"}}</span>
+        </Table::Header>
       </tr>
     </thead>
     <tbody>
       {{#each @invitations as |invitation|}}
         <tr aria-label="{{t "pages.team-invitations.table.row.aria-label"}}">
           <td>{{invitation.email}}</td>
-          <td class="hide-on-mobile" colspan="3">
+          <td class="hide-on-mobile">
             {{t "pages.team-invitations.table.row.message"}}
             {{moment-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
           </td>

--- a/orga/app/components/team/members-list.hbs
+++ b/orga/app/components/team/members-list.hbs
@@ -3,11 +3,15 @@
     <table>
       <thead>
         <tr>
-          <th>{{t "pages.team-members.table.column.last-name"}}</th>
-          <th>{{t "pages.team-members.table.column.first-name"}}</th>
-          <th>{{t "pages.team-members.table.column.organization-membership-role"}}</th>
-          {{#if this.currentUser.isAdminInOrganization}}
-            <th class="hide-on-mobile"></th>
+          <Table::Header @size="wide">{{t "pages.team-members.table.column.last-name"}}</Table::Header>
+          <Table::Header @size="wide">{{t "pages.team-members.table.column.first-name"}}</Table::Header>
+          <Table::Header @size="wide">{{t
+              "pages.team-members.table.column.organization-membership-role"
+            }}</Table::Header>
+          {{#if this.displayManagingColumn}}
+            <Table::Header @size="wide" class="hide-on-mobile">
+              <span class="sr-only">{{t "common.actions.global"}}</span>
+            </Table::Header>
           {{/if}}
         </tr>
       </thead>

--- a/orga/app/components/team/members-list.js
+++ b/orga/app/components/team/members-list.js
@@ -3,4 +3,8 @@ import Component from '@glimmer/component';
 
 export default class MembersList extends Component {
   @service currentUser;
+
+  get displayManagingColumn() {
+    return this.currentUser.isAdminInOrganization;
+  }
 }

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -114,6 +114,10 @@ th::first-letter {
     width: 25%;
   }
 
+  &--x-wide {
+    width: 50%;
+  }
+
   &--right {
     text-align: right;
     padding-right: 24px;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -139,7 +139,8 @@
     "actions": {
       "back": "Back",
       "cancel": "Cancel",
-      "close": "Close"
+      "close": "Close",
+      "global": "Actions"
     },
     "filters": {
       "loading": "Loading...",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -139,7 +139,8 @@
     "actions": {
       "back": "Retour",
       "cancel": "Annuler",
-      "close": "Fermer"
+      "close": "Fermer",
+      "global": "Actions"
     },
     "filters": {
       "loading": "Chargement...",


### PR DESCRIPTION
## :christmas_tree: Problème
Pour que les tableaux soient accessible plus facilement au lecteur d'écran, il nous manquait un attribut sur les colonnes

## :gift: Solution
Ajouter le role `columnheader` à chaque colonne des tableaux

## :star2: Remarques
RAS

## :santa: Pour tester
Se connecter sur Pix Orga avec pro.admin@example.net / pro.member@example.net, vérifier que les columnheader sont bien présent dans tout les tableaux

Ainsi qu'avec un compte sco.admin@example.net pour la liste des élèves