### PR TITLE
[BUGFIX] Correction graphiques sur les selects et multi-selects de Pix Orga (PIX-4236)

### DIFF
--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -23,10 +23,16 @@
         @selected={{@selectedDivisions}}
         @onSelect={{this.onSelectDivision}}
         @placeholder={{t "pages.campaign-results.filters.type.divisions.placeholder"}}
+        class="participant-filter-banner__multi-select"
       />
     {{/if}}
     {{#if this.displayGroupsFilter}}
-      <Ui::GroupsFilter @campaign={{@campaign}} @onSelect={{this.onSelectGroup}} @selectedGroups={{@selectedGroups}} />
+      <Ui::GroupsFilter
+        @campaign={{@campaign}}
+        @onSelect={{this.onSelectGroup}}
+        @selectedGroups={{@selectedGroups}}
+        class="participant-filter-banner__multi-select"
+      />
     {{/if}}
     {{#if this.displayStagesFilter}}
       <PixMultiSelect

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -6,7 +6,7 @@
       <col />
       <col />
       <col />
-      <col class="table__column--small hide-on-mobile" />
+      <col class="hide-on-mobile" />
     </colgroup>
     <thead>
       <tr>
@@ -15,7 +15,7 @@
         <Table::Header>{{t "pages.students-sco.table.column.date-of-birth"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.division"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
-        <Table::Header class="hide-on-mobile" />
+        <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
         <Table::HeaderFilterInput
@@ -33,15 +33,16 @@
           @triggerFiltering={{@onFilter}}
         />
         <Table::Header />
-        <Table::Header>
-          <Ui::DivisionsFilter
-            @model={{this.currentUser.organization}}
-            @selected={{@divisionsFilter}}
-            @onSelect={{this.onSearchDivisions}}
-            @placeholder={{t "pages.students-sco.table.filter.division.placeholder"}}
-            class="list-students-page__divisions-filter"
-          />
-        </Table::Header>
+        <Table::HeaderFilterMultiSelect
+          @field="divisions"
+          @title={{t "pages.students-sco.table.column.division"}}
+          @onSelect={{@onFilter}}
+          @selectedOption={{@divisionsFilter}}
+          @onLoadOptions={{this.loadDivisions}}
+          @placeholder={{t "pages.students-sco.table.filter.division.label"}}
+          @ariaLabel={{t "pages.students-sco.table.filter.division.aria-label"}}
+          @emptyMessage={{t "pages.students-sco.table.filter.division.empty"}}
+        />
         <Table::HeaderFilterSelect
           @field="connexionType"
           @options={{@connectionTypesOptions}}

--- a/orga/app/components/student/sco/list.js
+++ b/orga/app/components/student/sco/list.js
@@ -12,6 +12,16 @@ export default class ScoList extends Component {
   @tracked isShowingDissociateModal = false;
   @tracked isDissociateButtonEnabled = ENV.APP.IS_DISSOCIATE_BUTTON_ENABLED;
 
+  loadDivisions = async () => {
+    const divisions = await this.currentUser.organization.divisions;
+    return divisions.map(({ name }) => {
+      return {
+        label: name,
+        value: name,
+      };
+    });
+  };
+
   @action
   openAuthenticationMethodModal(student) {
     this.student = student;
@@ -32,10 +42,5 @@ export default class ScoList extends Component {
   @action
   closeDissociateModal() {
     this.isShowingDissociateModal = false;
-  }
-
-  @action
-  onSearchDivisions(divisions) {
-    this.args.onFilter('divisions', divisions);
   }
 }

--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -7,7 +7,7 @@
         <Table::Header>{{t "pages.students-sup.table.column.first-name"}}</Table::Header>
         <Table::Header>{{t "pages.students-sup.table.column.date-of-birth"}}</Table::Header>
         <Table::Header>{{t "pages.students-sup.table.column.group"}}</Table::Header>
-        <Table::Header class="hide-on-mobile" />
+        <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
         <Table::HeaderFilterInput
@@ -40,6 +40,7 @@
           @onLoadOptions={{this.loadGroups}}
           @placeholder={{t "pages.students-sup.table.filter.group.label"}}
           @ariaLabel={{t "pages.students-sup.table.filter.group.aria-label"}}
+          @emptyMessage={{t "pages.students-sup.table.filter.group.empty"}}
         />
         <Table::Header />
       </tr>

--- a/orga/app/components/table/header-filter-multi-select.hbs
+++ b/orga/app/components/table/header-filter-multi-select.hbs
@@ -1,9 +1,11 @@
 <Table::Header ...attributes>
   <PixMultiSelect
-    id="select-{{@field}}"
-    class="table__input"
+    @id="select-{{@field}}"
+    class="table__multi-select"
     @title={{@title}}
     @placeholder={{@placeholder}}
+    @loadingMessage={{t "common.filters.loading"}}
+    @emptyMessage={{@emptyMessage}}
     aria-label={{@ariaLabel}}
     @showOptionsOnInput={{true}}
     @isSearchable={{true}}

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -140,11 +140,6 @@
   }
 }
 
-.pix-select {
-  margin-top: 16px;
-  margin-bottom: 12px;
-}
-
 .label {
   display: inline-block;
   color: $grey-70;

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -45,10 +45,11 @@
     padding: 16px;
     color: $grey-60;
     font-size: 0.875rem;
+    margin: 16px 0 0 0;
 
     @include device-is('desktop') {
       position: absolute;
-      margin: 16px 0 0 16px;
+      margin: 0 0 0 16px;
       left: 100%;
       width: calc(100vw - 100% - #{$app-sidebar-width} - 32px);
     }

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -6,13 +6,22 @@ table {
   box-sizing: border-box;
 
   .table__input {
-    border: 1px solid $grey-45;
-    font-size: 0.8rem;
     height: 36px;
     width: 100%;
 
     &:focus-within {
       border: 1px solid $blue;
+    }
+  }
+
+  .table__multi-select {
+    height: 36px;
+    min-width: 100%;
+
+    > label {
+      > input[type="text"]::placeholder {
+        color: $grey-30;
+      }
     }
   }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -35,5 +35,9 @@
 
 .participant-filter-banner {
   margin-bottom: 12px;
+
+  &__multi-select {
+    width: auto;
+  }
 }
 

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -13,23 +13,6 @@ $margin-right: 32px;
     margin: 1rem 0;
   }
 
-  &__divisions-filter {
-    height: 36px;
-    min-width: 100%;
-    font-weight: 400;
-    
-    > label {
-      border: 1px solid $grey-15;
-      padding-right: 8px;
-
-      > input[type="text"]::placeholder {
-        font-family: $roboto;
-        color: $grey-30;
-        font-size: 0.8rem;
-      }
-    }
-  }
-
   &__tooltip {
     display: inline-flex;
     .pix-tooltip ul {

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
@@ -86,13 +87,8 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       await fillByLabel('Entrer un nom', 'bob');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[0], 'lastName');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[1], 'bob');
+      sinon.assert.calledWithExactly(triggerFiltering, 'lastName', 'bob');
+      assert.ok(true);
     });
 
     test('it should trigger filtering with firstname', async function (assert) {
@@ -107,13 +103,8 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       await fillByLabel('Entrer un prénom', 'bob');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[0], 'firstName');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[1], 'bob');
+      sinon.assert.calledWithExactly(triggerFiltering, 'firstName', 'bob');
+      assert.ok(true);
     });
 
     test('it should trigger filtering with division', async function (assert) {
@@ -122,17 +113,19 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       this.set('triggerFiltering', triggerFiltering);
       this.set('students', []);
 
-      await render(hbs`<Student::Sco::List @students={{students}} @onFilter={{triggerFiltering}}/>`);
+      const { getByPlaceholderText } = await render(hbs`<Student::Sco::List
+        @students={{students}}
+        @onFilter={{triggerFiltering}}
+      />`);
 
       // when
-      await click('[for="division-3A"]');
+      const select = await getByPlaceholderText('Rechercher par classe');
+      await click(select);
+      await clickByName('3A');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[0], 'divisions');
-      assert.deepEqual(call.args[1], ['3A']);
+      sinon.assert.calledWithExactly(triggerFiltering, 'divisions', ['3A']);
+      assert.ok(true);
     });
 
     test('it should trigger filtering with connexionType', async function (assert) {
@@ -150,13 +143,8 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
       await fillByLabel('Rechercher par méthode de connexion', 'email');
 
       // then
-      const call = triggerFiltering.getCall(0);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[0], 'connexionType');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(call.args[1], 'email');
+      sinon.assert.calledWithExactly(triggerFiltering, 'connexionType', 'email');
+      assert.ok(true);
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -734,7 +734,9 @@
         "empty": "No students.",
         "filter": {
           "division": {
-            "placeholder": "Search by class"
+            "aria-label": "Enter a class",
+            "empty": "No class",
+            "label": "Search by class"
           },
           "first-name": {
             "aria-label": "Enter a first name",
@@ -788,8 +790,8 @@
           },
           "group": {
             "aria-label": "Enter a group",
-            "label": "Search by group",
-            "selected": "Groups: {groups}"
+            "empty": "No group",
+            "label": "Search by group"
           },
           "last-name": {
             "aria-label": "Enter a last name",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -734,7 +734,9 @@
         "empty": "Aucun élève.",
         "filter": {
           "division": {
-            "placeholder": "Rechercher par classe"
+            "aria-label": "Entrer une classe",
+            "empty": "Aucune classe",
+            "label": "Rechercher par classe"
           },
           "first-name": {
             "aria-label": "Entrer un prénom",
@@ -788,8 +790,8 @@
           },
           "group": {
             "aria-label": "Entrer un groupe",
-            "label": "Rechercher par groupe",
-            "selected": "Groupes: {groups}"
+            "empty": "Aucun groupe",
+            "label": "Rechercher par groupe"
           },
           "last-name": {
             "aria-label": "Entrer un nom",


### PR DESCRIPTION
## :unicorn: Problème
Une classe CSS ne devrait pas être présent dans l'application

## :robot: Solution
Retirer cette classe ss afin de ne pas perturber le bon affichage du composant pix ui dans l'application

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur pix orga et vérifier que l'affichage des pix-select est cohérent partout ( certifications / filtre SCO / SUP)