### PR TITLE
[FEATURE] Enregistre le prescrit dans la participation lors de la création de la participation (PIX-4114)

### DIFF
--- a/api/db/migrations/20220111143029_add-schooling-registration-id-campaign-participation.js
+++ b/api/db/migrations/20220111143029_add-schooling-registration-id-campaign-participation.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'campaign-participations';
+const REFERENCE_TABLE_NAME = 'schooling-registrations';
+const COLUMN_NAME = 'schoolingRegistrationId';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).references(`${REFERENCE_TABLE_NAME}.id`).defaultTo(null);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -26,6 +26,7 @@ class CampaignParticipation {
     userId,
     validatedSkillsCount,
     pixScore,
+    schoolingRegistrationId,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -40,6 +41,7 @@ class CampaignParticipation {
     this.status = status;
     this.validatedSkillsCount = validatedSkillsCount;
     this.pixScore = pixScore;
+    this.schoolingRegistrationId = schoolingRegistrationId;
   }
 
   static start(campaignParticipation) {

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -45,12 +45,17 @@ class CampaignParticipation {
   }
 
   static start(campaignParticipation) {
+    const { schoolingRegistrationId = null } = campaignParticipation;
     const { isAssessment } = campaignParticipation.campaign;
     const { STARTED, TO_SHARE } = CampaignParticipation.statuses;
 
     const status = isAssessment ? STARTED : TO_SHARE;
 
-    return new CampaignParticipation({ ...campaignParticipation, status });
+    return new CampaignParticipation({
+      ...campaignParticipation,
+      status,
+      schoolingRegistrationId,
+    });
   }
 
   get isShared() {

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -9,6 +9,7 @@ module.exports = async function startCampaignParticipation({
   campaignParticipationRepository,
   assessmentRepository,
   campaignToJoinRepository,
+  schoolingRegistrationRepository,
   domainTransaction,
 }) {
   const campaignToJoin = await campaignToJoinRepository.get(campaignParticipation.campaignId, domainTransaction);
@@ -57,6 +58,7 @@ module.exports = async function startCampaignParticipation({
       userId,
       campaignToJoin,
       campaignParticipationRepository,
+      schoolingRegistrationRepository,
       domainTransaction
     );
     if (campaignToJoin.isAssessment) {
@@ -73,6 +75,7 @@ module.exports = async function startCampaignParticipation({
       userId,
       campaignToJoin,
       campaignParticipationRepository,
+      schoolingRegistrationRepository,
       domainTransaction
     );
     if (campaignToJoin.isAssessment) {
@@ -96,9 +99,20 @@ async function _saveCampaignParticipation(
   userId,
   campaign,
   campaignParticipationRepository,
+  schoolingRegistrationRepository,
   domainTransaction
 ) {
-  const userParticipation = CampaignParticipation.start({ ...campaignParticipation, campaign, userId });
+  const schoolingRegistration = await schoolingRegistrationRepository.findOneByUserIdAndOrganizationId({
+    organizationId: campaign.organizationId,
+    userId,
+    domainTransaction,
+  });
+  const userParticipation = CampaignParticipation.start({
+    ...campaignParticipation,
+    campaign,
+    userId,
+    schoolingRegistrationId: schoolingRegistration?.id,
+  });
 
   return campaignParticipationRepository.save(userParticipation, domainTransaction);
 }

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -269,6 +269,7 @@ function _adaptModelToDb(campaignParticipation) {
     participantExternalId: campaignParticipation.participantExternalId,
     userId: campaignParticipation.userId,
     status: campaignParticipation.status,
+    schoolingRegistrationId: campaignParticipation.schoolingRegistrationId,
   };
 }
 

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -260,16 +260,17 @@ module.exports = {
     );
   },
 
-  findOneByUserIdAndOrganizationId({
+  async findOneByUserIdAndOrganizationId({
     userId,
     organizationId,
     domainTransaction = DomainTransaction.emptyTransaction(),
   }) {
-    return BookshelfSchoolingRegistration.where({ userId, organizationId })
-      .fetch({ require: false, transacting: domainTransaction.knexTransaction })
-      .then((schoolingRegistration) =>
-        bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration)
-      );
+    const schoolingRegistration = await knex('schooling-registrations')
+      .transacting(domainTransaction)
+      .first('*')
+      .where({ userId, organizationId });
+    if (!schoolingRegistration) return null;
+    return new SchoolingRegistration(schoolingRegistration);
   },
 
   async updateStudentNumber(studentId, studentNumber) {

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -260,9 +260,13 @@ module.exports = {
     );
   },
 
-  findOneByUserIdAndOrganizationId({ userId, organizationId }) {
+  findOneByUserIdAndOrganizationId({
+    userId,
+    organizationId,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
     return BookshelfSchoolingRegistration.where({ userId, organizationId })
-      .fetch({ require: false })
+      .fetch({ require: false, transacting: domainTransaction.knexTransaction })
       .then((schoolingRegistration) =>
         bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration)
       );

--- a/api/tests/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/start-campaign-participation_test.js
@@ -12,6 +12,7 @@ const DomainTransaction = require('../../../../lib/infrastructure/DomainTransact
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
 const campaignToJoinRepository = require('../../../../lib/infrastructure/repositories/campaign-to-join-repository');
+const schoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/schooling-registration-repository');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
@@ -33,6 +34,70 @@ describe('Integration | UseCases | start-campaign-participation', function () {
   afterEach(async function () {
     await knex('assessments').delete();
     await knex('campaign-participations').delete();
+    await knex('schooling-registrations').delete();
+  });
+
+  context('when user has a schooling registration', function () {
+    let schoolingRegistrationId;
+    beforeEach(async function () {
+      schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId,
+        userId,
+      }).id;
+      await databaseBuilder.commit();
+    });
+    it('should save a campaign participation of type ASSESSMENT with a schoolingRegistrationId', async function () {
+      // given
+      campaignId = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, organizationId }).id;
+      await databaseBuilder.commit();
+      const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+      // when
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await startCampaignParticipation({
+          campaignParticipation,
+          userId,
+          campaignParticipationRepository,
+          assessmentRepository,
+          campaignToJoinRepository,
+          schoolingRegistrationRepository,
+          domainTransaction,
+        });
+      });
+
+      // then
+      const campaignParticipations = await knex('campaign-participations');
+      expect(campaignParticipations).to.have.lengthOf(1);
+      expect(campaignParticipations[0].schoolingRegistrationId).to.equal(schoolingRegistrationId);
+    });
+
+    it('should save a campaign participation of type PROFILES_COLLECTION with a schoolingRegistrationId', async function () {
+      // given
+      campaignId = databaseBuilder.factory.buildCampaign({
+        type: Campaign.types.PROFILES_COLLECTION,
+        organizationId,
+      }).id;
+      await databaseBuilder.commit();
+      const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+      // when
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await startCampaignParticipation({
+          campaignParticipation,
+          userId,
+          campaignParticipationRepository,
+          assessmentRepository,
+          campaignToJoinRepository,
+          schoolingRegistrationRepository,
+          domainTransaction,
+        });
+      });
+
+      // then
+      const campaignParticipations = await knex('campaign-participations');
+      expect(campaignParticipations).to.have.lengthOf(1);
+      expect(campaignParticipations[0].schoolingRegistrationId).to.equal(schoolingRegistrationId);
+    });
   });
 
   it('should save a campaign participation and its assessment when campaign is of type ASSESSMENT', async function () {
@@ -49,6 +114,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
         campaignParticipationRepository,
         assessmentRepository,
         campaignToJoinRepository,
+        schoolingRegistrationRepository,
         domainTransaction,
       });
     });
@@ -75,6 +141,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
         campaignParticipationRepository,
         assessmentRepository,
         campaignToJoinRepository,
+        schoolingRegistrationRepository,
         domainTransaction,
       });
     });
