### PR TITLE
[TECH] Mettre à jour Pix-UI sur Pix Orga

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -32,7 +32,6 @@
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
-        class="pix-input--wide"
       />
     </div>
 

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -26,13 +26,13 @@
         @id="login-email"
         @label={{t "pages.login-form.email"}}
         name="login"
-        @type="email"
-        @value={{this.email}}
+        type="email"
         {{on "focusout" this.validateEmail}}
         @errorMessage={{this.emailValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
+        class="pix-input--wide"
       />
     </div>
 

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -73,8 +73,8 @@ export default class LoginForm extends Component {
   }
 
   @action
-  validateEmail() {
-    this.email = this.email.trim();
+  validateEmail(event) {
+    this.email = event.target.value?.trim();
     const isInvalidInput = !isEmailValid(this.email);
 
     this.emailValidationMessage = null;

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -12,7 +12,6 @@
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
-        class="pix-input--wide"
       />
     </div>
 
@@ -27,7 +26,6 @@
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"
-        class="pix-input--wide"
       />
     </div>
 
@@ -42,7 +40,6 @@
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
-        class="pix-input--wide"
       />
     </div>
 

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -6,13 +6,13 @@
         @id="register-firstName"
         @label={{t "pages.login-or-register.register-form.fields.first-name.label"}}
         name="firstName"
-        @type="firstName"
-        @value={{this.firstName}}
+        type="firstName"
         {{on "focusout" this.validateFirstName}}
         @errorMessage={{this.firstNameValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
+        class="pix-input--wide"
       />
     </div>
 
@@ -21,13 +21,13 @@
         @id="register-lastName"
         @label={{t "pages.login-or-register.register-form.fields.last-name.label"}}
         name="lastName"
-        @type="lastName"
-        @value={{this.lastName}}
+        type="lastName"
         {{on "focusout" this.validateLastName}}
         @errorMessage={{this.lastNameValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"
+        class="pix-input--wide"
       />
     </div>
 
@@ -36,13 +36,13 @@
         @id="register-email"
         @label={{t "pages.login-or-register.register-form.fields.email.label"}}
         name="email"
-        @type="email"
-        @value={{this.email}}
+        type="email"
         {{on "focusout" this.validateEmail}}
         @errorMessage={{this.emailValidationMessage}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
+        class="pix-input--wide"
       />
     </div>
 

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -76,9 +76,9 @@ export default class RegisterForm extends Component {
   }
 
   @action
-  validateEmail() {
+  validateEmail(event) {
     this.emailValidationMessage = null;
-    this.email = this.email.trim();
+    this.email = event.target.value?.trim();
     const isInvalidInput = !isEmailValid(this.email);
 
     if (isInvalidInput) {
@@ -87,9 +87,9 @@ export default class RegisterForm extends Component {
   }
 
   @action
-  validateFirstName() {
+  validateFirstName(event) {
     this.firstNameValidationMessage = null;
-    this.firstName = this.firstName.trim();
+    this.firstName = event.target.value?.trim();
     const isInvalidInput = isEmpty(this.firstName);
 
     if (isInvalidInput) {
@@ -98,9 +98,9 @@ export default class RegisterForm extends Component {
   }
 
   @action
-  validateLastName() {
+  validateLastName(event) {
     this.lastNameValidationMessage = null;
-    this.lastName = this.lastName.trim();
+    this.lastName = event.target.value?.trim();
     const isInvalidInput = isEmpty(this.lastName);
 
     if (isInvalidInput) {

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -12,10 +12,10 @@
     <PixInput
       @id="campaign-name"
       @name="campaign-name"
-      @type="text"
-      class="input"
+      type="text"
+      class="input pix-input--wide"
       maxlength="255"
-      @value={{this.campaign.name}}
+      {{on "change" this.onChangeCampaignName}}
       required={{true}}
       aria-required={{true}}
     />
@@ -221,7 +221,8 @@
         @information={{t "pages.campaign-creation.external-id-label.suggestion"}}
         @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
-        @value={{this.campaign.idPixLabel}}
+        class="pix-input--wide"
+        {{on "change" this.onChangeExternalIdLabel}}
       />
       {{#if @errors.idPixLabel}}
         <div class="form__error error-message">
@@ -238,7 +239,8 @@
         @id="campaign-title"
         @name="campaign-title"
         maxlength="50"
-        @value={{this.campaign.title}}
+        class="pix-input--wide"
+        {{on "change" this.onChangeCampaignTitle}}
       />
     </div>
   {{/if}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -13,7 +13,7 @@
       @id="campaign-name"
       @name="campaign-name"
       type="text"
-      class="input pix-input--wide"
+      class="input"
       maxlength="255"
       {{on "change" this.onChangeCampaignName}}
       required={{true}}
@@ -221,7 +221,6 @@
         @information={{t "pages.campaign-creation.external-id-label.suggestion"}}
         @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
-        class="pix-input--wide"
         {{on "change" this.onChangeExternalIdLabel}}
       />
       {{#if @errors.idPixLabel}}
@@ -239,7 +238,6 @@
         @id="campaign-title"
         @name="campaign-title"
         maxlength="50"
-        class="pix-input--wide"
         {{on "change" this.onChangeCampaignTitle}}
       />
     </div>

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -138,6 +138,21 @@ export default class CreateForm extends Component {
   }
 
   @action
+  onChangeCampaignName(event) {
+    this.campaign.name = event.target.value?.trim();
+  }
+
+  @action
+  onChangeExternalIdLabel(event) {
+    this.campaign.idPixLabel = event.target.value;
+  }
+
+  @action
+  onChangeCampaignTitle(event) {
+    this.campaign.title = event.target.value?.trim();
+  }
+
+  @action
   onSubmit(event) {
     event.preventDefault();
     this.args.onSubmit(this.campaign);

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -12,9 +12,11 @@
       @id="campaign-name"
       @name="campaign-name"
       maxlength="255"
-      @value={{@campaign.name}}
+      value={{@campaign.name}}
+      {{on "change" this.onChangeCampaignName}}
       required={{true}}
       aria-required={{true}}
+      class="pix-input--wide"
     />
   </div>
 
@@ -26,6 +28,8 @@
         @label={{t "pages.campaign-modification.personalised-test-title"}}
         maxlength="50"
         @value={{@campaign.title}}
+        {{on "change" this.onChangeCampaignTitle}}
+        class="pix-input--wide"
       />
     </div>
   {{/if}}

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -16,7 +16,6 @@
       {{on "change" this.onChangeCampaignName}}
       required={{true}}
       aria-required={{true}}
-      class="pix-input--wide"
     />
   </div>
 
@@ -29,7 +28,6 @@
         maxlength="50"
         @value={{@campaign.title}}
         {{on "change" this.onChangeCampaignTitle}}
-        class="pix-input--wide"
       />
     </div>
   {{/if}}

--- a/orga/app/components/campaign/update-form.js
+++ b/orga/app/components/campaign/update-form.js
@@ -1,0 +1,14 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UpdateForm extends Component {
+  @action
+  onChangeCampaignName(event) {
+    this.args.campaign.name = event.target.value?.trim();
+  }
+
+  @action
+  onChangeCampaignTitle(event) {
+    this.args.campaign.title = event.target.value?.trim();
+  }
+}

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -226,7 +226,3 @@ input[type=radio]:hover::before {
 input[type=radio]:active::before {
   box-shadow: 0 0 0 8px rgba($blue, 0.3);
 }
-
-.pix-input--wide {
-  width: 100%; // should be in pix-ui
-}

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -226,3 +226,7 @@ input[type=radio]:hover::before {
 input[type=radio]:active::before {
   box-shadow: 0 0 0 8px rgba($blue, 0.3);
 }
+
+.pix-input--wide {
+  width: 100%; // should be in pix-ui
+}

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -17,7 +17,6 @@
       @isValidationActive={{true}}
       placeholder={{this.firstTwoDivisions}}
       required={{true}}
-      autocomplete="off"
     />
     <PixButton @type="submit" id="download_results" @size="small">
       {{t "pages.certifications.download-button"}}

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26690,8 +26690,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v11.2.0",
-      "integrity": "sha512-BJUQjOc3c8JWtNqgZ3v68Wva6BRrVCpcMuFjL5pbmecvab0qgrd1UAFRzipVfZjhphsDQDmUwpTmCcxQPRFWRg==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v12.0.0",
+      "integrity": "sha512-8v0K5AabehSsdaRO5SGRknDCmtm1DpBmzmEzmr2SMIy+3Jr1WRyFnCKzQdCeqvXNy2uWDN0bgU3FrFylJFBZcA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26690,8 +26690,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v11.0.0",
-      "integrity": "sha512-4K6zcmFWNNM2i/ztlM/97QlRnzlUD2YMIkMYOZntJv6vjwkoExAA3avk51G/GlkNSxwxW9QA0jgPZ94uVl5fhw==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v11.0.1",
+      "integrity": "sha512-PrcHyElLdV3AmQJrubf9xZ5dxbH0wMsxPM1XSEYksUXDveu2ZQwNGf9EpHgYHI+kzCRFkg2cQSSVGNa/4O1z4w==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26690,8 +26690,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v11.0.1",
-      "integrity": "sha512-PrcHyElLdV3AmQJrubf9xZ5dxbH0wMsxPM1XSEYksUXDveu2ZQwNGf9EpHgYHI+kzCRFkg2cQSSVGNa/4O1z4w==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v11.1.0",
+      "integrity": "sha512-ptzBmAX3BJxiDxBB/y5n9HQZT29kNDmlOE+iPgWpQ3c87jR17oJBMIpcgrWzt0KbwPRfIGpf5OGTO8dpk4oprg==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26690,8 +26690,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v12.0.0",
-      "integrity": "sha512-8v0K5AabehSsdaRO5SGRknDCmtm1DpBmzmEzmr2SMIy+3Jr1WRyFnCKzQdCeqvXNy2uWDN0bgU3FrFylJFBZcA==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v13.0.0",
+      "integrity": "sha512-Pf+P0EJSkJBGZSjmURemsknxEc/qLg/VuiagrH5IQHWCl119cqKkUu0GYgJhipNQTMXvBWlyMA3tYn/bs8kQZA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26690,8 +26690,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v11.1.1",
-      "integrity": "sha512-j67a63qnQH3aKzeMxmnxywcMCigE2tfh3wKWEukoYN0Vc8ebDn153WM1b0gfAYPiQjWRh4Yc1d2xi2AGNo0ktA==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v11.2.0",
+      "integrity": "sha512-BJUQjOc3c8JWtNqgZ3v68Wva6BRrVCpcMuFjL5pbmecvab0qgrd1UAFRzipVfZjhphsDQDmUwpTmCcxQPRFWRg==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26690,8 +26690,8 @@
       }
     },
     "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v11.1.0",
-      "integrity": "sha512-ptzBmAX3BJxiDxBB/y5n9HQZT29kNDmlOE+iPgWpQ3c87jR17oJBMIpcgrWzt0KbwPRfIGpf5OGTO8dpk4oprg==",
+      "version": "https://github.com/1024pix/pix-ui/tarball/v11.1.1",
+      "integrity": "sha512-j67a63qnQH3aKzeMxmnxywcMCigE2tfh3wKWEukoYN0Vc8ebDn153WM1b0gfAYPiQjWRh4Yc1d2xi2AGNo0ktA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package.json
+++ b/orga/package.json
@@ -101,7 +101,7 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.1.1",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.2.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -101,7 +101,7 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v12.0.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v13.0.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -101,7 +101,7 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.1.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.1.1",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -101,7 +101,7 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.0.1",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.1.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -101,7 +101,7 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.2.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v12.0.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -101,7 +101,7 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.0.0",
+    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v11.0.1",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",


### PR DESCRIPTION
## :unicorn: Problème
On a besoin des dernières features / composants de Pix-UI sur Pix Orga mais Pix-UI n'est pas à jour sur l'application.

## :robot: Solution
Mettre à jour Pix-UI sur Pix Orga.

## :rainbow: Remarques
Changelog de Pix-UI : https://ui.pix.fr/?path=/docs/changelog--page

Je n'arrive pas à voir si la v12.0.0 inclue des modifications à faire côté Pix Orga...

La version v11.1.0 est en réalité une montée de version majeure, elle inclue pas mal de changements cassants, il faut faire une passe sur tout les formulaires.

## :100: Pour tester
Faire des tests de non régression sur les formulaires d'Orga (en particulier tout les champs de texte).
Se balader dans Pix-Orga et constater que rien ne change visuellement.
