### PR TITLE
[TECH] Prévenir les tests Qunit exclusifs (.only). 

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -23401,9 +23401,9 @@
       }
     },
     "eslint-plugin-qunit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
-      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
+      "integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-ember": "^10.5.5",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-qunit": "^6.2.0",
+    "eslint-plugin-qunit": "^7.2.0",
     "eslint-plugin-yml": "^0.11.0",
     "faker": "^5.5.2",
     "loader.js": "^4.7.0",

--- a/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
+++ b/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
@@ -15,6 +15,8 @@ module('Acceptance | Campaign Page', function (hooks) {
       await visit('/campaigns/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -32,6 +34,8 @@ module('Acceptance | Campaign Page', function (hooks) {
       await visit('/campaigns/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campaigns/1');
       assert.contains('Campaign name');
     });

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -40,6 +40,8 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     await click(screen.getByRole('button', { name: 'Ajouter' }));
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/certification-centers/99');
     assert.contains(name);
     assert.contains(type.label);

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -29,6 +29,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     await visit(`/certification-centers/${certificationCenter.id}`);
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/certification-centers/1');
   });
 

--- a/admin/tests/acceptance/authenticated/certification-centers/list_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list_test.js
@@ -16,6 +16,8 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       await visit('/certification-centers/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -31,6 +33,8 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       await visit('/certification-centers/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/certification-centers/list');
     });
 
@@ -67,6 +71,8 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       await click('[data-test-certification="1"]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/certification-centers/1');
     });
   });

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -427,6 +427,8 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       await clickByLabel("Voir les détails de l'utilisateur");
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/users/888');
     });
   });

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
@@ -277,8 +277,14 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       const firstRowContent = document.querySelector('tr:nth-child(1) td:nth-child(2)').innerText;
       const secondRowContent = document.querySelector('tr:nth-child(2) td:nth-child(2)').innerText;
       const thirdRowContent = document.querySelector('tr:nth-child(3) td:nth-child(2)').innerText;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstRowContent, 'recCGEqqWBQnzD3NZ');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(secondRowContent, 'recABCEdeef1234');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(thirdRowContent, 'recZXYW4321');
     });
   });

--- a/admin/tests/acceptance/authenticated/certifications/certification/profile_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/profile_test.js
@@ -18,6 +18,8 @@ module('Acceptance | authenticated/certifications/certification/profile', functi
       await visit(`/certifications/${certification.id}/profile`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -15,6 +15,8 @@ module('Acceptance | Organizations | List', function (hooks) {
       await visit('/organizations/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -30,6 +32,8 @@ module('Acceptance | Organizations | List', function (hooks) {
       await visit('/organizations/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/organizations/list');
     });
 
@@ -83,6 +87,8 @@ module('Acceptance | Organizations | List', function (hooks) {
       await click('[data-test-orga="1"]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/organizations/1/team');
     });
   });

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -24,6 +24,8 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
     await visit(`/organizations/${organization.id}`);
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/organizations/${organization.id}/team`);
   });
 
@@ -103,6 +105,8 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       await clickByLabel('Ajouter un membre');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.element.querySelectorAll('div[data-test-id="member-list"] table > tbody > tr').length, 1);
       assert.contains('Denise');
       assert.dom('#userEmailToAdd').hasValue('denise@example.com');
@@ -122,6 +126,8 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       await clickByLabel('Ajouter un membre');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.element.querySelectorAll('div[data-test-id="member-list"] table > tbody > tr').length, 1);
       assert.contains('Erica');
       assert.dom('#userEmailToAdd').hasValue('unexisting@example.com');
@@ -144,6 +150,8 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       await clickByLabel('Enregistrer');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(membership.organizationRole, 'MEMBER');
       assert.contains('Le rôle du membre a été mis à jour avec succès.');
     });

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
@@ -18,6 +18,8 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
       await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -34,6 +36,8 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
       await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
     });
 

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
@@ -15,6 +15,8 @@ module('Acceptance | authenticated/sessions/list/with required action', function
       await visit('/sessions/list/with-required-action');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -31,6 +33,8 @@ module('Acceptance | authenticated/sessions/list/with required action', function
       await visit('/sessions/list/with-required-action');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/list/with-required-action');
     });
 

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -17,6 +17,8 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
       await visit('/sessions/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -34,6 +36,8 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
       await visit('/sessions/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/1');
     });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -16,6 +16,8 @@ module('Acceptance | Target Profiles | List', function (hooks) {
       await visit('/target-profiles/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -31,6 +33,8 @@ module('Acceptance | Target Profiles | List', function (hooks) {
       await visit('/target-profiles/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/target-profiles/list');
     });
 
@@ -88,6 +92,8 @@ module('Acceptance | Target Profiles | List', function (hooks) {
       await clickByLabel('Profil Cible');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/target-profiles/1');
       assert.contains('Competence 1');
     });
@@ -101,6 +107,8 @@ module('Acceptance | Target Profiles | List', function (hooks) {
       await clickByLabel('Nouveau profil cible');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/target-profiles/new');
     });
   });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -19,6 +19,8 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
       await visit('/target-profiles/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -37,6 +39,8 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
       await visit('/target-profiles/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/target-profiles/1');
     });
 
@@ -102,6 +106,8 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
       await click('a[href="/organizations/456"]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/organizations/456/team');
     });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -39,6 +39,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
       await click('.insights__section:nth-child(1) a');
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/badges/100');
     });
 
@@ -47,6 +49,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
       await click('[data-test="badges-creation-redirect"]');
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/target-profiles/${targetProfile.id}/badges/new`);
     });
 
@@ -58,6 +62,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await click('[data-test="badge-form-cancel-button"]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/target-profiles/${targetProfile.id}/insights`);
     });
 
@@ -73,6 +79,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await click('[data-test="badge-form-submit-button"]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/target-profiles/${targetProfile.id}/insights`);
     });
   });
@@ -82,6 +90,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await visit(`/target-profiles/${targetProfile.id}/insights`);
 
       const stageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stageCount, 1);
 
       assert.notContains('Enregistrer');
@@ -91,6 +101,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       assert.contains('Enregistrer');
       assert.contains('Annuler');
       const newTableRowCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newTableRowCount, 2);
 
       fillIn('.insights__section:nth-child(2) tbody tr td:nth-child(3) input', '0');
@@ -101,6 +113,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       assert.notContains('Enregistrer');
 
       const newStageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newStageCount, 2);
     });
 
@@ -108,12 +122,16 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       // when
       await visit(`/target-profiles/${targetProfile.id}/insights`);
       const stageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stageCount, 1);
       await click("button[data-test='Nouveau palier']");
       await click('button[data-test="form-action-cancel"]');
 
       // then
       const newStageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newStageCount, 1);
     });
 
@@ -121,6 +139,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       // when
       await visit(`/target-profiles/${targetProfile.id}/insights`);
       const stageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stageCount, 1);
       await click("button[data-test='Nouveau palier']");
       await click("button[data-test='Nouveau palier']");
@@ -128,6 +148,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
       // then
       const newStageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newStageCount, 2);
     });
   });

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -17,6 +17,8 @@ module('Acceptance | authenticated/users/get', function (hooks) {
 
   test('User detail page can be accessed by URL /users/:id', async function (assert) {
     await visit(`/users/${currentUser.id}`);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/users/${currentUser.id}`);
   });
 
@@ -40,13 +42,19 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     // when
     await visit('/users/list?email=userpix1example.net');
     await click('tbody > tr:nth-child(1) > td:nth-child(1) > a');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/users/${currentUser.id}`);
   });
 
   test('Should redirect to list users page when click page title', async function (assert) {
     await visit(`/users/${currentUser.id}`);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/users/${currentUser.id}`);
     await click('#link-to-users-page');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/users/list');
   });
 });

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
@@ -21,6 +21,8 @@ module('Acceptance | Session page', function (hooks) {
       await visitSessionsPage();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/list');
     });
   });

--- a/admin/tests/acceptance/routes-protection_test.js
+++ b/admin/tests/acceptance/routes-protection_test.js
@@ -15,6 +15,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/about');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/about');
     });
   });
@@ -25,6 +27,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/organizations/new');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
 
@@ -37,6 +41,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/organizations/new');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/organizations/new');
     });
   });
@@ -47,6 +53,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/organizations/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -57,6 +65,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/certifications');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -67,6 +77,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/certifications/single');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -77,6 +89,8 @@ module('Acceptance | routes protection', function (hooks) {
       await visit('/sessions');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -19,6 +19,8 @@ module('Acceptance | Session pages', function (hooks) {
       await visit('/sessions/session');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -48,6 +50,8 @@ module('Acceptance | Session pages', function (hooks) {
 
       test('it should be accessible for an authenticated user', function (assert) {
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/sessions/1');
       });
 
@@ -55,6 +59,8 @@ module('Acceptance | Session pages', function (hooks) {
         test('it should show a header with title and sessionId search', function (assert) {
           // then
           assert.dom('.page-title').hasText('Sessions de certification');
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(document.querySelector('.page-actions form input').value, '1');
         });
 
@@ -65,8 +71,12 @@ module('Acceptance | Session pages', function (hooks) {
           await click('.navbar-item:first-child');
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(sessionIdInput.value, '2');
           assert.dom('.page-actions form button').hasText('Charger');
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/sessions/1');
         });
       });
@@ -78,6 +88,8 @@ module('Acceptance | Session pages', function (hooks) {
 
           // then
           assert.dom('.navbar-item:first-child').hasText('Informations');
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/sessions/1');
         });
 
@@ -87,6 +99,8 @@ module('Acceptance | Session pages', function (hooks) {
 
           // then
           assert.dom('.navbar-item:last-child').hasText('Certifications');
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/sessions/1/certifications');
         });
       });
@@ -107,6 +121,8 @@ module('Acceptance | Session pages', function (hooks) {
           await clickByLabel(session.certificationCenterName);
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/certification-centers/1234');
         });
       });
@@ -161,6 +177,8 @@ module('Acceptance | Session pages', function (hooks) {
           );
           assert.contains(juryCertificationSummary.firstName);
           assert.contains(juryCertificationSummary.lastName);
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(circle.attributes.fill.value, '#39B97A');
         });
       });

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -15,6 +15,8 @@ module('Acceptance | Session List', function (hooks) {
       await visit('/sessions/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -30,6 +32,8 @@ module('Acceptance | Session List', function (hooks) {
       await visit('/sessions/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/list');
     });
 
@@ -41,6 +45,8 @@ module('Acceptance | Session List', function (hooks) {
       await visit('/sessions/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/list');
       assert.contains('Sessions à traiter (10)');
     });

--- a/admin/tests/acceptance/tools_test.js
+++ b/admin/tests/acceptance/tools_test.js
@@ -20,6 +20,8 @@ module('Acceptance | tools', function (hooks) {
       await visit('/tools');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/tools');
     });
   });

--- a/admin/tests/acceptance/user-details-personal-information_test.js
+++ b/admin/tests/acceptance/user-details-personal-information_test.js
@@ -36,6 +36,8 @@ module('Acceptance | User details personal information', function (hooks) {
     await visit(`/users/${user.id}`);
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/users/${user.id}`);
   });
 
