### PR TITLE
[A11Y] Suppression d'une partie du texte des aria-label dans les QROC (PIX-4174).

### DIFF
--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -7,15 +7,24 @@ import { inject as service } from '@ember/service';
 export default class QrocmProposal extends Component {
   @service intl;
 
+  ARIA_LABEL_DELIMITATOR = '#';
+
   get proposalBlocks() {
     return proposalsAsBlocks(this.args.proposals).map((block) => {
       block.showText = block.text && !block.ariaLabel && !block.input;
       block.randomName = generateRandomString(block.input);
-      block.ariaLabel = block.autoAriaLabel
-        ? this.intl.t('pages.challenge.answer-input.numbered-label', { number: block.ariaLabel })
-        : block.ariaLabel;
+      if (block.ariaLabel) {
+        if (block.autoAriaLabel) {
+          block.ariaLabel = this.intl.t('pages.challenge.answer-input.numbered-label', { number: block.ariaLabel });
+        }
+        block.ariaLabel = this._formatAriaLabel(block.ariaLabel);
+      }
       return block;
     });
+  }
+
+  _formatAriaLabel(rawAriaLabel) {
+    return rawAriaLabel.split(this.ARIA_LABEL_DELIMITATOR)[0];
   }
 
   @action

--- a/mon-pix/tests/integration/components/qrocm-proposal_test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal_test.js
@@ -15,7 +15,7 @@ describe('Integration | Component | QROCm proposal', function () {
 
   describe('When block type is select', function () {
     beforeEach(function () {
-      this.set('proposals', '${potato#samurai options=["salad", "tomato", "onion"]}');
+      this.set('proposals', '${potato§La patate#samurai options=["salad", "tomato", "onion"]}');
     });
 
     it('should display a selector with related options', async function () {
@@ -32,6 +32,7 @@ describe('Integration | Component | QROCm proposal', function () {
       const optionValues = options.map((option) => option.value);
 
       expect(selector.tagName).to.equal('SELECT');
+      expect(selector.getAttribute('aria-label')).to.equal('La patate');
       expect(optionValues).to.deep.equal(expectedOptionValues);
     });
 


### PR DESCRIPTION
## :unicorn: Problème

On veut mettre situation A en aria label mais l'aria label inclus le placeholder en plus.
Ça donne Situation A#- Sélectionner -...

## :robot: Solution

Formatage de la donnée supplémentaire

## :rainbow: Remarques
N/A

## :100: Pour tester
Aller sur épreuve `challengeSo1fJf8FLaR2b` et constater que le aria-label ne contient plus que `Situation A`  (ou autre lettre) sans le # par la suite.
