### PR TITLE
[FEATURE] Ajouter les traductions manquantes à la nouvelle page de fin de test (PIX-4121)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -50,7 +50,7 @@ export default class CandidateInList extends Component {
 
   @action
   askUserToConfirmTestEnd() {
-    this.modalDescriptionText = 'Attention : cette action entraine la fin de son test de certification et est irréversible.';
+    this.modalDescriptionText = 'Attention : cette action entraîne la fin de son test de certification et est irréversible.';
     this.modalCancelText = 'Annuler';
     this.modalConfirmationText = 'Terminer le test';
     this.modalInstructionText = `Terminer le test de ${this.args.candidate.firstName} ${this.args.candidate.lastName} ?`;

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -327,7 +327,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
           // then
           assert.equal(actions.length, 2);
-          assert.contains('Attention : cette action entraine la fin de son test de certification et est irréversible.');
+          assert.contains('Attention : cette action entraîne la fin de son test de certification et est irréversible.');
           assert.contains('Terminer le test de Drax The Destroyer ?');
         });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -272,10 +272,10 @@
     },
     "certification-ender": {
       "candidate": {
-        "title": "Test terminé !",
-        "ended-by-supervisor": "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.",
-        "disconnect": "Déconnecter mon compte",
-        "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.",
+        "title": "Your test is finished!",
+        "ended-by-supervisor": "Your invigilator has marked your certification test as completed. You cannot continue to answer questions.",
+        "disconnect": "Log out of my account",
+        "disconnect-tip": "If this is not your computer, please remember to log out.",
         "test-completed-alt": "test terminé"
       },
       "results": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -275,8 +275,7 @@
         "title": "Your test is finished!",
         "ended-by-supervisor": "Your invigilator has marked your certification test as completed. You cannot continue to answer questions.",
         "disconnect": "Log out of my account",
-        "disconnect-tip": "If this is not your computer, please remember to log out.",
-        "test-completed-alt": "test terminé"
+        "disconnect-tip": "If this is not your computer, please remember to log out."
       },
       "results": {
         "disclaimer": "Your results, pending validation by the Pix team, will soon be available on your Pix account",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -275,8 +275,7 @@
         "title": "Test terminé !",
         "ended-by-supervisor": "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.",
         "disconnect": "Déconnecter mon compte",
-        "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.",
-        "test-completed-alt": "test terminé"
+        "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter."
       },
       "results": {
         "disclaimer": "Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles depuis votre compte Pix",


### PR DESCRIPTION
## :christmas_tree: Problème
Des traductions anglaises étaient manquantes dans la partie candidat de la page de fin de test.

## :gift: Solution
Rajouter les traductions en question : 
Your test is finished!
Your invigilator has marked your certification test as completed. You cannot continue to answer questions.
Log out of my account
If this is not your computer, please remember to log out.

## :santa: Pour tester

Attendre le merge de https://github.com/1024pix/pix/pull/3915

- Passer son interface Pix App en anglais (?lang=en marche ?)
- Commencer un test de certification
- Terminer le test de certification depuis l'espace surveillant (pour voir tous les textes)
- Constater que les traductions anglaises sont présentes