### PR TITLE
[TECH] Détecter et interdire les eslint-disable inutiles

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,7 @@
 extends:
   - 'eslint:recommended'
   - 'plugin:yml/standard'
+  - 'plugin:eslint-comments/recommended'
 root: true
 parserOptions:
   ecmaVersion: 2018
@@ -19,6 +20,8 @@ rules:
     - error
     - never
   eol-last:
+    - error
+  eslint-comments/no-unused-disable:
     - error
   indent:
     - error

--- a/admin/app/components/certification-centers/information.js
+++ b/admin/app/components/certification-centers/information.js
@@ -1,5 +1,5 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
 import Component from '@glimmer/component';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import Object, { action, computed } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/admin/app/components/certifications/list-select-all.js
+++ b/admin/app/components/certifications/list-select-all.js
@@ -1,11 +1,9 @@
-/* eslint-disable ember/no-actions-hash */
-/* eslint-disable ember/require-tagless-components */
-/* eslint-disable ember/no-classic-classes */
-/* eslint-disable ember/no-classic-components */
-
+// eslint-disable-next-line ember/no-classic-components
 import Component from '@ember/component';
 
+// eslint-disable-next-line ember/no-classic-classes, ember/require-tagless-components
 export default Component.extend({
+  // eslint-disable-next-line ember/no-actions-hash
   actions: {
     onToggleAllSelection() {
       this.toggleAllSelection();

--- a/admin/app/components/users/user-detail-personal-information.js
+++ b/admin/app/components/users/user-detail-personal-information.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
@@ -23,6 +21,7 @@ export default class ListController extends Controller {
     const value = event.target.value;
     this.pendingFilters[fieldName] = value;
     yield timeout(this.DEBOUNCE_MS);
+    // eslint-disable-next-line ember/classic-decorator-no-classic-methods
     this.setProperties(this.pendingFilters);
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;

--- a/admin/app/controllers/authenticated/certifications/certification/details.js
+++ b/admin/app/controllers/authenticated/certifications/certification/details.js
@@ -1,8 +1,6 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { schedule } from '@ember/runloop';
@@ -28,11 +26,14 @@ export default class CertificationDetailsController extends Controller {
     const competences = this.details.competences;
     const { good, count, jury } = _getCertificationResultsAfterJuryUpdate(competences);
 
+    /* eslint-disable ember/classic-decorator-no-classic-methods */
     if (jury) {
       this.set('juryRate', Math.round((good * 10000) / count) / 100);
     } else {
       this.set('juryRate', false);
     }
+    /* eslint-enable ember/classic-decorator-no-classic-methods */
+
     // TODO: find a better way
     schedule('afterRender', this, () => {
       const score = this.score;
@@ -42,11 +43,13 @@ export default class CertificationDetailsController extends Controller {
         value += isJuryScoreCorrect ? competence.juryScore : competence.obtainedScore;
         return value;
       }, 0);
+      /* eslint-disable ember/classic-decorator-no-classic-methods */
       if (newScore !== score) {
         this.set('juryScore', newScore);
       } else {
         this.set('juryScore', false);
       }
+      /* eslint-enable ember/classic-decorator-no-classic-methods */
     });
   }
 

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -1,9 +1,9 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import { A } from '@ember/array';
 import Controller from '@ember/controller';
+/* eslint-disable ember/no-computed-properties-in-native-classes */
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+/* eslint-enable ember/no-computed-properties-in-native-classes */
 import { inject as service } from '@ember/service';
 import { schedule } from '@ember/runloop';
 import cloneDeep from 'lodash/cloneDeep';

--- a/admin/app/controllers/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/controllers/authenticated/certifications/certification/neutralization.js
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import Controller from '@ember/controller';
 import { action, set } from '@ember/object';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 

--- a/admin/app/controllers/authenticated/organizations/get/invitations.js
+++ b/admin/app/controllers/authenticated/organizations/get/invitations.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -26,6 +24,7 @@ export default class GetTeamController extends Controller {
   @service notifications;
 
   updateFilters() {
+    // eslint-disable-next-line ember/classic-decorator-no-classic-methods
     this.setProperties(this.pendingFilters);
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;

--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
@@ -52,6 +50,7 @@ export default class AuthenticatedSessionsListAllController extends Controller {
     this.pendingFilters[fieldName] = value;
     yield timeout(debounceDuration);
 
+    // eslint-disable-next-line ember/classic-decorator-no-classic-methods
     this.setProperties(this.pendingFilters);
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -1,8 +1,7 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 
 export default class AuthenticatedSessionsWithRequiredActionListController extends Controller {

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -1,10 +1,9 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import some from 'lodash/some';
 
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { action, computed } from '@ember/object';
 
 export default class ListController extends Controller {

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/controllers/authenticated/target-profiles/list.js
+++ b/admin/app/controllers/authenticated/target-profiles/list.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
@@ -21,6 +19,7 @@ export default class ListController extends Controller {
     const value = event.target.value;
     this.pendingFilters[fieldName] = value;
     yield timeout(this.DEBOUNCE_MS);
+    // eslint-disable-next-line ember/classic-decorator-no-classic-methods
     this.setProperties(this.pendingFilters);
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;

--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods */
-
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import debounce from 'lodash/debounce';

--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -1,5 +1,4 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import Model, { attr, hasMany } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -1,5 +1,4 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 import find from 'lodash/find';

--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -1,5 +1,4 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import Model, { belongsTo, attr } from '@ember-data/model';
 

--- a/admin/app/models/organization-invitation.js
+++ b/admin/app/models/organization-invitation.js
@@ -1,6 +1,5 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import Model, { belongsTo, attr } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { equal } from '@ember/object/computed';
 
 export default class OrganizationInvitation extends Model {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import { memberAction } from 'ember-api-actions';
 import Model, { hasMany, attr } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { equal } from '@ember/object/computed';
 
 export default class Organization extends Model {

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,11 +1,10 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import some from 'lodash/some';
 import trim from 'lodash/trim';
 
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import { memberAction } from 'ember-api-actions';
 

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -1,6 +1,5 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes */
-
 import Model, { hasMany, attr } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 
 export default class User extends Model {

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-hooks */
-
 import EmberRouter from '@ember/routing/router';
 import config from 'pix-admin/config/environment';
 
@@ -7,6 +5,7 @@ class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 
+  // eslint-disable-next-line ember/classic-decorator-hooks
   init() {
     super.init(...arguments);
     this.on('routeDidChange', () => {

--- a/admin/app/routes/authenticated/certifications/certification/informations.js
+++ b/admin/app/routes/authenticated/certifications/certification/informations.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-controller-access-in-routes */
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import RSVP from 'rsvp';
@@ -22,11 +21,13 @@ export default class CertificationInformationsRoute extends Route {
 
   @action
   willTransition(transition) {
+    /* eslint-disable ember/no-controller-access-in-routes */
     if (this.controller.edition && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else {
       this.controller.edition = false;
       return true;
     }
+    /* eslint-enable ember/no-controller-access-in-routes */
   }
 }

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-sync */
-
 const isNil = require('lodash/isNil');
 const isUndefined = require('lodash/isUndefined');
 
@@ -26,6 +24,7 @@ function _buildPixAuthenticationMethod({
   createdAt,
   updatedAt,
 } = {}) {
+  // eslint-disable-next-line no-sync
   const hashedPassword = encrypt.hashPasswordSync(rawPassword);
 
   const values = {

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -97,7 +97,7 @@ async function emptyAllTables() {
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
 
   const query = _dbSpecificQueries.emptyTableQuery;
-  // eslint-disable-next-line knex/avoid-injections,no-restricted-syntax
+  // eslint-disable-next-line knex/avoid-injections
   return knex.raw(`${query}${tables}`);
 }
 

--- a/api/lib/application/preHandlers/assessment-authorization.js
+++ b/api/lib/application/preHandlers/assessment-authorization.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax */
-
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
 const validationErrorSerializer = require('../../infrastructure/serializers/jsonapi/validation-error-serializer');
 const { extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
@@ -7,6 +5,7 @@ const { extractUserIdFromRequest } = require('../../infrastructure/utils/request
 module.exports = {
   verify(request, h) {
     const userId = extractUserIdFromRequest(request);
+    // eslint-disable-next-line no-restricted-syntax
     const assessmentId = parseInt(request.params.id);
 
     return assessmentRepository.getByAssessmentIdAndUserId(assessmentId, userId).catch(() => {

--- a/api/lib/application/preHandlers/assessment-supervisor-authorization.js
+++ b/api/lib/application/preHandlers/assessment-supervisor-authorization.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax */
-
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
 const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository');
 const supervisorAccessRepository = require('../../infrastructure/repositories/supervisor-access-repository');
@@ -9,6 +7,7 @@ const { extractUserIdFromRequest } = require('../../infrastructure/utils/request
 module.exports = {
   async verify(request, h) {
     const userId = extractUserIdFromRequest(request);
+    // eslint-disable-next-line no-restricted-syntax
     const candidateId = parseInt(request.params.id);
     const assessment = await assessmentRepository.getByCertificationCandidateId(candidateId);
     const certificationCourse = await certificationCourseRepository.get(assessment.certificationCourseId);

--- a/api/lib/application/preHandlers/user-existence-verification.js
+++ b/api/lib/application/preHandlers/user-existence-verification.js
@@ -1,11 +1,10 @@
-/* eslint-disable no-restricted-syntax */
 const userRepository = require('../../../lib/infrastructure/repositories/user-repository');
 const errorSerializer = require('../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 const { UserNotFoundError } = require('../../domain/errors');
 
 module.exports = {
   verifyById(request, h) {
-    return userRepository.get(parseInt(request.params.id)).catch((err) => {
+    return userRepository.get(request.params.id).catch((err) => {
       if (err instanceof UserNotFoundError) {
         const serializedError = errorSerializer.serialize(new UserNotFoundError().getErrorMessage());
         return h.response(serializedError).code(404).takeover();

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -242,6 +242,8 @@ async function checkUserIsMemberOfAnOrganization(request, h) {
   return _replyForbiddenError(h);
 }
 
+/* eslint-enable no-restricted-syntax */
+
 module.exports = {
   checkRequestedUserIsAuthenticatedUser,
   checkUserBelongsToOrganizationOrHasRolePixMaster,

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 const { AssessmentEndedError } = require('../errors');
 const smartRandom = require('../services/algorithm-methods/smart-random');
 const flash = require('../services/algorithm-methods/flash');

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -1,16 +1,10 @@
-/* eslint-disable no-unused-vars */
 const { AssessmentEndedError, UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 const smartRandom = require('../services/algorithm-methods/smart-random');
 const dataFetcher = require('../services/algorithm-methods/data-fetcher');
 
 module.exports = async function getNextChallengeForCompetenceEvaluation({
-  knowledgeElementRepository,
-  challengeRepository,
-  answerRepository,
-  skillRepository,
   pickChallengeService,
-  improvementService,
   assessment,
   userId,
   locale,

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -56,7 +56,6 @@ function _findByUserId({ userId }) {
 }
 
 function _computeCampaignParticipationState() {
-  // eslint-disable-next-line no-restricted-syntax
   return knex.raw(
     `
   CASE

--- a/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -24,7 +24,6 @@ const CampaignParticipationsStatsRepository = {
 };
 
 async function _getCumulativeParticipationCountsByDay(campaignId, column) {
-  // eslint-disable-next-line knex/avoid-injections
   const { rows: data } = await knex.raw(
     `
     SELECT CAST(:column: AS DATE) AS "day", SUM(COUNT(*)) OVER (ORDER BY CAST(:column: AS DATE)) AS "count"

--- a/api/lib/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-to-join-repository.js
@@ -47,7 +47,7 @@ module.exports = {
         targetProfileImageUrl: 'target-profiles.imageUrl',
         targetProfileIsSimplifiedAccess: 'target-profiles.isSimplifiedAccess',
       })
-      // eslint-disable-next-line no-restricted-syntax
+
       .select(
         knex.raw(`EXISTS(SELECT true FROM "organization-tags"
         JOIN tags ON "organization-tags"."tagId" = "tags".id

--- a/api/scripts/add-tags-to-organizations.js
+++ b/api/scripts/add-tags-to-organizations.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Usage: node add-tags-to-organizations.js path/file.csv
 // To use on file with columns |organizationId, tagName|
 

--- a/api/scripts/create-or-update-sco-agri-organizations.js
+++ b/api/scripts/create-or-update-sco-agri-organizations.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Usage: scalingo scalingo --region osc-secnum-fr1 -a pix-api-production run --file file.csv node scripts/create-or-update-sco-agri-organizations.js /tmp/uploads/file.csv
 // To use on file with columns |externalId, name, email| (email is optional)
 

--- a/api/scripts/create-or-update-sco-organizations.js
+++ b/api/scripts/create-or-update-sco-organizations.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Usage: BASE_URL=... PIXMASTER_EMAIL=... PIXMASTER_PASSWORD=... node create-or-update-sco-organizations.js path/file.csv
 // To use on file with columns |externalId, name|
 

--- a/api/scripts/create-pro-organizations-with-tags.js
+++ b/api/scripts/create-pro-organizations-with-tags.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 // Usage: node create-pro-organizations-with-tags.js path/file.csv
 // To use on file with columns |externalId, name, provinceCode, canCollectProfiles, credit, email, organizationInvitationRole, locale, tags, createdBy|
 

--- a/api/scripts/generate-certification-test-statistics.js
+++ b/api/scripts/generate-certification-test-statistics.js
@@ -28,7 +28,6 @@ function makeRefDataFaster() {
 makeRefDataFaster();
 
 async function _retrieveUserIds() {
-  // eslint-disable-next-line no-restricted-syntax
   const result = await knex.raw(
     `
     SELECT "users"."id"

--- a/api/scripts/get-next-commit-subject.js
+++ b/api/scripts/get-next-commit-subject.js
@@ -19,7 +19,6 @@
  * My awesome commit -> [pi-123] My awesome commit
  */
 
-/* eslint-disable no-console */
 module.exports = function getNextCommitSubject(messageTitle, branchName) {
   const startsWithBraces = (str) => str.match(/^\[[^\]]/);
   const startsWithMergeBranch = (str) => str.indexOf('Merge branch') === 0;

--- a/api/scripts/import-certification-cpf-cities.js
+++ b/api/scripts/import-certification-cpf-cities.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-console */
 // Usage: node import-certification-cpf-cities path/file.csv
 // File downloaded from https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/
 

--- a/api/scripts/import-certification-cpf-countries.js
+++ b/api/scripts/import-certification-cpf-countries.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-console */
 // Usage: node import-certification-cpf-countries.js path/file.csv
 // File Millésime 2021 : Liste des pays et territoires étrangers au 01/01/2021
 // downloaded from https://www.data.gouv.fr/fr/datasets/code-officiel-geographique-cog/

--- a/api/scripts/prod/add-target-profile-shares-to-organizations.js
+++ b/api/scripts/prod/add-target-profile-shares-to-organizations.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Usage: node add-target-profile-shares-to-organizations.js path/file.csv
 // To use on file with columns |externalId, targetProfileId-targetProfileId-targetProfileId|
 

--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -1,5 +1,5 @@
 // Usage: node compute-participation-results.js
-/* eslint-disable no-restricted-syntax */
+
 require('dotenv').config({ path: `${__dirname}/../../.env` });
 
 const knowlegeElementSnapshotRepository = require('../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');

--- a/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
+++ b/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Usage: BASE_URL=... PIXMASTER_EMAIL=... PIXMASTER_PASSWORD=... node update-sco-organizations-with-is-managing-students-to-true.js path/file.csv
 // To use on file with columns |externalId|
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-sync */
-
 const each = require('lodash/each');
 const map = require('lodash/map');
 const times = require('lodash/times');

--- a/api/tests/integration/scripts/populate-organizations-email_test.js
+++ b/api/tests/integration/scripts/populate-organizations-email_test.js
@@ -10,7 +10,7 @@ describe('Integration | Scripts | populate-organizations-email.js', function () 
     beforeEach(async function () {
       databaseBuilder.factory.buildOrganization({ externalId: externalId1, email: 'first.last@example.net' });
       databaseBuilder.factory.buildOrganization({ externalId: externalId2 });
-      // eslint-disable-next-line no-console
+
       sinon.stub(console, 'error');
 
       await databaseBuilder.commit();

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,5 +1,3 @@
-/* eslint-disable mocha/no-exports, mocha/no-top-level-hooks */
-
 const _ = require('lodash');
 const chai = require('chai');
 const expect = chai.expect;
@@ -26,6 +24,7 @@ const tokenService = require('../lib/domain/services/token-service');
 const Membership = require('../lib/domain/models/Membership');
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
 
+/* eslint-disable mocha/no-top-level-hooks */
 afterEach(function () {
   sinon.restore();
   cache.flushAll();
@@ -36,6 +35,7 @@ afterEach(function () {
 after(function () {
   return disconnect();
 });
+/* eslint-enable mocha/no-top-level-hooks */
 
 function generateValidRequestAuthorizationHeader(userId = 1234, source = 'pix') {
   const accessToken = tokenService.createAccessTokenFromUser(userId, source).accessToken;
@@ -208,6 +208,7 @@ global.chaiErr = function globalErr(fn, val) {
   throw new chai.AssertionError('Expected an error');
 };
 
+// eslint-disable-next-line mocha/no-exports
 module.exports = {
   EMPTY_BLANK_AND_NULL,
   expect,

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-sync */
 const isUndefined = require('lodash/isUndefined');
 
 const encrypt = require('../../../../lib/domain/services/encryption-service');
@@ -45,6 +44,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword = function ({
   createdAt,
   updatedAt,
 } = {}) {
+  // eslint-disable-next-line no-sync
   const password = encrypt.hashPasswordSync(rawPassword);
   userId = isUndefined(userId) ? _buildUser().id : userId;
 

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -295,7 +295,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
             courseId: 'courseId',
             userId: 5,
             // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
+
             type: Assessment.types.COMPETENCE_EVALUATION,
             state: 'completed',
           });

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1295,79 +1295,78 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
   context('#resolve', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
-      // eslint-disable-next-line mocha/no-setup-in-describe
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
         strategyToBeApplied: 'doNotResolve',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
         strategyToBeApplied: 'doNotResolve',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
         strategyToBeApplied: 'doNotResolve',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
         strategyToBeApplied: 'doNotResolve',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
         strategyToBeApplied: 'neutralizeIfImage',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.LINK_NOT_WORKING,
         strategyToBeApplied: 'doNotResolve',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
         strategyToBeApplied: 'neutralizeIfEmbed',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
         strategyToBeApplied: 'neutralizeIfAttachment',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
         strategyToBeApplied: 'neutralizeIfTimedChallenge',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
         strategyToBeApplied: 'neutralizeWithoutChecking',
       },
-      // eslint-disable-next-line mocha/no-setup-in-describe
+
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.OTHER,

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -136,7 +136,7 @@ describe('Unit | Domain | Models | CertificationResult', function () {
           assessmentResultStatus: CertificationResult.status.ERROR,
           validationFunction: 'isInError',
         },
-        // eslint-disable-next-line mocha/no-setup-in-describe
+
         { statusName: 'started', isCancelled: false, assessmentResultStatus: null, validationFunction: 'isStarted' },
       ].forEach(function (testCase) {
         it(`should build a ${testCase.statusName} CertificationResult`, async function () {

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -10,7 +10,7 @@ describe('Unit | Service | Encryption', function () {
       it('should resolve to undefined', async function () {
         // given
         const password = 'my-real-password';
-        /* eslint-disable no-sync */
+        // eslint-disable-next-line no-sync
         const passwordHash = bcrypt.hashSync(password, 1);
 
         // when
@@ -45,7 +45,7 @@ describe('Unit | Service | Encryption', function () {
       it('should reject, but not a PasswordNotMatching error ', async function () {
         // given
         const password = undefined;
-        /* eslint-disable no-sync */
+        // eslint-disable-next-line no-sync
         const passwordHash = bcrypt.hashSync('my-real-password', 1);
 
         try {

--- a/api/tests/unit/domain/validators/stage-validator_test.js
+++ b/api/tests/unit/domain/validators/stage-validator_test.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-identical-title */
 const { expect, catchErr } = require('../../../test-helper');
 
 const Stage = require('../../../../lib/domain/models/Stage');

--- a/api/tests/unit/domain/validators/user-validator_test.js
+++ b/api/tests/unit/domain/validators/user-validator_test.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-identical-title */
 const { expect, catchErr } = require('../../../test-helper');
 
 const User = require('../../../../lib/domain/models/User');

--- a/certif/app/components/app-modal.js
+++ b/certif/app/components/app-modal.js
@@ -1,8 +1,8 @@
-/* eslint-disable ember/require-tagless-components,ember/no-component-lifecycle-hooks,ember/no-actions-hash*/
 import { on } from '@ember/object/evented';
 import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
 import { EKMixin as EmberKeyboardMixin, keyUp } from 'ember-keyboard';
 
+// eslint-disable-next-line ember/require-tagless-components
 export default ModalDialog.extend(EmberKeyboardMixin, {
   translucentOverlay: true,
   targetAttachment: 'none',
@@ -18,6 +18,7 @@ export default ModalDialog.extend(EmberKeyboardMixin, {
     this.set('keyboardActivated', true);
   },
 
+  // eslint-disable-next-line ember/no-component-lifecycle-hooks
   didRender() {
     this._super(...arguments);
     document.querySelector('#modal-overlays').classList.add('active');
@@ -25,6 +26,7 @@ export default ModalDialog.extend(EmberKeyboardMixin, {
     document.body.style.overflowY = 'hidden';
   },
 
+  // eslint-disable-next-line ember/no-component-lifecycle-hooks
   willDestroyElement() {
     document.querySelector('#modal-overlays').classList.remove('active');
     document.body.classList.remove('centered-modal-showing');
@@ -43,6 +45,7 @@ export default ModalDialog.extend(EmberKeyboardMixin, {
   // We can remove it after upgrading to a stable version of ember-modal-dialog (> v3.0.0-beta.3)
   //
   // cf. https://github.com/yapplabs/ember-modal-dialog/blob/26b3a89bab37bc584c3a3e9a221f1de4bb9ff979/addon/components/modal-dialog.js#L107-L114
+  // eslint-disable-next-line ember/no-actions-hash
   actions: {
     onClickOverlay(e) {
       e.preventDefault();

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -1,9 +1,9 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+/* eslint-disable ember/no-computed-properties-in-native-classes*/
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+/* eslint-enable ember/no-computed-properties-in-native-classes*/
 
 export default class SessionsDetailsController extends Controller {
   @service currentUser;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -1,9 +1,9 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Controller from '@ember/controller';
-import { alias } from '@ember/object/computed';
 import every from 'lodash/every';
+/* eslint-disable ember/no-computed-properties-in-native-classes*/
+import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
+/* eslint-enable ember/no-computed-properties-in-native-classes*/
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -1,10 +1,10 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+/* eslint-disable ember/no-computed-properties-in-native-classes*/
 import { alias } from '@ember/object/computed';
-import { tracked } from '@glimmer/tracking';
 import { computed } from '@ember/object';
+/* eslint-enable ember/no-computed-properties-in-native-classes*/
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class SessionParametersController extends Controller {

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -1,8 +1,7 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import sumBy from 'lodash/sumBy';

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 
 export default class SessionsNewController extends Controller {

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -1,7 +1,6 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 
 export default class SessionsUpdateController extends Controller {

--- a/certif/app/models/certification-report.js
+++ b/certif/app/models/certification-report.js
@@ -1,6 +1,5 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Model, { attr, hasMany } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import { memberAction } from 'ember-api-actions';
 

--- a/certif/app/models/session-summary.js
+++ b/certif/app/models/session-summary.js
@@ -1,6 +1,5 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Model, { attr } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 
 export default class Session extends Model {

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -1,6 +1,5 @@
-/* eslint-disable ember/no-computed-properties-in-native-classes*/
-
 import Model, { attr, hasMany } from '@ember-data/model';
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import ENV from 'pix-certif/config/environment';

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/no-controller-access-in-routes*/
-
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -57,6 +55,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
   setupController(controller, model) {
     super.setupController(controller, model);
 
+    // eslint-disable-next-line ember/no-controller-access-in-routes
     this.controllerFor('authenticated.sessions.add-student').set('returnToSessionCandidates', (sessionId) =>
       this.transitionTo('authenticated.sessions.details.certification-candidates', sessionId)
     );

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/classic-decorator-no-classic-methods*/
-
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import EmberObject from '@ember/object';
@@ -24,6 +22,7 @@ export default class SessionsDetailsRoute extends Route {
       certificationCandidates,
       async reloadCertificationCandidate() {
         const certificationCandidates = await loadCertificationCandidates();
+        // eslint-disable-next-line ember/classic-decorator-no-classic-methods
         this.set('certificationCandidates', certificationCandidates);
       },
     });

--- a/certif/app/routes/authenticated/sessions/new.js
+++ b/certif/app/routes/authenticated/sessions/new.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/no-controller-access-in-routes*/
-
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -17,8 +15,10 @@ export default class SessionsNewRoute extends Route {
   }
 
   deactivate() {
+    /* eslint-disable ember/no-controller-access-in-routes*/
     if (this.controller.model.hasDirtyAttributes) {
       this.controller.model.deleteRecord();
     }
+    /* eslint-enable ember/no-controller-access-in-routes*/
   }
 }

--- a/certif/app/routes/authenticated/sessions/update.js
+++ b/certif/app/routes/authenticated/sessions/update.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/no-controller-access-in-routes*/
-
 import Route from '@ember/routing/route';
 import moment from 'moment';
 import { inject as service } from '@ember/service';
@@ -22,6 +20,7 @@ export default class SessionsUpdateRoute extends Route {
   }
 
   deactivate() {
+    // eslint-disable-next-line ember/no-controller-access-in-routes
     this.controller.model.rollbackAttributes();
   }
 }

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/no-classic-classes,ember/require-tagless-components*/
-
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillIn, render } from '@ember/test-helpers';
@@ -20,6 +18,7 @@ module('Integration | Component | login-form', function (hooks) {
   let sessionStub;
 
   hooks.beforeEach(function () {
+    // eslint-disable-next-line ember/no-classic-classes, ember/require-tagless-components
     sessionStub = Service.extend({});
     this.owner.register('service:session', sessionStub);
   });

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -18,7 +18,6 @@ export default class Router extends EmberRouter {
   }
 }
 
-/* eslint-disable max-statements */
 Router.map(function () {
   this.route('index', { path: '/' });
   this.route('inscription');

--- a/orga/app/utils/email-validator.js
+++ b/orga/app/utils/email-validator.js
@@ -1,11 +1,10 @@
-/* eslint-disable no-useless-escape */
 export default function isEmailValid(email) {
   if (!email) {
     return false;
   }
   // From http://stackoverflow.com/a/46181/5430854
-  // eslint-disable-next-line no-useless-escape
   const pattern =
+    // eslint-disable-next-line no-useless-escape
     /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
   return pattern.test(email.trim());
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1404,19 +1404,18 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -1433,31 +1432,10 @@
             "uri-js": "^4.2.2"
           }
         },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -1576,6 +1554,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-1.1.0.tgz",
       "integrity": "sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==",
+      "dev": true
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "@jest/types": {
@@ -2045,9 +2040,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -4667,14 +4662,6 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-          "dev": true
-        }
       }
     },
     "ensure-posix-path": {
@@ -4808,29 +4795,32 @@
       }
     },
     "eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -4838,7 +4828,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -4847,11 +4837,17 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4862,9 +4858,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -4897,31 +4893,31 @@
             "which": "^2.0.1"
           }
         },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "is-glob": "^4.0.1"
           }
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "path-key": {
@@ -4931,9 +4927,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4955,12 +4951,12 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -4980,6 +4976,24 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        }
+      }
+    },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
         }
       }
     },
@@ -5033,9 +5047,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
     "espree": {
@@ -5072,9 +5086,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -5491,9 +5505,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
     "flush-write-stream": {
@@ -5807,12 +5821,12 @@
       }
     },
     "globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       }
     },
     "globby": {
@@ -6490,9 +6504,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -6704,6 +6718,12 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
@@ -6720,6 +6740,12 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -8013,9 +8039,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -8243,9 +8269,9 @@
       }
     },
     "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "regexpu-core": {
@@ -9228,21 +9254,22 @@
       }
     },
     "table": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
-      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dev": true,
       "requires": {
-        "ajv": "^7.0.2",
-        "lodash": "^4.17.20",
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
-          "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -9250,6 +9277,12 @@
             "require-from-string": "^2.0.2",
             "uri-js": "^4.2.2"
           }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
@@ -9263,11 +9296,25 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
         }
       }
     },
@@ -9623,9 +9670,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
     "typedarray": {
@@ -9828,9 +9875,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "@1024pix/ember-testing-library": "^0.4.1",
     "chai": "^4.3.0",
     "ember-template-lint": "^3.7.0",
-    "eslint": "^7.20.0",
+    "eslint": "^7.32.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-yml": "^0.10.1",
     "mocha": "^8.3.0"

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable no-console */
 const axios = require('axios');
 
 const JIRA_API_VERSION = '2';


### PR DESCRIPTION
## :unicorn: Problème

Certains commentaires `eslint-disable` sont inutiles, car le code sur lequel ils sont appliqués respectent les règles désactivées.

## :robot: Solution

Ajouter le plugin [eslint-plugin-eslint-comments](https://mysticatea.github.io/eslint-plugin-eslint-comments/) pour détecter et interdire les commentaires `eslint-disable` inutiles.

## :rainbow: Remarques

Le plugin apporte plusieurs nouvelles règles, notamment [eslint-comments/disable-enable-pair](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html) qui interdit les commentaires `eslint-disable` s'appliquant sur tout un fichier ou tout le reste d'un fichier, et incite donc à faire des `eslint-disable` plus précis.

Pas de modification de code dans cette PR, à l'exception de [api/lib/application/preHandlers/user-existence-verification.js](https://github.com/1024pix/pix/pull/3960/files#diff-d2bc19f1b59fde5ee5768b856ec45cfb54194cb8debbce157cfabccffc25d497) ou on a supprimé un appel inutile à `parseInt()` après vérification, il pourrait être intéressant de faire la même chose dans les autres fichiers concernés dans une autre PR.

## :100: Pour tester

Éventuellement vérifier la réinitialisation de mot de passe sur mon-pix, qui est la seule partie du code modifiée dans cette PR.