@@ -102,6 +169,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
           campaignParticipationRepository,
           assessmentRepository,
           campaignToJoinRepository,
+          schoolingRegistrationRepository,
           domainTransaction,
         });
         throw new Error('an error occurs within the domain transaction');
@@ -139,6 +207,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
           campaignParticipationRepository,
           assessmentRepository,
           campaignToJoinRepository,
+          schoolingRegistrationRepository,
           domainTransaction,
         });
       });
@@ -165,6 +234,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
           campaignParticipationRepository,
           assessmentRepository,
           campaignToJoinRepository,
+          schoolingRegistrationRepository,
           domainTransaction,
         });
       });
@@ -190,6 +260,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
         campaignParticipationRepository,
         assessmentRepository,
         campaignToJoinRepository,
+        schoolingRegistrationRepository,
       });
 
       expect(error).to.be.instanceOf(EntityValidationError);
@@ -206,6 +277,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
         campaignParticipationRepository,
         assessmentRepository,
         campaignToJoinRepository,
+        schoolingRegistrationRepository,
       });
 
       const campaignParticipations = await knex('campaign-participations');
@@ -232,6 +304,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
             campaignParticipationRepository,
             assessmentRepository,
             campaignToJoinRepository,
+            schoolingRegistrationRepository,
           });
 
           expect(error).to.be.instanceOf(EntityValidationError);
