### PR TITLE
[DOC] Mise à jour des tags de titre de PR

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -68,9 +68,11 @@ Nom | Usage
 --- | ---
 FEATURE | PR relative à une story
 BUGFIX | PR relative à une correction d'un bug
-CLEANUP | PR relative à du refactoring
-INFRA | PR relative à du code technique / d'infra
-DOC | PR relative à de la documentation
+TECH | PR relative à du code technique / d'infra
+
+Ce tag nous permet de générer automatiquement un fichier [CHANGELOG.md](./CHANGELOG.md) regroupant les modifications d'une version à l'autre. Il est possible d'utiliser d'autres tags mais le CHANGELOG les regroupera comme des modifications "Autres".
+
+Le titre de la PR originel (et donc son tag) reste dans tous les cas affiché dans chaque ligne du CHANGELOG.
 
 #### DESCRIPTION
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le fichier CONTRIBUTING.md, la convention de nommage des PR n'est plus à jour.

## :robot: Solution
Remise à jour des tags acceptés.

Sources :
- https://github.com/1024pix/pix-bot/blob/11e80a7022b1e199f924aa191e99b946c44ca520/scripts/models/Tags.js
- https://github.com/1024pix/pix-bot/blob/11e80a7022b1e199f924aa191e99b946c44ca520/scripts/models/PullRequestGroupFactory.js

## :rainbow: Remarques
J'en ai profité pour ajouter des infos sur l'utilité de respecter cette convention et ce qui se passe si on n'utilise pas de tags existants.

## :100: Pour tester
N/A
