### PR TITLE
[TECH] Remplace un paramétrage VSCode deprecated par le nouveau

### DIFF
--- a/.vscode/sample.settings.json
+++ b/.vscode/sample.settings.json
@@ -10,5 +10,5 @@
         "./api",
         "./orga"
     ],
-    "javascript.implicitProjectConfig.experimentalDecorators": true
+    "js/ts.implicitProjectConfig.experimentalDecorators": true
 }


### PR DESCRIPTION
## :unicorn: Problème
Le paramétrage VSCode `javascript.implicitProjectConfig.experimentalDecorators` est deprecated.

![image](https://user-images.githubusercontent.com/5855339/152185534-ed7cb6e6-96c9-479b-a22e-9b0099cb914d.png)

## :robot: Solution
Le remplace par le nouveau.

## :rainbow: Remarques
RAS

## :100: Pour tester
N/A
