### PR TITLE
[TECH] Activer l'espace surveillant sur une propriété BDD du centre de certification (PIX-4229).

### DIFF
--- a/api/db/database-builder/factory/build-certification-center.js
+++ b/api/db/database-builder/factory/build-certification-center.js
@@ -7,6 +7,7 @@ module.exports = function buildCertificationCenter({
   externalId = 'EX123',
   createdAt = new Date('2020-01-01'),
   updatedAt,
+  isSupervisorAccessEnabled = false,
 } = {}) {
   const values = {
     id,
@@ -15,6 +16,7 @@ module.exports = function buildCertificationCenter({
     externalId,
     createdAt,
     updatedAt,
+    isSupervisorAccessEnabled,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-centers',

--- a/api/db/migrations/20220128223044_add-certification-center-isSupervisorAccessEnabled.js
+++ b/api/db/migrations/20220128223044_add-certification-center-isSupervisorAccessEnabled.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'isSupervisorAccessEnabled';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -8,7 +8,7 @@ const usecases = require('../../domain/usecases');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
-const { isEndTestScreenRemovalEnabledBySessionId } = require('../../domain/services/end-test-screen-removal-service');
+const isEndTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 
 module.exports = {
   async getCertificationDetails(request) {
@@ -66,7 +66,9 @@ module.exports = {
     const userId = request.auth.credentials.userId;
 
     const certificationCourse = await usecases.getCertificationCourse({ userId, certificationCourseId });
-    const isEndScreenRemoveEnabled = await isEndTestScreenRemovalEnabledBySessionId(certificationCourse.getSessionId());
+    const isEndScreenRemoveEnabled = await isEndTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
+      certificationCourse.getSessionId()
+    );
     return certificationCourseSerializer.serialize(certificationCourse, isEndScreenRemoveEnabled);
   },
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -156,12 +156,10 @@ module.exports = (function () {
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
-      endTestScreenRemovalWhiteList: getArrayOfStrings(process.env.END_TEST_SCREEN_REMOVAL_WHITELIST),
     },
 
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
-      isEndTestScreenRemovalEnabled: Boolean(getArrayOfStrings(process.env.END_TEST_SCREEN_REMOVAL_WHITELIST).length),
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -11,7 +11,16 @@ const types = {
 };
 
 class CertificationCenter {
-  constructor({ id, name, externalId, type, createdAt, updatedAt, habilitations = [] } = {}) {
+  constructor({
+    id,
+    name,
+    externalId,
+    type,
+    createdAt,
+    updatedAt,
+    habilitations = [],
+    isSupervisorAccessEnabled = false,
+  } = {}) {
     this.id = id;
     this.name = name;
     this.externalId = externalId;
@@ -19,6 +28,7 @@ class CertificationCenter {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.habilitations = habilitations;
+    this.isSupervisorAccessEnabled = isSupervisorAccessEnabled;
   }
 
   get isSco() {

--- a/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
@@ -72,7 +72,7 @@ class AllowedCertificationCenterAccess {
     return features.pixCertifScoBlockedAccessWhitelist.includes(this.externalId.toUpperCase());
   }
 
-  hasEndTestScreenRemovalEnabled() {
+  isEndTestScreenRemovalEnabled() {
     return this.isSupervisorAccessEnabled;
   }
 }

--- a/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
@@ -9,6 +9,7 @@ class AllowedCertificationCenterAccess {
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,
     habilitations,
+    isSupervisorAccessEnabled,
   }) {
     this.id = id;
     this.name = name;
@@ -17,6 +18,7 @@ class AllowedCertificationCenterAccess {
     this.isRelatedToManagingStudentsOrganization = isRelatedToManagingStudentsOrganization;
     this.relatedOrganizationTags = relatedOrganizationTags;
     this.habilitations = habilitations;
+    this.isSupervisorAccessEnabled = isSupervisorAccessEnabled;
   }
 
   isAccessBlockedCollege() {
@@ -71,7 +73,7 @@ class AllowedCertificationCenterAccess {
   }
 
   hasEndTestScreenRemovalEnabled() {
-    return features.endTestScreenRemovalWhiteList.includes(this.id.toString());
+    return this.isSupervisorAccessEnabled;
   }
 }
 

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -10,7 +10,7 @@ const apps = require('../constants');
 const authenticationService = require('../../domain/services/authentication-service');
 const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 
-function _checkUserAccessScope(scope, user) {
+async function _checkUserAccessScope(scope, user) {
   if (scope === apps.PIX_ORGA.SCOPE && !user.isLinkedToOrganizations()) {
     throw new ForbiddenAccess(apps.PIX_ORGA.NOT_LINKED_ORGANIZATION_MSG);
   }
@@ -21,7 +21,7 @@ function _checkUserAccessScope(scope, user) {
 
   if (scope === apps.PIX_CERTIF.SCOPE && !user.isLinkedToCertificationCenters()) {
     const isEndTestScreenRemovalEnabled =
-      endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter();
+      await endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter();
     if (!isEndTestScreenRemovalEnabled) {
       throw new ForbiddenAccess(apps.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG);
     }
@@ -49,7 +49,7 @@ module.exports = async function authenticateUser({
     );
 
     if (!shouldChangePassword) {
-      _checkUserAccessScope(scope, foundUser);
+      await _checkUserAccessScope(scope, foundUser);
       const refreshToken = await refreshTokenService.createRefreshTokenFromUserId({ userId: foundUser.id, source });
       const { accessToken, expirationDelaySeconds } = await refreshTokenService.createAccessTokenFromRefreshToken({
         refreshToken,

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -68,6 +68,7 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
       externalId: 'certification-centers.externalId',
       type: 'certification-centers.type',
       isRelatedToManagingStudentsOrganization: 'organizations.isManagingStudents',
+      isSupervisorAccessEnabled: 'certification-centers.isSupervisorAccessEnabled',
       tags: knex.raw('array_agg(?? order by ??)', ['tags.name', 'tags.name']),
       habilitations: knex.raw(
         `array_agg(json_build_object('id', "complementary-certifications".id, 'name', "complementary-certifications".name) order by "complementary-certifications".id)`

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -26,7 +26,7 @@ module.exports = {
           'isAccessBlockedAgri',
           'relatedOrganizationTags',
           'habilitations',
-          'hasEndTestScreenRemovalEnabled',
+          'isEndTestScreenRemovalEnabled',
         ],
       },
       typeForAttribute: function (attribute) {
@@ -51,7 +51,7 @@ module.exports = {
               isAccessBlockedLycee: access.isAccessBlockedLycee(),
               isAccessBlockedAEFE: access.isAccessBlockedAEFE(),
               isAccessBlockedAgri: access.isAccessBlockedAgri(),
-              hasEndTestScreenRemovalEnabled: access.hasEndTestScreenRemovalEnabled(),
+              isEndTestScreenRemovalEnabled: access.isEndTestScreenRemovalEnabled(),
             };
           }
         );

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -31,8 +31,6 @@ const schema = Joi.object({
   FT_CERTIFICATION_BILLING: Joi.string().optional().valid('true', 'false'),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
-  FT_END_TEST_SCREEN_REMOVAL_ENABLED: Joi.string().optional().valid('true', 'false'),
-  END_TEST_SCREEN_REMOVAL_WHITELIST: Joi.string().optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -6,13 +6,11 @@ const {
   mockLearningContent,
   generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster,
-  sinon,
 } = require('../../test-helper');
 const createServer = require('../../../server');
 const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationAssessment = require('../../../lib/domain/models/CertificationAssessment');
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
-const { features } = require('../../../lib/config');
 
 describe('Acceptance | API | Certification Course', function () {
   let server;
@@ -369,8 +367,11 @@ describe('Acceptance | API | Certification Course', function () {
 
     beforeEach(function () {
       otherUserId = databaseBuilder.factory.buildUser().id;
-      const certifiationCenter = databaseBuilder.factory.buildCertificationCenter({ id: 99 });
-      const session = databaseBuilder.factory.buildSession({ certificationCenterId: certifiationCenter.id });
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        id: 99,
+        isSupervisorAccessEnabled: true,
+      });
+      const session = databaseBuilder.factory.buildSession({ certificationCenterId: certificationCenter.id });
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         hasSeenEndTestScreen: false,
         sessionId: session.id,
@@ -430,7 +431,6 @@ describe('Acceptance | API | Certification Course', function () {
     it('should return the certification course', async function () {
       // given
       options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
-      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([99]);
 
       // when
       const response = await server.inject(options);
@@ -449,7 +449,7 @@ describe('Acceptance | API | Certification Course', function () {
 
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser().id;
-      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isSupervisorAccessEnabled: false }).id;
       sessionId = databaseBuilder.factory.buildSession({ accessCode: '123', certificationCenterId }).id;
       const payload = {
         data: {
@@ -469,8 +469,6 @@ describe('Acceptance | API | Certification Course', function () {
         payload,
       };
       await databaseBuilder.commit();
-
-      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
     });
 
     context('when the given access code does not correspond to the session', function () {

--- a/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
+++ b/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
@@ -30,7 +30,7 @@ describe('Acceptance | Route | CertificationPointOfContact', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.id).to.equal(userId.toString());
-      expect(response.result.included[0].attributes['has-end-test-screen-removal-enabled']).to.be.false;
+      expect(response.result.included[0].attributes['is-end-test-screen-removal-enabled']).to.be.false;
     });
   });
 });

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,7 +23,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-certification-billing-enabled': false,
             'is-email-validation-enabled': false,
-            'is-end-test-screen-removal-enabled': false,
             'is-complementary-certification-subscription-enabled': false,
           },
           type: 'feature-toggles',

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-get_test.js
@@ -1,6 +1,5 @@
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, sinon } = require('../../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { features } = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-for-supervising-controller-get', function () {
   let server;
@@ -12,8 +11,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
   context('when en test screen removal is enabled', function () {
     it('should return OK and a sessionForSupervisings type', async function () {
       // given
-      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([345]);
-      databaseBuilder.factory.buildCertificationCenter({ id: 345 });
+      databaseBuilder.factory.buildCertificationCenter({ id: 345, isSupervisorAccessEnabled: true });
       databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
       databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
       const userId = databaseBuilder.factory.buildUser().id;
@@ -40,13 +38,19 @@ describe('Acceptance | Controller | session-for-supervising-controller-get', fun
 
   context('when end test screen removal is not enabled', function () {
     it('should return 401 HTTP status code ', async function () {
+      databaseBuilder.factory.buildCertificationCenter({ id: 345, isSupervisorAccessEnabled: false });
+      databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
+      databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
+      await databaseBuilder.commit();
+
       const options = {
         method: 'GET',
         url: '/api/sessions/121/supervising',
         payload: {},
       };
-      options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
-      sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
 
       // when
       const response = await server.inject(options);

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
@@ -3,11 +3,9 @@ const {
   databaseBuilder,
   domainBuilder,
   generateValidRequestAuthorizationHeader,
-  sinon,
   knex,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const { features } = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-for-supervising-controller-supervise', function () {
   let server;
@@ -23,7 +21,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
   it('should return a HTTP 204 No Content', async function () {
     // given
 
-    const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+    const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ isSupervisorAccessEnabled: true });
     const session = domainBuilder.buildSession({ id: 121, certificationCenterId: certificationCenter.id });
     session.generateSupervisorPassword();
     const supervisorPassword = session.supervisorPassword;
@@ -31,7 +29,6 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
     databaseBuilder.factory.buildSession(session);
     await databaseBuilder.commit();
 
-    sinon.stub(features, 'endTestScreenRemovalWhiteList').value([0, certificationCenter.id, 1]);
     const headers = { authorization: generateValidRequestAuthorizationHeader(3456, 'pix-certif') };
 
     const options = {

--- a/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
+++ b/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
@@ -1,12 +1,11 @@
 const { unlink, writeFile } = require('fs').promises;
 const _ = require('lodash');
-const { expect, databaseBuilder, sinon } = require('../../../../test-helper');
+const { expect, databaseBuilder } = require('../../../../test-helper');
 const readOdsUtils = require('../../../../../lib/infrastructure/utils/ods/read-ods-utils');
 const sessionRepository = require('../../../../../lib/infrastructure/repositories/sessions/session-repository');
 const sessionForAttendanceSheetRepository = require('../../../../../lib/infrastructure/repositories/sessions/session-for-attendance-sheet-repository');
 const endTestScreenRemovalService = require('../../../../../lib/domain/services/end-test-screen-removal-service');
 const getAttendanceSheet = require('../../../../../lib/domain/usecases/get-attendance-sheet');
-const { features } = require('../../../../../lib/config');
 
 describe('Integration | UseCases | getAttendanceSheet', function () {
   describe('when certification center is not sco', function () {
@@ -14,77 +13,39 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
     let sessionId;
     let certificationCenterId;
 
-    beforeEach(async function () {
-      const certificationCenterName = 'Centre de certification';
-      databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
-      certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-        name: certificationCenterName,
-        type: 'SUP',
-        externalId: 'EXT1234',
-      }).id;
-
-      userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-
-      sessionId = databaseBuilder.factory.buildSession({
-        id: 10,
-        certificationCenter: certificationCenterName,
-        certificationCenterId: certificationCenterId,
-        accessCode: 'ABC123DEF',
-        address: '3 rue des bibiches',
-        room: '28D',
-        examiner: 'Johnny',
-        date: '2020-07-05',
-        time: '14:30',
-        description: 'La super description',
-      }).id;
-
-      _.each(
-        [
-          {
-            lastName: 'Jackson',
-            firstName: 'Michael',
-            birthdate: '2004-04-04',
-            sessionId,
-            externalId: 'ABC123',
-            extraTimePercentage: 0.6,
-          },
-          {
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            birthdate: '2005-12-05',
-            sessionId,
-            externalId: 'DEF456',
-            extraTimePercentage: null,
-          },
-          {
-            lastName: 'Mercury',
-            firstName: 'Freddy',
-            birthdate: '1925-06-28',
-            sessionId,
-            externalId: 'GHI789',
-            extraTimePercentage: 1.5,
-          },
-          {
-            lastName: 'Gallagher',
-            firstName: 'Jack',
-            birthdate: '1980-08-10',
-            sessionId,
-            externalId: null,
-            extraTimePercentage: 0.15,
-          },
-        ],
-        (candidate) => {
-          databaseBuilder.factory.buildCertificationCandidate(candidate);
-        }
-      );
-
-      await databaseBuilder.commit();
-    });
-
-    context('when certification center is not in the end test screen whitelist', function () {
+    context('when certification center does not have the supervisor access enabled', function () {
       const expectedOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_target_with_fdt.ods`;
       const actualOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_actual_with_fdt.tmp.ods`;
+
+      beforeEach(async function () {
+        const certificationCenterName = 'Centre de certification';
+        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          name: certificationCenterName,
+          type: 'SUP',
+          externalId: 'EXT1234',
+          isSupervisorAccessEnabled: false,
+        }).id;
+
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+
+        sessionId = databaseBuilder.factory.buildSession({
+          id: 10,
+          certificationCenter: certificationCenterName,
+          certificationCenterId: certificationCenterId,
+          accessCode: 'ABC123DEF',
+          address: '3 rue des bibiches',
+          room: '28D',
+          examiner: 'Johnny',
+          date: '2020-07-05',
+          time: '14:30',
+          description: 'La super description',
+        }).id;
+        _createCertificationCandidatesForSession(sessionId);
+
+        await databaseBuilder.commit();
+      });
 
       afterEach(async function () {
         await unlink(actualOdsFilePath);
@@ -92,7 +53,6 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
 
       it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
         // when
-        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
         const updatedOdsFileBuffer = await getAttendanceSheet({
           userId,
           sessionId,
@@ -109,9 +69,40 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
       });
     });
 
-    context('when certification center is in the end test screen whitelist', function () {
+    context('when certification center does have the supervisor access enabled', function () {
       const expectedOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_target.ods`;
       const actualOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_actual.tmp.ods`;
+
+      beforeEach(async function () {
+        const certificationCenterName = 'Centre de certification';
+        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          name: certificationCenterName,
+          type: 'SUP',
+          externalId: 'EXT1234',
+          isSupervisorAccessEnabled: true,
+        }).id;
+
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+
+        sessionId = databaseBuilder.factory.buildSession({
+          id: 10,
+          certificationCenter: certificationCenterName,
+          certificationCenterId: certificationCenterId,
+          accessCode: 'ABC123DEF',
+          address: '3 rue des bibiches',
+          room: '28D',
+          examiner: 'Johnny',
+          date: '2020-07-05',
+          time: '14:30',
+          description: 'La super description',
+        }).id;
+
+        _createCertificationCandidatesForSession(sessionId);
+
+        await databaseBuilder.commit();
+      });
 
       afterEach(async function () {
         await unlink(actualOdsFilePath);
@@ -119,7 +110,6 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
 
       it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
         // when
-        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenterId]);
         const updatedOdsFileBuffer = await getAttendanceSheet({
           userId,
           sessionId,
@@ -142,78 +132,40 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
     let sessionId;
     let certificationCenterId;
 
-    beforeEach(async function () {
-      const certificationCenterName = 'Centre de certification';
-      databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
-      certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-        name: certificationCenterName,
-        type: 'SCO',
-        externalId: 'EXT1234',
-      }).id;
-
-      userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-
-      sessionId = databaseBuilder.factory.buildSession({
-        id: 10,
-        certificationCenter: certificationCenterName,
-        certificationCenterId: certificationCenterId,
-        accessCode: 'ABC123DEF',
-        address: '3 rue des bibiches',
-        room: '28D',
-        examiner: 'Johnny',
-        date: '2020-07-05',
-        time: '14:30',
-        description: 'La super description',
-      }).id;
-
-      _.each(
-        [
-          {
-            lastName: 'Jackson',
-            firstName: 'Michael',
-            birthdate: '2004-04-04',
-            sessionId,
-            division: '2C',
-            extraTimePercentage: 0.6,
-          },
-          {
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            birthdate: '2005-12-05',
-            sessionId,
-            division: '3B',
-            extraTimePercentage: null,
-          },
-          {
-            lastName: 'Mercury',
-            firstName: 'Freddy',
-            birthdate: '1925-06-28',
-            sessionId,
-            division: '1A',
-            extraTimePercentage: 1.5,
-          },
-          {
-            lastName: 'Gallagher',
-            firstName: 'Jack',
-            birthdate: '1980-08-10',
-            sessionId,
-            division: '3B',
-            extraTimePercentage: 0.15,
-          },
-        ],
-        (candidate) => {
-          const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration(candidate).id;
-          databaseBuilder.factory.buildCertificationCandidate({ ...candidate, schoolingRegistrationId });
-        }
-      );
-
-      await databaseBuilder.commit();
-    });
-
-    context('when certification center is not in the end test screen whitelist', function () {
+    context('when certification center does not have the supervisor access enabled', function () {
       const expectedOdsFilePath = `${__dirname}/sco_attendance_sheet_template_target_with_fdt.ods`;
       const actualOdsFilePath = `${__dirname}/sco_attendance_sheet_template_actual_with_fdt.tmp.ods`;
+
+      beforeEach(async function () {
+        const certificationCenterName = 'Centre de certification';
+        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          name: certificationCenterName,
+          type: 'SCO',
+          externalId: 'EXT1234',
+          isSupervisorAccessEnabled: false,
+        }).id;
+
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+
+        sessionId = databaseBuilder.factory.buildSession({
+          id: 10,
+          certificationCenter: certificationCenterName,
+          certificationCenterId: certificationCenterId,
+          accessCode: 'ABC123DEF',
+          address: '3 rue des bibiches',
+          room: '28D',
+          examiner: 'Johnny',
+          date: '2020-07-05',
+          time: '14:30',
+          description: 'La super description',
+        }).id;
+
+        _createCertificationCandidatesScoForSession(sessionId);
+
+        await databaseBuilder.commit();
+      });
 
       afterEach(async function () {
         await unlink(actualOdsFilePath);
@@ -221,7 +173,6 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
 
       it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
         // when
-        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([]);
         const updatedOdsFileBuffer = await getAttendanceSheet({
           userId,
           sessionId,
@@ -238,9 +189,39 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
       });
     });
 
-    context('when certification center is in the end test screen whitelist', function () {
+    context('when certification center does have the supervisor access enabled', function () {
       const expectedOdsFilePath = `${__dirname}/sco_attendance_sheet_template_target.ods`;
       const actualOdsFilePath = `${__dirname}/sco_attendance_sheet_template_actual.tmp.ods`;
+
+      beforeEach(async function () {
+        const certificationCenterName = 'Centre de certification';
+        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          name: certificationCenterName,
+          type: 'SCO',
+          externalId: 'EXT1234',
+          isSupervisorAccessEnabled: true,
+        }).id;
+
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+
+        sessionId = databaseBuilder.factory.buildSession({
+          id: 10,
+          certificationCenter: certificationCenterName,
+          certificationCenterId: certificationCenterId,
+          accessCode: 'ABC123DEF',
+          address: '3 rue des bibiches',
+          room: '28D',
+          examiner: 'Johnny',
+          date: '2020-07-05',
+          time: '14:30',
+          description: 'La super description',
+        }).id;
+        _createCertificationCandidatesScoForSession(sessionId);
+
+        await databaseBuilder.commit();
+      });
 
       afterEach(async function () {
         await unlink(actualOdsFilePath);
@@ -248,7 +229,6 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
 
       it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
         // when
-        sinon.stub(features, 'endTestScreenRemovalWhiteList').value([certificationCenterId]);
         const updatedOdsFileBuffer = await getAttendanceSheet({
           userId,
           sessionId,
@@ -266,3 +246,88 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
     });
   });
 });
+
+function _createCertificationCandidatesScoForSession(sessionId) {
+  _.each(
+    [
+      {
+        lastName: 'Jackson',
+        firstName: 'Michael',
+        birthdate: '2004-04-04',
+        sessionId,
+        division: '2C',
+        extraTimePercentage: 0.6,
+      },
+      {
+        lastName: 'Jackson',
+        firstName: 'Janet',
+        birthdate: '2005-12-05',
+        sessionId,
+        division: '3B',
+        extraTimePercentage: null,
+      },
+      {
+        lastName: 'Mercury',
+        firstName: 'Freddy',
+        birthdate: '1925-06-28',
+        sessionId,
+        division: '1A',
+        extraTimePercentage: 1.5,
+      },
+      {
+        lastName: 'Gallagher',
+        firstName: 'Jack',
+        birthdate: '1980-08-10',
+        sessionId,
+        division: '3B',
+        extraTimePercentage: 0.15,
+      },
+    ],
+    (candidate) => {
+      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration(candidate).id;
+      databaseBuilder.factory.buildCertificationCandidate({ ...candidate, schoolingRegistrationId });
+    }
+  );
+}
+
+function _createCertificationCandidatesForSession(sessionId) {
+  _.each(
+    [
+      {
+        lastName: 'Jackson',
+        firstName: 'Michael',
+        birthdate: '2004-04-04',
+        sessionId,
+        externalId: 'ABC123',
+        extraTimePercentage: 0.6,
+      },
+      {
+        lastName: 'Jackson',
+        firstName: 'Janet',
+        birthdate: '2005-12-05',
+        sessionId,
+        externalId: 'DEF456',
+        extraTimePercentage: null,
+      },
+      {
+        lastName: 'Mercury',
+        firstName: 'Freddy',
+        birthdate: '1925-06-28',
+        sessionId,
+        externalId: 'GHI789',
+        extraTimePercentage: 1.5,
+      },
+      {
+        lastName: 'Gallagher',
+        firstName: 'Jack',
+        birthdate: '1980-08-10',
+        sessionId,
+        externalId: null,
+        extraTimePercentage: 0.15,
+      },
+    ],
+    (candidate) => {
+      databaseBuilder.factory.buildCertificationCandidate(candidate);
+    }
+  );
+}

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -8,6 +8,7 @@ function buildAllowedCertificationCenterAccess({
   isRelatedToManagingStudentsOrganization = false,
   relatedOrganizationTags = [],
   habilitations = [],
+  isSupervisorAccessEnabled = false,
 } = {}) {
   return new AllowedCertificationCenterAccess({
     id,
@@ -17,6 +18,7 @@ function buildAllowedCertificationCenterAccess({
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,
     habilitations,
+    isSupervisorAccessEnabled,
   });
 }
 

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -7,6 +7,7 @@ const {
 } = require('../../../test-helper');
 const certificationCourseController = require('../../../../lib/application/certification-courses/certification-course-controller');
 const usecases = require('../../../../lib/domain/usecases');
+const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
 const certifiedProfileRepository = require('../../../../lib/infrastructure/repositories/certified-profile-repository');
 const certificationCourseSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-course-serializer');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
@@ -335,10 +336,11 @@ describe('Unit | Controller | certification-course-controller', function () {
 
   describe('#get', function () {
     let certificationCourse;
+    const sessionId = 5;
     const certificationCourseId = 'certification_course_id';
 
     beforeEach(function () {
-      certificationCourse = new CertificationCourse({ id: certificationCourseId });
+      certificationCourse = new CertificationCourse({ id: certificationCourseId, sessionId });
     });
 
     it('should fetch and return the given course, serialized as JSONAPI', async function () {
@@ -352,6 +354,10 @@ describe('Unit | Controller | certification-course-controller', function () {
         .stub(certificationCourseSerializer, 'serialize')
         .withArgs(certificationCourse)
         .resolves(certificationCourse);
+      sinon
+        .stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId')
+        .withArgs(sessionId)
+        .resolves(true);
       const request = {
         params: { id: certificationCourseId },
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -73,7 +73,7 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
               'is-related-to-managing-students-organization': false,
               'related-organization-tags': [],
               habilitations: [],
-              'has-end-test-screen-removal-enabled': false,
+              'is-end-test-screen-removal-enabled': false,
             },
           },
         ],

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -692,8 +692,10 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
   context('#hasEndTestScreenRemovalEnabled', function () {
     it('should return true when whitelisted', function () {
       // given
-      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({ id: 1 });
-      settings.features.endTestScreenRemovalWhiteList = ['1'];
+      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+        id: 1,
+        isSupervisorAccessEnabled: true,
+      });
 
       // when
       const result = allowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled();
@@ -704,8 +706,10 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
 
     it('should return false when not whitelisted', function () {
       // given
-      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({ id: 1 });
-      settings.features.endTestScreenRemovalWhiteList = ['2'];
+      const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+        id: 1,
+        isSupervisorAccessEnabled: false,
+      });
 
       // when
       const result = allowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled();

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -689,7 +689,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     });
   });
 
-  context('#hasEndTestScreenRemovalEnabled', function () {
+  context('#isEndTestScreenRemovalEnabled', function () {
     it('should return true when whitelisted', function () {
       // given
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
@@ -698,7 +698,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       });
 
       // when
-      const result = allowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled();
+      const result = allowedCertificationCenterAccess.isEndTestScreenRemovalEnabled();
 
       // then
       expect(result).to.be.true;
@@ -712,7 +712,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       });
 
       // when
-      const result = allowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled();
+      const result = allowedCertificationCenterAccess.isEndTestScreenRemovalEnabled();
 
       // then
       expect(result).to.be.false;

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -174,7 +174,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
         const scope = appMessages.PIX_CERTIF.SCOPE;
         const user = domainBuilder.buildUser({ email: userEmail, certificationCenterMemberships: [] });
         authenticationService.getUserByUsernameAndPassword.resolves(user);
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter.returns(false);
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter.resolves(false);
 
         const expectedErrorMessage = appMessages.PIX_CERTIF.NOT_LINKED_CERTIFICATION_MSG;
         // when
@@ -202,7 +202,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
           certificationCenterMemberships: [Symbol('certificationCenterMembership')],
         });
 
-        endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter.returns(true);
+        endTestScreenRemovalService.isEndTestScreenRemovalEnabledForSomeCertificationCenter.resolves(true);
         authenticationService.getUserByUsernameAndPassword.resolves(user);
         refreshTokenService.createRefreshTokenFromUserId
           .withArgs({

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         relatedOrganizationTags: ['tag1'],
         habilitations: [],
       });
-      allowedCertificationCenterAccess2.hasEndTestScreenRemovalEnabled = sinon.stub().returns(true);
+      allowedCertificationCenterAccess2.isEndTestScreenRemovalEnabled = sinon.stub().returns(true);
       const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 789,
         firstName: 'Buffy',
@@ -86,7 +86,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 { id: 1, name: 'Certif comp 1' },
                 { id: 2, name: 'Certif comp 2' },
               ],
-              'has-end-test-screen-removal-enabled': false,
+              'is-end-test-screen-removal-enabled': false,
             },
           },
           {
@@ -103,7 +103,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-agri': false,
               'related-organization-tags': ['tag1'],
               habilitations: [],
-              'has-end-test-screen-removal-enabled': true,
+              'is-end-test-screen-removal-enabled': true,
             },
           },
         ],
@@ -189,7 +189,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 'is-access-blocked-agri': false,
                 'related-organization-tags': [],
                 habilitations: [],
-                'has-end-test-screen-removal-enabled': false,
+                'is-end-test-screen-removal-enabled': false,
               },
             },
             {
@@ -206,7 +206,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
                 'is-access-blocked-agri': false,
                 'related-organization-tags': ['tag1'],
                 habilitations: [],
-                'has-end-test-screen-removal-enabled': false,
+                'is-end-test-screen-removal-enabled': false,
               },
             },
           ],

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -34,7 +34,7 @@ export default class AuthenticatedController extends Controller {
   }
 
   get isEndTestScreenRemovalEnabled() {
-    return this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
+    return this.currentUser.currentAllowedCertificationCenterAccess.isEndTestScreenRemovalEnabled;
   }
 
   @action

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -22,7 +22,7 @@ export default class SessionParametersController extends Controller {
   }
 
   get supervisorPasswordShouldBeDisplayed() {
-    return this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
+    return this.currentUser.currentAllowedCertificationCenterAccess.isEndTestScreenRemovalEnabled;
   }
 
   @action

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -25,7 +25,7 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   get shouldDisplayHasSeenEndTestScreenCheckbox() {
-    return !this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
+    return !this.currentUser.currentAllowedCertificationCenterAccess.isEndTestScreenRemovalEnabled;
   }
 
   get uncheckedHasSeenEndTestScreenCount() {

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -11,7 +11,7 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() isAccessBlockedAgri;
   @attr() relatedOrganizationTags;
   @attr() habilitations;
-  @attr() hasEndTestScreenRemovalEnabled;
+  @attr() isEndTestScreenRemovalEnabled;
 
   get isSco() {
     return this.type === 'SCO';

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,6 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isEndTestScreenRemovalEnabled;
   @attr('boolean') isComplementaryCertificationSubscriptionEnabled;
 }

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -59,7 +59,7 @@ module('Acceptance | authenticated', function (hooks) {
         const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
           name: 'Bibiche',
           externalId: 'ABC123',
-          hasEndTestScreenRemovalEnabled: true,
+          isEndTestScreenRemovalEnabled: true,
         });
         const certificationPointOfContact = server.create('certification-point-of-contact', {
           firstName: 'Buffy',
@@ -81,7 +81,7 @@ module('Acceptance | authenticated', function (hooks) {
         const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
           name: 'Bibiche',
           externalId: 'ABC123',
-          hasEndTestScreenRemovalEnabled: true,
+          isEndTestScreenRemovalEnabled: true,
         });
         const certificationPointOfContact = server.create('certification-point-of-contact', {
           firstName: 'Buffy',
@@ -108,7 +108,7 @@ module('Acceptance | authenticated', function (hooks) {
         const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
           name: 'Bibiche',
           externalId: 'ABC123',
-          hasEndTestScreenRemovalEnabled: false,
+          isEndTestScreenRemovalEnabled: false,
         });
         const certificationPointOfContact = server.create('certification-point-of-contact', {
           firstName: 'Buffy',

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -28,7 +28,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
         isAccessBlockedLycee: false,
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
-        hasEndTestScreenRemovalEnabled: false,
+        isEndTestScreenRemovalEnabled: false,
       });
       certificationPointOfContact = server.create('certification-point-of-contact', {
         firstName: 'Buffy',
@@ -105,7 +105,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           module('when the certification center is in the end test screen removal whitelist', function () {
             test('it should display supervisor password', async function (assert) {
               // given
-              allowedCertificationCenterAccess.update({ hasEndTestScreenRemovalEnabled: true });
+              allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: true });
               const sessionWithSupervisorPassword = server.create('session', {
                 supervisorPassword: 'SOWHAT',
                 status: CREATED,

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -23,7 +23,7 @@ module('Acceptance | Session Finalization', function (hooks) {
       isAccessBlockedLycee: false,
       isAccessBlockedAEFE: false,
       isAccessBlockedAgri: false,
-      hasEndTestScreenRemovalEnabled: false,
+      isEndTestScreenRemovalEnabled: false,
     });
     certificationPointOfContact = server.create('certification-point-of-contact', {
       firstName: 'Buffy',
@@ -270,7 +270,7 @@ module('Acceptance | Session Finalization', function (hooks) {
               });
 
               allowedCertificationCenterAccess.update({
-                hasEndTestScreenRemovalEnabled: true,
+                isEndTestScreenRemovalEnabled: true,
               });
 
               session.update({ certificationReports: [certificationReport] });

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -85,7 +85,6 @@ module('Acceptance | Session Finalization', function (hooks) {
 
     test('it should display the end screen column when the center has no access to the supervisor space', async function (assert) {
       // when
-      server.create('feature-toggle', { isEndTestScreenRemovalEnabled: true });
       const screen = await visit(`/sessions/${session.id}/finalisation`);
 
       // then

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -184,7 +184,7 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     assert.dom(screen.getByRole('table', { name: 'Certification(s) terminée(s)' })).exists();
   });
 
-  module('when isEndTestScreenRemovalEnabled feature toggle is disabled', function () {
+  module('when the end test screen removal feature is disabled', function () {
     test('it shows the "Écran de fin de test vu" column', async function (assert) {
       // given
       this.certificationReports = [
@@ -215,7 +215,7 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     });
   });
 
-  module('when isEndTestScreenRemovalEnabled feature toggle is enabled', function () {
+  module('when the end test screen removal feature is enabled', function () {
     test('it hides the "Écran de fin de test vu" column', async function (assert) {
       // given
       this.certificationReports = [

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -108,7 +108,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
         id: 123,
         name: 'Test certification center',
         type: 'NOT_SCO',
-        hasEndTestScreenRemovalEnabled: true,
+        isEndTestScreenRemovalEnabled: true,
       });
 
       class CurrentUserStub extends Service {
@@ -136,7 +136,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
         id: 123,
         name: 'Test certification center',
         type: 'NOT_SCO',
-        hasEndTestScreenRemovalEnabled: false,
+        isEndTestScreenRemovalEnabled: false,
       });
 
       class CurrentUserStub extends Service {

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -250,7 +250,7 @@ module('Unit | Controller | authenticated', function (hooks) {
       const store = this.owner.lookup('service:store');
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,
-        hasEndTestScreenRemovalEnabled: true,
+        isEndTestScreenRemovalEnabled: true,
       });
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
@@ -270,7 +270,7 @@ module('Unit | Controller | authenticated', function (hooks) {
       const store = this.owner.lookup('service:store');
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,
-        hasEndTestScreenRemovalEnabled: false,
+        isEndTestScreenRemovalEnabled: false,
       });
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -245,7 +245,7 @@ module('Unit | Controller | authenticated', function (hooks) {
   });
 
   module('#get isEndTestScreenRemovalEnabled', function () {
-    test('should return true when end test screen removal is enabled', function (assert) {
+    test('should return true when current allowed certification center has end test screen removal enabled', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
@@ -266,7 +266,7 @@ module('Unit | Controller | authenticated', function (hooks) {
       assert.true(isEndTestScreenRemovalEnabled);
     });
 
-    test('should return false when end test screen removal is not enabled', function (assert) {
+    test('should return true when current allowed certification center has end test screen removal disabled', function (assert) {
       const store = this.owner.lookup('service:store');
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,


### PR DESCRIPTION
## :unicorn: Problème
On peut accéder à l'espace surveillant si le centre de certification associé est dans une whitelist en variable d'environnement. On souhaite y ajouter tout les SCO, ce qui rendrait la varenv très grande et difficile à maintenir

## :robot: Solution
Passer par la base de donnée pour stocker l'information, via une colonne `isSupervisorAccessEnabled` (boolean) dans la table `certification-centers`

## :rainbow: Remarques
On renomme hasEndTest... en isEndTest pour homogeneiser le code. On pourrait remplacer tout les isEndTest par isSupervisorAccess qui serait plus comprehensible (mais beaucoup de changement).

## :100: Pour tester
1) S'assurer que le centre pro n'est pas autorisé:


```sql
SELECT  cc.id, cc.name, cc."isSupervisorAccessEnabled"
FROM "certification-centers" cc
WHERE cc.name = 'Centre PRO des Anne-Étoiles';

UPDATE "certification-centers" SET "isSupervisorAccessEnabled"=false 
WHERE name = 'Centre PRO des Anne-Étoiles';
```

Aller sur certif avec certifpro@example.net, aller sur une session, verifier que le lien vers l'espace surveillant n'existe pas et que le mot de passe vers le portail surveillant non plus (en rouge sur le screenshot)

2) S'assurer que le centre pro est autorisé:
`update "certification-centers" set "isSupervisorAccessEnabled"=true where id=2`

Aller sur certif avec certifpro@example.net, aller sur une session, verifier que le lien vers l'espace surveillant apparait ainsi que le mot de passe vers le portail surveillant (en rouge sur le screenshot)

<img width="1155" alt="Screenshot 2022-01-31 at 11 58 36" src="https://user-images.githubusercontent.com/3769147/151782395-db54acfb-4cba-437c-a735-f4bc6fb5ef9a.png">


