### PR TITLE
[FEATURE][A11Y] Amélioration de l'accessibilité de la navigation sur Pix Orga (PIX-3892).

### DIFF
--- a/orga/app/components/campaign/header/tabs.hbs
+++ b/orga/app/components/campaign/header/tabs.hbs
@@ -1,5 +1,5 @@
 <div class="panel campaign-header-tabs">
-  <nav class="navbar">
+  <nav class="navbar" aria-label={{t "navigation.campaign-page.aria-label"}}>
     <LinkTo @route="authenticated.campaigns.campaign.activity" @model={{@campaign}} class="navbar-item">
       {{t "pages.campaign.tab.activity"}}
     </LinkTo>

--- a/orga/app/components/layout/footer.hbs
+++ b/orga/app/components/layout/footer.hbs
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <nav class="footer__navigation">
+  <nav class="footer__navigation" aria-label={{t "navigation.footer.aria-label"}}>
     <ul class="footer__navigation-list">
       <li>
         <a href="{{this.legalNoticeUrl}}" target="_blank" class="footer-navigation__item" rel="noopener noreferrer">

--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -5,7 +5,7 @@
     </LinkTo>
   </header>
 
-  <nav class="sidebar-nav">
+  <nav class="sidebar-nav" aria-label={{t "navigation.main.aria-label"}}>
     <LinkTo @route="authenticated.campaigns" class="sidebar-nav__item">
       <span class="sidebar-nav__item-icon">
         <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="" role="none" />

--- a/orga/app/components/participant/assessment/tabs.hbs
+++ b/orga/app/components/participant/assessment/tabs.hbs
@@ -1,5 +1,5 @@
 <div class="panel participant-tabs">
-  <nav class="navbar">
+  <nav class="navbar" aria-label={{t "navigation.assessment-individual-results.aria-label"}}>
     <LinkTo
       @route="authenticated.campaigns.participant-assessment.results"
       @models={{array @campaignId @participationId}}

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -4,7 +4,7 @@
   align-items: center;
   flex-shrink: 0;
   background-color: $white;
