### PR TITLE
[TECH] Permettre de tout logguer en local lors des tests si besoin.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -68,7 +68,6 @@ module.exports = (function () {
 
     logging: {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
-      colorEnabled: false,
       logLevel: process.env.LOG_LEVEL || 'info',
       logForHumans: isFeatureEnabled(process.env.LOG_FOR_HUMANS),
       enableLogKnexQueries: isFeatureEnabled(process.env.LOG_KNEX_QUERIES),
@@ -235,7 +234,6 @@ module.exports = (function () {
 
   if (config.environment === 'development') {
     config.enabled = true;
-    config.logging.colorEnabled = true;
   } else if (process.env.NODE_ENV === 'test') {
     config.port = 0;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -233,7 +233,7 @@ module.exports = (function () {
   };
 
   if (config.environment === 'development') {
-    config.enabled = true;
+    config.logging.enabled = true;
   } else if (process.env.NODE_ENV === 'test') {
     config.port = 0;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -15,6 +15,10 @@ function isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';
 }
 
+function isBooleanFeatureEnabledElseDefault(environmentVariable, defaultValue) {
+  return environmentVariable === 'true' ? true : defaultValue;
+}
+
 function _getNumber(numberAsString, defaultIntNumber) {
   const number = parseInt(numberAsString, 10);
   return isNaN(number) ? defaultIntNumber : number;
@@ -307,7 +311,7 @@ module.exports = (function () {
     config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };
     config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
-    config.logging.enabled = false;
+    config.logging.enabled = isBooleanFeatureEnabledElseDefault(process.env.LOG_ENABLED, false);
     config.logging.enableLogKnexQueries = false;
     config.logging.enableLogStartingEventDispatch = false;
     config.logging.enableLogEndingEventDispatch = false;

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -1,13 +1,9 @@
 const pino = require('pino');
-const settings = require('../config');
-
-const nullDestination = {
-  write() {},
-};
+const { logging: logSettings } = require('../config');
 
 let transport;
 
-if (settings.logging.logForHumans) {
+if (logSettings.logForHumans) {
   const omitDay = 'h:MM:ss';
 
   transport = {
@@ -20,14 +16,12 @@ if (settings.logging.logForHumans) {
   };
 }
 
-const logger = pino(
-  {
-    level: settings.logging.logLevel,
-    redact: ['req.headers.authorization'],
-    transport,
-  },
-  settings.logging.enabled ? pino.destination() : nullDestination
-);
+const logger = pino({
+  level: logSettings.logLevel,
+  redact: ['req.headers.authorization'],
+  transport,
+  enabled: logSettings.enabled,
+});
 
 logger.debug('DEBUG logs enabled');
 logger.trace('TRACE logs enabled');

--- a/api/sample.env
+++ b/api/sample.env
@@ -319,7 +319,7 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # presence: optional
 # type: Boolean
 # default: `false`
-LOG_ENABLED=true
+# LOG_ENABLED=true
 LOG_STARTING_EVENT_DISPATCH=true
 LOG_ENDING_EVENT_DISPATCH=true
 


### PR DESCRIPTION
## :unicorn: Problème

On veut pouvoir voir ponctuellement tous les logs:
- lors des tests;
- en local;
- à des fins de débogage, ex erreur 500 Hapi.

## :robot: Solution
Supprimer la configuration forcée `LOG_ENABLED=false` dans le `config.js` si `NODE_ENV=test`
La remplacer par la variable d'environnement, et si non active, à false (valeur par défaut).

Ajouter `LOG_ENABLED=true` 
- au template Mocha de test de l'IDE lorsqu'on veut voir les logs
- lors de l'appel de mocha via terminal (`npx`)

:warning: Cela ne marche pas pour Webstorm et Intellij
Une piste: https://github.com/pinojs/pino/issues/542

## :rainbow: Remarques
Un bug a aussi été corrigé: le log devrait toujours être activé en local (hors test), mais ne l'était pas

Dans la CI, il y avait une var d'env `LOG_ENABLED=true` :thinking: 
Du coup, ça mettait les logs dans les rapports de test
Je l'ai supprimée et tout se passe bien
https://app.circleci.com/settings/project/github/1024pix/pix/environment-variables

Une amélioration possible dans le même style
https://github.com/1024pix/pix/issues/4033

## :100: Pour tester

###  npm
Lancer les tests avec npm, vérifier que la progression en point fonctionne, sans autre message
`npm test`

### mocha dans terminal
Lancer un test en terminal avec le logging pretty
- exécuter `
NODE_ENV=test LOG_ENABLED=true LOG_FOR_HUMANS=true npx mocha ./tests/acceptance/application/account-recovery/account-recovery-route-get_test.js`
- vérifier que l'on obtient

```
❯ NODE_ENV=test LOG_ENABLED=true LOG_FOR_HUMANS=true npx mocha ./tests/acceptance/application/account-recovery/account-recovery-route-get_test.js

  Acceptance | Application | Account-Recovery | Routes
    GET /api/account-recovery/{temporaryKey}
      ✔ should return 200 http status code when account recovery demand found (1210ms)

  1 passing (1s)

[5:48:23] INFO: request completed
    queryParams: {}
    req: {
      "id": "1643910503674:OCTO-TOPI:73779:kz79vajq:10000",
      "method": "get",
      "url": "/api/account-recovery/FfgpFXgyuO062nPUPwcb8Wy3KcgkqR2p2GyEuGVaNI4=",
      "headers": {
        "user-agent": "shot",

```