@@ -135,6 +137,8 @@ module('Acceptance | User details personal information', function (hooks) {
       await clickByLabel('Oui, je dissocie');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/users/${user.id}`);
       assert.notContains(organizationName);
     });

--- a/admin/tests/acceptance/user-list_test.js
+++ b/admin/tests/acceptance/user-list_test.js
@@ -15,6 +15,8 @@ module('Acceptance | User List', function (hooks) {
       await visit('/users/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/login');
     });
   });
@@ -30,6 +32,8 @@ module('Acceptance | User List', function (hooks) {
       await visit('/users/list');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/users/list');
     });
 

--- a/admin/tests/integration/components/certification-centers/form_test.js
+++ b/admin/tests/integration/components/certification-centers/form_test.js
@@ -40,6 +40,8 @@ module('Integration | Component | certification-centers/form', function (hooks) 
       await fillIn('#certificationCenterTypeSelector', 'SCO');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.certificationCenter.type, 'SCO');
     });
   });

--- a/admin/tests/integration/components/certifications/certified-profile_test.js
+++ b/admin/tests/integration/components/certifications/certified-profile_test.js
@@ -152,7 +152,11 @@ module('Integration | Component | certifications/certified-profile', function (h
       const iconSkill1 = find('[aria-label="skill1"]').getAttribute('data-icon');
       const iconSkill2 = find('[aria-label="skill2"]').getAttribute('data-icon');
       assert.contains('tube1');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(iconSkill1, 'check-double');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(iconSkill2, 'check');
     });
   });

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -109,6 +109,8 @@ module('Integration | Component | certifications/details-answer', function (hook
       answer: answerData,
       onUpdateRate: () => {
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(answerData.jury, 'ok');
         return resolve();
       },
@@ -132,6 +134,8 @@ module('Integration | Component | certifications/details-answer', function (hook
     await selectChoose('.answer-result', 'Succès partiel');
 
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(answerData.jury, null);
   });
 

--- a/admin/tests/integration/components/certifications/list_test.js
+++ b/admin/tests/integration/components/certifications/list_test.js
@@ -22,6 +22,8 @@ module('Integration | Component | certifications/list', function (hooks) {
     await render(hbs`<Certifications::List @certifications={{certifications}} />`);
 
     const $tableRows = this.element.querySelectorAll('tbody > tr');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal($tableRows.length, 3);
   });
 

--- a/admin/tests/integration/components/certifications/status-select_test.js
+++ b/admin/tests/integration/components/certifications/status-select_test.js
@@ -49,6 +49,8 @@ module('Integration | Component | certifications/status-select', function (hooks
 
         // then
         const elementOptions = this.element.querySelectorAll('#certification-status-selector > option');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(elementOptions.length, 4);
         elementOptions.forEach((elementOption, index) => {
           const expectedOption = expectedOptions[index];
@@ -69,6 +71,8 @@ module('Integration | Component | certifications/status-select', function (hooks
         await fillIn('#certification-status-selector', 'validated');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(certification.status, 'validated');
       });
     });

--- a/admin/tests/integration/components/member-item_test.js
+++ b/admin/tests/integration/components/member-item_test.js
@@ -61,6 +61,8 @@ module('Integration | Component | member-item', function (hooks) {
 
       // then
       assert.notContains('Enregistrer');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.membership.organizationRole, 'MEMBER');
       assert.ok(this.updateMembership.called);
     });

--- a/admin/tests/integration/components/organizations/all-tags_test.js
+++ b/admin/tests/integration/components/organizations/all-tags_test.js
@@ -89,6 +89,8 @@ module('Integration | Component | organizations/all-tags', function (hooks) {
 
         // then
         assert.ok(save.called);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(this.model.organization.tags.length, 1);
       });
     });
@@ -108,6 +110,8 @@ module('Integration | Component | organizations/all-tags', function (hooks) {
 
         // then
         assert.ok(save.called);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(this.model.organization.tags.length, 0);
       });
     });

--- a/admin/tests/integration/components/organizations/form_test.js
+++ b/admin/tests/integration/components/organizations/form_test.js
@@ -35,6 +35,8 @@ module('Integration | Component | organizations/form', function (hooks) {
       await selectChoose('#organizationTypeSelector', 'Établissement scolaire');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.organization.type, 'SCO');
       assert.dom('.ember-power-select-selected-item').hasText('Établissement scolaire');
     });

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -127,6 +127,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
       // then
       const elementOptions = this.element.querySelectorAll('#certificationCenterType > option');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(elementOptions.length, 4);
       elementOptions.forEach((elementOption, index) => {
         const expectedOption = expectedOptions[index];
@@ -147,6 +149,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       await fillIn('#certificationCenterType', 'PRO');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.certificationCenterType, 'PRO');
     });
   });
@@ -167,6 +171,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
       // then
       const elementOptions = this.element.querySelectorAll('#status > option');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(elementOptions.length, 5);
       elementOptions.forEach((elementOption, index) => {
         const expectedOption = expectedOptions[index];
@@ -187,6 +193,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       await fillIn('#status', 'created');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.status, 'created');
     });
   });
@@ -205,6 +213,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
       // then
       const elementOptions = this.element.querySelectorAll('#resultsSentToPrescriberAt > option');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(elementOptions.length, 3);
       elementOptions.forEach((elementOption, index) => {
         const expectedOption = expectedOptions[index];
@@ -227,6 +237,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       await fillIn('#resultsSentToPrescriberAt', 'false');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(this.resultsSentToPrescriberAt, 'false');
     });
   });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -28,6 +28,8 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}`);
       assert.dom('.session-info__details div:nth-child(1) div:last-child').hasText(session.certificationCenterName);
       assert
@@ -55,7 +57,11 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(find('[data-test-id="session-info__examiner-comment"]'), undefined);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(find('[data-test-id="session-info__number-of-not-checked-end-screen"]'), undefined);
     });
 
@@ -126,6 +132,8 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(find('[data-test-id="session-info__examiner-comment"]'), undefined);
     });
 
