### PR TITLE
[FEATURE] À la sortie de la campagne, afficher le nombre de Pix (PIX-3787)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -49,6 +49,10 @@
             </p>
             <p class="rounded-panel-title skill-review-result-abstract__subtext">
               {{t "pages.skill-review.flash.pixCount" count=this.flashPixCount}}
+              <br />
+              <span class="skill-review-result-abstract__nonDefinitive">
+                {{t "pages.skill-review.flash.nonDefinitive"}}
+              </span>
             </p>
           {{else}}
             <p class="rounded-panel-title skill-review-result-abstract__text">

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -48,7 +48,7 @@
               {{t "pages.skill-review.flash.abstract"}}
             </p>
             <p class="rounded-panel-title skill-review-result-abstract__subtext">
-              {{t "pages.skill-review.flash.estimatedLevel" level=this.estimatedFlashLevel}}
+              {{t "pages.skill-review.flash.pixCount" count=this.flashPixCount}}
             </p>
           {{else}}
             <p class="rounded-panel-title skill-review-result-abstract__text">

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -104,6 +104,10 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipationResult.estimatedFlashLevel;
   }
 
+  get flashPixCount() {
+    return ((this.estimatedFlashLevel + 10) / 20) * 1024;
+  }
+
   get participantExternalId() {
     return this.args.model.campaignParticipationResult.participantExternalId;
   }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -295,6 +295,10 @@
     text-align: center;
   }
 
+  &__nonDefinitive {
+    font-size: 0.8em;
+  }
+
   &__share-container {
     padding: 16px 40px 32px 40px;
     text-align: center;

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -119,8 +119,10 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     });
 
     it("should display the user's flash estimated level", function () {
+      const expectedPixCount = 257;
+
       // Then
-      expect(contains(this.intl.t('pages.skill-review.flash.estimatedLevel', { level: estimatedFlashLevel }))).to.exist;
+      expect(contains(this.intl.t('pages.skill-review.flash.pixCount', { count: expectedPixCount }))).to.exist;
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1257,7 +1257,7 @@
       },
       "flash": {
         "abstract": "Congratulations, you went all the way !",
-        "estimatedLevel": "Your FLASH score is {level, number}."
+        "pixCount": "You got {count, number, ::.} Pix."
       }
     },
     "terms-of-service": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1257,7 +1257,8 @@
       },
       "flash": {
         "abstract": "Congratulations, you went all the way !",
-        "pixCount": "You got {count, number, ::.} Pix."
+        "pixCount": "You got {count, number, ::.} Pix",
+        "nonDefinitive": "(non-definitive calculation)"
       }
     },
     "terms-of-service": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1257,7 +1257,7 @@
       },
       "flash": {
         "abstract": "Bravo, vous êtes allé·e jusqu'au bout !",
-        "estimatedLevel": "Votre score FLASH est {level, number}."
+        "pixCount": "Vous avez obtenu {count, number, ::.} Pix."
       }
     },
     "terms-of-service": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1257,7 +1257,8 @@
       },
       "flash": {
         "abstract": "Bravo, vous êtes allé·e jusqu'au bout !",
-        "pixCount": "Vous avez obtenu {count, number, ::.} Pix."
+        "pixCount": "Vous avez obtenu {count, number, ::.} Pix",
+        "nonDefinitive": "(calcul non définitif)"
       }
     },
     "terms-of-service": {


### PR DESCRIPTION
## :unicorn: Problème
Le niveau FLASH n'est pas parlant.

## :robot: Solution
On le remplace par un nombre de Pix.

Sachant que le niveau FLASH vaut entre -10 et 10, on applique la règle suivante :
NombreDePix = (NiveauFlash + 10) / 20 * 1024

## :rainbow: Remarques
Il faut peut-être revoir la formule car là si on dépasse un miveau de 5, on dépasse les 768 Pix.

## :100: Pour tester
Finir la campagne `FLASH1234`.