### PR TITLE
[CLEANUP] Mise à jour des états possible "validé" des épreuves (PIX-4126)

### DIFF
--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const hashInt = require('hash-int');
 const NON_EXISTING_ITEM = null;
-const VALIDATED_STATUSES = ['validé', 'validé sans test', 'pré-validé'];
+const VALIDATED_STATUS = 'validé';
 
 module.exports = {
   pickChallenge({ skills, randomSeed, locale }) {
@@ -27,8 +27,6 @@ function _pickChallengeAtIndex(challenges, index) {
 }
 
 function _findPreferablyValidatedChallenges(localeChallenges) {
-  const validatedChallenges = _.filter(localeChallenges, (challenge) =>
-    _.includes(VALIDATED_STATUSES, challenge.status)
-  );
+  const validatedChallenges = _.filter(localeChallenges, (challenge) => challenge.status === VALIDATED_STATUS);
   return validatedChallenges.length > 0 ? validatedChallenges : localeChallenges;
 }

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
-const OPERATIVE_CHALLENGES = [...VALIDATED_CHALLENGES, 'archivé'];
+const VALIDATED_CHALLENGE = 'validé';
+const OPERATIVE_CHALLENGES = [VALIDATED_CHALLENGE, 'archivé'];
 
 module.exports = datasource.extend({
   modelName: 'challenges',
@@ -32,14 +32,14 @@ module.exports = datasource.extend({
 
   async findValidated() {
     const challenges = await this.list();
-    return challenges.filter((challengeData) => _.includes(VALIDATED_CHALLENGES, challengeData.status));
+    return challenges.filter((challengeData) => challengeData.status === VALIDATED_CHALLENGE);
   },
 
   async findFlashCompatible(locale) {
     const challenges = await this.list();
     return challenges.filter(
       (challengeData) =>
-        _.includes(VALIDATED_CHALLENGES, challengeData.status) &&
+        challengeData.status === VALIDATED_CHALLENGE &&
         !_.isEmpty(challengeData.skillIds) &&
         _.includes(challengeData.locales, locale) &&
         challengeData.alpha != null &&


### PR DESCRIPTION
## :christmas_tree: Problème
Les états validé sans test et pré-validé des épreuves n'existent plus car ils ne sont plus utile et n'étaient que le reflet d'un legacy bien trop présent dans le référentiel. Désormais le référentiel ne renvoie que le statut validé pour les épreuves validé.

## :gift: Solution
Mettre a jour le code qui gère les différents statut d'une épreuve

## :santa: Pour tester
1. :open_mouth: 
