### PR TITLE
[FEATURE] Afficher le statut des certifications Pix+ Édu dans la page de détail d'une certification dans Pix Admin (PIX-3993).

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -46,6 +46,10 @@ export default class Certification extends Model {
   @attr() cleaCertificationStatus;
   @attr() pixPlusDroitMaitreCertificationStatus;
   @attr() pixPlusDroitExpertCertificationStatus;
+  @attr() pixPlusEduAutonomeCertificationStatus;
+  @attr() pixPlusEduAvanceCertificationStatus;
+  @attr() pixPlusEduExpertCertificationStatus;
+  @attr() pixPlusEduFormateurCertificationStatus;
 
   @hasMany('certification-issue-report') certificationIssueReports;
 
@@ -103,6 +107,23 @@ export default class Certification extends Model {
   @computed('pixPlusDroitExpertCertificationStatus')
   get pixPlusDroitExpertCertificationStatusLabel() {
     return partnerCertificationStatusToDisplayName[this.pixPlusDroitExpertCertificationStatus];
+  }
+
+  @computed('pixPlusEduAutonomeCertificationStatus')
+  get pixPlusEduAutonomeCertificationStatusLabel() {
+    return partnerCertificationStatusToDisplayName[this.pixPlusEduAutonomeCertificationStatus];
+  }
+  @computed('pixPlusEduAvanceCertificationStatus')
+  get pixPlusEduAvanceCertificationStatusLabel() {
+    return partnerCertificationStatusToDisplayName[this.pixPlusEduAvanceCertificationStatus];
+  }
+  @computed('pixPlusEduExpertCertificationStatus')
+  get pixPlusEduExpertCertificationStatusLabel() {
+    return partnerCertificationStatusToDisplayName[this.pixPlusEduExpertCertificationStatus];
+  }
+  @computed('pixPlusEduFormateurCertificationStatus')
+  get pixPlusEduFormateurCertificationStatusLabel() {
+    return partnerCertificationStatusToDisplayName[this.pixPlusEduFormateurCertificationStatus];
   }
 
   get wasRegisteredBeforeCPF() {

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -75,6 +75,30 @@
               @label="Certification Pix+ Droit Expert :"
               @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitExpertCertificationStatus}}"
             />
+            <Certifications::InfoField
+              @value={{this.certification.pixPlusEduAutonomeCertificationStatusLabel}}
+              @edition={{false}}
+              @label="Certification Pix+ Édu Autonome :"
+              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduAutonomeCertificationStatus}}"
+            />
+            <Certifications::InfoField
+              @value={{this.certification.pixPlusEduAvanceCertificationStatusLabel}}
+              @edition={{false}}
+              @label="Certification Pix+ Édu Avancé :"
+              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduAvanceCertificationStatus}}"
+            />
+            <Certifications::InfoField
+              @value={{this.certification.pixPlusEduExpertCertificationStatusLabel}}
+              @edition={{false}}
+              @label="Certification Pix+ Édu Expert :"
+              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduExpertCertificationStatus}}"
+            />
+            <Certifications::InfoField
+              @value={{this.certification.pixPlusEduFormateurCertificationStatusLabel}}
+              @edition={{false}}
+              @label="Certification Pix+ Édu Formateur :"
+              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduFormateurCertificationStatus}}"
+            />
           </div>
         </div>
       </div>

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -41,6 +41,13 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       competencesWithMark: [],
       listChallengesAndAnswers: [],
       createdAt: new Date('2020-01-01'),
+      cleaCertificationStatus: 'not_taken',
+      pixPlusDroitMaitreCertificationStatus: 'not_taken',
+      pixPlusDroitExpertCertificationStatus: 'not_taken',
+      pixPlusEduAutonomeCertificationStatus: 'not_taken',
+      pixPlusEduAvanceCertificationStatus: 'not_taken',
+      pixPlusEduExpertCertificationStatus: 'not_taken',
+      pixPlusEduFormateurCertificationStatus: 'not_taken',
     });
   });
 
@@ -57,6 +64,13 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     assert.contains('Code INSEE de naissance : 99217');
     assert.contains('Code postal de naissance : ');
     assert.contains('Pays de naissance : JAPON');
