### PR TITLE
[TECH] Toujours afficher les certifications incomplètes (PIX-4161).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -161,7 +161,6 @@ module.exports = (function () {
 
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
-      isManageUncompletedCertifEnabled: isFeatureEnabled(process.env.FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED),
       isEndTestScreenRemovalEnabled: Boolean(getArrayOfStrings(process.env.END_TEST_SCREEN_REMOVAL_WHITELIST).length),
       isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -7,7 +7,6 @@ const ChallengeNeutralized = require('./ChallengeNeutralized');
 const ChallengeDeneutralized = require('./ChallengeDeneutralized');
 const CertificationJuryDone = require('./CertificationJuryDone');
 const { checkEventTypes } = require('./check-event-types');
-const { featureToggles } = require('../../config');
 
 const eventTypes = [ChallengeNeutralized, ChallengeDeneutralized, CertificationJuryDone];
 const EMITTER = 'PIX-ALGO-NEUTRALIZATION';
@@ -41,14 +40,12 @@ async function handleCertificationRescoring({
 
     await _saveCompetenceMarks(certificationAssessmentScore, assessmentResultId, competenceMarkRepository);
 
-    if (featureToggles.isManageUncompletedCertifEnabled) {
-      await _cancelCertificationCourseIfHasNotEnoughNonNeutralizedChallengesToBeTrusted({
-        certificationCourseId: certificationAssessment.certificationCourseId,
-        hasEnoughNonNeutralizedChallengesToBeTrusted:
-          certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted,
-        certificationCourseRepository,
-      });
-    }
+    await _cancelCertificationCourseIfHasNotEnoughNonNeutralizedChallengesToBeTrusted({
+      certificationCourseId: certificationAssessment.certificationCourseId,
+      hasEnoughNonNeutralizedChallengesToBeTrusted:
+        certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted,
+      certificationCourseRepository,
+    });
 
     return new CertificationRescoringCompleted({
       userId: certificationAssessment.userId,
@@ -105,10 +102,7 @@ async function _saveAssessmentResult(
   assessmentResultRepository
 ) {
   let assessmentResult;
-  if (
-    !certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted &&
-    featureToggles.isManageUncompletedCertifEnabled
-  ) {
+  if (!certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted) {
     assessmentResult = AssessmentResult.buildNotTrustableAssessmentResult({
       pixScore: certificationAssessmentScore.nbPix,
       status: certificationAssessmentScore.status,

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -22,7 +22,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           id: '0',
           attributes: {
             'is-certification-billing-enabled': false,
-            'is-manage-uncompleted-certif-enabled': false,
             'is-email-validation-enabled': false,
             'is-end-test-screen-removal-enabled': false,
             'is-complementary-certification-subscription-enabled': false,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -4,12 +4,10 @@ const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeu
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
-const { featureToggles } = require('../../../../lib/config');
 
 describe('Unit | Domain | Events | handle-certification-rescoring', function () {
   it('computes and persists the assessment result and competence marks when computation succeeds', async function () {
     // given
-    sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
     const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
     const assessmentResultRepository = { save: sinon.stub() };
     const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
@@ -92,176 +90,22 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
   });
 
-  context('when FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED is enabled', function () {
-    context('when the certification has not enough non neutralized challenges to be trusted', function () {
-      it('cancels the certification and save a not trustable assessment result', async function () {
-        // given
-        sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
-        const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-        const assessmentResultRepository = { save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-        const competenceMarkRepository = { save: sinon.stub() };
-        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
-        sinon.spy(certificationCourse, 'cancel');
-
-        const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
-        const certificationAssessment = new CertificationAssessment({
-          id: 123,
-          userId: 123,
-          certificationCourseId: 789,
-          createdAt: new Date('2020-01-01'),
-          completedAt: new Date('2020-01-01'),
-          state: CertificationAssessment.states.STARTED,
-          isV2Certification: true,
-          certificationChallenges: [
-            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-          ],
-          certificationAnswersByDate: ['answer'],
-        });
-        certificationAssessmentRepository.getByCertificationCourseId
-          .withArgs({ certificationCourseId: 789 })
-          .resolves(certificationAssessment);
-        certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
-        const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
-        const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
-        const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-          status: AssessmentResult.status.VALIDATED,
-          competenceMarks: [competenceMarkData1, competenceMarkData2],
-          percentageCorrectAnswers: 80,
-          hasEnoughNonNeutralizedChallengesToBeTrusted: false,
-        });
-        scoringCertificationService.calculateCertificationAssessmentScore
-          .withArgs({ certificationAssessment, continueOnError: false })
-          .resolves(certificationAssessmentScore);
-
-        const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.notTrustable({
-          emitter: 'PIX-ALGO-NEUTRALIZATION',
-          pixScore: 30,
-          status: AssessmentResult.status.VALIDATED,
-          assessmentId: 123,
-          juryId: 7,
-        });
-        const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-        assessmentResultRepository.save.resolves(savedAssessmentResult);
-
-        const dependendencies = {
-          assessmentResultRepository,
-          certificationAssessmentRepository,
-          competenceMarkRepository,
-          scoringCertificationService,
-          certificationCourseRepository,
-        };
-
-        // when
-        await handleCertificationRescoring({
-          ...dependendencies,
-          event,
-        });
-
-        // then
-        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResultToBeSaved);
-        expect(certificationCourse.cancel).to.have.been.calledOnce;
-        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
-      });
-    });
-
-    context('when the certification has enough non neutralized challenges to be trusted', function () {
-      it('uncancels the certification and save a standard assessment result', async function () {
-        // given
-        sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(true);
-        const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
-        const assessmentResultRepository = { save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-        const competenceMarkRepository = { save: sinon.stub() };
-        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
-        sinon.spy(certificationCourse, 'uncancel');
-
-        const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
-        const certificationAssessment = new CertificationAssessment({
-          id: 123,
-          userId: 123,
-          certificationCourseId: 789,
-          createdAt: new Date('2020-01-01'),
-          completedAt: new Date('2020-01-01'),
-          state: CertificationAssessment.states.STARTED,
-          isV2Certification: true,
-          certificationChallenges: [
-            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-            domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
-          ],
-          certificationAnswersByDate: ['answer'],
-        });
-        certificationAssessmentRepository.getByCertificationCourseId
-          .withArgs({ certificationCourseId: 789 })
-          .resolves(certificationAssessment);
-        certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
-        const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
-        const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
-        const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
-          status: AssessmentResult.status.VALIDATED,
-          competenceMarks: [competenceMarkData1, competenceMarkData2],
-          percentageCorrectAnswers: 80,
-          hasEnoughNonNeutralizedChallengesToBeTrusted: true,
-        });
-        scoringCertificationService.calculateCertificationAssessmentScore
-          .withArgs({ certificationAssessment, continueOnError: false })
-          .resolves(certificationAssessmentScore);
-
-        const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.standard({
-          emitter: 'PIX-ALGO-NEUTRALIZATION',
-          pixScore: 30,
-          status: AssessmentResult.status.VALIDATED,
-          assessmentId: 123,
-          juryId: 7,
-        });
-        const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-        assessmentResultRepository.save.resolves(savedAssessmentResult);
-
-        const dependendencies = {
-          assessmentResultRepository,
-          certificationAssessmentRepository,
-          competenceMarkRepository,
-          scoringCertificationService,
-          certificationCourseRepository,
-        };
-
-        // when
-        await handleCertificationRescoring({
-          ...dependendencies,
-          event,
-        });
-
-        // then
-        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResultToBeSaved);
-        expect(certificationCourse.uncancel).to.have.been.calledOnce;
-        expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
-      });
-    });
-  });
-
-  context('when FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED is not enabled', function () {
-    it('does not cancel the certification course if certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function () {
+  context('when the certification has not enough non neutralized challenges to be trusted', function () {
+    it('cancels the certification and save a not trustable assessment result', async function () {
       // given
-      sinon.stub(featureToggles, 'isManageUncompletedCertifEnabled').value(false);
       const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
       const assessmentResultRepository = { save: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
       const competenceMarkRepository = { save: sinon.stub() };
       const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        isCancelled: false,
-      });
+      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
+      sinon.spy(certificationCourse, 'cancel');
 
-      certificationCourse.cancel = sinon.stub();
-
-      const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
+      const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
       const certificationAssessment = new CertificationAssessment({
         id: 123,
         userId: 123,
-        certificationCourseId: certificationCourse.getId(),
+        certificationCourseId: 789,
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-01-01'),
         state: CertificationAssessment.states.STARTED,
@@ -273,36 +117,30 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         certificationAnswersByDate: ['answer'],
       });
       certificationAssessmentRepository.getByCertificationCourseId
-        .withArgs({ certificationCourseId: certificationCourse.getId() })
+        .withArgs({ certificationCourseId: 789 })
         .resolves(certificationAssessment);
-      certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
-
-      const competenceMarkData2 = domainBuilder.buildCompetenceMark();
-      const competenceMarkData1 = domainBuilder.buildCompetenceMark();
-      const nbPix = Symbol('nbPix');
-      const status = Symbol('status');
-      const certificationAssessmentScore = {
-        nbPix,
-        status,
+      certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
+      const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
+      const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
+      const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+        status: AssessmentResult.status.VALIDATED,
         competenceMarks: [competenceMarkData1, competenceMarkData2],
         percentageCorrectAnswers: 80,
         hasEnoughNonNeutralizedChallengesToBeTrusted: false,
-      };
+      });
       scoringCertificationService.calculateCertificationAssessmentScore
         .withArgs({ certificationAssessment, continueOnError: false })
         .resolves(certificationAssessmentScore);
 
-      const assessmentResultToBeSaved = new AssessmentResult({
-        id: undefined,
-        commentForJury: 'Computed',
+      const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.notTrustable({
         emitter: 'PIX-ALGO-NEUTRALIZATION',
-        pixScore: nbPix,
-        status: status,
+        pixScore: 30,
+        status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 7,
       });
       const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
-      assessmentResultRepository.save.withArgs(assessmentResultToBeSaved).resolves(savedAssessmentResult);
+      assessmentResultRepository.save.resolves(savedAssessmentResult);
 
       const dependendencies = {
         assessmentResultRepository,
@@ -319,8 +157,82 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       });
 
       // then
-      expect(certificationCourseRepository.update).to.not.have.been.called;
-      expect(certificationCourse.cancel).to.not.have.been.called;
+      expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResultToBeSaved);
+      expect(certificationCourse.cancel).to.have.been.calledOnce;
+      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
+    });
+  });
+
+  context('when the certification has enough non neutralized challenges to be trusted', function () {
+    it('uncancels the certification and save a standard assessment result', async function () {
+      // given
+      const certificationCourseRepository = { get: sinon.stub(), update: sinon.stub() };
+      const assessmentResultRepository = { save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+      const competenceMarkRepository = { save: sinon.stub() };
+      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
+      sinon.spy(certificationCourse, 'uncancel');
+
+      const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
+      const certificationAssessment = new CertificationAssessment({
+        id: 123,
+        userId: 123,
+        certificationCourseId: 789,
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-01-01'),
+        state: CertificationAssessment.states.STARTED,
+        isV2Certification: true,
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
+        ],
+        certificationAnswersByDate: ['answer'],
+      });
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId: 789 })
+        .resolves(certificationAssessment);
+      certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
+      const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
+      const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
+      const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+        status: AssessmentResult.status.VALIDATED,
+        competenceMarks: [competenceMarkData1, competenceMarkData2],
+        percentageCorrectAnswers: 80,
+        hasEnoughNonNeutralizedChallengesToBeTrusted: true,
+      });
+      scoringCertificationService.calculateCertificationAssessmentScore
+        .withArgs({ certificationAssessment, continueOnError: false })
+        .resolves(certificationAssessmentScore);
+
+      const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.standard({
+        emitter: 'PIX-ALGO-NEUTRALIZATION',
+        pixScore: 30,
+        status: AssessmentResult.status.VALIDATED,
+        assessmentId: 123,
+        juryId: 7,
+      });
+      const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+      assessmentResultRepository.save.resolves(savedAssessmentResult);
+
+      const dependendencies = {
+        assessmentResultRepository,
+        certificationAssessmentRepository,
+        competenceMarkRepository,
+        scoringCertificationService,
+        certificationCourseRepository,
+      };
+
+      // when
+      await handleCertificationRescoring({
+        ...dependendencies,
+        event,
+      });
+
+      // then
+      expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResultToBeSaved);
+      expect(certificationCourse.uncancel).to.have.been.calledOnce;
+      expect(certificationCourseRepository.update).to.have.been.calledWithExactly(certificationCourse);
     });
   });
 

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -126,7 +126,7 @@ export default class SessionsFinalizeController extends Controller {
 
   isValid() {
     const invalidCertificationReports = this.session.certificationReports.filter(
-      (certificationReport) => !certificationReport.isCompleted && certificationReport.abortReason === null
+      (certificationReport) => certificationReport.isInvalid
     );
 
     if (invalidCertificationReports.length) {

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -24,10 +24,6 @@ export default class SessionsFinalizeController extends Controller {
     return `Finalisation | Session ${this.session.id} | Pix Certif`;
   }
 
-  get isManageUncompletedCertifEnabled() {
-    return this.featureToggles.featureToggles.isManageUncompletedCertifEnabled;
-  }
-
   get shouldDisplayHasSeenEndTestScreenCheckbox() {
     return !this.currentUser.currentAllowedCertificationCenterAccess.hasEndTestScreenRemovalEnabled;
   }

--- a/certif/app/models/certification-report.js
+++ b/certif/app/models/certification-report.js
@@ -19,6 +19,10 @@ export default class CertificationReport extends Model {
     return firstIssueReport ? firstIssueReport.description : '';
   }
 
+  get isInvalid() {
+    return !this.isCompleted && this.abortReason === null;
+  }
+
   abort = memberAction({
     type: 'post',
     urlType: 'abort-certification',

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,7 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isManageUncompletedCertifEnabled;
   @attr('boolean') isEndTestScreenRemovalEnabled;
   @attr('boolean') isComplementaryCertificationSubscriptionEnabled;
 }

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -62,11 +62,7 @@ export default class Session extends Model {
   }
 
   get completedCertificationReports() {
-    if (this.featureToggles.featureToggles.isManageUncompletedCertifEnabled) {
-      return this.certificationReports.filter((certificationReport) => certificationReport.isCompleted);
-    }
-
-    return this.certificationReports;
+    return this.certificationReports.filter((certificationReport) => certificationReport.isCompleted);
   }
 
   get uncompletedCertificationReports() {

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -18,15 +18,13 @@
     @icon="/icons/session-finalization-user.svg"
     @iconAlt=""
   >
-    {{#if this.isManageUncompletedCertifEnabled}}
-      {{#if (gt this.session.uncompletedCertificationReports.length 0)}}
-        <SessionFinalization::UncompletedReportsInformationStep
-          @certificationReports={{this.session.uncompletedCertificationReports}}
-          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
-          @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
-          @onChangeAbortReason={{this.abort}}
-        />
-      {{/if}}
+    {{#if (gt this.session.uncompletedCertificationReports.length 0)}}
+      <SessionFinalization::UncompletedReportsInformationStep
+        @certificationReports={{this.session.uncompletedCertificationReports}}
+        @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+        @onIssueReportDeleteButtonClicked={{this.deleteCertificationIssueReport}}
+        @onChangeAbortReason={{this.abort}}
+      />
     {{/if}}
     {{#if (gt this.session.completedCertificationReports.length 0)}}
       <SessionFinalization::CompletedReportsInformationStep

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -50,9 +50,7 @@ module('Acceptance | Session Finalization', function (hooks) {
       await visit(`/sessions/${session.id}/finalisation`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -70,9 +68,7 @@ module('Acceptance | Session Finalization', function (hooks) {
         await visit(`/sessions/${session.id}/finalisation`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/espace-ferme');
+        assert.strictEqual(currentURL(), '/espace-ferme');
       });
     });
 
@@ -81,9 +77,7 @@ module('Acceptance | Session Finalization', function (hooks) {
       await visit(`/sessions/${session.id}/finalisation`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
+      assert.strictEqual(currentURL(), `/sessions/${session.id}/finalisation`);
     });
 
     test('it should display the end screen column when the center has no access to the supervisor space', async function (assert) {

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -31,7 +31,10 @@ module('Acceptance | Session Finalization', function (hooks) {
       allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
       pixCertifTermsOfServiceAccepted: true,
     });
-    const certificationReports = server.createList('certification-report', 2, { hasSeenEndTestScreen: false });
+    const certificationReports = server.createList('certification-report', 2, {
+      hasSeenEndTestScreen: false,
+      isCompleted: true,
+    });
     session = server.create('session', {
       certificationCenterId: allowedCertificationCenterAccess.id,
       certificationReports,
@@ -186,7 +189,6 @@ module('Acceptance | Session Finalization', function (hooks) {
               isCompleted: true,
               abortReason: 'technical',
             });
-            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
 
             session.update({ certificationReports: [certificationReport] });
 
@@ -208,7 +210,6 @@ module('Acceptance | Session Finalization', function (hooks) {
               isCompleted: true,
               abortReason: 'technical',
             });
-            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
 
             session.update({ certificationReports: [certificationReport] });
 
@@ -227,7 +228,6 @@ module('Acceptance | Session Finalization', function (hooks) {
         test('it should not show the uncompleted reports table', async function (assert) {
           // given
           const certificationReport = server.create('certification-report', { isCompleted: true });
-          server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
           session.update({ certificationReports: [certificationReport] });
 
           // when
@@ -248,7 +248,6 @@ module('Acceptance | Session Finalization', function (hooks) {
                 isCompleted: true,
                 abortReason: 'technical',
               });
-              server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
 
               session.update({ certificationReports: [certificationReport] });
 
@@ -270,7 +269,6 @@ module('Acceptance | Session Finalization', function (hooks) {
                 isCompleted: true,
                 abortReason: 'technical',
               });
-              server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
 
               allowedCertificationCenterAccess.update({
                 hasEndTestScreenRemovalEnabled: true,
@@ -292,7 +290,6 @@ module('Acceptance | Session Finalization', function (hooks) {
         test('it should not show the completed reports table', async function (assert) {
           // given
           const certificationReport = server.create('certification-report', { isCompleted: false, abortReason: null });
-          server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
           session.update({ certificationReports: [certificationReport] });
 
           // when
@@ -306,7 +303,6 @@ module('Acceptance | Session Finalization', function (hooks) {
         test('it should show the uncompleted reports table', async function (assert) {
           // given
           const certificationReport = server.create('certification-report', { isCompleted: false });
-          server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
           session.update({ certificationReports: [certificationReport] });
 
           // when
@@ -323,7 +319,6 @@ module('Acceptance | Session Finalization', function (hooks) {
               isCompleted: false,
               abortReason: null,
             });
-            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
             session.update({ certificationReports: [certificationReport] });
 
             // when
@@ -343,7 +338,6 @@ module('Acceptance | Session Finalization', function (hooks) {
               isCompleted: false,
               abortReason: 'technical',
             });
-            server.create('feature-toggle', { isManageUncompletedCertifEnabled: true });
             session.update({ certificationReports: [certificationReport] });
 
             // when

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -11,13 +11,6 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
   module('#computed uncheckedHasSeenEndTestScreenCount', function () {
     test('it should count no unchecked box if no report', function (assert) {
       // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = {
-          isManageUncompletedCertifEnabled: false,
-        };
-      }
-
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       controller.model = store.createRecord('session', {
@@ -33,24 +26,20 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
 
     test('it should count unchecked boxes', function (assert) {
       // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = {
-          isManageUncompletedCertifEnabled: false,
-        };
-      }
-
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
-      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       const certificationReportA = store.createRecord('certification-report', {
         hasSeenEndTestScreen: true,
+        isCompleted: true,
       });
       const certificationReportB = store.createRecord('certification-report', {
         hasSeenEndTestScreen: false,
+        isCompleted: true,
       });
       const certificationReportC = store.createRecord('certification-report', {
         hasSeenEndTestScreen: false,
+        isCompleted: true,
       });
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       controller.model = store.createRecord('session', {
         certificationReports: [certificationReportA, certificationReportB, certificationReportC],
       });
@@ -66,21 +55,16 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
   module('#computed hasUncheckedHasSeenEndTestScreen', function () {
     test('it should be false if no unchecked certification reports', function (assert) {
       // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = {
-          isManageUncompletedCertifEnabled: false,
-        };
-      }
-
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
-      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       const certificationReportA = store.createRecord('certification-report', {
         hasSeenEndTestScreen: true,
+        isCompleted: true,
       });
       const certificationReportB = store.createRecord('certification-report', {
         hasSeenEndTestScreen: true,
+        isCompleted: true,
       });
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       controller.model = store.createRecord('session', {
         certificationReports: [certificationReportA, certificationReportB],
       });
@@ -94,20 +78,15 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
 
     test('it should be true if at least one unchecked certification reports', function (assert) {
       // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = {
-          isManageUncompletedCertifEnabled: false,
-        };
-      }
-
-      this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       const certificationReportA = store.createRecord('certification-report', {
         hasSeenEndTestScreen: true,
+        isCompleted: true,
       });
       const certificationReportB = store.createRecord('certification-report', {
         hasSeenEndTestScreen: false,
+        isCompleted: true,
       });
       controller.model = store.createRecord('session', {
         certificationReports: [certificationReportA, certificationReportB],

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
@@ -21,19 +20,15 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      controller.model = run(() =>
-        store.createRecord('session', {
-          certificationReports: [],
-        })
-      );
+      controller.model = store.createRecord('session', {
+        certificationReports: [],
+      });
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(uncheckedHasSeenEndTestScreenCount, 0);
+      assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 0);
     });
 
     test('it should count unchecked boxes', function (assert) {
@@ -47,34 +42,24 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const certificationReportA = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: true,
-        })
-      );
-      const certificationReportB = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: false,
-        })
-      );
-      const certificationReportC = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: false,
-        })
-      );
-      controller.model = run(() =>
-        store.createRecord('session', {
-          certificationReports: [certificationReportA, certificationReportB, certificationReportC],
-        })
-      );
+      const certificationReportA = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      });
+      const certificationReportB = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: false,
+      });
+      const certificationReportC = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: false,
+      });
+      controller.model = store.createRecord('session', {
+        certificationReports: [certificationReportA, certificationReportB, certificationReportC],
+      });
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(uncheckedHasSeenEndTestScreenCount, 2);
+      assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 2);
     });
   });
 
@@ -90,21 +75,15 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const certificationReportA = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: true,
-        })
-      );
-      const certificationReportB = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: true,
-        })
-      );
-      controller.model = run(() =>
-        store.createRecord('session', {
-          certificationReports: [certificationReportA, certificationReportB],
-        })
-      );
+      const certificationReportA = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      });
+      const certificationReportB = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      });
+      controller.model = store.createRecord('session', {
+        certificationReports: [certificationReportA, certificationReportB],
+      });
 
       // when
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
@@ -124,21 +103,15 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const certificationReportA = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: true,
-        })
-      );
-      const certificationReportB = run(() =>
-        store.createRecord('certification-report', {
-          hasSeenEndTestScreen: false,
-        })
-      );
-      controller.model = run(() =>
-        store.createRecord('session', {
-          certificationReports: [certificationReportA, certificationReportB],
-        })
-      );
+      const certificationReportA = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: true,
+      });
+      const certificationReportB = store.createRecord('certification-report', {
+        hasSeenEndTestScreen: false,
+      });
+      controller.model = store.createRecord('session', {
+        certificationReports: [certificationReportA, certificationReportB],
+      });
 
       // when
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
@@ -152,14 +125,12 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
     test('it should return false if certification center has access to supervisor space', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = run(() =>
-        store.createRecord('allowed-certification-center-access', {
-          id: 123,
-          name: 'Test certification center',
-          type: 'NOT_SCO',
-          hasEndTestScreenRemovalEnabled: true,
-        })
-      );
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+        name: 'Test certification center',
+        type: 'NOT_SCO',
+        hasEndTestScreenRemovalEnabled: true,
+      });
 
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
@@ -168,11 +139,9 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
 
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      controller.model = run(() =>
-        store.createRecord('session', {
-          certificationReports: [],
-        })
-      );
+      controller.model = store.createRecord('session', {
+        certificationReports: [],
+      });
 
       // when
       const result = controller.shouldDisplayHasSeenEndTestScreenCheckbox;
@@ -184,14 +153,12 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
     test('it should return true if certification center has access to supervisor space', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = run(() =>
-        store.createRecord('allowed-certification-center-access', {
-          id: 123,
-          name: 'Test certification center',
-          type: 'NOT_SCO',
-          hasEndTestScreenRemovalEnabled: false,
-        })
-      );
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+        name: 'Test certification center',
+        type: 'NOT_SCO',
+        hasEndTestScreenRemovalEnabled: false,
+      });
 
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
@@ -200,11 +167,9 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
 
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      controller.model = run(() =>
-        store.createRecord('session', {
-          certificationReports: [],
-        })
-      );
+      controller.model = store.createRecord('session', {
+        certificationReports: [],
+      });
 
       // when
       const result = controller.shouldDisplayHasSeenEndTestScreenCheckbox;
@@ -227,9 +192,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('updateExaminerGlobalComment', { target: { value: 'MoreThan5Characters' } });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.examinerGlobalComment, initialValue);
+      assert.strictEqual(session.examinerGlobalComment, initialValue);
     });
 
     test('it should update session examiner global comment if input value is not exceeding max size', function (assert) {
@@ -244,9 +207,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.examinerGlobalComment, newValue);
+      assert.strictEqual(session.examinerGlobalComment, newValue);
     });
 
     test('it should update session examiner global comment to null if trimmed input value is still empty', function (assert) {
@@ -261,9 +222,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.examinerGlobalComment, null);
+      assert.strictEqual(session.examinerGlobalComment, null);
     });
   });
 
@@ -278,9 +237,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       controller.send('toggleCertificationReportHasSeenEndTestScreen', certifReport);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(certifReport.hasSeenEndTestScreen, !initialValue);
+      assert.strictEqual(certifReport.hasSeenEndTestScreen, !initialValue);
     });
   });
 
