### PR TITLE
[BUGFIX] Une devDepency est référencée sur les environnements hors développement.

### DIFF
--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -5,28 +5,26 @@ const nullDestination = {
   write() {},
 };
 
-let pinoPrettyOptions;
+let transport;
 
 if (settings.logging.logForHumans) {
   const omitDay = 'h:MM:ss';
 
-  pinoPrettyOptions = {
-    colorize: true,
-    translateTime: omitDay,
-    ignore: 'pid,hostname',
+  transport = {
+    target: 'pino-pretty',
+    options: {
+      colorize: true,
+      translateTime: omitDay,
+      ignore: 'pid,hostname',
+    },
   };
-} else {
-  pinoPrettyOptions = false;
 }
 
 const logger = pino(
   {
     level: settings.logging.logLevel,
     redact: ['req.headers.authorization'],
-    transport: {
-      target: 'pino-pretty',
-      options: pinoPrettyOptions,
-    },
+    transport,
   },
   settings.logging.enabled ? pino.destination() : nullDestination
 );


### PR DESCRIPTION
## :unicorn: Problème
Régression suite à https://github.com/1024pix/pix/pull/4015, voir https://dashboard.scalingo.com/apps/osc-fr1/pix-api-integration/deploy/list

Le message est 
```
======== BEGIN APP LOGS ========
2022-02-03 11:51:39.679672439 +0000 UTC [web-1] /app/node_modules/pino/lib/transport.js:140
2022-02-03 11:51:39.679701948 +0000 UTC [web-1] throw new Error(`unable to determine transport target for "${origin}"`)
```

En conséquence, les déploiements échouent tous

## :robot: Solution
Extraire la section 'transport' 

## :rainbow: Remarques
On aurait pu le voir avant :roll_eyes: 
On pourrait peut-être mettre le check "Déploiement RA" obligatoire dans Gihub pour éviter ça à l'avenir ?

![image](https://user-images.githubusercontent.com/56302715/152340479-6229f588-329b-47a5-b91d-e04178d09752.png)


## :100: Pour tester
Voir si le déploiement est Ok en RA
