### PR TITLE
[TECH] Prévenir les attaques par réponse utilisateur trop longue.

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { NotFoundError } = require('../../domain/errors');
+const USER_ANSWERS_MAX_LENGTH = 500;
 
 exports.register = async (server) => {
   server.route([
@@ -14,7 +15,7 @@ exports.register = async (server) => {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                value: Joi.string().allow('').allow(null),
+                value: Joi.string().max(USER_ANSWERS_MAX_LENGTH).allow('').allow(null),
                 result: Joi.string().allow(null),
                 'result-details': Joi.string().allow(null),
                 timeout: Joi.number().allow(null),

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -31,6 +31,39 @@ describe('Unit | Application | Router | answer-router', function () {
       // then
       expect(response.statusCode).to.equal(201);
     });
+
+    it('should return BAD_REQUEST with message if answer length is too long (security issue)', async function () {
+      // given
+      sinon.stub(answerController, 'save').callsFake((request, h) => h.response().created());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const USER_ANSWERS_MAX_LENGTH = 500;
+      const value = 'X'.repeat(USER_ANSWERS_MAX_LENGTH + 1);
+
+      const payload = {
+        data: {
+          attributes: {
+            value,
+            result: null,
+            'result-details': null,
+            timeout: null,
+          },
+          relationships: {},
+          assessment: {},
+          challenge: {},
+          type: 'answers',
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/answers', payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(response.result.errors[0].detail).to.equal(
+        '"data.attributes.value" length must be less than or equal to 500 characters long'
+      );
+    });
   });
 
   describe('GET /api/answers/{id}', function () {

--- a/high-level-tests/load-testing/processor/functions.js
+++ b/high-level-tests/load-testing/processor/functions.js
@@ -6,6 +6,7 @@ module.exports = {
   foundNextChallenge,
   handleResponseForChallengeId,
   setupSignupFormData,
+  generateLengthyValue,
 };
 
 function foundNextChallenge(context, next) {
@@ -24,5 +25,11 @@ function setupSignupFormData(context, events, done) {
   context.vars['lastName'] = faker.name.lastName();
   context.vars['email'] = `${faker.datatype.uuid().slice(19)}@example.net`;
   context.vars['password'] = 'Password123';
+  return done();
+}
+
+function generateLengthyValue(context, events, done) {
+  const oneMillion = 1000000;
+  context.vars['lengthyValue'] = 'X'.repeat(oneMillion);
   return done();
 }

--- a/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yaml
+++ b/high-level-tests/load-testing/scenarios/signup-and-competence-evaluation.yaml
@@ -12,6 +12,7 @@ scenarios:
   - name: "Inscription et évaluation"
     flow:
       - function: "setupSignupFormData"
+      - function: "generateLengthyValue"
 
       ### ---------------------- ###
       ### From page /inscription ###
@@ -79,7 +80,7 @@ scenarios:
           capture:
             json: "$.data.relationships.assessment.data.id"
             as: "assessmentId"
-          expect: 
+          expect:
             - statusCode: 201
 
 
@@ -123,7 +124,7 @@ scenarios:
               json:
                 data:
                   attributes:
-                    value: "#ABAND#"
+                    value: "{{ lengthyValue }}"
                   relationships:
                     assessment:
                       data:


### PR DESCRIPTION
## :unicorn: Problème
Voir #3804 et la [recommandation OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html#implementing-input-validation)
> Minimum and maximum value range check for numerical parameters and dates, minimum and maximum length check for strings.

On peut aussi utiliser le scénario de test rajouté
- démarrer API et mon-pix
- exécuter `npm run arti:cmd`
- suivre l'évolution de la  taille de `answers` (+10MB/minute) avec `SELECT pg_size_pretty( pg_total_relation_size('answers') ); \watch `

## :robot: Solution
Limiter la taille de la réponse à une valeur compatible avec l'ensemble des solutions possible, stockées dans
- `Epreuves.Bonnes Réponses`
- `Challenge.Solution`

On est à 36 000 caractères max, mais cela inclut un ensemble de bonnes réponses (donc supérieur à la taille d'une seule réponse utilisateur). On choisit 500 caractères.

La solution definitive est 
- limiter la taille du champ de saisie en Front
- modifier la taille en BDD

On pourrait aussi déplacer cette vérification dans le domaine API si besoin.

## :rainbow: Remarques
En général, on n'écrit pas de test sur la validation JOI.
Ici, un test uniatire de routeur a été écrit pour mettre l'intention (sécurité) en avant.

## :100: Pour tester

Démarrer un test, récupérer le `challengeId` de la question courante dans le store Ember.

Dans l'onglet Network du navigateur, modifier l'appel POST précédent sur `/api/answers`  avec le `challengeId` récupéré, et une chaîne [de plus de 500 caractères](http://www.unit-conversion.info/texttools/random-string-generator/) dans `value`.

Vérifiez que vous obtenez un statut HTTP 400 et le message suivant:
> "data.attributes.value" length must be less than or equal to 500 characters long

