### PR TITLE
[FEATURE] Rafraîchir l'affichage de l'espace surveillant périodiquement (PIX-3660).

### DIFF
--- a/certif/app/routes/session-supervising.js
+++ b/certif/app/routes/session-supervising.js
@@ -1,7 +1,20 @@
 import Route from '@ember/routing/route';
+import ENV from 'pix-certif/config/environment';
 
 export default class SessionSupervisingRoute extends Route {
   model(params) {
-    return this.store.queryRecord('session-for-supervising', { sessionId: params.session_id });
+    const sessionForSupervising = this.store.queryRecord('session-for-supervising', { sessionId: params.session_id });
+
+    this.poller = setInterval(() => {
+      this.store.queryRecord('session-for-supervising', { sessionId: params.session_id });
+    }, ENV.APP.sessionSupervisingPollingRate);
+
+    return sessionForSupervising;
+  }
+
+  deactivate() {
+    if (this.poller) {
+      clearInterval(this.poller);
+    }
   }
 }

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -61,6 +61,7 @@ module.exports = function (environment) {
         defaultValue: 8,
         minValue: 1,
       }),
+      sessionSupervisingPollingRate: process.env.SESSION_SUPERVISING_POLLING_RATE ?? 5000,
     },
 
     googleFonts: [


### PR DESCRIPTION
## :unicorn: Problème
Nous avons permis depuis le portail surveillant de suivre les candidats ayant démarré leur test de certification, et ceux l’ayant terminé. Cependant, le surveillant doit recharger la page pour suivre les changements d'état.

## :robot: Solution
- Recharger périodiquement les données afin d'avoir un affichage au plus proche du temps réel.

## :rainbow: Remarques
La fréquence de rechargement est ici fixée à 5 secondes mais cela peut être changé.

## :100: Pour tester
- Aller sur Pix Certif et créer une session.
- Ajouter un candidat
- Passer a certification et suivre depuis l'espace surveillant l'entrée en session et la fin du parcours.
- Ouvrir la console sur l'espace surveillant et vérifier qu'une requête part toutes les 5 secondes
- Cliquer sur le bouton quitter et vérifier que l'envoi des requêtes s'est arrêté.