### PR TITLE
[TECH] Expliciter les conventions de nommage dans la BDD.

### DIFF
--- a/api/.ls-lint.yml
+++ b/api/.ls-lint.yml
@@ -29,3 +29,4 @@ ignore:
   - db/migrations
   - db/seeds
   - scripts
+  - ./tests/acceptance/database/.schemalintrc.js

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -655,6 +655,15 @@
         "moment": "2.x.x"
       }
     },
+    "@kristiandupont/recase": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kristiandupont/recase/-/recase-1.1.1.tgz",
+      "integrity": "sha512-oDt82hNAu3X/bu2BGcrLDdfjrqR2UThwSiJRl+SizjBJT0U9CmWGJ+HYJxDLbo02PpyJCR9nPk26vrNt7xQ7BA==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.27.0"
+      }
+    },
     "@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -906,11 +915,28 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "16.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "@types/yoga-layout": {
       "version": "1.9.2",
@@ -2570,6 +2596,72 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
+    },
     "eslint": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
@@ -3072,6 +3164,81 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extract-pg-schema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/extract-pg-schema/-/extract-pg-schema-3.1.1.tgz",
+      "integrity": "sha512-BweYZ8TNvktPA+tpTen2iBVN4h3m0Q/fAO2BSd3g8OLSsloR12xsq2i+/IZMeyvTcpyJ5b6q514RgnS1AkkLiA==",
+      "dev": true,
+      "requires": {
+        "@types/pg": "^8.0.0",
+        "jsonpath": "^1.0.2",
+        "knex": "0.95.6",
+        "pg-query-emscripten": "^0.1.0",
+        "ramda": "^0.27.0"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+          "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+          "dev": true
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "knex": {
+          "version": "0.95.6",
+          "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.6.tgz",
+          "integrity": "sha512-noRcmkJl1MdicUbezrcr8OtVLcqQ/cfLIwgAx5EaxNxQOIJff88rBeyLywUScGhQNd/b78DIKKXZzLMrm6h/cw==",
+          "dev": true,
+          "requires": {
+            "colorette": "1.2.1",
+            "commander": "^7.1.0",
+            "debug": "4.3.1",
+            "escalade": "^3.1.1",
+            "esm": "^3.2.25",
+            "getopts": "2.2.5",
+            "interpret": "^2.2.0",
+            "lodash": "^4.17.21",
+            "pg-connection-string": "2.4.0",
+            "rechoir": "^0.7.0",
+            "resolve-from": "^5.0.0",
+            "tarn": "^3.0.1",
+            "tildify": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "pg-connection-string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+          "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -4352,6 +4519,31 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "dev": true,
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+          "dev": true
+        }
+      }
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -5782,6 +5974,12 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
       "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
+    "pg-query-emscripten": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/pg-query-emscripten/-/pg-query-emscripten-0.1.0.tgz",
+      "integrity": "sha512-Awwf0s6gyVZEmZeMLXnXZOIQveqVEBFhxMkR0UcMmijwX/y9FW1od71X1hNRtGFWrU/ML5sxerZyH20pvpLGuA==",
+      "dev": true
+    },
     "pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
@@ -6620,6 +6818,78 @@
         "object-assign": "^4.1.1"
       }
     },
