### PR TITLE
[FEATURE] Pouvoir éditer le flag "Affichage acquis dans l'export résultats" d'une orga dans Pix Admin (PIX-4103).

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -140,6 +140,20 @@
               @checked={{this.form.canCollectProfiles}}
             />
           </div>
+          <div class="form-field organization-edit-form__checkbox">
+            <label for="showSkills" class="form-field__label">Affichage des acquis dans l'export de résultats</label>
+            {{#if (v-get this.form "showSkills" "isInvalid")}}
+              <div class="form-field__error">
+                {{v-get this.form "showSkills" "message"}}
+              </div>
+            {{/if}}
+            <Input
+              id="showSkills"
+              @type="checkbox"
+              class={{if (v-get this.form "showSkills" "isInvalid") "form-control is-invalid" "form-control"}}
+              @checked={{this.form.showSkills}}
+            />
+          </div>
           <div class="form-actions">
             <PixButton
               @size="small"

--- a/admin/app/components/organizations/information-section.js
+++ b/admin/app/components/organizations/information-section.js
@@ -83,6 +83,13 @@ const Validations = buildValidations({
       }),
     ],
   },
+  showSkills: {
+    validators: [
+      validator('inclusion', {
+        in: [true, false],
+      }),
+    ],
+  },
 });
 
 class Form extends Object.extend(Validations) {
@@ -94,6 +101,7 @@ class Form extends Object.extend(Validations) {
   @tracked isManagingStudents;
   @tracked canCollectProfiles;
   @tracked documentationUrl;
+  @tracked showSkills;
 }
 
 export default class OrganizationInformationSection extends Component {
@@ -146,6 +154,7 @@ export default class OrganizationInformationSection extends Component {
     this.args.organization.set('isManagingStudents', this.form.isManagingStudents);
     this.args.organization.set('canCollectProfiles', this.form.canCollectProfiles);
     this.args.organization.set('documentationUrl', this.form.documentationUrl);
+    this.args.organization.set('showSkills', this.form.showSkills);
 
     this.isEditMode = false;
     return this.args.onSubmit();
@@ -160,5 +169,6 @@ export default class OrganizationInformationSection extends Component {
     this.form.isManagingStudents = this.args.organization.isManagingStudents;
     this.form.canCollectProfiles = this.args.organization.canCollectProfiles;
     this.form.documentationUrl = this.args.organization.documentationUrl;
+    this.form.showSkills = this.args.organization.showSkills;
   }
 }

--- a/admin/mirage/factories/organization.js
+++ b/admin/mirage/factories/organization.js
@@ -7,4 +7,7 @@ export default Factory.extend({
   isManagingStudents() {
     return false;
   },
+  showSkills() {
+    return false;
+  },
 });

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -128,6 +128,7 @@ module('Integration | Component | organizations/information-section', function (
         isManagingStudents: false,
         credit: 0,
         documentationUrl: 'https://pix.fr/',
+        showSkills: false,
       });
       this.set('organization', organization);
     });
@@ -167,6 +168,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom('input#canCollectProfiles').isNotChecked();
       assert.dom('input#isManagingStudents').isNotChecked();
       assert.dom('input#documentationUrl').hasValue(organization.documentationUrl);
+      assert.dom('input#showSkills').isNotChecked();
     });
 
     test("it should show error message if organization's name is empty", async function (assert) {
@@ -288,6 +290,7 @@ module('Integration | Component | organizations/information-section', function (
       await clickByLabel('Gestion d’élèves/étudiants');
       await clickByLabel('Collecte de profils');
       await fillIn('input#documentationUrl', 'new documentationUrl');
+      await clickByLabel("Affichage des acquis dans l'export de résultats");
 
       // when
       await clickByLabel('Annuler');
@@ -299,6 +302,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom('.organization__isManagingStudents').hasText('Non');
       assert.dom('.organization__canCollectProfiles').hasText('Non');
       assert.contains(organization.documentationUrl);
+      assert.dom('.organization__showSkills').hasText('Non');
     });
 
     test('it should submit the form if there is no error', async function (assert) {

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -26,7 +26,7 @@ module.exports = async function updateOrganizationInformation({
   existingOrganization.isManagingStudents = organization.isManagingStudents;
   existingOrganization.canCollectProfiles = organization.canCollectProfiles;
   existingOrganization.documentationUrl = organization.documentationUrl;
-
+  existingOrganization.showSkills = organization.showSkills;
   return organizationRepository.update(existingOrganization);
 };
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -106,6 +106,7 @@ module.exports = {
       'email',
       'credit',
       'documentationUrl',
+      'showSkills',
     ]);
 
     return new BookshelfOrganization({ id: organization.id })

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -85,6 +85,7 @@ module.exports = {
       canCollectProfiles: attributes['can-collect-profiles'],
       createdBy: attributes['created-by'],
       documentationUrl: attributes['documentation-url'],
+      showSkills: attributes['show-skills'],
       tags,
     });
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -136,6 +136,7 @@ describe('Integration | Repository | Organization', function () {
       expect(organizationSaved.credit).to.equal(organization.credit);
       expect(organizationSaved.email).to.equal(organization.email);
       expect(organizationSaved.documentationUrl).to.equal('https://pix.fr/');
+      expect(organizationSaved.showSkills).to.equal(organization.showSkills);
     });
   });
 

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -268,6 +268,28 @@ describe('Unit | UseCase | update-organization-information', function () {
       });
     });
 