@@ -307,12 +264,8 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
         controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(session.certificationReports[0].hasSeenEndTestScreen, expectedState);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(session.certificationReports[1].hasSeenEndTestScreen, expectedState);
+        assert.strictEqual(session.certificationReports[0].hasSeenEndTestScreen, expectedState);
+        assert.strictEqual(session.certificationReports[1].hasSeenEndTestScreen, expectedState);
       })
     );
 

--- a/certif/tests/unit/models/certification-report_test.js
+++ b/certif/tests/unit/models/certification-report_test.js
@@ -41,5 +41,61 @@ module('Unit | Model | certification report', function (hooks) {
       // when / then
       assert.deepEqual(certificationReport.firstIssueReportDescription, description);
     });
+
+    module('#isInvalid', function () {
+      module('when the certification is incomplete', function () {
+        module('when the certification has no abort reason', function () {
+          test('it should return true', function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const certificationReport = store.createRecord('certification-report', {
+              isCompleted: false,
+              abortReason: null,
+            });
+            // when / then
+            assert.true(certificationReport.isInvalid);
+          });
+        });
+        module('when the certification has abort reasons', function () {
+          test('it should return false', function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const certificationReport = store.createRecord('certification-report', {
+              isCompleted: false,
+              abortReason: 'technical',
+            });
+            // when / then
+            assert.false(certificationReport.isInvalid);
+          });
+        });
+      });
+
+      module('when the certification is complete ', function () {
+        module('when the certification has no abort reasons', function () {
+          test('it should return false', function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const certificationReport = store.createRecord('certification-report', {
+              isCompleted: true,
+              abortReason: null,
+            });
+            // when / then
+            assert.false(certificationReport.isInvalid);
+          });
+        });
+        module('when the certification has abort reasons', function () {
+          test('it should return false', function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const certificationReport = store.createRecord('certification-report', {
+              isCompleted: true,
+              abortReason: 'technical',
+            });
+            // when / then
+            assert.false(certificationReport.isInvalid);
+          });
+        });
+      });
+    });
   });
 });