-  min-height: 60px;
+  height: 60px;
 
   &__organization-credit-info {
     padding: 0 30px;

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -2,9 +2,10 @@
   <Layout::Sidebar />
 
   <div class="main-content">
-    <Layout::Topbar />
-
-    <Banner::Information />
+    <header>
+      <Layout::Topbar />
+      <Banner::Information />
+    </header>
 
     <main class="main-content__body page">
       {{outlet}}

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -11,7 +11,7 @@
   </div>
 
   {{#if this.currentUser.isAdminInOrganization}}
-    <nav class="panel navbar list-team-page__tabs">
+    <nav class="panel navbar list-team-page__tabs" aria-label={{t "navigation.team-members.aria-label"}}>
       <LinkTo @route="authenticated.team.list.members" class="navbar-item">
         {{t "pages.team-list.tabs.member" count=@model.memberships.meta.rowCount}}
       </LinkTo>

--- a/orga/tests/acceptance/campaign-details_test.js
+++ b/orga/tests/acceptance/campaign-details_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
 
@@ -24,16 +24,14 @@ module('Acceptance | Campaign Details', function (hooks) {
     });
   });
 
-  module('When prescriber is logged in', function (hooks) {
-    hooks.beforeEach(async () => {
+  module('When prescriber is logged in', function () {
+    test('it should redirect to update page on click on return button', async function (assert) {
+      // given
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
       createPrescriberByUser(user);
 
       await authenticateSession(user.id);
-    });
 
-    test('it should redirect to update page on click on return button', async function (assert) {
-      // given
       server.create('campaign', { id: 1 });
       server.create('campaign-participant-activity', { firstName: 'toto' });
       await visit('/campagnes/1');
@@ -43,6 +41,25 @@ module('Acceptance | Campaign Details', function (hooks) {
 
       // then
       assert.equal(currentURL(), '/campagnes');
+    });
+
+    test('[A11Y] it should contain accessibility aria-label nav', async function (assert) {
+      // given
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      createPrescriberByUser(user);
+
+      await authenticateSession(user.id);
+
+      server.create('campaign', { id: 1 });
+      server.create('campaign-participant-activity', { firstName: 'toto' });
+
+      // when
+      const screen = await visitScreen('/campagnes/1');
+
+      // then
+      assert.dom(screen.getByLabelText('Navigation principale')).exists();
+      assert.dom(screen.getByLabelText("Navigation de la section détails d'une campagne")).exists();
+      assert.dom(screen.getByLabelText('Navigation de pied de page')).exists();
     });
   });
 });

--- a/orga/tests/acceptance/campaign-participants-individual-analysis_test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-analysis_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Campaign Participants Individual Analysis', function (hooks) {
   setupApplicationTest(hooks);
@@ -21,16 +21,30 @@ module('Acceptance | Campaign Participants Individual Analysis', function (hooks
     await authenticateSession(user.id);
   });
 
+  test('[a11y] it should contain accessibility aria-label nav', async function (assert) {
+    // given
+    campaignAnalysis = server.create('campaign-analysis', 'withTubeRecommendations', { id: 1, campaignId: 1 });
+    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAnalysis });
+
+    // when
+    const screen = await visitScreen('/campagnes/1/evaluations/1/analyse');
+
+    // then
+    assert.dom(screen.getByLabelText('Navigation principale')).exists();
+    assert.dom(screen.getByLabelText("Navigation de la section résultat d'une évaluation individuelle")).exists();
+    assert.dom(screen.getByLabelText('Navigation de pied de page')).exists();
+  });
+
   test('it should display individual analysis', async function (assert) {
     // given
     campaignAnalysis = server.create('campaign-analysis', 'withTubeRecommendations', { id: 1, campaignId: 1 });
     server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAnalysis });
 
     // when
-    await visit('/campagnes/1/evaluations/1/analyse');
+    const screen = await visitScreen('/campagnes/1/evaluations/1/analyse');
 
     // then
-    assert.dom('[aria-label="Analyse par sujet"]').containsText('Sujets (2)');
+    assert.dom(screen.getByText('Sujets (2)')).exists();
   });
 
   test('it should not display individual analysis when tube recommendations are empty', async function (assert) {
@@ -39,9 +53,9 @@ module('Acceptance | Campaign Participants Individual Analysis', function (hooks
     server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAnalysis });
 
     // when
-    await visit('/campagnes/1/evaluations/1/analyse');
+    const screen = await visitScreen('/campagnes/1/evaluations/1/analyse');
 
     // then
-    assert.dom('[aria-label="Analyse par sujet"]').containsText('Sujets (-)');
+    assert.dom(screen.getByText('Sujets (-)')).exists();
   });
 });

--- a/orga/tests/acceptance/campaign-participants-individual-results_test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-results_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Campaign Participants Individual Results', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,6 +19,24 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
     await authenticateSession(user.id);
   });
 
+  test('[a11y] it should contain accessibility aria-label nav', async function (assert) {
+    // given
+    const campaignAssessmentParticipationResult = server.create(
+      'campaign-assessment-participation-result',
+      'withCompetenceResults',
+      { id: 1, campaignId: 1 }
+    );
+    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
+
+    // when
+    const screen = await visitScreen('/campagnes/1/evaluations/1');
+
+    // then
+    assert.dom(screen.getByLabelText('Navigation principale')).exists();
+    assert.dom(screen.getByLabelText("Navigation de la section résultat d'une évaluation individuelle")).exists();
+    assert.dom(screen.getByLabelText('Navigation de pied de page')).exists();
+  });
+
   test('it should display individual results', async function (assert) {
     // given
     const campaignAssessmentParticipationResult = server.create(
@@ -29,10 +47,10 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
     server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
 
     // when
-    await visit('/campagnes/1/evaluations/1');
+    const screen = await visitScreen('/campagnes/1/evaluations/1');
 
     // then
-    assert.contains('Compétences (2)');
+    assert.dom(screen.getByText('Compétences (2)')).exists();
   });
 
   test('it should not display individual results when competence results are empty', async function (assert) {
@@ -45,9 +63,9 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
     server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
 
     // when
-    await visit('/campagnes/1/evaluations/1');
+    const screen = await visitScreen('/campagnes/1/evaluations/1');
 
     // then
-    assert.contains('Compétences (-)');
+    assert.dom(screen.getByText('Compétences (-)')).exists();
   });
 });

--- a/orga/tests/acceptance/team-list_test.js
+++ b/orga/tests/acceptance/team-list_test.js
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
 import { currentURL, visit } from '@ember/test-helpers';
 import { clickByName } from '@1024pix/ember-testing-library';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
