### PR TITLE
[FEATURE] Ajout du champ Propriétaire lors de la création d'une campagne (PIX-4073).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -28,6 +28,7 @@ module.exports = {
       'multiple-sendings': multipleSendings,
       'id-pix-label': idPixLabel,
       'custom-landing-page-text': customLandingPageText,
+      'owner-id': ownerId,
     } = request.payload.data.attributes;
     // eslint-disable-next-line no-restricted-syntax
     const targetProfileId = parseInt(_.get(request, 'payload.data.relationships.target-profile.data.id')) || null;
@@ -41,7 +42,7 @@ module.exports = {
       idPixLabel,
       customLandingPageText,
       creatorId: userId,
-      ownerId: userId,
+      ownerId,
       organizationId,
       targetProfileId,
       multipleSendings,

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -2,7 +2,10 @@ const campaignCodeGenerator = require('../services/campaigns/campaign-code-gener
 
 module.exports = async function createCampaign({ campaign, campaignRepository, campaignCreatorRepository }) {
   const generatedCampaignCode = await campaignCodeGenerator.generate(campaignRepository);
-  const campaignCreator = await campaignCreatorRepository.get(campaign.creatorId, campaign.organizationId);
+  const campaignCreator = await campaignCreatorRepository.get({
+    userId: campaign.creatorId,
+    organizationId: campaign.organizationId,
+  });
 
   const campaignForCreation = campaignCreator.createCampaign({ ...campaign, code: generatedCampaignCode });
 

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -5,6 +5,7 @@ module.exports = async function createCampaign({ campaign, campaignRepository, c
   const campaignCreator = await campaignCreatorRepository.get({
     userId: campaign.creatorId,
     organizationId: campaign.organizationId,
+    ownerId: campaign.ownerId,
   });
 
   const campaignForCreation = campaignCreator.createCampaign({ ...campaign, code: generatedCampaignCode });

--- a/api/lib/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-creator-repository.js
@@ -2,8 +2,8 @@ const { knex } = require('../../../db/knex-database-connection');
 const CampaignCreator = require('../../../lib/domain/models/CampaignCreator');
 const { UserNotAuthorizedToCreateCampaignError } = require('../../domain/errors');
 
-async function get(userId, organizationId) {
-  await _checkUserIsAMemberOfOrganization(organizationId, userId);
+async function get({ userId, organizationId }) {
+  await _checkUserIsAMemberOfOrganization({ organizationId, userId });
   const { canCollectProfiles } = await knex('organizations')
     .where({ id: organizationId })
     .select('canCollectProfiles')
@@ -26,7 +26,7 @@ module.exports = {
   get,
 };
 
-async function _checkUserIsAMemberOfOrganization(organizationId, userId) {
+async function _checkUserIsAMemberOfOrganization({ organizationId, userId }) {
   const membership = await knex('memberships').where({ organizationId, userId }).first();
   if (!membership) {
     throw new UserNotAuthorizedToCreateCampaignError(

--- a/api/lib/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-creator-repository.js
@@ -2,8 +2,9 @@ const { knex } = require('../../../db/knex-database-connection');
 const CampaignCreator = require('../../../lib/domain/models/CampaignCreator');
 const { UserNotAuthorizedToCreateCampaignError } = require('../../domain/errors');
 
-async function get({ userId, organizationId }) {
+async function get({ userId, organizationId, ownerId }) {
   await _checkUserIsAMemberOfOrganization({ organizationId, userId });
+  await _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId });
   const { canCollectProfiles } = await knex('organizations')
     .where({ id: organizationId })
     .select('canCollectProfiles')
@@ -31,6 +32,15 @@ async function _checkUserIsAMemberOfOrganization({ organizationId, userId }) {
   if (!membership) {
     throw new UserNotAuthorizedToCreateCampaignError(
       `User does not have an access to the organization ${organizationId}`
+    );
+  }
+}
+
+async function _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId }) {
+  const membership = await knex('memberships').where({ organizationId, userId: ownerId }).first();
+  if (!membership) {
+    throw new UserNotAuthorizedToCreateCampaignError(
+      `Owner does not have an access to the organization ${organizationId}`
     );
   }
 }

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -549,6 +549,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           attributes: {
             name: 'Campagne collège',
             type: 'ASSESSMENT',
+            'owner-id': userId,
           },
           relationships: {
             'target-profile': {
@@ -579,6 +580,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       // then
       expect(response.statusCode).to.equal(201);
       expect(response.result.data.attributes.name).to.equal('Campagne collège');
+      expect(response.result.data.attributes['owner-id']).to.equal(userId);
       expect(response.result.data.attributes.type).to.equal('ASSESSMENT');
     });
 
@@ -622,6 +624,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           attributes: {
             name: 'Campagne lycée',
             type: 'PROFILES_COLLECTION',
+            'owner-id': userId,
           },
           relationships: {
             'target-profile': {
@@ -652,6 +655,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       // then
       expect(response.statusCode).to.equal(201);
       expect(response.result.data.attributes.name).to.equal('Campagne lycée');
+      expect(response.result.data.attributes['owner-id']).to.equal(userId);
       expect(response.result.data.attributes.type).to.equal('PROFILES_COLLECTION');
     });
 
@@ -696,6 +700,7 @@ describe('Acceptance | API | Campaign Controller', function () {
           attributes: {
             name: 'Campagne collège',
             type: 'ASSESSMENT',
+            'owner-id': userId,
           },
           relationships: {
             'target-profile': {

--- a/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -12,7 +12,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
       databaseBuilder.factory.buildMembership({ organizationId: otherOrganizationId, userId });
       await databaseBuilder.commit();
 
-      const creator = await campaignCreatorRepository.get(userId, organizationId);
+      const creator = await campaignCreatorRepository.get({ userId, organizationId });
 
       expect(creator.notAllowedToCreateProfileCollectionCampaign).to.equal(false);
     });
@@ -31,7 +31,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          const creator = await campaignCreatorRepository.get({ userId, organizationId });
           expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfilePublicId]);
         });
       });
@@ -54,7 +54,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          const creator = await campaignCreatorRepository.get({ userId, organizationId });
           expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfileSharedId]);
         });
 
@@ -71,7 +71,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          const creator = await campaignCreatorRepository.get({ userId, organizationId });
           expect(creator.availableTargetProfileIds).to.exactlyContain([organizationTargetProfileId]);
         });
       });