@@ -141,6 +149,8 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         const buttonSendResultsToCandidates = this.element.querySelector(
           '.session-info__actions .row button:nth-child(3)'
         );
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(buttonSendResultsToCandidates.innerHTML.trim(), 'Résultats transmis au prescripteur');
       });
     });

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -32,15 +32,23 @@ module('Integration | Component | UpdateStage', function (hooks) {
     // when
     await render(hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`);
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(
       this.element.querySelector('label[for="prescriberTitle"]').textContent.trim(),
       'Titre pour le prescripteur'
     );
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(
       this.element.querySelector('label[for="prescriberDescription"]').textContent.trim(),
       'Description pour le prescripteur'
     );
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(this.element.querySelector('#prescriberTitle').value, 'Ceci est un titre');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(this.element.querySelector('#prescriberDescription').value, 'Ceci est une description');
     assert.contains('Annuler');
     assert.contains('Enregistrer');

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -33,9 +33,15 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     assert.contains('Message');
     assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:first-child').textContent, '1');
     assert.dom('tbody tr td:nth-child(2) img').exists();
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('alt'), 'My alt message');
     assert.contains('My key');
     assert.contains('My title');

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -34,12 +34,24 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
     assert.contains('Description prescripteur');
     assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:first-child').textContent.trim(), '1');
     assert.dom('tbody tr td:nth-child(2) img').exists();
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(3)').textContent.trim(), '100');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(4)').textContent.trim(), 'My title');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(5)').textContent.trim(), 'My message');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(find('tbody tr td:nth-child(8)').textContent.trim(), 'Voir détail');
     assert.notContains('Aucun résultat thématique associé');
   });

--- a/admin/tests/unit/adapters/application_test.js
+++ b/admin/tests/unit/adapters/application_test.js
@@ -10,6 +10,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
@@ -23,6 +25,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
     });
 

--- a/admin/tests/unit/adapters/campaign-test.js
+++ b/admin/tests/unit/adapters/campaign-test.js
@@ -17,6 +17,8 @@ module('Unit | Adapter | Campaign', function (hooks) {
 
       // then
       assert.ok(url.endsWith('/admin/organizations/10/campaigns'));
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(query.organizationId, undefined);
     });
   });

--- a/admin/tests/unit/adapters/certification-center-membership_test.js
+++ b/admin/tests/unit/adapters/certification-center-membership_test.js
@@ -18,6 +18,8 @@ module('Unit | Adapter | certificationCenterMembership', function (hooks) {
       const url = await adapter.urlForQuery(query);
 
       assert.ok(url.endsWith('/api/certification-centers/1/certification-center-memberships'));
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(query.filter.certificationCenterId, undefined);
     });
   });

--- a/admin/tests/unit/adapters/certification_test.js
+++ b/admin/tests/unit/adapters/certification_test.js
@@ -117,6 +117,8 @@ module('Unit | Adapter | certification', function (hooks) {
       const url = adapter.buildURL('not_used', 123, 'not_used', 'cancel', 'not_used');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, 'http://localhost:3000/api/admin/certification-courses/123/cancel');
     });
 
@@ -125,6 +127,8 @@ module('Unit | Adapter | certification', function (hooks) {
       const url = adapter.buildURL('not_used', 123, 'not_used', 'uncancel', 'not_used');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, 'http://localhost:3000/api/admin/certification-courses/123/uncancel');
     });
   });

--- a/admin/tests/unit/adapters/schooling-registration_test.js
+++ b/admin/tests/unit/adapters/schooling-registration_test.js
@@ -22,6 +22,8 @@ module('Unit | Adapter | schooling-registration', function (hooks) {
       const url = adapter.urlForDeleteRecord(schoolingRegistration.id);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
   });

--- a/admin/tests/unit/components/badges/badge_test.js
+++ b/admin/tests/unit/components/badges/badge_test.js
@@ -13,7 +13,11 @@ module('Unit |  Component | Badges | badge', function (hooks) {
         badge: { isCertifiable: true },
       };
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.isCertifiableColor, 'green');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.isCertifiableText, 'Certifiable');
     });
   });
@@ -24,8 +28,11 @@ module('Unit |  Component | Badges | badge', function (hooks) {
       component.args = {
         badge: { isAlwaysVisible: true },
       };
-
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.isAlwaysVisibleColor, 'green');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.isAlwaysVisibleText, 'Lacunes');
     });
   });

--- a/admin/tests/unit/components/badges/badge_test.js
+++ b/admin/tests/unit/components/badges/badge_test.js
@@ -23,7 +23,7 @@ module('Unit |  Component | Badges | badge', function (hooks) {
   });
 
   module('isAlwaysVisible', function () {
-    test.only('returns color and text when is always visible', function (assert) {
+    test('returns color and text when is always visible', function (assert) {
       const component = createComponent('component:badges/badge');
       component.args = {
         badge: { isAlwaysVisible: true },

--- a/admin/tests/unit/components/campaigns/update_test.js
+++ b/admin/tests/unit/components/campaigns/update_test.js
@@ -40,11 +40,23 @@ module('Unit | Component | Campaigns | update', function (hooks) {
       // then
       assert.ok(event.preventDefault.called);
       assert.ok(component.args.campaign.save.called);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.form.name, 'some name');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.form.title, 'some title');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.form.customLandingPageText, 'some text');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.form.customResultPageText, 'some text again');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.form.customResultPageButtonText, 'some button text');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.form.customResultPageButtonUrl, 'google.com');
     });
 
@@ -69,6 +81,8 @@ module('Unit | Component | Campaigns | update', function (hooks) {
 
       // then
       assert.ok(component.args.campaign.save.called);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.campaign.title, null);
     });
 

--- a/admin/tests/unit/components/certifications/details-competence_test.js
+++ b/admin/tests/unit/components/certifications/details-competence_test.js
@@ -60,7 +60,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -91,7 +95,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -107,7 +115,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -123,7 +135,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -139,7 +155,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -155,7 +175,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -171,7 +195,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 2);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 17);
     });
 
@@ -187,7 +215,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 2);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 17);
     });
 
@@ -203,7 +235,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 2);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 17);
     });
 
@@ -219,7 +255,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 2);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 17);
     });
 
@@ -235,7 +275,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, -1);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 0);
     });
 
@@ -251,7 +295,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, -1);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 0);
     });
 
@@ -267,7 +315,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -283,7 +335,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -299,7 +355,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 3);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 25);
     });
 
@@ -315,7 +375,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, 2);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 17);
     });
 
@@ -331,7 +395,11 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.level, -1);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actual.score, 0);
     });
   });
@@ -345,8 +413,14 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
     };
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(component.positionedWidth.toString(), htmlSafe('width:' + Math.round((3 / 8) * 100) + '%'));
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(component.certifiedWidth.toString(), htmlSafe('width:' + Math.round((2 / 8) * 100) + '%'));
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(component.competenceJury.width.toString(), htmlSafe('width:' + Math.round((3 / 8) * 100) + '%'));
   });
 

--- a/admin/tests/unit/components/organizations/information-section_test.js
+++ b/admin/tests/unit/components/organizations/information-section_test.js
@@ -23,6 +23,8 @@ module('Unit | Component | organizations/information-section', function (hooks) 
 
     // when
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(component.externalURL, expectedURL);
   });
 });

--- a/admin/tests/unit/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/unit/components/organizations/target-profiles-section_test.js
@@ -38,6 +38,8 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
         assert.ok(
           component.args.organization.attachTargetProfiles.calledWith({ 'target-profiles-to-attach': ['1', '2'] })
         );
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(component.organizationsToAttach, null);
         assert.ok(
           component.notifications.success.calledWith('Profil(s) cible(s) rattaché(s) avec succès.', {
@@ -123,6 +125,8 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
 
           await component.attachTargetProfiles(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.targetProfilesToAttach, '1,1,2,3,3');
           assert.ok(component.notifications.error.calledWith('I am displayed 1'));
           assert.ok(component.notifications.error.calledWith('I am displayed 2'));
@@ -142,6 +146,8 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
 
           await component.attachTargetProfiles(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.targetProfilesToAttach, '1,1,5,3,3');
           assert.ok(component.notifications.error.calledWith('I am displayed too 1'));
           assert.ok(component.notifications.error.calledWith('I am displayed too 2'));
@@ -161,7 +167,11 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
 
           await component.attachTargetProfiles(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.targetProfilesToAttach, '1,1,2,3,3');
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
         });
       });
@@ -176,6 +186,8 @@ module('Unit | Component | organizations/target-profiles-section', function (hoo
 
           await component.attachTargetProfiles(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.targetProfilesToAttach, '1,1,2,3,3');
           assert.ok(component.notifications.error.calledWith('Une erreur est survenue.'));
         });

--- a/admin/tests/unit/components/target-profiles/organizations_test.js
+++ b/admin/tests/unit/components/target-profiles/organizations_test.js
@@ -36,6 +36,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.', { htmlContent: true })
@@ -61,6 +63,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1] }));
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith(
@@ -89,6 +93,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith(
@@ -119,6 +125,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
         await component.attachOrganizations(event);
 
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2, 3] }));
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(component.organizationsToAttach, '');
         assert.ok(
           component.router.replaceWith.calledWith('authenticated.target-profiles.target-profile.organizations')
@@ -142,6 +150,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
 
           await component.attachOrganizations(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.organizationsToAttach, '1,1,2,3,3');
           assert.ok(component.notifications.error.calledWith('I am displayed 1'));
           assert.ok(component.notifications.error.calledWith('I am displayed 2'));
@@ -161,6 +171,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
 
           await component.attachOrganizations(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.organizationsToAttach, '1,1,5,3,3');
           assert.ok(component.notifications.error.calledWith('I am displayed too 1'));
           assert.ok(component.notifications.error.calledWith('I am displayed too 2'));
@@ -180,7 +192,11 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
 
           await component.attachOrganizations(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.organizationsToAttach, '1,1,2,3,3');
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
         });
       });
@@ -195,6 +211,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
 
           await component.attachOrganizations(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.organizationsToAttach, '1,1,2,3,3');
           assert.ok(component.notifications.error.calledWith('Une erreur est survenue.'));
         });
@@ -224,6 +242,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
             'target-profile-id': 1,
           })
         );
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(component.existingTargetProfile, '');
         assert.ok(component.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.'));
         assert.ok(
@@ -290,6 +310,8 @@ module('Unit |  Component | Target Profiles | Organizations', function (hooks) {
 
           await component.attachOrganizationsFromExistingTargetProfile(event);
 
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
         });
       });

--- a/admin/tests/unit/components/update-stage_test.js
+++ b/admin/tests/unit/components/update-stage_test.js
@@ -32,7 +32,11 @@ module('Unit | Component | update-stage', function (hooks) {
       // then
       assert.ok(event.preventDefault.called);
       assert.ok(component.args.model.save.called);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.prescriberTitle, 'palier intermédiaire');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.prescriberDescription, 'le niveau est moyen');
     });
 
@@ -58,7 +62,11 @@ module('Unit | Component | update-stage', function (hooks) {
 
       // then
       assert.ok(component.args.model.save.called);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.prescriberDescription, 'Ceci est une description');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.prescriberTitle, null);
     });
 

--- a/admin/tests/unit/components/update-target-profile_test.js
+++ b/admin/tests/unit/components/update-target-profile_test.js
@@ -64,6 +64,8 @@ module('Unit | Component | update-target-profile', function (hooks) {
 
       // then
       assert.ok(event.preventDefault.called);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.name, 'Edited name');
     });
 
@@ -94,6 +96,8 @@ module('Unit | Component | update-target-profile', function (hooks) {
       // when
       await component.updateProfile(event);
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.description, 'Edited description');
     });
 
@@ -124,6 +128,8 @@ module('Unit | Component | update-target-profile', function (hooks) {
       // when
       await component.updateProfile(event);
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.model.comment, 'Edited comment');
     });
 

--- a/admin/tests/unit/components/users/user-detail-personal-information/user-overview_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information/user-overview_test.js
@@ -26,6 +26,8 @@ module('Unit | Component | users | user-detail-personal-information', function (
       const actualUrl = component.externalURL;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(actualUrl, expectedUrl);
     });
   });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get_test.js
@@ -58,6 +58,8 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
       controller.send('updateEmailErrorMessage');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.errorMessage, controller.EMAIL_INVALID_ERROR_MESSAGE);
     });
 
@@ -70,6 +72,8 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
       controller.send('updateEmailErrorMessage');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.errorMessage, null);
     });
   });
@@ -114,6 +118,8 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
         await controller.addCertificationCenterMembership(event);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.errorMessage, null);
       });
 
@@ -150,6 +156,8 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
         await controller.addCertificationCenterMembership(event);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.errorMessage, controller.EMAIL_REQUIRED_ERROR_MESSAGE);
       });
 
@@ -161,6 +169,8 @@ module('Unit | Controller | authenticated/certification-centers/get', function (
         await controller.addCertificationCenterMembership(event);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.errorMessage, controller.EMAIL_INVALID_ERROR_MESSAGE);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/list_test.js
@@ -20,6 +20,8 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, expectedValue);
       });
     });
@@ -34,6 +36,8 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, expectedValue);
       });
     });
@@ -48,6 +52,8 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('type', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, expectedValue);
       });
     });
@@ -62,6 +68,8 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('externalId', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, expectedValue);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/details_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/details_test.js
@@ -51,6 +51,8 @@ module('Unit | Controller | authenticated/certifications/certification/details',
     });
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(controller.get('juryRate'), 78.57);
   });
 
@@ -77,6 +79,8 @@ module('Unit | Controller | authenticated/certifications/certification/details',
 
     // then
     // 3 jury scores + 2 obtained scores
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(controller.get('juryScore'), 12 * 3 + 26 * 2);
   });
 

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -190,6 +190,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       };
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.impactfulCertificationIssueReports.length, 2);
     });
   });
@@ -211,6 +213,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       };
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.unimpactfulCertificationIssueReports.length, 3);
     });
   });
@@ -224,6 +228,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(anExistingCompetenceCode, competences);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(aCompetence.score, 55);
       });
     });
@@ -249,6 +255,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(aNewCompetenceCode, competences);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(aCompetence.score, 55);
       });
     });
@@ -263,6 +271,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(anExistingCompetenceCode, competences);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(aCompetence.level, 5);
       });
     });
@@ -288,6 +298,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(aNewCompetenceCode, competences);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(aCompetence.level, 8);
       });
     });
@@ -321,6 +333,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         await controller.onCandidateResultsSaveConfirm();
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
@@ -348,6 +362,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const levelErrorRegexp = `.*niveau.*${anExistingCompetenceCode}.*${controller.MAX_REACHABLE_LEVEL}`;
         const scoreErrorRegexp = `.*nombre de pix.*${anotherExistingCompetenceCode}.*${controller.MAX_REACHABLE_PIX_BY_COMPETENCE}`;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
@@ -410,6 +426,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         const state = await getSettledState();
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certification.pixScore, score);
         assert.deepEqual(controller.certification.competencesWithMark, expectedCompetencesWithMark);
         assert.ok(state.hasPendingTimers);
@@ -468,12 +486,20 @@ module('Unit | Controller | authenticated/certifications/certification/informati
 
     let aCompetence = _getCompetenceWithMark(anotherExistingCompetenceCode);
     let aCompetenceRef = _getCompetenceWithMark(anotherExistingCompetenceCode);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(aCompetence.score, aCompetenceRef.score);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(aCompetence.level, aCompetenceRef.level);
 
     aCompetence = _getCompetenceWithMark(anExistingCompetenceCode, competences);
     aCompetenceRef = _getCompetenceWithMark(anExistingCompetenceCode);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(aCompetence.score, aCompetenceRef.score);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(aCompetence.level, aCompetenceRef.level);
 
     sinon.assert.calledOnce(rollbackAttributes);

--- a/admin/tests/unit/controllers/authenticated/organizations/get/invitations_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/invitations_test.js
@@ -46,6 +46,8 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.createOrganizationInvitation();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
     });
 
@@ -57,6 +59,8 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.createOrganizationInvitation();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
     });
 
@@ -68,6 +72,8 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.createOrganizationInvitation();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.userEmailToInviteError, "L'adresse e-mail saisie n'est pas valide.");
     });
   });

--- a/admin/tests/unit/controllers/authenticated/organizations/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/list_test.js
@@ -20,6 +20,8 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
         await controller.updateFilters({ name: expectedValue });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, expectedValue);
       });
     });
@@ -34,6 +36,8 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
         await controller.updateFilters({ type: expectedValue });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, expectedValue);
       });
     });
@@ -48,6 +52,8 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
         await controller.updateFilters({ externalId: expectedValue });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, expectedValue);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/all_test.js
@@ -20,6 +20,8 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, expectedValue);
       });
     });
@@ -34,6 +36,8 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('certificationCenterName', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certificationCenterName, expectedValue);
       });
     });
@@ -48,6 +52,8 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('status', expectedValue);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, expectedValue);
       });
     });
@@ -62,6 +68,8 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('resultsSentToPrescriberAt', expectedValue);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.resultsSentToPrescriberAt, expectedValue);
       });
     });
@@ -76,6 +84,8 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('certificationCenterType', expectedValue);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certificationCenterType, expectedValue);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
@@ -67,6 +67,8 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
         await controller.actions.displayCertificationStatusUpdateConfirmationModal.call(controller);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.confirmMessage, 'Souhaitez-vous publier la session ?');
         assert.true(controller.displayConfirm);
       });
@@ -82,6 +84,8 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
         await controller.actions.displayCertificationStatusUpdateConfirmationModal.call(controller);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.confirmMessage, 'Souhaitez-vous dépublier la session ?');
         assert.true(controller.displayConfirm);
       });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
@@ -139,6 +139,8 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
 
       // then
       assert.ok(writeTextStub.calledWithExactly('www.jeremypluquet.com'));
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.copyButtonText, 'Copié');
       assert.ok(controller.isCopyButtonClicked);
       assert.ok(window.setTimeout);
@@ -156,6 +158,8 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       await controller.actions.copyResultsDownloadLink.call(controller);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.copyButtonText, 'Erreur !');
       assert.ok(controller.isCopyButtonClicked);
       assert.ok(window.setTimeout);

--- a/admin/tests/unit/controllers/authenticated/target-profiles/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/list_test.js
@@ -20,6 +20,8 @@ module('Unit | Controller | authenticated/target-profiles/list', function (hooks
         await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, expectedValue);
       });
     });
@@ -34,6 +36,8 @@ module('Unit | Controller | authenticated/target-profiles/list', function (hooks
         await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, expectedValue);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations_test.js
@@ -20,6 +20,8 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         await controller.updateFilters({ name: expectedValue });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, expectedValue);
       });
     });
@@ -34,6 +36,8 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         await controller.updateFilters({ type: expectedValue });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, expectedValue);
       });
     });
@@ -48,6 +52,8 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         await controller.updateFilters({ externalId: expectedValue });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, expectedValue);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/users/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/users/list_test.js
@@ -18,6 +18,8 @@ module('Unit | Controller | authenticated/users/list', function (hooks) {
         // when
         await controller.updateFilters({ firstName: expectedValue });
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.firstName, expectedValue);
       });
     });
@@ -30,6 +32,8 @@ module('Unit | Controller | authenticated/users/list', function (hooks) {
         // when
         await controller.updateFilters({ lastName: expectedValue });
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.lastName, expectedValue);
       });
     });
@@ -42,6 +46,8 @@ module('Unit | Controller | authenticated/users/list', function (hooks) {
         // when
         await controller.updateFilters({ email: expectedValue });
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.email, expectedValue);
       });
     });

--- a/admin/tests/unit/controllers/campaigns/campaign_test.js
+++ b/admin/tests/unit/controllers/campaigns/campaign_test.js
@@ -14,6 +14,8 @@ module('Unit | Controller | authenticated/campaigns/campaign', function (hooks) 
       await controller.toggleEditMode();
 
       //then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.isEditMode, expectedValue);
     });
   });

--- a/admin/tests/unit/controllers/stages/stage_test.js
+++ b/admin/tests/unit/controllers/stages/stage_test.js
@@ -14,6 +14,8 @@ module('Unit | Controller | authenticated/stages/stage', function (hooks) {
       await controller.toggleEditMode();
 
       //then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.isEditMode, expectedValue);
     });
   });

--- a/admin/tests/unit/helpers/format-date_test.js
+++ b/admin/tests/unit/helpers/format-date_test.js
@@ -10,6 +10,8 @@ module('Unit | Helpers | formatDate', function () {
     const value = formatDate([date]);
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(value, null);
   });
 
@@ -21,6 +23,8 @@ module('Unit | Helpers | formatDate', function () {
     const value = formatDate([date]);
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(value, '14/08/2020');
   });
 });

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -26,6 +26,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.categoryLabel, categoryToLabel[model.category]);
     }
   });
@@ -41,6 +43,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
     }
   });
@@ -56,6 +60,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.categoryCode, categoryToCode[model.category]);
     }
   });
@@ -71,6 +77,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.subcategoryCode, subcategoryToCode[model.subcategory]);
     }
   });
@@ -82,6 +90,8 @@ module('Unit | Model | certification issue report', function (hooks) {
     const model = run(() => store.createRecord('certification-issue-report', { subcategory: null }));
 
     // when / then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.subcategoryLabel, '');
   });
 });

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -29,6 +29,8 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.cleaCertificationStatusLabel;
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(label, expectedLabel);
         });
       });
@@ -53,6 +55,8 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusDroitMaitreCertificationStatusLabel;
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(label, expectedLabel);
         });
       });
@@ -77,6 +81,8 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusDroitExpertCertificationStatusLabel;
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(label, expectedLabel);
         });
       });
@@ -103,6 +109,8 @@ module('Unit | Model | certification', function (hooks) {
             const label = certification.pixPlusEduAutonomeCertificationStatusLabel;
 
             // then
+            // TODO: Fix this the next time the file is edited.
+            // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(label, expectedLabel);
           });
         }
@@ -128,6 +136,8 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusEduAvanceCertificationStatusLabel;
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(label, expectedLabel);
         });
       });
@@ -152,6 +162,8 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusEduExpertCertificationStatusLabel;
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(label, expectedLabel);
         });
       });
@@ -178,6 +190,8 @@ module('Unit | Model | certification', function (hooks) {
             const label = certification.pixPlusEduFormateurCertificationStatusLabel;
 
             // then
+            // TODO: Fix this the next time the file is edited.
+            // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(label, expectedLabel);
           });
         }
@@ -196,6 +210,8 @@ module('Unit | Model | certification', function (hooks) {
       const isPublishedLabel = certification.publishedText;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(isPublishedLabel, 'Oui');
     });
 
@@ -209,6 +225,8 @@ module('Unit | Model | certification', function (hooks) {
       const isPublishedLabel = certification.publishedText;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(isPublishedLabel, 'Non');
     });
   });
@@ -360,6 +378,8 @@ module('Unit | Model | certification', function (hooks) {
       const juryCertificationSummary = store.createRecord('certification', { completedAt: null });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(juryCertificationSummary.completionDate, null);
     });
 
@@ -368,6 +388,8 @@ module('Unit | Model | certification', function (hooks) {
       const juryCertificationSummary = store.createRecord('certification', { completedAt: '2021-06-30 15:10:45' });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
     });
   });

--- a/admin/tests/unit/models/jury-certification-summary_test.js
+++ b/admin/tests/unit/models/jury-certification-summary_test.js
@@ -25,6 +25,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
           const statusLabel = juryCertificationSummaryProcessed.get('statusLabel');
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(statusLabel, label);
         });
       });
@@ -42,6 +44,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
       const hasSeenEndTestScreenLabel = juryCertificationSummaryProcessed.hasSeenEndTestScreenLabel;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(hasSeenEndTestScreenLabel, '');
     });
 
@@ -55,6 +59,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
       const hasSeenEndTestScreenLabel = juryCertificationSummaryProcessed.hasSeenEndTestScreenLabel;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(hasSeenEndTestScreenLabel, 'non');
     });
   });
@@ -73,6 +79,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
         juryCertificationSummaryProcessed.numberOfCertificationIssueReportsWithRequiredActionLabel;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(numberOfCertificationIssueReportsWithRequiredActionLabel, '');
     });
 
@@ -89,6 +97,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
         juryCertificationSummaryProcessed.numberOfCertificationIssueReportsWithRequiredActionLabel;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(numberOfCertificationIssueReportsWithRequiredActionLabel, 4);
     });
   });
@@ -112,6 +122,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
       const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(complementaryCertificationsLabel, '');
     });
 
@@ -143,6 +155,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
         const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(complementaryCertificationsLabel, expectedMessage);
       });
     });
@@ -165,6 +179,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
       const complementaryCertificationsLabel = juryCertificationSummaryProcessed.complementaryCertificationsLabel;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(complementaryCertificationsLabel, 'CléA Numérique\nPix+ Droit Expert');
     });
   });
@@ -311,6 +327,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
       });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(juryCertificationSummary.completionDate, null);
     });
 
@@ -321,6 +339,8 @@ module('Unit | Model | jury-certification-summary', function (hooks) {
       });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
     });
   });

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -176,10 +176,14 @@ module('Unit | Model | session', function (hooks) {
     });
 
     test('it should count 6 certification issue reports', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionWithCertificationIssueReports.countCertificationIssueReports, 6);
     });
 
     test('it should count 0 certification issue report', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionWithoutCertificationIssueReport.countCertificationIssueReports, 0);
     });
   });
@@ -208,10 +212,14 @@ module('Unit | Model | session', function (hooks) {
     });
 
     test('it should count 6 certification issue reports ', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionWithCertificationIssueReports.countCertificationIssueReportsWithActionRequired, 6);
     });
 
     test('it should count 0 certification issue report ', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionWithoutCertificationIssueReport.countCertificationIssueReportsWithActionRequired, 0);
     });
   });
@@ -234,11 +242,15 @@ module('Unit | Model | session', function (hooks) {
 
     test('it should count 1 unchecked box if only one box (unchecked)', function (assert) {
       const countNotCheckedEndScreen = sessionWithOneUncheckedEndScreen.countNotCheckedEndScreen;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countNotCheckedEndScreen, 1);
     });
 
     test('it should count 0 unchecked box if only one box (checked)', function (assert) {
       const countNotCheckedEndScreen = sessionWithOneCheckedEndScreen.countNotCheckedEndScreen;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countNotCheckedEndScreen, 0);
     });
   });
@@ -257,6 +269,8 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countStartedAndInErrorCertifications, 1);
     });
 
@@ -273,6 +287,8 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countStartedAndInErrorCertifications, 1);
     });
 
@@ -289,6 +305,8 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countStartedAndInErrorCertifications, 0);
     });
 
@@ -305,6 +323,8 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countStartedAndInErrorCertifications, 0);
     });
 
@@ -321,6 +341,8 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countStartedAndInErrorCertifications, 0);
     });
 
@@ -345,6 +367,8 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countStartedAndInErrorCertifications, 3);
     });
   });
@@ -361,6 +385,8 @@ module('Unit | Model | session', function (hooks) {
       const countCertificationsFlaggedAsAborted = session.countCertificationsFlaggedAsAborted;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(countCertificationsFlaggedAsAborted, 1);
     });
   });
@@ -403,6 +429,8 @@ module('Unit | Model | session', function (hooks) {
         const displayStatus = session.displayStatus;
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(displayStatus, 'Créée');
       });
     });
@@ -416,6 +444,8 @@ module('Unit | Model | session', function (hooks) {
         const displayStatus = session.displayStatus;
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(displayStatus, 'Finalisée');
       });
     });
@@ -429,6 +459,8 @@ module('Unit | Model | session', function (hooks) {
         const displayStatus = session.displayStatus;
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(displayStatus, 'Résultats transmis par Pix');
       });
     });

--- a/admin/tests/unit/models/to-be-published-session_test.js
+++ b/admin/tests/unit/models/to-be-published-session_test.js
@@ -17,6 +17,8 @@ module('Unit | Model | to be published session', function (hooks) {
       const printableDateAndTime = toBePublishedSession.printableDateAndTime;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(printableDateAndTime, '01/02/2020 à 14:30');
     });
   });
@@ -33,6 +35,8 @@ module('Unit | Model | to be published session', function (hooks) {
       const printableFinalizationDate = toBePublishedSession.printableFinalizationDate;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(printableFinalizationDate, '01/02/2020');
     });
   });

--- a/admin/tests/unit/models/user_test.js
+++ b/admin/tests/unit/models/user_test.js
@@ -22,6 +22,8 @@ module('Unit | Model | user', function (hooks) {
       const fullName = user.fullName;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(fullName, 'Jean-Baptiste Poquelin');
     });
   });

--- a/admin/tests/unit/models/with-required-action-session_test.js
+++ b/admin/tests/unit/models/with-required-action-session_test.js
@@ -17,6 +17,8 @@ module('Unit | Model | with required action session', function (hooks) {
       const printableDateAndTime = sessionWithRequiredAction.printableDateAndTime;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(printableDateAndTime, '01/02/2020 à 14:30');
     });
   });
@@ -33,6 +35,8 @@ module('Unit | Model | with required action session', function (hooks) {
       const printableFinalizationDate = sessionWithRequiredAction.printableFinalizationDate;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(printableFinalizationDate, '01/02/2020');
     });
   });

--- a/admin/tests/unit/routes/authenticated/certification-centers/list_test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/list_test.js
@@ -85,11 +85,23 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
         route.resetController(controller, true);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, null);
       });
     });
@@ -100,11 +112,23 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
         route.resetController(controller, false);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 'somePageNumber');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 'somePageSize');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, 'someId');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, 'someName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, 'someType');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, 'someExternalId');
       });
     });

--- a/admin/tests/unit/routes/authenticated/certifications/certification/profile_test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification/profile_test.js
@@ -25,6 +25,8 @@ module('Unit | Route | authenticated/certifications/certification/profile', func
       const model = await route.model();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model, expectedModel);
     });
   });

--- a/admin/tests/unit/routes/authenticated/certifications/certification_test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification_test.js
@@ -15,6 +15,8 @@ module('Unit | Route | authenticated/certifications/certification', function (ho
     route.setupController(certifications, { id });
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(certifications.inputId, id);
   });
 

--- a/admin/tests/unit/routes/authenticated/organizations/list_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list_test.js
@@ -85,11 +85,23 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, null);
       });
     });
@@ -100,11 +112,23 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 'somePageNumber');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 'somePageSize');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, 'someId');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, 'someName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, 'someType');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, 'someExternalId');
       });
     });

--- a/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
@@ -198,6 +198,8 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         const returnedSessions = await route.model({});
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(returnedSessions, 'someSessions');
       });
     });
@@ -224,12 +226,26 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         route.resetController(controller, true);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certificationCenterName, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certificationCenterType, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, 'finalized');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.resultsSentToPrescriberAt, null);
       });
     });
@@ -240,12 +256,26 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         route.resetController(controller, false);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 'somePageNumber');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 'somePageSize');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, 'someId');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certificationCenterName, 'someName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, 'someStatus');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.certificationCenterType, 'someType');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.resultsSentToPrescriberAt, 'someValue');
       });
     });

--- a/admin/tests/unit/routes/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/to-be-published_test.js
@@ -33,6 +33,8 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function (h
       const result = await route.model();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(result, toBePublishedSessions);
     });
   });

--- a/admin/tests/unit/routes/authenticated/sessions/session_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session_test.js
@@ -15,6 +15,8 @@ module('Unit | Route | authenticated/sessions/session', function (hooks) {
     route.setupController(sessions, { id });
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sessions.inputId, id);
   });
 

--- a/admin/tests/unit/routes/authenticated/target-profiles/list_test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list_test.js
@@ -77,9 +77,17 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, null);
       });
     });
@@ -90,9 +98,17 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 'somePageNumber');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 'somePageSize');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, 'someName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.id, 'someId');
       });
     });

--- a/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations_test.js
@@ -28,10 +28,20 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         route.resetController(controller, true);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, null);
       });
     });
@@ -42,10 +52,20 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         route.resetController(controller, false);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 'somePageNumber');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 'somePageSize');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.name, 'someName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.type, 'someType');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.externalId, 'someExternalId');
       });
     });

--- a/admin/tests/unit/routes/authenticated/users/list_test.js
+++ b/admin/tests/unit/routes/authenticated/users/list_test.js
@@ -81,10 +81,20 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.firstName, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.lastName, null);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.email, null);
       });
     });
@@ -95,10 +105,20 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 'somePageNumber');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 'somePageSize');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.firstName, 'someFirstName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.lastName, 'someLastName');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.email, 'someEmail');
       });
     });

--- a/admin/tests/unit/services/current-user_test.js
+++ b/admin/tests/unit/services/current-user_test.js
@@ -27,6 +27,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.user, connectedUser);
     });
   });
@@ -44,6 +46,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.user, null);
     });
   });
@@ -68,6 +72,8 @@ module('Unit | Service | current-user', function (hooks) {
       const result = await currentUser.load();
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(result, 'invalidate');
     });
   });

--- a/admin/tests/unit/validators/absolute-url-test.js
+++ b/admin/tests/unit/validators/absolute-url-test.js
@@ -21,6 +21,8 @@ module('Unit | Validator | absolute-url', function (hooks) {
 
     const message = await validator.validate(badUrl, options);
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(message, options.message);
   });
 
@@ -48,6 +50,8 @@ module('Unit | Validator | absolute-url', function (hooks) {
 
     const message = await validator.validate(badUrl, options);
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(message, options.message);
   });
 });

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -17739,9 +17739,9 @@
       }
     },
     "eslint-plugin-qunit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
-      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
+      "integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -89,7 +89,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.0.2",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-qunit": "^6.2.0",
+    "eslint-plugin-qunit": "^7.2.0",
     "eslint-plugin-yml": "^0.11.0",
     "faker": "^5.5.2",
     "loader.js": "^4.7.0",

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -28,6 +28,8 @@ module('Acceptance | authenticated', function (hooks) {
       await click('.sidebar__logo a');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
   });
@@ -46,6 +48,8 @@ module('Acceptance | authenticated', function (hooks) {
       await clickByLabel('Sessions de certification');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
 
@@ -92,6 +96,8 @@ module('Acceptance | authenticated', function (hooks) {
         await clickByLabel('Espace surveillant');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/connexion-espace-surveillant');
       });
     });
@@ -222,6 +228,8 @@ module('Acceptance | authenticated', function (hooks) {
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
 
@@ -259,6 +267,8 @@ module('Acceptance | authenticated', function (hooks) {
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/espace-ferme');
     });
 
@@ -296,6 +306,8 @@ module('Acceptance | authenticated', function (hooks) {
       await click(screen.getByRole('button', { name: 'Poupoune (DEF456)' }));
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
   });

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -25,6 +25,8 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
       assert.notOk(
         currentSession(this.application).get('isAuthenticated'),
@@ -47,6 +49,8 @@ module('Acceptance | authentication', function (hooks) {
       await click('button[type=submit]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/cgu');
       assert.ok(
         currentSession(this.application).get('isAuthenticated'),
@@ -91,6 +95,8 @@ module('Acceptance | authentication', function (hooks) {
       await click('button[type=submit]');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
       assert.ok(
         currentSession(this.application).get('isAuthenticated'),
@@ -129,6 +135,8 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/sessions/liste');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
       assert.ok(
         currentSession(this.application).get('isAuthenticated'),
@@ -157,6 +165,8 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
   });

--- a/certif/tests/acceptance/restricted-access_test.js
+++ b/certif/tests/acceptance/restricted-access_test.js
@@ -14,6 +14,8 @@ module('Acceptance | Restricted access', function (hooks) {
       await visit('/espace-ferme');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -47,6 +49,8 @@ module('Acceptance | Restricted access', function (hooks) {
         await visit('/espace-ferme');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/sessions/liste');
       });
     });

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -45,6 +45,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await visit(`/sessions/${session.id}/ajout-eleves`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -64,6 +66,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
         await visit(`/sessions/${session.id}/ajout-eleves`);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -74,6 +78,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await clickByLabel('Ajouter des candidats');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}/ajout-eleves`);
       assert.dom('.add-student__title').hasText('Ajouter des candidats');
     });