+
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 
@@ -26,6 +28,21 @@ module('Acceptance | Team List', function (hooks) {
   });
 
   module('When prescriber is logged in', function () {
+    test('[a11y] it should contain accessibility aria-label nav', async function (assert) {
+      // given
+      user = createUserMembershipWithRole('ADMIN');
+      createPrescriberByUser(user);
+
+      await authenticateSession(user.id);
+      // when
+      const screen = await visitScreen('/equipe');
+
+      // then
+      assert.dom(screen.getByLabelText('Navigation principale')).exists();
+      assert.dom(screen.getByLabelText('Navigation de la section équipe')).exists();
+      assert.dom(screen.getByLabelText('Navigation de pied de page')).exists();
+    });
+
     module('When prescriber is a member', function () {
       test('it should show title of team page', async function (assert) {
         // given
@@ -35,10 +52,10 @@ module('Acceptance | Team List', function (hooks) {
         await authenticateSession(user.id);
 
         // when
-        await visit('/equipe');
+        const screen = await visitScreen('/equipe');
 
         // then
-        assert.contains('Équipe');
+        assert.dom(screen.getByText('Équipe', { selector: 'h1' })).exists();
       });
 
       test('it should be possible to see only members list', async function (assert) {
@@ -49,14 +66,14 @@ module('Acceptance | Team List', function (hooks) {
         await authenticateSession(user.id);
 
         // when
-        await visit('/equipe');
+        const screen = await visitScreen('/equipe');
 
         // then
         assert.equal(currentURL(), '/equipe/membres');
-        assert.notContains('Membres');
-        assert.notContains('Invitations');
-        assert.notContains('Inviter un membre');
-        assert.contains('Rôle');
+        assert.dom(screen.queryByLabelText('Membres')).isNotVisible();
+        assert.dom(screen.queryByLabelText('Invitations')).isNotVisible();
+        assert.dom(screen.queryByLabelText('Inviter un membre')).isNotVisible();
+        assert.dom(screen.getByText('Rôle')).exists();
       });
     });
 
@@ -83,10 +100,10 @@ module('Acceptance | Team List', function (hooks) {
         await authenticateSession(user.id);
 
         // when
-        await visit('/equipe');
+        const screen = await visitScreen('/equipe');
 
         // then
-        assert.contains('Équipe');
+        assert.dom(screen.getByText('Équipe', { selector: 'h1' })).exists();
       });
 
       test('it should show members list, invitations list and add an invitation button', async function (assert) {
@@ -97,12 +114,12 @@ module('Acceptance | Team List', function (hooks) {
         await authenticateSession(user.id);
 
         // when
-        await visit('/equipe');
+        const screen = await visitScreen('/equipe');
 
         // then
-        assert.contains('Membres');
-        assert.contains('Invitations');
-        assert.contains('Inviter un membre');
+        assert.dom(screen.getByText('Inviter un membre')).exists();
+        assert.dom(screen.getByText('Membres (1)')).exists();
+        assert.dom(screen.getByText('Invitations (-)')).exists();
       });
     });
   });

--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Layout::Footer', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -13,10 +13,10 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     const expectedYear = date.getFullYear().toString();
 
     // when
-    await render(hbs`<Layout::Footer />}`);
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.contains(`© ${expectedYear} Pix`);
+    assert.dom(screen.getByText(`© ${expectedYear} Pix`)).exists();
   });
 
   test('should display legal notice link', async function (assert) {
@@ -25,10 +25,10 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
     // when
-    await render(hbs`<Layout::Footer />}`);
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.contains('Mentions légales');
+    assert.dom(screen.getByText('Mentions légales')).exists();
     assert.dom('a[href="https://pix.fr/mentions-legales"]').exists();
   });
 
@@ -38,10 +38,10 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
     // when
-    await render(hbs`<Layout::Footer />}`);
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.contains('Accessibilité : non conforme');
+    assert.dom(screen.getByText('Accessibilité : non conforme')).exists();
     assert.dom('a[href="https://pix.fr/accessibilite-pix-orga"]').exists();
   });
 });

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Layout::Sidebar', function (hooks) {
   setupRenderingTest(hooks);
@@ -42,10 +43,10 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     intl.setLocale(['fr', 'fr']);
 
     // when
