### PR TITLE
[BUGFIX] Ne pas afficher les résultats/attestations des élèves désactivés dans Pix Orga (PIX-4176)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -49,7 +49,10 @@ module.exports = {
         'certification-candidates.schoolingRegistrationId'
       )
       .innerJoin('organizations', 'organizations.id', 'schooling-registrations.organizationId')
-      .where('schooling-registrations.organizationId', '=', organizationId)
+      .where({
+        'schooling-registrations.organizationId': organizationId,
+        'schooling-registrations.isDisabled': false,
+      })
       .whereRaw('LOWER("schooling-registrations"."division") = ?', division.toLowerCase())
       .whereRaw('"certification-candidates"."userId" = "certification-courses"."userId"')
       .whereRaw('"certification-candidates"."sessionId" = "certification-courses"."sessionId"')

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -47,7 +47,8 @@ module.exports = {
           .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
       )
 
-      .where('certification-courses.isCancelled', '=', false)
+      .where({ 'certification-courses.isCancelled': false })
+      .where({ 'schooling-registrations.isDisabled': false })
       .where(
         'schooling-registrations.organizationId',
         '=',

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -30,7 +30,10 @@ module.exports = {
       .select(['certification-candidates.id'])
       .from('certification-candidates')
       .join('schooling-registrations', 'schooling-registrations.id', 'certification-candidates.schoolingRegistrationId')
-      .where('schooling-registrations.organizationId', '=', organizationId)
+      .where({
+        'schooling-registrations.organizationId': organizationId,
+        'schooling-registrations.isDisabled': false,
+      })
       .whereRaw('LOWER("schooling-registrations"."division") = ?', division.toLowerCase())
       .orderBy('certification-candidates.lastName', 'ASC')
       .orderBy('certification-candidates.firstName', 'ASC');

--- a/api/scripts/update-certification-infos.js
+++ b/api/scripts/update-certification-infos.js
@@ -93,12 +93,12 @@ async function updateCertificationInfos(dataFilePath, sessionIdsFilePath) {
       }
     );
 
-    trx.commit();
+    await trx.commit();
     logger.info('✅ ');
     logger.info(`Certifications mises à jour: ${info.success}/${csvData.length} (${info.failure})`);
   } catch (error) {
     if (trx) {
-      trx.rollback();
+      await trx.rollback();
     }
     logger.error(error);
     process.exit(1);

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -91,6 +91,33 @@ describe('Integration | Repository | Certification-ls ', function () {
       expect(certificationResults).to.deep.equal([expected]);
     });
 
+    it('should not return disabled schooling registration certification results for a given UAI', async function () {
+      // given
+      const organizationId = buildOrganization(uai).id;
+      const user = buildUser();
+      const schoolingRegistration = buildSchoolingRegistration({
+        userId: user.id,
+        organizationId,
+        isDisabled: true,
+      });
+
+      buildValidatedPublishedCertificationData({
+        user,
+        schoolingRegistration,
+        verificationCode,
+        pixScore,
+        competenceMarks,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const certificationResults = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
+      expect(certificationResults).to.deep.equal([]);
+    });
+
     it('should not return cancelled certification for a given UAI', async function () {
       // given
       const organizationId = buildOrganization(uai).id;

--- a/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -80,7 +80,7 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
   });
 
   describe('#findIdsByOrganizationIdAndDivision', function () {
-    it('retrieves no candidates when no one belongs to organisation', async function () {
+    it('retrieves no candidates when no one belongs to organization', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const anOrganizationId = databaseBuilder.factory.buildOrganization().id;
@@ -105,17 +105,28 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
       expect(candidatesIds).to.be.empty;
     });
 
-    it('retrieves the candidates that belong to the organisation and division', async function () {
+    it('retrieves the non disabled candidates that belong to the organization and division', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const anOrganizationId = databaseBuilder.factory.buildOrganization().id;
-      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+      const nonDisabledSchoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
         organizationId: anOrganizationId,
         division: '3ème A',
+        isDisabled: false,
       }).id;
-      const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+      const nonDisabledCandidateId = databaseBuilder.factory.buildCertificationCandidate({
         sessionId,
-        schoolingRegistrationId,
+        schoolingRegistrationId: nonDisabledSchoolingRegistrationId,
+      }).id;
+
+      const disabledSchoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: anOrganizationId,
+        division: '3ème A',
+        isDisabled: true,
+      }).id;
+      databaseBuilder.factory.buildCertificationCandidate({
+        sessionId,
+        schoolingRegistrationId: disabledSchoolingRegistrationId,
       }).id;
       await databaseBuilder.commit();
 
@@ -126,7 +137,7 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
       });
 
       // then
-      expect(candidatesIds).to.deep.equal([candidateId]);
+      expect(candidatesIds).to.deep.equal([nonDisabledCandidateId]);
     });
 
     it('retrieves only the candidates that belongs to the given division', async function () {

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
@@ -11,8 +11,8 @@ function buildUser() {
   return databaseBuilder.factory.buildUser();
 }
 
-function buildSchoolingRegistration({ userId, organizationId }) {
-  return databaseBuilder.factory.buildSchoolingRegistration({ userId, organizationId });
+function buildSchoolingRegistration({ userId, organizationId, isDisabled }) {
+  return databaseBuilder.factory.buildSchoolingRegistration({ userId, organizationId, isDisabled });
 }
 
 function _createCertificationCenter() {


### PR DESCRIPTION
## :unicorn: Problème
De nombreuses remontées support d'établissements scolaires indiquent que lorsque les Admin Pix Orga téléchargent les résultats de certification / attestations de certification des élèves depuis le menu Certifications, les élèves de l’année scolaire dernière sont également présents dans le fichier, ce qui n’est pas bon.

## :robot: Solution
Ne permettre le téléchargement des résultats/attestations que des élèves actifs.

## :100: Pour tester
Se connecter à pix-orga avec _sco.admin@example.net_:
- Télécharger les résultats de la classe 3A
- Constater que les résultats de Blue Ivy Carter et George De Cambridge sont présents

Se connecter à la base de la RA:
- Exécuter la requête suivante ```update "schooling-registrations" set "isDisabled"=true where id=100038;```
- Se connecter à pix-orga
- Télécharger les résultats et les attestations de la classe 3A
- Constater que seuls les résultats de Blue Ivy Carter sont présents

Penser aux copains qui vont re tester derrière et remettre le isDisabled à false sur George ```update "schooling-registrations" set "isDisabled"=false where id=100038;``` XD
