### PR TITLE
[FEATURE] Ajouter une croix pour supprimer le contenu de l'input des profiles cibles (PIX-4165)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -137,12 +137,32 @@
           @onChange={{this.selectTargetProfile}}
           @options={{this.targetProfilesOptions}}
           @emptyOptionLabel=""
+          class="campaign-target-profile"
           aria-describedby="target-profile-info"
           placeholder={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
           @isSearchable={{true}}
           required={{true}}
           aria-required={{true}}
         />
+        {{#if this.displayDeleteInputButton}}
+          <PixTooltip @id="clean-input-button" @position="bottom" class="clean-input-button__tooltip hide-on-mobile">
+            <:triggerElement>
+              <PixIconButton
+                @ariaLabel={{t "pages.campaign-creation.actions.delete"}}
+                aria-describedby="clean-input-button"
+                @icon="times"
+                @size="small"
+                @triggerAction={{this.cleanInput}}
+              />
+            </:triggerElement>
+            <:tooltip>
+              {{t "pages.campaign-creation.actions.delete"}}
+            </:tooltip>
+          </PixTooltip>
+        {{/if}}
+        <span class="target-profile-option">
+          <FaIcon @icon="chevron-down" role="img" aria-label={{t "pages.campaign-creation.target-profiles.chevron"}} />
+        </span>
         {{#if @errors.targetProfile}}
           <div class="form__error error-message">
             {{display-campaign-errors @errors.targetProfile}}

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -19,6 +19,7 @@ export default class CreateForm extends Component {
   @tracked targetProfile;
   @tracked selectedCategories = [];
   @tracked targetProfilesOptions = [];
+  @tracked displayDeleteInputButton = false;
 
   constructor() {
     super(...arguments);
@@ -89,6 +90,26 @@ export default class CreateForm extends Component {
     });
   }
 
+  _isTargetProfileInputEmpty() {
+    return document.getElementById('campaign-target-profile').value.length === 0;
+  }
+
+  _toggleDeleteButton() {
+    if (!this._isTargetProfileInputEmpty()) {
+      this.displayDeleteInputButton = true;
+    } else {
+      this.displayDeleteInputButton = false;
+    }
+  }
+
+  @action
+  cleanInput() {
+    const input = document.getElementById('campaign-target-profile');
+    input.value = '';
+    this.displayDeleteInputButton = false;
+    this.targetProfile = '';
+  }
+
   @action
   toggleCategory(category, isChecked) {
     if (isChecked) {
@@ -113,6 +134,7 @@ export default class CreateForm extends Component {
 
   @action
   selectTargetProfile(event) {
+    this._toggleDeleteButton();
     this.targetProfile = this.args.targetProfiles.find((targetProfile) => targetProfile.name === event.target.value);
     this.campaign.targetProfile = this.targetProfile;
   }

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -54,6 +54,7 @@
       width: calc(100vw - 100% - #{$app-sidebar-width} - 32px);
     }
 
+    
     &-icon {
       color: $blue;
       margin-right: 8px;

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -4,3 +4,34 @@
     width: 100%;
   }
 }
+
+//enlever la flèche par défaut de la datalist sur chrome
+.campaign-target-profile::-webkit-calendar-picker-indicator {
+  opacity: 0;
+}
+
+.clean-input-button__tooltip {
+  position: absolute;
+  height: 20px;
+  top: 0;
+  bottom: 0;
+  right: 30px;
+  margin: auto;
+  border-right: solid 0.5px $grey-30;
+
+  &__content {
+    width: auto;
+  }
+}
+
+
+.target-profile-option {
+  position: absolute;
+  height: 20px;
+  width: 14px;
+  top: 2px;
+  bottom: 0;
+  right: 10px;
+  margin: auto;
+  color :$grey-30;
+}

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -249,12 +249,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         await clickByName(t('pages.campaign-creation.tags.SUBJECT'));
         // then
         const option = document.getElementsByTagName('option');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(option.length, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(option[0].label, 'targetProfile4');
+        assert.strictEqual(option.length, 1);
+        assert.strictEqual(option[0].label, 'targetProfile4');
       });
     });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -301,7 +301,8 @@
         "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign."
       },
       "actions": {
-        "create": "Create a campaign"
+        "create": "Create a campaign",
+        "delete": "Delete"
       },
       "external-id-label": {
         "label": "external user ID label",
@@ -337,6 +338,9 @@
         "SUBJECT": "Subject"
       },
       "tags-title": "Filter:",
+      "target-profiles": {
+        "chevron": "Toggle target profile options dropdown"
+      },
       "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -301,7 +301,8 @@
         "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier ou archiver cette campagne."
       },
       "actions": {
-        "create": "Créer la campagne"
+        "create": "Créer la campagne",
+        "delete": "Effacer"
       },
       "external-id-label": {
         "label": "Libellé de l’identifiant",
@@ -337,6 +338,9 @@
         "SUBJECT": "Thématique"
       },
       "tags-title": "Filtrer la recherche :",
+      "target-profiles": {
+        "chevron": "Afficher le menu déroulant des profils cibles"
+      },
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {


### PR DESCRIPTION
## :unicorn: Problème
Quand on saisissait du texte dans le champ des profils cibles, dans le formulaire de création d'une campagne, il n'y avait aucun moyen de supprimer ce qui avait été écrit.

## :robot: Solution
Ajouter une croix pour supprimer le contenu de l'input.

## :rainbow: Remarques
bsr: remplacer dans les tests `equal` par `strictEqual`

## :100: Pour tester
- Aller sur pix Orga
- Créer une nouvelle campagne de type Évaluation
- Écrire dans le champ des profils cible => Constater l'apparition de la croix
- Cliquer sur la croix => constater que le champs est de nouveau vide