--- a/certif/tests/unit/models/certification-report_test.js
+++ b/certif/tests/unit/models/certification-report_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 import { A } from '@ember/array';
 
 module('Unit | Model | certification report', function (hooks) {
@@ -9,33 +8,20 @@ module('Unit | Model | certification report', function (hooks) {
   test('it should return the right data in the finalized session model', function (assert) {
     // given
     const store = this.owner.lookup('service:store');
-    const model = run(() =>
-      store.createRecord('certification-report', {
-        id: 123,
-        firstName: 'Clément',
-        lastName: 'Tine',
-        certificationCourseId: 987,
-        hasSeenEndTestScreen: false,
-      })
-    );
+    const model = store.createRecord('certification-report', {
+      id: 123,
+      firstName: 'Clément',
+      lastName: 'Tine',
+      certificationCourseId: 987,
+      hasSeenEndTestScreen: false,
+    });
 
-    // when / then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.id, 123);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.firstName, 'Clément');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.lastName, 'Tine');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.certificationCourseId, 987);
+    assert.notPropEqual(model.id, 123);
+    assert.deepEqual(model.firstName, 'Clément');
+    assert.deepEqual(model.lastName, 'Tine');
+    assert.deepEqual(model.certificationCourseId, 987);
     assert.false(model.hasSeenEndTestScreen);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.firstIssueReportDescription, '');
+    assert.deepEqual(model.firstIssueReportDescription, '');
   });
 
   module('#firstIssueReportDescription', function () {
@@ -43,24 +29,17 @@ module('Unit | Model | certification report', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const description = 'Il était en retard à la certification';
-      const issueReport = run(() =>
-        store.createRecord('certification-issue-report', {
-          description,
-          category: 'Retard',
-        })
-      );
-      const certificationReport = run(() =>
-        store.createRecord('certification-report', {
-          id: 123,
-          certificationIssueReports: A([issueReport]),
-          hasSeenEndTestScreen: false,
-        })
-      );
-
+      const issueReport = store.createRecord('certification-issue-report', {
+        description,
+        category: 'Retard',
+      });
+      const certificationReport = store.createRecord('certification-report', {
+        id: 123,
+        certificationIssueReports: A([issueReport]),
+        hasSeenEndTestScreen: false,
+      });
       // when / then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(certificationReport.firstIssueReportDescription, description);
+      assert.deepEqual(certificationReport.firstIssueReportDescription, description);
     });
   });
 });

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -93,45 +93,16 @@ module('Unit | Model | session', function (hooks) {
   });
 
   module('#completedCertificationReports', function () {
-    module('when isManageUncompletedCertifEnabled is enabled', function () {
-      test('it should return the complete certification reports', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
+    test('it should return the complete certification reports', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
 
-        class FeatureToggleStub extends Service {
-          featureToggles = {
-            isManageUncompletedCertifEnabled: true,
-          };
-        }
+      const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
-        this.owner.register('service:featureToggles', FeatureToggleStub);
-
-        const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
-
-        // when/then
+      // when/then
       assert.strictEqual(model.completedCertificationReports.length, 2);
       assert.notPropEqual(model.completedCertificationReports[0].id, 2);
       assert.notPropEqual(model.completedCertificationReports[1].id, 3);
-      });
-    });
-
-    module('when isManageUncompletedCertifEnabled is not enabled', function () {
-      test('it should return the all certification reports', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-
-        class FeatureToggleStub extends Service {
-          featureToggles = {
-            isManageUncompletedCertifEnabled: false,
-          };
-        }
-
-        this.owner.register('service:featureToggles', FeatureToggleStub);
-
-        const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
-        // when/then
-        assert.strictEqual(model.completedCertificationReports.length, 3);
-      });
     });
   });
 });

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 import config from '../../../config/environment';
 import Service from '@ember/service';
 import { CREATED, FINALIZED } from 'pix-certif/models/session';
