### PR TITLE
[FEATURE] Permettre l'ajout de l'url de documentation dans le script de création d'organisations PRO (PIX-4118).

### DIFF
--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -85,6 +85,7 @@ module.exports = {
         'canCollectProfiles',
         'credit',
         'createdBy',
+        'documentationUrl',
       ])
     );
     return Bookshelf.knex

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -967,5 +967,34 @@ describe('Integration | Repository | Organization', function () {
       const foundOrganizations = await knex('organizations').select();
       expect(foundOrganizations.length).to.equal(2);
     });
+
+    it('should save organization attributes', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      const organization = domainBuilder.buildOrganization({
+        id: null,
+        externalId: '1237457A',
+        name: 'Orga 1',
+        provinceCode: '12',
+        canCollectProfiles: true,
+        credit: 100,
+        createdBy: userId,
+        documentationUrl: 'http://example.net/',
+      });
+
+      // when
+      await organizationRepository.batchCreateProOrganizations([organization]);
+
+      // then
+      const foundOrganizations = await knex('organizations').select();
+      expect(foundOrganizations[0].id).to.not.be.undefined;
+      expect(foundOrganizations[0].name).to.equal(organization.name);
+      expect(foundOrganizations[0].externalId).to.equal(organization.externalId);
+      expect(foundOrganizations[0].provinceCode).to.equal(organization.provinceCode);
+      expect(foundOrganizations[0].createdBy).to.equal(organization.createdBy);
+      expect(foundOrganizations[0].documentationUrl).to.equal(organization.documentationUrl);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il existe un script qui créer en masse des organisations PRO. Actuellement il ne permet pas d'inclure l'url de documentation. Or le métier en a besoin pour ne pas avoir à l'ajouter à la main après coup.

## :robot: Solution
Ajouter l'url de documentation dans le script de création d'organisation PRO.
Il n'est pas obligatoire.
ℹ️ Le wiki devra être modifié lorsque ce ticket sera merge

## :100: Pour tester
- Créer un fichier csv [en se basant sur ce wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2631630885/2020-04-20+Cr+ation+des+organisations+PRO)
- Y ajouter documentationUrl, exemple: https://pix.fr/

`externalId;name;provinceCode;canCollectProfiles;credit;email;locale;tags;createdBy;documentationUrl`

`123b;Nom orga;123;false;0;user@example.net;fr-fr;PUBLIC_AGRICULTURE;100;https://pix.fr/`

- Lancer le script en local `create-pro-organizations-with-tags.js`
- Constater en BDD que l'url à bien été renseigné
- Tester en laissant le champ vide > constater que documenationUrl est `null`