### PR TITLE
[FEATURE] Suppression de la barre de progression dans les campagnes FLASH (PIX-3934).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -47,6 +47,7 @@ module.exports = {
         'progression',
         'competenceId',
         'lastQuestionState',
+        'method',
       ],
       answers: {
         ref: 'id',

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -74,6 +74,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'certification-number': null,
           'last-question-state': Assessment.statesOfLastQuestion.ASKED,
           'competence-id': 'recCompetenceId',
+          method: Assessment.methods.CHOSEN,
         },
         relationships: {
           course: {
@@ -198,6 +199,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'certification-number': null,
           'competence-id': 'recCompetenceId',
           'last-question-state': Assessment.statesOfLastQuestion.ASKED,
+          method: Assessment.methods.CHOSEN,
         },
         relationships: {
           course: { data: { type: 'courses', id: courseId } },
@@ -295,6 +297,7 @@ describe('Acceptance | API | assessment-controller-get', function () {
           'code-campaign': 'TESTCODE',
           'competence-id': 'recCompetenceId',
           'last-question-state': Assessment.statesOfLastQuestion.ASKED,
+          method: Assessment.methods.SMART_RANDOM,
         },
         relationships: {
           course: { data: { type: 'courses', id: 'anyFromLearningContent' } },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
             title: assessment.courseId.toString(),
             'competence-id': assessment.competenceId,
             'last-question-state': Assessment.statesOfLastQuestion.ASKED,
+            method: Assessment.methods.CERTIFICATION_DETERMINED,
           },
           relationships: {
             answers: {
@@ -115,6 +116,33 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
       expect(json.data.attributes['certification-number']).to.be.null;
       expect(json.data.attributes['code-campaign']).to.equal('Konami');
+    });
+
+    it('should convert an Assessment model object with type CAMPAIGN and method FLASH into JSON API data', function () {
+      //given
+      const assessment = domainBuilder.buildAssessment({
+        type: Assessment.types.CAMPAIGN,
+        method: Assessment.methods.FLASH,
+        campaignParticipation: { campaign: { code: 'Konami' } },
+      });
+      const expectedProgressionJson = {
+        data: {
+          id: `progression-${assessment.id}`,
+          type: 'progressions',
+        },
+        links: {
+          related: `/api/progressions/progression-${assessment.id}`,
+        },
+      };
+
+      // when
+      const json = serializer.serialize(assessment);
+
+      // then
+      expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
+      expect(json.data.attributes['certification-number']).to.be.null;
+      expect(json.data.attributes['code-campaign']).to.equal('Konami');
+      expect(json.data.attributes['method']).to.equal(Assessment.methods.FLASH);
     });
 
     it('should convert an Assessment model object without course into JSON API data', function () {

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -1,7 +1,7 @@
 /* eslint ember/no-computed-properties-in-native-classes: 0 */
 
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import { equal, or } from '@ember/object/computed';
+import { equal, or, not, and } from '@ember/object/computed';
 import ENV from 'mon-pix/config/environment';
 export default class Assessment extends Model {
   // attributes
@@ -30,6 +30,8 @@ export default class Assessment extends Model {
   @equal('type', 'CAMPAIGN') isForCampaign;
 
   @equal('method', 'FLASH') isFlash;
+  @not('isFlash') isNotFlash;
+  @and('isForCampaign', 'isNotFlash') isForNotFlashCampaign;
 
   @equal('state', 'aborted') isAborted;
   @equal('state', 'completed') isCompleted;
@@ -38,9 +40,9 @@ export default class Assessment extends Model {
   @equal('lastQuestionState', 'timeout') hasTimeoutChallenge;
   @equal('lastQuestionState', 'focusedout') hasFocusedOutChallenge;
 
-  @or('isCompetenceEvaluation', 'isForCampaign') hasCheckpoints;
-  @or('isCompetenceEvaluation', 'isForCampaign') showLevelup;
-  @or('isCompetenceEvaluation', 'isForCampaign', 'isDemo') showProgressBar;
+  @or('isCompetenceEvaluation', 'isForNotFlashCampaign') hasCheckpoints;
+  @or('isCompetenceEvaluation', 'isForNotFlashCampaign') showLevelup;
+  @or('isCompetenceEvaluation', 'isForNotFlashCampaign', 'isDemo') showProgressBar;
 
   get answersSinceLastCheckpoints() {
     const answers = this.answers.toArray();

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -11,6 +11,7 @@ export default class Assessment extends Model {
   @attr('string') title;
   @attr('string') type;
   @attr('string') lastQuestionState;
+  @attr('string') method;
 
   // references
   @attr('string') competenceId;
@@ -27,6 +28,8 @@ export default class Assessment extends Model {
   @equal('type', 'DEMO') isDemo;
   @equal('type', 'PREVIEW') isPreview;
   @equal('type', 'CAMPAIGN') isForCampaign;
+
+  @equal('method', 'FLASH') isFlash;
 
   @equal('state', 'aborted') isAborted;
   @equal('state', 'completed') isCompleted;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -34,7 +34,6 @@
   </div>
 
   <main class="challenge__content rounded-panel--over-background-banner">
-    {{log @model.assessment.isFlash}}
     <ProgressBar @assessment={{@model.assessment}} @currentChallengeNumber={{@model.currentChallengeNumber}} />
 
     {{#if this.displayTimedChallengeInstructions}}

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -34,6 +34,7 @@
   </div>
 
   <main class="challenge__content rounded-panel--over-background-banner">
+    {{log @model.assessment.isFlash}}
     <ProgressBar @assessment={{@model.assessment}} @currentChallengeNumber={{@model.currentChallengeNumber}} />
 
     {{#if this.displayTimedChallengeInstructions}}

--- a/mon-pix/app/utils/progress-in-assessment.js
+++ b/mon-pix/app/utils/progress-in-assessment.js
@@ -5,6 +5,9 @@ function getMaxStepsNumber(assessment) {
   if (assessment.isPreview) {
     return ONE_STEP;
   }
+  if (assessment.isFlash) {
+    return ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD;
+  }
   if (assessment.isCertification) {
     return assessment.get('certificationCourse.nbChallenges');
   }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -111,6 +111,11 @@ module.exports = function (environment) {
       },
       AUTHENTICATED_SOURCE_FROM_MEDIACENTRE: 'external',
       AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI: 'pole_emploi_connect',
+      NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD: _getEnvironmentVariableAsNumber({
+        environmentVariableName: 'NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD',
+        defaultValue: 48,
+        minValue: 1,
+      }),
     },
 
     googleFonts: [

--- a/mon-pix/mirage/factories/assessment.js
+++ b/mon-pix/mirage/factories/assessment.js
@@ -34,6 +34,11 @@ export default Factory.extend({
     type: 'CAMPAIGN',
   }),
 
+  ofFlashCampaignType: trait({
+    type: 'CAMPAIGN',
+    method: 'FLASH',
+  }),
+
   withCurrentChallengeTimeout: trait({
     lastQuestionState: 'timeout',
   }),

--- a/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
+++ b/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
@@ -1,0 +1,37 @@
+import { find } from '@ember/test-helpers';
+import { describe, it, beforeEach } from 'mocha';
+import { expect } from 'chai';
+import visit from '../helpers/visit';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import environment from '../../config/environment';
+
+describe('Acceptance | Flash', () => {
+  setupApplicationTest();
+  setupMirage();
+  let assessment;
+
+  beforeEach(function () {
+    assessment = server.create('assessment', 'ofFlashCampaignType');
+  });
+
+  describe('Campaign', () => {
+    beforeEach(function () {
+      // In reality we should have 48 challenges but we just use one in this test.
+      server.create('challenge', 'forCampaign');
+    });
+
+    it('should display 1/48 counter on first challenge', async () => {
+      // when
+      await visit(`/assessments/${assessment.id}/challenges/0`);
+
+      // then
+      expect(find('.challenge__content')).to.exist;
+      expect(find('.assessment-progress__value')).to.exist;
+
+      const progressValue = find('.assessment-progress__value').textContent.replace(/\s+/g, '');
+      const maxNbOfQuestions = environment.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD;
+      expect(progressValue).to.equal(`1/${maxNbOfQuestions}`);
+    });
+  });
+});

--- a/mon-pix/tests/unit/models/assessment_test.js
+++ b/mon-pix/tests/unit/models/assessment_test.js
@@ -180,4 +180,27 @@ describe('Unit | Model | Assessment', function () {
       expect(model.isPreview).to.be.false;
     });
   });
+
+  describe('#isFlash', function () {
+    it('should return true when the assessment method is FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.method = 'FLASH';
+
+      //then
+      expect(model.isFlash).to.be.true;
+    });
+    it('should return false when the assessment method is not FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.method = '_';
+
+      //then
+      expect(model.isFlash).to.be.false;
+    });
+  });
 });

--- a/mon-pix/tests/unit/models/assessment_test.js
+++ b/mon-pix/tests/unit/models/assessment_test.js
@@ -192,6 +192,7 @@ describe('Unit | Model | Assessment', function () {
       //then
       expect(model.isFlash).to.be.true;
     });
+
     it('should return false when the assessment method is not FLASH', function () {
       // given
       const model = store.createRecord('assessment');
@@ -201,6 +202,191 @@ describe('Unit | Model | Assessment', function () {
 
       //then
       expect(model.isFlash).to.be.false;
+    });
+  });
+
+  describe('#hasCheckpoints', function () {
+    it('should return false when the assessment type is CERTIFICATION', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CERTIFICATION';
+
+      //then
+      expect(model.hasCheckpoints).to.be.false;
+    });
+
+    it('should return false when the assessment type is PREVIEW', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'PREVIEW';
+
+      //then
+      expect(model.hasCheckpoints).to.be.false;
+    });
+
+    it('should return true when the assessment type is COMPETENCE_EVALUATION', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'COMPETENCE_EVALUATION';
+
+      //then
+      expect(model.hasCheckpoints).to.be.true;
+    });
+
+    it('should return true when the assessment type is CAMPAIGN and method is not FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CAMPAIGN';
+
+      //then
+      expect(model.hasCheckpoints).to.be.true;
+    });
+
+    it('should return false when the assessment type is CAMPAIGN and method is FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CAMPAIGN';
+      model.method = 'FLASH';
+
+      //then
+      expect(model.hasCheckpoints).to.be.false;
+    });
+  });
+
+  describe('#showLevelup', function () {
+    it('should return false when the assessment type is CERTIFICATION', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CERTIFICATION';
+
+      //then
+      expect(model.showLevelup).to.be.false;
+    });
+
+    it('should return false when the assessment type is PREVIEW', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'PREVIEW';
+
+      //then
+      expect(model.showLevelup).to.be.false;
+    });
+
+    it('should return true when the assessment type is COMPETENCE_EVALUATION', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'COMPETENCE_EVALUATION';
+
+      //then
+      expect(model.showLevelup).to.be.true;
+    });
+
+    it('should return true when the assessment type is CAMPAIGN and method is not FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CAMPAIGN';
+
+      //then
+      expect(model.showLevelup).to.be.true;
+    });
+
+    it('should return false when the assessment type is CAMPAIGN and method is FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CAMPAIGN';
+      model.method = 'FLASH';
+
+      //then
+      expect(model.showLevelup).to.be.false;
+    });
+  });
+
+  describe('#showProgressBar', function () {
+    it('should return false when the assessment type is CERTIFICATION', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CERTIFICATION';
+
+      //then
+      expect(model.showProgressBar).to.be.false;
+    });
+
+    it('should return false when the assessment type is PREVIEW', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'PREVIEW';
+
+      //then
+      expect(model.showProgressBar).to.be.false;
+    });
+
+    it('should return true when the assessment type is COMPETENCE_EVALUATION', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'COMPETENCE_EVALUATION';
+
+      //then
+      expect(model.showProgressBar).to.be.true;
+    });
+
+    it('should return true when the assessment type is CAMPAIGN and method is not FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CAMPAIGN';
+
+      //then
+      expect(model.showProgressBar).to.be.true;
+    });
+
+    it('should return false when the assessment type is CAMPAIGN and method is FLASH', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'CAMPAIGN';
+      model.method = 'FLASH';
+
+      //then
+      expect(model.showProgressBar).to.be.false;
+    });
+
+    it('should return true when the assessment type is DEMO', function () {
+      // given
+      const model = store.createRecord('assessment');
+
+      // when
+      model.type = 'DEMO';
+
+      //then
+      expect(model.showProgressBar).to.be.true;
     });
   });
 });