@@ -85,6 +91,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await clickByLabel('Retour à la session');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
     });
 
@@ -119,6 +127,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
         // then
         const studentRows = document.querySelectorAll(rowSelector);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(studentRows.length, 2);
       });
 
@@ -135,6 +145,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
           // then
           const allRow = document.querySelectorAll(rowSelector);
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
         });
 
@@ -158,8 +170,12 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
             // then
             const allRow = document.querySelectorAll(rowSelector);
+            // TODO: Fix this the next time the file is edited.
+            // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
             const checkboxChecked = document.querySelectorAll(checkboxCheckedSelector);
+            // TODO: Fix this the next time the file is edited.
+            // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(checkboxChecked.length, 3);
           });
 
@@ -177,6 +193,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             await clickByLabel('Annuler');
 
             // then
+            // TODO: Fix this the next time the file is edited.
+            // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
           });
 
@@ -193,6 +211,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
               await clickByLabel('Ajouter');
 
               // then
+              // TODO: Fix this the next time the file is edited.
+              // eslint-disable-next-line qunit/no-assert-equal
               assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
             });
 
@@ -214,6 +234,8 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
               // then
               const certificationCandidates = await detailController.model.certificationCandidates;
+              // TODO: Fix this the next time the file is edited.
+              // eslint-disable-next-line qunit/no-assert-equal
               assert.equal(certificationCandidates.length, 3);
             });
           });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -24,6 +24,8 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
       await visit(`/sessions/${session.id}/candidats`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -59,6 +61,8 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         await visit(`/sessions/${session.id}/candidats`);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -240,6 +244,8 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
       await click(linkToCandidate);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
     });
 

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -49,6 +49,8 @@ module('Acceptance | Session Details Parameters', function (hooks) {
         await visit(`/sessions/${sessionCreated.id}`);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -78,6 +80,8 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             await clickByLabel('Finaliser la session');
 
             // then
+            // TODO: Fix this the next time the file is edited.
+            // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
           });
 
