### PR TITLE
[TECH] Suppression d'une méthode non utilisée

### DIFF
--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -155,12 +155,6 @@ function catchErr(promiseFn, ctx) {
   };
 }
 
-function compareDatabaseObject(evaluatedObject, expectedObject) {
-  return expect(_.omit(evaluatedObject, ['id', 'createdAt', 'updatedAt'])).to.deep.equal(
-    _.omit(expectedObject, ['id', 'createdAt', 'updatedAt'])
-  );
-}
-
 chai.use(function (chai) {
   const Assertion = chai.Assertion;
 
@@ -232,7 +226,6 @@ module.exports = {
   streamToPromise,
   catchErr,
   testErr: new Error('Fake Error'),
-  compareDatabaseObject,
   mockLearningContent,
   learningContentBuilder,
 };


### PR DESCRIPTION
## :unicorn: Problème
La méthode `compareDatabaseObject` des test-helper api n'est plus utilisée.

## :robot: Solution
Supprimer cette méthode.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que tout compile correctement.
