### PR TITLE
[BUGFIX] Corriger la longueur des champs input quand les contenus sont trop longs (PIX-4261)

### DIFF
--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -131,15 +131,14 @@
 .comparison-window-solution {
   display: flex;
   align-items: stretch;
-  margin-top: 10px;
-  margin-left: 3px;
 
   &__text {
     font-size: 1rem;
     font-weight: $font-bold;
     color: $green;
     display: flex;
-    margin-left: 7px;
+    margin-left: 10px;
+    margin-top: 10px;
     position: relative;
     bottom: 3px;
     overflow-wrap: break-word;

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -131,7 +131,8 @@
 .comparison-window-solution {
   display: flex;
   align-items: stretch;
-  margin-top: 5px;
+  margin-top: 10px;
+  margin-left: 3px;
 
   &__text {
     font-size: 1rem;

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -11,6 +11,7 @@
   border: solid 1px $grey-20;
   padding: 0 10px;
   font-size: 1rem;
+  max-width: 100%;
 
   &--paragraph {
     width: 100%;

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -46,6 +46,7 @@
     &-img {
       width: 18px;
       height: 18px;
+      margin-right: 4px;
     }
 
     &-text {

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -5,6 +5,7 @@
     font-size: 1rem;
     line-height: 1.75rem;
     color: $grey-80;
+    width: 100%;
   }
 
   &__answer {
@@ -41,19 +42,13 @@
   &__solution {
     display: flex;
     align-items: center;
-    margin-top: 4px;
-
-    &-img {
-      width: 18px;
-      height: 18px;
-      margin-right: 4px;
-    }
 
     &-text {
       font-weight: $font-bold;
       color: $green;
       font-size: 1rem;
-      margin-left: 3px;
+      margin-left: 10px;
+      margin-top: 3px;
       padding-bottom: 1px;
     }
   }

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -18,6 +18,7 @@
     &-wrapper {
       display: inline-block;
       vertical-align: top;
+      width: 100%;
     }
 
     &--paragraph {
@@ -33,6 +34,7 @@
     &--input {
       display: inline-block;
       height: 26px;
+      max-width: 100%;
     }
   }
 

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -27,6 +27,7 @@
 
   &__row {
     padding: 20px;
+    width: 100%;
   }
 
   &__row label {

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -27,7 +27,6 @@
 
   &__row {
     padding: 20px;
-    width: 100%;
   }
 
   &__row label {

--- a/mon-pix/app/templates/components/qcm-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcm-solution-panel.hbs
@@ -24,12 +24,6 @@
   {{#if this.isNotCorrectlyAnswered}}
     {{#if @solutionToDisplay}}
       <div class="comparison-window-solution comparison-window-solution--with-margin">
-        <img
-          class="comparison-window-solution__img"
-          src="/images/icons/comparison-window/icon-arrow-right.svg"
-          alt=""
-          role="none"
-        />
         <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
         <div class="comparison-window-solution__text">{{@solutionToDisplay}}</div>
       </div>

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -32,12 +32,6 @@
     {{#if this.isNotCorrectlyAnswered}}
       {{#if this.understandableSolution}}
         <div class="comparison-window-solution">
-          <img
-            class="comparison-window-solution__img"
-            src="/images/icons/comparison-window/icon-arrow-right.svg"
-            alt=""
-            role="none"
-          />
           <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
           <div class="comparison-window-solution__text">{{this.understandableSolution}}</div>
         </div>

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -21,7 +21,7 @@
         {{else}}
           <input
             class="correction-qroc-box-answer {{this.inputClass}}"
-            size="{{get-qroc-input-size @answer.challenge.format}}"
+            size="{{this.answerToDisplay.length}}"
             value="{{this.answerToDisplay}}"
             aria-label={{t "pages.comparison-window.results.a11y.given-answer"}}
             disabled

--- a/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
@@ -30,7 +30,7 @@
           <div class="correction-qrocm__answer-wrapper">
             <input
               value="{{block.answer}}"
-              size="{{get-qroc-input-size @challenge.format}}"
+              size="{{block.answer.length}}"
               class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}"
               id="{{block.input}}"
               disabled

--- a/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
@@ -45,12 +45,6 @@
     {{/each}}
     {{#unless this.answerIsCorrect}}
       <div class="comparison-window-solution">
-        <img
-          class="comparison-window-solution__img"
-          src="/images/icons/comparison-window/icon-arrow-right.svg"
-          alt=""
-          role="none"
-        />
         <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
         <div class="correction-qrocm__solution-text">{{this.understandableSolution}}</div>
       </div>

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -50,7 +50,7 @@
         {{else}}
           <div class="correction-qrocm__answer-wrapper">
             <input
-              value="{{block.answer}} "
+              value="{{block.answer}}"
               size="{{block.answer.length}}"
               class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}"
               id="{{block.input}}"

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -31,12 +31,6 @@
           </textarea>
           {{#if block.emptyOrWrongAnswer}}
             <div class="correction-qrocm__solution">
-              <img
-                class="correction-qrocm__solution-img"
-                src="/images/icons/comparison-window/icon-arrow-right.svg"
-                alt=""
-                role="none"
-              />
               <div class="correction-qrocm__solution-text">{{block.solution}}</div>
             </div>
           {{/if}}
@@ -50,12 +44,6 @@
           />
           {{#if block.emptyOrWrongAnswer}}
             <div class="correction-qrocm__solution">
-              <img
-                class="correction-qrocm__solution-img"
-                src="/images/icons/comparison-window/icon-arrow-right.svg"
-                alt=""
-                role="none"
-              />
               <div class="correction-qrocm__solution-text">{{block.solution}}</div>
             </div>
           {{/if}}
@@ -70,12 +58,6 @@
             />
             {{#if block.emptyOrWrongAnswer}}
               <div class="correction-qrocm__solution">
-                <img
-                  class="correction-qrocm__solution-img"
-                  src="/images/icons/comparison-window/icon-arrow-right.svg"
-                  alt=""
-                  role="none"
-                />
                 <div class="correction-qrocm__solution-text">{{block.solution}}</div>
               </div>
             {{/if}}
@@ -93,12 +75,6 @@
   {{#if this.isNotCorrectlyAnswered}}
     {{#if @solutionToDisplay}}
       <div class="comparison-window-solution comparison-window-solution--with-margin">
-        <img
-          class="comparison-window-solution__img"
-          src="/images/icons/comparison-window/icon-arrow-right.svg"
-          alt=""
-          role="none"
-        />
         <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
         <div class="comparison-window-solution__text">{{@solutionToDisplay}}</div>
       </div>

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -62,8 +62,8 @@
         {{else}}
           <div class="correction-qrocm__answer-wrapper">
             <input
-              value="{{block.answer}}"
-              size="{{get-qroc-input-size @challenge.format}}"
+              value="{{block.answer}} "
+              size="{{block.answer.length}}"
               class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}"
               id="{{block.input}}"
               disabled

--- a/mon-pix/public/images/icons/comparison-window/icon-arrow-right.svg
+++ b/mon-pix/public/images/icons/comparison-window/icon-arrow-right.svg
@@ -3,6 +3,6 @@
      style="width:18px;height:18px"
      version="1.1" width="24" height="24"
      viewBox="0 0 24 24">
-  <path fill="#12caa1"
+  <path fill="#038A25"
         d="M5,21A2,2 0 0,1 3,19V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5V19C21,20.11 20.1,21 19,21H5M6,13H14.5L11,16.5L12.42,17.92L18.34,12L12.42,6.08L11,7.5L14.5,11H6V13Z"/>
 </svg>

--- a/mon-pix/public/images/icons/comparison-window/icon-arrow-right.svg
+++ b/mon-pix/public/images/icons/comparison-window/icon-arrow-right.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink"
-     style="width:18px;height:18px"
-     version="1.1" width="24" height="24"
-     viewBox="0 0 24 24">
-  <path fill="#038A25"
-        d="M5,21A2,2 0 0,1 3,19V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5V19C21,20.11 20.1,21 19,21H5M6,13H14.5L11,16.5L12.42,17.92L18.34,12L12.42,6.08L11,7.5L14.5,11H6V13Z"/>
-</svg>

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -45,28 +45,22 @@ describe('Integration | Component | QROC solution panel', function () {
   });
 
   describe('When format is neither a paragraph nor a sentence', function () {
-    [
-      { format: 'petit', expectedSize: '11' },
-      { format: 'mots', expectedSize: '20' },
-      { format: 'unreferenced_format', expectedSize: '20' },
-    ].forEach((data) => {
-      it(`should display a disabled input with expected size (${data.expectedSize}) when format is ${data.format}`, async function () {
-        // given
-        const challenge = EmberObject.create({ format: data.format });
-        const answer = EmberObject.create({ challenge });
-        const solution = '4';
-        this.set('answer', answer);
-        this.set('solution', solution);
+    it(`should display a disabled input with expected size`, async function () {
+      // given
+      const challenge = EmberObject.create({ format: '' });
+      const answer = EmberObject.create({ id: 'answer_id', result: 'ok', value: 'test', challenge });
+      const solution = '4';
+      this.set('answer', answer);
+      this.set('solution', solution);
 
-        //when
-        await render(hbs`<QrocSolutionPanel @answer={{this.answer}} @solution={{this.solution}}/>`);
+      //when
+      await render(hbs`<QrocSolutionPanel @answer={{this.answer}} @solution={{this.solution}}/>`);
 
-        // then
-        expect(find('textarea.correction-qroc-box-answer--paragraph')).to.not.exist;
-        expect(find('textarea.correction-qroc-box-answer--sentence')).to.not.exist;
-        expect(find('input.correction-qroc-box-answer')).to.have.attr('disabled');
-        expect(find('input.correction-qroc-box-answer').getAttribute('size')).to.equal(data.expectedSize);
-      });
+      // then
+      expect(find('textarea.correction-qroc-box-answer--paragraph')).to.not.exist;
+      expect(find('textarea.correction-qroc-box-answer--sentence')).to.not.exist;
+      expect(find('input.correction-qroc-box-answer')).to.have.attr('disabled');
+      expect(find('input.correction-qroc-box-answer').getAttribute('size')).to.equal(answer.value.length.toString());
     });
   });
 

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -123,12 +123,10 @@ describe('Integration | Component | QROC solution panel', function () {
 
           it('should display the solution with an arrow and the solution in bold green', function () {
             const blockSolution = find('.comparison-window-solution');
-            const arrowImg = find('.comparison-window-solution__img');
             const solutionText = find('.comparison-window-solution__text');
 
             // then
             expect(blockSolution).to.exist;
-            expect(arrowImg).to.exist;
             expect(solutionText).to.exist;
           });
         });

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -176,27 +176,20 @@ describe('Integration | Component | QROCm dep solution panel', function () {
       this.set('challenge', challenge);
     });
 
-    [
-      { format: 'petit', expectedSize: '11' },
-      { format: 'mots', expectedSize: '20' },
-      { format: 'unreferenced_format', expectedSize: '20' },
-    ].forEach((data) => {
-      it(`should display a disabled input with expected size (${data.expectedSize}) when format is ${data.format}`, async function () {
-        //given
-        this.challenge.set('format', data.format);
+    it(`should display a disabled input with expected size`, async function () {
+      //given
+      const answerSize = 'rightAnswer1'.length;
+      //when
+      await render(
+        hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
+      );
 
-        //when
-        await render(
-          hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`
-        );
-
-        //then
-        expect(find(PARAGRAPH)).to.not.exist;
-        expect(find(SENTENCE)).to.not.exist;
-        expect(find(INPUT).tagName).to.equal('INPUT');
-        expect(find(INPUT).getAttribute('size')).to.equal(data.expectedSize);
-        expect(find(INPUT).hasAttribute('disabled')).to.be.true;
-      });
+      //then
+      expect(find(PARAGRAPH)).to.not.exist;
+      expect(find(SENTENCE)).to.not.exist;
+      expect(find(INPUT).tagName).to.equal('INPUT');
+      expect(find(INPUT).getAttribute('size')).to.equal(answerSize.toString());
+      expect(find(INPUT).hasAttribute('disabled')).to.be.true;
     });
   });
 

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -137,24 +137,18 @@ describe('Integration | Component | QROCm ind solution panel', function () {
       this.set('challenge', challenge);
     });
 
-    [
-      { format: 'petit', expectedSize: '11' },
-      { format: 'mots', expectedSize: '20' },
-      { format: 'unreferenced_format', expectedSize: '20' },
-    ].forEach((data) => {
-      it(`should display a disabled input with expected size (${data.expectedSize}) when format is ${data.format}`, async function () {
-        //given
-        this.challenge.set('format', data.format);
+    it(`should display a disabled input with expected size`, async function () {
+      //given
+      const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
+      //when
+      await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+      //then
 
-        //when
-        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
-
-        //then
-        expect(find(PARAGRAPH)).to.not.exist;
-        expect(find(INPUT).tagName).to.equal('INPUT');
-        expect(find(INPUT).getAttribute('size')).to.equal(data.expectedSize);
-        expect(find(INPUT).hasAttribute('disabled')).to.be.true;
-      });
+      expect(find(PARAGRAPH)).to.not.exist;
+      expect(find(INPUT).tagName).to.equal('INPUT');
+      expect(find(INPUT).value).to.equal(EMPTY_DEFAULT_MESSAGE);
+      expect(find(INPUT).getAttribute('size')).to.equal(EMPTY_DEFAULT_MESSAGE.length.toString());
+      expect(find(INPUT).hasAttribute('disabled')).to.be.true;
     });
   });
 

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -137,7 +137,7 @@ describe('Integration | Component | QROCm ind solution panel', function () {
       this.set('challenge', challenge);
     });
 
-    it(`should display a disabled input with expected size`, async function () {
+    it(`should display a disabled input with size based on the length of the value`, async function () {
       //given
       const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
       //when


### PR DESCRIPTION
## :unicorn: Problème
- Sur certaines réponses, le contenu saisi par l’utilisateur est plus long que l’input.
- Suppression du svg de la fléche à droite de la bonne réponse.

## :robot: Solution
- Donner la longeur de la valeur à l'attribut size pour définir la taille de l'input.
- Modifier la valeur de Fill dans le SVG.
- Gérer les débordements de la questions et de l'input dans la version mobile
- Supprimer la flèche verte devant la bonne réponse


## :rainbow: Remarques
/

> 

> 

## :100: Pour tester
Vérifier sur la page résultat via cet url : '/challenges/rec11cH3eqixmdQdf/preview'
QROC : /challenges/recNanzf3oEjJ7vA9/preview
QROCM Ind (si format pas paragraphe ou phrase) : /challenges/challengeLkXw2AkjDFXaS/preview
QROCM Dep (si format pas paragraphe ou phrase) : /challenges/recUcM3s9DFvpnFqj/preview
