### PR TITLE
[FEATURE] Ajout du header pour la nouvelle page de tutoriels (PIX-4292).

### DIFF
--- a/mon-pix/app/components/tutorials/content.hbs
+++ b/mon-pix/app/components/tutorials/content.hbs
@@ -1,0 +1,8 @@
+<header class="background-banner-v2">
+  <div class="user-tutorials-banner-v2">
+    <h1 class="user-tutorials-banner-v2__title">{{t "pages.user-tutorials-v2.title"}}</h1>
+    <p class="user-tutorials-banner-v2__description">
+      {{t "pages.user-tutorials-v2.description"}}
+    </p>
+  </div>
+</header>

--- a/mon-pix/app/controllers/user-tutorials.js
+++ b/mon-pix/app/controllers/user-tutorials.js
@@ -3,4 +3,9 @@ import Controller from '@ember/controller';
 
 export default class UserTutorialsController extends Controller {
   @service intl;
+  @service featureToggles;
+
+  get showNewTutorialsPage() {
+    return this.featureToggles.featureToggles.isNewTutorialsPageEnabled;
+  }
 }

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class FeatureToggle extends Model {
   @attr('boolean') isEmailValidationEnabled;
   @attr('boolean') isEndTestScreenRemovalEnabled;
+  @attr('boolean') isNewTutorialsPageEnabled;
 }

--- a/mon-pix/app/styles/components/_background-banner.scss
+++ b/mon-pix/app/styles/components/_background-banner.scss
@@ -6,6 +6,12 @@
   color: $white;
 }
 
+.background-banner-v2 {
+  width: 100%;
+  background: $white;
+  box-shadow: 0 2px 5px 0 rgba($grey-90, 0.06);
+}
+
 .background-banner-wrapper {
   display: flex;
   flex-direction: column;

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -2,16 +2,12 @@
 
   &__container {
     margin: 0 auto;
-    max-width: 1280px;
+    max-width: 1320px;
     display: flex;
     flex-direction: row;
-    padding: 20px 0;
+    padding: 20px;
     align-items: center;
     position: relative;
-  }
-
-  @include device-is('desktop') {
-    margin-left: 20px;
   }
 }
 

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -51,6 +51,38 @@
   }
 }
 
