### PR TITLE
[TECH] Corriger le flaky test sur Pix Certif

### DIFF
--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -14,6 +14,7 @@ module('Acceptance | Session supervising', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    sinon.stub(ENV.APP, 'sessionSupervisingPollingRate').value(10000);
     const certificationPointOfContact = server.create('certification-point-of-contact', {
       firstName: 'Buffy',
       lastName: 'Summers',


### PR DESCRIPTION
## :unicorn: Problème
Un flaky test a été découvert sur Pix Certif. Il s'agit d'un test d'acceptance qui, de temps en temps, échoue car une requête à l'API n'est pas gérée par mirage et tente donc de communiquer avec le backend. La route Ember testée dans ce test d'acceptance est un peu particulière car un mécanisme de "polling" a été mis en place afin d'éviter à l'utilisateur de devoir recharger la page afin de voir les dernière modifications. C'est ce mécanisme de "polling" qui semble poser problème. Je suspecte qu'une requête supplémentaire parte après que le test se soit terminé et que mirage ait arrêté son serveur. Ce dernier n'est donc plus en mesure de gérer une requête à l'API.   

## :robot: Solution
La solution la plus simple consiste à augmenter la fréquence de polling pour ces tests afin d'éviter des requêtes supplémentaires qui n'apportent rien aux tests pouvant échouer.