-    await render(hbs`<Layout::Sidebar />`);
+    const screen = await renderScreen(hbs`<Layout::Sidebar />`);
 
     // then
-    assert.contains('Équipe');
+    assert.dom(screen.getByText('Équipe')).exists();
   });
 
   test('it should display Certifications menu in the sidebar-menu when user is SCOManagingStudents', async function (assert) {
@@ -61,10 +62,10 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     intl.setLocale(['fr', 'fr']);
 
     // when
-    await render(hbs`<Layout::Sidebar />`);
+    const screen = await renderScreen(hbs`<Layout::Sidebar />`);
 
     // then
-    assert.contains('Certifications');
+    assert.dom(screen.getByText('Certifications')).exists();
   });
 
   test('it should hide Certification menu in the sidebar-menu', async function (assert) {
@@ -80,9 +81,25 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     intl.setLocale(['fr', 'fr']);
 
     // when
-    await render(hbs`<Layout::Sidebar />`);
+    const screen = await renderScreen(hbs`<Layout::Sidebar />`);
 
     // then
-    assert.notContains('Certification');
+    assert.dom(screen.queryByLabelText('Certifications')).isNotVisible();
+  });
+
+  test('[a11y] it should contain accessibility aria-label nav', async function (assert) {
+    // given
+    class CurrentUserStub extends Service {
+      organization = Object.create({ id: 1, isPro: true });
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+    const intl = this.owner.lookup('service:intl');
+    intl.setLocale(['fr', 'fr']);
+
+    // when
+    const screen = await renderScreen(hbs`<Layout::Sidebar />`);
+
+    // then
+    assert.dom(screen.getByLabelText('Navigation principale')).exists();
   });
 });

--- a/orga/tests/integration/components/participant/assessment/tabs_test.js
+++ b/orga/tests/integration/components/participant/assessment/tabs_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Participant::Assessment::Tabs', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -16,12 +16,26 @@ module('Integration | Component | Participant::Assessment::Tabs', function (hook
     this.participationId = 2;
 
     // when
-    await render(
+    const screen = await renderScreen(
       hbs`<Participant::Assessment::Tabs @campaignId={{campaignId}} @participationId={{participationId}} />`
     );
 
     // then
-    assert.dom('a[href="/campagnes/1/evaluations/2/resultats"]').hasText('Résultats');
-    assert.dom('a[href="/campagnes/1/evaluations/2/analyse"]').hasText('Analyse');
+    assert.dom(screen.getByText('Résultats')).exists();
+    assert.dom(screen.getByText('Analyse')).exists();
+  });
+
+  test('[A11Y] it should contain accessibility aria-label nav', async function (assert) {
+    // given
+    this.campaignId = 1;
+    this.participationId = 2;
+
+    // when
+    const screen = await renderScreen(
+      hbs`<Participant::Assessment::Tabs @campaignId={{campaignId}} @participationId={{participationId}} />`
+    );
+
+    // then
+    assert.dom(screen.getByLabelText("Navigation de la section résultat d'une évaluation individuelle")).exists();
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -206,6 +206,9 @@
     "campaign-page": {
       "aria-label": "Campaign navigation"
     },
+    "assessment-individual-results": {
+      "aria-label": "Individual assessment resultas navigation"
+    },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Log out",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -197,7 +197,8 @@
       "documentation": "Documentation",
       "students-sco": "Students",
       "students-sup": "Students",
-      "team": "Team"
+      "team": "Team",
+      "aria-label": "Main navigation"
     },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -200,6 +200,9 @@
       "team": "Team",
       "aria-label": "Main navigation"
     },
+    "team-members": {
+      "aria-label": "Team members navigation"
+    },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Log out",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -188,7 +188,8 @@
       "a11y": "Accessibility",
       "copyrights": "©",
       "legal-notice": "Legal notice",
-      "pix": "Pix"
+      "pix": "Pix",
+      "aria-label": "Footer navigation"
     },
     "main": {
       "campaigns": "Campaigns",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -203,6 +203,9 @@
     "team-members": {
       "aria-label": "Team members navigation"
     },
+    "campaign-page": {
+      "aria-label": "Campaign navigation"
+    },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Log out",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -197,7 +197,8 @@
       "documentation": "Documentation",
       "students-sco": "Élèves",
       "students-sup": "Étudiants",
-      "team": "Équipe"
+      "team": "Équipe",
+      "aria-label": "Navigation principale"
     },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -203,6 +203,9 @@
     "team-members": {
       "aria-label": "Navigation de la section équipe"
     },
