### PR TITLE
[FEATURE] Supprimer la case de fin de test pour les sessions dont le centre est autorisé (PIX-4141)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -149,18 +149,6 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  onTogglePublishConfirm() {
-    const state = this.certification.isPublished;
-    if (state) {
-      this.confirmMessage = 'Souhaitez-vous dépublier cette certification ?';
-    } else {
-      this.confirmMessage = 'Souhaitez-vous publier cette certification ?';
-    }
-    this.confirmAction = 'onTogglePublish';
-    this.displayConfirm = true;
-  }
-
-  @action
   onCheckMarks() {
     if (this._markStore.hasState()) {
       const state = this._markStore.getState();

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -8,6 +8,7 @@ const usecases = require('../../domain/usecases');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+const { isEndTestScreenRemovalEnabledBySessionId } = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
   async getCertificationDetails(request) {
@@ -65,8 +66,8 @@ module.exports = {
     const userId = request.auth.credentials.userId;
 
     const certificationCourse = await usecases.getCertificationCourse({ userId, certificationCourseId });
-
-    return certificationCourseSerializer.serialize(certificationCourse);
+    const isEndScreenRemoveEnabled = await isEndTestScreenRemovalEnabledBySessionId(certificationCourse.getSessionId());
+    return certificationCourseSerializer.serialize(certificationCourse, isEndScreenRemoveEnabled);
   },
 
   async getCertifiedProfile(request) {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -20,7 +20,6 @@ const fillCandidatesImportSheet = require('../../infrastructure/files/candidates
 const trim = require('lodash/trim');
 const UserLinkedToCertificationCandidate = require('../../domain/events/UserLinkedToCertificationCandidate');
 const logger = require('../../infrastructure/logger');
-const endTestScreenRemovalEnabled = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
   async findPaginatedFilteredJurySessions(request) {
@@ -44,12 +43,6 @@ module.exports = {
   async get(request) {
     const sessionId = request.params.id;
     const session = await usecases.getSession({ sessionId });
-    const isEndTestScreenRemovalEnabled = await endTestScreenRemovalEnabled.isEndTestScreenRemovalEnabledBySessionId(
-      sessionId
-    );
-    if (!isEndTestScreenRemovalEnabled) {
-      session.supervisorPassword = undefined;
-    }
     return sessionSerializer.serialize(session, true);
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -1,16 +1,24 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(certificationCourse) {
+  serialize(certificationCourse, isEndTestScreenRemovalEnabled) {
     return new Serializer('certification-course', {
       transform(currentCertificationCourse) {
         const certificationCourseDTO = currentCertificationCourse.toDTO();
         certificationCourseDTO.nbChallenges = certificationCourseDTO?.challenges?.length ?? 0;
         certificationCourseDTO.examinerComment = certificationCourseDTO.certificationIssueReports?.[0]?.description;
-
+        certificationCourseDTO.isEndTestScreenRemovalEnabled = isEndTestScreenRemovalEnabled;
         return certificationCourseDTO;
       },
-      attributes: ['assessment', 'nbChallenges', 'examinerComment', 'hasSeenEndTestScreen', 'firstName', 'lastName'],
+      attributes: [
+        'assessment',
+        'nbChallenges',
+        'examinerComment',
+        'hasSeenEndTestScreen',
+        'firstName',
+        'lastName',
+        'isEndTestScreenRemovalEnabled',
+      ],
       assessment: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -365,9 +365,11 @@ describe('Acceptance | API | Certification Course', function () {
 
     beforeEach(function () {
       otherUserId = databaseBuilder.factory.buildUser().id;
-
+      const certifiationCenter = databaseBuilder.factory.buildCertificationCenter({ id: 99 });
+      const session = databaseBuilder.factory.buildSession({ certificationCenterId: certifiationCenter.id });
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         hasSeenEndTestScreen: false,
+        sessionId: session.id,
       });
       userId = certificationCourse.userId;
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -393,6 +395,7 @@ describe('Acceptance | API | Certification Course', function () {
           'nb-challenges': 0,
           'first-name': certificationCourse.firstName,
           'last-name': certificationCourse.lastName,
+          'is-end-test-screen-removal-enabled': true,
         },
         relationships: {
           assessment: {
@@ -423,6 +426,7 @@ describe('Acceptance | API | Certification Course', function () {
     it('should return the certification course', async function () {
       // given
       options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([99]);
 
       // when
       const response = await server.inject(options);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -38,6 +38,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
           attributes: {
             'nb-challenges': 2,
             'examiner-comment': "Signalement de l'examinateur",
+            'is-end-test-screen-removal-enabled': true,
             'has-seen-end-test-screen': true,
             'first-name': certificationCourse.toDTO().firstName,
             'last-name': certificationCourse.toDTO().lastName,
@@ -53,7 +54,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
       };
 
       // when
-      const json = serializer.serialize(certificationCourse);
+      const json = serializer.serialize(certificationCourse, true);
 
       // then
       expect(json).to.deep.equal(jsonCertificationCourseWithAssessment);
@@ -80,6 +81,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'nb-challenges': 2,
             'examiner-comment': undefined,
             'has-seen-end-test-screen': true,
+            'is-end-test-screen-removal-enabled': undefined,
             'first-name': certificationCourse.toDTO().firstName,
             'last-name': certificationCourse.toDTO().lastName,
           },
@@ -121,6 +123,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'nb-challenges': 0,
             'examiner-comment': undefined,
             'has-seen-end-test-screen': true,
+            'is-end-test-screen-removal-enabled': undefined,
             'first-name': certificationCourse.toDTO().firstName,
             'last-name': certificationCourse.toDTO().lastName,
           },

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -34,7 +34,7 @@ export default class AuthenticatedController extends Controller {
   }
 
   get isEndTestScreenRemovalEnabled() {
-    return this.featureToggles.featureToggles.isEndTestScreenRemovalEnabled;
+    return this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
   }
 
   @action

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -14,6 +14,7 @@ export default class SessionParametersController extends Controller {
   @tracked accessCodeTooltipText = '';
   @tracked supervisorPasswordTooltipText = '';
   @service featureToggles;
+  @service currentUser;
 
   @computed('certificationCandidates.@each.isLinked')
   get sessionHasStarted() {
@@ -21,7 +22,7 @@ export default class SessionParametersController extends Controller {
   }
 
   get supervisorPasswordShouldBeDisplayed() {
-    return Boolean(this.session.supervisorPassword);
+    return this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
   }
 
   @action

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -81,7 +81,7 @@
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="app-modal-body__attention">Vous êtes sur le point de finaliser cette session.</div>
         <div class="app-modal-body__warning">
-          {{#if this.hasUncheckedHasSeenEndTestScreen}}
+          {{#if (and this.hasUncheckedHasSeenEndTestScreen this.shouldDisplayHasSeenEndTestScreenCheckbox)}}
             <p class="app-modal-body__contextual">La case "Écran de fin du test vu" n'est pas cochée pour
               {{this.uncheckedHasSeenEndTestScreenCount}}
               candidat(s)</p>

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -52,11 +52,17 @@ module('Acceptance | authenticated', function (hooks) {
     module('when end test screen removal is enabled', function () {
       test('it should show a "Espace surveillant" button', async function (assert) {
         // given
-        server.create('feature-toggle', {
-          id: 0,
-          isEndTestScreenRemovalEnabled: true,
+        const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+          name: 'Bibiche',
+          externalId: 'ABC123',
+          hasEndTestScreenRemovalEnabled: true,
         });
-        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        const certificationPointOfContact = server.create('certification-point-of-contact', {
+          firstName: 'Buffy',
+          lastName: 'Summers',
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [currentAllowedCertificationCenterAccess],
+        });
         await authenticateSession(certificationPointOfContact.id);
 
         // when
@@ -68,11 +74,17 @@ module('Acceptance | authenticated', function (hooks) {
 
       test('it should redirect to the login session supervisor', async function (assert) {
         // given
-        server.create('feature-toggle', {
-          id: 0,
-          isEndTestScreenRemovalEnabled: true,
+        const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+          name: 'Bibiche',
+          externalId: 'ABC123',
+          hasEndTestScreenRemovalEnabled: true,
         });
-        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        const certificationPointOfContact = server.create('certification-point-of-contact', {
+          firstName: 'Buffy',
+          lastName: 'Summers',
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [currentAllowedCertificationCenterAccess],
+        });
         await authenticateSession(certificationPointOfContact.id);
 
         // when
@@ -87,11 +99,17 @@ module('Acceptance | authenticated', function (hooks) {
     module('when end test screen removal is not enabled', function () {
       test('it should not show a "Espace surveillant" button', async function (assert) {
         // given
-        server.create('feature-toggle', {
-          id: 0,
-          isEndTestScreenRemovalEnabled: false,
+        const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+          name: 'Bibiche',
+          externalId: 'ABC123',
+          hasEndTestScreenRemovalEnabled: false,
         });
-        const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        const certificationPointOfContact = server.create('certification-point-of-contact', {
+          firstName: 'Buffy',
+          lastName: 'Summers',
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [currentAllowedCertificationCenterAccess],
+        });
         await authenticateSession(certificationPointOfContact.id);
 
         // when

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -28,6 +28,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
         isAccessBlockedLycee: false,
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
+        hasEndTestScreenRemovalEnabled: false,
       });
       certificationPointOfContact = server.create('certification-point-of-contact', {
         firstName: 'Buffy',
@@ -80,11 +81,11 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             assert.equal(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
           });
 
-          module('when the the supervisorPassword is unset meaning the FT is disabled for this session', function () {
+          module('when the certification center is not in the end test screen removal whitelist', function () {
             test('it should not display supervisor password', async function (assert) {
               // given
               const sessionWithSupervisorPassword = server.create('session', {
-                supervisorPassword: undefined,
+                supervisorPassword: 'SOWHAT',
                 status: CREATED,
               });
 
@@ -97,13 +98,10 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             });
           });
 
-          module('when the feature toggle FT_END_TEST_SCREEN_REMOVAL_ENABLED is enabled', function () {
+          module('when the certification center is in the end test screen removal whitelist', function () {
             test('it should display supervisor password', async function (assert) {
               // given
-              server.create('feature-toggle', {
-                id: 0,
-                isEndTestScreenRemovalEnabled: true,
-              });
+              allowedCertificationCenterAccess.update({ hasEndTestScreenRemovalEnabled: true });
               const sessionWithSupervisorPassword = server.create('session', {
                 supervisorPassword: 'SOWHAT',
                 status: CREATED,

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -177,6 +177,52 @@ module('Acceptance | Session Finalization', function (hooks) {
         });
       });
 
+      module('when there is completed report', function () {
+        module('when end test screen has been seen', function () {
+          test('it should not display end test screen warning', async function (assert) {
+            // given
+            const certificationReport = server.create('certification-report', {
+              hasSeenEndTestScreen: true,
+              isCompleted: true,
+              abortReason: 'technical',
+            });
+            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
+
+            session.update({ certificationReports: [certificationReport] });
+
+            // when
+            await visit(`/sessions/${session.id}/finalisation`);
+            await clickByLabel('Finaliser');
+
+            // then
+            assert.contains(CONFIRMATION_TEXT);
+            assert.notContains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
+          });
+        });
+
+        module('when end test screen has not been seen', function () {
+          test('it should display end test screen warning', async function (assert) {
+            // given
+            const certificationReport = server.create('certification-report', {
+              hasSeenEndTestScreen: false,
+              isCompleted: true,
+              abortReason: 'technical',
+            });
+            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
+
+            session.update({ certificationReports: [certificationReport] });
+
+            // when
+            await visit(`/sessions/${session.id}/finalisation`);
+            await clickByLabel('Finaliser');
+
+            // then
+            assert.contains(CONFIRMATION_TEXT);
+            assert.contains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
+          });
+        });
+      });
+
       module('when there is no uncompleted report', function () {
         test('it should not show the uncompleted reports table', async function (assert) {
           // given
@@ -192,25 +238,27 @@ module('Acceptance | Session Finalization', function (hooks) {
         });
       });
 
-      module('when there are no completed report', function () {
-        test('it should not display end test screen warning', async function (assert) {
-          // given
-          const certificationReport = server.create('certification-report', {
-            hasSeenEndTestScreen: false,
-            isCompleted: false,
-            abortReason: 'technical',
+      module('when there are uncompleted reports', function () {
+        module('when end test screen has not been seen', function () {
+          test('it should display end test screen warning', async function (assert) {
+            // given
+            const certificationReport = server.create('certification-report', {
+              hasSeenEndTestScreen: false,
+              isCompleted: true,
+              abortReason: 'technical',
+            });
+            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
+
+            session.update({ certificationReports: [certificationReport] });
+
+            // when
+            await visit(`/sessions/${session.id}/finalisation`);
+            await clickByLabel('Finaliser');
+
+            // then
+            assert.contains(CONFIRMATION_TEXT);
+            assert.contains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
           });
-          server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
-
-          session.update({ certificationReports: [certificationReport] });
-
-          // when
-          await visit(`/sessions/${session.id}/finalisation`);
-          await clickByLabel('Finaliser');
-
-          // then
-          assert.contains(CONFIRMATION_TEXT);
-          assert.notContains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
         });
 
         test('it should not show the completed reports table', async function (assert) {
@@ -226,9 +274,7 @@ module('Acceptance | Session Finalization', function (hooks) {
           assert.notContains('Certification(s) terminée(s)\n');
           assert.notContains('Écran de fin du test vu\n');
         });
-      });
 
-      module('when there are uncompleted reports', function () {
         test('it should show the uncompleted reports table', async function (assert) {
           // given
           const certificationReport = server.create('certification-report', { isCompleted: false });

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -240,24 +240,52 @@ module('Acceptance | Session Finalization', function (hooks) {
 
       module('when there are uncompleted reports', function () {
         module('when end test screen has not been seen', function () {
-          test('it should display end test screen warning', async function (assert) {
-            // given
-            const certificationReport = server.create('certification-report', {
-              hasSeenEndTestScreen: false,
-              isCompleted: true,
-              abortReason: 'technical',
+          module('when certification center is not in the whitelist', function () {
+            test('it should display end test screen warning', async function (assert) {
+              // given
+              const certificationReport = server.create('certification-report', {
+                hasSeenEndTestScreen: false,
+                isCompleted: true,
+                abortReason: 'technical',
+              });
+              server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
+
+              session.update({ certificationReports: [certificationReport] });
+
+              // when
+              await visit(`/sessions/${session.id}/finalisation`);
+              await clickByLabel('Finaliser');
+
+              // then
+              assert.contains(CONFIRMATION_TEXT);
+              assert.contains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
             });
-            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
+          });
 
-            session.update({ certificationReports: [certificationReport] });
+          module('when certification center is in the whitelist', function () {
+            test('it should not display end test screen warning', async function (assert) {
+              // given
+              const certificationReport = server.create('certification-report', {
+                hasSeenEndTestScreen: false,
+                isCompleted: true,
+                abortReason: 'technical',
+              });
+              server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
 
-            // when
-            await visit(`/sessions/${session.id}/finalisation`);
-            await clickByLabel('Finaliser');
+              allowedCertificationCenterAccess.update({
+                hasEndTestScreenRemovalEnabled: true,
+              });
 
-            // then
-            assert.contains(CONFIRMATION_TEXT);
-            assert.contains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
+              session.update({ certificationReports: [certificationReport] });
+
+              // when
+              await visit(`/sessions/${session.id}/finalisation`);
+              await clickByLabel('Finaliser');
+
+              // then
+              assert.contains(CONFIRMATION_TEXT);
+              assert.notContains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
+            });
           });
         });
 

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -243,13 +243,15 @@ module('Unit | Controller | authenticated', function (hooks) {
   module('#get isEndTestScreenRemovalEnabled', function () {
     test('should return true when end test screen removal is enabled', function (assert) {
       // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = {
-          isEndTestScreenRemovalEnabled: true,
-        };
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+        hasEndTestScreenRemovalEnabled: true,
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
-
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      this.owner.register('service:current-user', CurrentUserStub);
 
       const controller = this.owner.lookup('controller:authenticated');
 
@@ -261,14 +263,15 @@ module('Unit | Controller | authenticated', function (hooks) {
     });
 
     test('should return false when end test screen removal is not enabled', function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = {
-          isEndTestScreenRemovalEnabled: false,
-        };
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+        hasEndTestScreenRemovalEnabled: false,
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
-
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      this.owner.register('service:current-user', CurrentUserStub);
 
       const controller = this.owner.lookup('controller:authenticated');
 

--- a/mon-pix/app/controllers/certifications/results.js
+++ b/mon-pix/app/controllers/certifications/results.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
 
 export default class CertificationResultsController extends Controller {
-  @service featureToggles;
-
   get isEndedBySupervisor() {
     return this.model.assessment.get('state') === 'endedBySupervisor';
   }

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -6,6 +6,7 @@ export default class CertificationCourse extends Model {
   @attr('number') nbChallenges;
   @attr('string') firstName;
   @attr('string') lastName;
+  @attr('boolean') isEndTestScreenRemovalEnabled;
 
   // references
   @attr('number') sessionId;

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,6 +1,6 @@
 {{page-title (t "pages.certification-results.title")}}
 
-{{#if this.featureToggles.featureToggles.isEndTestScreenRemovalEnabled}}
+{{#if @model.isEndTestScreenRemovalEnabled}}
   <Certifications::CertificationEnder
     @certificationNumber={{@model.id}}
     @isEndedBySupervisor={{this.isEndedBySupervisor}}

--- a/mon-pix/mirage/serializers/certification-course.js
+++ b/mon-pix/mirage/serializers/certification-course.js
@@ -1,7 +1,14 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  attrs: ['nbChallenges', 'examinerComment', 'hasSeenEndTestScreen', 'firstName', 'lastName'],
+  attrs: [
+    'nbChallenges',
+    'examinerComment',
+    'hasSeenEndTestScreen',
+    'firstName',
+    'lastName',
+    'isEndTestScreenRemovalEnabled',
+  ],
   links(certificationCourse) {
     return {
       assessment: {

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -331,8 +331,6 @@ describe('Acceptance | Certification | Certification Course', function () {
         it('should display "Test terminé !"', async function () {
           this.timeout(5000);
           // given
-          server.create('feature-toggle', { id: 0, isEndTestScreenRemovalEnabled: true });
-
           user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
 
           const NB_CHALLENGES = 3;
@@ -345,6 +343,7 @@ describe('Acceptance | Certification | Certification Course', function () {
             nbChallenges: NB_CHALLENGES,
             firstName: 'Laura',
             lastName: 'Bravo',
+            isEndTestScreenRemovalEnabled: true,
           });
           this.server.create('certification-candidate-subscription', {
             id: 2,
@@ -379,9 +378,10 @@ describe('Acceptance | Certification | Certification Course', function () {
       context('when test was ended by supervisor', function () {
         it('should display "Votre surveillant a mis fin…"', async function () {
           // given
-          server.create('feature-toggle', { id: 0, isEndTestScreenRemovalEnabled: true });
           const user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
-          const certificationCourse = this.server.create('certification-course');
+          const certificationCourse = this.server.create('certification-course', {
+            isEndTestScreenRemovalEnabled: true,
+          });
           this.server.create('assessment', {
             certificationCourseId: certificationCourse.id,
             state: 'endedBySupervisor',


### PR DESCRIPTION
## :unicorn: Problème
2 feature sont sous FT de case de fin de test mais sans prendre en compte le centre de certification:
- ecran de fin de test du passage de certification
- lien dans le menu (gauche) de certif

## :robot: Solution
Faire dépendre ces 2 features des centres de certification autorisés par la whitelist

## :rainbow: Remarques
On a choisi de ne pas modifié le model et de rajouter des infos directement dans le serializer

## :100: Pour tester
Verifier le lien vers l'espace surveillant dans certif et s'assurer qu'il s'affiche en fonction du centre de certification en cours (en haut à droit)
<img width="1430" alt="Screenshot 2022-01-12 at 15 08 48" src="https://user-images.githubusercontent.com/3769147/149732720-58c1115d-1103-40aa-a3e4-853effd0bc13.png">

Passer la certification sur une session dans un centre NON autorisé, voir que la case de fin de test s'affiche comme avant. 

Passer la certification sur une session dans un centre autorisé, voir que la case de fin de test ne s'affiche plus et qu'on a bien le nouvel ecran. 

