### PR TITLE
[FEATURE] Permettre de filtrer les profils cibles avec les tags Catégories (PIX-3764).

### DIFF
--- a/api/lib/domain/read-models/campaign/TargetProfileForSpecifier.js
+++ b/api/lib/domain/read-models/campaign/TargetProfileForSpecifier.js
@@ -1,13 +1,14 @@
 const _ = require('lodash');
 
 class TargetProfileForSpecifier {
-  constructor({ id, name, skills, thematicResults, hasStage, description }) {
+  constructor({ id, name, skills, thematicResults, hasStage, description, category }) {
     this.id = id;
     this.name = name;
     this.tubeCount = _(skills).map('tubeId').uniq().size();
     this.thematicResultCount = thematicResults.length;
     this.hasStage = hasStage;
     this.description = description;
+    this.category = category;
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
@@ -16,6 +16,7 @@ function _fetchTargetProfiles(organizationId) {
       'target-profiles.id',
       'target-profiles.name',
       'target-profiles.description',
+      'target-profiles.category',
       knex.raw('ARRAY_AGG("skillId") AS "skillIds"'),
       knex.raw('ARRAY_AGG("badges"."id")  AS "badgeIds"'),
       knex.raw('ARRAY_AGG("stages"."id")  AS "stageIds"'),
@@ -44,6 +45,7 @@ async function _buildTargetProfileForSpecifier(row) {
     thematicResults: thematicResultsIds,
     hasStage,
     description: row.description,
+    category: row.category,
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer.js
@@ -3,7 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(targetProfiles, meta) {
     return new Serializer('target-profile', {
-      attributes: ['name', 'tubeCount', 'thematicResultCount', 'hasStage', 'description'],
+      attributes: ['name', 'tubeCount', 'thematicResultCount', 'hasStage', 'description', 'category'],
       meta,
     }).serialize(targetProfiles);
   },

--- a/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
@@ -1,6 +1,7 @@
 const { expect, databaseBuilder, domainBuilder, mockLearningContent } = require('../../../../test-helper');
 const TargetProfileForSpecifierRepository = require('../../../../../lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository');
 const TargetProfileForSpecifier = require('../../../../../lib/domain/read-models/campaign/TargetProfileForSpecifier');
+const { categories } = require('../../../../../lib/domain/models/TargetProfile');
 
 describe('Integration | Infrastructure | Repository | target-profile-for-campaign-repository', function () {
   describe('#availableForOrganization', function () {
@@ -17,11 +18,11 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
         mockLearningContent({ skills: [skill1, skill2] });
         await databaseBuilder.commit();
 
-        const [TargetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
+        const [targetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
           organizationId
         );
 
-        expect(TargetProfileForSpecifier.tubeCount).to.equal(2);
+        expect(targetProfileForSpecifier.tubeCount).to.equal(2);
       });
 
       it('returns the count of thematic results', async function () {
@@ -37,11 +38,11 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
         mockLearningContent({ skills: [] });
         await databaseBuilder.commit();
 
-        const [TargetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
+        const [targetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
           organizationId
         );
 
-        expect(TargetProfileForSpecifier.thematicResultCount).to.equal(1);
+        expect(targetProfileForSpecifier.thematicResultCount).to.equal(1);
       });
 
       it('returns a boolean to know if target profile has stages', async function () {
@@ -53,11 +54,24 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
         mockLearningContent({ skills: [] });
         await databaseBuilder.commit();
 
-        const [TargetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
+        const [targetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
           organizationId
         );
 
-        expect(TargetProfileForSpecifier.hasStage).to.equal(true);
+        expect(targetProfileForSpecifier.hasStage).to.equal(true);
+      });
+
+      it('returns the target profile category', async function () {
+        databaseBuilder.factory.buildTargetProfile({ category: categories.CUSTOM });
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+        mockLearningContent({ skills: [] });
+        await databaseBuilder.commit();
+
+        const [targetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
+          organizationId
+        );
+
+        expect(targetProfileForSpecifier.category).to.equal('CUSTOM');
       });
 
       it('returns the target profile description', async function () {
@@ -66,11 +80,11 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
         mockLearningContent({ skills: [] });
         await databaseBuilder.commit();
 
-        const [TargetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
+        const [targetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
           organizationId
         );
 
-        expect(TargetProfileForSpecifier.description).to.equal('THIS IS SPARTA!');
+        expect(targetProfileForSpecifier.description).to.equal('THIS IS SPARTA!');
       });
     });
 
@@ -96,6 +110,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           thematicResults: [badge],
           hasStage: false,
           description: null,
+          category: 'OTHER',
         });
         const targetProfile2 = new TargetProfileForSpecifier({
           id: targetProfileId2,
@@ -104,6 +119,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           thematicResults: [],
           hasStage: true,
           description: null,
+          category: 'OTHER',
         });
         const availableTargetProfiles = await TargetProfileForSpecifierRepository.availableForOrganization(
           organizationId

--- a/api/tests/unit/domain/read-models/campaign/TargetProfileForSpecifier_test.js
+++ b/api/tests/unit/domain/read-models/campaign/TargetProfileForSpecifier_test.js
@@ -100,4 +100,20 @@ describe('TargetProfileForSpecifier', function () {
       expect(targetProfile.description).to.equal('description');
     });
   });
+
+  describe('#category', function () {
+    it('returns the category', function () {
+      const targetProfile = new TargetProfileForSpecifier({
+        id: 1,
+        name: 'name',
+        skills: [],
+        thematicResults: [],
+        hasStage: false,
+        description: 'description',
+        category: 'SUBJECT',
+      });
+
+      expect(targetProfile.category).to.equal('SUBJECT');
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer_test.js
@@ -15,6 +15,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
         thematicResults,
         hasStage: true,
         description: 'description',
+        category: 'SUBJECT',
       });
 
       const meta = { some: 'meta' };
@@ -29,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer'
             'thematic-result-count': 1,
             'has-stage': true,
             description: 'description',
+            category: 'SUBJECT',
           },
         },
         meta,

--- a/high-level-tests/e2e/README.md
+++ b/high-level-tests/e2e/README.md
@@ -70,7 +70,7 @@ Pour les détails, voir [section dédiée](../INSTALLATION.md#L42-L42) du guide 
 
 ##### Configurer le cache applicatif pour les tests
 
-- Dans `~/api/.env`, renseignez/décommentez les variables `CYPRESS_AIRTABLE_BASE` et `CYPRESS_AIRTABLE_API_KEY`. Si vous ne possédez pas ces clefs, je vous invite à demander de l'aide à quelqu'un.
+- Dans `~/api/.env`, renseignez/décommentez les variables `CYPRESS_LCMS_API_URL` et `CYPRESS_LCMS_API_KEY`. Si vous ne possédez pas ces clefs, je vous invite à demander de l'aide à quelqu'un.
 
 - Nettoyez le cache Redis grâce aux commandes suivantes pour que les données du Airtable minimal soient récupérées au lancement des tests :
 

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "NERA" dans le champ "Ce code permet de démarrer un parcours"
+    Et je saisis "NERA" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
     Lorsque je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne evaluation" est correctement affichée
@@ -42,7 +42,7 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
+    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
     Et je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"
@@ -56,7 +56,7 @@ Fonctionnalité: Campagne d'évaluation
 
   Scénario: Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
+    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
     Et je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "LION" dans le champ "Ce code permet de démarrer un parcours"
+    Et je saisis "LION" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
     Lorsque je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne collecte profils" est correctement affichée
@@ -34,7 +34,7 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
+    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
     Et je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C'est parti !"
@@ -50,7 +50,7 @@ Fonctionnalité: Campagne de collecte de profils
 
   Scénario: Je partage mon profil de manière restreinte en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
+    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
     Et je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C'est parti !"

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -77,7 +77,7 @@ When('je reviens en arrière', () => {
 });
 
 When(`je saisis {string} dans le champ {string}`, (value, label) => {
-  cy.contains(label).parent().within(() => cy.get('input').type(value));
+  cy.contains(label).type(value);
 });
 
 When(`je sélectionne {string} dans le champ {string}`, (value, label) => {

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -7,6 +7,7 @@
     padding-bottom: 30px;
     display: flex;
     flex-direction: column;
+    align-items: center;
     width: 100%;
 
     @include device-is('tablet') {
@@ -27,6 +28,7 @@
     text-align: center;
     font-weight: $font-light;
     margin-bottom: 16px;
+    max-width: 390px;
   }
 
   &__form-field {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -710,7 +710,7 @@
     },
     "fill-in-campaign-code": {
       "title": "I have a code",
-      "description": "This code can be used to start a customised test'<br>'or to submit your profile to an organisation",
+      "description": "This code can be used to start a customised test or to submit your profile to an organisation",
       "errors": {
         "forbidden": "Oops! We can’t find you. Check your details to continue or contact the organiser.",
         "missing-code": "Please enter a code.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -710,7 +710,7 @@
     },
     "fill-in-campaign-code": {
       "title": "J'ai un code",
-      "description": "Ce code permet de démarrer un parcours'<br>'ou d’envoyer votre profil à une organisation",
+      "description": "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation",
       "errors": {
         "forbidden": "Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.",
         "missing-code": "Veuillez saisir un code.",

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -28,12 +28,12 @@
   </div>
 
   {{#if this.currentUser.organization.canCollectProfiles}}
-    <div class="form__field-with-info">
-      <div class="form__field" role="radiogroup" aria-labelledby="collect-profiles-label">
-        <p id="collect-profiles-label" class="label">
-          <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "pages.campaign-creation.purpose.label"}}
-        </p>
+    <div class="form__field" role="radiogroup" aria-labelledby="collect-profiles-label">
+      <p id="collect-profiles-label" class="label">
+        <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+        {{t "pages.campaign-creation.purpose.label"}}
+      </p>
+      <div class="form__field-with-info">
         <div class="form__radio-button">
           <input
             type="radio"
@@ -64,34 +64,48 @@
             {{display-campaign-errors @errors.type}}
           </div>
         {{/if}}
+        {{#if this.isCampaignGoalAssessment}}
+          <div class="form__field-info" id="campaign-goal-assessment-info">
+            <span class="form__field-info-title">
+              <FaIcon @icon="info-circle" class="form__field-info-icon" />
+              <span>{{t "pages.campaign-creation.purpose.assessment"}}</span>
+            </span>
+            <span class="form__field-info-message">{{t "pages.campaign-creation.purpose.assessment-info"}}</span>
+          </div>
+        {{else if this.isCampaignGoalProfileCollection}}
+          <div class="form__field-info" id="campaign-goal-profiles-collection-info">
+            <span class="form__field-info-title">
+              <FaIcon @icon="info-circle" class="form__field-info-icon" />
+              <span>{{t "pages.campaign-creation.purpose.profiles-collection"}}</span>
+            </span>
+            <span class="form__field-info-message">
+              {{t "pages.campaign-creation.purpose.profiles-collection-info"}}
+            </span>
+          </div>
+        {{/if}}
       </div>
-      {{#if this.isCampaignGoalAssessment}}
-        <div class="form__field-info" id="campaign-goal-assessment-info">
-          <span class="form__field-info-title">
-            <FaIcon @icon="info-circle" class="form__field-info-icon" />
-            <span>{{t "pages.campaign-creation.purpose.assessment"}}</span>
-          </span>
-          <span class="form__field-info-message">{{t "pages.campaign-creation.purpose.assessment-info"}}</span>
-        </div>
-      {{else if this.isCampaignGoalProfileCollection}}
-        <div class="form__field-info" id="campaign-goal-profiles-collection-info">
-          <span class="form__field-info-title">
-            <FaIcon @icon="info-circle" class="form__field-info-icon" />
-            <span>{{t "pages.campaign-creation.purpose.profiles-collection"}}</span>
-          </span>
-          <span class="form__field-info-message">{{t "pages.campaign-creation.purpose.profiles-collection-info"}}</span>
-        </div>
-      {{/if}}
     </div>
   {{/if}}
 
   {{#if this.isCampaignGoalAssessment}}
     <div class="form__field-with-info form__field-with-info--small">
-      <div class="form__field form__field--wide">
-        <label class="label" for="campaign-target-profile">
-          <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "pages.campaign-creation.target-profiles-list-label"}}
-        </label>
+      <label class="label" for="campaign-target-profile">
+        <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+        {{t "pages.campaign-creation.target-profiles-list-label"}}
+      </label>
+      {{#if this.categories}}
+        <fieldset class="form__field-filters">
+          <legend class="form__field-filters-title">{{t "pages.campaign-creation.tags-title"}}</legend>
+          {{#each this.categories as |category|}}
+            <PixSelectableTag
+              @label={{category.translation}}
+              @id={{category.name}}
+              @onChange={{fn this.toggleCategory category.name}}
+            />
+          {{/each}}
+        </fieldset>
+      {{/if}}
+      <div class="form__field-with-info form__field--wide">
         <PixSelect
           @id="campaign-target-profile"
           @onChange={{this.selectTargetProfile}}
@@ -108,24 +122,24 @@
             {{display-campaign-errors @errors.targetProfile}}
           </div>
         {{/if}}
-      </div>
-      {{#if this.targetProfile}}
-        <div class="form__field-info" id="target-profile-info">
-          <span class="form__field-info-title">
-            <FaIcon @icon="info-circle" class="form__field-info-icon" />
-            <span>{{this.targetProfile.name}}</span>
-          </span>
+        {{#if this.targetProfile}}
+          <div class="form__field-info" id="target-profile-info">
+            <span class="form__field-info-title">
+              <FaIcon @icon="info-circle" class="form__field-info-icon" />
+              <span>{{this.targetProfile.name}}</span>
+            </span>
 
-          <Campaign::TargetProfileDetails
-            class="form__field-info-message"
-            @targetProfileDescription={{this.targetProfile.description}}
-            @hasStages={{this.targetProfile.hasStage}}
-            @hasBadges={{gt this.targetProfile.thematicResultCount 0}}
-            @targetProfileTubesCount={{this.targetProfile.tubeCount}}
-            @targetProfileThematicResultCount={{this.targetProfile.thematicResultCount}}
-          />
-        </div>
-      {{/if}}
+            <Campaign::TargetProfileDetails
+              class="form__field-info-message"
+              @targetProfileDescription={{this.targetProfile.description}}
+              @hasStages={{this.targetProfile.hasStage}}
+              @hasBadges={{gt this.targetProfile.thematicResultCount 0}}
+              @targetProfileTubesCount={{this.targetProfile.tubeCount}}
+              @targetProfileThematicResultCount={{this.targetProfile.thematicResultCount}}
+            />
+          </div>
+        {{/if}}
+      </div>
     </div>
   {{/if}}
 

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -2,21 +2,29 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import _sortBy from 'lodash/sortBy';
+import _find from 'lodash/find';
+import _pull from 'lodash/pull';
 
 export default class CreateForm extends Component {
   @service currentUser;
+  @service intl;
+
   @tracked campaign;
   @tracked wantIdPix = false;
   @tracked multipleSendingsEnabled = true;
   @tracked isCampaignGoalAssessment = null;
   @tracked isCampaignGoalProfileCollection = null;
   @tracked targetProfile;
+  @tracked selectedCategories = [];
+  @tracked targetProfilesOptions = [];
 
   constructor() {
     super(...arguments);
     this.campaign = {
       organization: this.currentUser.organization,
     };
+    this._setTargetProfilesOptions(this.args.targetProfiles);
 
     if (!this.currentUser.organization.canCollectProfiles) {
       this.isCampaignGoalAssessment = true;
@@ -24,11 +32,57 @@ export default class CreateForm extends Component {
     }
   }
 
-  get targetProfilesOptions() {
+  get categories() {
     if (!this.args.targetProfiles) return [];
-    return this.args.targetProfiles.map((targetProfile) => {
+    let allCategories = this.args.targetProfiles.map((targetProfile) => targetProfile.category);
+
+    const otherCategoryIsPresents = allCategories.includes('OTHER');
+    allCategories = allCategories.map((category) => {
+      return { name: category, translation: this.intl.t(`pages.campaign-creation.tags.${category}`) };
+    });
+
+    allCategories = _sortBy(allCategories, 'translation');
+
+    if (otherCategoryIsPresents) {
+      const other = _find(allCategories, ['name', 'OTHER']);
+      _pull(allCategories, other);
+      allCategories.push(other);
+    }
+
+    return allCategories;
+  }
+
+  _filterTargetProfilesOptions() {
+    if (!this.args.targetProfiles) return [];
+    if (this.selectedCategories.length > 0) {
+      const filteredTargetProfiles = [];
+      this.selectedCategories.forEach((category) => {
+        const targetProfilesForOneCategory = this.args.targetProfiles.filter((targetProfile) => {
+          return targetProfile.category === category;
+        });
+        filteredTargetProfiles.push(...targetProfilesForOneCategory);
+      });
+      this._setTargetProfilesOptions(filteredTargetProfiles);
+    } else {
+      this._setTargetProfilesOptions(this.args.targetProfiles);
+    }
+  }
+
+  _setTargetProfilesOptions(targetProfiles) {
+    if (!targetProfiles) return [];
+    this.targetProfilesOptions = targetProfiles.map((targetProfile) => {
       return { value: targetProfile.id, label: targetProfile.name };
     });
+  }
+
+  @action
+  toggleCategory(category, isChecked) {
+    if (isChecked) {
+      this.selectedCategories.push(category);
+    } else {
+      this.selectedCategories = this.selectedCategories.filter((oldCategory) => oldCategory !== category);
+    }
+    this._filterTargetProfilesOptions();
   }
 
   @action

--- a/orga/app/models/target-profile.js
+++ b/orga/app/models/target-profile.js
@@ -6,4 +6,5 @@ export default class TargetProfile extends Model {
   @attr('number') tubeCount;
   @attr('number') thematicResultCount;
   @attr('boolean') hasStage;
+  @attr('string') category;
 }

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -32,7 +32,6 @@
     }
 
     @include device-is('desktop') {
-      flex-direction: row;
       max-width: 500px;
     }
   }
@@ -69,6 +68,27 @@
     &-message {
       font-size: 0.8125rem;
       color: $grey-60;
+    }
+  }
+  
+  &__field-filters {
+    margin-bottom: 16px;
+    border: 0;
+    padding: 0;
+
+    > legend {
+      font-size: 0.875rem;
+      color: $grey-50;
+      margin-bottom: 2px;
+    }
+
+    .pix-selectable-tag {
+      margin-top: 8px;
+      margin-inline-end: 8px;
+    }
+
+    @include device-is('desktop') {
+      max-width: 500px;
     }
   }
 
@@ -118,6 +138,11 @@
     text-decoration: none;
     border: none;
   }
+}
+
+.pix-select {
+  margin-top: 16px;
+  margin-bottom: 12px;
 }
 
 .label {

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -123,6 +123,91 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.notContains(t('pages.campaign-creation.multiple-sendings.info'));
     });
 
+    module('when there are several target profiles associated to the organization', function () {
+      test('it should display the all category tags', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          organization = EmberObject.create({ canCollectProfiles: true });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.targetProfiles = [
+          EmberObject.create({
+            id: '4',
+            name: 'targetProfile4',
+            description: 'description4',
+            category: 'SUBJECT',
+          }),
+          EmberObject.create({
+            id: '5',
+            name: 'targetProfile5',
+            description: 'description7',
+            category: 'OTHER',
+          }),
+        ];
+        // when
+        await renderScreen(
+          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        );
+        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+        // then
+        assert.contains(t('pages.campaign-creation.tags-title'));
+        assert.contains(t('pages.campaign-creation.tags.SUBJECT'));
+        assert.contains(t('pages.campaign-creation.tags.OTHER'));
+      });
+
+      test('it should display only the target profiles associated to the tag selected', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          organization = EmberObject.create({ canCollectProfiles: true });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.targetProfiles = [
+          EmberObject.create({
+            id: '4',
+            name: 'targetProfile4',
+            description: 'description4',
+            category: 'SUBJECT',
+          }),
+          EmberObject.create({
+            id: '5',
+            name: 'targetProfile5',
+            description: 'description7',
+            category: 'OTHER',
+          }),
+        ];
+        // when
+        await renderScreen(
+          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        );
+        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+        await clickByName(t('pages.campaign-creation.tags.SUBJECT'));
+        // then
+        const option = document.getElementsByTagName('option');
+        assert.equal(option.length, 1);
+        assert.equal(option[0].label, 'targetProfile4');
+      });
+    });
+
+    module('when there is no target profiles associated to the organization', function () {
+      test('it should not display the category tags', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          organization = EmberObject.create({ canCollectProfiles: true });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.targetProfiles = [];
+        // when
+        await renderScreen(
+          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        );
+        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+        // then
+        assert.notContains(t('pages.campaign-creation.tags-title'));
+      });
+    });
+
     module('when the user chose a target profile', function () {
       test('it should display informations about target profile', async function (assert) {
         // given

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -1,0 +1,114 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import Service from '@ember/service';
+
+module('Unit | Component | Campaign::CreateForm', (hooks) => {
+  setupTest(hooks);
+
+  module('#categories', function () {
+    module('when this a target profile without OTHER category', function () {
+      test('should sort categories in alphabetic order', async function (assert) {
+        // given
+        const targetProfiles = [
+          {
+            category: 'SUBJECT',
+            name: 'Accès simplifié',
+          },
+          {
+            category: 'CUSTOM',
+            name: 'PC sur mesure',
+          },
+          {
+            category: 'PREDEFINED',
+            name: 'PC prédéfini',
+          },
+        ];
+        class CurrentUserStub extends Service {
+          organization = { canCollectProfiles: true };
+        }
+        this.owner.lookup('service:intl').setLocale('fr');
+        this.owner.register('service:current-user', CurrentUserStub);
+        const component = await createGlimmerComponent('component:campaign/create-form', {
+          targetProfiles,
+        });
+        //when
+        const allCategories = await component.categories;
+
+        //then
+        const expectedOrder = [
+          {
+            name: 'PREDEFINED',
+            translation: 'Prédéfinie',
+          },
+          {
+            name: 'CUSTOM',
+            translation: 'Sur-mesure',
+          },
+          {
+            name: 'SUBJECT',
+            translation: 'Thématique',
+          },
+        ];
+        assert.deepEqual(allCategories, expectedOrder);
+      });
+    });
+
+    module('when this a target profile with OTHER category', function () {
+      test('should sort categories in alphabetic order and put the other category at the end.', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          organization = { canCollectProfiles: true };
+        }
+        this.owner.lookup('service:intl').setLocale('fr');
+        this.owner.register('service:current-user', CurrentUserStub);
+        const targetProfiles = [
+          {
+            category: 'SUBJECT',
+            name: 'Accès simplifié',
+          },
+          {
+            category: 'CUSTOM',
+            name: 'PC sur mesure',
+          },
+          {
+            category: 'PREDEFINED',
+            name: 'PC prédéfini',
+          },
+          {
+            category: 'OTHER',
+            name: 'PC autre',
+          },
+        ];
+
+        const component = await createGlimmerComponent('component:campaign/create-form', {
+          targetProfiles,
+        });
+
+        //when
+        const allCategories = await component.categories;
+
+        //then
+        const expectedOrder = [
+          {
+            name: 'PREDEFINED',
+            translation: 'Prédéfinie',
+          },
+          {
+            name: 'CUSTOM',
+            translation: 'Sur-mesure',
+          },
+          {
+            name: 'SUBJECT',
+            translation: 'Thématique',
+          },
+          {
+            name: 'OTHER',
+            translation: 'Autre',
+          },
+        ];
+        assert.deepEqual(allCategories, expectedOrder);
+      });
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -320,6 +320,15 @@
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score."
       },
+      "tags": {
+        "COMPETENCES": "Pix Competences",
+        "CUSTOM": "Created for you",
+        "DISCIPLINE": "Schools",
+        "PREDEFINED": "Ready-made",
+        "OTHER": "Other",
+        "SUBJECT": "Subject"
+      },
+      "tags-title": "Filter:",
       "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -320,6 +320,15 @@
         "profiles-collection": "Collecter les profils Pix des participants",
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
       },
+      "tags": {
+        "COMPETENCES": "Compétences Pix",
+        "CUSTOM": "Sur-mesure",
+        "DISCIPLINE": "Disciplinaire",
+        "PREDEFINED": "Prédéfinie",
+        "OTHER": "Autre",
+        "SUBJECT": "Thématique"
+      },
+      "tags-title": "Filtrer la recherche :",
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de la création d'une nouvelle campagne, il était impossible de filtrer des profils cibles en fonction de leur catégories.
Ce qui pouvait rendre la création pénible dû au nombre de profils cibles qu'il fallait parcourir pour trouver le bon profil.

## :gift: Solution
Ajouter des tags correspondant aux catégories des profils cibles de l'orga et lorsqu'on clique sur un tag filtrer les PC correspondant à cette catégorie.

## :star2: Remarques

## :santa: Pour tester
- Aller sur pix orga
- Créer une campagne
- Sélectionner le type campagne d'évaluation
- Constater la présence des tags
- Cliquer sur un ou plusieurs tags et vérifier que les PC proposés sont bien ceux des catégories sélectionnées.