+.user-tutorials-banner-v2 {
+  margin: 0 24px;
+  font-family: $font-roboto;
+  font-weight: $font-light;
+
+  @include device-is('desktop') {
+    max-width: 1320px;
+    padding: 0 20px;
+    margin: 0 auto;
+  }
+
+  &__title {
+    color: $grey-90;
+    font-size: 2rem;
+    font-family: $font-open-sans;
+    font-weight: $font-normal;
+    letter-spacing: 0.0093rem;
+    line-height: 2.6875rem;
+  }
+
+  &__description {
+    margin: 0;
+    padding: 8px 0 32px 0;
+    color: $grey-60;
+    font-family: $font-roboto;
+    font-weight: $font-normal;
+    font-size: 1rem;
+    letter-spacing: 0.0093rem;
+    line-height: 1.375rem;
+  }
+}
+
 .user-tutorials-content {
   max-width: 980px;
   margin: 24px auto;

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -4,45 +4,49 @@
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
     <main id="main" class="main">
-      <header role="banner" class="background-banner">
-        <div class="user-tutorials-banner">
-          <img
-            src="{{rootURL}}/images/background/tutorials-banner.svg"
-            class="user-tutorials-banner__icon"
-            role="none"
-            alt=""
-          />
-          <h3 class="user-tutorials-banner__title">{{t "pages.user-tutorials.title"}}</h3>
-          <p class="user-tutorials-banner__description">
-            {{t "pages.user-tutorials.description"}}
-          </p>
-        </div>
-      </header>
-      {{#if this.model}}
-        <article aria-label={{t "pages.user-tutorials.label"}} class="user-tutorials-content">
-          <h3 class="user-tutorials-content__title">{{t "pages.user-tutorials.list.title"}}</h3>
-          <div>
-            {{#each this.model as |userTutorial|}}
-              <TutorialItem @tutorial={{userTutorial.tutorial}} />
-            {{/each}}
-          </div>
-        </article>
+      {{#if this.showNewTutorialsPage}}
+        <Tutorials::Content />
       {{else}}
-        <article aria-label={{t "pages.user-tutorials.label"}} class="rounded-panel user-tutorials-no-tutorial">
-          <div class="user-tutorials-no-tutorial__illustration">
-            <img src="{{rootURL}}/{{t "pages.user-tutorials.empty-list-info.image-link"}}" role="none" alt="" />
-          </div>
-          <div class="user-tutorials-no-tutorial__instructions">
-            <h4 class="user-tutorials-no-tutorial-instructions__title">{{t
-                "pages.user-tutorials.empty-list-info.title"
-              }}</h4>
-            <p class="user-tutorials-no-tutorial-instructions__description">
-              {{t "pages.user-tutorials.empty-list-info.description.part1"}}
-              <FaIcon @prefix="far" @icon="bookmark" />
-              {{t "pages.user-tutorials.empty-list-info.description.part2"}}
+        <header role="banner" class="background-banner">
+          <div class="user-tutorials-banner">
+            <img
+              src="{{rootURL}}/images/background/tutorials-banner.svg"
+              class="user-tutorials-banner__icon"
+              role="none"
+              alt=""
+            />
+            <h3 class="user-tutorials-banner__title">{{t "pages.user-tutorials.title"}}</h3>
+            <p class="user-tutorials-banner__description">
+              {{t "pages.user-tutorials.description"}}
             </p>
           </div>
-        </article>
+        </header>
+        {{#if this.model}}
+          <article aria-label={{t "pages.user-tutorials.label"}} class="user-tutorials-content">
+            <h3 class="user-tutorials-content__title">{{t "pages.user-tutorials.list.title"}}</h3>
+            <div>
+              {{#each this.model as |userTutorial|}}
+                <TutorialItem @tutorial={{userTutorial.tutorial}} />
+              {{/each}}
+            </div>
+          </article>
+        {{else}}
+          <article aria-label={{t "pages.user-tutorials.label"}} class="rounded-panel user-tutorials-no-tutorial">
+            <div class="user-tutorials-no-tutorial__illustration">
+              <img src="{{rootURL}}/{{t "pages.user-tutorials.empty-list-info.image-link"}}" role="none" alt="" />
+            </div>
+            <div class="user-tutorials-no-tutorial__instructions">
+              <h4 class="user-tutorials-no-tutorial-instructions__title">{{t
+                  "pages.user-tutorials.empty-list-info.title"
+                }}</h4>
+              <p class="user-tutorials-no-tutorial-instructions__description">
+                {{t "pages.user-tutorials.empty-list-info.description.part1"}}
+                <FaIcon @prefix="far" @icon="bookmark" />
+                {{t "pages.user-tutorials.empty-list-info.description.part2"}}
+              </p>
+            </div>
+          </article>
+        {{/if}}
       {{/if}}
     </main>
     <Footer />

--- a/mon-pix/tests/integration/components/tutorials/content_test.js
+++ b/mon-pix/tests/integration/components/tutorials/content_test.js
@@ -1,0 +1,18 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+describe('Integration | Component | Tutorials | Content', function () {
+  setupIntlRenderingTest();
+
+  it('renders the header', async function () {
+    // when
+    await render(hbs`<Tutorials::Content />`);
+
+    // then
+    expect(find('.user-tutorials-banner-v2__title')).to.exist;
+    expect(find('.user-tutorials-banner-v2__description')).to.exist;
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1462,6 +1462,10 @@
           "source": "By"
         }
       }
+    },
+    "user-tutorials-v2": {
+      "title": "My tutorials",
+      "description": "Improve with the help of tutorials suggested by the Pix users’ community."
     }
   }
 }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1462,6 +1462,10 @@
           "source": "Par"
         }
       }
+    },
+    "user-tutorials-v2": {
+      "title": "Mes tutos",
+      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix."
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Afin de créer la nouvelle page de tutoriels, nous remplaçons d'abord la bannière de l'ancienne page par une nouvelle visible uniquement via FT.

## :robot: Solution

Ajout d'une nouvelle bannière au rendu conditionné par un FT sur la page existante des tutoriels.

## :rainbow: Remarques

Afin de ne pas avoir à tester le conditionnement du rendu du composant, nous créons un composant contenant l'intégralité du contenu de la nouvelle page de tutos.

Afin d'avoir un comportement identique entre la navigation générale à Pix et le nouveau header, un souci d'alignement concernant la barre de navigation est également corrigé dans cette PR via l'ajout d'un `padding`.

## :100: Pour tester

Sur `mon-pix`, aller sur la page de tutoriels et vérifier que seul le nouveau header est visible.
