### PR TITLE
[FEATURE] Renommer les labels "Créée par" en "Propriétaire" sur Pix Orga (PIX-4148).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -46,7 +46,8 @@ Fonctionnalité: Gestion des Campagnes
   Scénario: Je créé une campagne d'évaluation
     Étant donné que je suis connecté à Pix Orga
     Lorsque je clique sur "Créer une campagne"
-    Et je saisis "Campagne du Nord" dans le champ "Nom de la campagne"
+    Alors je suis redirigé vers la page "creation"
+    Lorsque je saisis "Campagne du Nord" dans le champ "Nom de la campagne"
     Et je clique sur "Évaluer les participants"
     Et je saisis "Compétences pour un Mestre" dans le champ "Que souhaitez-vous tester ?"
     Et je clique sur "Non"
@@ -56,7 +57,8 @@ Fonctionnalité: Gestion des Campagnes
   Scénario: Je créé une campagne de collecte de profils
     Étant donné que je suis connecté à Pix Orga
     Lorsque je clique sur "Créer une campagne"
-    Et je saisis "Campagne de l'Ouest" dans le champ "Nom de la campagne"
+    Alors je suis redirigé vers la page "creation"
+    Lorsque je saisis "Campagne de l'Ouest" dans le champ "Nom de la campagne"
     Et je clique sur "Collecter les profils Pix des participants"
     Et je clique sur "Non"
     Et je clique sur "Créer la campagne"
@@ -82,7 +84,8 @@ Fonctionnalité: Gestion des Campagnes
     Et je clique sur "Campagne du Mur"
     Et je clique sur "Paramètres"
     Lorsque je clique sur "Modifier"
-    Et que je saisis "Parcours pour les marcheurs blancs" dans le champ "Titre du parcours"
+    Alors je suis redirigé vers la page "modification"
+    Lorsque je saisis "Parcours pour les marcheurs blancs" dans le champ "Titre du parcours"
     Et que je clique sur "Modifier"
     Et que je clique sur "Paramètres"
     Alors je vois le détail de la campagne "Campagne du Mur"

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -81,7 +81,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           await visitScreen('/campagnes/toutes');
 
           // when
-          await fillByLabel('Rechercher un créateur', owner.firstName);
+          await fillByLabel('Rechercher un propriétaire', owner.firstName);
 
           // then
           assert.strictEqual(currentURL(), `/campagnes/toutes?ownerName=${owner.firstName}`);
@@ -98,7 +98,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           await visitScreen(`/campagnes/toutes?ownerName=${owner.firstName}`);
 
           // when
-          await fillByLabel('Rechercher un créateur', '');
+          await fillByLabel('Rechercher un propriétaire', '');
 
           // then
           assert.strictEqual(currentURL(), '/campagnes/toutes');
@@ -125,7 +125,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           const screen = await visitScreen('/campagnes/toutes');
 
           // when
-          await fillByLabel('Rechercher un créateur', owner.firstName);
+          await fillByLabel('Rechercher un propriétaire', owner.firstName);
 
           // then
           assert.dom(screen.getByText('ma super campagne')).exists();
@@ -201,7 +201,7 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           await visitScreen('/campagnes/toutes');
 
           // when
-          await fillByLabel('Rechercher un créateur', 'Harry');
+          await fillByLabel('Rechercher un propriétaire', 'Harry');
           await fillByLabel('Rechercher une campagne', 'campagne');
 
           // then

--- a/orga/tests/integration/components/campaign/filter/filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/filters_test.js
@@ -21,12 +21,12 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
     );
 
     // then
-    assert.contains('Filtres');
+    assert.dom(screen.getByText('Filtres')).exists();
     assert.dom(screen.getByLabelText('Rechercher une campagne')).exists();
-    assert.dom(screen.getByLabelText('Rechercher un créateur')).exists();
+    assert.dom(screen.getByLabelText('Rechercher un propriétaire')).exists();
     assert.dom(screen.getByLabelText('Archivées')).exists();
     assert.dom(screen.getByLabelText('Actives')).exists();