@@ -99,7 +99,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get(userId, organizationId);
+          const creator = await campaignCreatorRepository.get({ userId, organizationId });
           expect(creator.availableTargetProfileIds).to.be.empty;
         });
       });
@@ -114,7 +114,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
         await databaseBuilder.commit();
 
-        const error = await catchErr(campaignCreatorRepository.get)(userId, organizationId);
+        const error = await catchErr(campaignCreatorRepository.get)({ userId, organizationId });
 
         expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
         expect(error.message).to.equal(`User does not have an access to the organization ${organizationId}`);

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -82,13 +82,13 @@ describe('Integration | Repository | Campaign', function () {
       // given
       const user = databaseBuilder.factory.buildUser();
       const creatorId = user.id;
-      const ownerId = user.id;
+      const ownerId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       await databaseBuilder.commit();
 
-      const campaignAttributes = {
+      const campaignToSave = {
         name: 'Evaluation niveau 1 recherche internet',
         code: 'BCTERD153',
         customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
@@ -96,9 +96,6 @@ describe('Integration | Repository | Campaign', function () {
         ownerId,
         organizationId,
         multipleSendings: true,
-      };
-      const campaignToSave = {
-        ...campaignAttributes,
         type: Campaign.types.ASSESSMENT,
         targetProfileId,
         title: 'Parcours recherche internet',
@@ -122,6 +119,7 @@ describe('Integration | Repository | Campaign', function () {
           'organization',
           'targetProfile',
           'multipleSendings',
+          'ownerId',
         ])
       );
     });
@@ -130,7 +128,7 @@ describe('Integration | Repository | Campaign', function () {
       // given
       const user = databaseBuilder.factory.buildUser();
       const creatorId = user.id;
-      const ownerId = user.id;
+      const ownerId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
       await databaseBuilder.commit();
@@ -164,6 +162,7 @@ describe('Integration | Repository | Campaign', function () {
           'creator',
           'organization',
           'multipleSendings',
+          'ownerId',
         ])
       );
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -73,21 +73,22 @@ describe('Integration | Repository | Campaign', function () {
     });
   });
 
-  describe('#create', function () {
-    let creatorId, organizationId, targetProfileId;
-    let savedCampaign, campaignToSave, campaignAttributes;
+  describe('#save', function () {
+    afterEach(function () {
+      return knex('campaigns').delete();
+    });
 
-    beforeEach(async function () {
+    it('should save the given campaign with type ASSESSMENT', async function () {
       // given
-      const user = databaseBuilder.factory.buildUser({});
-      creatorId = user.id;
+      const user = databaseBuilder.factory.buildUser();
+      const creatorId = user.id;
       const ownerId = user.id;
-      organizationId = databaseBuilder.factory.buildOrganization({}).id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
-      targetProfileId = databaseBuilder.factory.buildTargetProfile({}).id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       await databaseBuilder.commit();
 
-      campaignAttributes = {
+      const campaignAttributes = {
         name: 'Evaluation niveau 1 recherche internet',
         code: 'BCTERD153',
         customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
@@ -96,15 +97,7 @@ describe('Integration | Repository | Campaign', function () {
         organizationId,
         multipleSendings: true,
       };
-    });
-
-    afterEach(function () {
-      return knex('campaigns').delete();
-    });
-
-    it('should save the given campaign with type ASSESSMENT', async function () {
-      // given
-      campaignToSave = {
+      const campaignToSave = {
         ...campaignAttributes,
         type: Campaign.types.ASSESSMENT,
         targetProfileId,
@@ -112,7 +105,7 @@ describe('Integration | Repository | Campaign', function () {
       };
 
       // when
-      savedCampaign = await campaignRepository.save(campaignToSave);
+      const savedCampaign = await campaignRepository.save(campaignToSave);
 
       // then
       expect(savedCampaign).to.be.instanceof(Campaign);
@@ -135,10 +128,27 @@ describe('Integration | Repository | Campaign', function () {
 
     it('should save the given campaign with type PROFILES_COLLECTION', async function () {
       // given
-      campaignToSave = { ...campaignAttributes, type: Campaign.types.PROFILES_COLLECTION };
+      const user = databaseBuilder.factory.buildUser();
+      const creatorId = user.id;
+      const ownerId = user.id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+      await databaseBuilder.commit();
+
+      const campaignAttributes = {
+        name: 'Evaluation niveau 1 recherche internet',
+        code: 'BCTERD153',
+        customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+        creatorId,
+        ownerId,
+        organizationId,
+        multipleSendings: true,
+      };
+
+      const campaignToSave = { ...campaignAttributes, type: Campaign.types.PROFILES_COLLECTION };
 
       // when
-      savedCampaign = await campaignRepository.save(campaignToSave);
+      const savedCampaign = await campaignRepository.save(campaignToSave);
 
       // then
       expect(savedCampaign).to.be.instanceof(Campaign);

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -23,6 +23,7 @@ describe('Unit | Application | Controller | Campaign', function () {
     it('should return a serialized campaign when the campaign has been successfully created', async function () {
       // given
       const connectedUserId = 1;
+      const ownerId = 4;
       const request = {
         auth: { credentials: { userId: connectedUserId } },
         payload: {
@@ -34,6 +35,7 @@ describe('Unit | Application | Controller | Campaign', function () {
               'id-pix-label': 'idPixLabel',
               'custom-landing-page-text': 'customLandingPageText',
               'multiple-sendings': true,
+              'owner-id': ownerId,
             },
             relationships: {
               'target-profile': { data: { id: '123' } },
@@ -54,7 +56,7 @@ describe('Unit | Application | Controller | Campaign', function () {
         organizationId: 456,
         targetProfileId: 123,
         creatorId: 1,
-        ownerId: 1,
+        ownerId: 4,
         multipleSendings: true,
       };
 

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -33,7 +33,7 @@ describe('Unit | UseCase | create-campaign', function () {
     const campaignForCreation = new CampaignForCreation({ ...campaignData, code });
 
     const campaignCreator = new CampaignCreator([targetProfileId], false);
-    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId }).resolves(campaignCreator);
+    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
 
     campaignCodeGenerator.generate.resolves(code);
     campaignRepository.save.resolves();
@@ -65,7 +65,7 @@ describe('Unit | UseCase | create-campaign', function () {
       organizationId,
     };
     const campaignCreator = new CampaignCreator([targetProfileId], false);
-    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId }).resolves(campaignCreator);
+    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
 
     campaignCodeGenerator.generate.resolves(code);
     const savedCampaign = Symbol('a saved campaign');

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -33,7 +33,7 @@ describe('Unit | UseCase | create-campaign', function () {
     const campaignForCreation = new CampaignForCreation({ ...campaignData, code });
 
     const campaignCreator = new CampaignCreator([targetProfileId], false);
-    campaignCreatorRepository.get.withArgs(creatorId, organizationId).resolves(campaignCreator);
+    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId }).resolves(campaignCreator);
 
     campaignCodeGenerator.generate.resolves(code);
     campaignRepository.save.resolves();
@@ -65,7 +65,7 @@ describe('Unit | UseCase | create-campaign', function () {
       organizationId,
     };
     const campaignCreator = new CampaignCreator([targetProfileId], false);
-    campaignCreatorRepository.get.withArgs(creatorId, organizationId).resolves(campaignCreator);
+    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId }).resolves(campaignCreator);
 
     campaignCodeGenerator.generate.resolves(code);
     const savedCampaign = Symbol('a saved campaign');

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -43,6 +43,14 @@
       required={{true}}
       aria-required={{true}}
     />
+
+    <div class="form__field-info">
+      <span class="form__field-info-title">
+        <FaIcon @icon="info-circle" class="form__field-info-icon" />
+        <span>{{t "pages.campaign-creation.owner.title"}}</span>
+      </span>
+      <span class="form__field-info-message">{{t "pages.campaign-creation.owner.info"}}</span>
+    </div>
   </div>
 
   {{#if this.currentUser.organization.canCollectProfiles}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -35,6 +35,8 @@
     <PixSelect
       class="create-campaign__select"
       @id="campaign-owner"
+      @onChange={{this.onChangeCampaignOwner}}
+      @options={{this.campaignOwnerOptions}}
       placeholder={{t "pages.campaign-creation.owner.placeholder"}}
       @isSearchable={{true}}
       value={{this.currentUserFullName}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -27,6 +27,22 @@
     {{/if}}
   </div>
 
+  <div class="form__field-with-info form__field">
+    <label class="label" for="campaign-owner">
+      <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{t "pages.campaign-creation.owner.label"}}
+    </label>
+    <PixSelect
+      class="create-campaign__select"
+      @id="campaign-owner"
+      placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+      @isSearchable={{true}}
+      value={{this.currentUserFullName}}
+      required={{true}}
+      aria-required={{true}}
+    />
+  </div>
+
   {{#if this.currentUser.organization.canCollectProfiles}}
     <div class="form__field" role="radiogroup" aria-labelledby="collect-profiles-label">
       <p id="collect-profiles-label" class="label">

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -31,6 +31,7 @@ export default class CreateForm extends Component {
       this.isCampaignGoalAssessment = true;
       this.campaign.type = 'ASSESSMENT';
     }
+    this.campaign.ownerId = this.currentUser.prescriber.id;
   }
 
   get currentUserFullName() {

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -158,6 +158,17 @@ export default class CreateForm extends Component {
   }
 
   @action
+  onChangeCampaignOwner(event) {
+    const newOwnerFullName = event.target.value;
+    const selectedMember = this.args.membersSortedByFullName.find(
+      (member) => newOwnerFullName === member.get('fullName')
+    );
+    if (selectedMember) {
+      this.campaign.ownerId = selectedMember.get('id');
+    }
+  }
+
+  @action
   onSubmit(event) {
     event.preventDefault();
     this.args.onSubmit(this.campaign);

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -33,6 +33,10 @@ export default class CreateForm extends Component {
     }
   }
 
+  get currentUserFullName() {
+    return this.currentUser.prescriber.fullName;
+  }
+
   get categories() {
     if (!this.args.targetProfiles) return [];
     let allCategories = _uniq(this.args.targetProfiles.map((targetProfile) => targetProfile.category));

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -8,4 +8,8 @@ export default class Prescriber extends Model {
   @attr('string') lang;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
+
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -6,7 +6,7 @@ export default class NewRoute extends Route {
   @service store;
   @service currentUser;
 
-  async model(params) {
+  async model() {
     const organization = this.currentUser.organization;
 
     const memberships = await this.store.query('membership', {
@@ -14,8 +14,7 @@ export default class NewRoute extends Route {
         organizationId: organization.id,
       },
       page: {
-        number: params.pageNumber,
-        size: params.pageSize,
+        size: 500,
       },
     });
     const members = memberships.map((membership) => membership.user);

--- a/orga/app/routes/authenticated/campaigns/update.js
+++ b/orga/app/routes/authenticated/campaigns/update.js
@@ -13,8 +13,7 @@ export default class UpdateRoute extends Route {
         organizationId: organization.id,
       },
       page: {
-        number: params.pageNumber,
-        size: params.pageSize,
+        size: 500,
       },
     });
     const members = memberships.map((membership) => membership.user);

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -49,6 +49,7 @@
 @import "pages/join-request";
 @import "pages/authenticated";
 @import "pages/authenticated/campaigns/campaign";
+@import 'pages/authenticated/campaigns/create-form';
 @import "pages/authenticated/campaigns/new";
 @import "pages/authenticated/campaigns/new-item";
 @import "pages/authenticated/campaigns/list";

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -1,6 +1,6 @@
 .create-campaign {
 
   &__select {
-    width: 500px;
+    width: 100%;
   }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -1,0 +1,6 @@
+.create-campaign {
+
+  &__select {
+    width: 500px;
+  }
+}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -313,10 +313,16 @@ export default function () {
 
   this.post('/campaigns', (schema, request) => {
     const body = JSON.parse(request.requestBody);
+
+    const ownerId = body.data.attributes['owner-id'];
+    const owner = schema.users.findBy({ id: ownerId });
+
     const campaign = {
       ...body.data.attributes,
       customLandingPageText: body.data.attributes['custom-landing-page-text'],
       idPixLabel: body.data.attributes['id-pix-label'],
+      ownerFirstName: owner.firstName,
+      ownerLastName: owner.lastName,
     };
     if (campaign.type === 'PROFILES_COLLECTION') {
       return schema.campaigns.create(campaign);

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -96,6 +96,25 @@ module('Acceptance | Campaign Creation', function (hooks) {
       assert.equal(currentURL(), '/campagnes/1/parametres');
     });
 
+    test('it should allow to create a campaign of with current user as owner by default', async function (assert) {
+      // given
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      createPrescriberByUser(user);
+
+      await authenticateSession(user.id);
+      const screen = await visit('/campagnes/creation');
+
+      const targetProfileName = availableTargetProfiles[1].name;
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
+      await selectByLabelAndOption('Que souhaitez-vous tester ?', targetProfileName);
+
+      // when
+      await clickByName('Créer la campagne');
+
+      // then
+      assert.dom(screen.getByText('Harry Cover', { selector: 'dd' })).exists();
+    });
+
     test('it should display error on global form when error 500 is returned from backend', async function (assert) {
       // given
       const expectedTargetProfileName = availableTargetProfiles[1].name;

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -13,7 +13,9 @@ import {
   createUserWithMembershipAndTermsOfServiceAccepted,
   createUserThatCanCollectProfiles,
   createPrescriberByUser,
+  createMembershipByOrganizationIdAndUser,
 } from '../helpers/test-init';
+import setupIntl from '../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -22,6 +24,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(() => {
     availableTargetProfiles = server.createList('target-profile', 2);
@@ -38,20 +41,19 @@ module('Acceptance | Campaign Creation', function (hooks) {
   });
 
   module('when the prescriber is authenticated', (hooks) => {
-    hooks.beforeEach(async function () {
-      const user = createUserWithMembershipAndTermsOfServiceAccepted();
-      createPrescriberByUser(user);
-
-      await authenticateSession(user.id);
-      await visit('/campagnes/creation');
-    });
-
     hooks.afterEach(function () {
       const notificationMessagesService = this.owner.lookup('service:notifications');
       notificationMessagesService.clearAll();
     });
 
     test('it should be accessible for an authenticated prescriber', async function (assert) {
+      // given / when
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      createPrescriberByUser(user);
+
+      await authenticateSession(user.id);
+      await visit('/campagnes/creation');
+
       // then
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
@@ -61,6 +63,12 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
     test('it should allow to create a campaign of type ASSESSMENT by default and redirect to the newly created campaign', async function (assert) {
       // given
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      createPrescriberByUser(user);
+
+      await authenticateSession(user.id);
+      await visit('/campagnes/creation');
+
       const expectedTargetProfileId = availableTargetProfiles[1].id;
       const expectedTargetProfileName = availableTargetProfiles[1].name;
 
@@ -115,8 +123,53 @@ module('Acceptance | Campaign Creation', function (hooks) {
       assert.dom(screen.getByText('Harry Cover', { selector: 'dd' })).exists();
     });
 
+    test('it should be possible to change default campaign owner', async function (assert) {
+      // given
+      const organization = server.create('organization', { name: 'BRO & Evil Associates' });
+
+      const currentUser = server.create('user', {
+        id: 7,
+        firstName: 'Harry',
+        lastName: 'Cover',
+        email: 'harry@cover.com',
+        pixOrgaTermsOfServiceAccepted: true,
+      });
+      currentUser.userOrgaSettings = server.create('user-orga-setting', { user: currentUser, organization });
+      const currentUserWithMembership = createMembershipByOrganizationIdAndUser(organization.id, currentUser);
+      createPrescriberByUser(currentUserWithMembership);
+
+      const otherUser = server.create('user', {
+        id: 10,
+        firstName: 'Tom',
+        lastName: 'Égérie',
+        pixOrgaTermsOfServiceAccepted: true,
+      });
+      const otherUserWithMembership = createMembershipByOrganizationIdAndUser(organization.id, otherUser);
+      createPrescriberByUser(otherUserWithMembership);
+
+      await authenticateSession(currentUser.id);
+
+      const screen = await visit('/campagnes/creation');
+
+      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
+      await selectByLabelAndOption('Que souhaitez-vous tester ?', availableTargetProfiles[1].name);
+
+      // when
+      await selectByLabelAndOption(this.intl.t('pages.campaign-creation.owner.label'), 'Tom Égérie');
+      await clickByName('Créer la campagne');
+
+      // then
+      assert.dom(screen.getByText('Tom Égérie', { selector: 'dd' })).exists();
+    });
+
     test('it should display error on global form when error 500 is returned from backend', async function (assert) {
       // given
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      createPrescriberByUser(user);
+
+      await authenticateSession(user.id);
+      await visit('/campagnes/creation');
+
       const expectedTargetProfileName = availableTargetProfiles[1].name;
       server.post('/campaigns', {}, 500);
 

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -104,7 +104,7 @@ module('Acceptance | Campaign Creation', function (hooks) {
       assert.equal(currentURL(), '/campagnes/1/parametres');
     });
 
-    test('it should allow to create a campaign of with current user as owner by default', async function (assert) {
+    test('it should set the current user as owner by default when creating a campaign', async function (assert) {
       // given
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
       createPrescriberByUser(user);

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -173,36 +173,16 @@ export function createPrescriberForOrganization(userAttributes = {}, organizatio
   return user;
 }
 
-export function createAdminMembershipWithNbMembers(countMembers) {
-  const organization = server.create('organization', {
-    name: 'BRO & Evil Associates',
+export function createMembershipByOrganizationIdAndUser(organizationId, user, role = 'MEMBER') {
+  const membership = server.create('membership', {
+    userId: user.id,
+    organizationId,
+    role,
   });
 
-  const admin = server.create('user', {
-    firstName: 'Harry',
-    lastName: 'Cover',
-    email: 'harry@cover.com',
-    pixOrgaTermsOfServiceAccepted: true,
-  });
+  user.memberships = [membership];
 
-  const adminMemberships = server.create('membership', {
-    userId: admin.id,
-    organizationId: organization.id,
-    organizationRole: 'ADMIN',
-  });
-
-  admin.userOrgaSettings = server.create('user-orga-setting', { user: admin, organization });
-  admin.memberships = [adminMemberships];
-
-  server.createList('user', countMembers).forEach((user) => {
-    server.create('membership', {
-      userId: user.id,
-      organizationId: organization.id,
-      organizationRole: 'MEMBER',
-    });
-  });
-
-  return admin;
+  return user;
 }
 
 export function createUserManagingStudents(role = 'MEMBER', type = 'SCO') {

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -53,7 +53,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.dom(screen.getByText(t('pages.campaign-creation.owner.title'))).exists();
   });
 
-  test('it should auto complete owner field by current user full name', async function (assert) {
+  test("it should auto complete owner field with current user's full name", async function (assert) {
     // when
     const screen = await renderScreen(
       hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     this.errors = {};
     class CurrentUserStub extends Service {
       organization = EmberObject.create({ canCollectProfiles: false });
-      prescriber = EmberObject.create({ fullName: 'Adam Troisjour' });
+      prescriber = EmberObject.create({ fullName: 'Adam Troisjour', id: 1 });
     }
     this.owner.register('service:current-user', CurrentUserStub);
   });
@@ -91,8 +91,10 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = EmberObject.create({ canCollectProfiles: true });
+        prescriber = EmberObject.create({ id: 1 });
       }
       this.owner.register('service:current-user', CurrentUserStub);
+
       // when
       await renderScreen(
         hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
@@ -108,6 +110,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = EmberObject.create({ canCollectProfiles: true });
+        prescriber = EmberObject.create({ id: 1 });
       }
       this.owner.register('service:current-user', CurrentUserStub);
       this.campaign = EmberObject.create({});
@@ -139,6 +142,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // given
         class CurrentUserStub extends Service {
           organization = EmberObject.create({ canCollectProfiles: true });
+          prescriber = EmberObject.create({ id: 1 });
         }
         this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
@@ -171,6 +175,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // given
         class CurrentUserStub extends Service {
           organization = EmberObject.create({ canCollectProfiles: true });
+          prescriber = EmberObject.create({ id: 1 });
         }
         this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
@@ -208,6 +213,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // given
         class CurrentUserStub extends Service {
           organization = EmberObject.create({ canCollectProfiles: true });
+          prescriber = EmberObject.create({ id: 1 });
         }
         this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
@@ -246,6 +252,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // given
         class CurrentUserStub extends Service {
           organization = EmberObject.create({ canCollectProfiles: true });
+          prescriber = EmberObject.create({ id: 1 });
         }
         this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [];
@@ -265,6 +272,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // given
         class CurrentUserStub extends Service {
           organization = EmberObject.create({ canCollectProfiles: true });
+          prescriber = EmberObject.create({ id: 1 });
         }
         this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
@@ -302,6 +310,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // given
         class CurrentUserStub extends Service {
           organization = EmberObject.create({ canCollectProfiles: true });
+          prescriber = EmberObject.create({ id: 1 });
         }
         this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
@@ -340,6 +349,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = EmberObject.create({ canCollectProfiles: true });
+        prescriber = EmberObject.create({ id: 1 });
       }
       this.owner.register('service:current-user', CurrentUserStub);
       // when
@@ -357,6 +367,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = EmberObject.create({ canCollectProfiles: true });
+        prescriber = EmberObject.create({ id: 1 });
       }
       this.owner.register('service:current-user', CurrentUserStub);
       // when
@@ -373,6 +384,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = EmberObject.create({ canCollectProfiles: true });
+        prescriber = EmberObject.create({ id: 1 });
       }
       this.owner.register('service:current-user', CurrentUserStub);
       this.campaign = EmberObject.create({});
@@ -451,6 +463,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = EmberObject.create({ canCollectProfiles: true });
+        prescriber = EmberObject.create({ id: 1 });
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const campaign = EmberObject.create({

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -42,6 +42,17 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.dom('textarea').hasAttribute('maxLength', '5000');
   });
 
+  test('it should display block information for owner', async function (assert) {
+    // when
+    const screen = await renderScreen(
+      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText(t('pages.campaign-creation.owner.info'))).exists();
+    assert.dom(screen.getByText(t('pages.campaign-creation.owner.title'))).exists();
+  });
+
   test('it should auto complete owner field by current user full name', async function (assert) {
     // when
     const screen = await renderScreen(

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -24,6 +24,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     this.errors = {};
     class CurrentUserStub extends Service {
       organization = EmberObject.create({ canCollectProfiles: false });
+      prescriber = EmberObject.create({ fullName: 'Adam Troisjour' });
     }
     this.owner.register('service:current-user', CurrentUserStub);
   });
@@ -39,6 +40,16 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     assert.dom('button[type="submit"]').exists();
     assert.dom('input[type=text]').hasAttribute('maxLength', '255');
     assert.dom('textarea').hasAttribute('maxLength', '5000');
+  });
+
+  test('it should auto complete owner field by current user full name', async function (assert) {
+    // when
+    const screen = await renderScreen(
+      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByLabelText('* ' + t('pages.campaign-creation.owner.label'))).hasValue('Adam Troisjour');
   });
 
   test('[a11y] it should display a message that some inputs are required', async function (assert) {

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
+import sinon from 'sinon';
 
 module('Unit | Component | Campaign::CreateForm', (hooks) => {
   setupTest(hooks);
@@ -111,6 +112,32 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         ];
         assert.deepEqual(allCategories, expectedOrder);
       });
+    });
+  });
+
+  module('#onChangeCampaignOwner', function () {
+    test('should set new owner id', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        organization = { canCollectProfiles: true };
+        prescriber = { id: 1 };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const getStub1 = sinon.stub();
+      getStub1.withArgs('fullName').returns('Remy Fasol');
+      getStub1.withArgs('id').returns(1);
+      const getStub2 = sinon.stub();
+      getStub2.withArgs('fullName').returns('Thierry Golo');
+      getStub2.withArgs('id').returns(7);
+      const membersSortedByFullName = [{ get: getStub1 }, { get: getStub2 }];
+      const component = await createGlimmerComponent('component:campaign/create-form', { membersSortedByFullName });
+      const event = { target: { value: 'Thierry Golo' } };
+
+      //when
+      await component.onChangeCampaignOwner(event);
+
+      //then
+      assert.deepEqual(component.campaign.ownerId, 7);
     });
   });
 });

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -26,6 +26,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         ];
         class CurrentUserStub extends Service {
           organization = { canCollectProfiles: true };
+          prescriber = { id: 1 };
         }
         this.owner.lookup('service:intl').setLocale('fr');
         this.owner.register('service:current-user', CurrentUserStub);
@@ -59,6 +60,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         // given
         class CurrentUserStub extends Service {
           organization = { canCollectProfiles: true };
+          prescriber = { id: 1 };
         }
         this.owner.lookup('service:intl').setLocale('fr');
         this.owner.register('service:current-user', CurrentUserStub);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -292,6 +292,9 @@
     },
     "campaign-creation": {
       "title": "Create a campaign",
+      "owner": {
+        "label": "Owner of the campaign"
+      },
       "actions": {
         "create": "Create a campaign"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -293,10 +293,10 @@
     "campaign-creation": {
       "title": "Create a campaign",
       "owner": {
-        "label": "Owner of the campaign",
+        "label": "Campaign owner",
         "placeholder": "Owner’s first and last name",
-        "title": "Owner of the campaign",
-        "info": "The owner of this campaign, along with the administrators of this organisation, are the only people who can modify and archive this campaign."
+        "title": "Campaign owner",
+        "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign."
       },
       "actions": {
         "create": "Create a campaign"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -293,7 +293,10 @@
     "campaign-creation": {
       "title": "Create a campaign",
       "owner": {
-        "label": "Owner of the campaign"
+        "label": "Owner of the campaign",
+        "placeholder": "Owner’s first and last name",
+        "title": "Owner of the campaign",
+        "info": "The owner of this campaign, along with the administrators of this organisation, are the only people who can modify and archive this campaign."
       },
       "actions": {
         "create": "Create a campaign"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -292,6 +292,9 @@
     },
     "campaign-creation": {
       "title": "Création d'une campagne",
+      "owner": {
+        "label": "Propriétaire de la campagne"
+      },
       "actions": {
         "create": "Créer la campagne"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -296,7 +296,7 @@
         "label": "Propriétaire de la campagne",
         "placeholder": "Nom et prénom du propriétaire",
         "title": "Propriétaire de la campagne",
-        "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier et archiver cette campagne."
+        "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier ou archiver cette campagne."
       },
       "actions": {
         "create": "Créer la campagne"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -293,7 +293,10 @@
     "campaign-creation": {
       "title": "Création d'une campagne",
       "owner": {
-        "label": "Propriétaire de la campagne"
+        "label": "Propriétaire de la campagne",
+        "placeholder": "Nom et prénom du propriétaire",
+        "title": "Propriétaire de la campagne",
+        "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier et archiver cette campagne."
       },
       "actions": {
         "create": "Créer la campagne"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la notion de propriétaire d'une campagne existe techniquement, mais les labels n'ont pas été changé (c'est prévu dans la PR https://github.com/1024pix/pix/pull/3975). Ce nouveau rôle dans Pix Orga a pour but de faciliter la gestion des campagnes des utilisateurs de Pix Orga, qui jusqu'à présent voyait toutes les campagnes de leur organisation et devait chercher leur campagne par leur nom.
Une fois les labels changés, les utilisateurs pourront voir qui est propriétaire d'une campagne dans les listes de campagne ou bien le détail d'une campagne. Ils pourront changer le propriétaire dans le détail d'une campagne dès que https://github.com/1024pix/pix/pull/3994 sera mergé. 

Par défaut c'est la personne qui créé la campagne qui en devient le propriétaire. Cependant ce n'est pas forcément cette personne qui gère ensuite la campagne (c'est la personne qu'on appelle le propriétaire). Il serait donc utile de pouvoir déterminer ce propriétaire dès la création de la campagne (plutôt que de devoir le modifier dans les paramètres de la campagne).


## :robot: Solution
Ajouter le champ "Propriétaire d'une campagne" dans le formulaire de création d'une campagne.

## :rainbow: Remarques
> RAS

## :100: Pour tester
- Lancer Pix Orga
- Cliquer sur "Créer une campagne"
- Constater que le champ "Propriétaire de la campagne" apparaît ainsi qu'une bulle d'info expliquant ce champ
- Créer une campagne sans changer le champ
- Constater que sur la page de détail , le nom du propriétaire est bien l'utilisateur avec lequel vous êtes connecté
- Faire la même chose en changeant le champ
- Constater que sur la page de détail, le nom du propriétaire est bien celui que vous avez choisis
