### PR TITLE
[FEATURE] Edition du message d'un palier dans Pix-Admin (PIX-3959).

### DIFF
--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -1,6 +1,24 @@
 <section class="page-section mb_10">
   <form class="form" {{on "submit" this.updateStage}}>
     <div class="form-field">
+      <label for="threshold" class="form-field__label">
+        Seuil
+      </label>
+      <Input id="threshold" @type="number" class="form-control" @value={{this.form.threshold}} min="0" max="100" />
+      <br />
+
+      <label for="title" class="form-field__label">
+        Titre
+      </label>
+      <Input id="title" @type="text" class="form-control" @value={{this.form.title}} />
+      <br />
+
+      <label for="message" class="form-field__label">
+        Message
+      </label>
+      <Input id="message" @type="text" class="form-control" @value={{this.form.message}} />
+      <br />
+
       <label for="prescriberTitle" class="form-field__label">
         Titre pour le prescripteur
       </label>

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -1,5 +1,5 @@
 <section class="page-section mb_10">
-  <form class="form" {{on "submit" this.updateStage}}>
+  <form class="form stage-form" {{on "submit" this.updateStage}}>
     <div class="form-field">
       <label for="threshold" class="form-field__label">
         Seuil
@@ -16,7 +16,7 @@
       <label for="message" class="form-field__label">
         Message
       </label>
-      <Input id="message" @type="text" class="form-control" @value={{this.form.message}} />
+      <Textarea id="message" class="form-control" @value={{this.form.message}} rows="4" />
       <br />
 
       <label for="prescriberTitle" class="form-field__label">
@@ -39,11 +39,11 @@
       <label for="prescriberDescription" class="form-field__label">
         Description pour le prescripteur
       </label>
-      <Input
+      <Textarea
         id="prescriberDescription"
-        @type="text"
         class="form-control {{if (v-get this.form "prescriberDescription" "isInvalid") "is-invalid"}}"
         @value={{this.form.prescriberDescription}}
+        rows="4"
       />
     </div>
     <div class="form-actions">