@@ -12,26 +11,17 @@ module('Unit | Model | session', function (hooks) {
     test('it should return the correct displayName', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const model1 = run(() =>
-        store.createRecord('session', {
-          id: 123,
-          status: CREATED,
-        })
-      );
-      const model2 = run(() =>
-        store.createRecord('session', {
-          id: 1234,
-          status: FINALIZED,
-        })
-      );
+      const model1 = store.createRecord('session', {
+        id: 123,
+        status: CREATED,
+      });
+      const model2 = store.createRecord('session', {
+        id: 1234,
+        status: FINALIZED,
+      });
 
-      // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model1.displayStatus, 'Créée');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model2.displayStatus, 'Finalisée');
+      assert.strictEqual(model1.displayStatus, 'Créée');
+      assert.strictEqual(model2.displayStatus, 'Finalisée');
     });
   });
 
@@ -39,12 +29,10 @@ module('Unit | Model | session', function (hooks) {
     test('it should return the correct urlToUpload', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const model = run(() => store.createRecord('session', { id: 1 }));
+      const model = store.createRecord('session', { id: 1 });
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
+      assert.strictEqual(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
     });
   });
 
@@ -60,13 +48,11 @@ module('Unit | Model | session', function (hooks) {
         };
       }
 
-      const model = run(() => store.createRecord('session', { id: 1 }));
+      const model = store.createRecord('session', { id: 1 });
       this.owner.register('service:session', SessionStub);
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         model.urlToDownloadAttendanceSheet,
         `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`
       );