-    assert.contains('1 campagne');
+    assert.dom(screen.getByText('1 campagne')).exists();
   });
 
   module('when showing current user campaign list', function () {
@@ -41,7 +41,7 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
       );
 
       // then
-      assert.dom(screen.queryByLabelText('Rechercher un créateur')).doesNotExist();
+      assert.dom(screen.queryByLabelText('Rechercher un propriétaire')).doesNotExist();
     });
   });
 

--- a/orga/tests/integration/components/campaign/list_test.js
+++ b/orga/tests/integration/components/campaign/list_test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -21,14 +20,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      const screen = await renderScreen(hbs`<Campaign::List
                   @campaigns={{campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
                   @onClickStatusFilter={{this.onClickStatusFilterSpy}} />`);
 
       // then
-      assert.contains('Aucune campagne');
+      assert.dom(screen.getByText('Aucune campagne')).exists();
     });
   });
 
@@ -45,14 +44,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      const screen = await renderScreen(hbs`<Campaign::List
                   @campaigns={{this.campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
                   @onClickStatusFilter={{this.onClickStatusFilterSpy}} />`);
 
       // then
-      assert.notContains('Aucune campagne');
+      assert.dom(screen.queryByLabelText('Aucune campagne')).doesNotExist();
       assert.dom('[aria-label="Campagne"]').exists({ count: 2 });
     });
 
