### PR TITLE
[FEATURE] WIP - Permettre l'utilisation de l'algo Flash dans les certifications

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -1,4 +1,3 @@
-const hashInt = require('hash-int');
 const { ObjectValidationError } = require('../errors');
 
 const courseIdMessage = {
@@ -141,10 +140,6 @@ class Assessment {
     return this.method === methods.SMART_RANDOM;
   }
 
-  chooseNextFlashChallenge(challenges) {
-    return challenges[Math.abs(hashInt(this.id)) % challenges.length];
-  }
-
   static computeMethodFromType(type) {
     switch (type) {
       case Assessment.types.CERTIFICATION:
@@ -158,14 +153,14 @@ class Assessment {
     }
   }
 
-  static createForCertificationCourse({ userId, certificationCourseId }) {
+  static createForCertificationCourse({ userId, certificationCourseId, method = methods.CERTIFICATION_DETERMINED }) {
     return new Assessment({
       userId,
       certificationCourseId,
       state: Assessment.states.STARTED,
       type: Assessment.types.CERTIFICATION,
       isImproving: false,
-      method: methods.CERTIFICATION_DETERMINED,
+      method,
     });
   }
 

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -104,9 +104,28 @@ async function fetchForFlashLevelEstimation({ assessment, answerRepository, chal
   };
 }
 
+async function fetchForFlashCertification({
+  assessment,
+  answerRepository,
+  challengeRepository,
+  locale,
+  domainTransaction,
+}) {
+  const [allAnswers, challenges] = await Promise.all([
+    assessment != null ? answerRepository.findByAssessment(assessment.id, domainTransaction) : [],
+    challengeRepository.findFlashCompatible(locale),
+  ]);
+
+  return {
+    allAnswers,
+    challenges,
+  };
+}
+
 module.exports = {
   fetchForCampaigns,
   fetchForCompetenceEvaluations,
   fetchForFlashCampaigns,
   fetchForFlashLevelEstimation,
+  fetchForFlashCertification,
 };

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const hashInt = require('hash-int');
 
 const config = require('../../../config');
 
@@ -15,6 +16,7 @@ module.exports = {
   getPossibleNextChallenges,
   getEstimatedLevelAndErrorRate,
   getNonAnsweredChallenges,
+  pickRandomChallenge,
 };
 
 function getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel = DEFAULT_ESTIMATED_LEVEL } = {}) {
@@ -119,6 +121,10 @@ function getNonAnsweredChallenges({ allAnswers, challenges }) {
   const nonAnsweredChallenges = _.filter(challenges, filterNonAnsweredChallenges);
 
   return nonAnsweredChallenges;
+}
+
+function pickRandomChallenge(challenges, seed) {
+  return challenges[Math.abs(hashInt(seed)) % challenges.length];
 }
 
 function _getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -27,7 +27,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
       throw new AssessmentEndedError();
     }
 
-    return assessment.chooseNextFlashChallenge(algoResult.possibleChallenges);
+    return flash.pickRandomChallenge(algoResult.possibleChallenges, assessment.id);
   } else {
     const inputValues = await dataFetcher.fetchForCampaigns(...arguments);
     algoResult = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, locale });


### PR DESCRIPTION
## :christmas_tree: Problème
Pour le moment, il est impossible de faire une certification avec l'algo flash.

## :gift: Solution
Ajout du traitement si l'`assessment` est de `method` `FLASH` pour choisir la prochaine question en certification.

La cinématique que l’on a dev pour mettre les mains dans le cambouis est la suivante :
1. Création de la session de certif avec un nouveau champ pour savoir si elle doit utiliser l’algo Flash => pas encore de contenu dans `certification-challenges`
1. Lancement de la certif par le candidat => génération du 1er challenge dans `certification-challenges`
1. Le candidat répond => génération du challenge suivant

## :star2: Remarques
Reste à faire
[ ] des fois en fin de certif `throw MissingCertifiedLevelRuleError` selon les challenges auxquels on a répondu.
[ ] croiser avec Certif

## :santa: Pour tester
TODO