@@ -132,6 +136,8 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           await clickByLabel('Finaliser la session');
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), `/sessions/${sessionFinalized.id}`);
         });
 

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -26,6 +26,8 @@ module('Acceptance | Session Details', function (hooks) {
       await visit(`/sessions/${session.id}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -61,6 +63,8 @@ module('Acceptance | Session Details', function (hooks) {
         await visit(`/sessions/${session.id}`);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -71,6 +75,8 @@ module('Acceptance | Session Details', function (hooks) {
       await click('.session-details-content__return-button');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
 

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -50,6 +50,8 @@ module('Acceptance | Session Finalization', function (hooks) {
       await visit(`/sessions/${session.id}/finalisation`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -68,6 +70,8 @@ module('Acceptance | Session Finalization', function (hooks) {
         await visit(`/sessions/${session.id}/finalisation`);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -77,6 +81,8 @@ module('Acceptance | Session Finalization', function (hooks) {
       await visit(`/sessions/${session.id}/finalisation`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
     });
 

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -21,6 +21,8 @@ module('Acceptance | Session List', function (hooks) {
       await visit('/sessions/liste');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -55,6 +57,8 @@ module('Acceptance | Session List', function (hooks) {
         await visit('/sessions/liste');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -64,6 +68,8 @@ module('Acceptance | Session List', function (hooks) {
       await visit('/sessions/liste');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
 
@@ -109,6 +115,8 @@ module('Acceptance | Session List', function (hooks) {
         await click('[aria-label="Session de certification"]');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/sessions/123');
       });
 

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -15,6 +15,8 @@ module('Acceptance | Session creation', function (hooks) {
     await visit('/sessions/creation');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/connexion');
   });
 
@@ -47,6 +49,8 @@ module('Acceptance | Session creation', function (hooks) {
         await visit('/sessions/creation');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/espace-ferme');
       });
     });
@@ -77,12 +81,26 @@ module('Acceptance | Session creation', function (hooks) {
 
       // then
       const session = server.schema.sessions.findBy({ date: sessionDate });
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.address, 'My address');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.room, 'My room');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.examiner, 'My examiner');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.description, 'My description');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.date, sessionDate);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.time, '13:45');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}`);
     });
 
@@ -96,7 +114,11 @@ module('Acceptance | Session creation', function (hooks) {
 
       // then
       const actualSessionsCount = server.schema.sessions.all().length;
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(previousSessionsCount, actualSessionsCount);
     });
   });

--- a/certif/tests/acceptance/session-update_test.js
+++ b/certif/tests/acceptance/session-update_test.js
@@ -38,6 +38,8 @@ module('Acceptance | Session Update', function (hooks) {
       await visit(`/sessions/${session.id}/modification`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/espace-ferme');
     });
   });
@@ -73,8 +75,14 @@ module('Acceptance | Session Update', function (hooks) {
 
     // then
     session.reload();
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(session.room, newRoom);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(session.examiner, newExaminer);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/sessions/${session.id}`);
   });
 
@@ -93,8 +101,14 @@ module('Acceptance | Session Update', function (hooks) {
 
     // then
     session.reload();
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(session.room, 'beforeRoom');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(session.examiner, 'beforeExaminer');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), `/sessions/${session.id}`);
   });
 });

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -33,6 +33,8 @@ module('Acceptance | Supervisor Portal', function (hooks) {
       await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/12345/surveiller');
     });
   });
@@ -50,6 +52,8 @@ module('Acceptance | Supervisor Portal', function (hooks) {
         await click(screen.getByText('Quitter'));
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/connexion-espace-surveillant');
       });
     });

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -24,6 +24,8 @@ module('Acceptance | authenticated | team', function (hooks) {
       await visit('/equipe');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/equipe');
       assert.contains('Lili');
       assert.contains('Dupont');

--- a/certif/tests/acceptance/terms-of-service_test.js
+++ b/certif/tests/acceptance/terms-of-service_test.js
@@ -22,6 +22,8 @@ module('Acceptance | terms-of-service', function (hooks) {
     await visit('/cgu');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/connexion');
     assert.notOk(
       currentSession(this.application).get('isAuthenticated'),
@@ -61,6 +63,8 @@ module('Acceptance | terms-of-service', function (hooks) {
         await click(screen.getByRole('button', { name: 'J’accepte les conditions d’utilisation' }));
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/sessions/liste');
       });
 
@@ -72,6 +76,8 @@ module('Acceptance | terms-of-service', function (hooks) {
         await visit('/campagnes');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/cgu');
       });
     }
@@ -89,6 +95,8 @@ module('Acceptance | terms-of-service', function (hooks) {
       await visit('/cgu');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/sessions/liste');
     });
   });

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -237,6 +237,8 @@ module('Integration | Component | add-student-list', function (hooks) {
         await click(addCandidateButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(this.students, studentList);
         sinon.assert.calledWith(save, {
           adapterOptions: {

--- a/certif/tests/integration/components/formbuilder-link-step_test.js
+++ b/certif/tests/integration/components/formbuilder-link-step_test.js
@@ -22,6 +22,8 @@ module('Integration | Component | SessionFinalization::FormbuilderLinkStep', fun
     assert.contains(
       "Il n'est plus obligatoire de nous transmettre la feuille d'émargement et le PV d'incident scannés. En revanche, ces deux documents doivent être conservés par votre établissement pendant une durée de 2 ans et pouvoir être fournis à Pix en cas de besoin."
     );
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(this.element.querySelector('a').getAttribute('href'), formBuilderLinkUrl);
   });
 });

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -58,9 +58,17 @@ module('Integration | Component | login-form', function (hooks) {
     await clickByLabel('Je me connecte');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sessionServiceObserver.email, 'pix@example.net');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sessionServiceObserver.password, 'JeMeLoggue1024');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sessionServiceObserver.scope, 'pix-certif');
   });
 

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -400,7 +400,11 @@ module('Integration | Component | new-certification-candidate-modal', function (
       await clickByLabel('Ajouter le candidat');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(updateCandidateFromValueStub.callCount, 7);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(updateCandidateFromEventStub.callCount, 8);
       sinon.assert.calledOnce(saveCandidateStub);
     });

--- a/certif/tests/integration/components/session-finalization-step-container_test.js
+++ b/certif/tests/integration/components/session-finalization-step-container_test.js
@@ -13,6 +13,8 @@ module('Integration | Component | session-finalization-step-container', function
       </SessionFinalizationStepContainer>
     `);
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(this.element.textContent.trim().replace(/\s+/g, ' '), 'Étape 1 : title template block text');
   });
 });

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -330,6 +330,8 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           const actions = screen.getAllByRole('button', { name: 'Terminer le test' });
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(actions.length, 2);
           assert.contains('Attention : cette action entraîne la fin de son test de certification et est irréversible.');
           assert.contains('Terminer le test de Drax The Destroyer ?');

--- a/certif/tests/unit/adapters/application_test.js
+++ b/certif/tests/unit/adapters/application_test.js
@@ -10,6 +10,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
@@ -23,6 +25,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       applicationAdapter.session = { isAuthenticated: true, data: { authenticated: { access_token } } };
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
     });
 

--- a/certif/tests/unit/components/add-student-list_test.js
+++ b/certif/tests/unit/components/add-student-list_test.js
@@ -86,6 +86,8 @@ module('Unit | Component | add-student-list', function (hooks) {
       component.toggleItem(student);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(student.isSelected, !initialValue);
     });
   });

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -71,6 +71,8 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
       // then
       sinon.assert.notCalled(savableCandidate.save);
       sinon.assert.calledOnce(savableCandidate.deleteRecord);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.args.certificationCandidates.length, 1);
     });
   });
@@ -137,6 +139,8 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
 
       // then
       assert.true(component.shouldDisplayCertificationCandidateModal);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.certificationCandidateInDetailsModal, candidate);
     });
   });
@@ -158,6 +162,8 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
 
       // then
       assert.false(component.shouldDisplayCertificationCandidateModal);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(component.certificationCandidateInDetailsModal, null);
     });
   });

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -26,6 +26,8 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
         await modal.selectBirthGeoCodeOption('insee');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(modal.selectedBirthGeoCodeOption, 'insee');
       });
 
@@ -74,6 +76,8 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
         await modal.selectBirthGeoCodeOption('postal');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(modal.selectedBirthGeoCodeOption, 'postal');
       });
 

--- a/certif/tests/unit/controllers/authenticated/sessions/details_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details_test.js
@@ -14,6 +14,8 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
       const certificationCandidatesCountResult = controller.certificationCandidatesCount;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(certificationCandidatesCountResult, '(2)');
     });
 
@@ -26,6 +28,8 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
       const certificationCandidatesCountResult = controller.certificationCandidatesCount;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(certificationCandidatesCountResult, '');
     });
   });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -31,6 +31,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(uncheckedHasSeenEndTestScreenCount, 0);
     });
 
@@ -70,6 +72,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(uncheckedHasSeenEndTestScreenCount, 2);
     });
   });
@@ -223,6 +227,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('updateExaminerGlobalComment', { target: { value: 'MoreThan5Characters' } });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.examinerGlobalComment, initialValue);
     });
 
@@ -238,6 +244,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.examinerGlobalComment, newValue);
     });
 
@@ -253,6 +261,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.examinerGlobalComment, null);
     });
   });
@@ -268,6 +278,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('toggleCertificationReportHasSeenEndTestScreen', certifReport);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(certifReport.hasSeenEndTestScreen, !initialValue);
     });
   });
@@ -295,7 +307,11 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
         controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(session.certificationReports[0].hasSeenEndTestScreen, expectedState);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(session.certificationReports[1].hasSeenEndTestScreen, expectedState);
       })
     );

--- a/certif/tests/unit/controllers/authenticated/sessions/new_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/new_test.js
@@ -79,6 +79,8 @@ module('Unit | Controller | authenticated/sessions/new', function (hooks) {
       controller.send('onDatePicked', 'ignoredParam', lastSelectedDateFormatted);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.date, lastSelectedDateFormatted);
     });
   });
@@ -98,6 +100,8 @@ module('Unit | Controller | authenticated/sessions/new', function (hooks) {
       controller.send('onTimePicked', 'ignoredParam', lastSelectedTimeFormatted);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.time, lastSelectedTimeFormatted);
     });
   });

--- a/certif/tests/unit/controllers/authenticated/sessions/update_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/update_test.js
@@ -79,6 +79,8 @@ module('Unit | Controller | authenticated/sessions/update', function (hooks) {
       controller.send('onDatePicked', 'ignoredParam', lastSelectedDateFormatted);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.date, lastSelectedDateFormatted);
     });
   });
@@ -98,6 +100,8 @@ module('Unit | Controller | authenticated/sessions/update', function (hooks) {
       controller.send('onTimePicked', 'ignoredParam', lastSelectedTimeFormatted);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(session.time, lastSelectedTimeFormatted);
     });
   });

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -27,6 +27,8 @@ module('Unit | Controller | authenticated', function (hooks) {
       const documentationLink = controller.documentationLink;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(documentationLink, 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF');
     });
 
@@ -51,6 +53,8 @@ module('Unit | Controller | authenticated', function (hooks) {
       const documentationLink = controller.documentationLink;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(documentationLink, 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS');
     });
   });

--- a/certif/tests/unit/models/certification-candidate_test.js
+++ b/certif/tests/unit/models/certification-candidate_test.js
@@ -38,6 +38,8 @@ module('Unit | Model | certification-candidate', function (hooks) {
       // when
       const model = store.createRecord('certification-candidate', data);
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.sexLabel, 'Homme');
     });
 
@@ -50,6 +52,8 @@ module('Unit | Model | certification-candidate', function (hooks) {
       // when
       const model = store.createRecord('certification-candidate', data);
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.sexLabel, 'Femme');
     });
 
@@ -60,6 +64,8 @@ module('Unit | Model | certification-candidate', function (hooks) {
       // when
       const model = store.createRecord('certification-candidate', data);
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.sexLabel, null);
     });
   });
