### PR TITLE
[FEATURE] Améliorer l'affichage des colonnes des tableaux sur Pix Orga (PIX-4149).

### DIFF
--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -13,14 +13,22 @@
 <section ...attributes>
   <div class="panel">
     <table class="table content-text content-text--small">
+      <colgroup class="table__column">
+        <col class="table__column--wide" />
+        <col class="table__column--wide" />
+        {{#if @campaign.idPixLabel}}
+          <col class="table__column--wide" />
+        {{/if}}
+        <col class="table__column--wide" />
+      </colgroup>
       <thead>
         <tr>
-          <Table::Header @size="wide">{{t "pages.campaign-activity.table.column.last-name"}}</Table::Header>
-          <Table::Header @size="wide">{{t "pages.campaign-activity.table.column.first-name"}}</Table::Header>
+          <Table::Header>{{t "pages.campaign-activity.table.column.last-name"}}</Table::Header>
+          <Table::Header>{{t "pages.campaign-activity.table.column.first-name"}}</Table::Header>
           {{#if @campaign.idPixLabel}}
-            <Table::Header @size="wide">{{@campaign.idPixLabel}}</Table::Header>
+            <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
-          <Table::Header @size="wide">{{t "pages.campaign-activity.table.column.status"}}</Table::Header>
+          <Table::Header>{{t "pages.campaign-activity.table.column.status"}}</Table::Header>
         </tr>
       </thead>
 

--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -9,21 +9,20 @@
   />
   <div class="panel">
     <table class="table content-text content-text--small">
+      <colgroup class="table__column">
+        <col class="table__column--wide" />
+        <col class="table__column--wide hide-on-mobile" />
+        <col class="table__column--small hide-on-mobile" />
+        <col class="table__column--small hide-on-mobile" />
+        <col class="table__column--small hide-on-mobile" />
+      </colgroup>
       <thead>
         <tr>
-          <Table::Header @size="wide">{{t "pages.campaigns-list.table.column.campaign"}}</Table::Header>
-          <Table::Header @size="wide" class="hide-on-mobile">{{t
-              "pages.campaigns-list.table.column.created-by"
-            }}</Table::Header>
-          <Table::Header @size="small" class="hide-on-mobile">{{t
-              "pages.campaigns-list.table.column.created-on"
-            }}</Table::Header>
-          <Table::Header @size="small" class="hide-on-mobile">{{t
-              "pages.campaigns-list.table.column.participants"
-            }}</Table::Header>
-          <Table::Header @size="small" class="hide-on-mobile">{{t
-              "pages.campaigns-list.table.column.results"
-            }}</Table::Header>
+          <Table::Header>{{t "pages.campaigns-list.table.column.campaign"}}</Table::Header>
+          <Table::Header class="hide-on-mobile">{{t "pages.campaigns-list.table.column.created-by"}}</Table::Header>
+          <Table::Header class="hide-on-mobile">{{t "pages.campaigns-list.table.column.created-on"}}</Table::Header>
+          <Table::Header class="hide-on-mobile">{{t "pages.campaigns-list.table.column.participants"}}</Table::Header>
+          <Table::Header class="hide-on-mobile">{{t "pages.campaigns-list.table.column.results"}}</Table::Header>
         </tr>
       </thead>
 

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -15,6 +15,17 @@
 
   <div class="panel">
     <table class="table content-text content-text--small">
+      <colgroup class="table__column">
+        <col />
+        <col />
+        {{#if @campaign.idPixLabel}}
+          <col />
+        {{/if}}
+        <col />
+        {{#if @campaign.hasBadges}}
+          <col />
+        {{/if}}
+      </colgroup>
       <thead>
         <tr>
           <Table::Header>{{t "pages.campaign-results.table.column.last-name"}}</Table::Header>

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -13,6 +13,17 @@
 
   <div class="panel">
     <table class="table content-text content-text--small">
+      <colgroup class="table__column">
+        <col />
+        <col />
+        {{#if @campaign.idPixLabel}}
+          <col />
+        {{/if}}
+        <col />
+        <col />
+        <col class="hide-on-mobile" />
+        <col class="hide-on-mobile" />
+      </colgroup>
       <thead>
         <tr>
           <Table::Header>{{t "pages.profiles-list.table.column.last-name"}}</Table::Header>

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -1,5 +1,13 @@
 <div class="panel">
   <table class="table content-text content-text--small">
+    <colgroup class="table__column">
+      <col />
+      <col />
+      <col />
+      <col />
+      <col />
+      <col class="table__column--small hide-on-mobile" />
+    </colgroup>
     <thead>
       <tr>
         <Table::Header>{{t "pages.students-sco.table.column.last-name"}}</Table::Header>
@@ -7,7 +15,7 @@
         <Table::Header>{{t "pages.students-sco.table.column.date-of-birth"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.division"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
-        <Table::Header @size="small" class="hide-on-mobile" />
+        <Table::Header class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
         <Table::HeaderFilterInput

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -58,8 +58,8 @@
       <tbody>
         {{#each @students as |student|}}
           <tr aria-label={{t "pages.students-sco.table.row-title"}}>
-            <td>{{student.lastName}}</td>
-            <td>{{student.firstName}}</td>
+            <td class="ellipsis" title={{student.lastName}}>{{student.lastName}}</td>
+            <td class="ellipsis" title={{student.firstName}}>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
             <td>{{student.division}}</td>
             <td class="list-students-page__authentication-methods">

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -97,6 +97,10 @@ th::first-letter {
 .table__column {
   width: 16%;
 
+  col {
+    min-width: 100px;
+  }
+
   &--center {
     text-align: center;
   }
@@ -108,6 +112,7 @@ th::first-letter {
 
   &--small {
     width: 6%;
+    max-width: 150px;
   }
 
   &--wide {
@@ -146,7 +151,6 @@ th::first-letter {
 
 @media (max-width: 768px) {
   .table {
-    display: block;
     width: 100%;
     overflow-x: auto;
   }

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -66,6 +66,11 @@ tbody {
     color: $grey-80;
     position: relative;
 
+    &.ellipsis {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     > a {
       color: $grey-80;
       text-decoration: none;

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -55,8 +55,6 @@
   color: $grey-60;
   font-family: $roboto;
   font-size: 1rem;
-  word-break: break-word;
-  -ms-word-break: break-all;
 
   &--bold {
     color: $grey-100;


### PR DESCRIPTION
## :unicorn: Problème
Quand la page n'est pas assez large, le texte dans les colonnes est tronqué parfois au milieu du mot.

## :robot: Solution
Ne pas permettre le troncage en milieu de mot et limiter la largeur des colonnes. 

## :100: Pour tester
Accéder à [Pix-Orga](https://orga-pr3954.review.pix.fr)
Vérifier le texte dans les colonnes en changeant la largeur de la page.

**campaign/list.hbs**
- Aller sur Campagnes

**campaign/activity/participants-list.hbs**
- Se connecter avec `sco.admin@example.net`
- Aller sur Campagnes
- Cliquer sur la campagne `Sco - Collège - Campagne d’évaluation Badges (avec un titre très long pour voir le comportement de cette PR :) )`
- Le tableau se trouve en bas de cette page 

**campaign/results/assessment-list.hbs**
- Se connecter avec `sco.admin@example.net`
- Aller sur Campagnes
- Cliquer sur la campagne `Sco - Collège - Campagne d’évaluation Badges (avec un titre très long pour voir le comportement de cette PR :) )`
- Cliquer sur l'onglet Résultats 
- Le tableau se trouve en bas de cette page 

**campaign/results/profile-list.hbs**
- Se connecter avec `pro.admin@example.net`
- Cliquer sur la campagne `Pro - Campagne de collecte de profils` (c'est une campagne de collecte de profil, le tableau est différent du test plus haut)
- Cliquer sur l'onglet Résultats 
- Le tableau se trouve en bas de cette page 

**student/sco/list.hbs**
- Aller dans l'onglet Elèves