### PR TITLE
[FEATURE] Afficher la colonne "Écran de fin de test vu" sur la page de finalisation de session si le centre de certification n'utilise pas le portail surveillant (PIX-3748)

### DIFF
--- a/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
@@ -69,6 +69,10 @@ class AllowedCertificationCenterAccess {
   isInWhitelist() {
     return features.pixCertifScoBlockedAccessWhitelist.includes(this.externalId.toUpperCase());
   }
+
+  hasEndTestScreenRemovalEnabled() {
+    return features.endTestScreenRemovalWhiteList.includes(this.id.toString());
+  }
 }
 
 module.exports = AllowedCertificationCenterAccess;

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -26,6 +26,7 @@ module.exports = {
           'isAccessBlockedAgri',
           'relatedOrganizationTags',
           'habilitations',
+          'hasEndTestScreenRemovalEnabled',
         ],
       },
       typeForAttribute: function (attribute) {
@@ -50,6 +51,7 @@ module.exports = {
               isAccessBlockedLycee: access.isAccessBlockedLycee(),
               isAccessBlockedAEFE: access.isAccessBlockedAEFE(),
               isAccessBlockedAgri: access.isAccessBlockedAgri(),
+              hasEndTestScreenRemovalEnabled: access.hasEndTestScreenRemovalEnabled(),
             };
           }
         );

--- a/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
+++ b/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
@@ -30,6 +30,7 @@ describe('Acceptance | Route | CertificationPointOfContact', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.id).to.equal(userId.toString());
+      expect(response.result.included[0].attributes['has-end-test-screen-removal-enabled']).to.be.false;
     });
   });
 });

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -73,6 +73,7 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
               'is-related-to-managing-students-organization': false,
               'related-organization-tags': [],
               habilitations: [],
+              'has-end-test-screen-removal-enabled': false,
             },
           },
         ],

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -688,4 +688,30 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       expect(isScoManagingStudents).to.be.true;
     });
   });
