### PR TITLE
[FEATURE] Envoyer une erreur quand un candidat tente de reprendre son test sans autorisation (PIX-3875)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -393,6 +393,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.ForbiddenError(error.message);
   }
 
+  if (error instanceof DomainErrors.CandidateNotAuthorizedToResumeCertificationTestError) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -968,6 +968,12 @@ class CandidateNotAuthorizedToJoinSessionError extends DomainError {
   }
 }
 
+class CandidateNotAuthorizedToResumeCertificationTestError extends DomainError {
+  constructor(message = "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.") {
+    super(message);
+  }
+}
+
 class InvalidSkillSetError extends DomainError {
   constructor(message = 'Acquis non valide') {
     super(message);
@@ -1001,6 +1007,7 @@ module.exports = {
   CampaignCodeError,
   CancelledOrganizationInvitationError,
   CandidateNotAuthorizedToJoinSessionError,
+  CandidateNotAuthorizedToResumeCertificationTestError,
   CertificateVerificationCodeGenerationTooManyTrials,
   NoCertificationAttestationForDivisionError,
   CertificationCandidateForbiddenDeletionError,

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -17,6 +17,7 @@ const {
   InvalidVerificationCodeError,
   EmailModificationDemandNotFoundOrExpiredError,
   CandidateNotAuthorizedToJoinSessionError,
+  CandidateNotAuthorizedToResumeCertificationTestError,
   UncancellableOrganizationInvitationError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
@@ -328,6 +329,19 @@ describe('Unit | Application | ErrorManager', function () {
     it('should instantiate ForbiddenError when CandidateNotAuthorizedToJoinSessionError', async function () {
       // given
       const error = new CandidateNotAuthorizedToJoinSessionError();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate ForbiddenError when CandidateNotAuthorizedToResumeCertificationTestError', async function () {
+      // given
+      const error = new CandidateNotAuthorizedToResumeCertificationTestError();
       sinon.stub(HttpErrors, 'ForbiddenError');
       const params = { request: {}, h: hFake, error };
 


### PR DESCRIPTION
## :unicorn: Problème
Pour le moment, lorsqu’un candidat tente de reprendre son test de certification alors qu’il n’y a pas été autorisé par son surveillant, il voit le message d’erreur suivant : “Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.”

Il ne s’agit pas ici pour le surveillant de cocher la présence du candidat mais de l’autoriser à reprendre son test

## :robot: Solution
Modifier le message d’erreur : “Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test”

## :100: Pour tester
- Créer une session de certification avec un centre dans la whitelist de l'espace surveillant
- Tenter de rejoindre la session avec un candidat sans y avoir été autorisé
- Constater le message d'erreur suivant: ```Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.```
- Débuter la session avec un candidat autorisé
- Fermer la fenêtre
- Tenter de se reconnecter et constater le message d'erreur suivant : ```Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.```