+    "schemalint": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/schemalint/-/schemalint-0.5.6.tgz",
+      "integrity": "sha512-LQY01nIJBoeBrqMfRroOnpFGiMczDGCqnOlKjnTnBxIciEr9EplacqgOJGq5JWFGvLe0LfQnCJjceip9b7xM6g==",
+      "dev": true,
+      "requires": {
+        "@kristiandupont/recase": "^1.1.1",
+        "chalk": "^4.1.0",
+        "extract-pg-schema": "^3.0.0",
+        "irregular-plurals": "^3.2.0",
+        "optionator": "^0.9.1",
+        "pg": "^8.3.3",
+        "ramda": "^0.27.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "irregular-plurals": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+          "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "scss-parser": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/scss-parser/-/scss-parser-1.0.5.tgz",
@@ -7007,6 +7277,15 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "dev": true,
+      "requires": {
+        "escodegen": "^1.8.1"
       }
     },
     "stealthy-require": {

--- a/api/package.json
+++ b/api/package.json
@@ -79,6 +79,7 @@
     "yargs": "^17.2.1"
   },
   "devDependencies": {
+    "@kristiandupont/recase": "^1.1.1",
     "@ls-lint/ls-lint": "^1.10.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
@@ -98,6 +99,8 @@
     "nodemon": "^2.0.14",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
+    "pg-connection-string": "^2.5.0",
+    "schemalint": "^0.5.5",
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "stream-to-promise": "^3.0.0"
@@ -126,7 +129,7 @@
     "scalingo-postbuild": "echo 'nothing to do'",
     "start": "node bin/www",
     "start:watch": "nodemon bin/www",
-    "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
+    "test": "NODE_ENV=test npm run db:prepare && npm run test:database && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
     "test:api:unit": "TEST_DATABASE_URL=postgres://SHOULD_NOT_REACH_DB_IN_UNIT_TESTS REDIS_URL=redis://SHOULD_NOT_REACH_REDIS_IN_UNIT_TESTS npm run test:api:path -- tests/unit",
@@ -136,6 +139,7 @@
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:ci": "npm run test",
+    "test:database": "schemalint --config tests/acceptance/database/.schemalintrc.js",
     "test:lint": "npm test && npm run lint"
   },
   "nodemonConfig": {

--- a/api/tests/acceptance/database/.schemalintrc.js
+++ b/api/tests/acceptance/database/.schemalintrc.js
@@ -1,0 +1,38 @@
+require('dotenv').config();
+const pgUrlParser = require('pg-connection-string').parse;
+
+const whiteList = [
+  ...require('./whitelist/column-name-casing'),
+  ...require('./whitelist/name-inflection'),
+  ...require('./whitelist/table-name-casing'),
+  ...require('./whitelist/identifier-naming'),
+  ...require('./whitelist/library-tables'),
+];
+
+const errorLevel = {
+  'name-inflection': ['error', 'plural'],
+  'identifier-naming': ['error'],
+  'table-name-casing': ['error'],
+  'column-name-casing': ['error'],
+}
+
+const rules = {
+  customRulesPath: './tests/acceptance/database/custom-rules',
+  whiteList,
+  errorLevel
+}
+
+const databaseToLint = {
+  connectString: pgUrlParser(process.env.TEST_DATABASE_URL),
+  schema: [{name: 'public'}]
+}
+
+const config = {
+  connection: databaseToLint.connectString,
+  schemas: databaseToLint.schema,
+  rules: rules.errorLevel,
+  ignores: rules.whiteList,
+  plugins: [rules.customRulesPath],
+}
+
+module.exports = config;

--- a/api/tests/acceptance/database/custom-rules/column-name-casing.js
+++ b/api/tests/acceptance/database/custom-rules/column-name-casing.js
@@ -1,0 +1,36 @@
+const { detectCasing, recase } = require('@kristiandupont/recase');
+const { casings } = require('../utils');
+const expectedCasing = casings.camelCase;
+
+const columnNameCasing = {
+  name: 'column-name-casing',
+  docs: {
+    description: `Column name should be ${expectedCasing} cased`,
+    url: '...',
+  },
+  process({ schemaObject, report }) {
+    const columnValidator =
+      (entityType) =>
+      ({ name: entityName }) =>
+      ({ name: columnName }) => {
+        const casing = detectCasing(columnName);
+        const matches = casing === null || casing === expectedCasing;
+        if (!matches) {
+          const expectedColumnName = recase(casing, expectedCasing, columnName);
+          const suggestedAction = `Fix the knex migration you created by replacing t.string('${columnName}') by t.string('${expectedColumnName}')`;
+          report({
+            rule: this.name,
+            identifier: `${schemaObject.name}.${entityName}.${columnName}`,
+            message: `The column ${columnName} on the ${entityType} ${entityName} seems to be ${casing}-cased rather than ${expectedCasing}-cased.`,
+            suggestedMigration: suggestedAction,
+          });
+        }
+      };
+
+    schemaObject.tables.forEach((entity) => {
+      entity.columns.forEach(columnValidator('table')(entity));
+    });
+  },
+};
+
+module.exports = columnNameCasing;

--- a/api/tests/acceptance/database/custom-rules/identifier-naming.js
+++ b/api/tests/acceptance/database/custom-rules/identifier-naming.js
@@ -1,0 +1,28 @@
+const identifierColumnName = 'id';
+
+const identifierNaming = {
+  name: 'identifier-naming',
+  docs: {
+    description: `Identifier columns should be named ${identifierColumnName}`,
+    url: '...',
+  },
+  process({ schemaObject, report }) {
+    const validator = ({ columns, name: tableName }) => {
+      const idColumns = columns.filter((c) => c.isPrimary);
+      if (idColumns.length > 0) {
+        const [idColumn] = idColumns;
+        if (idColumn.name !== identifierColumnName) {
+          report({
+            rule: this.name,
+            identifier: `${schemaObject.name}.${tableName}`,
+            message: `The primary column on ${tableName} is called ${idColumn.name} which doesn't follow the convention. Expected name was: ${identifierColumnName}`,
+            suggestedMigration: `ALTER TABLE "${tableName}" RENAME COLUMN "${idColumn.name}" TO "${identifierColumnName}";`,
+          });
+        }
+      }
+    };
+    schemaObject.tables.forEach(validator);
+  },
+};
+
+module.exports = identifierNaming;

--- a/api/tests/acceptance/database/custom-rules/index.js
+++ b/api/tests/acceptance/database/custom-rules/index.js
@@ -1,0 +1,9 @@
+const identifierNaming = require('./identifier-naming');
+const tableNameCasing = require('./table-name-casing');
+const columnNameCasing = require('./column-name-casing');
+
+module.exports = {
+  identifierNaming,
+  tableNameCasing,
+  columnNameCasing,
+};

--- a/api/tests/acceptance/database/custom-rules/table-name-casing.js
+++ b/api/tests/acceptance/database/custom-rules/table-name-casing.js
@@ -1,0 +1,37 @@
+const { detectCasing, recase } = require('@kristiandupont/recase');
+
+const tableNameCasing = {
+  name: 'table-name-casing',
+  docs: {
+    description: 'Table name should be kebab-case',
+    url: '...',
+  },
+  process({ schemaObject, report }) {
+    const expectedCasing = 'dash';
+
+    const validator =
+      (entityType) =>
+      ({ name: entityName }) => {
+        const casing = detectCasing(entityName);
+        const matches = casing === null || casing === expectedCasing;
+        if (!matches) {
+          report({
+            rule: this.name,
+            identifier: `${schemaObject.name}.${entityName}`,
+            message: `The ${entityType} ${entityName} seems to be ${casing}-cased rather than ${expectedCasing}-cased.`,
+            suggestedMigration: `ALTER ${entityType.toUpperCase()} "${entityName}" RENAME TO "${recase(
+              casing,
+              expectedCasing,
+              entityName
+            )}";`,
+          });
+        }
+      };
+
+    schemaObject.tables.forEach((entity) => {
+      validator('table')(entity);
+    });
+  },
+};
+
+module.exports = tableNameCasing;

--- a/api/tests/acceptance/database/utils.js
+++ b/api/tests/acceptance/database/utils.js
@@ -1,0 +1,2 @@
+const casings = { snakeCase: 'snake', camelCase: 'camel' };
+module.exports = { casings };

--- a/api/tests/acceptance/database/whitelist/column-name-casing.js
+++ b/api/tests/acceptance/database/whitelist/column-name-casing.js
@@ -1,0 +1,15 @@
+const legitimateUsages = [
+  { identifier: 'public.certification-cpf-cities.INSEECode', rule: 'column-name-casing' },
+  { identifier: 'public.schooling-registrations.MEFCode', rule: 'column-name-casing' },
+];
+
+const uncheckedUsages = [
+  { identifier: 'public.competence-marks.area_code', rule: 'column-name-casing' },
+  { identifier: 'public.users_pix_roles.user_id', rule: 'column-name-casing' },
+  { identifier: 'public.users_pix_roles.pix_role_id', rule: 'column-name-casing' },
+  { identifier: 'public.competence-marks.competence_code', rule: 'column-name-casing' },
+];
+
+const exceptions = [...legitimateUsages, ...uncheckedUsages];
+
+module.exports = exceptions;

--- a/api/tests/acceptance/database/whitelist/identifier-naming.js
+++ b/api/tests/acceptance/database/whitelist/identifier-naming.js
@@ -1,0 +1,5 @@
+const nonLegitimateUsages = [{ identifier: 'public.finalized-sessions', rule: 'identifier-naming' }];
+const legitimateUsages = [];
+const exceptions = [...nonLegitimateUsages, ...legitimateUsages];
+
+module.exports = exceptions;

--- a/api/tests/acceptance/database/whitelist/library-tables.js
+++ b/api/tests/acceptance/database/whitelist/library-tables.js
@@ -1,0 +1,3 @@
+const exceptions = [{ identifierPattern: 'public\\.knex_migrations.*', rulePattern: '.*' }];
+
+module.exports = exceptions;

--- a/api/tests/acceptance/database/whitelist/name-inflection.js
+++ b/api/tests/acceptance/database/whitelist/name-inflection.js
@@ -1,0 +1,3 @@
+const legitimateUsages = [{ identifier: 'public.badge-criteria', rule: 'name-inflection' }];
+const exceptions = [...legitimateUsages];
+module.exports = exceptions;

--- a/api/tests/acceptance/database/whitelist/table-name-casing.js
+++ b/api/tests/acceptance/database/whitelist/table-name-casing.js
@@ -1,0 +1,11 @@
+const legitimateUsages = [{ identifier: 'public.target-profiles_skills', rule: 'table-name-casing' }];
+
+const nonLegitimateUsages = [
+  { identifier: 'public.users_pix_roles', rule: 'table-name-casing' },
+  { identifier: 'public.pix_roles', rule: 'table-name-casing' },
+  { identifier: 'public.user_tutorials', rule: 'table-name-casing' },
+];
+
+const exceptions = [...legitimateUsages, ...nonLegitimateUsages];
+
+module.exports = exceptions;

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,46 @@
+# Conventions
+
+## Nommage
+
+### Tables
+
+Le nom d'une table :
+
+- est au pluriel : `users` au lieu de  `user`;
+- suivant sa nature :
+  - pour les entités, est au format kebab-case : `certification-centers` au lieu de `certificationCenters`;
+  - pour les relations, est au format snake_case pour les relations, ex: `user_tutorials` pour la relation entre `users`
+    et `tutorials`.
+
+Les règles sont cumulables : `target-profiles_skills` est valide pour les relations entre `target-profiles` et `skills`.
+
+#### Exceptions
+
+Les exceptions possibles sont :
+
+- les tables utilisées par les libraires, par exemple la table `knex_migrations` utilisée par la librairie `knex`.
+
+Dans ce cas, elles peuvent être ajoutées à
+la [whitelist](../api/tests/acceptance/database/whitelist/table-name-casing.js).
+
+### Colonnes
+
+Le nom d'une colonne :
+
+- est au format camelCase : `userId` au lieu de  `user_id`;
+- est au singulier : `email` au lieu de `emails` (si la cardinalité est 1:N, créer une table de relation).
+
+Suivant le rôle de la colonne, des règles supplémentaires s'appliquent :
+
+- si c'est un identifiant couplé à une séquence, jouant le rôle de clef primaire, elle est nommée `id`;
+- si c'est une clef étrangère vers un identifiant technique, elle est au singulier et suffixée par `id`, ex `userId`
+  référence `users.id`.
+
+#### Exceptions
+
+Les exceptions possibles sont :
+
+- la mention d'acronymes ou de sigles, ex: `INSEECode`.
+
+Dans ce cas, elles peuvent être ajoutées à
+la [whitelist](../api/tests/acceptance/database/whitelist/column-name-casing.js).


### PR DESCRIPTION
## :christmas_tree: Problème

Les conventions de commage du schéma de BDD ne sont pas documentés explicitement.
De plus, ils sont complexes à modifier à posteriori sans occasionner de _downtime_.

## :gift: Solution
Linter le schéma de BDD avec ce [package](https://github.com/kristiandupont/schemalint).

Utiliser des règles custom pour coller au plus près des pratiques, et utiliser des exceptions si les règles custom ne sufffisent pas.

Afin d'empêcher dès maintenant l'introduction de nouvelles violations, ajout d'exceptions pour gérer les violations existantes.

Ajout d'une documentation au format texte dans le dossier `docs`.

## :star2: Remarques

Les règles de nommage ont été extraites [du thread Slack](https://1024pix.slack.com/archives/C658LDBAQ/p1587996104019700).

Le lint est effectué sur le schéma de BDD instancié, il est donc déclenché par la tâche `test` et non pas `lint`.

## :santa: Pour tester

Introduire une violation et vérifier que la tâche `test` sort en erreur, un exemple suit.

Créer une migration.
```shell
npm run db:new-migration create-foo-table
```

Alimenter la migration.
``` js
exports.up = async function (knex) {
  await knex.schema.createTable('foo-bar', (t) => {
    t.increments('fooId').primary();
    t.text('bar-rulezzz');
    t.text('bars');
    t.text('INSEECode');
  });
};

exports.down = function () {};
```

Exécuter `npm test` .

Vérifier les messages.
```shell
schema-lint
Connecting to pix on localhost
public.foo-bar: error name-inflection : Expected plural names, but 'foo-bar' seems to be singular
public.foo-bar: error identifier-naming : The primary column on foo-bar is called fooId which doesn't follow the convention. Expected name was: id
public.foo-bar.bar-rulezzz: error column-name-casing : The column bar-rulezzz on the table foo-bar seems to be dash-cased rather than camel-cased.
public.foo-bar.INSEECode: error column-name-casing : The column INSEECode on the table foo-bar seems to be pascal-cased rather than camel-cased.

```
Vérifier que le code retour est différent de zéro.
