### PR TITLE
[TECH] Ne pas afficher la liste des routes lors du démarrage de l'API.

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -1,6 +1,5 @@
 const Pack = require('../package');
 const settings = require('./config');
-const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
 const monitoringTools = require('./infrastructure/monitoring-tools');
@@ -25,7 +24,6 @@ function logObjectSerializer(req) {
 const plugins = [
   Inert,
   Vision,
-  Blipp,
   {
     plugin: require('hapi-i18n'),
     options: {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1368,62 +1368,6 @@
         }
       }
     },
-    "blipp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/blipp/-/blipp-4.0.2.tgz",
-      "integrity": "sha512-QA5amT0IFJgCFgJeWw2udD2zZLui60NgqXTyvbSq+qpVbS6jfqELTRlC8PWW0yD4+chdZ2a+svnN6WE9zqfK5Q==",
-      "requires": {
-        "@hapi/hoek": "9.x.x",
-        "chalk": "4.x.x",
-        "easy-table": "1.x.x",
-        "joi": "17.x.x"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2227,23 +2171,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "optional": true,
-      "requires": {
-        "clone": "^1.0.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "optional": true
-        }
-      }
-    },
     "defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -2445,22 +2372,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "easy-table": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.1.tgz",
-      "integrity": "sha512-C9Lvm0WFcn2RgxbMnTbXZenMIWcBtkzMr+dWqq/JsVoGFSVUVlPqeOa5LP5kM0I3zoOazFpckOEb2/0LDFfToQ==",
-      "requires": {
-        "ansi-regex": "^3.0.0",
-        "wcwidth": ">=1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        }
-      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -7652,15 +7563,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "optional": true,
-      "requires": {
-        "defaults": "^1.0.3"
       }
     },
     "which": {

--- a/api/package.json
+++ b/api/package.json
@@ -25,7 +25,6 @@
     "@pdf-lib/fontkit": "^1.1.1",
     "axios": "^0.24.0",
     "bcrypt": "^5.0.1",
-    "blipp": "^4.0.2",
     "bluebird": "^3.7.2",
     "bookshelf": "^1.2.0",
     "bookshelf-json-columns": "^3.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Les développeurs n'ont pas besoin que la liste des routes soit affichée lors du démarrage de l'API.
La liste est trop longue pour être utile.

## :robot: Solution
Désinstaller le plugin API Blipp

## :rainbow: Remarques
Si vous en avez besoin, dites le nous pour qu'on applique [une analyse du XY problem](https://xyproblem.info/)

## :100: Pour tester
Démarrer l'API `npm start`

Vérifier l'absence des routes 
```shell
❯ npm start
> node bin/www

[3:45:41] INFO: server started
    created: 1643816740993
    started: 1643816741280
    host: "OCTO-TOPI"
    port: 3000
    protocol: "http"
    id: "OCTO-TOPI:45177:kz5q1myp"
    uri: "http://OCTO-TOPI:3000"
    address: "0.0.0.0"
[3:45:41] INFO: Server running at http://OCTO-TOPI:3000
[3:45:41] INFO: Connected to server
    redisClient: "distributed-cache-publisher"
[3:45:41] INFO: Connected to server
    redisClient: "distributed-cache-subscriber"
[3:45:41] INFO: Connected to server
    redisClient: "redis-cache-query-client"
[3:45:41] INFO: Connected to server
    redisClient: "temporary-storage"
[3:45:41] INFO: Connected to server
    redisClient: "redis-monitor"
[3:45:41] INFO: Subscribed to channel 'Learning content'
    redisClient: "distributed-cache-subscriber"
^C[3:45:43] INFO: Received signal SIGINT. Closing DB connections before exiting.
```