+
+  context('#hasEndTestScreenRemovalEnabled', function () {
+    it('should return true when whitelisted', function () {
+      // given
+      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({ id: 1 });
+      settings.features.endTestScreenRemovalWhiteList = ['1'];
+
+      // when
+      const result = allowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when not whitelisted', function () {
+      // given
+      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({ id: 1 });
+      settings.features.endTestScreenRemovalWhiteList = ['2'];
+
+      // when
+      const result = allowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
+++ b/api/tests/unit/domain/services/end-test-screen-removal-service_test.js
@@ -4,16 +4,19 @@ const endTestScreenRemovalService = require('../../../../lib/domain/services/end
 
 describe('Unit | Domain | Service | EndTestScreenRemoval', function () {
   describe('#isEndTestScreenRemovalEnabledBySessionId', function () {
-    it('should call repository with sessionId', async function () {
+    it('should return value from repository', async function () {
       // given
       const sessionId = Symbol('sessionId');
-      sinon.spy(endTestScreenRemovalRepository, 'isEndTestScreenRemovalEnabledBySessionId');
+      sinon.stub(endTestScreenRemovalRepository, 'isEndTestScreenRemovalEnabledBySessionId');
+      endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledBySessionId.withArgs(sessionId).resolves(false);
 
       // when
-      await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(sessionId);
+      const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
+        sessionId
+      );
 
       // then
-      expect(endTestScreenRemovalRepository.isEndTestScreenRemovalEnabledBySessionId).to.be.calledWith(sessionId);
+      expect(isEndTestScreenRemovalEnabled).to.equals(false);
     });
   });
 

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -30,7 +30,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
       updateLastLoggedAt: sinon.stub(),
     };
     sinon.stub(authenticationService, 'getUserByUsernameAndPassword');
-    sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledByCertificationCenterId');
+    sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledForSomeCertificationCenter');
   });
 
   it('should resolves a valid JWT access token when authentication succeeded', async function () {
@@ -161,15 +161,14 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
     });
 
     context('when scope is pix-certif and user is not linked to any certification centers', function () {
-      it('should rejects an error when feature toggle is disabled for linked certification center', async function () {
+      it('should rejects an error when feature toggle is disabled for all certification center', async function () {
         // given
         const scope = appMessages.PIX_CERTIF.SCOPE;
         const user = domainBuilder.buildUser({ email: userEmail, certificationCenterMemberships: [] });
         authenticationService.getUserByUsernameAndPassword.resolves(user);
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCertificationCenterId.returns(true);
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter.returns(false);
 
         const expectedErrorMessage = appMessages.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG;
-
         // when
         const error = await catchErr(authenticateUser)({
           username: userEmail,
@@ -194,7 +193,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           certificationCenterMemberships: [Symbol('certificationCenterMembership')],
         });
 
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledByCertificationCenterId.returns(true);
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter.returns(true);
         authenticationService.getUserByUsernameAndPassword.resolves(user);
         tokenService.createAccessTokenFromUser.returns(accessToken);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -29,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         relatedOrganizationTags: ['tag1'],
         habilitations: [],
       });
+      allowedCertificationCenterAccess2.hasEndTestScreenRemovalEnabled = sinon.stub().returns(true);
       const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 789,
         firstName: 'Buffy',
@@ -85,6 +86,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 { id: 1, name: 'Certif comp 1' },
                 { id: 2, name: 'Certif comp 2' },
               ],
+              'has-end-test-screen-removal-enabled': false,
             },
           },
           {
@@ -101,6 +103,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-agri': false,
               'related-organization-tags': ['tag1'],
               habilitations: [],
+              'has-end-test-screen-removal-enabled': true,
             },
           },
         ],
@@ -186,6 +189,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 'is-access-blocked-agri': false,
                 'related-organization-tags': [],
                 habilitations: [],
+                'has-end-test-screen-removal-enabled': false,
               },
             },
             {
@@ -202,6 +206,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 'is-access-blocked-agri': false,
                 'related-organization-tags': ['tag1'],
                 habilitations: [],
+                'has-end-test-screen-removal-enabled': false,
               },
             },
           ],

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -14,17 +14,22 @@
         <th>Prénom</th>
         <th>N° de certification</th>
         <th>Signalement</th>
