### PR TITLE
[BUGFIX] Affiche le message d'erreur lorsqu'une campagne n'a pas de profil cible (PIX-4091).

### DIFF
--- a/api/lib/domain/validators/stage-validator.js
+++ b/api/lib/domain/validators/stage-validator.js
@@ -14,7 +14,7 @@ const stageValidationJoiSchema = Joi.object({
   }),
 
   targetProfileId: Joi.number().required().integer().messages({
-    'number.base': 'TARGET_PROFILE_IS_REQUIRED',
+    'number.base': 'STAGE_TARGET_PROFILE_IS_REQUIRED',
   }),
 });
 

--- a/api/tests/unit/domain/validators/stage-validator_test.js
+++ b/api/tests/unit/domain/validators/stage-validator_test.js
@@ -82,7 +82,7 @@ describe('Unit | Domain | Validators | stage-validator', function () {
         // given
         const expectedError = {
           attribute: 'targetProfileId',
-          message: 'TARGET_PROFILE_IS_REQUIRED',
+          message: 'STAGE_TARGET_PROFILE_IS_REQUIRED',
         };
         stage.targetProfileId = MISSING_VALUE;
 

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -158,7 +158,7 @@
     "MAX_SIZE_LAST_NAME": "Your last name must not exceed 255 characters.",
     "STAGE_THRESHOLD_IS_REQUIRED": "The threshold is required",
     "STAGE_TITLE_IS_REQUIRED": "The title is required",
-    "TARGET_PROFILE_IS_REQUIRED": "The target profile is required",
+    "STAGE_TARGET_PROFILE_IS_REQUIRED": "The target profile is required",
     "WRONG_EMAIL_FORMAT": "The email address format is invalid."
   },
   "organization-invitation-email": {

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -170,7 +170,7 @@
     "MAX_SIZE_LAST_NAME": "Votre nom ne doit pas dépasser les 255 caractères.",
     "STAGE_THRESHOLD_IS_REQUIRED": "Le seuil du palier est obligatoire",
     "STAGE_TITLE_IS_REQUIRED": "Le titre du palier est obligatoire",
-    "TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire",
+    "STAGE_TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire",
     "WRONG_EMAIL_FORMAT": "Le format de l'adresse e-mail est incorrect."
   },
   "organization-invitation-email": {


### PR DESCRIPTION
## :christmas_tree: Problème
Le message d'erreur à la création de campagne qui s'affiche lorsqu'on n'a pas sélectionné de profil cible ne s'affiche plus. La clé d'erreur a été réutilisé pour les stages et associé à une traduction (cf ce commit https://github.com/1024pix/pix/commit/518ac07fef77f9006d10a56f2c2a271b0914dcda). La conséquence est que le endpoint de création de campagne ne retourne plus une clé d'erreur mais un message directement. Du côté du formulaire de création de campagne on se sert de ce code d'erreur pour récupérer la bonne traduction côté frontend. Sauf qu'aucun traduction n'est lié au message d'erreur directement ce qui explique pourquoi il n'y a plus aucun message d'erreur affiché.

## :gift: Solution
Côté stage on a préfixé l'erreur lié au profil cible avec "STAGE" comme pour les autres clés d'erreur.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Orga
- Aller sur le formulaire de création de campagne
- Valider le formulaire sans sélectionner de profil cible
- Constater la présence d'un message d'erreur sous le select du profil cible
