### PR TITLE
[TECH] Mise à jour des channels de notification Slack 

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -34,7 +34,7 @@ jobs:
           transition: "Move to 'Deployed in Integration'"
 
       - name: Notify team on config file change
-        uses: 1024pix/notify-team-on-config-file-change@v1.0.1
+        uses: 1024pix/notify-team-on-config-file-change@v1.0.2
         with:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
Les channels ayant été modifiés sur Slack, les notifications automatiques via Github ne fonctionnent plus

## :robot: Solution
Mettre à jour le notifier pour refléter les changements

## :100: Pour tester
Merger la PR, et valider qu'à la prochaine modification sur dev du fichier de config de l'API, une notification est bien envoyée sur le channel Slack de l'équipe identifiée sur la PR 