-        <th>
-          <div class="session-finalization-reports-information-step__row">
-            <div
-              class="session-finalization-reports-information-step__checker"
-              {{on "click" (fn @onAllHasSeenEndTestScreenCheckboxesClicked this.hasCheckedSomething)}}
-            >
-              <CertifCheckbox @state={{this.headerCheckboxStatus}} />
+        {{#if @shouldDisplayHasSeenEndTestScreenCheckbox}}
+          <th>
+            <div class="session-finalization-reports-information-step__row">
+              <div
+                class="session-finalization-reports-information-step__checker"
+                {{on "click" (fn @onAllHasSeenEndTestScreenCheckboxesClicked this.hasCheckedSomething)}}
+              >
+                <CertifCheckbox
+                  data-test-id="finalization-report-all-candidates-have-seen-end-test-screen"
+                  @state={{this.headerCheckboxStatus}}
+                />
+              </div>
+              Écran de fin du test vu
             </div>
-            Écran de fin du test vu
-          </div>
-        </th>
+          </th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
@@ -64,13 +69,15 @@
               {{/if}}
             </div>
           </td>
-          <td>
-            <CertifCheckbox
-              data-test-id="finalization-report-has-seen-end-test-screen_{{report.certificationCourseId}}"
-              @state={{if report.hasSeenEndTestScreen "checked" "unchecked"}}
-              {{on "click" (fn @onHasSeenEndTestScreenCheckboxClicked report)}}
-            />
-          </td>
+          {{#if @shouldDisplayHasSeenEndTestScreenCheckbox}}
+            <td>
+              <CertifCheckbox
+                data-test-id="finalization-report-has-seen-end-test-screen_{{report.certificationCourseId}}"
+                @state={{if report.hasSeenEndTestScreen "checked" "unchecked"}}
+                {{on "click" (fn @onHasSeenEndTestScreenCheckboxClicked report)}}
+              />
+            </td>
+          {{/if}}
         </tr>
       {{/each}}
     </tbody>

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -11,6 +11,7 @@ import trim from 'lodash/trim';
 
 export default class SessionsFinalizeController extends Controller {
   @service featureToggles;
+  @service currentUser;
 
   @service notifications;
 
@@ -26,6 +27,10 @@ export default class SessionsFinalizeController extends Controller {
 
   get isManageUncompletedCertifEnabled() {
     return this.featureToggles.featureToggles.isManageUncompletedCertifEnabled;
+  }
+
+  get shouldDisplayHasSeenEndTestScreenCheckbox() {
+    return !this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
   }
 
   get uncheckedHasSeenEndTestScreenCount() {

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -11,6 +11,7 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() isAccessBlockedAgri;
   @attr() relatedOrganizationTags;
   @attr() habilitations;
+  @attr() hasEndTestScreenRemovalEnabled;
 
   get isSco() {
     return this.type === 'SCO';

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -36,6 +36,7 @@
         @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
         @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
         @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
+          @shouldDisplayHasSeenEndTestScreenCheckbox={{true}}
       />
     {{/if}}
   </SessionFinalizationStepContainer>

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -36,7 +36,7 @@
         @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
         @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
         @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
-          @shouldDisplayHasSeenEndTestScreenCheckbox={{true}}
+        @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
       />
     {{/if}}
   </SessionFinalizationStepContainer>

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import { visit } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -22,6 +23,7 @@ module('Acceptance | Session Finalization', function (hooks) {
       isAccessBlockedLycee: false,
       isAccessBlockedAEFE: false,
       isAccessBlockedAgri: false,
+      hasEndTestScreenRemovalEnabled: false,
     });
     certificationPointOfContact = server.create('certification-point-of-contact', {
       firstName: 'Buffy',
@@ -76,6 +78,15 @@ module('Acceptance | Session Finalization', function (hooks) {
 
       // then
       assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
+    });
+
+    test('it should display the end screen column when the center has no access to the supervisor space', async function (assert) {
+      // when
+      server.create('feature-toggle', { isEndTestScreenRemovalEnabled: true });
+      const screen = await visit(`/sessions/${session.id}/finalisation`);
+
+      // then
+      assert.dom(screen.queryByText('Écran de fin du test vu')).exists();
     });
 
     module('When certificationPointOfContact click on "Finaliser" button', function () {

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -208,4 +208,58 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     // then
     assert.dom(screen.getByRole('table', { name: 'Certification(s) terminée(s)' })).exists();
   });
+
+  module('when isEndTestScreenRemovalEnabled feature toggle is disabled', function() {
+    test('it shows the "Écran de fin de test vu" column', async function(assert) {
+      // given
+      this.certificationReports = [run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: null,
+        certificationCourseId: 1,
+      }))];
+      this.issueReportDescriptionMaxLength = 500;
+      this.toggleCertificationReportHasSeenEndTestScreen = sinon.stub().returns();
+      this.toggleAllCertificationReportsHasSeenEndTestScreen = sinon.stub().returns();
+      this.shouldDisplayHasSeenEndTestScreenCheckbox = true;
+
+      // when
+      await render(hbs`
+        <SessionFinalization::CompletedReportsInformationStep
+          @certificationReports={{this.certificationReports}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+          @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
+          @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+          @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+        />
+      `);
+
+      // then
+      assert.dom('[data-test-id="finalization-report-all-candidates-have-seen-end-test-screen"]').exists();
+      assert.dom('[data-test-id="finalization-report-has-seen-end-test-screen_1"]').exists();
+    });
+  });
+
+  module('when isEndTestScreenRemovalEnabled feature toggle is enabled', function() {
+    test('it hides the "Écran de fin de test vu" column', async function(assert) {
+      // given
+      this.certificationReports = [run(() => store.createRecord('certification-report', {
+        hasSeenEndTestScreen: null,
+        certificationCourseId: 1,
+      }))];
+      this.issueReportDescriptionMaxLength = 500;
+      this.shouldDisplayHasSeenEndTestScreenCheckbox = false;
+
+      // when
+      await render(hbs`
+        <SessionFinalization::CompletedReportsInformationStep
+          @certificationReports={{this.certificationReports}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+          @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+        />
+      `);
+
+      // then
+      assert.dom('[data-test-id="finalization-report-all-candidates-have-seen-end-test-screen"]').doesNotExist();
+      assert.dom('[data-test-id="finalization-report-has-seen-end-test-screen_1"]').doesNotExist();
+    });
+  });
 });

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -4,7 +4,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { A } from '@ember/array';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { run } from '@ember/runloop';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
@@ -18,31 +17,25 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
 
-    certificationIssueReportA = run(() =>
-      store.createRecord('certification-issue-report', {
-        description: 'Coucou',
-        category: certificationIssueReportCategories.OTHER,
-      })
-    );
+    certificationIssueReportA = store.createRecord('certification-issue-report', {
+      description: 'Coucou',
+      category: certificationIssueReportCategories.OTHER,
+    });
 
-    reportA = run(() =>
-      store.createRecord('certification-report', {
-        certificationCourseId: 1234,
-        firstName: 'Alice',
-        lastName: 'Alister',
-        certificationIssueReports: A([certificationIssueReportA]),
-        hasSeenEndTestScreen: null,
-      })
-    );
+    reportA = store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      firstName: 'Alice',
+      lastName: 'Alister',
+      certificationIssueReports: A([certificationIssueReportA]),
+      hasSeenEndTestScreen: null,
+    });
 
-    reportB = run(() =>
-      store.createRecord('certification-report', {
-        certificationCourseId: 3,
-        firstName: 'Bob',
-        lastName: 'Bober',
-        hasSeenEndTestScreen: true,
-      })
-    );
+    reportB = store.createRecord('certification-report', {
+      certificationCourseId: 3,
+      firstName: 'Bob',
+      lastName: 'Bober',
+      hasSeenEndTestScreen: true,
+    });
 
     this.set('certificationReports', [reportA, reportB]);
     this.set('issueReportDescriptionMaxLength', 500);
@@ -52,21 +45,17 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
 
   test('it shows "1 signalement" if there is exactly one certification issue report', async function (assert) {
     // given
-    const certificationIssueReport = run(() =>
-      store.createRecord('certification-issue-report', {
-        description: 'Coucou',
-        category: certificationIssueReportCategories.OTHER,
-      })
-    );
-    const certificationReport = run(() =>
-      store.createRecord('certification-report', {
-        certificationCourseId: 1234,
-        firstName: 'Alice',
-        lastName: 'Alister',
-        certificationIssueReports: [certificationIssueReport],
-        hasSeenEndTestScreen: null,
-      })
-    );
+    const certificationIssueReport = store.createRecord('certification-issue-report', {
+      description: 'Coucou',
+      category: certificationIssueReportCategories.OTHER,
+    });
+    const certificationReport = store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      firstName: 'Alice',
+      lastName: 'Alister',
+      certificationIssueReports: [certificationIssueReport],
+      hasSeenEndTestScreen: null,
+    });
     this.set('certificationReports', [certificationReport]);
 
     // when
@@ -87,27 +76,21 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
 
   test('it shows "X signalements" (plural) if there is more than one certification issue reports', async function (assert) {
     // given
-    const certificationIssueReport1 = run(() =>
-      store.createRecord('certification-issue-report', {
-        description: 'Coucou',
-        category: certificationIssueReportCategories.OTHER,
-      })
-    );
-    const certificationIssueReport2 = run(() =>
-      store.createRecord('certification-issue-report', {
-        description: 'Les zouzous',
-        category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
-      })
-    );
-    const certificationReport = run(() =>
-      store.createRecord('certification-report', {
-        certificationCourseId: 1234,
-        firstName: 'Alice',
-        lastName: 'Alister',
-        certificationIssueReports: [certificationIssueReport1, certificationIssueReport2],
-        hasSeenEndTestScreen: null,
-      })
-    );
+    const certificationIssueReport1 = store.createRecord('certification-issue-report', {
+      description: 'Coucou',
+      category: certificationIssueReportCategories.OTHER,
+    });
+    const certificationIssueReport2 = store.createRecord('certification-issue-report', {
+      description: 'Les zouzous',
+      category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
+    });
+    const certificationReport = store.createRecord('certification-report', {
+      certificationCourseId: 1234,
+      firstName: 'Alice',
+      lastName: 'Alister',
+      certificationIssueReports: [certificationIssueReport1, certificationIssueReport2],
+      hasSeenEndTestScreen: null,
+    });
     this.set('certificationReports', [certificationReport]);
 
     // when
@@ -128,14 +111,11 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
 
   test('it shows "Certification(s) terminée(s)" if there is at least one uncomplete certification report', async function (assert) {
     // given
-    const certificationReport1 = run(() => store.createRecord('certification-report', { isCompleted: false }));
-    const certificationReport2 = run(() => store.createRecord('certification-report', { isCompleted: true }));
-    const session = run(() =>
-      store.createRecord('session', {
-        certificationReports: [certificationReport1, certificationReport2],
-      })
-    );
-
+    const certificationReport1 = store.createRecord('certification-report', { isCompleted: false });
+    const certificationReport2 = store.createRecord('certification-report', { isCompleted: true });
+    const session = store.createRecord('session', {
+      certificationReports: [certificationReport1, certificationReport2],
+    });
     this.set('certificationReports', [certificationReport1, certificationReport2]);
     this.set('session', session);
 
@@ -156,14 +136,11 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
 
   test('it does not show "Certification(s) terminée(s)" if there is no uncomplete certification report', async function (assert) {
     // given
-    const certificationReport1 = run(() => store.createRecord('certification-report', { isCompleted: true }));
-    const certificationReport2 = run(() => store.createRecord('certification-report', { isCompleted: true }));
-    const session = run(() =>
-      store.createRecord('session', {
-        certificationReports: [certificationReport1, certificationReport2],
-      })
-    );
-
+    const certificationReport1 = store.createRecord('certification-report', { isCompleted: true });
+    const certificationReport2 = store.createRecord('certification-report', { isCompleted: true });
+    const session = store.createRecord('session', {
+      certificationReports: [certificationReport1, certificationReport2],
+    });
     this.set('certificationReports', [certificationReport1, certificationReport2]);
     this.set('session', session);
 
@@ -185,11 +162,9 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
   test('it has an accessible label', async function (assert) {
     // given
     this.certificationReports = [
-      run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: null,
-        })
-      ),
+      store.createRecord('certification-report', {
+        hasSeenEndTestScreen: null,
+      }),
     ];
     this.issueReportDescriptionMaxLength = 500;
     this.toggleCertificationReportHasSeenEndTestScreen = sinon.stub().returns();
@@ -209,13 +184,15 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     assert.dom(screen.getByRole('table', { name: 'Certification(s) terminée(s)' })).exists();
   });
 
-  module('when isEndTestScreenRemovalEnabled feature toggle is disabled', function() {
-    test('it shows the "Écran de fin de test vu" column', async function(assert) {
+  module('when isEndTestScreenRemovalEnabled feature toggle is disabled', function () {
+    test('it shows the "Écran de fin de test vu" column', async function (assert) {
       // given
-      this.certificationReports = [run(() => store.createRecord('certification-report', {
-        hasSeenEndTestScreen: null,
-        certificationCourseId: 1,
-      }))];
+      this.certificationReports = [
+        store.createRecord('certification-report', {
+          hasSeenEndTestScreen: null,
+          certificationCourseId: 1,
+        }),
+      ];
       this.issueReportDescriptionMaxLength = 500;
       this.toggleCertificationReportHasSeenEndTestScreen = sinon.stub().returns();
       this.toggleAllCertificationReportsHasSeenEndTestScreen = sinon.stub().returns();
@@ -238,13 +215,15 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     });
   });
 
-  module('when isEndTestScreenRemovalEnabled feature toggle is enabled', function() {
-    test('it hides the "Écran de fin de test vu" column', async function(assert) {
+  module('when isEndTestScreenRemovalEnabled feature toggle is enabled', function () {
+    test('it hides the "Écran de fin de test vu" column', async function (assert) {
       // given
-      this.certificationReports = [run(() => store.createRecord('certification-report', {
-        hasSeenEndTestScreen: null,
-        certificationCourseId: 1,
-      }))];
+      this.certificationReports = [
+        store.createRecord('certification-report', {
+          hasSeenEndTestScreen: null,
+          certificationCourseId: 1,
+        }),
+      ];
       this.issueReportDescriptionMaxLength = 500;
       this.shouldDisplayHasSeenEndTestScreenCheckbox = false;
 

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -17,6 +17,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
           isManageUncompletedCertifEnabled: false,
         };
       }
+
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
@@ -40,6 +41,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
           isManageUncompletedCertifEnabled: false,
         };
       }
+
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
@@ -80,6 +82,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
           isManageUncompletedCertifEnabled: false,
         };
       }
+
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
@@ -113,6 +116,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
           isManageUncompletedCertifEnabled: false,
         };
       }
+
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
@@ -137,6 +141,72 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
 
       // then
       assert.true(hasUncheckedHasSeenEndTestScreen);
+    });
+  });
+
+  module('#computed shouldDisplayHasSeenEndTestScreenCheckbox', function () {
+    test('it should return false if certification center has access to supervisor space', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = run(() =>
+        store.createRecord('allowed-certification-center-access', {
+          id: 123,
+          name: 'Test certification center',
+          type: 'NOT_SCO',
+          hasEndTestScreenRemovalEnabled: true,
+        })
+      );
+
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      controller.model = run(() =>
+        store.createRecord('session', {
+          certificationReports: [],
+        })
+      );
+
+      // when
+      const result = controller.shouldDisplayHasSeenEndTestScreenCheckbox;
+
+      // then
+      assert.false(result);
+    });
+
+    test('it should return true if certification center has access to supervisor space', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = run(() =>
+        store.createRecord('allowed-certification-center-access', {
+          id: 123,
+          name: 'Test certification center',
+          type: 'NOT_SCO',
+          hasEndTestScreenRemovalEnabled: false,
+        })
+      );
+
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      controller.model = run(() =>
+        store.createRecord('session', {
+          certificationReports: [],
+        })
+      );
+
+      // when
+      const result = controller.shouldDisplayHasSeenEndTestScreenCheckbox;
+
+      // then
+      assert.true(result);
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Les fonctionnalités du nouvel espace surveillant permettent de s’assurer qu’un candidat passant son test de certification l’ai fait de A à Z sous surveillance. Il n’est donc plus nécessaire de signifier manuellement la fin de test d’un candidat pour le surveillant.

## :gift: Solution
Sur la page de finalisation de session, retirer la colonne “Ecran de fin de test vu”
- pour tous les types de CDC
- si le CDC a accès au portail surveillant (est dans la whitelist)

## :star2: Remarques
La case à cocher en question est implémentée à l'aide bouton sans libellé avec une icône pour indiquer son état ce qui est *affreux* :scream: d'un point de vue accessibilité, mais je me suis retenu de corriger vu que ce code est amené à disparaître rapidement.

## :santa: Pour tester

### Avec un centre qui ***n'a pas*** d'espace surveillant

1. Se connecter à Pix Certif
2. S'assurer que l'external ID du centre sélectionné ***n'est pas*** dans la var d'env END_TEST_SCREEN_REMOVAL_WHITELIST
3. Accéder à une session finalisable et cliquer sur *Finaliser*
4. Constater que la colonne "Écran de fin de test vu" ***apparaît***

### Avec un centre qui ***a*** un espace surveillant

1. Se connecter à Pix Certif
2. S'assurer que l'external ID du centre sélectionné ***est*** dans la var d'env END_TEST_SCREEN_REMOVAL_WHITELIST
3. Accéder à une session finalisable et cliquer sur *Finaliser*
4. Constater que la colonne "Écran de fin de test vu" ***n'apparaît pas***
