### PR TITLE
[TECH] Corriger la connexion avec une auto completion du formulaire de connexion (PIX-4283)

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -28,6 +28,7 @@
         name="login"
         type="email"
         {{on "focusout" this.validateEmail}}
+        {{on "input" this.updateEmail}}
         @errorMessage={{this.emailValidationMessage}}
         required={{true}}
         aria-required={{true}}

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -84,6 +84,11 @@ export default class LoginForm extends Component {
     }
   }
 
+  @action
+  updateEmail(event) {
+    this.email = event.target.value?.trim();
+  }
+
   get isFormValid() {
     return isEmailValid(this.email) && !isEmpty(this.password);
   }

--- a/orga/tests/unit/components/auth/login-form_test.js
+++ b/orga/tests/unit/components/auth/login-form_test.js
@@ -98,4 +98,19 @@ module('Unit | Component | Routes | login-form', (hooks) => {
       });
     });
   });
+
+  module('#updateEmail', () => {
+    test('should update email without spaces', function (assert) {
+      // given
+      const emailWithSpaces = '    user@example.net  ';
+      const event = { target: { value: emailWithSpaces } };
+
+      // when
+      component.updateEmail(event);
+
+      // then
+      const expectedEmail = emailWithSpaces.trim();
+      assert.strictEqual(component.email, expectedEmail);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le navigateur auto remplis le formulaire de connexion et que l'utilisateur clique directement sur "Je me connecte" (sans passer dans le champ email), rien ne se passe, l'utilisateur n'est pas connecté et reste sur la page de connexion.

https://1024pix.slack.com/archives/C6YRM9407/p1643638390523909?thread_ts=1643637570.203279&cid=C6YRM9407

## :robot: Solution
Trigger la validation du champ "input" et la mise à jour de la valeur de this.email quand le navigateur auto remplis le formulaire de connexion.

## :rainbow: Remarques
Ce soucis est inclu avec la version v11.1.0 de Pix-UI.
Il implique que `{{on focusout }}` sur le `PixInput` ne suffit pas à faire la validation d'un champ au submit d'un formulaire. Autrement dit, `PixInput` peut poser soucis pour les champs de formulaire auto compléter par le navigateur si on oublie de mettre l'évènement `{{on "input"}}`

🚧 Attention aux autres app lors de la montée de version.

## :100: Pour tester
- Aller sur Pix Orga avec un auto compléteur de login / mdp
- NE CLIQUEZ PAS DANS LE CHAMP ADRESSE-EMAIL
- Cliquez directement sur "Je me connecte"
- Constater qu'on arrive bien à se connecter
