### PR TITLE
[FEATURE] Autorise l'utilisation d'un wildcard dans les URLs autorisées a avoir un embed (PIX-4132)

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -54,7 +54,10 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
 
   _getMessageFromEventData(event) {
     let data = null;
-    if (this.embedOrigins.includes(event.origin)) {
+    const isAllowedOrigin = this.allowedOriginWithRegExp.some((allowedOrigin) => {
+      return event.origin.match(allowedOrigin);
+    });
+    if (isAllowedOrigin) {
       if (this._isNumeric(event.data)) {
         data = this._transformToObjectMessage(event.data);
       } else if (typeof event.data === 'string') {
@@ -106,5 +109,11 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
     const answerIfExist = this.args.answer && this.args.answer.value;
     const answer = answerIfExist || '';
     return answer.indexOf('#ABAND#') > -1 ? '' : answer;
+  }
+
+  get allowedOriginWithRegExp() {
+    return this.embedOrigins.map((allowedOrigin) => {
+      return new RegExp(allowedOrigin.replace('*', '[\\w-]+'));
+    });
   }
 }

--- a/mon-pix/tests/unit/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc_test.js
@@ -16,7 +16,7 @@ describe('Unit | Component | Challenge item QROC', function () {
       });
 
       component = createGlimmerComponent('component:challenge-item-qroc', { challenge });
-      component.embedOrigins = ['https://epreuves.pix.fr', 'https://1024pix.github.io'];
+      component.embedOrigins = ['https://epreuves.pix.fr', 'https://1024pix.github.io', 'https://*.review.pix.fr'];
     });
 
     context('when the event message is from Pix', function () {
@@ -64,6 +64,7 @@ describe('Unit | Component | Challenge item QROC', function () {
         // then
         expect(component.autoReplyAnswer).to.deep.equal(answer);
       });
+
       it('should set the autoreply answer from a object', function () {
         // given
         const answer = 'magicWord';
@@ -85,6 +86,21 @@ describe('Unit | Component | Challenge item QROC', function () {
         const event = {
           data: { answer, from: 'pix' },
           origin: 'https://1024pix.github.io',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal(answer);
+      });
+
+      it('should set the autoreply answer from a object when the origin is allowed via a wildcard', function () {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: { answer, from: 'pix' },
+          origin: 'https://test-pr14.review.pix.fr',
         };
 
         // when

--- a/mon-pix/tests/unit/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc_test.js
@@ -16,6 +16,7 @@ describe('Unit | Component | Challenge item QROC', function () {
       });
 
       component = createGlimmerComponent('component:challenge-item-qroc', { challenge });
+      component.embedOrigins = ['https://epreuves.pix.fr', 'https://1024pix.github.io'];
     });
 
     context('when the event message is from Pix', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
En recette, on veut intégrer des embeds qui sont actuellement en review pour tester leur fonctionnement.

## :gift: Solution
Comme les urls des RA des épreuves sont dynamique (mais de la même forme) on permet de mettre un wildcard dans l'URL. Comme https://test-pr*.pix.fr

## :star2: Remarques
Pour des raisons de performances, les URLs autorisées sont compilé en expression régulière une seule fois.

## :santa: Pour tester
1. Mettre en variable d'environnement EMBED_ALLOWED_ORIGINS=https://epreuves.pix.fr,https://pix-epreuves-review-pr*.osc-fr1.scalingo.io
2. Vérifier que l'épreuve challenge2LF6krPmW5Zhw4 est bien répondable
