### PR TITLE
[FEATURE] Enregistrer l'évolution du score FLASH en base (PIX-4306)

### DIFF
--- a/api/db/database-builder/factory/build-flash-assessment-result.js
+++ b/api/db/database-builder/factory/build-flash-assessment-result.js
@@ -1,18 +1,20 @@
 const databaseBuffer = require('../database-buffer');
-const buildAssessment = require('./build-assessment');
+const buildAnswer = require('./build-answer');
 
 module.exports = function buildFlashAssessmentResult({
   id = databaseBuffer.getNextId(),
+  answerId,
   assessmentId,
   estimatedLevel = 2.64,
   errorRate = 0.391,
 } = {}) {
-  if (!assessmentId) assessmentId = buildAssessment({ method: 'FLASH' }).id;
+  if (!answerId && !assessmentId) throw new Error('either `answerId` or `assessmentId` must be defined');
+  if (!answerId) answerId = buildAnswer({ assessmentId }).id;
   return databaseBuffer.pushInsertable({
     tableName: 'flash-assessment-results',
     values: {
       id,
-      assessmentId,
+      answerId,
       estimatedLevel,
       errorRate,
     },

--- a/api/db/migrations/20220202140419_flash-assessment-result-history.js
+++ b/api/db/migrations/20220202140419_flash-assessment-result-history.js
@@ -1,0 +1,61 @@
+const TABLE_NAME = 'flash-assessment-results';
+
+exports.up = async function (knex) {
+  await knex.schema.raw('alter table "flash-assessment-results" alter column id type bigint');
+
+  await knex.schema.table(TABLE_NAME, (t) => {
+    t.bigInteger('answerId').nullable().references('answers.id');
+  });
+
+  await knex(TABLE_NAME).update({
+    answerId: knex('answers')
+      .select('answers.id')
+      .where('answers.assessmentId', knex.ref('flash-assessment-results.assessmentId'))
+      .orderBy('createdAt', 'desc')
+      .limit(1),
+  });
+
+  await knex.schema.table(TABLE_NAME, (t) => {
+    t.dropNullable('answerId');
+    t.unique('answerId');
+    t.dropColumn('assessmentId');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex(TABLE_NAME)
+    .whereIn(
+      'answerId',
+      knex({
+        answerRanked: knex(TABLE_NAME)
+          .join('answers', 'answers.id', 'answerId')
+          .select('answerId')
+          .rank(
+            'rank',
+            function () {
+              this.orderBy('createdAt', 'desc');
+            },
+            'assessmentId'
+          ),
+      })
+        .select('answerRanked.answerId')
+        .where('answerRanked.rank', '>', 1)
+    )
+    .delete();
+
+  await knex.schema.table(TABLE_NAME, (t) => {
+    t.integer('assessmentId').nullable().references('assessments.id');
+  });
+
+  await knex(TABLE_NAME).update({
+    assessmentId: knex('answers')
+      .select('answers.assessmentId')
+      .where('answers.id', knex.ref('flash-assessment-results.answerId')),
+  });
+
+  await knex.schema.table(TABLE_NAME, (t) => {
+    t.dropNullable('assessmentId');
+    t.unique('assessmentId');
+    t.dropColumn('answerId');
+  });
+};

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -84,7 +84,7 @@ async function fetchForFlashCampaigns({
   const [allAnswers, challenges, { estimatedLevel } = {}] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
     challengeRepository.findFlashCompatible(locale),
-    flashAssessmentResultRepository.getByAssessmentId(assessment.id),
+    flashAssessmentResultRepository.getLatestByAssessmentId(assessment.id),
   ]);
 
   return {

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -94,8 +94,8 @@ module.exports = async function correctAnswerThenUpdateAssessment({
 
     const { estimatedLevel, errorRate } = flashAlgorithmService.getEstimatedLevelAndErrorRate(flashData);
 
-    await flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate({
-      assessmentId: assessment.id,
+    await flashAssessmentResultRepository.save({
+      answerId: answerSaved.id,
       estimatedLevel,
       errorRate,
     });

--- a/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
@@ -4,25 +4,28 @@ const DomainTransaction = require('../DomainTransaction');
 const TABLE_NAME = 'flash-assessment-results';
 
 module.exports = {
-  async updateEstimatedLevelAndErrorRate({
-    assessmentId,
+  async save({
+    answerId,
     estimatedLevel,
     errorRate,
     domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
   }) {
-    const query = knex(TABLE_NAME)
-      .insert({
-        assessmentId,
-        estimatedLevel,
-        errorRate,
-      })
-      .onConflict('assessmentId')
-      .merge();
+    const query = knex(TABLE_NAME).insert({
+      answerId,
+      estimatedLevel,
+      errorRate,
+    });
     if (knexTransaction) query.transacting(knexTransaction);
     return query;
   },
 
-  async getByAssessmentId(assessmentId) {
-    return knex(TABLE_NAME).select().where({ assessmentId }).first();
+  async getLatestByAssessmentId(assessmentId) {
+    return knex(TABLE_NAME)
+      .join('answers', 'answers.id', '=', `${TABLE_NAME}.answerId`)
+      .select(`${TABLE_NAME}.*`)
+      .where({ assessmentId })
+      .orderBy('createdAt', 'desc')
+      .limit(1)
+      .first();
   },
 };

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -197,7 +197,7 @@ async function _isRegistrationActive(userId, campaignId) {
 }
 
 async function _getEstimatedFlashLevel(assessmentId) {
-  const flashAssessmentResult = await flashAssessmentResultRepository.getByAssessmentId(assessmentId);
+  const flashAssessmentResult = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
   return flashAssessmentResult?.estimatedLevel;
 }
 

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -190,7 +190,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
 
       estimatedLevel = Symbol('estimatedLevel');
       flashAssessmentResultRepository = {
-        getByAssessmentId: sinon.stub().withArgs(assessmentId).resolves({ estimatedLevel }),
+        getLatestByAssessmentId: sinon.stub().withArgs(assessmentId).resolves({ estimatedLevel }),
       };
 
       const web2 = domainBuilder.buildSkill({ name: '@web2' });

--- a/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
@@ -2,55 +2,110 @@ const { expect, knex, databaseBuilder } = require('../../../test-helper');
 const flashAssessmentResultRepository = require('../../../../lib/infrastructure/repositories/flash-assessment-result-repository');
 
 describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepository', function () {
-  describe('#updateEstimatedLevelAndErrorRate', function () {
-    let assessmentWithoutResultId;
-    let assessmentWithResultId;
+  afterEach(async function () {
+    await knex('flash-assessment-results').delete();
+  });
+
+  describe('#getLatestByAssessmentId', function () {
+    let assessmentId;
 
     beforeEach(async function () {
-      assessmentWithoutResultId = databaseBuilder.factory.buildAssessment({ method: 'FLASH' }).id;
-      assessmentWithResultId = databaseBuilder.factory.buildFlashAssessmentResult().assessmentId;
+      assessmentId = databaseBuilder.factory.buildAssessment({ method: 'FLASH' }).id;
       await databaseBuilder.commit();
     });
 
-    afterEach(async function () {
-      await knex('flash-assessment-results').delete();
-    });
-
-    context("if a result doesn't already exist for assessment", function () {
-      it('should create a result with estimated level and error rate', async function () {
-        // given
-        const assessmentId = assessmentWithoutResultId;
-
+    context('when assessment has no answers yet', function () {
+      it('should return undefined', async function () {
         // when
-        await flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate({
-          assessmentId,
-          estimatedLevel: 1.9,
-          errorRate: 1.3,
-        });
+        const result = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
 
         // then
-        const createdResult = await knex('flash-assessment-results').select().where({ assessmentId }).first();
-        expect(createdResult.estimatedLevel).to.equal(1.9);
-        expect(createdResult.errorRate).to.equal(1.3);
+        expect(result).to.be.undefined;
       });
     });
 
-    context('if a result already exists for assessment', function () {
-      it("should update the result's estimated level and error rate", async function () {
-        // given
-        const assessmentId = assessmentWithResultId;
+    context('when assessment has one answer', function () {
+      let expectedResult;
 
+      beforeEach(async function () {
+        expectedResult = databaseBuilder.factory.buildFlashAssessmentResult({ assessmentId });
+        await databaseBuilder.commit();
+      });
+
+      it('should return flash result for this answer', async function () {
         // when
-        await flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate({
-          assessmentId,
-          estimatedLevel: -2.8,
-          errorRate: 0.44,
-        });
+        const result = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
 
         // then
-        const updatedResult = await knex('flash-assessment-results').select().where({ assessmentId }).first();
-        expect(updatedResult.estimatedLevel).to.equal(-2.8);
-        expect(updatedResult.errorRate).to.equal(0.44);
+        expect(result).to.contain({
+          id: expectedResult.id,
+          estimatedLevel: expectedResult.estimatedLevel,
+          errorRate: expectedResult.errorRate,
+        });
+      });
+    });
+
+    context('when assessment has several answers', function () {
+      let expectedResult;
+
+      beforeEach(async function () {
+        const thirdAnswer = databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2022-01-03') });
+        const secondAnswer = databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2022-01-02') });
+        const firstAnswer = databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2022-01-01') });
+        expectedResult = databaseBuilder.factory.buildFlashAssessmentResult({
+          answerId: thirdAnswer.id,
+          estimatedLevel: 1,
+          errorRate: 2,
+        });
+        databaseBuilder.factory.buildFlashAssessmentResult({
+          answerId: secondAnswer.id,
+          estimatedLevel: 3,
+          errorRate: 4,
+        });
+        databaseBuilder.factory.buildFlashAssessmentResult({
+          answerId: firstAnswer.id,
+          estimatedLevel: 5,
+          errorRate: 6,
+        });
+        await databaseBuilder.commit();
+      });
+
+      it('should return flash result for the latest answer', async function () {
+        // when
+        const result = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
+
+        // then
+        expect(result).to.contain({
+          id: expectedResult.id,
+          estimatedLevel: expectedResult.estimatedLevel,
+          errorRate: expectedResult.errorRate,
+        });
+      });
+    });
+  });
+
+  describe('#save', function () {
+    let answerId;
+
+    beforeEach(async function () {
+      answerId = databaseBuilder.factory.buildAnswer().id;
+      await databaseBuilder.commit();
+    });
+
+    it('should create a result with estimated level and error rate', async function () {
+      // when
+      await flashAssessmentResultRepository.save({
+        answerId,
+        estimatedLevel: 1.9,
+        errorRate: 1.3,
+      });
+
+      // then
+      const createdResult = await knex('flash-assessment-results').select().where({ answerId }).first();
+      expect(createdResult).to.contain({
+        answerId,
+        estimatedLevel: 1.9,
+        errorRate: 1.3,
       });
     });
   });

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -163,7 +163,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
         findFlashCompatible: sinon.stub(),
       };
       flashAssessmentResultRepository = {
-        getByAssessmentId: sinon.stub(),
+        getLatestByAssessmentId: sinon.stub(),
       };
     });
 
@@ -181,7 +181,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       challengeRepository.findFlashCompatible.withArgs().resolves(challenges);
-      flashAssessmentResultRepository.getByAssessmentId.withArgs(assessment.id).resolves({ estimatedLevel });
+      flashAssessmentResultRepository.getLatestByAssessmentId.withArgs(assessment.id).resolves({ estimatedLevel });
 
       // when
       const data = await dataFetcher.fetchForFlashCampaigns({

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -34,7 +34,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   const competenceEvaluationRepository = {};
   const targetProfileRepository = { getByCampaignParticipationId: () => undefined };
   const skillRepository = { findActiveByCompetenceId: () => undefined };
-  const flashAssessmentResultRepository = { updateEstimatedLevelAndErrorRate: () => undefined };
+  const flashAssessmentResultRepository = { save: () => undefined };
   const scorecardService = { computeScorecard: () => undefined };
   const knowledgeElementRepository = {
     findUniqByUserIdAndAssessmentId: () => undefined,
@@ -55,7 +55,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     sinon.stub(challengeRepository, 'get');
     sinon.stub(skillRepository, 'findActiveByCompetenceId');
     sinon.stub(targetProfileRepository, 'getByCampaignParticipationId');
-    sinon.stub(flashAssessmentResultRepository, 'updateEstimatedLevelAndErrorRate');
+    sinon.stub(flashAssessmentResultRepository, 'save');
     sinon.stub(scorecardService, 'computeScorecard');
     sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndAssessmentId');
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
@@ -621,14 +621,14 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
       it('should call the flash assessment result repository to save estimatedLevel and errorRate', async function () {
         // when
-        await correctAnswerThenUpdateAssessment({
+        const { id } = await correctAnswerThenUpdateAssessment({
           answer,
           userId,
           ...dependencies,
         });
 
-        expect(flashAssessmentResultRepository.updateEstimatedLevelAndErrorRate).to.have.been.calledWith({
-          assessmentId: assessment.id,
+        expect(flashAssessmentResultRepository.save).to.have.been.calledWith({
+          answerId: id,
           estimatedLevel,
           errorRate,
         });


### PR DESCRIPTION
## :unicorn: Problème
On ne connait pas l'historique du score FLASH de l'utilisateur, on ne connaît que sa dernière valeur.

## :robot: Solution
On enregistre la valeur du score FLASH pour chaque réponse à un assessment flash.

## :rainbow: Remarques
On ne recalcule pas l'historique pour les réponses des utilisateurs ayant déjà répondu à la campagne FLASH beta.

## :100: Pour tester
Faire la campagne `FLASH1234`, et vérifier que les valeurs du score FLASH sont bien enregistrées dans la table `flash-assessment-results`.
Vérifier que c'est bien la valeur du score FLASH de la dernière réponse qui est utilisée sur la page de fin de campagne.