@@ -83,6 +89,8 @@ module('Unit | Model | certification-candidate', function (hooks) {
       // when
       const model = store.createRecord('certification-candidate', data);
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.complementaryCertificationsList, 'Pix+Edu, Pix+Droit');
     });
   });

--- a/certif/tests/unit/models/certification-issue-report_test.js
+++ b/certif/tests/unit/models/certification-issue-report_test.js
@@ -26,6 +26,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.categoryLabel, categoryToLabel[model.category]);
     }
   });
@@ -41,6 +43,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
     }
   });
@@ -56,6 +60,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.categoryCode, categoryToCode[model.category]);
     }
   });
@@ -71,6 +77,8 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.subcategoryCode, subcategoryToCode[model.subcategory]);
     }
   });
@@ -82,6 +90,8 @@ module('Unit | Model | certification issue report', function (hooks) {
     const model = run(() => store.createRecord('certification-issue-report', { subcategory: null }));
 
     // when / then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.subcategoryLabel, '');
   });
 });

--- a/certif/tests/unit/models/certification-report_test.js
+++ b/certif/tests/unit/models/certification-report_test.js
@@ -20,11 +20,21 @@ module('Unit | Model | certification report', function (hooks) {
     );
 
     // when / then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.id, 123);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.firstName, 'Clément');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.lastName, 'Tine');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.certificationCourseId, 987);
     assert.false(model.hasSeenEndTestScreen);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.firstIssueReportDescription, '');
   });
 
@@ -48,6 +58,8 @@ module('Unit | Model | certification report', function (hooks) {
       );
 
       // when / then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(certificationReport.firstIssueReportDescription, description);
     });
   });

--- a/certif/tests/unit/models/session-summary_test.js
+++ b/certif/tests/unit/models/session-summary_test.js
@@ -17,6 +17,8 @@ module('Unit | Model | session-summary', function (hooks) {
       );
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionSummary.statusLabel, 'Finalisée');
     });
 
@@ -31,6 +33,8 @@ module('Unit | Model | session-summary', function (hooks) {
       );
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionSummary.statusLabel, 'Résultats transmis par Pix');
     });
 
@@ -45,6 +49,8 @@ module('Unit | Model | session-summary', function (hooks) {
       );
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionSummary.statusLabel, 'Créée');
     });
   });

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -26,7 +26,11 @@ module('Unit | Model | session', function (hooks) {
       );
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model1.displayStatus, 'Créée');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model2.displayStatus, 'Finalisée');
     });
   });
@@ -38,6 +42,8 @@ module('Unit | Model | session', function (hooks) {
       const model = run(() => store.createRecord('session', { id: 1 }));
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
     });
   });
@@ -58,6 +64,8 @@ module('Unit | Model | session', function (hooks) {
       this.owner.register('service:session', SessionStub);
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(
         model.urlToDownloadAttendanceSheet,
         `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`
@@ -81,6 +89,8 @@ module('Unit | Model | session', function (hooks) {
       this.owner.register('service:session', SessionStub);
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.urlToDownloadSessionIssueReportSheet, config.urlToDownloadSessionIssueReportSheet);
     });
   });
@@ -93,7 +103,11 @@ module('Unit | Model | session', function (hooks) {
       const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
       // when/then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.uncompletedCertificationReports.length, 1);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.uncompletedCertificationReports[0].id, 1);
     });
   });
@@ -115,8 +129,14 @@ module('Unit | Model | session', function (hooks) {
         const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
         // when/then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(model.completedCertificationReports.length, 2);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(model.completedCertificationReports[0].id, 2);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(model.completedCertificationReports[1].id, 3);
       });
     });
@@ -136,6 +156,8 @@ module('Unit | Model | session', function (hooks) {
 
         const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
         // when/then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(model.completedCertificationReports.length, 3);
       });
     });

--- a/certif/tests/unit/routes/not-found_test.js
+++ b/certif/tests/unit/routes/not-found_test.js
@@ -10,6 +10,8 @@ module('Unit | Route | not-found', function (hooks) {
     const expectedRedirection = 'application';
 
     route.transitionTo = (redirection) => {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(redirection, expectedRedirection, `expect transition to ${expectedRedirection}, got ${redirection}`);
     };
 

--- a/certif/tests/unit/services/current-user_test.js
+++ b/certif/tests/unit/services/current-user_test.js
@@ -34,7 +34,11 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.certificationPointOfContact, certificationPointOfContact);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.currentAllowedCertificationCenterAccess, allowedCertificationCenterAccesseA);
     });
   });
@@ -52,6 +56,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.certificationPointOfContact, null);
     });
   });
@@ -75,6 +81,8 @@ module('Unit | Service | current-user', function (hooks) {
       const result = await currentUser.load();
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(result, 'invalidate');
     });
   });
@@ -162,6 +170,8 @@ module('Unit | Service | current-user', function (hooks) {
       currentUser.updateCurrentCertificationCenter(222);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.currentAllowedCertificationCenterAccess, newAllowedCertificationCenterAccess);
     });
   });

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -21747,9 +21747,9 @@
       }
     },
     "eslint-plugin-qunit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
-      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
+      "integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-ember": "^10.0.2",
     "eslint-plugin-i18n-json": "^3.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-qunit": "^6.2.0",
+    "eslint-plugin-qunit": "^7.2.0",
     "eslint-plugin-yml": "^0.11.0",
     "faker": "^5.5.2",
     "loader.js": "^4.7.0",

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -25,6 +25,8 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
@@ -43,6 +45,8 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/connexion');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
@@ -66,6 +70,8 @@ module('Acceptance | authentication', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/cgu');
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
     });
@@ -109,6 +115,8 @@ module('Acceptance | authentication', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
     });
@@ -164,6 +172,8 @@ module('Acceptance | authentication', function (hooks) {
         await visit('/campagnes/creation');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes/creation');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
@@ -181,6 +191,8 @@ module('Acceptance | authentication', function (hooks) {
         await visit('/');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes');
       });
     });
@@ -368,6 +380,8 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/certifications');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
     });
   });

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -41,6 +41,8 @@ module('Acceptance | Campaign Activity', function (hooks) {
         await clickByName('Bacri');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');
       });
     });
@@ -59,6 +61,8 @@ module('Acceptance | Campaign Activity', function (hooks) {
         await clickByName('Bacri');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes/2/profils/1');
       });
     });
@@ -69,6 +73,8 @@ module('Acceptance | Campaign Activity', function (hooks) {
       await clickByName('Retour');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1');
     });
   });
@@ -82,6 +88,8 @@ module('Acceptance | Campaign Activity', function (hooks) {
       await clickByName('Effacer les filtres');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(screen.getByLabelText('Statut').value, '');
     });
   });

--- a/orga/tests/acceptance/campaign-assessment-results_test.js
+++ b/orga/tests/acceptance/campaign-assessment-results_test.js
@@ -69,6 +69,8 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       await clickByName('AAAAAAAA_IAM_FIRST');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');
     });
   });

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -32,6 +32,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
     await visit('/campagnes/creation');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/connexion');
   });
 
@@ -51,6 +53,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should be accessible for an authenticated prescriber', async function (assert) {
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/creation');
       assert.contains("Création d'une campagne");
     });
@@ -72,11 +76,23 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
       // then
       const firstCampaign = server.db.campaigns[0];
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.name, 'Ma Campagne');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.title, 'Savoir rechercher');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.targetProfileId, expectedTargetProfileId);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.customLandingPageText, 'Texte personnalisé');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.idPixLabel, 'Mail Pro');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1/parametres');
     });
 
@@ -92,6 +108,8 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByName('Créer la campagne');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/creation');
       assert.contains('Une erreur est survenue. Veuillez réessayer ultérieurement.');
     });
@@ -121,8 +139,14 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
       // then
       const firstCampaign = server.db.campaigns[0];
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.name, 'Ma Campagne');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(firstCampaign.targetProfileId, expectedTargetProfileId);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1/parametres');
     });
 
@@ -136,7 +160,11 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByName('Créer la campagne');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1/parametres');
     });
 
@@ -154,7 +182,11 @@ module('Acceptance | Campaign Creation', function (hooks) {
       await clickByName('Créer la campagne');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1/parametres');
     });
   });

--- a/orga/tests/acceptance/campaign-details_test.js
+++ b/orga/tests/acceptance/campaign-details_test.js
@@ -20,6 +20,8 @@ module('Acceptance | Campaign Details', function (hooks) {
       await visit('/campagnes/1');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -40,6 +42,8 @@ module('Acceptance | Campaign Details', function (hooks) {
       await clickByName('Retour');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
     });
 

--- a/orga/tests/acceptance/campaign-list_test.js
+++ b/orga/tests/acceptance/campaign-list_test.js
@@ -17,6 +17,8 @@ module('Acceptance | Campaign List', function (hooks) {
       await visit('/campagnes');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -36,6 +38,8 @@ module('Acceptance | Campaign List', function (hooks) {
       await visit('/campagnes');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
     });
 
@@ -67,6 +71,8 @@ module('Acceptance | Campaign List', function (hooks) {
       await clickByName('CampagneEtPrairie');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes/1');
     });
 
@@ -81,6 +87,8 @@ module('Acceptance | Campaign List', function (hooks) {
         await fillByLabel('Rechercher un créateur', owner.firstName);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), `/campagnes?ownerName=${owner.firstName}`);
       });
 
@@ -94,6 +102,8 @@ module('Acceptance | Campaign List', function (hooks) {
         await fillByLabel('Rechercher un créateur', '');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes');
       });
 
@@ -151,6 +161,8 @@ module('Acceptance | Campaign List', function (hooks) {
         await fillByLabel('Rechercher une campagne', campaignName);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), `/campagnes?name=${campaignName}`);
       });
     });

--- a/orga/tests/acceptance/campaign-update_test.js
+++ b/orga/tests/acceptance/campaign-update_test.js
@@ -32,8 +32,14 @@ module('Acceptance | Campaign Update', function (hooks) {
     await clickByName('Modifier');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(server.db.campaigns.find(1).name, newName);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(server.db.campaigns.find(1).customLandingPageText, newText);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/campagnes/1/parametres');
   });
 });

--- a/orga/tests/acceptance/information-banner_test.js
+++ b/orga/tests/acceptance/information-banner_test.js
@@ -34,6 +34,8 @@ module('Acceptance | Information Banner', function (hooks) {
       await clickByName('importer ou ré-importer la base élèves');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/eleves');
     });
   });

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -40,6 +40,8 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
@@ -49,6 +51,8 @@ module('Acceptance | join', function (hooks) {
       await visit('rejoindre?invitationId=123456&code=FAKE999');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
@@ -69,6 +73,8 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       assert.dom('.login-form__invitation-error').exists();
@@ -90,6 +96,8 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
@@ -136,6 +144,8 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/cgu');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
@@ -191,6 +201,8 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
@@ -254,6 +266,8 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
         assert.contains(expectedErrorMessage);
@@ -305,6 +319,8 @@ module('Acceptance | join', function (hooks) {
           await clickByName(loginButton);
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/cgu');
           assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
         });
@@ -358,9 +374,13 @@ module('Acceptance | join', function (hooks) {
           await clickByName(registerButtonLabel);
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/cgu');
           assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
           const organizationInvitation = server.db.organizationInvitations[0];
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(organizationInvitation.status, 'accepted');
         });
       });
@@ -407,6 +427,8 @@ module('Acceptance | join', function (hooks) {
           await clickByName(registerButtonLabel);
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
           assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
         });

--- a/orga/tests/acceptance/profile_test.js
+++ b/orga/tests/acceptance/profile_test.js
@@ -27,6 +27,8 @@ module('Acceptance | Campaign Profile', function (hooks) {
     await clickByName('Retour');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/campagnes/1');
   });
 

--- a/orga/tests/acceptance/sco-student-list_test.js
+++ b/orga/tests/acceptance/sco-student-list_test.js
@@ -24,6 +24,8 @@ module('Acceptance | Sco Student List', function (hooks) {
       await visit('/eleves');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -49,6 +51,8 @@ module('Acceptance | Sco Student List', function (hooks) {
         await visit('/eleves');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes');
       });
     });
@@ -66,6 +70,8 @@ module('Acceptance | Sco Student List', function (hooks) {
         await visit('/eleves');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/eleves');
       });
 
@@ -121,6 +127,8 @@ module('Acceptance | Sco Student List', function (hooks) {
           await visit('/eleves');
           await fillByLabel('Entrer un nom', 'ambo');
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/eleves?lastName=ambo');
           assert.contains('Rambo');
           assert.notContains('Norris');
@@ -132,6 +140,8 @@ module('Acceptance | Sco Student List', function (hooks) {
           await fillByLabel('Entrer un prénom', 'Jo');
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/eleves?firstName=Jo');
           assert.contains('Rambo');
           assert.notContains('Norris');
@@ -143,6 +153,8 @@ module('Acceptance | Sco Student List', function (hooks) {
           await fillByLabel('Rechercher par méthode de connexion', 'email');
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/eleves?connexionType=email');
           assert.contains('Rambo');
           assert.notContains('Norris');

--- a/orga/tests/acceptance/sup-student-import_test.js
+++ b/orga/tests/acceptance/sup-student-import_test.js
@@ -96,6 +96,8 @@ module('Acceptance | Sup Student Import', function (hooks) {
       await visit('/etudiants/import');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
     });
   });

--- a/orga/tests/acceptance/switch-organization_test.js
+++ b/orga/tests/acceptance/switch-organization_test.js
@@ -94,6 +94,8 @@ module('Acceptance | Switch Organization', function (hooks) {
           await clickByName('My Heaven Company (HEAVEN)');
 
           // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
           assert.equal(currentURL(), '/campagnes');
         });
       });

--- a/orga/tests/acceptance/team-creation_test.js
+++ b/orga/tests/acceptance/team-creation_test.js
@@ -21,6 +21,8 @@ module('Acceptance | Team Creation', function (hooks) {
     await visit('/equipe/creation');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/connexion');
   });
 
@@ -46,6 +48,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await visit('/equipe/creation');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/campagnes');
       });
     });
