### PR TITLE
[FEATURE] Ajouter le lien vers la politique de confidentialité sur la double mire inscription/connexion sur Pix Orga (PIX-4162)

### DIFF
--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -58,9 +58,8 @@
     </div>
 
     <div id="register-cgu-container" class="input-container">
-      <label for="register-cgu" class="label register-form__cgu-label">
+      <div class="checkbox-container">
         <Input
-          id="register-cgu"
           @type="checkbox"
           @checked={{this.cgu}}
           required={{true}}
@@ -68,20 +67,19 @@
           aria-label="{{t "pages.login-or-register.register-form.fields.cgu.aria-label"}}"
           {{on "focusout" this.validateCgu}}
         />
-        <span class="register-form__cgu">
+        <p class="register-form__cgu-label">
           {{t "pages.login-or-register.register-form.fields.cgu.accept"}}
-          <a
-            href="{{t "pages.login-or-register.register-form.fields.cgu.link"}}"
-            class="link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
             {{t "pages.login-or-register.register-form.fields.cgu.terms-of-use"}}
           </a>
-        </span>
-      </label>
+          {{t "pages.login-or-register.register-form.fields.cgu.and"}}
+          <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
+            {{t "pages.login-or-register.register-form.fields.cgu.data-protection-policy"}}
+          </a>
+        </p>
+      </div>
       {{#if this.cguValidationMessage}}
-        <div class="register-form__cgu-error" role="alert">{{this.cguValidationMessage}}</div>
+        <p class="register-form__cgu-error" role="alert">{{this.cguValidationMessage}}</p>
       {{/if}}
     </div>
 

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -11,6 +11,7 @@ export default class RegisterForm extends Component {
   @service session;
   @service store;
   @service intl;
+  @service url;
 
   @tracked isLoading = false;
   @tracked firstName = null;
@@ -23,6 +24,14 @@ export default class RegisterForm extends Component {
   @tracked lastNameValidationMessage = null;
   @tracked cguValidationMessage = null;
   @tracked errorMessage = null;
+
+  get cguUrl() {
+    return this.url.cguUrl;
+  }
+
+  get dataProtectionPolicyUrl() {
+    return this.url.dataProtectionPolicyUrl;
+  }
 
   @action
   async register(event) {

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -30,10 +30,20 @@ export default class Url extends Service {
 
   get legalNoticeUrl() {
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/legal-notice';
-    }
+    if (currentLanguage === 'en') return 'https://pix.org/en-gb/legal-notice';
     return `https://pix.${this.currentDomain.getExtension()}/mentions-legales`;
+  }
+
+  get cguUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') return 'https://pix.org/en-gb/terms-and-conditions';
+    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+  }
+
+  get dataProtectionPolicyUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') return 'https://pix.org/en-gb/personal-data-protection-policy';
+    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
   }
 
   get accessibilityUrl() {

--- a/orga/app/styles/components/register-form.scss
+++ b/orga/app/styles/components/register-form.scss
@@ -1,34 +1,34 @@
 .register-form {
   max-width: 360px;
 
-  &__cgu {
+  &__cgu-label {
     font-family: $roboto;
     font-size: 0.875rem;
-  }
-
-  &__cgu-label {
-    display: flex;
-    align-items: center;
-
-    input[type=checkbox] {
-      margin: 0 6px 0 0;
-    }
+    margin: 0;
   }
 
   &__cgu-error {
     color: $red;
     font-size: 0.75em;
+    margin-top: 20px;
   }
 
   .input-container {
     margin: 16px 2px 25px 2px;
-
-    &:nth-child(6){
-      padding-top: 20px;
-    }
   }
 
   .pix-input-password > .pix-input__error-message {
     bottom: calc(-18px - 1px - 0.75rem);
+  }
+
+  .checkbox-container {
+    display: flex;
+    input[type=checkbox] {
+      margin: 1px 6px 0 0;
+    }
+  }
+
+  .cgu-validation-message {
+    margin-top: 20px;
   }
 }

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -54,6 +54,33 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
   });
 
+  test('it should display legal mentions with related links', async function (assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+    // when
+    const screen = await renderScreen(hbs`<Auth::RegisterForm/>`);
+
+    // then
+    assert
+      .dom(screen.getByText(this.intl.t('pages.login-or-register.register-form.fields.cgu.accept'), { exact: false }))
+      .exists();
+    assert
+      .dom(screen.getByText(`${this.intl.t('pages.login-or-register.register-form.fields.cgu.terms-of-use')}`))
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('pages.login-or-register.register-form.fields.cgu.and'), { exact: false }))
+      .exists();
+    assert
+      .dom(
+        screen.getByText(`${this.intl.t('pages.login-or-register.register-form.fields.cgu.data-protection-policy')}`)
+      )
+      .exists();
+    assert.dom('a[href="https://pix.fr/conditions-generales-d-utilisation"]').exists();
+    assert.dom('a[href="https://pix.fr/politique-protection-donnees-personnelles-app"]').exists();
+  });
+
   module('successful cases', function (hooks) {
     hooks.beforeEach(function () {
       this.owner.unregister('service:store');
@@ -92,18 +119,10 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
 
       // then
       assert.dom('.alert-input--error').doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.email, 'shi@fu.me');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.password, 'Mypassword1');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.scope, 'pix-orga');
+      assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+      assert.strictEqual(sessionServiceObserver.email, 'shi@fu.me');
+      assert.strictEqual(sessionServiceObserver.password, 'Mypassword1');
+      assert.strictEqual(sessionServiceObserver.scope, 'pix-orga');
     });
   });
 
@@ -135,9 +154,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(spy.callCount, 0);
+        assert.strictEqual(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(EMPTY_FIRSTNAME_ERROR_MESSAGE))).exists();
       });
     });
