### PR TITLE
[FEATURE] Afficher un bouton de téléchargement du kit surveillant (PIX-4284).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -15,6 +15,10 @@ export default class SessionsDetailsController extends Controller {
     return `Détails | Session ${this.session.id} | Pix Certif`;
   }
 
+  get shouldDisplaySupervisorKitButton() {
+    return this.currentUser.currentAllowedCertificationCenterAccess.isEndTestScreenRemovalEnabled;
+  }
+
   @computed('certificationCandidates.length')
   get certificationCandidatesCount() {
     const certificationCandidatesCount = this.certificationCandidates.length;

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -47,6 +47,11 @@ export default class Session extends Model {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/candidates-import-sheet?accessToken=${this.session.data.authenticated.access_token}`;
   }
 
+  @computed('id', 'session.data.authenticated.access_token')
+  get urlToDownloadSupervisorKitPdf() {
+    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/supervisor-kit?accessToken=${this.session.data.authenticated.access_token}`;
+  }
+
   @computed('id')
   get urlToUpload() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/certification-candidates/import`;

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -14,15 +14,10 @@
 }
 
 .session-details-header {
-
   &__title {
     display: flex;
     align-items: center;
     min-width: 300px;
-
-    &__download-button {
-      margin-left: 50px;
-    }
   }
 
   &__datetime {
@@ -33,7 +28,6 @@
 }
 
 .session-details-header-datetime {
-
   &__date {
     padding-right: 40px;
     margin-right: 40px;
@@ -130,12 +124,52 @@ $details-content-margin: 8px;
   }
 }
 
-.session-details__controls {
-  display: flex;
-  justify-content: space-between;
-  margin: 1em 0;
-}
+.session-details {
+  &__controls {
+    display: flex;
+    justify-content: space-between;
+    margin: 1em 0;
+    flex-direction: column;
 
-.session-details-controls__navbar-tabs {
-  display: flex;
+    @include device-is('desktop') {
+      flex-direction: row;
+    }
+  }
+
+  &__controls-navbar-tabs {
+    display: flex;
+  }
+
+  &__controls-title {
+    color: $grey-70;
+    display: inline-block;
+    font-size: 0.875rem;
+    font-family: $roboto;
+    font-weight: 500;
+    margin-right: 8px;
+    width: 117px;
+  }
+
+  &__controls-links {
+    align-items: center;
+    display: flex;
+    justify-content: right;
+    margin-right: 24px;
+    flex-wrap: wrap;
+
+    @include device-is('desktop') {
+      flex-direction: row;
+    }
+  }
+
+  &__controls-download-button {
+    border: 1px solid $grey-50;
+    color: $grey-70;
+    margin: 8px 6px;
+    padding: 8px 16px;
+  }
+
+  &__controls-icon {
+    margin-right: 8px;
+  }
 }

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -4,43 +4,6 @@
     <div class="session-details-header__title">
       <PixReturnTo @route="authenticated.sessions.list" class="session-details-content__return-button" />
       <h1 class="page-title">Session {{this.session.id}}</h1>
-      <PixButtonLink
-        class="session-details-header__title__download-button"
-        @href="{{this.session.urlToDownloadSessionIssueReportSheet}}"
-        target="_blank"
-        aria-label="Télécharger le pv d'incident"
-        rel="noopener noreferrer"
-        download
-      >
-        PV d'incident&nbsp;
-        <FaIcon @icon="file-download" />
-      </PixButtonLink>
-      {{#if this.shouldDisplayDownloadButton}}
-        <PixButtonLink
-          class="session-details-header__title__download-button"
-          @href="{{this.session.urlToDownloadAttendanceSheet}}"
-          target="_blank"
-          aria-label="Télécharger la feuille d'émargement"
-          rel="noopener noreferrer"
-          download
-        >
-          Feuille d'émargement&nbsp;
-          <FaIcon @icon="file-download" />
-        </PixButtonLink>
-      {{/if}}
-      {{#if this.shouldDisplaySupervisorKitButton}}
-        <PixButtonLink
-          class="session-details-header__title__download-button"
-          @href="{{this.session.urlToDownloadSupervisorKitPdf}}"
-          target="_blank"
-          aria-label="Télécharger le kit surveillant"
-          rel="noopener noreferrer"
-          download
-        >
-          Kit surveillant&nbsp;
-          <FaIcon @icon="file-download" />
-        </PixButtonLink>
-      {{/if}}
     </div>
 
     <div class="session-details-header__datetime">
@@ -71,7 +34,7 @@
   {{/if}}
 
   <div class="panel session-details__controls">
-    <nav class="navbar session-details-controls__navbar-tabs">
+    <nav class="navbar session-details__controls-navbar-tabs">
       <LinkTo @route="authenticated.sessions.details.parameters" class="navbar-item">
         Détails
       </LinkTo>
@@ -80,7 +43,49 @@
         {{this.certificationCandidatesCount}}
       </LinkTo>
     </nav>
-
+    <div class="session-details__controls-links">
+      <span class="session-details__controls-title">Téléchargements :</span>
+      <PixButtonLink
+        class="session-details__controls-download-button"
+        @href="{{this.session.urlToDownloadSessionIssueReportSheet}}"
+        @backgroundColor="transparent"
+        target="_blank"
+        aria-label="Télécharger le pv d'incident"
+        rel="noopener noreferrer"
+        download
+      >
+        <FaIcon @icon="file-download" class="session-details__controls-icon" />
+        PV d'incident
+      </PixButtonLink>
+      {{#if this.shouldDisplaySupervisorKitButton}}
+        <PixButtonLink
+          class="session-details__controls-download-button"
+          @href="{{this.session.urlToDownloadSupervisorKitPdf}}"
+          @backgroundColor="transparent"
+          target="_blank"
+          aria-label="Télécharger le kit surveillant"
+          rel="noopener noreferrer"
+          download
+        >
+          <FaIcon @icon="file-download" class="session-details__controls-icon" />
+          Kit surveillant
+        </PixButtonLink>
+      {{/if}}
+      {{#if this.shouldDisplayDownloadButton}}
+        <PixButtonLink
+          class="session-details__controls-download-button"
+          @href="{{this.session.urlToDownloadAttendanceSheet}}"
+          @backgroundColor="transparent"
+          target="_blank"
+          aria-label="Télécharger la feuille d'émargement"
+          rel="noopener noreferrer"
+          download
+        >
+          <FaIcon @icon="file-download" class="session-details__controls-icon" />
+          Feuille d'émargement
+        </PixButtonLink>
+      {{/if}}
+    </div>
   </div>
   {{outlet}}
 </div>

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -28,6 +28,19 @@
           <FaIcon @icon="file-download" />
         </PixButtonLink>
       {{/if}}
+      {{#if this.shouldDisplaySupervisorKitButton}}
+        <PixButtonLink
+          class="session-details-header__title__download-button"
+          @href="{{this.session.urlToDownloadSupervisorKitPdf}}"
+          target="_blank"
+          aria-label="Télécharger le kit surveillant"
+          rel="noopener noreferrer"
+          download
+        >
+          Kit surveillant&nbsp;
+          <FaIcon @icon="file-download" />
+        </PixButtonLink>
+      {{/if}}
     </div>
 
     <div class="session-details-header__datetime">

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -98,36 +98,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         });
       });
 
-      module('when current certification center has access to supervisor space', function (hooks) {
-        hooks.afterEach(function () {
-          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: false });
-        });
-
-        test('it should display the supervisor kit download button', async function (assert) {
-          // given
-          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: true });
-
-          // when
-          await visit(`/sessions/${sessionWithCandidates.id}`);
-
-          // then
-          assert.contains('Kit surveillant');
-        });
-      });
-
-      module('when current certification center has not access to supervisor space', function () {
-        test('it should not display the supervisor kit download button', async function (assert) {
-          // given
-          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: false });
-
-          // when
-          await visit(`/sessions/${sessionWithCandidates.id}`);
-
-          // then
-          assert.notContains('Kit surveillant');
-        });
-      });
-
       test('it should display details modal button', async function (assert) {
         // when
         await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
@@ -344,17 +314,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
             // then
             assert.dom('table tbody tr').exists({ count: 1 });
-          });
-
-          test('it should display the attendance sheet download button', async function (assert) {
-            // when
-            const screen = await visitScreen(`/sessions/${session.id}/candidats`);
-            await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
-            await _fillFormWithCorrectData(screen);
-            await click(screen.getByRole('button', { name: 'Ajouter le candidat' }));
-
-            // then
-            assert.contains("Feuille d'émargement");
           });
         });
       });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -24,9 +24,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
       await visit(`/sessions/${session.id}/candidats`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -61,9 +59,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         await visit(`/sessions/${session.id}/candidats`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/espace-ferme');
+        assert.strictEqual(currentURL(), '/espace-ferme');
       });
     });
 
@@ -99,6 +95,36 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           sessionId: sessionWithCandidates.id,
           isLinked: false,
           resultRecipientEmail: 'recipient@example.com',
+        });
+      });
+
+      module('when current certification center has access to supervisor space', function (hooks) {
+        hooks.afterEach(function () {
+          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: false });
+        });
+
+        test('it should display the supervisor kit download button', async function (assert) {
+          // given
+          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: true });
+
+          // when
+          await visit(`/sessions/${sessionWithCandidates.id}`);
+
+          // then
+          assert.contains('Kit surveillant');
+        });
+      });
+
+      module('when current certification center has not access to supervisor space', function () {
+        test('it should not display the supervisor kit download button', async function (assert) {
+          // given
+          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: false });
+
+          // when
+          await visit(`/sessions/${sessionWithCandidates.id}`);
+
+          // then
+          assert.notContains('Kit surveillant');
         });
       });
 
@@ -235,7 +261,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
     test('it should redirect to the default candidates detail view', async function (assert) {
       // given
-      const linkToCandidate = '.session-details-controls__navbar-tabs a:nth-of-type(2)';
+      const linkToCandidate = '.session-details__controls-navbar-tabs a:nth-of-type(2)';
       const connectedcertificationPointOfContactId = certificationPointOfContact.id;
       await authenticateSession(connectedcertificationPointOfContactId);
 
@@ -244,9 +270,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
       await click(linkToCandidate);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
+      assert.strictEqual(currentURL(), `/sessions/${session.id}/candidats`);
     });
 
     module('when the addCandidate button is clicked', function () {

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -4,8 +4,6 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import { visit } from '@1024pix/ember-testing-library';
 
-import config from 'pix-certif/config/environment';
-
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | Session Details', function (hooks) {
@@ -117,77 +115,70 @@ module('Acceptance | Session Details', function (hooks) {
         assert.contains('14:00');
       });
 
-      module('when FT_REPORTS_CATEGORISATION is on', function () {
-        test('it should show issue report sheet download button', async function (assert) {
+      test('it should show issue report sheet download button', async function (assert) {
+        // given
+        const sessionWithCandidates = server.create('session');
+        server.createList('certification-candidate', 3, { isLinked: true, sessionId: 1234321 });
+
+        // when
+        const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: "Télécharger le pv d'incident" })).exists();
+      });
+
+      test('it should show attendance sheet download button when there is one or more candidate', async function (assert) {
+        // given
+        const sessionWithCandidates = server.create('session');
+        server.createList('certification-candidate', 3, { isLinked: true, sessionId: sessionWithCandidates.id });
+
+        // when
+        const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: "Télécharger la feuille d'émargement" })).exists();
+      });
+
+      test('it should not show download attendance sheet button where there is no candidate', async function (assert) {
+        // given
+        const sessionWithoutCandidate = server.create('session');
+
+        // when
+        const screen = await visit(`/sessions/${sessionWithoutCandidate.id}`);
+
+        // then
+        assert.dom(screen.queryByRole('link', { name: "Télécharger la feuille d'émargement" })).doesNotExist();
+      });
+    });
+
+    module('when looking at the session details controls', function () {
+      module('when current certification center has access to supervisor space', function (hooks) {
+        hooks.afterEach(function () {
+          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: false });
+        });
+
+        test('it should display the supervisor kit download button', async function (assert) {
           // given
-          const sessionWithCandidates = server.create('session');
-          server.createList('certification-candidate', 3, { isLinked: true, sessionId: 1234321 });
-          server.create('feature-toggle', { id: 0, reportsCategorization: true });
+          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: true });
 
           // when
-          await visit(`/sessions/${sessionWithCandidates.id}`);
+          const screen = await visit(`/sessions/${session.id}`);
 
           // then
-          assert.dom('[aria-label="Télécharger le pv d\'incident"]').hasText("PV d'incident");
+          assert.dom(screen.getByRole('link', { name: 'Télécharger le kit surveillant' })).exists();
         });
       });
 
-      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is on', function (hooks) {
-        const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
-
-        hooks.before(() => {
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
-        });
-
-        hooks.after(() => {
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
-        });
-
-        test('it should show attendance sheet download button when there is one or more candidate', async function (assert) {
+      module('when current certification center has not access to supervisor space', function () {
+        test('it should not display the supervisor kit download button', async function (assert) {
           // given
-          const sessionWithCandidates = server.create('session');
-          server.createList('certification-candidate', 3, { isLinked: true, sessionId: sessionWithCandidates.id });
+          allowedCertificationCenterAccess.update({ isEndTestScreenRemovalEnabled: false });
 
           // when
-          await visit(`/sessions/${sessionWithCandidates.id}`);
+          const screen = await visit(`/sessions/${session.id}`);
 
           // then
-          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').hasText("Feuille d'émargement");
-        });
-
-        test('it should not show download attendance sheet button where there is no candidate', async function (assert) {
-          // given
-          const sessionWithoutCandidate = server.create('session');
-
-          // when
-          await visit(`/sessions/${sessionWithoutCandidate.id}`);
-
-          // then
-          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').doesNotExist();
-        });
-      });
-
-      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is off', function (hooks) {
-        const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
-
-        hooks.before(() => {
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
-        });
-
-        hooks.after(() => {
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
-        });
-
-        test('it should not show download attendance sheet button', async function (assert) {
-          // given
-          const sessionWithCandidates = server.create('session');
-          server.createList('certification-candidate', 3, { isLinked: true });
-
-          // when
-          await visit(`/sessions/${sessionWithCandidates.id}`);
-
-          // then
-          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').doesNotExist();
+          assert.dom(screen.queryByRole('link', { name: 'Télécharger le kit surveillant' })).doesNotExist();
         });
       });
     });

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -128,7 +128,7 @@ module('Acceptance | Session Details', function (hooks) {
           await visit(`/sessions/${sessionWithCandidates.id}`);
 
           // then
-          assert.dom('[aria-label="Télécharger le pv d\'incident"]').hasText("PV d'incident\u00a0");
+          assert.dom('[aria-label="Télécharger le pv d\'incident"]').hasText("PV d'incident");
         });
       });
 
@@ -152,7 +152,7 @@ module('Acceptance | Session Details', function (hooks) {
           await visit(`/sessions/${sessionWithCandidates.id}`);
 
           // then
-          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').hasText("Feuille d'émargement\u00a0");
+          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').hasText("Feuille d'émargement");
         });
 
         test('it should not show download attendance sheet button where there is no candidate', async function (assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/details_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
 
 module('Unit | Controller | authenticated/sessions/details', function (hooks) {
   setupTest(hooks);
@@ -57,6 +58,44 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
 
       // then
       assert.notOk(hasOneOrMoreCandidates);
+    });
+  });
+
+  module('#shouldDisplaySupervisorKitButton', function () {
+    test('should return true if current certification center is allowed to access supervisor space', function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      class currentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = {
+          isEndTestScreenRemovalEnabled: true,
+        };
+      }
+
+      this.owner.register('service:currentUser', currentUserStub);
+
+      // when
+      const shouldDisplaySupervisorKitButton = controller.shouldDisplaySupervisorKitButton;
+
+      // then
+      assert.true(shouldDisplaySupervisorKitButton);
+    });
+
+    test('should return false if current certification center is allowed to access supervisor space', function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      class currentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = {
+          isEndTestScreenRemovalEnabled: false,
+        };
+      }
+
+      this.owner.register('service:currentUser', currentUserStub);
+
+      // when
+      const shouldDisplaySupervisorKitButton = controller.shouldDisplaySupervisorKitButton;
+
+      // then
+      assert.false(shouldDisplaySupervisorKitButton);
     });
   });
 

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -25,6 +25,29 @@ module('Unit | Model | session', function (hooks) {
     });
   });
 
+  module('#urlToDownloadSupervisorKitPdf', function () {
+    test('it should return the correct urlToDownloadSupervisorKitPdf', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('session', { id: 1 });
+      class SessionStub extends Service {
+        data = {
+          authenticated: {
+            access_token: '123',
+          },
+        };
+      }
+
+      this.owner.register('service:session', SessionStub);
+
+      // when/then
+      assert.strictEqual(
+        model.urlToDownloadSupervisorKitPdf,
+        `${config.APP.API_HOST}/api/sessions/1/supervisor-kit?accessToken=123`
+      );
+    });
+  });
+
   module('#urlToUpload', function () {
     test('it should return the correct urlToUpload', function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Après la création d’une session + inscription des candidats dans Pix Certif, beaucoup d’informations doivent être transmises au surveillant par le référent de centre (ou tout autre membre Pix Certif habilité à créer des sessions de certification). Nous avons notamment ajouté récemment le “Mot de passe de sessio,”, nécessaire pour que le surveillant puisse se connecter à l’espace surveillant. Aujourd’hui, nous n’avons pas d’outil facilitant la transmission de toutes ces informations au surveillant.

## :robot: Solution
Permettre à l’utilisateur Pix Certif de télécharger un document reprenant toutes les infos utiles au surveillant depuis Pix Certif : 

Dans Pix Certif > page de détails d’une session, afficher une section “Téléchargements” (voir capture ci-dessous), avec les boutons suivants (dans cet ordre, attention maquette pas à jour !) : 

- PV d’incident : affiché tout le temps à partir de la création de la session - déjà implémenté :wink:

- Kit surveillant : affiché tout le temps à partir de la création de la session

- Feuille d'émargement : affiché à partir du moment où au moins un candidat a été inscrit dans la session -  c’est déjà implémenté :wink: 

## :rainbow: Remarques
![image](https://user-images.githubusercontent.com/37305474/152352892-7a98262e-9145-42ce-95da-5ddc65011549.png)


## :100: Pour tester
- Se connecter à pix-certif avec un centre NON whitelisté ```espace surveillant```
- Créer une session
- Constater l'absence du bouton ```Kit surveillant```



 
- Se connecter à pix-certif avec un centre whitelisté ```espace surveillant```
- Créer une session
- Constater la présence du bouton ```Kit surveillant```
- Cliquer sur le bouton et constater le téléchargement du kit surveillant avec les infos de la session au format pdf
