### PR TITLE
[FEATURE] Afficher les acquis dans les export CSV en fonction du flag showSkills (PIX-4105)

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -172,6 +172,6 @@ function _createHeaderOfCSV(targetProfile, idPixLabel, organization, translate) 
       translate('campaign-export.assessment.competence-area.items-successfully-completed', { name: area.title }),
     ]),
 
-    ...(organization.isSco ? [] : targetProfile.skillNames),
+    ...(organization.showSkills ? targetProfile.skillNames : []),
   ];
 }

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -118,9 +118,9 @@ class CampaignAssessmentCsvLine {
     return [
       ...this._makeCompetenceColumns(),
       ...this._makeAreaColumns(),
-      ...(this.organization.isSco
-        ? []
-        : _.map(this.targetProfileWithLearningContent.skills, (targetedSkill) => this._makeSkillColumn(targetedSkill))),
+      ...(this.organization.showSkills
+        ? _.map(this.targetProfileWithLearningContent.skills, (targetedSkill) => this._makeSkillColumn(targetedSkill))
+        : []),
     ];
   }
 
@@ -132,7 +132,9 @@ class CampaignAssessmentCsvLine {
     return [
       ...this._makeEmptyColumns(this.targetProfileWithLearningContent.competences.length * STATS_COLUMNS_COUNT),
       ...this._makeEmptyColumns(this.targetProfileWithLearningContent.areas.length * STATS_COLUMNS_COUNT),
-      ...(this.organization.isSco ? [] : this._makeEmptyColumns(this.targetProfileWithLearningContent.skills.length)),
+      ...(this.organization.showSkills
+        ? this._makeEmptyColumns(this.targetProfileWithLearningContent.skills.length)
+        : []),
     ];
   }
 

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -217,6 +217,7 @@ async function _createCampaign({ organizationId, campaignType, targetProfileId }
     .insert({
       name: `Campaign_${organizationId}_${targetProfileId}`,
       code: 'FAKECODE',
+      ownerId: 1,
       organizationId,
       creatorId: adminMemberId,
       targetProfileId,

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -37,7 +37,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     const i18n = getI18n();
 
     beforeEach(async function () {
-      organization = databaseBuilder.factory.buildOrganization();
+      organization = databaseBuilder.factory.buildOrganization({ showSkills: true });
       user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
       const skillWeb1 = domainBuilder.buildTargetedSkill({ id: 'recSkillWeb1', name: '@web1', tubeId: 'recTube1' });

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -250,11 +250,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
       });
     });
 
-    context('when organization type is not SCO', function () {
+    context('when organization showSkills is true', function () {
       context('when participation is shared', function () {
         it('should show details for each competence, area and skills', function () {
           // given
-          const organization = domainBuilder.buildOrganization({ type: 'SUP' });
+          const organization = domainBuilder.buildOrganization({ showSkills: true });
           const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
           const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
             sharedAt: new Date('2020-01-01'),
@@ -382,7 +382,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
       context('when participation is not shared', function () {
         it('should show NA for each competence, area and skills', function () {
           // given
-          const organization = domainBuilder.buildOrganization({ type: 'SUP' });
+          const organization = domainBuilder.buildOrganization({ showSkills: true });
           const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
           const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: null });
           const skill1_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
@@ -571,11 +571,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', function (
       });
     });
 
-    context('when organization type is SCO', function () {
+    context('when organization showSkills is false', function () {
       context('when participation is shared', function () {
         it('should show details for each competence and area but not skills', function () {
           // given
-          const organization = domainBuilder.buildOrganization({ type: 'SCO' });
+          const organization = domainBuilder.buildOrganization({ showSkills: false });
           const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
           const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({
             sharedAt: new Date('2020-01-01'),


### PR DESCRIPTION
## :unicorn: Problème
Actullement l'affichage des acquis est conditionné par rapport au type de l'organisation. Nous souhaitons pouvoir activé ou non l'affichage des acquis aux organisations en ayant besoin

## :robot: Solution
Utiliser le flag showSkills dans les export CSV pour remonter ou non les acquis.

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur Pix Admin, Vérifier l'état du champs "Affichage des acquis dans les exports"
Se connecter sur Pix Orga, se connecter sur pro.admin@example.net. télécharger l'export vérifier que l'affichage des acquis correspond à l'état du flag.
Modifier l'état du champs "Affichage des acquis dans les exports"
Télécharger l'export à nouveau et vérifier l'affichage des exports