+    assert.contains('Certification CléA numérique : Non passée');
+    assert.contains('Certification Pix+ Droit Maître : Non passée');
+    assert.contains('Certification Pix+ Droit Expert : Non passée');
+    assert.contains('Certification Pix+ Édu Autonome : Non passée');
+    assert.contains('Certification Pix+ Édu Avancé : Non passée');
+    assert.contains('Certification Pix+ Édu Expert : Non passée');
+    assert.contains('Certification Pix+ Édu Formateur : Non passée');
   });
 
   module('Candidate information edition', function () {

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 import { ACQUIRED, REJECTED, NOT_TAKEN } from 'pix-admin/models/certification';
 
 module('Unit | Model | certification', function (hooks) {
@@ -22,11 +21,9 @@ module('Unit | Model | certification', function (hooks) {
       module(`when cleaCertificationStatus is ${cleaStatus}`, function () {
         test(`cleaCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
           // given
-          const certification = run(() =>
-            store.createRecord('certification', {
-              cleaCertificationStatus: cleaStatus,
-            })
-          );
+          const certification = store.createRecord('certification', {
+            cleaCertificationStatus: cleaStatus,
+          });
 
           // when
           const label = certification.cleaCertificationStatusLabel;
@@ -48,11 +45,9 @@ module('Unit | Model | certification', function (hooks) {
       module(`when pixPlusDroitMaitreCertificationStatus is ${pixPlusDroitMaitreCertificationStatus}`, function () {
         test(`pixPlusDroitMaitreCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
           // given
-          const certification = run(() =>
-            store.createRecord('certification', {
-              pixPlusDroitMaitreCertificationStatus: pixPlusDroitMaitreCertificationStatus,
-            })
-          );
+          const certification = store.createRecord('certification', {
+            pixPlusDroitMaitreCertificationStatus: pixPlusDroitMaitreCertificationStatus,
+          });
 
           // when
           const label = certification.pixPlusDroitMaitreCertificationStatusLabel;
@@ -74,11 +69,9 @@ module('Unit | Model | certification', function (hooks) {
       module(`when pixPlusDroitExpertCertificationStatus is ${pixPlusDroitExpertCertificationStatus}`, function () {
         test(`pixPlusDroitMaitreCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
           // given
-          const certification = run(() =>
-            store.createRecord('certification', {
-              pixPlusDroitExpertCertificationStatus: pixPlusDroitExpertCertificationStatus,
-            })
-          );
+          const certification = store.createRecord('certification', {
+            pixPlusDroitExpertCertificationStatus: pixPlusDroitExpertCertificationStatus,
+          });
 
           // when
           const label = certification.pixPlusDroitExpertCertificationStatusLabel;
@@ -90,14 +83,114 @@ module('Unit | Model | certification', function (hooks) {
     });
   });
 
+  module('#pixPlusEduAutonomeCertificationStatusLabel', function () {
+    const pixPlusEduAutonomeStatusesAndExpectedLabel = new Map([
+      [ACQUIRED, 'Validée'],
+      [REJECTED, 'Rejetée'],
+      [NOT_TAKEN, 'Non passée'],
+    ]);
+    pixPlusEduAutonomeStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduAutonomeCertificationStatus) => {
+      module(
+        `when pixPlusEduAutonomeCertificationStatusLabel is ${pixPlusEduAutonomeCertificationStatus}`,
+        function () {
+          test(`pixPlusEduAutonomeCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
+            // given
+            const certification = store.createRecord('certification', {
+              pixPlusEduAutonomeCertificationStatus,
+            });
+
+            // when
+            const label = certification.pixPlusEduAutonomeCertificationStatusLabel;
+
+            // then
+            assert.equal(label, expectedLabel);
+          });
+        }
+      );
+    });
+  });
+
+  module('#pixPlusEduAvanceCertificationStatusLabel', function () {
+    const pixPlusEduAvanceStatusesAndExpectedLabel = new Map([
+      [ACQUIRED, 'Validée'],
+      [REJECTED, 'Rejetée'],
+      [NOT_TAKEN, 'Non passée'],
+    ]);
+    pixPlusEduAvanceStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduAvanceCertificationStatus) => {
+      module(`when pixPlusEduAvanceCertificationStatusLabel is ${pixPlusEduAvanceCertificationStatus}`, function () {
+        test(`pixPlusEduAvanceCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            pixPlusEduAvanceCertificationStatus,
+          });
+
+          // when
+          const label = certification.pixPlusEduAvanceCertificationStatusLabel;
+
+          // then
+          assert.equal(label, expectedLabel);
+        });
+      });
+    });
+  });
+
+  module('#pixPlusEduExpertCertificationStatusLabel', function () {
+    const pixPlusEduExpertStatusesAndExpectedLabel = new Map([
+      [ACQUIRED, 'Validée'],
+      [REJECTED, 'Rejetée'],
+      [NOT_TAKEN, 'Non passée'],
+    ]);
+    pixPlusEduExpertStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduExpertCertificationStatus) => {
+      module(`when pixPlusEduExpertCertificationStatusLabel is ${pixPlusEduExpertCertificationStatus}`, function () {
+        test(`pixPlusEduExpertCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            pixPlusEduExpertCertificationStatus,
+          });
+
+          // when
+          const label = certification.pixPlusEduExpertCertificationStatusLabel;
+
+          // then
+          assert.equal(label, expectedLabel);
+        });
+      });
+    });
+  });
+
+  module('#pixPlusEduFormateurCertificationStatusLabel', function () {
+    const pixPlusEduFormateurStatusesAndExpectedLabel = new Map([
+      [ACQUIRED, 'Validée'],
+      [REJECTED, 'Rejetée'],
+      [NOT_TAKEN, 'Non passée'],
+    ]);
+    pixPlusEduFormateurStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduFormateurCertificationStatus) => {
+      module(
+        `when pixPlusEduFormateurCertificationStatusLabel is ${pixPlusEduFormateurCertificationStatus}`,
+        function () {
+          test(`pixPlusEduFormateurCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
+            // given
+            const certification = store.createRecord('certification', {
+              pixPlusEduFormateurCertificationStatus,
+            });
+
+            // when
+            const label = certification.pixPlusEduFormateurCertificationStatusLabel;
+
+            // then
+            assert.equal(label, expectedLabel);
+          });
+        }
+      );
+    });
+  });
+
   module('#publishedText', function () {
     test('it should return "oui" when isPublished is true', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          isPublished: true,
-        })
-      );
+      const certification = store.createRecord('certification', {
+        isPublished: true,
+      });
 
       // when
       const isPublishedLabel = certification.publishedText;
@@ -108,11 +201,9 @@ module('Unit | Model | certification', function (hooks) {
 
     test('it should return "non" when isPublished is false', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          isPublished: false,
-        })
-      );
+      const certification = store.createRecord('certification', {
+        isPublished: false,
+      });
 
       // when
       const isPublishedLabel = certification.publishedText;
@@ -125,30 +216,28 @@ module('Unit | Model | certification', function (hooks) {
   module('#indexedCompetences', function () {
     test('it should return the indexedCompetences from the competencesWithMark', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          competencesWithMark: [
-            {
-              id: 1,
-              area_code: '1',
-              competence_code: '1.1',
-              competenceId: 'rec11',
-              level: 4,
-              score: 39,
-              assessmentResultId: 123,
-            },
-            {
-              id: 2,
-              area_code: '2',
-              competence_code: '2.1',
-              competenceId: 'rec21',
-              level: 5,
-              score: 20,
-              assessmentResultId: 123,
-            },
-          ],
-        })
-      );
+      const certification = store.createRecord('certification', {
+        competencesWithMark: [
+          {
+            id: 1,
+            area_code: '1',
+            competence_code: '1.1',
+            competenceId: 'rec11',
+            level: 4,
+            score: 39,
+            assessmentResultId: 123,
+          },
+          {
+            id: 2,
+            area_code: '2',
+            competence_code: '2.1',
+            competenceId: 'rec21',
+            level: 5,
+            score: 20,
+            assessmentResultId: 123,
+          },
+        ],
+      });
 
       // when
       const indexedCompetences = certification.indexedCompetences;
@@ -172,30 +261,28 @@ module('Unit | Model | certification', function (hooks) {
   module('#competences', function () {
     test('it should return the competences from the indexedCompetences', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          competencesWithMark: [
-            {
-              id: 1,
-              area_code: '1',
-              competence_code: '1.1',
-              competenceId: 'rec11',
-              level: 4,
-              score: 39,
-              assessmentResultId: 123,
-            },
-            {
-              id: 2,
-              area_code: '2',
-              competence_code: '2.1',
-              competenceId: 'rec21',
-              level: 5,
-              score: 20,
-              assessmentResultId: 123,
-            },
-          ],
-        })
-      );
+      const certification = store.createRecord('certification', {
+        competencesWithMark: [
+          {
+            id: 1,
+            area_code: '1',
+            competence_code: '1.1',
+            competenceId: 'rec11',
+            level: 4,
+            score: 39,
+            assessmentResultId: 123,
+          },
+          {
+            id: 2,
+            area_code: '2',
+            competence_code: '2.1',
+            competenceId: 'rec21',
+            level: 5,
+            score: 20,
+            assessmentResultId: 123,
+          },
+        ],
+      });
 
       // when
       const competences = certification.competences;
@@ -226,11 +313,9 @@ module('Unit | Model | certification', function (hooks) {
     ].forEach((certificationStatus) => {
       test('it should return the right pair of label and value', function (assert) {
         // given
-        const certification = run(() =>
-          store.createRecord('certification', {
-            status: certificationStatus.value,
-          })
-        );
+        const certification = store.createRecord('certification', {
+          status: certificationStatus.value,
+        });
 
         // then
         assert.deepEqual(certification.statusLabelAndValue, {
@@ -249,11 +334,9 @@ module('Unit | Model | certification', function (hooks) {
     ].forEach(({ value, label }) => {
       test(`it should return true when sex value is ${label}`, function (assert) {
         // given
-        const certification = run(() =>
-          store.createRecord('certification', {
-            sex: value,
-          })
-        );
+        const certification = store.createRecord('certification', {
+          sex: value,
+        });
 
         // then
         assert.true(certification.wasRegisteredBeforeCPF);
@@ -262,11 +345,9 @@ module('Unit | Model | certification', function (hooks) {
 
     test('should return false when sex is defined', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          sex: 'M',
-        })
-      );
+      const certification = store.createRecord('certification', {
+        sex: 'M',
+      });
 
       // then
       assert.false(certification.wasRegisteredBeforeCPF);
@@ -276,9 +357,7 @@ module('Unit | Model | certification', function (hooks) {
   module('#get completionDate', function () {
     test('it should return null if completedAt is null', function (assert) {
       // given
-      const juryCertificationSummary = run(() => {
-        return store.createRecord('certification', { completedAt: null });
-      });
+      const juryCertificationSummary = store.createRecord('certification', { completedAt: null });
 
       // then
       assert.equal(juryCertificationSummary.completionDate, null);
@@ -286,9 +365,7 @@ module('Unit | Model | certification', function (hooks) {
 
     test('it should a formatted date when completedAt is defined', function (assert) {
       // given
-      const juryCertificationSummary = run(() => {
-        return store.createRecord('certification', { completedAt: '2021-06-30 15:10:45' });
-      });
+      const juryCertificationSummary = store.createRecord('certification', { completedAt: '2021-06-30 15:10:45' });
 
       // then
       assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
@@ -298,18 +375,16 @@ module('Unit | Model | certification', function (hooks) {
   module('#getInformation', function () {
     test('it should return the certification candidate information', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          firstName: 'Buffy',
-          lastName: 'Summers',
-          birthdate: '1981-01-19',
-          birthplace: 'Torreilles',
-          sex: 'F',
-          birthInseeCode: '66212',
-          birthPostalCode: null,
-          birthCountry: 'FRANCE',
-        })
-      );
+      const certification = store.createRecord('certification', {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+        birthdate: '1981-01-19',
+        birthplace: 'Torreilles',
+        sex: 'F',
+        birthInseeCode: '66212',
+        birthPostalCode: null,
+        birthCountry: 'FRANCE',
+      });
 
       // when
       const information = certification.getInformation();
@@ -331,18 +406,16 @@ module('Unit | Model | certification', function (hooks) {
   module('#updateInformation', function () {
     test('it should update the certification candidate information', function (assert) {
       // given
-      const certification = run(() =>
-        store.createRecord('certification', {
-          firstName: 'Buffy',
-          lastName: 'Summers',
-          birthdate: '1981-01-19',
-          birthplace: 'Torreilles',
-          sex: 'F',
-          birthInseeCode: '66212',
-          birthPostalCode: null,
-          birthCountry: 'FRANCE',
-        })
-      );
+      const certification = store.createRecord('certification', {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+        birthdate: '1981-01-19',
+        birthplace: 'Torreilles',
+        sex: 'F',
+        birthInseeCode: '66212',
+        birthPostalCode: null,
+        birthCountry: 'FRANCE',
+      });
 
       // when
       certification.updateInformation({
@@ -373,7 +446,7 @@ module('Unit | Model | certification', function (hooks) {
   module('#wasBornInFrance', function () {
     test('it should return true when candidate was born in France', function (assert) {
       // given
-      const certification = run(() => store.createRecord('certification', { birthCountry: 'FRANCE' }));
+      const certification = store.createRecord('certification', { birthCountry: 'FRANCE' });
 
       // when
       const wasBornInFrance = certification.wasBornInFrance();
@@ -384,7 +457,7 @@ module('Unit | Model | certification', function (hooks) {
 
     test('it should return false when candidate was not born in France', function (assert) {
       // given
-      const certification = run(() => store.createRecord('certification', { birthCountry: 'OTHER_COUNTRY' }));
+      const certification = store.createRecord('certification', { birthCountry: 'OTHER_COUNTRY' });
 
       // when
       const wasBornInFrance = certification.wasBornInFrance();

--- a/api/lib/domain/models/JuryCertification.js
+++ b/api/lib/domain/models/JuryCertification.js
@@ -1,7 +1,16 @@
 const _ = require('lodash');
 const CompetenceMark = require('./CompetenceMark');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../models/Badge').keys;
 
 const status = {
   CANCELLED: 'cancelled',
@@ -112,6 +121,25 @@ class JuryCertification {
 
   getPixPlusDroitExpertCertificationStatus() {
     return this._getStatusFromPartnerCertification([PIX_DROIT_EXPERT_CERTIF]);
+  }
+
+  getPixPlusEduAutonomeCertificationStatus() {
+    return this._getStatusFromPartnerCertification([PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME]);
+  }
+
+  getPixPlusEduAvanceCertificationStatus() {
+    return this._getStatusFromPartnerCertification([
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+    ]);
+  }
+
+  getPixPlusEduExpertCertificationStatus() {
+    return this._getStatusFromPartnerCertification([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]);
+  }
+
+  getPixPlusEduFormateurCertificationStatus() {
+    return this._getStatusFromPartnerCertification([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR]);
   }
 
   _getStatusFromPartnerCertification(partnerCertificationKeys) {

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -1,10 +1,14 @@
 const { knex } = require('../../../db/knex-database-connection');
 const { NotFoundError } = require('../../domain/errors');
+const _ = require('lodash');
 const JuryCertification = require('../../domain/models/JuryCertification');
 const CertificationIssueReport = require('../../domain/models/CertificationIssueReport');
-const cleaCertificationResultRepository = require('./clea-certification-result-repository');
-const pixPlusDroitMaitreCertificationResultRepository = require('./pix-plus-droit-maitre-certification-result-repository');
-const pixPlusDroitExpertCertificationResultRepository = require('./pix-plus-droit-expert-certification-result-repository');
+const PartnerCertification = require('../../domain/models/PartnerCertification');
+const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
+  require('../../domain/models/Badge').keys;
+const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
+const PixPlusDroitMaitreCertificationResult = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
+const PixPlusDroitExpertCertificationResult = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
 
 module.exports = {
   async get(certificationCourseId) {
@@ -50,12 +54,14 @@ function _selectJuryCertifications() {
       commentForOrganization: 'assessment-results.commentForOrganization',
       commentForJury: 'assessment-results.commentForJury',
       competenceMarks: knex.raw('json_agg("competence-marks".* ORDER BY "competence-marks"."competence_code" asc)'),
+      partnerCertifications: knex.raw('json_agg("partner-certifications".*)'),
     })
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
     .modify(_filterMostRecentAssessmentResult)
     .leftJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
+    .leftJoin('partner-certifications', 'partner-certifications.certificationCourseId', 'certification-courses.id')
     .groupBy('certification-courses.id', 'assessments.id', 'assessment-results.id');
 }
 
@@ -84,15 +90,28 @@ async function _toDomainWithComplementaryCertifications({ juryCertificationDTO, 
       })
   );
 
-  const cleaCertificationResult = await cleaCertificationResultRepository.get({
-    certificationCourseId: juryCertificationDTO.certificationCourseId,
-  });
-  const pixPlusDroitMaitreCertificationResult = await pixPlusDroitMaitreCertificationResultRepository.get({
-    certificationCourseId: juryCertificationDTO.certificationCourseId,
-  });
-  const pixPlusDroitExpertCertificationResult = await pixPlusDroitExpertCertificationResultRepository.get({
-    certificationCourseId: juryCertificationDTO.certificationCourseId,
-  });
+  const partnerCertifications = _.compact(juryCertificationDTO.partnerCertifications).map(PartnerCertification.from);
+
+  const cleaPartnerCertification = partnerCertifications.find(({ partnerKey }) =>
+    [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerKey)
+  );
+  const cleaCertificationResult = cleaPartnerCertification
+    ? CleaCertificationResult.buildFrom(cleaPartnerCertification)
+    : CleaCertificationResult.buildNotTaken();
+
+  const pixPlusDroitMaitrePartnerCertification = partnerCertifications.find(
+    ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF
+  );
+  const pixPlusDroitMaitreCertificationResult = pixPlusDroitMaitrePartnerCertification
+    ? PixPlusDroitMaitreCertificationResult.buildFrom(pixPlusDroitMaitrePartnerCertification)
+    : PixPlusDroitMaitreCertificationResult.buildNotTaken();
+
+  const pixPlusDroitExpertPartnerCertification = partnerCertifications.find(
+    ({ partnerKey }) => partnerKey === PIX_DROIT_EXPERT_CERTIF
+  );
+  const pixPlusDroitExpertCertificationResult = pixPlusDroitExpertPartnerCertification
+    ? PixPlusDroitExpertCertificationResult.buildFrom(pixPlusDroitExpertPartnerCertification)
+    : PixPlusDroitExpertCertificationResult.buildNotTaken();
 
   return JuryCertification.from({
     juryCertificationDTO,

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -4,11 +4,6 @@ const _ = require('lodash');
 const JuryCertification = require('../../domain/models/JuryCertification');
 const CertificationIssueReport = require('../../domain/models/CertificationIssueReport');
 const PartnerCertification = require('../../domain/models/PartnerCertification');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../domain/models/Badge').keys;
-const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
-const PixPlusDroitMaitreCertificationResult = require('../../../lib/domain/models/PixPlusDroitMaitreCertificationResult');
-const PixPlusDroitExpertCertificationResult = require('../../../lib/domain/models/PixPlusDroitExpertCertificationResult');
 
 module.exports = {
   async get(certificationCourseId) {
@@ -92,32 +87,9 @@ async function _toDomainWithComplementaryCertifications({ juryCertificationDTO, 
 
   const partnerCertifications = _.compact(juryCertificationDTO.partnerCertifications).map(PartnerCertification.from);
 
-  const cleaPartnerCertification = partnerCertifications.find(({ partnerKey }) =>
-    [PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].includes(partnerKey)
-  );
-  const cleaCertificationResult = cleaPartnerCertification
-    ? CleaCertificationResult.buildFrom(cleaPartnerCertification)
-    : CleaCertificationResult.buildNotTaken();
-
-  const pixPlusDroitMaitrePartnerCertification = partnerCertifications.find(
-    ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF
-  );
-  const pixPlusDroitMaitreCertificationResult = pixPlusDroitMaitrePartnerCertification
-    ? PixPlusDroitMaitreCertificationResult.buildFrom(pixPlusDroitMaitrePartnerCertification)
-    : PixPlusDroitMaitreCertificationResult.buildNotTaken();
-
-  const pixPlusDroitExpertPartnerCertification = partnerCertifications.find(
-    ({ partnerKey }) => partnerKey === PIX_DROIT_EXPERT_CERTIF
-  );
-  const pixPlusDroitExpertCertificationResult = pixPlusDroitExpertPartnerCertification
-    ? PixPlusDroitExpertCertificationResult.buildFrom(pixPlusDroitExpertPartnerCertification)
-    : PixPlusDroitExpertCertificationResult.buildNotTaken();
-
   return JuryCertification.from({
     juryCertificationDTO,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
     certificationIssueReports,
+    partnerCertifications,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -8,9 +8,9 @@ module.exports = {
           id: juryCertification.certificationCourseId,
           ...juryCertification,
           competencesWithMark: juryCertification.competenceMarks,
-          cleaCertificationStatus: juryCertification.cleaCertificationResult.status,
-          pixPlusDroitMaitreCertificationStatus: juryCertification.pixPlusDroitMaitreCertificationResult.status,
-          pixPlusDroitExpertCertificationStatus: juryCertification.pixPlusDroitExpertCertificationResult.status,
+          cleaCertificationStatus: juryCertification.getCleaCertificationStatus(),
+          pixPlusDroitMaitreCertificationStatus: juryCertification.getPixPlusDroitMaitreCertificationStatus(),
+          pixPlusDroitExpertCertificationStatus: juryCertification.getPixPlusDroitExpertCertificationStatus(),
         };
       },
       attributes: [

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -11,6 +11,10 @@ module.exports = {
           cleaCertificationStatus: juryCertification.getCleaCertificationStatus(),
           pixPlusDroitMaitreCertificationStatus: juryCertification.getPixPlusDroitMaitreCertificationStatus(),
           pixPlusDroitExpertCertificationStatus: juryCertification.getPixPlusDroitExpertCertificationStatus(),
+          pixPlusEduAutonomeCertificationStatus: juryCertification.getPixPlusEduAutonomeCertificationStatus(),
+          pixPlusEduAvanceCertificationStatus: juryCertification.getPixPlusEduAvanceCertificationStatus(),
+          pixPlusEduExpertCertificationStatus: juryCertification.getPixPlusEduExpertCertificationStatus(),
+          pixPlusEduFormateurCertificationStatus: juryCertification.getPixPlusEduFormateurCertificationStatus(),
         };
       },
       attributes: [
@@ -38,6 +42,10 @@ module.exports = {
         'cleaCertificationStatus',
         'pixPlusDroitMaitreCertificationStatus',
         'pixPlusDroitExpertCertificationStatus',
+        'pixPlusEduAutonomeCertificationStatus',
+        'pixPlusEduAvanceCertificationStatus',
+        'pixPlusEduExpertCertificationStatus',
+        'pixPlusEduFormateurCertificationStatus',
         'certificationIssueReports',
       ],
       certificationIssueReports: {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -242,6 +242,10 @@ describe('Acceptance | API | Certification Course', function () {
           'clea-certification-status': 'not_taken',
           'pix-plus-droit-expert-certification-status': 'not_taken',
           'pix-plus-droit-maitre-certification-status': 'not_taken',
+          'pix-plus-edu-autonome-certification-status': 'not_taken',
+          'pix-plus-edu-avance-certification-status': 'not_taken',
+          'pix-plus-edu-expert-certification-status': 'not_taken',
+          'pix-plus-edu-formateur-certification-status': 'not_taken',
         },
         relationships: {
           'certification-issue-reports': {

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -101,10 +101,8 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         commentForCandidate: 'Un commentaire candidat',
         commentForJury: 'Un commentaire jury',
         competenceMarks: [expectedCompetenceMark],
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         certificationIssueReports: [],
+        partnerCertifications: [],
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
     });
@@ -151,34 +149,18 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
 
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      {
-        complementaryCertificationName: 'CléA V1',
-        badgeKey: PIX_EMPLOI_CLEA,
-        complementaryCertificationResult: 'cleaCertificationResult',
-      },
-      {
-        complementaryCertificationName: 'CléA V2',
-        badgeKey: PIX_EMPLOI_CLEA_V2,
-        complementaryCertificationResult: 'cleaCertificationResult',
-      },
-      {
-        complementaryCertificationName: 'PixPlus Droit Maître',
-        badgeKey: PIX_DROIT_MAITRE_CERTIF,
-        complementaryCertificationResult: 'pixPlusDroitMaitreCertificationResult',
-      },
-      {
-        complementaryCertificationName: 'PixPlus Droit Expert',
-        badgeKey: PIX_DROIT_EXPERT_CERTIF,
-        complementaryCertificationResult: 'pixPlusDroitExpertCertificationResult',
-      },
-    ].forEach(function (testCase) {
-      it(`should get the ${testCase.complementaryCertificationName} result if this complementary certification was taken`, async function () {
+      { partnerKey: PIX_EMPLOI_CLEA, method: 'getCleaCertificationStatus' },
+      { partnerKey: PIX_EMPLOI_CLEA_V2, method: 'getCleaCertificationStatus' },
+      { partnerKey: PIX_DROIT_MAITRE_CERTIF, method: 'getPixPlusDroitMaitreCertificationStatus' },
+      { partnerKey: PIX_DROIT_EXPERT_CERTIF, method: 'getPixPlusDroitExpertCertificationStatus' },
+    ].forEach(function ({ partnerKey, method }) {
+      it(`should have the status acquired when ${partnerKey} certification is acquired`, async function () {
         // given
         await _buildJuryCertification(1);
-        databaseBuilder.factory.buildBadge({ key: testCase.badgeKey });
+        databaseBuilder.factory.buildBadge({ key: partnerKey });
         databaseBuilder.factory.buildPartnerCertification({
           certificationCourseId: 1,
-          partnerKey: testCase.badgeKey,
+          partnerKey,
           acquired: true,
         });
         await databaseBuilder.commit();
@@ -187,7 +169,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         const juryCertification = await juryCertificationRepository.get(1);
 
         // then
-        expect(juryCertification[testCase.complementaryCertificationResult].status).to.equal('acquired');
+        expect(juryCertification[method]()).to.equal('acquired');
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -1,8 +1,17 @@
 const { expect, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const juryCertificationRepository = require('../../../../lib/infrastructure/repositories/jury-certification-repository');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+} = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Repository | Jury Certification', function () {
   describe('#get', function () {
@@ -153,6 +162,14 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       { partnerKey: PIX_EMPLOI_CLEA_V2, method: 'getCleaCertificationStatus' },
       { partnerKey: PIX_DROIT_MAITRE_CERTIF, method: 'getPixPlusDroitMaitreCertificationStatus' },
       { partnerKey: PIX_DROIT_EXPERT_CERTIF, method: 'getPixPlusDroitExpertCertificationStatus' },
+      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AUTONOME, method: 'getPixPlusEduAutonomeCertificationStatus' },
+      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_AVANCE, method: 'getPixPlusEduAvanceCertificationStatus' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, method: 'getPixPlusEduAvanceCertificationStatus' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, method: 'getPixPlusEduExpertCertificationStatus' },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_FORMATEUR,
+        method: 'getPixPlusEduFormateurCertificationStatus',
+      },
     ].forEach(function ({ partnerKey, method }) {
       it(`should have the status acquired when ${partnerKey} certification is acquired`, async function () {
         // given

--- a/api/tests/tooling/domain-builder/factory/build-jury-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-certification.js
@@ -1,6 +1,4 @@
 const JuryCertification = require('../../../../lib/domain/models/JuryCertification');
-const buildCleaCertificationResult = require('./build-clea-certification-result');
-const buildPixPlusDroitCertificationResult = require('./build-pix-plus-droit-certification-result');
 const buildCertificationIssueReport = require('./build-certification-issue-report');
 const buildCompetenceMark = require('./build-competence-mark');
 
@@ -27,10 +25,8 @@ const buildJuryCertification = function ({
   commentForOrganization = 'comment organization',
   commentForJury = 'comment jury',
   competenceMarks = [buildCompetenceMark()],
-  cleaCertificationResult = buildCleaCertificationResult.notTaken(),
-  pixPlusDroitMaitreCertificationResult = buildPixPlusDroitCertificationResult.maitre.notTaken(),
-  pixPlusDroitExpertCertificationResult = buildPixPlusDroitCertificationResult.expert.notTaken(),
   certificationIssueReports = [buildCertificationIssueReport()],
+  partnerCertifications = [],
 } = {}) {
   return new JuryCertification({
     certificationCourseId,
@@ -55,10 +51,8 @@ const buildJuryCertification = function ({
     commentForOrganization,
     commentForJury,
     competenceMarks,
-    cleaCertificationResult,
-    pixPlusDroitMaitreCertificationResult,
-    pixPlusDroitExpertCertificationResult,
     certificationIssueReports,
+    partnerCertifications,
   });
 };
 

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -168,6 +168,10 @@ describe('Unit | Controller | certification-course-controller', function () {
           'clea-certification-status': 'not_taken',
           'pix-plus-droit-expert-certification-status': 'not_taken',
           'pix-plus-droit-maitre-certification-status': 'not_taken',
+          'pix-plus-edu-autonome-certification-status': 'not_taken',
+          'pix-plus-edu-avance-certification-status': 'not_taken',
+          'pix-plus-edu-expert-certification-status': 'not_taken',
+          'pix-plus-edu-formateur-certification-status': 'not_taken',
         },
         relationships: {
           'certification-issue-reports': {

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -131,10 +131,8 @@ describe('Unit | Controller | certification-course-controller', function () {
         commentForOrganization: 'comment organization',
         commentForJury: 'comment jury',
         competenceMarks: [],
-        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
-        pixPlusDroitMaitreCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken(),
-        pixPlusDroitExpertCertificationResult: domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken(),
         certificationIssueReports: [],
+        partnerCertifications: [],
       });
       sinon.stub(usecases, 'getJuryCertification').withArgs({ certificationCourseId }).resolves(juryCertification);
 

--- a/api/tests/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/unit/domain/models/JuryCertification_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const JuryCertification = require('../../../../lib/domain/models/JuryCertification');
+const { PIX_EMPLOI_CLEA } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Models | JuryCertification', function () {
   describe('#from', function () {
@@ -49,20 +50,16 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         ...juryCertificationBaseDTO,
         isCancelled: false,
       };
-      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.acquired();
-      const pixPlusDroitMaitreCertificationResult =
-        domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
-      const pixPlusDroitExpertCertificationResult =
-        domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
       const certificationIssueReports = [certificationIssueReport];
+      const partnerCertifications = [
+        domainBuilder.buildPartnerCertification({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
+      ];
 
       // when
       const juryCertification = JuryCertification.from({
         juryCertificationDTO,
         certificationIssueReports,
-        cleaCertificationResult,
-        pixPlusDroitMaitreCertificationResult,
-        pixPlusDroitExpertCertificationResult,
+        partnerCertifications,
       });
 
       // then
@@ -99,9 +96,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         commentForJury: 'ça va',
         competenceMarks: [expectedCompetenceMark],
         certificationIssueReports,
-        cleaCertificationResult,
-        pixPlusDroitMaitreCertificationResult,
-        pixPlusDroitExpertCertificationResult,
+        partnerCertifications,
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
     });
@@ -114,19 +109,12 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           isCancelled: true,
           assessmentResultStatus: 'WHATEVERIWANT',
         };
-        const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
-        const pixPlusDroitMaitreCertificationResult =
-          domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
-        const pixPlusDroitExpertCertificationResult =
-          domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
 
         // when
         const juryCertification = JuryCertification.from({
           juryCertificationDTO,
           certificationIssueReports: [],
-          cleaCertificationResult,
-          pixPlusDroitMaitreCertificationResult,
-          pixPlusDroitExpertCertificationResult,
+          partnerCertifications: [],
         });
 
         // then
@@ -140,19 +128,12 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           isCancelled: false,
           assessmentResultStatus: 'WHATEVERIWANT',
         };
-        const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
-        const pixPlusDroitMaitreCertificationResult =
-          domainBuilder.buildPixPlusDroitCertificationResult.maitre.notTaken();
-        const pixPlusDroitExpertCertificationResult =
-          domainBuilder.buildPixPlusDroitCertificationResult.expert.notTaken();
 
         // when
         const juryCertification = JuryCertification.from({
           juryCertificationDTO,
           certificationIssueReports: [],
-          cleaCertificationResult,
-          pixPlusDroitMaitreCertificationResult,
-          pixPlusDroitExpertCertificationResult,
+          partnerCertifications: [],
         });
 
         // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -1,6 +1,11 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-certification-serializer');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+} = require('../../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function () {
   describe('#serialize', function () {
@@ -41,6 +46,14 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
         partnerCertifications: [
           domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: true }),
           domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: false }),
+          domainBuilder.buildPartnerCertification({
+            partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+            acquired: true,
+          }),
+          domainBuilder.buildPartnerCertification({
+            partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+            acquired: false,
+          }),
         ],
       });
 
@@ -77,6 +90,10 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             'clea-certification-status': 'not_taken',
             'pix-plus-droit-maitre-certification-status': 'acquired',
             'pix-plus-droit-expert-certification-status': 'rejected',
+            'pix-plus-edu-autonome-certification-status': 'not_taken',
+            'pix-plus-edu-avance-certification-status': 'acquired',
+            'pix-plus-edu-expert-certification-status': 'rejected',
+            'pix-plus-edu-formateur-certification-status': 'not_taken',
           },
           relationships: {
             'certification-issue-reports': {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-certification-serializer');
+const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function () {
   describe('#serialize', function () {
@@ -13,11 +14,6 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
       });
       const certificationIssueReports = [certificationIssueReport];
       const competenceMarks = [domainBuilder.buildCompetenceMark()];
-      const cleaCertificationResult = domainBuilder.buildCleaCertificationResult.notTaken();
-      const pixPlusDroitMaitreCertificationResult =
-        domainBuilder.buildPixPlusDroitCertificationResult.maitre.acquired();
-      const pixPlusDroitExpertCertificationResult =
-        domainBuilder.buildPixPlusDroitCertificationResult.expert.rejected();
       const juryCertification = domainBuilder.buildJuryCertification({
         certificationCourseId,
         sessionId: 11,
@@ -41,10 +37,11 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
         commentForOrganization: 'comment',
         commentForJury: 'ça va',
         competenceMarks,
-        cleaCertificationResult,
-        pixPlusDroitMaitreCertificationResult,
-        pixPlusDroitExpertCertificationResult,
         certificationIssueReports,
+        partnerCertifications: [
+          domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_MAITRE_CERTIF, acquired: true }),
+          domainBuilder.buildPartnerCertification({ partnerKey: PIX_DROIT_EXPERT_CERTIF, acquired: false }),
+        ],
       });
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Nous allons permettre le passage de la certification complémentaire Pix+ Edu. Le pôle certif doit pouvoir savoir si cette certif a été validée, ou rejetée pour un candidat.

## :robot: Solution
Afficher le statut des certifications Pix+ Édu dans la page de détail d'une certification.

## :100: Pour tester
- Se connecter à Pix Admin
- Aller sur https://admin-pr3948.review.pix.fr/certifications/18000
- Vérifier que le candidat a bien validé sa certification Pix+ Édu Formateur et n'a pas passé les autres.
