### PR TITLE
[TECH] Ajout d'un feature toggle pour l'affichage de la nouvelle page de tutoriels sur mon-pix (PIX-4287).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -164,6 +164,7 @@ module.exports = (function () {
         process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
       ),
       isCertificationBillingEnabled: isFeatureEnabled(process.env.FT_CERTIFICATION_BILLING),
+      isNewTutorialsPageEnabled: isFeatureEnabled(process.env.FT_NEW_TUTORIALS_PAGE),
     },
 
     infra: {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -31,6 +31,7 @@ const schema = Joi.object({
   FT_CERTIFICATION_BILLING: Joi.string().optional().valid('true', 'false'),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
   FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
+  FT_NEW_TUTORIALS_PAGE: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -23,7 +23,7 @@
 
 # Enable email validation in Pix App
 #
-# presence: optionnal
+# presence: optional
 # type: boolean
 # default: false
 
@@ -31,17 +31,24 @@ FT_VALIDATE_EMAIL=false
 
 # Prevent candidate from getting a complementary certification without applying
 #
-# presence: optionnal
+# presence: optional
 # type: boolean
 # default: false
 FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=false
 
 # Add info about certification billing
 #
-# presence: optionnal
+# presence: optional
 # type: boolean
 # default: false
 FT_CERTIFICATION_BILLING
+
+# Prevent user from seeing the tutorial page in progress
+#
+# presence: optional
+# type: boolean
+# default: false
+FT_NEW_TUTORIALS_PAGE
 
 # =======
 # CACHING

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-certification-billing-enabled': false,
             'is-email-validation-enabled': false,
             'is-complementary-certification-subscription-enabled': false,
+            'is-new-tutorials-page-enabled': false,
           },
           type: 'feature-toggles',
         },


### PR DESCRIPTION
## :unicorn: Problème

Nous ne souhaitons pas que les utilisateurs puissent accéder à la nouvelle page de tutos bientôt en développement.

## :robot: Solution

Ajout d'un FT dans l'API : `FT_NEW_TUTORIALS_PAGE`

## :rainbow: Remarques

Seulement le côté API est fait au cours de cette PR puisqu'aucun développement côté mon-pix n'a encore eu lieu

## :100: Pour tester

Vérifier que les tests et la CI passent.
