### PR TITLE
[BUGFIX] Afficher qu'une seule fois un même tag dans le formulaire de création de campagne (PIX-4187)

### DIFF
--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import _sortBy from 'lodash/sortBy';
 import _find from 'lodash/find';
 import _pull from 'lodash/pull';
+import _uniq from 'lodash/uniq';
 
 export default class CreateForm extends Component {
   @service currentUser;
@@ -34,7 +35,7 @@ export default class CreateForm extends Component {
 
   get categories() {
     if (!this.args.targetProfiles) return [];
-    let allCategories = this.args.targetProfiles.map((targetProfile) => targetProfile.category);
+    let allCategories = _uniq(this.args.targetProfiles.map((targetProfile) => targetProfile.category));
 
     const otherCategoryIsPresents = allCategories.includes('OTHER');
     allCategories = allCategories.map((category) => {

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -156,6 +156,43 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         assert.contains(t('pages.campaign-creation.tags.OTHER'));
       });
 
+      test('it should display each category tags once', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          organization = EmberObject.create({ canCollectProfiles: true });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.targetProfiles = [
+          EmberObject.create({
+            id: '4',
+            name: 'targetProfile4',
+            description: 'description4',
+            category: 'SUBJECT',
+          }),
+          EmberObject.create({
+            id: '4',
+            name: 'targetProfile6',
+            description: 'description6',
+            category: 'SUBJECT',
+          }),
+          EmberObject.create({
+            id: '5',
+            name: 'targetProfile5',
+            description: 'description7',
+            category: 'OTHER',
+          }),
+        ];
+        // when
+        await renderScreen(
+          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        );
+        await clickByName(t('pages.campaign-creation.purpose.assessment'));
+        // then
+        assert.contains(t('pages.campaign-creation.tags-title'));
+        assert.dom('label[for="SUBJECT"]').exists({ count: 1 });
+        assert.contains(t('pages.campaign-creation.tags.OTHER'));
+      });
+
       test('it should display only the target profiles associated to the tag selected', async function (assert) {
         // given
         class CurrentUserStub extends Service {


### PR DESCRIPTION
## :unicorn: Problème
Si on avait plusieurs profiles cibles, on affichait plusieurs fois le même tag
![Capture d’écran du 2022-01-20 17-43-44](https://user-images.githubusercontent.com/35958509/150389993-220c0a54-a832-4dd5-b244-9e2a7b5ccbbc.png)


## :robot: Solution
Ajouter un uniq pour avoir qu'une fois chaque catégorie.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Chaque categorie doit apparaitre une seule fois dans le formulaire de création de campagne.
