### PR TITLE
[FEATURE] Afficher le compte connecté et pouvoir en changer dans l'espace surveillant (PIX-3728)

### DIFF
--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -37,4 +37,9 @@
   <p class="login-session-supervisor-form__description">
     Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif.
   </p>
+
+  <div class="login-session-supervisor-form__current-user-email">
+    <span><FaIcon @icon="user-circle" /></span>
+    {{@currentUserEmail}}
+  </div>
 </div>

--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -39,7 +39,11 @@
   </p>
 
   <div class="login-session-supervisor-form__current-user-email">
-    <span><FaIcon @icon="user-circle" /></span>
-    {{@currentUserEmail}}
+    <span><FaIcon @icon="user-circle" />
+      {{@currentUserEmail}}
+    </span>
+    <LinkTo class="login-session-supervisor-form__logout" @route="logout">
+      Changer de compte
+    </LinkTo>
   </div>
 </div>

--- a/certif/app/controllers/login-session-supervisor.js
+++ b/certif/app/controllers/login-session-supervisor.js
@@ -5,6 +5,11 @@ import { inject as service } from '@ember/service';
 export default class LoginSessionSupervisorController extends Controller {
   @service store;
   @service router;
+  @service currentUser;
+
+  get currentUserEmail() {
+    return this.currentUser.certificationPointOfContact.email;
+  }
 
   @action
   async authenticateSupervisor({ sessionId, supervisorPassword }) {

--- a/certif/app/styles/components/login-session-supervisor-form.scss
+++ b/certif/app/styles/components/login-session-supervisor-form.scss
@@ -1,13 +1,14 @@
-
 .login-session-supervisor-form {
   box-sizing: border-box;
   display: flex;
+  position: relative;
   flex-direction: column;
   align-items: center;
   background-color: white;
   border-radius: 10px;
   margin: 8px;
   max-width: 463px;
+  height: 622px;
   padding: 32px 8px 16px;
   width: 100%;
 
@@ -60,5 +61,27 @@
     font-size: 0.8rem;
     margin: 0;
     text-align: center;
+  }
+
+  &__current-user-email {
+    display: flex;
+    position: absolute;
+    border-radius: 0px 0px 10px 10px;
+    bottom: 0px;
+    background: $grey-10;
+    align-items: center;
+    justify-content: center;
+    font-family: $roboto;
+    color: $blue-zodiac;
+    width: 100%;
+    font-size: 14px;
+    font-weight: normal;
+    height: 80px;
+    letter-spacing: 0.15px;
+    line-height: 22px;
+
+    span {
+      margin-right: 8px;
+    }
   }
 }

--- a/certif/app/styles/components/login-session-supervisor-form.scss
+++ b/certif/app/styles/components/login-session-supervisor-form.scss
@@ -65,9 +65,10 @@
 
   &__current-user-email {
     display: flex;
+    flex-direction: column;
     position: absolute;
-    border-radius: 0px 0px 10px 10px;
-    bottom: 0px;
+    border-radius: 0 0 10px 10px;
+    bottom: 0;
     background: $grey-10;
     align-items: center;
     justify-content: center;
@@ -80,8 +81,13 @@
     letter-spacing: 0.15px;
     line-height: 22px;
 
-    span {
+    svg {
       margin-right: 8px;
     }
+  }
+
+  &__logout {
+    margin-top: 4px;
+    color: $blue-zodiac;
   }
 }

--- a/certif/app/templates/login-session-supervisor.hbs
+++ b/certif/app/templates/login-session-supervisor.hbs
@@ -1,4 +1,7 @@
 {{page-title "Connexion à l'espace surveillant"}}
 <div class="login-session-supervisor-page">
-  <LoginSessionSupervisorForm @onFormSubmit={{this.authenticateSupervisor}} />
+  <LoginSessionSupervisorForm
+    @onFormSubmit={{this.authenticateSupervisor}}
+    @currentUserEmail={{this.currentUserEmail}}
+  />
 </div>

--- a/certif/tests/acceptance/login-session-supervisor_test.js
+++ b/certif/tests/acceptance/login-session-supervisor_test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { authenticateSession } from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Login session supervisor', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    const certificationPointOfContact = server.create('certification-point-of-contact', {
+      firstName: 'Buffy',
+      lastName: 'Summers',
+      pixCertifTermsOfServiceAccepted: true,
+      allowedCertificationCenterAccesses: [],
+    });
+    await authenticateSession(certificationPointOfContact.id);
+
+    server.create('session-for-supervising', { id: 12345 });
+  });
+
+  module('When supervisor wants to change account', function () {
+    test('it should redirect to logout page', async function (assert) {
+      // given
+      const screen = await visitScreen('/connexion-espace-surveillant');
+
+      // when
+      await click(screen.getByText('Changer de compte'));
+
+      // then
+      assert.strictEqual(currentURL(), '/logout');
+    });
+  });
+});

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -22,6 +22,7 @@ module('Integration | Component | login-session-supervisor-form', function (hook
     assert.dom(screen.getByLabelText('Mot de passe de la session')).exists();
     assert.dom(screen.getByText('Surveiller la session')).exists();
     assert.dom(screen.getByText('toto@example.net')).exists();
+    assert.dom(screen.getByText('Changer de compte')).exists();
   });
 
   module('On click on supervise button', function () {

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -12,12 +12,16 @@ module('Integration | Component | login-session-supervisor-form', function (hook
   test('it should render supervisor login form', async function (assert) {
     // when
     this.onFormSubmit = sinon.stub();
-    const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} />`);
+    this.currentUserEmail = 'toto@example.net';
+    const screen = await renderScreen(
+      hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} @currentUserEmail={{this.currentUserEmail}}/>`
+    );
 
     // then
     assert.dom(screen.getByLabelText('Numéro de la session')).exists();
     assert.dom(screen.getByLabelText('Mot de passe de la session')).exists();
     assert.dom(screen.getByText('Surveiller la session')).exists();
+    assert.dom(screen.getByText('toto@example.net')).exists();
   });
 
   module('On click on supervise button', function () {


### PR DESCRIPTION
## :unicorn: Problème
La maquette du portail surveillant propose un bouton "Quitter" qui permet de quitter la session en cours pour en surveiller une autre. Mais il faut aussi prévoir un bouton pour se déconnecter de son compte Pix.

## :robot: Solution
Ajouter sous le formulaire de connexion l’espace surveillant :

- Ajouter l’e-mail de l’utilisateur 

- Ajouter un bouton "Changer de compte" qui permet de se déconnecter

## :rainbow: Remarques
https://app.abstract.com/projects/280f7ad0-eaa1-410f-92ea-939377685856/branches/31e8904a-4175-4af6-a5ec-1ad7f92c5617/commits/latest/files/3900F4DC-0E21-45EA-BEC2-01D2435AB1F2/layers/0B48D6A6-A088-43D5-9E5B-545431153EE5?collectionId=f77779b7-9b38-45fc-a457-da1bfe890962&collectionLayerId=9049c397-a1dc-4ae5-80d6-236badf07ecb&mode=design&selected=root-251ABD10-BC30-4FD4-8585-C8C6B78CDA36

## :100: Pour tester
- Se connecter à pix-certif avec ```certif-success@example.net```
- Constater que l'email de l'utilisateur est affiché
- Constater qu'un lien 'Changer de compte' est présent
- Cliquer sur ce lien et constater que l'utilisateur est redirigé vers la page de connexion pix-certif