--- a/admin/app/components/stages/update-stage.js
+++ b/admin/app/components/stages/update-stage.js
@@ -35,6 +35,9 @@ export default class UpdateStage extends Component {
   constructor() {
     super(...arguments);
     this.form = Form.create(getOwner(this).ownerInjection());
+    this.form.threshold = this.args.model.threshold;
+    this.form.title = this.args.model.title;
+    this.form.message = this.args.model.message;
     this.form.prescriberTitle = this.args.model.prescriberTitle;
     this.form.prescriberDescription = this.args.model.prescriberDescription;
   }
@@ -46,6 +49,9 @@ export default class UpdateStage extends Component {
 
   async _updateStage() {
     const model = this.args.model;
+    model.threshold = this.form.threshold ?? null;
+    model.title = this.form.title ? this.form.title.trim() : null;
+    model.message = this.form.message ? this.form.message.trim() : null;
     model.prescriberTitle = this.form.prescriberTitle ? this.form.prescriberTitle.trim() : null;
     model.prescriberDescription = this.form.prescriberDescription ? this.form.prescriberDescription.trim() : null;
     try {

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -68,4 +68,5 @@
 @import 'components/target-profiles/list-items';
 @import 'components/target-profiles/organizations';
 @import 'components/target-profiles/stages';
+@import 'components/target-profiles/stage-form';
 @import 'components/badges/badge';

--- a/admin/app/styles/components/target-profiles/stage-form.scss
+++ b/admin/app/styles/components/target-profiles/stage-form.scss
@@ -1,0 +1,3 @@
+.stage-form {
+  max-width: 60%;
+}

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -18,6 +18,9 @@ module('Integration | Component | UpdateStage', function (hooks) {
     toggleEditMode = sinon.stub();
     const save = sinon.stub();
     stage = EmberObject.create({
+      threshold: 50,
+      title: 'Titre du palier',
+      message: 'Ceci est un message',
       prescriberTitle: 'Ceci est un titre',
       prescriberDescription: 'Ceci est une description',
       save,
@@ -34,6 +37,15 @@ module('Integration | Component | UpdateStage', function (hooks) {
     // then
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
+    assert.equal(this.element.querySelector('label[for="threshold"]').textContent.trim(), 'Seuil');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
+    assert.equal(this.element.querySelector('label[for="title"]').textContent.trim(), 'Titre');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
+    assert.equal(this.element.querySelector('label[for="message"]').textContent.trim(), 'Message');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(
       this.element.querySelector('label[for="prescriberTitle"]').textContent.trim(),
       'Titre pour le prescripteur'
@@ -44,6 +56,15 @@ module('Integration | Component | UpdateStage', function (hooks) {
       this.element.querySelector('label[for="prescriberDescription"]').textContent.trim(),
       'Description pour le prescripteur'
     );
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
+    assert.equal(this.element.querySelector('#threshold').value, '50');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
+    assert.equal(this.element.querySelector('#title').value, 'Titre du palier');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
+    assert.equal(this.element.querySelector('#message').value, 'Ceci est un message');
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(this.element.querySelector('#prescriberTitle').value, 'Ceci est un titre');

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -35,42 +35,22 @@ module('Integration | Component | UpdateStage', function (hooks) {
     // when
     await render(hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`);
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('label[for="threshold"]').textContent.trim(), 'Seuil');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('label[for="title"]').textContent.trim(), 'Titre');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('label[for="message"]').textContent.trim(), 'Message');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(this.element.querySelector('label[for="threshold"]').textContent.trim(), 'Seuil');
+    assert.strictEqual(this.element.querySelector('label[for="title"]').textContent.trim(), 'Titre');
+    assert.strictEqual(this.element.querySelector('label[for="message"]').textContent.trim(), 'Message');
+    assert.strictEqual(
       this.element.querySelector('label[for="prescriberTitle"]').textContent.trim(),
       'Titre pour le prescripteur'
     );
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('label[for="prescriberDescription"]').textContent.trim(),
       'Description pour le prescripteur'
     );
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('#threshold').value, '50');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('#title').value, 'Titre du palier');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('#message').value, 'Ceci est un message');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('#prescriberTitle').value, 'Ceci est un titre');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('#prescriberDescription').value, 'Ceci est une description');
+    assert.strictEqual(this.element.querySelector('#threshold').value, '50');
+    assert.strictEqual(this.element.querySelector('#title').value, 'Titre du palier');
+    assert.strictEqual(this.element.querySelector('#message').value, 'Ceci est un message');
+    assert.strictEqual(this.element.querySelector('#prescriberTitle').value, 'Ceci est un titre');
+    assert.strictEqual(this.element.querySelector('#prescriberDescription').value, 'Ceci est une description');
     assert.contains('Annuler');
     assert.contains('Enregistrer');
   });

--- a/admin/tests/unit/components/update-stage_test.js
+++ b/admin/tests/unit/components/update-stage_test.js
@@ -38,21 +38,11 @@ module('Unit | Component | update-stage', function (hooks) {
       // then
       assert.ok(event.preventDefault.called);
       assert.ok(component.args.model.save.called);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.threshold, 42);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.title, 'titre modifié');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.message, 'message modifié');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.prescriberTitle, 'palier intermédiaire');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.prescriberDescription, 'le niveau est moyen');
+      assert.strictEqual(component.args.model.threshold, 42);
+      assert.strictEqual(component.args.model.title, 'titre modifié');
+      assert.strictEqual(component.args.model.message, 'message modifié');
+      assert.strictEqual(component.args.model.prescriberTitle, 'palier intermédiaire');
+      assert.strictEqual(component.args.model.prescriberDescription, 'le niveau est moyen');
     });
 
     test('it should update stage field even if a field is empty', async function (assert) {
@@ -83,21 +73,11 @@ module('Unit | Component | update-stage', function (hooks) {
 
       // then
       assert.ok(component.args.model.save.called);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.threshold, 50);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.title, 'titre du palier');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.message, null);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.prescriberDescription, 'Ceci est une description');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.prescriberTitle, null);
+      assert.strictEqual(component.args.model.threshold, 50);
+      assert.strictEqual(component.args.model.title, 'titre du palier');
+      assert.strictEqual(component.args.model.message, null);
+      assert.strictEqual(component.args.model.prescriberDescription, 'Ceci est une description');
+      assert.strictEqual(component.args.model.prescriberTitle, null);
     });
 
     test('it should display a success notification when model has been saved', async function (assert) {

--- a/admin/tests/unit/components/update-stage_test.js
+++ b/admin/tests/unit/components/update-stage_test.js
@@ -11,6 +11,9 @@ module('Unit | Component | update-stage', function (hooks) {
       // given
       const component = createGlimmerComponent('component:stages/update-stage', {
         model: {
+          threshold: 50,
+          title: 'titre originel',
+          message: 'message originel',
           prescriberTitle: '',
           prescriberDescription: '',
           save: sinon.stub(),
@@ -21,6 +24,9 @@ module('Unit | Component | update-stage', function (hooks) {
       const event = {
         preventDefault: sinon.stub(),
       };
+      component.form.threshold = 42;
+      component.form.title = 'titre modifié';
+      component.form.message = 'message modifié';
       component.form.prescriberTitle = 'palier intermédiaire';
       component.form.prescriberDescription = 'le niveau est moyen';
 
@@ -34,6 +40,15 @@ module('Unit | Component | update-stage', function (hooks) {
       assert.ok(component.args.model.save.called);
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
+      assert.equal(component.args.model.threshold, 42);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
+      assert.equal(component.args.model.title, 'titre modifié');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
+      assert.equal(component.args.model.message, 'message modifié');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.prescriberTitle, 'palier intermédiaire');
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
@@ -44,6 +59,9 @@ module('Unit | Component | update-stage', function (hooks) {
       // given
       const component = createGlimmerComponent('component:stages/update-stage', {
         model: {
+          threshold: 50,
+          title: 'titre du palier',
+          message: '',
           prescriberTitle: 'palier intermédiaire',
           prescriberDescription: '',
           save: sinon.stub(),
@@ -54,6 +72,9 @@ module('Unit | Component | update-stage', function (hooks) {
       const event = {
         preventDefault: sinon.stub(),
       };
+      component.threshold = 50;
+      component.title = 'titre du palier';
+      component.form.message = '';
       component.form.prescriberDescription = 'Ceci est une description';
       component.form.prescriberTitle = '';
 
@@ -62,6 +83,15 @@ module('Unit | Component | update-stage', function (hooks) {
 
       // then
       assert.ok(component.args.model.save.called);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
+      assert.equal(component.args.model.threshold, 50);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
+      assert.equal(component.args.model.title, 'titre du palier');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
+      assert.equal(component.args.model.message, null);
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.prescriberDescription, 'Ceci est une description');
@@ -74,6 +104,9 @@ module('Unit | Component | update-stage', function (hooks) {
       // given
       const component = createGlimmerComponent('component:stages/update-stage', {
         model: {
+          threshold: 50,
+          title: '',
+          message: '',
           prescriberTitle: '',
           prescriberDescription: '',
           save: sinon.stub(),
@@ -84,6 +117,9 @@ module('Unit | Component | update-stage', function (hooks) {
       const event = {
         preventDefault: sinon.stub(),
       };
+      component.form.threshold = 50;
+      component.form.title = '';
+      component.form.message = '';
       component.form.prescriberTitle = 'palier intermédiaire';
       component.form.prescriberDescription = 'le niveau est moyen';
 

--- a/api/lib/application/stages/index.js
+++ b/api/lib/application/stages/index.js
@@ -59,6 +59,9 @@ exports.register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
+                threshold: Joi.number().required().allow(null),
+                title: Joi.string().required().allow(null),
+                message: Joi.string().required().allow(null),
                 'prescriber-title': Joi.string().required().allow(null),
                 'prescriber-description': Joi.string().required().allow(null),
               },

--- a/api/lib/application/stages/stages-controller.js
+++ b/api/lib/application/stages/stages-controller.js
@@ -10,14 +10,8 @@ module.exports = {
 
   async updateStage(request, h) {
     const stageId = request.params.id;
-    const {
-      title,
-      message,
-      threshold,
-      'prescriber-title': prescriberTitle,
-      'prescriber-description': prescriberDescription,
-    } = request.payload.data.attributes;
-    await usecases.updateStage({ stageId, title, message, threshold, prescriberTitle, prescriberDescription });
+    const stage = stageSerializer.deserialize(request.payload);
+    await usecases.updateStage({ ...stage, stageId });
     return h.response({}).code(204);
   },
 

--- a/api/lib/application/stages/stages-controller.js
+++ b/api/lib/application/stages/stages-controller.js
@@ -10,9 +10,14 @@ module.exports = {
 
   async updateStage(request, h) {
     const stageId = request.params.id;
-    const prescriberTitle = request.payload.data.attributes['prescriber-title'];
-    const prescriberDescription = request.payload.data.attributes['prescriber-description'];
-    await usecases.updateStage({ stageId, prescriberTitle, prescriberDescription });
+    const {
+      title,
+      message,
+      threshold,
+      'prescriber-title': prescriberTitle,
+      'prescriber-description': prescriberDescription,
+    } = request.payload.data.attributes;
+    await usecases.updateStage({ stageId, title, message, threshold, prescriberTitle, prescriberDescription });
     return h.response({}).code(204);
   },
 

--- a/api/lib/domain/usecases/update-stage.js
+++ b/api/lib/domain/usecases/update-stage.js
@@ -1,3 +1,18 @@
-module.exports = function updateStage({ stageId, prescriberTitle, prescriberDescription, stageRepository }) {
-  return stageRepository.updateStagePrescriberAttributes({ id: stageId, prescriberTitle, prescriberDescription });
+module.exports = function updateStage({
+  stageId,
+  title,
+  message,
+  threshold,
+  prescriberTitle,
+  prescriberDescription,
+  stageRepository,
+}) {
+  return stageRepository.updateStage({
+    id: stageId,
+    title,
+    message,
+    threshold,
+    prescriberTitle,
+    prescriberDescription,
+  });
 };

--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -27,10 +27,12 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfStage, createdStage);
   },
 
-  async updateStagePrescriberAttributes(stage) {
-    const { id, prescriberTitle, prescriberDescription } = stage;
+  async updateStage({ id, title, message, threshold, prescriberTitle, prescriberDescription }) {
     try {
-      await new BookshelfStage({ id }).save({ prescriberTitle, prescriberDescription }, { patch: true });
+      await new BookshelfStage({ id }).save(
+        { title, message, threshold, prescriberTitle, prescriberDescription },
+        { patch: true }
+      );
     } catch (error) {
       if (error instanceof BookshelfStage.NoRowsUpdatedError) {
         throw new NotFoundError(`Le palier avec l'id ${id} n'existe pas`);

--- a/api/lib/infrastructure/serializers/jsonapi/stage-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/stage-serializer.js
@@ -13,7 +13,7 @@ module.exports = {
       title: json.data.attributes.title,
       message: json.data.attributes.message,
       threshold: json.data.attributes.threshold,
-      targetProfileId: json.data.relationships['target-profile'].data.id,
+      targetProfileId: json.data.relationships?.['target-profile']?.data.id,
       prescriberTitle: json.data.attributes['prescriber-title'],
       prescriberDescription: json.data.attributes['prescriber-description'],
     });

--- a/api/tests/unit/application/stages/index_test.js
+++ b/api/tests/unit/application/stages/index_test.js
@@ -71,6 +71,9 @@ describe('Unit | Router | stages-router', function () {
       const payload = {
         data: {
           attributes: {
+            threshold: 42,
+            title: 'titre',
+            message: 'message',
             'prescriber-title': 'test',
             'prescriber-description': 'bidule',
           },
@@ -96,6 +99,9 @@ describe('Unit | Router | stages-router', function () {
       const payload = {
         data: {
           attributes: {
+            threshold: 42,
+            title: 'titre',
+            message: null,
             'prescriber-title': null,
             'prescriber-description': 'bidule',
           },

--- a/api/tests/unit/application/stages/stages-controller_test.js
+++ b/api/tests/unit/application/stages/stages-controller_test.js
@@ -54,6 +54,9 @@ describe('Unit | Controller | stages-controller', function () {
         payload: {
           data: {
             attributes: {
+              title: "c'est cool",
+              message: "ça va aller t'inquiète pas",
+              threshold: 64,
               'prescriber-title': 'palier bof',
               'prescriber-description': 'tu es moyen',
             },
@@ -70,6 +73,9 @@ describe('Unit | Controller | stages-controller', function () {
         // then
         expect(response.statusCode).to.equal(204);
         expect(usecases.updateStage).to.have.been.calledWithMatch({
+          title: "c'est cool",
+          message: "ça va aller t'inquiète pas",
+          threshold: 64,
           prescriberDescription: 'tu es moyen',
           prescriberTitle: 'palier bof',
           stageId: 44,

--- a/api/tests/unit/domain/usecases/update-stage_test.js
+++ b/api/tests/unit/domain/usecases/update-stage_test.js
@@ -5,20 +5,26 @@ describe('Unit | UseCase | update-stage', function () {
   it('should call repository method to update prescriberTitle and prescriberDescription for a stage', async function () {
     //given
     const stageRepository = {
-      updateStagePrescriberAttributes: sinon.stub(),
+      updateStage: sinon.stub(),
     };
 
     //when
     await updateStage({
       stageId: 44,
+      title: "c'est cool",
+      message: "ça va aller t'inquiète pas",
+      threshold: 86,
       prescriberTitle: 'palier bof',
       prescriberDescription: 'tu es moyen',
       stageRepository,
     });
 
     //then
-    expect(stageRepository.updateStagePrescriberAttributes).to.have.been.calledOnceWithExactly({
+    expect(stageRepository.updateStage).to.have.been.calledOnceWithExactly({
       id: 44,
+      title: "c'est cool",
+      message: "ça va aller t'inquiète pas",
+      threshold: 86,
       prescriberTitle: 'palier bof',
       prescriberDescription: 'tu es moyen',
     });


### PR DESCRIPTION
## :unicorn: Problème

Nous souhaitons pouvoir modifier plusieurs champs associés au paliers dans Pix-admin : 
- Seuil
- Titre
- Message

## :robot: Solution

Ajout de champs au formulaire et à la route d'update déjà existants.

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur Pix-admin, créer un palier, et l'éditer après avoir cliqué sur `détails`.
Vérifier que tous les champs (dont `seuil`, `titre` et `message`) sont bien éditables et édités.