### PR TITLE
[FEATURE] Permettre d'activer la facturation des certifications via FT (PIX-4262).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -166,6 +166,7 @@ module.exports = (function () {
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),
+      isCertificationBillingEnabled: isFeatureEnabled(process.env.FT_CERTIFICATION_BILLING),
     },
 
     infra: {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -28,6 +28,7 @@ const schema = Joi.object({
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   CACHE_RELOAD_TIME: Joi.string().optional(),
+  FT_CERTIFICATION_BILLING: Joi.string().optional().valid('true', 'false'),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_END_TEST_SCREEN_REMOVAL_ENABLED: Joi.string().optional().valid('true', 'false'),

--- a/api/sample.env
+++ b/api/sample.env
@@ -36,6 +36,13 @@ FT_VALIDATE_EMAIL=false
 # default: false
 FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=false
 
+# Add info about certification billing
+#
+# presence: optionnal
+# type: boolean
+# default: false
+FT_CERTIFICATION_BILLING
+
 # =======
 # CACHING
 # =======

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -21,6 +21,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
         data: {
           id: '0',
           attributes: {
+            'is-certification-billing-enabled': false,
             'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,


### PR DESCRIPTION
## :unicorn: Problème
On souhaite pouvoir développer la factu certif sans pour autant le rendre accessible en production 

## :robot: Solution
Ajouter dans API FT_CERTIFICATION_BILLING


## :100: Pour tester
On peut voir la valeur du toggle depuis l'URL /api/feature-toggles