### PR TITLE
[FEATURE] Récupérer la liste des membres d'une organisation dans la création et la modification d'une campagne sur Pix Orga (PIX-4147).

### DIFF
--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -76,6 +76,14 @@ export default class CreateForm extends Component {
     });
   }
 
+  get campaignOwnerOptions() {
+    if (!this.args.membersSortedByFullName) return [];
+
+    return this.args.membersSortedByFullName.map((member) => {
+      return { value: member.get('id'), label: member.get('fullName') };
+    });
+  }
+
   @action
   toggleCategory(category, isChecked) {
     if (isChecked) {

--- a/orga/app/controllers/authenticated/campaigns/update.js
+++ b/orga/app/controllers/authenticated/campaigns/update.js
@@ -8,7 +8,7 @@ export default class UpdateController extends Controller {
   @action
   update(event) {
     event.preventDefault();
-    return this.model
+    return this.model.campaign
       .save()
       .then((campaign) => this.transitionToRoute('authenticated.campaigns.campaign.settings', campaign.id));
   }

--- a/orga/app/models/user.js
+++ b/orga/app/models/user.js
@@ -9,4 +9,8 @@ export default class User extends Model {
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
+
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -6,11 +6,25 @@ export default class NewRoute extends Route {
   @service store;
   @service currentUser;
 
-  model() {
+  async model(params) {
     const organization = this.currentUser.organization;
+
+    const memberships = await this.store.query('membership', {
+      filter: {
+        organizationId: organization.id,
+      },
+      page: {
+        number: params.pageNumber,
+        size: params.pageSize,
+      },
+    });
+    const members = memberships.map((membership) => membership.user);
+    const membersSortedByFullName = members.sortBy('firstName', 'lastName');
+
     return RSVP.hash({
       campaign: this.store.createRecord('campaign', { organizationId: organization.id }),
       targetProfiles: organization.targetProfiles,
+      membersSortedByFullName,
     });
   }
 }

--- a/orga/app/routes/authenticated/campaigns/update.js
+++ b/orga/app/routes/authenticated/campaigns/update.js
@@ -1,8 +1,26 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class UpdateRoute extends Route {
-  model(params) {
-    return this.store.findRecord('campaign', params.campaign_id);
+  @service currentUser;
+
+  async model(params) {
+    const organization = this.currentUser.organization;
+    const campaign = await this.store.findRecord('campaign', params.campaign_id);
+
+    const memberships = await this.store.query('membership', {
+      filter: {
+        organizationId: organization.id,
+      },
+      page: {
+        number: params.pageNumber,
+        size: params.pageSize,
+      },
+    });
+    const members = memberships.map((membership) => membership.user);
+    const membersSortedByFullName = members.sortBy('firstName', 'lastName');
+
+    return { campaign, membersSortedByFullName };
   }
 
   setupController(controller, model) {

--- a/orga/app/templates/authenticated/campaigns/new.hbs
+++ b/orga/app/templates/authenticated/campaigns/new.hbs
@@ -9,5 +9,6 @@
     @errors={{this.errors}}
     @onSubmit={{this.createCampaign}}
     @onCancel={{this.cancel}}
+    @membersSortedByFullName={{@model.membersSortedByFullName}}
   />
 </div>

--- a/orga/app/templates/authenticated/campaigns/update.hbs
+++ b/orga/app/templates/authenticated/campaigns/update.hbs
@@ -5,5 +5,10 @@
   <h1 class="page__title page-title">{{t "pages.campaign-modification.title"}}</h1>
   <h2 class="page-sub-title">{{this.campaignName}}</h2>
 
-  <Campaign::UpdateForm @campaign={{@model}} @onSubmit={{this.update}} @onCancel={{this.cancel}} />
+  <Campaign::UpdateForm
+    @campaign={{@model.campaign}}
+    @onSubmit={{this.update}}
+    @onCancel={{this.cancel}}
+    @membersSortedByFullName={{@model.membersSortedByFullName}}
+  />
 </div>

--- a/orga/tests/unit/routes/authenticated/campaigns/new_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new_test.js
@@ -1,11 +1,52 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
 
 module('Unit | Route | authenticated/campaigns/new', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function (assert) {
+  test('should return members list sorted by full name', async function (assert) {
+    // given
     const route = this.owner.lookup('route:authenticated/campaigns/new');
-    assert.ok(route);
+
+    class CurrentUserStub extends Service {
+      organization = EmberObject.create({
+        id: 12345,
+      });
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    const membership1 = EmberObject.create({
+      user: EmberObject.create({
+        firstName: 'Alice',
+        lastName: 'Delamer',
+      }),
+    });
+    const membership2 = EmberObject.create({
+      user: EmberObject.create({
+        firstName: 'Alice',
+        lastName: 'Delamare',
+      }),
+    });
+    const queryStub = sinon.stub();
+    const storeStub = {
+      query: queryStub.resolves([membership1, membership2]),
+      createRecord: sinon.stub(),
+    };
+    route.store = storeStub;
+
+    const params = {
+      pageNumber: 1,
+      pageSize: 2,
+    };
+
+    // when
+    const result = await route.model(params);
+
+    //then
+    assert.strictEqual(result.membersSortedByFullName[0].lastName, 'Delamare');
+    assert.strictEqual(result.membersSortedByFullName[1].lastName, 'Delamer');
   });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/update_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/update_test.js
@@ -1,11 +1,48 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
 
 module('Unit | Route | authenticated/campaigns/update', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function (assert) {
+  test('should return members list sorted by full name', async function (assert) {
+    // given
     const route = this.owner.lookup('route:authenticated/campaigns/update');
-    assert.ok(route);
+
+    route.currentUser = { organization: { id: 123 } };
+
+    const membership1 = EmberObject.create({
+      user: EmberObject.create({
+        firstName: 'Alice',
+        lastName: 'Delamer',
+      }),
+    });
+    const membership2 = EmberObject.create({
+      user: EmberObject.create({
+        firstName: 'Alice',
+        lastName: 'Delamare',
+      }),
+    });
+    const campaign = EmberObject.create({ ownerFirstName: 'Marc', ownerLastName: 'Dupont' });
+    const queryStub = sinon.stub();
+    const findRecordStub = sinon.stub();
+    const storeStub = {
+      query: queryStub.resolves([membership1, membership2]),
+      findRecord: findRecordStub.resolves(campaign),
+    };
+    route.store = storeStub;
+
+    const params = {
+      pageNumber: 1,
+      pageSize: 2,
+    };
+
+    // when
+    const result = await route.model(params);
+
+    //then
+    assert.strictEqual(result.membersSortedByFullName[0].lastName, 'Delamare');
+    assert.strictEqual(result.membersSortedByFullName[1].lastName, 'Delamer');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix Orga, lorsqu'un utilisateur souhaite créer une campagne mais ne veut pas en être le propriétaire, il ne peut pas choisir un autre membre de l'organisation. 
Même chose pour la modification d'une campagne, il n'est actuellement pas possible de changer le propriétaire de celle-ci.

## :robot: Solution
Permettre de récupérer la liste des membres de l'organisation dans la page de création et modification de campagne.

⚠️ Ce ticket n'inclus pas l'affichage du champ permettant de sélectionner les membres. Il sera fait dans un autre ticket.
Celui-ci va seulement préparer les méthodes coté js pour faire les appels à l'API et lister les membres.

## :rainbow: Remarques
La liste des membres est triée par prénom.

## 😗 Tests
- Se connecter sur Pix Orga
- Cliquer sur Créer une campagnes
- Dans la console > Network > vérifier que l'appel pour récupérer la liste des membres est fait

Autre cas : 
- Cliquer sur une campagne au hasard
- Aller dans l'onglet Paramètres > Modifier
- Dans la console > Network > vérifier que l'appel pour récupérer la liste des membres est fait