### PR TITLE
[FEATURE] Script pour corriger les infos persos des d'étudiants d'une université  (PIX-4160)

### DIFF
--- a/api/scripts/update-certification-infos.js
+++ b/api/scripts/update-certification-infos.js
@@ -55,7 +55,7 @@ async function updateCertificationInfos(dataFilePath, sessionIdsFilePath) {
         const certificationCourse = await trx
           .select('id', 'userId')
           .from('certification-courses')
-          .where({ externalId })
+          .where({ externalId: `${externalId}` })
           .whereInArray('sessionId', sessionIds)
           .first();
 

--- a/api/scripts/update-certification-infos.js
+++ b/api/scripts/update-certification-infos.js
@@ -1,0 +1,89 @@
+require('dotenv').config({ path: `${__dirname}/../.env` });
+
+const logger = require('../lib/infrastructure/logger');
+// Usage: node scripts/update-certifications-infos path/file.csv
+
+('use strict');
+const { parseCsv, checkCsvHeader } = require('./helpers/csvHelpers');
+const { knex } = require('../db/knex-database-connection');
+const values = require('lodash/values');
+
+const headers = {
+  externalId: 'externalId',
+  birthdate: 'birthdate',
+  birthINSEECode: 'birthINSEECode',
+  birthPostalCode: 'birthPostalCode',
+  birthCity: 'birthCity',
+  birthCountry: 'birthCountry',
+};
+
+async function main(filePath) {
+  logger.info('Starting script update-certifications-infos');
+
+  logger.trace(`Checking ${filePath} data file...`);
+  await checkCsvHeader({ filePath, requiredFieldNames: values(headers) });
+  logger.info('✅');
+
+  logger.info('Reading and parsing csv data file... ');
+  const csvData = await parseCsv(filePath, { header: true, delimiter: ',', skipEmptyLines: true });
+  logger.info('✅');
+
+  logger.info('Updating data in database... ');
+
+  const trx = await knex.transaction();
+
+  try {
+    for (const row of csvData) {
+      const { birthdate, birthINSEECode, birthPostalCode, birthCity, birthCountry, externalId } = row;
+      const { id, userId } = await trx
+        .select('id', 'userId')
+        .from('certification-courses')
+        .where({ externalId })
+        .first();
+
+      await trx
+        .table('certification-courses')
+        .update({
+          birthdate,
+          birthplace: birthCity,
+          birthPostalCode,
+          birthINSEECode,
+          birthCountry,
+        })
+        .where({ id });
+
+      await trx
+        .table('certification-candidates')
+        .update({
+          birthdate,
+          birthINSEECode,
+          birthPostalCode,
+          birthCity,
+          birthCountry,
+        })
+        .where({ externalId, userId });
+    }
+
+    trx.commit();
+    logger.info('✅');
+  } catch (error) {
+    if (trx) {
+      trx.rollback();
+    }
+    logger.error(error);
+    process.exit(1);
+  }
+
+  logger.info('Done.');
+}
+
+if (require.main === module) {
+  const filePath = process.argv[2];
+  main(filePath).then(
+    () => process.exit(0),
+    (err) => {
+      logger.error(err);
+      process.exit(1);
+    }
+  );
+}

--- a/api/scripts/update-certification-infos.js
+++ b/api/scripts/update-certification-infos.js
@@ -18,7 +18,7 @@ const headers = {
   birthCountry: 'birthCountry',
 };
 
-async function main(filePath) {
+async function updateCertificationInfos(filePath) {
   logger.info('Starting script update-certifications-infos');
 
   logger.trace(`Checking ${filePath} data file...`);
@@ -44,7 +44,7 @@ async function main(filePath) {
           .first();
 
         if (!certificationCourse) {
-          logger.error(`Certification for external id ${externalId} not found`);
+          logger.warn(`Certification for external id ${externalId} not found`);
           return;
         }
 
@@ -89,7 +89,7 @@ async function main(filePath) {
 
 if (require.main === module) {
   const filePath = process.argv[2];
-  main(filePath).then(
+  updateCertificationInfos(filePath).then(
     () => process.exit(0),
     (err) => {
       logger.error(err);
@@ -97,3 +97,8 @@ if (require.main === module) {
     }
   );
 }
+
+module.exports = {
+  updateCertificationInfos,
+  headers,
+};

--- a/api/tests/acceptance/scripts/update-certification-infos_test.js
+++ b/api/tests/acceptance/scripts/update-certification-infos_test.js
@@ -1,0 +1,152 @@
+const { expect, databaseBuilder, knex, sinon } = require('../../test-helper');
+const { writeFile, rm } = require('fs/promises');
+const values = require('lodash/values');
+const logger = require('../../../lib/infrastructure/logger');
+const { updateCertificationInfos, headers } = require('../../../scripts/update-certification-infos');
+const dataFile = `${__dirname}/data.csv`;
+
+describe('Acceptance | Scripts | update-certification-infos', function () {
+  describe('#updateCertificationInfos', function () {
+    afterEach(function () {
+      return rm(dataFile);
+    });
+
+    it('should update course and candidate by external id', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 5,
+        externalId: '123',
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildCertificationCandidate({
+        id: 50,
+        externalId: '123',
+        userId: user.id,
+      });
+
+      await databaseBuilder.commit();
+
+      await _createDataFile(dataFile, [
+        {
+          externalId: '123',
+          birthdate: '2000-12-31',
+          birthINSEECode: 'inseeUPDATED123',
+          birthPostalCode: 'postalUPDATED123',
+          birthCity: 'cityUPDATED123',
+          birthCountry: 'countryUPDATED123',
+        },
+      ]);
+      await updateCertificationInfos(dataFile);
+      const certificationCandidates = await _getCertificationCandidates();
+
+      // when
+      const certificationCourses = await _getCertificationCourses();
+
+      // then
+      expect(certificationCourses).to.deep.equal([
+        {
+          id: 5,
+          externalId: '123',
+          birthdate: '2000-12-31',
+          birthINSEECode: 'inseeUPDATED123',
+          birthPostalCode: 'postalUPDATED123',
+          birthplace: 'cityUPDATED123',
+          birthCountry: 'countryUPDATED123',
+        },
+      ]);
+      expect(certificationCandidates).to.deep.equal([
+        {
+          id: 50,
+          externalId: '123',
+          birthdate: '2000-12-31',
+          birthINSEECode: 'inseeUPDATED123',
+          birthPostalCode: 'postalUPDATED123',
+          birthCity: 'cityUPDATED123',
+          birthCountry: 'countryUPDATED123',
+        },
+      ]);
+    });
+
+    context('when there is no certification course for the candidate', function () {
+      it('should not update candidate', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCandidate({
+          id: 52,
+          externalId: '123',
+          userId: null,
+          birthdate: '2000-01-01',
+          birthINSEECode: 'y',
+          birthPostalCode: 'y',
+          birthCity: 'y',
+          birthCountry: 'y',
+        });
+
+        await databaseBuilder.commit();
+
+        await _createDataFile(dataFile, [
+          {
+            externalId: '123',
+            birthdate: '2000-12-31',
+            birthINSEECode: 'inseeUPDATED123',
+            birthPostalCode: 'postalUPDATED123',
+            birthCity: 'cityUPDATED123',
+            birthCountry: 'countryUPDATED123',
+          },
+        ]);
+        await updateCertificationInfos(dataFile);
+
+        // when
+        const certificationCandidates = await _getCertificationCandidates();
+
+        // then
+        expect(certificationCandidates.find(({ id }) => id === 52)).to.deep.equal({
+          id: 52,
+          externalId: '123',
+          birthdate: '2000-01-01',
+          birthINSEECode: 'y',
+          birthPostalCode: 'y',
+          birthCity: 'y',
+          birthCountry: 'y',
+        });
+      });
+
+      it('should log a warning', async function () {
+        // given
+        sinon.stub(logger, 'warn');
+        await _createDataFile(dataFile, [
+          {
+            externalId: '123',
+            birthdate: '2000-12-31',
+            birthINSEECode: 'inseeUPDATED123',
+            birthPostalCode: 'postalUPDATED123',
+            birthCity: 'cityUPDATED123',
+            birthCountry: 'countryUPDATED123',
+          },
+        ]);
+
+        // when
+        await updateCertificationInfos(dataFile);
+
+        // then
+        expect(logger.warn).to.have.been.calledWith('Certification for external id 123 not found');
+      });
+    });
+  });
+});
+
+function _getCertificationCandidates() {
+  return knex
+    .select('id', 'birthdate', 'birthCity', 'birthPostalCode', 'birthINSEECode', 'birthCountry', 'externalId')
+    .from('certification-candidates');
+}
+
+function _getCertificationCourses() {
+  return knex
+    .select('id', 'birthdate', 'birthplace', 'birthPostalCode', 'birthINSEECode', 'birthCountry', 'externalId')
+    .from('certification-courses');
+}
+
+async function _createDataFile(dataFile, data) {
+  return writeFile(dataFile, [values(headers).join(',')].concat(data.map((line) => values(line))).join('\n'));
+}


### PR DESCRIPTION
## :unicorn: Problème
En décembre dernier, une université avait été confrontée à beaucoup de messages d’erreur lors de l’inscription de candidats à plusieurs sessions de certification. Dans l’urgence et afin de débloquer la situation, tous les candidats ont été importés avec un lieu de naissance fictif. Nous avons demandé que nous soit fourni un fichier avec les bonnes informations afin de corriger.

## :robot: Solution
Créer un script qui permet, à partir de l’externalId des étudiants, de remplacer leur lieu de naissance.

## :rainbow: Remarques
Il faut deux csv.

Un contenant les infos à modifier :

```
externalId,birthdate,birthINSEECode,birthPostalCode,birthCity,birthCountry
123,2001-01-20,NULL,60000,TOTO,FRANCE
456,2001-01-01,NULL,06069,GRASSE,FRANCE
```

Un contenant les id des sessions concernées
```
3
```

## :100: Pour tester

A l'origine les candidate et les certification-courses concernant les étudiant ayant les externalId 123 dans la session3 et 456 ont Nantes comme ville de naissance

- Lancer le script ```node scripts/update-certification-infos.js </path/candidatesInfos.csv> </path/sessionIds.csv>```

- Vérifier que les infos des certification-courses et certification-candidates ont bien été mise à jour (par exemple les villes de naissances qui sont desormais TOTO et GRASSE)