--- a/mon-pix/tests/unit/utils/progress-in-assessment_test.js
+++ b/mon-pix/tests/unit/utils/progress-in-assessment_test.js
@@ -50,6 +50,30 @@ describe('Unit | Utility | progress-in-assessment', function () {
       expect(maxStepNumber).to.equal(ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS);
     });
 
+    describe('when assessment has flash method', function () {
+      it('should return the maximum number of challenges', function () {
+        // given
+        const assessment = EmberObject.create({ isFlash: true });
+
+        // when
+        const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
+
+        // then
+        expect(maxStepNumber).to.equal(ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD);
+      });
+
+      it('when assessment is certification, should return the maximum number of challenges', function () {
+        // given
+        const assessment = EmberObject.create({ isFlash: true, isCertification: true });
+
+        // when
+        const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
+
+        // then
+        expect(maxStepNumber).to.equal(ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD);
+      });
+    });
+
     it('when assessment is certification, should return the number of challenges in certification', function () {
       // given
       const nbChallenges = 23;


### PR DESCRIPTION
## :unicorn: Problème

Lors d'une campagne flash, nous souhaitons faire apparaitre le compteur de questions tel qu'il est visible dans le cas d'une certification.

## :robot: Solution

Suppression de la barre de progression pour la remplacer par le compteur de questions.

## :rainbow: Remarques

Cette suppression engendre la disparition des écrans de "checkpoints"

Ajout de la variable d'env `NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD` côté front.

## :100: Pour tester

Sur Pix-app, réaliser une campagne FLASH, et vérifier que la barre de progression a disparu pour être remplacée par le compteur de questions restantes.
