### PR TITLE
[BUGFIX] Empêcher l'envoi des résultats de campagne ET dans le même temps de retenter (Pix-4238).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -54,7 +54,7 @@
           class="skill-review-result-abstract__share-container
             {{if this.showStages "skill-review-result-abstract__share-container--left"}}"
         >
-          {{#if this.displayErrorMessage}}
+          {{#if this.showNotFinishedYetMessage}}
             <div class="skill-review-share__error-container">
               <div class="skill-review-share-error__message" aria-live="polite">
                 {{t "pages.skill-review.not-finished"}}
@@ -62,10 +62,18 @@
               <LinkTo
                 @route="campaigns.entry-point"
                 @model={{@model.campaign.code}}
-                class="skill-review-share-error__resume-button button button--big button--link"
+                class="skill-review-share-error__button button button--big button--link"
               ><span class="sr-only">{{t "pages.profile.resume-campaign-banner.accessibility.resume"}}</span>{{t
                   "pages.profile.resume-campaign-banner.actions.resume"
                 }}</LinkTo>
+            </div>
+          {{else if this.showGlobalErrorMessage}}
+            <div class="skill-review-share__error-container">
+              <div class="skill-review-share-error__message" aria-live="polite">
+                {{t "pages.skill-review.error"}}
+              </div>
+              <LinkTo @route="login" class="skill-review-share-error__button button button--big button--link">
+                {{t "navigation.back-to-homepage"}}</LinkTo>
             </div>
           {{else}}
             {{#if @model.campaign.isForAbsoluteNovice}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -167,7 +167,7 @@
     </div>
   {{/if}}
 
-  {{#if @model.campaignParticipationResult.canImprove}}
+  {{#if this.showImproveButton}}
     <SkillReviewImprove @improve={{this.improve}} />
   {{/if}}
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -14,6 +14,7 @@ export default class SkillReview extends Component {
   @service store;
 
   @tracked displayErrorMessage = false;
+  @tracked isShareButtonClicked = false;
 
   get showCleaCompetences() {
     const cleaBadge = this.args.model.campaignParticipationResult.cleaBadge;
@@ -125,6 +126,10 @@ export default class SkillReview extends Component {
     return this.args.model.campaign.organizationShowNPS && this.isShared;
   }
 
+  get showImproveButton() {
+    return this.args.model.campaignParticipationResult.canImprove && !this.isShareButtonClicked;
+  }
+
   _buildUrl(baseUrl, params) {
     const Url = new URL(baseUrl);
     const urlParams = new URLSearchParams(Url.search);
@@ -140,6 +145,7 @@ export default class SkillReview extends Component {
   @action
   async shareCampaignParticipation() {
     this.displayErrorMessage = false;
+    this.isShareButtonClicked = true;
     const campaignParticipationResult = this.args.model.campaignParticipationResult;
 
     const adapter = this.store.adapterFor('campaign-participation-result');

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -410,7 +410,7 @@
     padding-bottom: 10px;
   }
 
-  &__resume-button {
+  &__button {
     position: relative;
     top: 24px;
   }

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review_test.js
@@ -38,6 +38,23 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
       sinon.assert.calledWithExactly(adapter.share, 12345);
     });
 
+    context('before share', function () {
+      it('isShareButtonClicked should be false', async function () {
+        // then
+        expect(component.isShareButtonClicked).to.equal(false);
+      });
+    });
+
+    context('when share is not yet effective but button is pressed', function () {
+      it('should set isShareButtonClicked to true', async function () {
+        // when
+        await component.actions.shareCampaignParticipation.call(component);
+
+        // then
+        expect(component.isShareButtonClicked).to.equal(true);
+      });
+    });
+
     context('when share is effective', function () {
       it('should set isShared to true', async function () {
         // given
@@ -472,6 +489,41 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
       component.args.model.campaign.customResultPageButtonUrl = null;
       // when
       const result = component.displayPixLink;
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('#showImproveButton', function () {
+    it('should return false when canImprove is false', function () {
+      // given
+      component.args.model.campaignParticipationResult.canImprove = false;
+      component.isShareButtonClicked = false;
+      // when
+      const result = component.showImproveButton;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return false when isShareButtonClicked is true', function () {
+      // given
+      component.args.model.campaignParticipationResult.canImprove = true;
+      component.isShareButtonClicked = true;
+      // when
+      const result = component.showImproveButton;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return true when canImprove is true and isShareButtonClicked is false', function () {
+      // given
+      component.args.model.campaignParticipationResult.canImprove = true;
+      component.isShareButtonClicked = false;
+      // when
+      const result = component.showImproveButton;
 
       // then
       expect(result).to.be.true;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1226,6 +1226,7 @@
         "result-by-skill": "Your results for the competence",
         "percentage": "{rate, number, ::percent}"
       },
+      "error": "Oops, an error occurred!",
       "improve": {
         "title": "Want to improve your results?",
         "description": "You can retake some of the questions"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1226,6 +1226,7 @@
         "result-by-skill": "Votre résultat pour la compétence",
         "percentage": "{rate, number, ::percent}"
       },
+      "error": "Oups, une erreur est survenue !",
       "improve": {
         "title": "Envie d'améliorer vos résultats ?",
         "description": "Vous pouvez retenter certaines questions"


### PR DESCRIPTION
## :unicorn: Problème
Après investigation 🔍  on a trouvé des parcours où les participants avaient envoyé leurs résultats de campagne ET retenté dans la même minute. Il se trouve que sur la page en question, le bloc "retenter" reste après le partage de résultats.

Le click sur ce dernier n'est pas effectif (on reçoit une 422) si les résultats sont envoyés.

Cependant, si l'envoi prend un peu de temps (on fait pas mal de traitement à ce moment-là), l'utilisateur peut se dire "tiens tiens, il y a un autre bouton, et si je cliquais dessus" et PAF !

## :robot: Solution
Cacher le bloc "retenter" à partir du moment où le bouton "envoyer mes résultats" est cliqué.

## :rainbow: Remarques
ça représente une petite 10aine de participations en base.

## :100: Pour tester
- Participer à la campagne AZERTY456, passer ou répondre aux questions jusqu'à la fin.
- Participer à la campagne AZERTY654, se rendre compte qu'on tombe sur la page "c'est déjà fini" (car on a le même profil cible, donc déjà répondu dans la précédente campagne), aller sur la page de fin de parcours
- Vérifier que le bloc "retenter" est là puis envoyer les résultats
- Vérifier que le bloc "retenter" n'est plus là
