### PR TITLE
[BUGFIX] Correction de l'affichage du statut responsive d'un tube (PIX-4267)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -44,6 +44,7 @@ class Challenge {
    * @param discriminant
    * @param difficulty
    * @param responsive
+   * @param genealogy
    */
   constructor({
     id,
@@ -70,6 +71,7 @@ class Challenge {
     discriminant,
     difficulty,
     responsive,
+    genealogy,
   } = {}) {
     this.id = id;
     this.answer = answer;
@@ -95,6 +97,7 @@ class Challenge {
     this.discriminant = discriminant;
     this.difficulty = difficulty;
     this.responsive = responsive;
+    this.genealogy = genealogy;
   }
 
   addSkill(skill) {

--- a/api/lib/domain/usecases/get-pix-framework.js
+++ b/api/lib/domain/usecases/get-pix-framework.js
@@ -15,7 +15,7 @@ module.exports = async function getPixFramework({
   const tubesWithResponsiveStatus = await bluebird.mapSeries(tubes, async (tube) => {
     const skills = skillRepository.findActiveByTubeId(tube.id);
     let validatedChallenges = await bluebird.mapSeries(skills, ({ id }) => {
-      return challengeRepository.findValidatedBySkillId(id);
+      return challengeRepository.findValidatedPrototypeBySkillId(id);
     });
     validatedChallenges = validatedChallenges.flat();
 
@@ -27,13 +27,19 @@ module.exports = async function getPixFramework({
 };
 
 function _isResponsiveForMobile(challenges) {
-  return _.some(challenges, (challenge) => {
-    return challenge.responsive?.includes('Smartphone');
-  });
+  return (
+    challenges.length > 0 &&
+    _.every(challenges, (challenge) => {
+      return challenge.responsive?.includes('Smartphone');
+    })
+  );
 }
 
 function _isResponsiveForTablet(challenges) {
-  return _.some(challenges, (challenge) => {
-    return challenge.responsive?.includes('Tablette');
-  });
+  return (
+    challenges.length > 0 &&
+    _.every(challenges, (challenge) => {
+      return challenge.responsive?.includes('Tablette');
+    })
+  );
 }

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -3,6 +3,7 @@ const datasource = require('./datasource');
 
 const VALIDATED_CHALLENGE = 'validé';
 const OPERATIVE_CHALLENGES = [VALIDATED_CHALLENGE, 'archivé'];
+const PROTOTYPE_CHALLENGE = 'Prototype 1';
 
 module.exports = datasource.extend({
   modelName: 'challenges',
@@ -38,6 +39,13 @@ module.exports = datasource.extend({
   async findValidatedBySkillId(id) {
     const validatedChallenges = await this.findValidated();
     return validatedChallenges.filter((challenge) => challenge.skillIds.includes(id));
+  },
+
+  async findValidatedPrototypeBySkillId(id) {
+    const validatedChallenges = await this.findValidated();
+    return validatedChallenges.filter(
+      (challenge) => challenge.skillIds.includes(id) && challenge.genealogy === PROTOTYPE_CHALLENGE
+    );
   },
 
   async findFlashCompatible(locale) {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -77,6 +77,12 @@ module.exports = {
     const activeSkills = await skillDatasource.findActive();
     return _toDomainCollection({ challengeDataObjects, skills: activeSkills });
   },
+
+  async findValidatedPrototypeBySkillId(skillId) {
+    const challengeDataObjects = await challengeDatasource.findValidatedPrototypeBySkillId(skillId);
+    const activeSkills = await skillDatasource.findActive();
+    return _toDomainCollection({ challengeDataObjects, skills: activeSkills });
+  },
 };
 
 function _toDomainCollection({ challengeDataObjects, skills }) {
@@ -128,5 +134,6 @@ function _toDomain({ challengeDataObject, skillDataObjects }) {
     discriminant: challengeDataObject.alpha,
     difficulty: challengeDataObject.delta,
     responsive: challengeDataObject.responsive,
+    genealogy: challengeDataObject.genealogy,
   });
 }

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -398,4 +398,55 @@ describe('Integration | Repository | challenge-repository', function () {
       expect(_.omit(validatedChallenges[0], 'validator')).to.deep.equal(_.omit(challenge1, 'validator'));
     });
   });
+
+  describe('#findValidatedPrototypeBySkillId', function () {
+    it('should return validated prototype challenges of a skill', async function () {
+      // given
+      const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
+      const challenge1 = domainBuilder.buildChallenge({
+        id: 'recChallenge1',
+        skills: [skill],
+        status: 'validé',
+        genealogy: 'Prototype 1',
+      });
+      const challenge2 = domainBuilder.buildChallenge({
+        id: 'recChallenge2',
+        skills: [skill],
+        status: 'archivé',
+        genealogy: 'Declinaison 1',
+      });
+      const challenge3 = domainBuilder.buildChallenge({
+        id: 'recChallenge3',
+        skills: [skill],
+        status: 'périmé',
+        genealogy: 'Declinaison 1',
+      });
+      const challenge4 = domainBuilder.buildChallenge({
+        id: 'recChallenge1',
+        skills: [skill],
+        status: 'validé',
+        genealogy: 'Declinaison 1',
+      });
+
+      const learningContent = {
+        skills: [{ ...skill, status: 'actif' }],
+        challenges: [
+          { ...challenge1, skillIds: ['recSkill1'], alpha: 0, delta: 0 },
+          { ...challenge2, skillIds: ['recSkill1'] },
+          { ...challenge3, skillIds: ['recSkill1'] },
+          { ...challenge4, skillIds: ['recSkill1'] },
+        ],
+      };
+
+      mockLearningContent(learningContent);
+
+      // when
+      const validatedChallenges = await challengeRepository.findValidatedPrototypeBySkillId(skill.id);
+
+      // then
+      expect(validatedChallenges).to.have.lengthOf(1);
+      expect(validatedChallenges[0]).to.be.instanceOf(Challenge);
+      expect(_.omit(validatedChallenges[0], 'validator')).to.deep.equal(_.omit(challenge1, 'validator'));
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -22,6 +22,8 @@ module.exports = function buildChallenge({
   autoReply = false,
   discriminant = 0,
   difficulty = 0,
+  responsive = 'Smartphone/Tablette',
+  genealogy = 'Prototype 1',
   // includes
   answer,
   validator = new Validator(),
@@ -48,6 +50,8 @@ module.exports = function buildChallenge({
     discriminant,
     difficulty,
     alternativeInstruction,
+    genealogy,
+    responsive,
     // includes
     answer,
     validator,

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -41,6 +41,7 @@ describe('Unit | Domain | Models | Challenge', function () {
         discriminant: 0.75,
         difficulty: -0.23,
         responsive: 'Smartphone',
+        genealogy: 'Prototype 1',
       };
 
       // when

--- a/api/tests/unit/domain/usecases/get-pix-framework_test.js
+++ b/api/tests/unit/domain/usecases/get-pix-framework_test.js
@@ -22,6 +22,7 @@ describe('Unit | UseCase | get-pix-framework', function () {
 
     challengeRepository = {
       findValidatedBySkillId: sinon.stub().resolves(expectedChallengeResult),
+      findValidatedPrototypeBySkillId: sinon.stub().resolves(expectedChallengeResult),
     };
 
     skillRepository = {
@@ -58,56 +59,84 @@ describe('Unit | UseCase | get-pix-framework', function () {
     });
     expect(tubeRepository.findActivesFromPixFramework).to.have.been.calledWithExactly('fr');
     expect(skillRepository.findActiveByTubeId).to.have.been.called;
-    expect(challengeRepository.findValidatedBySkillId).to.have.been.called;
+    expect(challengeRepository.findValidatedPrototypeBySkillId).to.have.been.called;
   });
 
   // eslint-disable-next-line mocha/no-setup-in-describe
   [
     {
-      challengeResult: {
-        id: 'challengeId1',
-        responsive: 'Tablette/Smartphone',
-      },
+      challengeResult: [
+        {
+          id: 'challengeId1',
+          responsive: 'Tablette/Smartphone',
+        },
+      ],
       expectedResult: {
         mobile: true,
         tablet: true,
       },
     },
     {
-      challengeResult: {
-        id: 'challengeId1',
-        responsive: 'Tablette',
-      },
+      challengeResult: [
+        {
+          id: 'challengeId1',
+          responsive: 'Tablette/Smartphone',
+        },
+        {
+          id: 'challengeId2',
+          responsive: 'Tablette',
+        },
+      ],
       expectedResult: {
         mobile: false,
         tablet: true,
       },
     },
     {
-      challengeResult: {
-        id: 'challengeId1',
-        responsive: 'Smartphone',
-      },
+      challengeResult: [
+        {
+          id: 'challengeId1',
+          responsive: 'Tablette/Smartphone',
+        },
+        {
+          id: 'challengeId2',
+          responsive: 'Smartphone',
+        },
+      ],
       expectedResult: {
         mobile: true,
         tablet: false,
       },
     },
     {
-      challengeResult: {
-        id: 'challengeId1',
-        responsive: 'Non',
-      },
+      challengeResult: [
+        {
+          id: 'challengeId1',
+          responsive: 'Tablette/Smartphone',
+        },
+        {
+          id: 'challengeId2',
+          responsive: 'Non',
+        },
+      ],
       expectedResult: {
         mobile: false,
         tablet: false,
       },
     },
     {
-      challengeResult: {
-        id: 'challengeId1',
-        responsive: '',
+      challengeResult: [],
+      expectedResult: {
+        mobile: false,
+        tablet: false,
       },
+    },
+    {
+      challengeResult: [
+        {
+          id: 'challengeId2',
+        },
+      ],
       expectedResult: {
         mobile: false,
         tablet: false,
@@ -118,6 +147,7 @@ describe('Unit | UseCase | get-pix-framework', function () {
       // given
       challengeRepository = {
         findValidatedBySkillId: sinon.stub().resolves(challengeResult),
+        findValidatedPrototypeBySkillId: sinon.stub().resolves(challengeResult),
       };
 
       // when

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -35,6 +35,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr', 'fr-fr'],
       alpha: 2.11,
       delta: -3.56,
+      genealogy: 'Declinaison 1',
     };
     challenge_competence1_noSkills = {
       id: 'challenge-competence1-noSkills',
@@ -44,6 +45,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr', 'fr-fr'],
       alpha: 8.11,
       delta: 0.95,
+      genealogy: 'Declinaison 1',
     };
     challenge_competence1_notValidated = {
       id: 'challenge-competence1-notValidated',
@@ -53,6 +55,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       status: 'proposé',
       alpha: -0,
       delta: 0,
+      genealogy: 'Prototype 1',
     };
     challenge_competence2 = {
       id: 'challenge-competence2',
@@ -62,12 +65,14 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr', 'fr-fr'],
       alpha: 8.21,
       delta: -4.23,
+      genealogy: 'Declinaison 1',
     };
     challenge_web1 = {
       id: 'challenge-web1',
       skillIds: [web1.id],
       locales: ['fr', 'fr-fr'],
       status: 'validé',
+      genealogy: 'Prototype 1',
     };
     challenge_web1_notValidated = {
       id: 'challenge-web1-notValidated',
@@ -76,6 +81,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr', 'fr-fr'],
       alpha: -1.9,
       delta: 2.34,
+      genealogy: 'Declinaison 1',
     };
     challenge_web1_archived = {
       id: 'challenge_web1_archived',
@@ -84,6 +90,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr', 'fr-fr'],
       alpha: -1.9,
       delta: 2.34,
+      genealogy: 'Declinaison 1',
     };
     challenge_web2_en = {
       id: 'challenge-web2',
@@ -92,6 +99,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       status: 'validé',
       alpha: 1,
       delta: -2,
+      genealogy: 'Declinaison 1',
     };
     challenge_web3 = {
       id: 'challenge-web3',
@@ -100,6 +108,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr', 'fr-fr'],
       alpha: 1.83,
       delta: 0.27,
+      genealogy: 'Declinaison 1',
     };
     challenge_web3_archived = {
       id: 'challenge-web3-archived',
@@ -108,6 +117,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       locales: ['fr-fr'],
       alpha: -8.1,
       delta: 0,
+      genealogy: 'Declinaison 1',
     };
 
     sinon.stub(cache, 'get').callsFake((generator) => generator());
@@ -244,9 +254,26 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     it('should resolve an array of validated challenge of a skill from learning content ', async function () {
       // when
       const result = await challengeDatasource.findValidatedBySkillId('skill-web1');
+
       // then
       expect(lcms.getLatestRelease).to.have.been.called;
       expect(result).to.deep.equal([challenge_web1, challenge_competence2]);
+    });
+  });
+
+  describe('#findValidatedPrototypeBySkillId', function () {
+    beforeEach(function () {
+      sinon.stub(lcms, 'getLatestRelease').resolves({
+        challenges: [challenge_web1, challenge_web1_notValidated, challenge_web1_archived, challenge_competence2],
+      });
+    });
+    it('should resolve an array of validated prototype challenge of a skill from learning content ', async function () {
+      // when
+      const result = await challengeDatasource.findValidatedPrototypeBySkillId('skill-web1');
+
+      // then
+      expect(lcms.getLatestRelease).to.have.been.called;
+      expect(result).to.deep.equal([challenge_web1]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous affichions un sujet comme étant responsive si au moins une de ses épreuves l'était. Or il faut que la totalité des épreuves qui compose un tube soit responsive pour que le tube soit considéré comme responsive.

## :robot: Solution
Modifier la règle.

## :rainbow: Remarques
RAS

## :100: Pour tester
Afficher la page de sélection de sujet et vérifier que le statut responsive des tubes correspondent bien aux donnée du référentiel.
