### PR TITLE
[TECH] Ajout d'un script pour ajouter des membres à une organisation en env de développement (PIX-4275)

### DIFF
--- a/api/scripts/data-generation/add-many-fake-members-related-to-one-organization.js
+++ b/api/scripts/data-generation/add-many-fake-members-related-to-one-organization.js
@@ -1,0 +1,90 @@
+const { knex } = require('../../lib/infrastructure/bookshelf');
+const DomainTransaction = require('../../lib/infrastructure/DomainTransaction');
+const { MembershipUpdateError, UserCantBeCreatedError, ForbiddenAccess } = require('../../lib/domain/errors');
+const times = require('lodash/times');
+
+const INITIAL_ID = 300000;
+
+function _buildMembership(iteration) {
+  const organizationId = process.argv[3];
+  const memberRole = process.argv[4];
+  const initialIdStart = parseInt(process.argv[5]) || INITIAL_ID;
+
+  return {
+    organizationRole: memberRole,
+    organizationId: organizationId,
+    userId: initialIdStart + iteration,
+    disabledAt: null,
+  };
+}
+
+function _buildUser(iteration) {
+  const initialIdStart = parseInt(process.argv[5]) || INITIAL_ID;
+  return {
+    firstName: `firstName${initialIdStart + iteration}`,
+    lastName: `lastName${initialIdStart + iteration}`,
+    email: `firstname.lastname-${initialIdStart + iteration}@example.net`,
+    id: initialIdStart + iteration,
+    cgu: true,
+    lastPixOrgaTermsOfServiceValidatedAt: null,
+    lastPixCertifTermsOfServiceValidatedAt: null,
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    isAnonymous: true,
+  };
+}
+
+async function addManyMembersToExistingOrganization({ numberOfUsers }) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new ForbiddenAccess();
+  }
+
+  const manyUsers = times(numberOfUsers, _buildUser);
+
+  try {
+    await knex.batchInsert('users', manyUsers).transacting(DomainTransaction.emptyTransaction().knexTransaction);
+  } catch (err) {
+    throw new UserCantBeCreatedError();
+  }
+
+  const manyMemberShips = times(numberOfUsers, _buildMembership);
+
+  try {
+    await knex
+      .batchInsert('memberships', manyMemberShips)
+      .transacting(DomainTransaction.emptyTransaction().knexTransaction);
+  } catch (err) {
+    throw new MembershipUpdateError();
+  }
+}
+
+async function main() {
+  const numberOfUsers = process.argv[2];
+  const organizationId = process.argv[3];
+  const memberRole = process.argv[4];
+  const initialIdStart = parseInt(process.argv[5]) || INITIAL_ID;
+  console.log(
+    `Starting adding ${numberOfUsers} users with ${memberRole} role to organization with id ${organizationId}`
+  );
+  console.log(`User ids starting at ${initialIdStart}`);
+
+  await addManyMembersToExistingOrganization({ numberOfUsers });
+
+  console.log('\nDone.');
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  addManyMembersToExistingOrganization,
+};

--- a/api/tests/acceptance/scripts/add-many-fake-members-related-to-one-organization_test.js
+++ b/api/tests/acceptance/scripts/add-many-fake-members-related-to-one-organization_test.js
@@ -1,0 +1,52 @@
+const { expect, sinon, knex, databaseBuilder, catchErr } = require('../../test-helper');
+const {
+  addManyMembersToExistingOrganization,
+} = require('../../../scripts/data-generation/add-many-fake-members-related-to-one-organization');
+const { ForbiddenAccess } = require('../../../lib/domain/errors');
+
+describe('Acceptance | Scripts | add-many-divisions-and-students-to-sco-organization', function () {
+  it('should throw an error when env is production', async function () {
+    // given
+    const stub = sinon.stub(process.env, 'NODE_ENV').value('production');
+
+    // when
+    const error = await catchErr(addManyMembersToExistingOrganization)({ numberOfUsers: 1 });
+
+    // then
+    expect(error).to.be.an.instanceOf(ForbiddenAccess);
+    stub.restore();
+  });
+
+  it('should create an user and the membership related to the organization', async function () {
+    // given
+    const numberOfUsers = 2;
+    const organizationRole = 'MEMBER';
+    const userId = 45678902;
+    const userId2 = 45678903;
+    const organizationId = 234567890;
+
+    databaseBuilder.factory.buildOrganization({ id: organizationId });
+    await databaseBuilder.commit();
+
+    const stub = sinon
+      .stub(process, 'argv')
+      .value(['One argument', 'Another argument', numberOfUsers, organizationId, organizationRole, userId]);
+
+    // when
+    await addManyMembersToExistingOrganization({ numberOfUsers });
+
+    // then
+    const user = await knex('users').where('id', userId).first();
+    expect(user.firstName).to.equal('firstName45678902');
+    expect(user.lastName).to.equal('lastName45678902');
+    expect(user.email).to.equal('firstname.lastname-45678902@example.net');
+
+    const memberShip = await knex('memberships').where('userId', userId).first();
+    expect(memberShip.organizationRole).to.equal(organizationRole);
+    expect(memberShip.organizationId).to.equal(organizationId);
+
+    await knex('memberships').whereIn('userId', [userId, userId2]).delete();
+    await knex('users').whereIn('id', [userId, userId2]).delete();
+    stub.restore();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre d’ajout de la notion de propriétaire ([voir](https://github.com/1024pix/pix/pull/3994)), lorsqu’on choisit le propriétaire d’une campagne c’est un [PixSelect](https://ui.pix.fr/?path=/docs/form-select--default) qui nous permet d’afficher la liste des membres pouvant être propriétaire de la campagne. Cependant actuellement dans nos seeds nous n’avons pas d’organisation avec beaucoup de membres.

Or en production nous savons que dans certains cas les organisations on une centaine de membres.

Cela signifie que le [PixSelect](https://ui.pix.fr/?path=/docs/form-select--default) doit pouvoir afficher une liste de 100 noms en restant responsive et accessible.
Pour vérifier cela nous avons donc besoin d’une centaine de personnes minimum membre d’une même organisation. D’où l’idée de faire un script.

## :robot: Solution
Un script a été rajouté au côté d'autres scripts permettant d'ajouter des datas en base. Il n'y avait pas de besoin pour que cela soit ajouté dans les seeds.

## :rainbow: Remarques
C'est un script de "confort" qui a pour vocation à être joué en dev ou sur une review app. Une erreur est générée si on essaye de le jouer en prod ou recette.
Attention cela ne crée pas les memberships mais ça va nous permettre de pouvoir pour le moment tester la pagination du pix-select

## :100: Pour tester
Si vous voulez jouer le script sur votre terminal :
`node scripts/data-generation/add-many-members-to-an-organization.js 100  3 MEMBER  330000`

- premier paramètre : le nombre d'utilisateurs que l'on souhaite créer
- deuxième paramètre : l'id de l'organization
- troisième paramètre : le rôle (MEMBRE ou ADMIN), il y a une contrainte dans le modèle de BDD, aucune autre valeur n'est permise
- quatrième paramètre : la valeur de départ pour l'id de l'utilisateur (ça permet de jouer le script plusieurs fois de suite sans erreur car le userId doit être unique)

Vérifier en bdd l'insertion ou sur la liste des membres de l'organisation.


Pour vérifier que le script ne se joue pas en env de production ou de recette 
` NODE_ENV='production' node scripts/data-generation/add-many-members-to-an-organization.js 100  3 MEMBER  330000`

NB : la var d'env en recette est 'production' https://dashboard.scalingo.com/apps/osc-fr1/pix-api-recette/environment

