### PR TITLE
[FEATURE] Déplacer le bouton "Télécharger la sélection des sujets" à droite (PIX-4168).

### DIFF
--- a/orga/app/styles/pages/authenticated/preselect-target-profile.scss
+++ b/orga/app/styles/pages/authenticated/preselect-target-profile.scss
@@ -1,6 +1,8 @@
 .download-file {
+  display: flex;
+  justify-content: flex-end;
   position: sticky;
-  padding: 0.5em;
+  padding: 0.5em 0;
   top: 0;
   z-index: 1;
 


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "Télécharger la sélection des sujets" était à gauche.

## :robot: Solution
Déplacer le bouton à droite pour avoir la même similitude sur la page Pix Orga.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter sur Pix Orga
- Aller sur /selection-sujets
- Vérifier que le bouton s'affiche bien à droite