+    "campaign-page": {
+      "aria-label": "Navigation de la section détails d'une campagne"
+    },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Se déconnecter",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -206,6 +206,9 @@
     "campaign-page": {
       "aria-label": "Navigation de la section détails d'une campagne"
     },
+    "assessment-individual-results": {
+      "aria-label": "Navigation de la section résultat d'une évaluation individuelle"
+    },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Se déconnecter",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -200,6 +200,9 @@
       "team": "Équipe",
       "aria-label": "Navigation principale"
     },
+    "team-members": {
+      "aria-label": "Navigation de la section équipe"
+    },
     "pix-orga": "Pix Orga",
     "user-logged-menu": {
       "logout": "Se déconnecter",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -188,7 +188,8 @@
       "a11y": "Accessibilité : non conforme",
       "copyrights": "©",
       "legal-notice": "Mentions légales",
-      "pix": "Pix"
+      "pix": "Pix",
+      "aria-label": "Navigation de pied de page"
     },
     "main": {
       "campaigns": "Campagnes",


### PR DESCRIPTION
## :christmas_tree: Problème
Pour améliorer l'accessibilité de la navigation de Pix Orga, il était nécessaire de :
- mettre un aria-label pour distinguer les éléments <nav> quand il y en a plus d'un sur une page
- la bannière d'information devait être contenue dans une balise <header> ou <main>
- la top bar contenant les informations de l'utilisateur connecté devait être contenue dans une balise <header>

## :gift: Solution
- la bannière d'information et la top bar ont été ajouté à l'intérieur d'un élément header
- chaque nav possède désormais son aria-label en fr en en

## :star2: Remarques
Le fait de mettre la topbar dans un header a eu pour effet que cette le display et le flex de `.main-content`

```
.main-content {
    display: flex;
    flex-direction: column;
    height: 100%;
    width: 100%;
    background-color: #F4F5F7;
    overflow: auto;
}
```

ne s'appliquait plus aux composants "petits-enfants" et  le `button` contenu dans la div de classe `.topbar` n'avait plus une hauteur à 100%

Cela a été résolu en remplaçant la min height de la topbar en height tout court

Deux pistes d'explications (Merci @Anne-Gaelle-S ) :
- https://stackoverflow.com/questions/2341821/height100-vs-min-height100
- 'This is a reported webkit (chrome/safari) bug, children of parents with min-height can't inherit the height property: https://bugs.webkit.org/show_bug.cgi?id=26559'  https://stackoverflow.com/questions/8468066/child-inside-parent-with-min-height-100-not-inheriting-height#comment66853175_24481020

Il aurait également été possible d'ajouter une classe `<header class="main-content__header">` . au header et d'ajouter les propriétés display et flex-direction pour retrouver le comportement antérieur.
```
  &__header {
    display: flex;
    flex-direction: column;
  }
```
Il nous a paru plus intéressant de supprimer cette notion de min-height et de garder une hauteur fixe pour la topbar.

## :santa: Pour tester
- se connecter avec le compte `sco.admin@example.net` pour voir apparaitre la bannière d'information et vérifier que celle-ci et la top bar sont bien à l'intérieur d'un <header>
- se connecter avec le compte `pro.admin@example.net` et vérifier que l'élément qui affiche le crédit n'a pas bougé
- avec ce même compte :
    - sur la page `https://orga-pr3925.review.pix.fr/campagnes` trouver 3 nav : celles de la sidebar et du footer et celle spécifique à la liste des campagnes
    - sur la page de détail d'une campagne `https://orga-pr3925.review.pix.fr/campagnes/19` trouver 3 nav : celles de la sidebar et du footer et celle spécifique au détail d'une campagne
    - sur la page Equipe `https://orga-pr3925.review.pix.fr/equipe/membres` trouver 3 nav : celles de la sidebar et du footer et celle spécifique à la liste des membres
    - sur la page Résultats `https://orga-pr3925.review.pix.fr/campagnes/1/evaluations/108074/resultats` trouver 3 nav : celles de la sidebar et du footer et celle spécifique aux résultats d'une évaluation individuelle
    