### PR TITLE
[FEATURE] Centrer l'encart d'erreur et modifier le message de test (PIX-4291)

### DIFF
--- a/certif/app/styles/pages/session-supervising-error.scss
+++ b/certif/app/styles/pages/session-supervising-error.scss
@@ -16,7 +16,7 @@
   align-items: center;
   background-color: white;
   border-radius: 10px;
-  margin: 8px;
+  margin: auto 8px;
   max-width: 463px;
   padding: 32px 8px 16px;
 

--- a/certif/tests/acceptance/session-supervising-error_test.js
+++ b/certif/tests/acceptance/session-supervising-error_test.js
@@ -20,8 +20,8 @@ module('Acceptance | Session supervising error', function (hooks) {
     await authenticateSession(certificationPointOfContact.id);
   });
 
-  module('When there are candidates on the session', function () {
-    test('it should display candidates entries', async function (assert) {
+  module('When the supervisor tries to access a session he doesnt have a supervisor-access to', function () {
+    test('it should display an error page and a HTTP 401 error', async function (assert) {
       // given
       this.sessionForSupervising = server.create('session-for-supervising', {
         id: 2000,


### PR DESCRIPTION
## :unicorn: Problème
Par erreur, la PR [Afficher une page d'erreur lorsque le surveillant n'a pas accès à la session](https://github.com/1024pix/pix/pull/3989) a été mergée avant la prise en compte de deux modifications non-bloquantes.
La première modification concerne le centrage vertical de l'encart en mobile. La deuxième modification est un changement d'intitulé dans les tests. 

## :100: Pour tester
- Se connecter à pix-certif en tant que certifsup
- Créer deux sessions de certification
- Se connecter en tant que surveillant à l'une de ces sessions
- Modifier l'ID de la session dans l'URL avec l'ID de la session dont on n'est pas surveillant
- Constater l'affichage de l'encart en responsive centré verticalement.