@@ -85,13 +71,11 @@ module('Unit | Model | session', function (hooks) {
         };
       }
 
-      const model = run(() => store.createRecord('session', { id: 1 }));
+      const model = store.createRecord('session', { id: 1 });
       this.owner.register('service:session', SessionStub);
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.urlToDownloadSessionIssueReportSheet, config.urlToDownloadSessionIssueReportSheet);
+      assert.strictEqual(model.urlToDownloadSessionIssueReportSheet, config.urlToDownloadSessionIssueReportSheet);
     });
   });
 
@@ -103,12 +87,8 @@ module('Unit | Model | session', function (hooks) {
       const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.uncompletedCertificationReports.length, 1);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.uncompletedCertificationReports[0].id, 1);
+      assert.strictEqual(model.uncompletedCertificationReports.length, 1);
+      assert.notPropEqual(model.uncompletedCertificationReports[0].id, 1);
     });
   });
 
@@ -129,15 +109,9 @@ module('Unit | Model | session', function (hooks) {
         const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
 
         // when/then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(model.completedCertificationReports.length, 2);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(model.completedCertificationReports[0].id, 2);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(model.completedCertificationReports[1].id, 3);
+      assert.strictEqual(model.completedCertificationReports.length, 2);
+      assert.notPropEqual(model.completedCertificationReports[0].id, 2);
+      assert.notPropEqual(model.completedCertificationReports[1].id, 3);
       });
     });
 
