### PR TITLE
[FEATURE] Changement de la consigne des QCM (PIX-4131).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -480,7 +480,7 @@
       "parts": {
         "answer-input": "Your answer",
         "answer-instructions": {
-          "qcm": "Select one or more possible answers",
+          "qcm": "Select the right answers",
           "qcu": "Select the right answer"
         },
         "feedback": "Report a problem",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -480,7 +480,7 @@
       "parts": {
         "answer-input": "Votre réponse",
         "answer-instructions": {
-          "qcm": "Choisissez la ou les réponses possibles.",
+          "qcm": "Choisissez les bonnes réponses.",
           "qcu": "Choisissez la bonne réponse."
         },
         "feedback": "Signaler un problème",


### PR DESCRIPTION
## :christmas_tree: Problème

L'instruction actuelle des QCM peut prêter à confusion sur le nombre de réponses attendues.

## :gift: Solution

Nous le modifions pour quelque chose de plus explicite.

## :star2: Remarques
N/A

## :santa: Pour tester

Vérifier que l'instruction est modifiée dans un QCM.
