### PR TITLE
[FEATURE] Ignorer les écrans de FDT non renseignés dans les critères des sessions "à traiter" (PIX-4171)

### DIFF
--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -4,9 +4,18 @@ const AutoJuryDone = require('./AutoJuryDone');
 
 const eventTypes = [AutoJuryDone];
 
-async function handleSessionFinalized({ event, juryCertificationSummaryRepository, finalizedSessionRepository }) {
+async function handleSessionFinalized({
+  event,
+  juryCertificationSummaryRepository,
+  finalizedSessionRepository,
+  supervisorAccessRepository,
+}) {
   checkEventTypes(event, eventTypes);
   const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(event.sessionId);
+
+  const hasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({
+    sessionId: event.sessionId,
+  });
 
   const finalizedSession = FinalizedSession.from({
     sessionId: event.sessionId,
@@ -15,6 +24,7 @@ async function handleSessionFinalized({ event, juryCertificationSummaryRepositor
     sessionDate: event.sessionDate,
     sessionTime: event.sessionTime,
     hasExaminerGlobalComment: event.hasExaminerGlobalComment,
+    hasSupervisorAccess,
     juryCertificationSummaries,
   });
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -29,6 +29,7 @@ const dependencies = {
   poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
+  supervisorAccessRepository: require('../../infrastructure/repositories/supervisor-access-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),
   targetProfileWithLearningContentRepository: require('../../infrastructure/repositories/target-profile-with-learning-content-repository'),
   userRepository: require('../../infrastructure/repositories/user-repository'),

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -30,6 +30,7 @@ module.exports = class FinalizedSession {
     sessionTime,
     hasExaminerGlobalComment,
     juryCertificationSummaries,
+    hasSupervisorAccess,
   }) {
     return new FinalizedSession({
       sessionId,
@@ -42,7 +43,7 @@ module.exports = class FinalizedSession {
         _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries) &&
         _isNotFlaggedAsAborted(juryCertificationSummaries) &&
         _hasNoScoringErrorOrUncompletedAssessmentResults(juryCertificationSummaries) &&
-        _hasExaminerSeenAllEndScreens(juryCertificationSummaries),
+        (hasSupervisorAccess || _hasExaminerSeenAllEndScreens(juryCertificationSummaries)),
       publishedAt: null,
     });
   }

--- a/api/lib/infrastructure/repositories/supervisor-access-repository.js
+++ b/api/lib/infrastructure/repositories/supervisor-access-repository.js
@@ -10,6 +10,11 @@ module.exports = {
     return Boolean(result);
   },
 
+  async sessionHasSupervisorAccess({ sessionId }) {
+    const result = await knex.select(1).from('supervisor-accesses').where({ sessionId }).first();
+    return Boolean(result);
+  },
+
   async isUserSupervisorForSessionCandidate({ supervisorId, certificationCandidateId }) {
     const result = await knex
       .select(1)

--- a/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
@@ -104,4 +104,43 @@ describe('Integration | Repository | supervisor-access-repository', function () 
       expect(isUserSupervisorForSession).to.be.false;
     });
   });
+
+  describe('#sessionHasSupervisorAccess', function () {
+    afterEach(function () {
+      return knex('supervisor-accesses').delete();
+    });
+
+    it('should return true if session has at least one supervisor access', async function () {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId });
+      await databaseBuilder.commit();
+
+      // when
+      const sessionHasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({
+        sessionId,
+      });
+
+      // then
+      expect(sessionHasSupervisorAccess).to.be.true;
+    });
+
+    it('should return false if session has no supervisor access', async function () {
+      // given
+      const sessionWithSupervisor = databaseBuilder.factory.buildSession();
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId: sessionWithSupervisor.id, userId });
+      const sessionWithoutSupervisor = databaseBuilder.factory.buildSession();
+      await databaseBuilder.commit();
+
+      // when
+      const sessionHasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({
+        sessionId: sessionWithoutSupervisor.id,
+      });
+
+      // then
+      expect(sessionHasSupervisorAccess).to.be.false;
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/supervisor-access-repository_test.js
@@ -24,10 +24,6 @@ describe('Integration | Repository | supervisor-access-repository', function () 
   });
 
   describe('#isUserSupervisorForSession', function () {
-    afterEach(function () {
-      return knex('supervisor-accesses').delete();
-    });
-
     it('should return true if user is supervising the session', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
@@ -64,10 +60,6 @@ describe('Integration | Repository | supervisor-access-repository', function () 
   });
 
   describe('#isUserSupervisorForSessionCandidate', function () {
-    afterEach(function () {
-      return knex('supervisor-accesses').delete();
-    });
-
     it("should return true if the user is supervising the candidate's session", async function () {
       // given
       const supervisorId = databaseBuilder.factory.buildUser().id;
@@ -106,10 +98,6 @@ describe('Integration | Repository | supervisor-access-repository', function () 
   });
 
   describe('#sessionHasSupervisorAccess', function () {
-    afterEach(function () {
-      return knex('supervisor-accesses').delete();
-    });
-
     it('should return true if session has at least one supervisor access', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -9,19 +9,14 @@ const {
 const AutoJuryDone = require('../../../../lib/domain/events/AutoJuryDone');
 const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
 
+const juryCertificationSummaryRepository = { findBySessionId: sinon.stub() };
+const finalizedSessionRepository = { save: sinon.stub() };
+const dependencies = {
+  juryCertificationSummaryRepository,
+  finalizedSessionRepository,
+};
+
 describe('Unit | Domain | Events | handle-session-finalized', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const juryCertificationSummaryRepository = { findBySessionId: sinon.stub() };
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const finalizedSessionRepository = { save: sinon.stub() };
-
-  const dependencies = {
-    juryCertificationSummaryRepository,
-    finalizedSessionRepository,
-  };
-
   it('fails when event is not of correct type', async function () {
     // given
     const event = 'not an event of the correct type';

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -11,9 +11,11 @@ const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession
 
 const juryCertificationSummaryRepository = { findBySessionId: sinon.stub() };
 const finalizedSessionRepository = { save: sinon.stub() };
+const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
 const dependencies = {
   juryCertificationSummaryRepository,
   finalizedSessionRepository,
+  supervisorAccessRepository,
 };
 
 describe('Unit | Domain | Events | handle-session-finalized', function () {
@@ -38,32 +40,46 @@ describe('Unit | Domain | Events | handle-session-finalized', function () {
       sessionDate: '2021-01-29',
       sessionTime: '14:00',
     });
-    juryCertificationSummaryRepository.findBySessionId.withArgs(1234).resolves([
-      new JuryCertificationSummary({
-        id: 1,
-        firstName: 'firstName',
-        lastName: 'lastName',
-        status: assessmentResultStatuses.VALIDATED,
-        pixScore: 120,
-        createdAt: new Date(),
-        completedAt: new Date(),
-        isPublished: false,
-        hasSeenEndTestScreen: true,
-        cleaCertificationStatus: 'not_passed',
-        certificationIssueReports: [
-          domainBuilder.buildCertificationIssueReport({
-            category: CertificationIssueReportCategories.LATE_OR_LEAVING,
-            subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
-          }),
-        ],
-      }),
-    ]);
+    const juryCertificationSummary = new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: assessmentResultStatuses.VALIDATED,
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+          subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        }),
+      ],
+    });
+    juryCertificationSummaryRepository.findBySessionId.withArgs(1234).resolves([juryCertificationSummary]);
     finalizedSessionRepository.save.resolves();
+    supervisorAccessRepository.sessionHasSupervisorAccess.resolves(true);
+    const finalizedSessionFromSpy = sinon.spy(FinalizedSession, 'from');
 
     // when
     await handleFinalizedSession({ event, ...dependencies });
 
     // then
+    expect(supervisorAccessRepository.sessionHasSupervisorAccess).to.have.been.calledOnceWithExactly({
+      sessionId: 1234,
+    });
+    expect(finalizedSessionFromSpy).to.have.been.calledOnceWithExactly({
+      sessionId: event.sessionId,
+      finalizedAt: event.finalizedAt,
+      certificationCenterName: event.certificationCenterName,
+      sessionDate: event.sessionDate,
+      sessionTime: event.sessionTime,
+      hasExaminerGlobalComment: false,
+      hasSupervisorAccess: true,
+      juryCertificationSummaries: [juryCertificationSummary],
+    });
     expect(finalizedSessionRepository.save).to.have.been.calledWithExactly(
       new FinalizedSession({
         sessionId: event.sessionId,
@@ -72,6 +88,7 @@ describe('Unit | Domain | Events | handle-session-finalized', function () {
         sessionDate: event.sessionDate,
         sessionTime: event.sessionTime,
         isPublishable: true,
+        hasSupervisorAccess: true,
         publishedAt: null,
       })
     );

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -18,25 +18,49 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: true,
         juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        hasSupervisorAccess: false,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
       // then
       expect(finalizedSession.isPublishable).to.be.false;
     });
 
-    it('is not publishable when at least one test end screen has not been seen', function () {
-      // given / when
-      const finalizedSession = FinalizedSession.from({
-        sessionId: 1234,
-        certificationCenterName: 'a certification center',
-        sessionDate: '2021-01-29',
-        sessionTime: '16:00',
-        hasExaminerGlobalComment: false,
-        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatusButEndScreenNotSeen(),
-        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+    context('when supervisor space was not used', function () {
+      it('is not publishable when at least one test end screen has not been seen', function () {
+        // given / when
+        const finalizedSession = FinalizedSession.from({
+          sessionId: 1234,
+          certificationCenterName: 'a certification center',
+          sessionDate: '2021-01-29',
+          sessionTime: '16:00',
+          hasExaminerGlobalComment: false,
+          juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatusButEndScreenNotSeen(),
+          hasSupervisorAccess: false,
+          finalizedAt: new Date('2020-01-01T00:00:00Z'),
+        });
+
+        // then
+        expect(finalizedSession.isPublishable).to.be.false;
       });
-      // then
-      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
+    context('when supervisor space was used', function () {
+      it('is publishable even if an test end screen has not been seen', function () {
+        // when
+        const finalizedSession = FinalizedSession.from({
+          sessionId: 1234,
+          certificationCenterName: 'a certification center',
+          sessionDate: '2021-01-29',
+          sessionTime: '16:00',
+          hasExaminerGlobalComment: false,
+          juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatusButEndScreenNotSeen(),
+          hasSupervisorAccess: true,
+          finalizedAt: new Date('2020-01-01T00:00:00Z'),
+        });
+
+        // then
+        expect(finalizedSession.isPublishable).to.be.true;
+      });
     });
 
     it('is not publishable when at least one test is not completed and has an abort reason', function () {
@@ -48,6 +72,7 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
         juryCertificationSummaries: _someWhichAreFlaggedAborted(),
+        hasSupervisorAccess: false,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
       // then
@@ -63,6 +88,7 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
         juryCertificationSummaries: _someWithUnresolvedRequiredActionButNoErrorOrStartedStatus(),
+        hasSupervisorAccess: false,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
       // then
@@ -78,6 +104,7 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
         juryCertificationSummaries: _noneWithRequiredActionButSomeErrorStatus(),
+        hasSupervisorAccess: false,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
 
@@ -94,6 +121,7 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
         juryCertificationSummaries: _noneWithRequiredActionButSomeStartedStatus(),
+        hasSupervisorAccess: false,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
 
@@ -110,6 +138,24 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
         juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        hasSupervisorAccess: false,
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+
+      // then
+      expect(finalizedSession.isPublishable).to.be.true;
+    });
+
+    it('is publishable when session has no global comment, no started or error status, no issue report requiring action and supervisor was used', function () {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        hasSupervisorAccess: true,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
 
@@ -126,6 +172,7 @@ describe('Unit | Domain | Models | FinalizedSession', function () {
         sessionTime: '16:00',
         hasExaminerGlobalComment: false,
         juryCertificationSummaries: _someWithResolvedRequiredActionButNoErrorOrStartedStatus(),
+        hasSupervisorAccess: false,
         finalizedAt: new Date('2020-01-01T00:00:00Z'),
       });
       // then


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l’ajout des fonctionnalités liées à l’espace surveillant, tout ce qui concerne l'écran de fin de test va être supprimé. Il ne sera donc plus possible pour les utilisateurs Pix Certif de renseigner si l'écran de FDT a été vu depuis la page de finalisation de session.

Actuellement, l'écran de FDT non renseigné reste un critère qui fait d’une session une session à problème (et donc qui la fait apparaître dans la liste des sessions “à traiter” dans Pix Admin) même lorsque l’espace surveillant est activé. Donc toute session finalisée via le nouveau process espace surveillant apparaîtra dans la liste des session à traiter et ce même si c’est une session sans problème.

## :robot: Solution

Ne plus considérer l'écran de FDT non renseigné comme un critère de session “à traiter” pour les sessions qui ont utiliisées l’espace surveillant

## :rainbow: Remarques

*RAS*

## :100: Pour tester

- Se connecter à pix-certif avec ```certifsup```
- Créer une session de certification
- Passer la certification avec un candidat
- finaliser la session
- Se connecter à pix-admin et constater que la session est publiable directement