@@ -73,6 +77,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await visit('/equipe/creation');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/creation');
       });
 
@@ -94,9 +100,17 @@ module('Acceptance | Team Creation', function (hooks) {
 
         // then
         const organizationInvitation = server.db.organizationInvitations[server.db.organizationInvitations.length - 1];
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(organizationInvitation.email, email);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(organizationInvitation.status, 'PENDING');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(organizationInvitation.code, code);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/invitations');
         assert.contains(email);
         assert.contains(this.intl.t('pages.team-new.success.invitation', { email }));
@@ -125,6 +139,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/creation');
       });
 
@@ -149,6 +165,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(cancelButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/invitations');
       });
 
@@ -176,6 +194,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
@@ -204,6 +224,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
@@ -232,6 +254,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
@@ -260,6 +284,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });

--- a/orga/tests/acceptance/team-list_test.js
+++ b/orga/tests/acceptance/team-list_test.js
@@ -23,6 +23,8 @@ module('Acceptance | Team List', function (hooks) {
       await visit('/equipe');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/connexion');
     });
   });
@@ -69,6 +71,8 @@ module('Acceptance | Team List', function (hooks) {
         const screen = await visitScreen('/equipe');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/membres');
         assert.dom(screen.queryByLabelText('Membres')).isNotVisible();
         assert.dom(screen.queryByLabelText('Invitations')).isNotVisible();
@@ -89,6 +93,8 @@ module('Acceptance | Team List', function (hooks) {
         await visit('/equipe/membres');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentURL(), '/equipe/membres');
       });
 
@@ -145,6 +151,8 @@ module('Acceptance | Team List', function (hooks) {
       await clickByName('Équipe');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/equipe/membres');
     });
   });

--- a/orga/tests/acceptance/terms-of-service_test.js
+++ b/orga/tests/acceptance/terms-of-service_test.js
@@ -19,6 +19,8 @@ module('Acceptance | terms-of-service', function (hooks) {
     await visit('/cgu');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/connexion');
     assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
   });
@@ -38,6 +40,8 @@ module('Acceptance | terms-of-service', function (hooks) {
       await clickByName('J’accepte les conditions d’utilisation');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
     });
 
@@ -49,6 +53,8 @@ module('Acceptance | terms-of-service', function (hooks) {
       await visit('/campagnes');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/cgu');
     });
   });
@@ -65,6 +71,8 @@ module('Acceptance | terms-of-service', function (hooks) {
       await visit('/cgu');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), '/campagnes');
     });
   });

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -75,9 +75,17 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.email, 'pix@example.net');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.password, 'JeMeLoggue1024');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.scope, 'pix-orga');
     });
   });
@@ -113,9 +121,17 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.email, 'pix@example.net');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.password, 'JeMeLoggue1024');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.scope, 'pix-orga');
     });
   });

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -92,9 +92,17 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
       // then
       assert.dom('.alert-input--error').doesNotExist();
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.email, 'shi@fu.me');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.password, 'Mypassword1');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sessionServiceObserver.scope, 'pix-orga');
     });
   });
@@ -127,6 +135,8 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(EMPTY_FIRSTNAME_ERROR_MESSAGE))).exists();
       });
@@ -141,6 +151,8 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(EMPTY_LASTNAME_ERROR_MESSAGE))).exists();
       });
@@ -155,6 +167,8 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(EMPTY_EMAIL_ERROR_MESSAGE))).exists();
       });
@@ -169,6 +183,8 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE))).exists();
       });
@@ -183,6 +199,8 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(spy.callCount, 0);
       });
     });