@@ -151,9 +168,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(spy.callCount, 0);
+        assert.strictEqual(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(EMPTY_LASTNAME_ERROR_MESSAGE))).exists();
       });
     });
@@ -167,9 +182,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(spy.callCount, 0);
+        assert.strictEqual(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(EMPTY_EMAIL_ERROR_MESSAGE))).exists();
       });
     });
@@ -183,9 +196,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(spy.callCount, 0);
+        assert.strictEqual(spy.callCount, 0);
         assert.dom(screen.getByText(this.intl.t(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE))).exists();
       });
     });
@@ -199,9 +210,8 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
         await clickByName(registerButtonLabel);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(spy.callCount, 0);
+        // assert.strictEqual
+        assert.strictEqual(spy.callCount, 0);
       });
     });
   });

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -43,9 +43,7 @@ module('Unit | Service | url', function (hooks) {
       const campaignsRootUrl = service.campaignsRootUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(campaignsRootUrl, service.definedCampaignsRootUrl);
+      assert.strictEqual(campaignsRootUrl, service.definedCampaignsRootUrl);
     });
 
     test('should get "pix.test" url when current domain contains pix.test', function (assert) {
@@ -59,9 +57,7 @@ module('Unit | Service | url', function (hooks) {
       const campaignsRootUrl = service.campaignsRootUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(campaignsRootUrl, expectedCampaignsRootUrl);
+      assert.strictEqual(campaignsRootUrl, expectedCampaignsRootUrl);
     });
   });
 
@@ -90,9 +86,7 @@ module('Unit | Service | url', function (hooks) {
       const homeUrl = service.homeUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(homeUrl, expectedHomeUrl);
+      assert.strictEqual(homeUrl, expectedHomeUrl);
     });
   });
 
@@ -107,9 +101,7 @@ module('Unit | Service | url', function (hooks) {
       const url = service.legalNoticeUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
     });
 
     test('should get "pix.org" english url when current language is en', function (assert) {
@@ -123,9 +115,7 @@ module('Unit | Service | url', function (hooks) {
       const url = service.legalNoticeUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
     });
 
     test('should get "pix.org" french url when current language is fr', function (assert) {
@@ -139,9 +129,93 @@ module('Unit | Service | url', function (hooks) {
       const url = service.legalNoticeUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
+    });
+  });
+
+  module('#dataProtectionPolicyUrl', function () {
+    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('should get "pix.org" english url when current language is en', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const cguUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('should get "pix.org" french url when current language is fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+  });
+
+  module('#cguUrl', function () {
+    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('should get "pix.org" english url when current language is en', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('should get "pix.org" french url when current language is fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
   });
 
@@ -156,9 +230,7 @@ module('Unit | Service | url', function (hooks) {
       const url = service.accessibilityUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
     });
 
     test('should get "pix.org" in english when current language is en', function (assert) {
@@ -172,9 +244,7 @@ module('Unit | Service | url', function (hooks) {
       const url = service.accessibilityUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
     });
 
     test('should get "pix.org" in french when current language is fr', function (assert) {
@@ -188,9 +258,7 @@ module('Unit | Service | url', function (hooks) {
       const url = service.accessibilityUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -585,10 +585,11 @@
           },
           "cgu": {
             "accept": "I agree to the",
+            "and": "and",
             "aria-label": "Accept the terms of use of the Pix platform",
-            "error": "Please agree to the terms and conditions of use.",
-            "link": "https://pix.org/en-gb/terms-and-conditions/",
-            "terms-of-use": "terms and conditions of use of the Pix platform"
+            "data-protection-policy": "personal data protection policy",
+            "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
+            "terms-of-use": "Pix terms of use"
           },
           "email": {
             "error": "Please enter a valid email address.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -585,9 +585,10 @@
           },
           "cgu": {
             "accept": "J'accepte les",
+            "and": "et la",
             "aria-label": "Accepter les conditions d'utilisation de Pix",
-            "error": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
-            "link": "https://pix.fr/conditions-generales-d-utilisation",
+            "data-protection-policy": "politique de confidentialité",
+            "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
             "terms-of-use": "conditions d'utilisation de Pix"
           },
           "email": {


### PR DESCRIPTION
## :unicorn: Problème
Il manquait le lien vers la politique de confidentialité sur la page de connexion ou de création de compte, en bas du formulaire de création de compte

## :robot: Solution
Modification du texte de la checkbox existante en J'accepte les [conditions d'utilisation ](https://pix.fr/conditions-generales-d-utilisation)et la [politique de confidentialité](https://pix.fr/politique-protection-donnees-personnelles-app) de Pix

## :rainbow: Remarques
Le design n'est pas tout à fait le même que https://app.recette.pix.org/inscription?lang=en
Le texte est le même 'I agree to the [Pix terms of use ](https://pix.org/en-gb/terms-and-conditions)and [personal data protection policy](https://pix.org/en-gb/personal-data-protection-policy)'
et J'accepte les [conditions d'utilisation ](https://pix.org/conditions-generales-d-utilisation)et la [politique de confidentialité ](https://pix.org/politique-protection-donnees-personnelles-app)de Pix

## :100: Pour tester
- aller sur orga et se connecter par exemple avec l'utilisateur 
- sur la page équipe, inviter un membre en renseignant une adresse email
- cliquer sur le lien dans l'email reçu
- observer sur la page de connexion que le texte a bien été mis à jour et que les liens sont valides
- essayer de se connecter sans cocher la case pour voir apparaître un message d'erreur comme auparavant
- ajouter &lang=en à l'url pour tester en anglais
- finir par soumettre le formulaire pour se créer un compte
