### PR TITLE
[A11Y] Utiliser la même couleur pour le status des participations dans le tableau que celle utilisé sur le graphique des status dans Pix Orga (PIX-4205)

### DIFF
--- a/orga/app/components/campaign/activity/participation-status.js
+++ b/orga/app/components/campaign/activity/participation-status.js
@@ -17,7 +17,7 @@ export default class ParticipationStatus extends Component {
 }
 
 const COLORS = {
-  STARTED: 'yellow-light',
+  STARTED: 'orange-light',
   TO_SHARE: 'purple-light',
   SHARED: 'green-light',
 };


### PR DESCRIPTION
## :unicorn: Problème
Le jaune clair n'était pas assez contrasté afin que le contenu du tableau soit accessible

## :robot: Solution
Utiliser la couleur orange-light au lieu du yellow-light afin d'avoir un contraste suffisant

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur Pix Orga avec pro.admin@example.net et vérifier que dans les campagnes l'affichages des status des participations soient de la même couleur que celle du graphique 