### PR TITLE
[FEATURE] Réduire la durée de l'access token (PIX-4166).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -126,6 +126,7 @@ module.exports = (function () {
         firstName: 'PRE',
         lastName: 'NOM',
       },
+      accessTokenLifespanMs: ms(process.env.SAML_ACCESS_TOKEN_LIFESPAN || '4h'),
     },
 
     temporaryKey: {
@@ -276,6 +277,8 @@ module.exports = (function () {
     config.poleEmploi.tokenUrl = 'http://tokenUrl.fr';
     config.poleEmploi.sendingUrl = 'http://sendingUrl.fr';
     config.poleEmploi.userInfoUrl = 'http://userInfoUrl.fr';
+
+    config.saml.accessTokenLifespanMs = 1000;
 
     config.graviteeRegisterApplicationsCredentials = [
       {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -97,7 +97,7 @@ module.exports = (function () {
 
     authentication: {
       secret: process.env.AUTH_SECRET,
-      accessTokenLifespanMs: ms(process.env.ACCESS_TOKEN_LIFESPAN || '7d'),
+      accessTokenLifespanMs: ms(process.env.ACCESS_TOKEN_LIFESPAN || '20m'),
       refreshTokenLifespanMs: ms(process.env.REFRESH_TOKEN_LIFESPAN || '7d'),
       tokenForCampaignResultLifespan: '1h',
       tokenForStudentReconciliationLifespan: '1h',
@@ -126,7 +126,7 @@ module.exports = (function () {
         firstName: 'PRE',
         lastName: 'NOM',
       },
-      accessTokenLifespanMs: ms(process.env.SAML_ACCESS_TOKEN_LIFESPAN || '4h'),
+      accessTokenLifespanMs: ms(process.env.SAML_ACCESS_TOKEN_LIFESPAN || '7d'),
     },
 
     temporaryKey: {

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -19,7 +19,7 @@ function createAccessTokenFromUser(userId, source) {
   return { accessToken, expirationDelaySeconds };
 }
 
-function createAccessTokenFromExternalUser(userId) {
+function createAccessTokenForSaml(userId) {
   const expirationDelaySeconds = settings.saml.accessTokenLifespanMs / 1000;
   return _createAccessToken({ userId, source: 'external', expirationDelaySeconds });
 }
@@ -185,7 +185,7 @@ async function extractPayloadFromPoleEmploiIdToken(idToken) {
 
 module.exports = {
   createAccessTokenFromUser,
-  createAccessTokenFromExternalUser,
+  createAccessTokenForSaml,
   createAccessTokenFromApplication,
   createTokenForCampaignResults,
   createIdTokenForUserReconciliation,

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -7,16 +7,21 @@ const {
 } = require('../../domain/errors');
 const settings = require('../../config');
 
-function createAccessTokenFromUser(userId, source) {
-  const expirationDelaySeconds = settings.authentication.accessTokenLifespanMs / 1000;
-  const accessToken = jsonwebtoken.sign({ user_id: userId, source }, settings.authentication.secret, {
+function _createAccessToken({ userId, source, expirationDelaySeconds }) {
+  return jsonwebtoken.sign({ user_id: userId, source }, settings.authentication.secret, {
     expiresIn: expirationDelaySeconds,
   });
+}
+
+function createAccessTokenFromUser(userId, source) {
+  const expirationDelaySeconds = settings.authentication.accessTokenLifespanMs / 1000;
+  const accessToken = _createAccessToken({ userId, source, expirationDelaySeconds });
   return { accessToken, expirationDelaySeconds };
 }
 
 function createAccessTokenFromExternalUser(userId) {
-  return createAccessTokenFromUser(userId, 'external').accessToken;
+  const expirationDelaySeconds = settings.saml.accessTokenLifespanMs / 1000;
+  return _createAccessToken({ userId, source: 'external', expirationDelaySeconds });
 }
 
 function createAccessTokenFromApplication(

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -51,7 +51,7 @@ async function authenticateExternalUser({
       throw new UserShouldChangePasswordError();
     }
 
-    const token = tokenService.createAccessTokenFromExternalUser(userFromCredentials.id);
+    const token = tokenService.createAccessTokenForSaml(userFromCredentials.id);
     await userRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
     return token;
   } catch (error) {

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -91,7 +91,7 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
     }
   }
   const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
-  const accessToken = tokenService.createAccessTokenFromExternalUser(tokenUserId);
+  const accessToken = tokenService.createAccessTokenForSaml(tokenUserId);
   await userRepository.updateLastLoggedAt({ userId: tokenUserId });
   return accessToken;
 };

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -90,14 +90,8 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
       throw error;
     }
   }
-
-  if (userWithSamlId) {
-    const token = tokenService.createAccessTokenFromExternalUser(userWithSamlId.id);
-    await userRepository.updateLastLoggedAt({ userId: userWithSamlId.id });
-    return token;
-  } else {
-    const token = tokenService.createAccessTokenFromExternalUser(userId);
-    await userRepository.updateLastLoggedAt({ userId });
-    return token;
-  }
+  const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
+  const accessToken = tokenService.createAccessTokenFromExternalUser(tokenUserId);
+  await userRepository.updateLastLoggedAt({ userId: tokenUserId });
+  return accessToken;
 };

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -15,7 +15,7 @@ module.exports = async function getExternalAuthenticationRedirectionUrl({
   const user = await userRepository.getBySamlId(externalUser.samlId);
 
   if (user) {
-    const token = tokenService.createAccessTokenFromExternalUser(user.id);
+    const token = tokenService.createAccessTokenForSaml(user.id);
     await userRepository.updateLastLoggedAt({ userId: user.id });
     return `/?token=${encodeURIComponent(token)}&user-id=${user.id}`;
   } else {

--- a/api/sample.env
+++ b/api/sample.env
@@ -531,15 +531,21 @@ NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD=48
 # TOKENS
 # ========
 
-# Access token validity period
+# Access token lifespan
 # presence: optional
 # type: String
 # default: '20m'
 ACCESS_TOKEN_LIFESPAN=20m
 
-# Refresh token validity period
+# Refresh token lifespan
 # presence: optional
 # type: String
 # default: '7d'
 REFRESH_TOKEN_LIFESPAN=7d
+
+# Saml access token lifespan
+# presence: optional
+# type: String
+# default: '7d'
+SAML_ACCESS_TOKEN_LIFESPAN=7d
 

--- a/api/tests/integration/domain/services/token-service_test.js
+++ b/api/tests/integration/domain/services/token-service_test.js
@@ -3,13 +3,13 @@ const tokenService = require('../../../../lib/domain/services/token-service');
 const settings = require('../../../../lib/config');
 
 describe('Integration | Domain | Services | TokenService', function () {
-  describe('#createAccessTokenFromExternalUser', function () {
+  describe('#createAccessTokenForSaml', function () {
     it('should return a valid json web token', function () {
       // given
       const userId = 123;
 
       // when
-      const result = tokenService.createAccessTokenFromExternalUser(userId);
+      const result = tokenService.createAccessTokenForSaml(userId);
 
       // then
       const token = tokenService.getDecodedToken(result);

--- a/api/tests/integration/domain/services/token-service_test.js
+++ b/api/tests/integration/domain/services/token-service_test.js
@@ -1,0 +1,23 @@
+const { expect } = require('../../../test-helper');
+const tokenService = require('../../../../lib/domain/services/token-service');
+const settings = require('../../../../lib/config');
+
+describe('Integration | Domain | Services | TokenService', function () {
+  describe('#createAccessTokenFromExternalUser', function () {
+    it('should return a valid json web token', function () {
+      // given
+      const userId = 123;
+
+      // when
+      const result = tokenService.createAccessTokenFromExternalUser(userId);
+
+      // then
+      const token = tokenService.getDecodedToken(result);
+      expect(token).to.include({ source: 'external', user_id: userId });
+
+      const expirationDelaySeconds = token.exp - token.iat;
+      const expectedExpirationDelaySeconds = settings.saml.accessTokenLifespanMs / 1000;
+      expect(expirationDelaySeconds).to.equal(expectedExpirationDelaySeconds);
+    });
+  });
+});

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -35,25 +35,6 @@ describe('Unit | Domain | Service | Token Service', function () {
     });
   });
 
-  describe('#createAccessTokenFromExternalUser', function () {
-    it('should create access token with user id and source', function () {
-      // given
-      const userId = 123;
-      settings.authentication.secret = 'a secret';
-      settings.authentication.accessTokenLifespanMs = 1000;
-      sinon.stub(jsonwebtoken, 'sign');
-
-      // when
-      tokenService.createAccessTokenFromExternalUser(userId);
-
-      // then
-      const firstParameter = { user_id: userId, source: 'external' };
-      const secondParameter = 'a secret';
-      const thirdParameter = { expiresIn: 1 };
-      expect(jsonwebtoken.sign).to.be.calledWith(firstParameter, secondParameter, thirdParameter);
-    });
-  });
-
   describe('#createIdTokenForUserReconciliation', function () {
     it('should return a valid idToken with firstName, lastName, samlId', function () {
       // given

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -22,7 +22,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
 
   beforeEach(function () {
     tokenService = {
-      createAccessTokenFromExternalUser: sinon.stub(),
+      createAccessTokenForSaml: sinon.stub(),
       extractSamlId: sinon.stub(),
     };
     authenticationService = {
@@ -61,7 +61,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       const expectedToken = 'expected returned token';
-      tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(expectedToken);
+      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(expectedToken);
 
       // when
       const token = await authenticateExternalUser({
@@ -99,7 +99,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       });
 
       const expectedToken = 'expected returned token';
-      tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(expectedToken);
+      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(expectedToken);
 
       // when
       await authenticateExternalUser({

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-f
     };
     tokenService = {
       extractExternalUserFromIdToken: sinon.stub(),
-      createAccessTokenFromExternalUser: sinon.stub(),
+      createAccessTokenForSaml: sinon.stub(),
     };
     userReconciliationService = {
       findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser: sinon.stub(),
@@ -80,7 +80,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-f
         schoolingRegistration
       );
       userRepository.getBySamlId.resolves(user);
-      tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(token);
+      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(token);
 
       // when
       const result = await createUserAndReconcileToSchoolingRegistrationFromExternalUser({
@@ -152,7 +152,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-schooling-registration-f
       );
       userRepository.getBySamlId.resolves(null);
       userService.createAndReconcileUserToSchoolingRegistration.resolves(user.id);
-      tokenService.createAccessTokenFromExternalUser.withArgs(user.id).resolves(token);
+      tokenService.createAccessTokenForSaml.withArgs(user.id).resolves(token);
 
       // when
       const result = await createUserAndReconcileToSchoolingRegistrationFromExternalUser({

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
 
     tokenService = {
       createIdTokenForUserReconciliation: sinon.stub(),
-      createAccessTokenFromExternalUser: sinon.stub(),
+      createAccessTokenForSaml: sinon.stub(),
     };
   });
 
@@ -77,7 +77,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       });
 
       userRepository.getBySamlId.withArgs('saml-id-for-adele').resolves(expectedUser);
-      tokenService.createAccessTokenFromExternalUser.returns('access-token');
+      tokenService.createAccessTokenForSaml.returns('access-token');
 
       // when
       const result = await getExternalAuthenticationRedirectionUrl({


### PR DESCRIPTION
## :unicorn: Problème
Pour le scénario du GAR on a pu voir que laisser la durée de l’accès token à un temps très réduit (1min) pose des soucis : on ne peux pas rejoindre une campagne on a une 401 (not authorized) qui est jetée.

## :robot: Solution
Faire en sorte que lorsqu'on vient du GAR on génère un access token d'une durée différente (plus longue) que celui utilisé pour nos autres utilisateurs.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