+    it('should allow to update the organization showSkills flag', async function () {
+      // given
+      const newShowSkills = true;
+      const organizationId = 7;
+      const givenOrganization = _buildOrganizationWithNullAttributes({
+        id: organizationId,
+        showSkills: newShowSkills,
+      });
+      const originalOrganization = _buildOriginalOrganization(organizationId);
+
+      organizationRepository.get.resolves(originalOrganization);
+
+      // when
+      await updateOrganizationInformation({ organization: givenOrganization, organizationRepository });
+
+      // then
+      expect(organizationRepository.update).to.have.been.calledWithMatch({
+        ...originalOrganization,
+        showSkills: newShowSkills,
+      });
+    });
+
     context('when updating tags', function () {
       it('should allow to assign a tag to organization', async function () {
         // given
@@ -372,6 +394,7 @@ function _buildOrganizationWithNullAttributes(attributes) {
     credit: attributes.credit,
     tags: attributes.tags,
     documentationUrl: attributes.documentationUrl,
+    showSkills: attributes.showSkills,
   });
 }
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -124,6 +124,7 @@ describe('Unit | Serializer | organization-serializer', function () {
         canCollectProfiles: true,
         createdBy: 10,
         documentationUrl: 'https://pix.fr/',
+        showSkills: false,
       };
       const jsonApiOrganization = {
         data: {
@@ -141,6 +142,7 @@ describe('Unit | Serializer | organization-serializer', function () {
             'can-collect-profiles': organizationAttributes.canCollectProfiles,
             'created-by': organizationAttributes.createdBy,
             'documentation-url': organizationAttributes.documentationUrl,
+            'show-skills': organizationAttributes.showSkills,
           },
         },
       };
@@ -162,6 +164,7 @@ describe('Unit | Serializer | organization-serializer', function () {
         canCollectProfiles: organizationAttributes.canCollectProfiles,
         createdBy: organizationAttributes.createdBy,
         documentationUrl: organizationAttributes.documentationUrl,
+        showSkills: organizationAttributes.showSkills,
       });
       expect(organization).to.be.instanceOf(Organization);
       expect(organization).to.deep.equal(expectedOrganization);


### PR DESCRIPTION
## :christmas_tree: Problème
Après avoir afficher le flag 'showSkills' dans Pix Admin dans la PR #3917 pour décider quelle orga a le droit de voir les acquis ou non lors de son export de résultats, maintenant l'on souhaite donner la possibilité aux utilisateurs de pix Admin de modifier ce flag depuis l'edition de l'information d'une organization dans Pix Admin.

## :gift: Solution
Permettre à l’utilisateur d'éditer le boolean “show skills” ou aussi appelé  “Affichage acquis dans l'export résultats” lors du click sur le bouton éditer d’une organisation dans pix admin

## :star2: Remarques
RAS

## :santa: Pour tester

- Se connecter à Pix Admin
- Sélectionner une organization de la list d'organizations
- Aller sur le formulaire d’édition d'organization en cliquant sur le bouton 'Editer'
- Changer le valuer du flag 'Affichage des acquis dans l'export de résultats'
- Sauvegarder l’édition puis constater que le valuer du flag à bien été changé avec (Oui / Non) selon le choix qui à été fait.