--- a/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
@@ -46,6 +46,8 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
         @onClickParticipant={{onClickParticipant}}
       />`);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(find('[aria-label="Statut"]').selectedOptions[0].value, 'TO_SHARE');
     });
 

--- a/orga/tests/integration/components/campaign/badges_test.js
+++ b/orga/tests/integration/components/campaign/badges_test.js
@@ -18,8 +18,14 @@ module('Integration | Component | Campaign::Badges', function (hooks) {
 
     // then
     const badgeImages = this.element.querySelectorAll('img');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(badgeImages.length, 2);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(badgeImages[0].getAttribute('src'), 'img1');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(badgeImages[0].getAttribute('alt'), 'alt-img1');
   });
 

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -184,7 +184,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(t('pages.campaign-creation.tags.SUBJECT'));
         // then
         const option = document.getElementsByTagName('option');
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(option.length, 1);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(option[0].label, 'targetProfile4');
       });
     });

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -352,6 +352,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(find('[aria-label="Statut"]').selectedOptions[0].value, 'STARTED');
       });
 

--- a/orga/tests/integration/components/campaign/stage-stars_test.js
+++ b/orga/tests/integration/components/campaign/stage-stars_test.js
@@ -18,7 +18,11 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     const unacquiredStars = this.element.querySelectorAll('.pix-stars__unacquired');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(acquiredStars.length, 1);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(unacquiredStars.length, 1);
   });
 
@@ -34,7 +38,11 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     const unacquiredStars = this.element.querySelectorAll('.pix-stars__unacquired');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(acquiredStars.length, 1);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(unacquiredStars.length, 1);
   });
 
@@ -49,6 +57,8 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     const srOnly = this.element.querySelector('.sr-only');
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(srOnly.textContent.trim(), '1 étoiles sur 2');
   });
 

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -87,7 +87,11 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
 
       // then
       const call = triggerFiltering.getCall(0);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[0], 'lastName');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[1], 'bob');
     });
 
@@ -104,7 +108,11 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
 
       // then
       const call = triggerFiltering.getCall(0);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[0], 'firstName');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[1], 'bob');
     });
 
@@ -121,6 +129,8 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
 
       // then
       const call = triggerFiltering.getCall(0);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[0], 'divisions');
       assert.deepEqual(call.args[1], ['3A']);
     });
@@ -141,7 +151,11 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
 
       // then
       const call = triggerFiltering.getCall(0);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[0], 'connexionType');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(call.args[1], 'email');
     });
   });

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -132,6 +132,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         await clickByName('Annuler');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(memberMembership.organizationRole, 'MEMBER');
         sinon.assert.notCalled(memberMembership.save);
       });
@@ -150,6 +152,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         await clickByText('Enregistrer');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(memberMembership.organizationRole, 'ADMIN');
         sinon.assert.called(memberMembership.save);
       });
@@ -168,6 +172,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         await clickByText('Enregistrer');
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(adminMembership.organizationRole, 'MEMBER');
         sinon.assert.called(adminMembership.save);
       });

--- a/orga/tests/unit/adapters/application_test.js
+++ b/orga/tests/unit/adapters/application_test.js
@@ -10,6 +10,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
@@ -23,6 +25,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
     });
 
@@ -50,6 +54,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       });
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(applicationAdapter.headers['Accept-Language'], 'fr-fr');
     });
 
@@ -66,6 +72,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       });
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(applicationAdapter.headers['Accept-Language'], 'fr');
     });
 
@@ -77,6 +85,8 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       applicationAdapter.intl = { get: () => ['en'] };
 
       // Then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(applicationAdapter.headers['Accept-Language'], 'en');
     });
   });

--- a/orga/tests/unit/adapters/campaign-assessment-result-minimal_test.js
+++ b/orga/tests/unit/adapters/campaign-assessment-result-minimal_test.js
@@ -21,7 +21,7 @@ module('Unit | Adapters | CampaignAssessmentResultMinimal', function (hooks) {
 
       // then
       assert.true(url.endsWith(`/campaigns/${1}/assessment-results`));
-      assert.true(query.campaignId === undefined);
+      assert.strictEqual(query.campaignId, undefined);
     });
   });
 });

--- a/orga/tests/unit/adapters/campaign-profile_test.js
+++ b/orga/tests/unit/adapters/campaign-profile_test.js
@@ -18,7 +18,11 @@ module('Unit | Adapters | campaign-profile', function (hooks) {
       const url = await adapter.urlForQueryRecord(query);
 
       assert.ok(url.endsWith('/api/campaigns/campaignId1/profiles-collection-participations/campaignParticipationId1'));
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(query.campaignId, undefined);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(query.campaignParticipationId, undefined);
     });
   });

--- a/orga/tests/unit/adapters/campaign-stats_test.js
+++ b/orga/tests/unit/adapters/campaign-stats_test.js
@@ -23,6 +23,8 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByStage(campaignId);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stats, expectedStats);
     });
   });
@@ -35,6 +37,8 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByStatus(campaignId);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stats, expectedStats);
     });
   });
@@ -47,6 +51,8 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByDay(campaignId);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stats, expectedStats);
     });
   });
@@ -59,6 +65,8 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByMasteryRate(campaignId);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stats, expectedStats);
     });
   });

--- a/orga/tests/unit/adapters/membership_test.js
+++ b/orga/tests/unit/adapters/membership_test.js
@@ -22,6 +22,8 @@ module('Unit | Adapter | membership', function (hooks) {
       const url = await adapter.urlForQuery(query);
 
       assert.ok(url.endsWith('/api/organizations/1/memberships'));
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(query.filter.organizationId, undefined);
     });
   });

--- a/orga/tests/unit/adapters/student_test.js
+++ b/orga/tests/unit/adapters/student_test.js
@@ -21,6 +21,8 @@ module('Unit | Adapters | student', function (hooks) {
       const url = await adapter.urlForQuery(query);
 
       assert.ok(url.endsWith('/api/organizations/organizationId1/students'));
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(query.organizationId, undefined);
     });
   });

--- a/orga/tests/unit/components/campaign/activity/dashboard_test.js
+++ b/orga/tests/unit/components/campaign/activity/dashboard_test.js
@@ -30,7 +30,11 @@ module('Unit | Component | Campaign::Activity::Dashboard', (hooks) => {
     });
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(component.total, 3);
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(component.shared, 1);
     assert.deepEqual(component.participantCountByStatus, [
       ['started', 1],

--- a/orga/tests/unit/components/tube/list_test.js
+++ b/orga/tests/unit/components/tube/list_test.js
@@ -15,6 +15,8 @@ module('Unit | Component | Tube::List', function (hooks) {
 
     // then
     const text = await component.file.text();
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(text, expectedFile);
   });
 });

--- a/orga/tests/unit/components/user-logged-menu_test.js
+++ b/orga/tests/unit/components/user-logged-menu_test.js
@@ -43,6 +43,8 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       // when
       const computedOrganizationName = component.organizationNameAndExternalId;
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(computedOrganizationName, expectedOrganizationName);
     });
 
@@ -56,6 +58,8 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       // when
       const computedOrganizationName = component.organizationNameAndExternalId;
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(computedOrganizationName, `${expectedOrganizationName} (${expectedExternalId})`);
     });
   });

--- a/orga/tests/unit/controllers/authenticated/campaigns/assessment/analysis_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/assessment/analysis_test.js
@@ -11,6 +11,8 @@ module('Unit | Controller | authenticated/campaigns/assessment/analysis', functi
       lastName: 'attends',
     };
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(controller.pageTitle, 'Analyse pour Jaune attends');
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/assessment/results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/assessment/results_test.js
@@ -11,6 +11,8 @@ module('Unit | Controller | authenticated/campaigns/assessment/results', functio
       lastName: 'attends',
     };
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(controller.pageTitle, 'Résultats de Jaune attends');
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -52,8 +52,12 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED', groups: ['L3'] });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.pageNumber, null);
       assert.deepEqual(controller.divisions, ['A1']);
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.status, 'STARTED');
       assert.deepEqual(controller.groups, ['L3']);
     });
@@ -69,8 +73,12 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { status: 'COMPLETED' });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A2']);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, 'COMPLETED');
       });
     });
@@ -86,8 +94,12 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { status: 'COMPLETED' });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, null);
         assert.deepEqual(controller.groups, ['A2']);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, 'COMPLETED');
       });
     });
@@ -103,8 +115,12 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { divisions: ['A1'] });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A1']);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, 'SHARED');
       });
     });
@@ -119,6 +135,8 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { status: '' });
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.status, '');
       });
     });

--- a/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list_test.js
@@ -41,6 +41,8 @@ module('Unit | Controller | authenticated/campaigns/list', function (hooks) {
         };
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageTitle, pageTitle);
       });
     });
@@ -70,6 +72,8 @@ module('Unit | Controller | authenticated/campaigns/list', function (hooks) {
         };
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageTitle, pageTitle);
       });
     });
@@ -84,6 +88,8 @@ module('Unit | Controller | authenticated/campaigns/list', function (hooks) {
       controller.send('updateCampaignStatus', 'someOtherStatus');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.status, 'someOtherStatus');
     });
   });

--- a/orga/tests/unit/controllers/authenticated/campaigns/profile_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/profile_test.js
@@ -13,6 +13,8 @@ module('Unit | Controller | authenticated/campaigns/participant-profile', functi
       },
     };
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(controller.pageTitle, 'Profil de Jaune attends');
   });
 });

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -27,6 +27,8 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
       await controller.onSelectDivision(event);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(controller.selectedDivision, event.target.value);
     });
   });

--- a/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-students/list_test.js
@@ -54,6 +54,8 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a>.</div>'
@@ -68,6 +70,8 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
@@ -82,6 +86,8 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
@@ -96,6 +102,8 @@ module('Unit | Controller | authenticated/sco-students/list', function (hooks) {
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'

--- a/orga/tests/unit/controllers/authenticated/sup-students/import_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-students/import_test.js
@@ -43,6 +43,8 @@ module('Unit | Controller | authenticated/sup-students/import', function (hooks)
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a></div>'
@@ -57,6 +59,8 @@ module('Unit | Controller | authenticated/sup-students/import', function (hooks)
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
@@ -71,6 +75,8 @@ module('Unit | Controller | authenticated/sup-students/import', function (hooks)
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
@@ -99,6 +105,8 @@ module('Unit | Controller | authenticated/sup-students/import', function (hooks)
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a></div>'
@@ -113,6 +121,8 @@ module('Unit | Controller | authenticated/sup-students/import', function (hooks)
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
@@ -127,6 +137,8 @@ module('Unit | Controller | authenticated/sup-students/import', function (hooks)
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'

--- a/orga/tests/unit/controllers/authenticated/team/list/members_test.js
+++ b/orga/tests/unit/controllers/authenticated/team/list/members_test.js
@@ -25,6 +25,8 @@ module('Unit | Controller | authenticated/team/list/members', function (hooks) {
       await controller.removeMembership(membership);
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(membership.organization, currentUser.organization);
     });
 

--- a/orga/tests/unit/helpers/display-campaign-errors_test.js
+++ b/orga/tests/unit/helpers/display-campaign-errors_test.js
@@ -12,6 +12,8 @@ module('Unit | Helper | display-campaign-errors', function (hooks) {
   module('when there is an error', function () {
     test('it returns the intlKey corresponding to the name error message', function (assert) {
       const nameErrors = [{ attribute: 'name', message: 'CAMPAIGN_NAME_IS_REQUIRED' }];
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(helper.compute([nameErrors]), 'Veuillez donner un nom à votre campagne.');
     });
   });
@@ -19,6 +21,8 @@ module('Unit | Helper | display-campaign-errors', function (hooks) {
   module('when there is no error', function () {
     test('it returns the intlKey corresponding to the type error message', function (assert) {
       const noError = [];
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(helper.compute([noError]), null);
     });
   });

--- a/orga/tests/unit/helpers/join_test.js
+++ b/orga/tests/unit/helpers/join_test.js
@@ -8,11 +8,15 @@ module('Unit | Helper | join', function (hooks) {
   module('join', () => {
     module('when there are several values', () => {
       test('it joins all values using the seperator', function (assert) {
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(join([['Un', 'Deux'], ', ']), 'Un, Deux');
       });
     });
     module('when there is only one value', () => {
       test('it returns the value', function (assert) {
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(join([['Un'], ', ']), 'Un');
       });
     });

--- a/orga/tests/unit/helpers/multiply_test.js
+++ b/orga/tests/unit/helpers/multiply_test.js
@@ -7,10 +7,14 @@ module('Unit | Helper | multiply', function (hooks) {
 
   module('multiply', () => {
     test('it multiply 10 by 2', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(multiply([10, 2]), 20);
     });
 
     test('it multiply 10 by 2 by 20', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(multiply([10, 2, 20]), 400);
     });
   });

--- a/orga/tests/unit/helpers/percentage_test.js
+++ b/orga/tests/unit/helpers/percentage_test.js
@@ -7,10 +7,14 @@ module('Unit | Helper | percentage', function (hooks) {
 
   module('percentage', () => {
     test('it multiply by 100 the given value', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(percentage([1]), 100);
     });
 
     test('it rounds the given value with one digit', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(percentage([0.088]), 8.8);
     });
   });

--- a/orga/tests/unit/helpers/sum_test.js
+++ b/orga/tests/unit/helpers/sum_test.js
@@ -7,10 +7,14 @@ module('Unit | Helper | sum', function (hooks) {
 
   module('sum', () => {
     test('it sum 10 and 2', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sum([10, 2]), 12);
     });
 
     test('it sum 10 and 2 and 20', function (assert) {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sum([10, 2, 20]), 32);
     });
   });

--- a/orga/tests/unit/models/campaign-assessment-participation-result_test.js
+++ b/orga/tests/unit/models/campaign-assessment-participation-result_test.js
@@ -25,8 +25,14 @@ module('Unit | Model | campaignAssessmentParticipationResult', function (hooks) 
       const sortedCompetenceResults = model.get('sortedCompetenceResults');
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sortedCompetenceResults[0].index, '1.1');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sortedCompetenceResults[1].index, '1.2');
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(sortedCompetenceResults[2].index, '4.1');
     });
   });

--- a/orga/tests/unit/models/campaign-profile_test.js
+++ b/orga/tests/unit/models/campaign-profile_test.js
@@ -18,9 +18,17 @@ module('Unit | Model | campaign-profile', function (hooks) {
 
     const sortedCompetences = model.get('sortedCompetences');
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sortedCompetences[0].index, '1.1');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sortedCompetences[1].index, '1.1.1');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sortedCompetences[2].index, '1.2');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(sortedCompetences[3].index, '2.1');
   });
 });

--- a/orga/tests/unit/models/campaign_test.js
+++ b/orga/tests/unit/models/campaign_test.js
@@ -10,7 +10,11 @@ module('Unit | Model | campaign', function (hooks) {
       name: 'Fake name',
       code: 'ABC123',
     });
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.name, 'Fake name');
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(model.code, 'ABC123');
   });
 
@@ -24,6 +28,8 @@ module('Unit | Model | campaign', function (hooks) {
         tokenForCampaignResults: 'token',
         type: 'ASSESSMENT',
       });
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results?accessToken=token');
     });
 
@@ -36,6 +42,8 @@ module('Unit | Model | campaign', function (hooks) {
         tokenForCampaignResults: 'token',
         type: 'PROFILES_COLLECTION',
       });
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(
         model.urlToResult,
         'http://localhost:3000/api/campaigns/1/csv-profiles-collection-results?accessToken=token'
@@ -55,6 +63,8 @@ module('Unit | Model | campaign', function (hooks) {
       const model = store.createRecord('campaign', { type: 'ASSESSMENT' });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.readableType, 'Évaluation');
     });
 
@@ -63,6 +73,8 @@ module('Unit | Model | campaign', function (hooks) {
       const model = store.createRecord('campaign', { type: 'PROFILES_COLLECTION' });
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.readableType, 'Collecte de profils');
     });
   });
@@ -113,6 +125,8 @@ module('Unit | Model | campaign', function (hooks) {
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('campaign', { ownerFirstName: 'Jean-Baptiste', ownerLastName: 'Poquelin' });
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(model.ownerFullName, 'Jean-Baptiste Poquelin');
     });
   });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
@@ -61,6 +61,8 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
 
       const participations = route.fetchResultMinimalList(params);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(participations, expectedParticipations);
     });
   });
@@ -70,12 +72,16 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
       test('it reset pageNumber', function (assert) {
         const controller = { pageNumber: 2 };
         route.resetController(controller, true);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 1);
       });
 
       test('it reset pageSize', function (assert) {
         const controller = { pageSize: 10 };
         route.resetController(controller, true);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 25);
       });
 
@@ -108,12 +114,16 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
       test('it does not reset pageNumber', function (assert) {
         const controller = { pageNumber: 2 };
         route.resetController(controller, false);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageNumber, 2);
       });
 
       test('it does not reset pageSize', function (assert) {
         const controller = { pageSize: 10 };
         route.resetController(controller, false);
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.pageSize, 10);
       });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
@@ -56,6 +56,8 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
 
       const summaries = route.fetchProfileSummaries(params);
 
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(summaries, expectedSummaries);
     });
   });
@@ -86,6 +88,8 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     module('when the transition comes from somewhere else', function () {
       test('if returns undefined', function (assert) {
         const transition = { from: { name: 'authenticated.campaigns.campaign' } };
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(route.loading(transition), undefined);
       });
     });
@@ -93,6 +97,8 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     module('when the transition has no from attribute', function () {
       test('if keeps loading page', function (assert) {
         const transition = {};
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(route.loading(transition), undefined);
       });
     });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
@@ -28,6 +28,8 @@ module('Unit | Route | authenticated/campaigns/campaign', function (hooks) {
     // then
     const expectedRedirection = 'not-found';
     route.replaceWith = (redirection) => {
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(redirection, expectedRedirection, `expect transition to ${expectedRedirection}, got ${redirection}`);
     };
 

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -45,6 +45,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUserService.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUserService.prescriber, connectedUser);
     });
 
@@ -64,6 +66,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUserService.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUserService.memberships, memberships);
     });
 
@@ -77,6 +81,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUserService.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUserService.organization, organization);
     });
 
@@ -247,6 +253,8 @@ module('Unit | Service | current-user', function (hooks) {
         await currentUserService.load();
 
         // then
+        // TODO: Fix this the next time the file is edited.
+        // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(currentUserService.organization.id, organization2.id);
       });
     });
@@ -265,6 +273,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.prescriber, null);
     });
   });
@@ -289,6 +299,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentUser.prescriber, null);
     });
   });
@@ -313,6 +325,8 @@ module('Unit | Service | current-user', function (hooks) {
       const result = await currentUser.load();
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(result, 'invalidate');
     });
   });

--- a/orga/tests/unit/services/error-messages_test.js
+++ b/orga/tests/unit/services/error-messages_test.js
@@ -12,6 +12,8 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage(undefined);
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(message, undefined);
   });
 
@@ -21,6 +23,8 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('UNKNOWN_ERROR_CODE');
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(message, undefined);
   });
 
@@ -30,6 +34,8 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(message, t('api-errors-messages.campaign-creation.name-required'));
   });
 
@@ -39,6 +45,8 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('FIELD_MIN_LENGTH', { line: 1, field: 'Boo', limit: 2 });
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(
       message,
       t('api-errors-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 })
@@ -51,6 +59,8 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('FIELD_BAD_VALUES', { line: 1, field: 'Boo', valids: ['A', 'B'] });
     // Then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(
       message,
       t('api-errors-messages.student-csv-import.field-bad-values', {

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -43,6 +43,8 @@ module('Unit | Service | url', function (hooks) {
       const campaignsRootUrl = service.campaignsRootUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(campaignsRootUrl, service.definedCampaignsRootUrl);
     });
 
@@ -57,6 +59,8 @@ module('Unit | Service | url', function (hooks) {
       const campaignsRootUrl = service.campaignsRootUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(campaignsRootUrl, expectedCampaignsRootUrl);
     });
   });
@@ -86,6 +90,8 @@ module('Unit | Service | url', function (hooks) {
       const homeUrl = service.homeUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(homeUrl, expectedHomeUrl);
     });
   });
@@ -101,6 +107,8 @@ module('Unit | Service | url', function (hooks) {
       const url = service.legalNoticeUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
 
@@ -115,6 +123,8 @@ module('Unit | Service | url', function (hooks) {
       const url = service.legalNoticeUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
 
@@ -129,6 +139,8 @@ module('Unit | Service | url', function (hooks) {
       const url = service.legalNoticeUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
   });
@@ -144,6 +156,8 @@ module('Unit | Service | url', function (hooks) {
       const url = service.accessibilityUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
 
@@ -158,6 +172,8 @@ module('Unit | Service | url', function (hooks) {
       const url = service.accessibilityUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
 
@@ -172,6 +188,8 @@ module('Unit | Service | url', function (hooks) {
       const url = service.accessibilityUrl;
 
       // then
+      // TODO: Fix this the next time the file is edited.
+      // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(url, expectedUrl);
     });
   });

--- a/orga/tests/unit/utils/input-validator_test.js
+++ b/orga/tests/unit/utils/input-validator_test.js
@@ -24,6 +24,8 @@ module('Unit | Utils | input validator', function (hooks) {
     // when
     validator.validate({ value: false, resetServerMessage: true });
 
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(validator.serverMessage, null);
   });
 
@@ -35,6 +37,8 @@ module('Unit | Utils | input validator', function (hooks) {
     validator.serverMessage = 'serverMessage';
 
     // then
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(validator.message, 'serverMessage');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La présence d'un test exclusif (`test.only('it shoud do foo)`, utile au développement, n'est pas interdit lors du merge car la CI ne sort pas en erreur; voir [l'issue](https://github.com/1024pix/pix/issues/3941). Une règle existe mais n'est pas disponible dans cette version.

## :robot: Solution
Mettre à jour `eslint-plugin-qunit` afin d'activer la règle concernée

## :rainbow: Remarques

### Activation de `qunit/no-assert-equal`
La règle `qunit/no-assert-equal`, ajoutée par la mise à jour de `eslint-plugin-qunit` (set  `recommended`),  lève trop d’erreurs pour être traité lors de cette PR.

Les violations existantes ont été ignorées grâce à la commande suivante
`npx suppress-eslint-errors ./tests/ --rules=qunit/no-assert-equal` 

Elle ajoute l'exception suivante:
`// TODO: Fix this the next time the file is edited.
 // eslint-disable-next-line qunit/no-assert-equal`

### Périmètre
`eslint-plugin-qunit` n'a pas été mis à jour sur `mon-pix` car la librairie de test est Mocha

## :100: Pour tester
Ajouter un `test.only` sur un des test d'orga, certif ou admin, lancer la commande de lint et vérifier que la CI sort en échec.
