### PR TITLE
[FEATURE] Afficher le nombre de sujets sélectionnés dans le bouton de téléchargement (PIX-4167)

### DIFF
--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -2,7 +2,7 @@
   <div class="download-file">
     {{#if this.haveNoTubeSelected}}
       <PixButton class="download-file__button" @isDisabled={{this.haveNoTubeSelected}}>
-        {{t "pages.preselect-target-profile.download" fileSize=this.fileSize}}
+        {{t "pages.preselect-target-profile.no-tube-selected" fileSize=this.fileSize}}
       </PixButton>
     {{else}}
       <PixButtonLink
@@ -10,7 +10,11 @@
         @href={{this.downloadURL}}
         download={{t "pages.preselect-target-profile.download-filename"}}
       >
-        {{t "pages.preselect-target-profile.download" fileSize=this.fileSize}}
+        {{t
+          "pages.preselect-target-profile.download"
+          fileSize=this.fileSize
+          numberOfTubesSelected=this.numberOfTubesSelected
+        }}
       </PixButtonLink>
     {{/if}}
   </div>

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -10,6 +10,10 @@ export default class TubeList extends Component {
     return this.tubesSelected.length === 0;
   }
 
+  get numberOfTubesSelected() {
+    return this.tubesSelected.length;
+  }
+
   get file() {
     const json = JSON.stringify(this.tubesSelected);
     return new Blob([json], { type: 'application/json' });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -596,7 +596,8 @@
       }
     },
     "preselect-target-profile": {
-      "download": "Download topics selection (JSON, { fileSize }kb)",
+      "no-tube-selected": "Download topics selection (JSON, { fileSize }kb)",
+      "download": "Download topics selection ({ numberOfTubesSelected }) (JSON, { fileSize }kb)",
       "download-filename": "topic-selection.json",
       "title": "Topic selection",
       "table": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -596,7 +596,8 @@
       }
     },
     "preselect-target-profile": {
-      "download": "Télécharger la sélection des sujets (JSON, { fileSize }ko)",
+      "no-tube-selected": "Télécharger la sélection des sujets (JSON, { fileSize }ko)",
+      "download": "Télécharger la sélection des sujets ({ numberOfTubesSelected }) (JSON, { fileSize }ko)",
       "download-filename": "selection-sujets.json",
       "title": "Sélection des sujets",
       "table": {


### PR DESCRIPTION
## :unicorn: Problème
On aimerait pouvoir afficher dans la page de sélection de sujets, le nombre de sujets sélectionnés avant de pouvoir les télécharger.

## :robot: Solution
Ajouter cet information dans le bouton de téléchargement.

## :100: Pour tester
https://orga-pr3986.review.pix.fr/selection-sujets