@@ -248,6 +321,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
             campaignParticipationRepository,
             assessmentRepository,
             campaignToJoinRepository,
+            schoolingRegistrationRepository,
           });
 
           const campaignParticipations = await knex('campaign-participations');
@@ -270,6 +344,7 @@ describe('Integration | UseCases | start-campaign-participation', function () {
               campaignParticipationRepository,
               assessmentRepository,
               campaignToJoinRepository,
+              schoolingRegistrationRepository,
               domainTransaction,
             });
           });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -96,11 +96,12 @@ describe('Integration | Repository | Campaign Participation', function () {
   });
 
   describe('#save', function () {
-    let campaignId, userId;
+    let campaignId, userId, schoolingRegistrationId;
     beforeEach(async function () {
       await knex('campaign-participations').delete();
       userId = databaseBuilder.factory.buildUser({}).id;
       campaignId = databaseBuilder.factory.buildCampaign({}).id;
+      schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ userId }).id;
 
       await databaseBuilder.commit();
     });
@@ -161,6 +162,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       const campaignParticipationToSave = new CampaignParticipation({
         campaignId,
         userId,
+        schoolingRegistrationId,
         participantExternalId: '034516273645RET',
       });
 
@@ -169,12 +171,13 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       // then
       const campaignParticipationInDB = await knex
-        .select('id', 'campaignId', 'participantExternalId', 'userId')
+        .select('id', 'campaignId', 'participantExternalId', 'userId', 'schoolingRegistrationId')
         .from('campaign-participations')
         .where({ id: savedCampaignParticipation.id });
       expect(campaignParticipationInDB).to.have.length(1);
       expect(campaignParticipationInDB[0].id).to.equal(savedCampaignParticipation.id);
       expect(campaignParticipationInDB[0].campaignId).to.equal(campaignParticipationToSave.campaignId);
+      expect(campaignParticipationInDB[0].schoolingRegistrationId).to.equal(schoolingRegistrationId);
       expect(campaignParticipationInDB[0].participantExternalId).to.equal(
         savedCampaignParticipation.participantExternalId
       );

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
@@ -13,6 +13,7 @@ module.exports = function buildCampaignParticipation({
   userId = 123,
   status = SHARED,
   validatedSkillsCount,
+  schoolingRegistrationId = null,
 } = {}) {
   const isShared = status === SHARED;
   return new CampaignParticipation({
@@ -26,5 +27,6 @@ module.exports = function buildCampaignParticipation({
     assessments,
     userId,
     validatedSkillsCount,
+    schoolingRegistrationId,
   });
 };

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -185,6 +185,23 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
       expect(campaignParticipation instanceof CampaignParticipation).to.be.true;
     });
 
+    context('schoolingRegistrationId', function () {
+      it('it should set schoolingRegistrationId', function () {
+        const schoolingRegistrationId = 1;
+        const campaign = domainBuilder.buildCampaignToJoin();
+        const campaignParticipation = CampaignParticipation.start({ campaign, schoolingRegistrationId });
+
+        expect(campaignParticipation.schoolingRegistrationId).to.be.equal(schoolingRegistrationId);
+      });
+
+      it('it should set schoolingRegistrationId to null if it is not provided', function () {
+        const campaign = domainBuilder.buildCampaignToJoin();
+        const campaignParticipation = CampaignParticipation.start({ campaign });
+
+        expect(campaignParticipation.schoolingRegistrationId).to.be.equal(null);
+      });
+    });
+
     context('status', function () {
       context('when the campaign as the type PROFILES_COLLECTION', function () {
         it('status to TO_SHARE', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de la refonte du “prescrit” au sein de Pix, nous avons décidé de revoir complétement la notion de prescrit dans le code et en BDD. Ces US font partie d’une première épix permettant d’uniformiser cette entité entre tous types d’orgas (ayant l’import ou pas)

Une première étape consiste à lié les schooling registrations aux campaign participations lorsqu'elles existent.

## :gift: Solution
On ajoute une colonne schoolingRegistrationId sur la table campaign-participations

A la création d'une campaign participation on vérifie si l'utilisateur est lié à une schooling registration pour l'organisation qui possède la campagne. Si c'est le cas on la lie à la campaign participation.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Il n'y a aucun changement d'un point de vue fonctionnel. Il est possible de tester ce ticket localement : 
- Lancer Pix App 
- Participer à la campagne avec le code BADGES123
- Se connecter avec First, Last, 10/10/2010
- Aller voir en base de données dans la table campaign-participations que la dernière participation à la colonne schoolingRegistrationId qui vaut autre chose que null