@@ -74,7 +73,7 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      await renderScreen(hbs`<Campaign::List
                   @campaigns={{this.campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
@@ -105,14 +104,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      const screen = await renderScreen(hbs`<Campaign::List
                   @campaigns={{campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
                   @onClickStatusFilter={{this.onClickStatusFilterSpy}} />`);
       // then
-      assert.contains('campagne 1');
-      assert.contains('campagne 2');
+      assert.dom(screen.getByText('campagne 1')).exists();
+      assert.dom(screen.getByText('campagne 2')).exists();
     });
 
     test('it should display the owner of the campaigns', async function (assert) {
@@ -133,7 +132,7 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      await renderScreen(hbs`<Campaign::List
                   @campaigns={{campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
@@ -166,14 +165,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      const screen = await renderScreen(hbs`<Campaign::List
                   @campaigns={{campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
                   @onClickStatusFilter={{this.onClickStatusFilterSpy}} />`);
 
       // then
-      assert.contains('02/02/2020');
+      assert.dom(screen.getByText('02/02/2020')).exists();
     });
 
     test('it should display the participations count', async function (assert) {
@@ -190,7 +189,7 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      await renderScreen(hbs`<Campaign::List
                   @campaigns={{campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
@@ -214,7 +213,7 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      await renderScreen(hbs`<Campaign::List
                   @campaigns={{campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
@@ -231,14 +230,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      const screen = await renderScreen(hbs`<Campaign::List
                   @campaigns={{this.campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
                   @onClickStatusFilter={{this.onClickStatusFilterSpy}} />`);
 
       // then
-      assert.dom('[placeholder="Rechercher une campagne"]').exists();
+      assert.dom(screen.getByPlaceholderText('Rechercher une campagne')).exists();
     });
 
     test('it should display the placeholder of the filter by owner field', async function (assert) {
@@ -248,14 +247,14 @@ module('Integration | Component | Campaign::List', function (hooks) {
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Campaign::List
+      const screen = await renderScreen(hbs`<Campaign::List
                   @campaigns={{this.campaigns}}
                   @onFilter={{this.triggerFilteringSpy}}
                   @onClickCampaign={{this.goToCampaignPageSpy}}
                   @onClickStatusFilter={{this.onClickStatusFilterSpy}} />`);
 
       // then
-      assert.dom('[placeholder="Rechercher un créateur"]').exists();
+      assert.dom(screen.getByPlaceholderText('Rechercher un propriétaire')).exists();
     });
 
     module('when showing current user campaign list', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -259,7 +259,7 @@
           "default": "Copy direct link"
         }
       },
-      "created-by": "Created by",
+      "created-by": "Owner",
       "created-on": "Created on",
       "empty-state": "No participants yet! Share with them the following link to join this campaign.",
       "name": "Name of the campaign",
@@ -500,16 +500,16 @@
       },
       "no-campaign": "No campaign. To start, click on 'Create a campaign'.",
       "filter": {
-        "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du créateur. Des boutons permettent de filtrer les campagnes actives et archivées.",
+        "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du propriétaire. Des boutons permettent de filtrer les campagnes actives et archivées.",
         "title": "Filters",
-        "by-owner": "Search for a creator",
+        "by-owner": "Search for an owner",
         "by-name": "Search for a campaign",
         "results": "{total, plural, =0 {0 campaigns} =1 {1 campaign} other {{total, number} campaigns}}"
       },
       "table": {
         "column": {
-          "campaign": "Campaigns",
-          "created-by": "Created by",
+          "campaign": "Name of the campaign",
+          "created-by": "Owner",
           "created-on": "Created on",
           "participants": "Participants",
           "results": "Results submitted"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -259,7 +259,7 @@
           "default": "Copier le lien direct"
         }
       },
-      "created-by": "Créée par",
+      "created-by": "Propriétaire",
       "created-on": "Créée le",
       "empty-state": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
       "name": "Nom de la campagne",
@@ -500,17 +500,17 @@
       },
       "no-campaign": "Aucune campagne, pour commencer cliquez sur le bouton 'Créer une campagne'.",
       "filter": {
-        "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du créateur. Des boutons permettent de filtrer les campagnes actives et archivées.",
+        "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du propriétaire. Des boutons permettent de filtrer les campagnes actives et archivées.",
         "title": "Filtres",
-        "by-owner": "Rechercher un créateur",
+        "by-owner": "Rechercher un propriétaire",
         "by-name": "Rechercher une campagne",
         "results": "{total, plural, =0 {0 campagne} =1 {1 campagne} other {{total, number} campagnes}}"
       },
       "table": {
         "column": {
-          "campaign": "Campagnes",
-          "created-by": "Créé par",
-          "created-on": "Créé le",
+          "campaign": "Nom de la campagne",
+          "created-by": "Propriétaire",
+          "created-on": "Créée le",
           "participants": "Participants",
           "results": "Résultats reçus"
         },


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la gestion des accès sur Pix Orga, on affiche désormais le nom des propriétaires des campagnes. Mais les labels sont resté inchangés le temps d'implémenter la gestion.

## :robot: Solution
Renommer les labels "Créée par" en "Propriétaire" sur les pages suivantes : 
- Onglet Toutes les campagnes > Dans le tableau, deuxième colonne
- Dans la page de détails d'une campagne en haut à droite.

## :rainbow: Remarques
Le label "Campagnes" à également été renommé en "Nom de la campagne"

---

⚠️ Suite au changement de ce label, 3 tests e2e ont fail.

Sur les deux tests concernant la création de campagne, Cypress n’attendait pas que la page “Creation” soit affichée pour faire l’étape suivante (Remplir le “Nom de la campagne” par “blablabla”).
Le changement de label en “Nom de la campagne” était alors toujours affichée, Cypress essayait donc de remplir directement là.

<img width="548" alt="Capture d’écran 2022-02-01 à 16 35 10" src="https://user-images.githubusercontent.com/58915422/151999219-9a8a57f4-664d-4159-81b8-73de208e9528.png">


**Fix : Ajout d'une ligne de vérification "vérifie que tu es sur la page “Création”"** 

Ainsi on demande à Cypress de bien arriver sur la page de création de campagne avant de remplir le champ en question. Il trouvera alors le bon "Nom de la campagne" associé au champ.

## :100: Pour tester
Se connecter sur Pix Orga, se mettre en domaine `org` pour pouvoir changer facilement de langue.
- Onglet `Mes campagnes`  > la colonne "Campagnes" devient "Nom de la campagne" (en anglais “Name of the campaign”)
- Onglet `Mes campagnes` > "Créé le" devient "Créée le"

- Onglet `Toutes les campagnes` > la colonne "Campagnes" devient "Nom de la campagne" (en anglais “Name of the campaign”)
- Onglet `Toutes les campagnes` > "Créé le" devient "Créée le"
- Onglet `Toutes les campagnes` > "Créé par" devient "Propriétaire" (en anglais “Owner”)

- Sur la page de détails d'une campagne > "Créé par" devient "Propriétaire" (en anglais “Owner”)