@@ -156,23 +130,19 @@ module('Unit | Model | session', function (hooks) {
 
         const model = _createTwoCompleteAndOneUncompleteCertificationReports(store);
         // when/then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(model.completedCertificationReports.length, 3);
+        assert.strictEqual(model.completedCertificationReports.length, 3);
       });
     });
   });
 });
 
 function _createTwoCompleteAndOneUncompleteCertificationReports(store) {
-  return run(() =>
-    store.createRecord('session', {
-      id: 1,
-      certificationReports: [
-        store.createRecord('certification-report', { id: 1, isCompleted: false }),
-        store.createRecord('certification-report', { id: 2, isCompleted: true }),
-        store.createRecord('certification-report', { id: 3, isCompleted: true }),
-      ],
-    })
-  );
+  return store.createRecord('session', {
+    id: 1,
+    certificationReports: [
+      store.createRecord('certification-report', { id: 1, isCompleted: false }),
+      store.createRecord('certification-report', { id: 2, isCompleted: true }),
+      store.createRecord('certification-report', { id: 3, isCompleted: true }),
+    ],
+  });
 }


### PR DESCRIPTION
## :unicorn: Problème
Le feature Flag FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED est actif/validé en production. On a donc du code mort (pour le flag desactivé)

## :robot: Solution
Retirer ce feature flag

## :rainbow: Remarques
N/A

## :100: Pour tester

S'assurer de l'absence de la variable d'environnement `FT_MANAGE_UNCOMPLETED_CERTIF_ENABLED`.

Créer une session de certification.

Inscrire au moins deux candidats.

Passer un test de certification complet avec un candidat.

Rejoindre la session sans la terminer avec le deuxième candidat.

Finaliser la session.

Constater un affichage similaire à la capture d'écran ci-dessous : le candidat n'ayant pas fini son test est affiché à part, dans "Ces candidats n'ont pas fini leur test de certification"

![uncomplete](https://user-images.githubusercontent.com/3769147/151832125-a8310906-9838-4f7a-b0a0-c25b2dadd185.png)

L'affichage ne doit pas être celui ci-dessous ([autre RA](https://certif-pr4002.review.pix.fr/sessions/11/finalisation)), où le candidat n'ayant pas fini son test est dans "Certification(s) terminée(s)" 
![image](https://user-images.githubusercontent.com/56302715/151945968-c79795e1-f203-4423-b4a6-629fd78c5526.png)
