### PR TITLE
[FEATURE] Empêcher les membres de Pix Orga de modifier une campagne s'ils n'en sont pas propriétaires (PIX-4077)

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -141,6 +141,7 @@ exports.register = async function (server) {
       method: 'PATCH',
       path: '/api/campaigns/{id}',
       config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
         validate: {
           params: Joi.object({
             id: identifiersType.campaignId,

--- a/api/lib/application/preHandlers/models/CampaignAuthorization.js
+++ b/api/lib/application/preHandlers/models/CampaignAuthorization.js
@@ -1,0 +1,14 @@
+const prescriberRoles = {
+  ADMIN: 'ADMIN',
+  MEMBER: 'MEMBER',
+  OWNER: 'OWNER',
+};
+
+class CampaignAuthorization {
+  static isAllowedToManage({ prescriberRole }) {
+    return prescriberRole === prescriberRoles.ADMIN || prescriberRole === prescriberRoles.OWNER;
+  }
+}
+
+module.exports = CampaignAuthorization;
+module.exports.prescriberRoles = prescriberRoles;

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -8,6 +8,7 @@ const checkUserBelongsToOrganizationUseCase = require('./usecases/checkUserBelon
 const checkUserIsAdminAndManagingStudentsForOrganization = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
 const checkUserIsMemberOfAnOrganizationUseCase = require('./usecases/checkUserIsMemberOfAnOrganization');
 const checkUserIsMemberOfCertificationCenterUsecase = require('./usecases/checkUserIsMemberOfCertificationCenter');
+const checkAuthorizationToManageCampaignUsecase = require('./usecases/checkAuthorizationToManageCampaign');
 const Organization = require('../../lib/domain/models/Organization');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
@@ -242,6 +243,18 @@ async function checkUserIsMemberOfAnOrganization(request, h) {
   return _replyForbiddenError(h);
 }
 
+async function checkAuthorizationToManageCampaign(request, h) {
+  const userId = request.auth.credentials.userId;
+  const campaignId = request.params.id;
+  const isAdminOrOwnerOfTheCampaign = await checkAuthorizationToManageCampaignUsecase.execute({
+    userId,
+    campaignId,
+  });
+
+  if (isAdminOrOwnerOfTheCampaign) return h.response(true);
+  return _replyForbiddenError(h);
+}
+
 /* eslint-enable no-restricted-syntax */
 
 module.exports = {
@@ -252,6 +265,7 @@ module.exports = {
   checkUserBelongsToSupOrganizationAndManagesStudents,
   checkUserHasRolePixMaster,
   checkUserIsAdminInOrganization,
+  checkAuthorizationToManageCampaign,
   checkUserIsAdminInSCOOrganizationManagingStudents,
   checkUserIsAdminInSUPOrganizationManagingStudents,
   checkUserBelongsToOrganization,

--- a/api/lib/application/usecases/checkAuthorizationToManageCampaign.js
+++ b/api/lib/application/usecases/checkAuthorizationToManageCampaign.js
@@ -1,0 +1,9 @@
+const prescriberRoleRepository = require('../../infrastructure/repositories/prescriber-role-repository');
+const CampaignAuthorization = require('../preHandlers/models/CampaignAuthorization');
+
+module.exports = {
+  async execute({ userId, campaignId }) {
+    const prescriberRole = await prescriberRoleRepository.getForCampaign({ userId, campaignId });
+    return CampaignAuthorization.isAllowedToManage({ prescriberRole });
+  },
+};

--- a/api/lib/infrastructure/repositories/prescriber-role-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-role-repository.js
@@ -1,0 +1,35 @@
+const { NotFoundError } = require('../../domain/errors');
+const { knex } = require('../../../db/knex-database-connection');
+const CampaignAuthorization = require('../../application/preHandlers/models/CampaignAuthorization');
+
+module.exports = {
+  async getForCampaign({ userId, campaignId }) {
+    const { organizationId, ownerId } = await _getOrganizationIdAndOwnerId({ campaignId });
+    const organizationRole = await _getOrganizationRole({ userId, organizationId });
+
+    let prescriberRole = organizationRole;
+    if (userId === ownerId) {
+      prescriberRole = CampaignAuthorization.prescriberRoles.OWNER;
+    }
+    return prescriberRole;
+  },
+};
+
+async function _getOrganizationIdAndOwnerId({ campaignId }) {
+  const result = await knex('campaigns').select('organizationId', 'ownerId').where({ id: campaignId }).first();
+  if (!result) {
+    throw new NotFoundError('Campaign is not found');
+  }
+  return result;
+}
+
+async function _getOrganizationRole({ userId, organizationId }) {
+  const result = await knex('memberships')
+    .select('organizationRole')
+    .where({ userId, organizationId, disabledAt: null })
+    .first();
+  if (!result) {
+    throw new NotFoundError('Membership is not found');
+  }
+  return result.organizationRole;
+}

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1278,4 +1278,70 @@ describe('Acceptance | API | Campaign Controller', function () {
       expect(response.statusCode).to.equal(400);
     });
   });
+
+  describe('PATCH /api/campaigns/{id}', function () {
+    it('should return 200 when user is admin but not owner of the campaign', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const campaign = databaseBuilder.factory.buildAssessmentCampaign({ organizationId: organization.id });
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationRole: 'ADMIN', organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/campaigns/${campaign.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            type: 'campaigns',
+            attributes: {
+              name: 'toto',
+              title: null,
+              'custom-landing-page-text': 'toto',
+              'owner-id': userId,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403 when user is not an admin and is not the campaign owner', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const campaign = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        creatorId: databaseBuilder.factory.buildUser({ id: 3 }).id,
+        ownerId: databaseBuilder.factory.buildUser({ id: 2 }).id,
+      });
+      const userId = databaseBuilder.factory.buildUser({ id: 1 }).id;
+      databaseBuilder.factory.buildMembership({ userId, organizationRole: 'MEMBER', organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/campaigns/${campaign.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            type: 'campaigns',
+            attributes: {
+              name: 'toto',
+              title: null,
+              'custom-landing-page-text': 'toto',
+              'owner-id': userId,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -14,7 +14,6 @@ describe('Integration | Application | Route | campaignRouter', function () {
       .stub(campaignController, 'getCsvProfilesCollectionResults')
       .callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer();
@@ -82,26 +81,6 @@ describe('Integration | Application | Route | campaignRouter', function () {
 
       // then
       expect(response.statusCode).to.equal(400);
-    });
-  });
-
-  describe('PATCH /api/campaigns/{id}', function () {
-    it('should exist', async function () {
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/campaigns/1', {
-        data: {
-          type: 'campaigns',
-          attributes: {
-            name: 'toto',
-            title: null,
-            'custom-landing-page-text': 'toto',
-            'owner-id': 2,
-          },
-        },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(201);
     });
   });
 });

--- a/api/tests/integration/application/usecases/checkAuthorizationToManageCampaign_test.js
+++ b/api/tests/integration/application/usecases/checkAuthorizationToManageCampaign_test.js
@@ -1,0 +1,21 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const checkAuthorizationToManageCampaign = require('../../../../lib/application/usecases/checkAuthorizationToManageCampaign');
+
+describe('Integration | API | checkAuthorizationToManageCampaign', function () {
+  describe('when the user is member in organization and owner of the campaign', function () {
+    it('returns true', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
+      const campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id, ownerId: user.id });
+      await databaseBuilder.commit();
+
+      // when
+      const hasAccess = await checkAuthorizationToManageCampaign.execute({ campaignId: campaign.id, userId: user.id });
+
+      // then
+      expect(hasAccess).to.be.true;
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/prescriber-role-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-role-repository_test.js
@@ -1,0 +1,122 @@
+const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
+const prescriberRoleRepository = require('../../../../lib/infrastructure/repositories/prescriber-role-repository');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | Campaign', function () {
+  describe('#getForCampaign', function () {
+    describe("when user is an admin of the campaign's organization", function () {
+      it('should return ADMIN role', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        const campaign = databaseBuilder.factory.buildCampaign({ organizationId });
+        databaseBuilder.factory.buildMembership({ organizationId, userId, organizationRole: 'ADMIN' });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await prescriberRoleRepository.getForCampaign({ userId, campaignId: campaign.id });
+
+        // then
+        expect(result).to.deep.equal('ADMIN');
+      });
+    });
+
+    describe("when user is a MEMBER of the campaign's organization", function () {
+      describe('when user does not own the campaign', function () {
+        it('should return MEMBER role', async function () {
+          // given
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaign = databaseBuilder.factory.buildCampaign({ organizationId });
+          databaseBuilder.factory.buildMembership({ organizationId, userId, organizationRole: 'MEMBER' });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await prescriberRoleRepository.getForCampaign({ userId, campaignId: campaign.id });
+
+          // then
+          expect(result).to.deep.equal('MEMBER');
+        });
+      });
+
+      describe('when user own the campaign', function () {
+        it('should return OWNER role', async function () {
+          // given
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const userId = databaseBuilder.factory.buildUser().id;
+          const campaign = databaseBuilder.factory.buildCampaign({ organizationId, ownerId: userId });
+          databaseBuilder.factory.buildMembership({ organizationId, userId, organizationRole: 'MEMBER' });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await prescriberRoleRepository.getForCampaign({ userId, campaignId: campaign.id });
+
+          // then
+          expect(result).to.deep.equal('OWNER');
+        });
+      });
+    });
+
+    it('should throw a not found error if campaign does not exists', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      const unknownCampaignId = campaignId + 1;
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(prescriberRoleRepository.getForCampaign)({ userId, campaignId: unknownCampaignId });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    describe('when user is not a member of the organization', function () {
+      it('should throw a not found error if user has no membership', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const otherUserId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        databaseBuilder.factory.buildMembership({ userId: otherUserId, organizationId }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(prescriberRoleRepository.getForCampaign)({ userId, campaignId });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+
+      it('should throw a not found error if user is member of another organization', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign().id;
+        databaseBuilder.factory.buildMembership({ userId: userId, organizationId: otherOrganizationId }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(prescriberRoleRepository.getForCampaign)({ userId, campaignId });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+
+      it("should throw a not found error if user's membership has been disable", async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(prescriberRoleRepository.getForCampaign)({ userId, campaignId });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/preHandlers/models/CampaignAuthorization_test.js
+++ b/api/tests/unit/application/preHandlers/models/CampaignAuthorization_test.js
@@ -1,0 +1,39 @@
+const { expect } = require('../../../../test-helper');
+const CampaignAuthorization = require('../../../../../lib/application/preHandlers/models/CampaignAuthorization');
+
+describe('Unit | Domain | models | CampaignAuthorization', function () {
+  describe('#isAllowedToManage', function () {
+    it('should be false if user is member of organization and not owner of the campaign', function () {
+      // given
+      const prescriberRole = 'MEMBER';
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToManage({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.false;
+    });
+
+    it('should be true if user is admin of organization', function () {
+      // given
+      const prescriberRole = 'ADMIN';
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToManage({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.true;
+    });
+
+    it('should be true if user is owner of the campaign', function () {
+      // given
+      const prescriberRole = 'OWNER';
+
+      // when
+      const hasAccess = CampaignAuthorization.isAllowedToManage({ prescriberRole });
+
+      //then
+      expect(hasAccess).to.be.true;
+    });
+  });
+});

--- a/orga/app/components/campaign/settings/view.hbs
+++ b/orga/app/components/campaign/settings/view.hbs
@@ -87,7 +87,7 @@
     </div>
   </dl>
 
-  {{#unless @campaign.isArchived}}
+  {{#if this.displayCampaignActionsButtons}}
     <div class="campaign-settings-buttons">
       <PixButtonLink @route="authenticated.campaigns.update" @model={{@campaign.id}} @backgroundColor="grey">
         {{t "pages.campaign-settings.actions.edit"}}
@@ -96,5 +96,5 @@
         {{t "pages.campaign-settings.actions.archive"}}
       </PixButton>
     </div>
-  {{/unless}}
+  {{/if}}
 </div>

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -7,6 +7,17 @@ export default class CampaignView extends Component {
   @service notifications;
   @service url;
   @service intl;
+  @service currentUser;
+
+  get displayCampaignActionsButtons() {
+    const campaignIsNotArchived = !this.args.campaign.isArchived;
+
+    const isCurrentUserAdmin = this.currentUser.prescriber.isAdminOfTheCurrentOrganization;
+    const isCurrentUserOwnerOfTheCampaign = parseInt(this.currentUser.prescriber.id) === this.args.campaign.ownerId;
+    const isCurrentUserAllowedToUpdateCampaign = isCurrentUserAdmin || isCurrentUserOwnerOfTheCampaign;
+
+    return campaignIsNotArchived && isCurrentUserAllowedToUpdateCampaign;
+  }
 
   get campaignsRootUrl() {
     return `${this.url.campaignsRootUrl}${this.args.campaign.code}`;

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -29,7 +29,6 @@ export default class Campaign extends Model {
   @attr('number') averageResult;
   @attr('boolean') multipleSendings;
 
-  @belongsTo('user') owner;
   @belongsTo('organization') organization;
   @belongsTo('target-profile') targetProfile;
   @belongsTo('campaign-collective-result') campaignCollectiveResult;

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -12,4 +12,13 @@ export default class Prescriber extends Model {
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
+
+  get isAdminOfTheCurrentOrganization() {
+    const memberships = this.memberships.toArray();
+    return memberships.some(
+      (membership) =>
+        membership.get('organizationRole') === 'ADMIN' &&
+        membership.get('organization').get('id') === this.userOrgaSettings.get('organization').get('id')
+    );
+  }
 }

--- a/orga/app/routes/authenticated/campaigns/update.js
+++ b/orga/app/routes/authenticated/campaigns/update.js
@@ -22,6 +22,15 @@ export default class UpdateRoute extends Route {
     return { campaign, membersSortedByFullName };
   }
 
+  afterModel(model, transition) {
+    const isCurrentUserAdmin = this.currentUser.prescriber.isAdminOfTheCurrentOrganization;
+    const isCurrentUserOwnerOfTheCampaign = parseInt(this.currentUser.prescriber.id) === model.campaign.ownerId;
+    if (!isCurrentUserAdmin && !isCurrentUserOwnerOfTheCampaign) {
+      transition.abort();
+      this.transitionTo('authenticated.campaigns');
+    }
+  }
+
   setupController(controller, model) {
     super.setupController(controller, model);
     controller.campaignName = model.campaign.name;

--- a/orga/tests/acceptance/campaign-update_test.js
+++ b/orga/tests/acceptance/campaign-update_test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { fillByLabel, clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
-import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
+import { createAdmin, createMember } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -11,40 +11,10 @@ module('Acceptance | Campaign Update', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async () => {
-    const user = createUserWithMembershipAndTermsOfServiceAccepted();
-    createPrescriberByUser(user);
-
-    await authenticateSession(user.id);
-  });
-
-  test('it should allow to update a campaign and redirect to the newly updated campaign', async function (assert) {
-    // given
-    const campaign = server.create('campaign', { id: 1 });
-    const newName = 'New Name';
-    const newText = 'New text';
-
-    await visit(`/campagnes/${campaign.id}/modification`);
-    await fillByLabel('* Nom de la campagne', newName);
-    await fillByLabel("Texte de la page d'accueil", newText);
-
-    // when
-    await clickByName('Modifier');
-
-    // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(server.db.campaigns.find(1).name, newName);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(server.db.campaigns.find(1).customLandingPageText, newText);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/campagnes/1/parametres');
-  });
-
   test('it should show campaign title', async function (assert) {
     // given
+    const { user } = createAdmin();
+    await authenticateSession(user.id);
     const campaign = server.create('campaign', { id: 1, name: 'Super Campagne' });
 
     // when
@@ -52,5 +22,73 @@ module('Acceptance | Campaign Update', function (hooks) {
 
     // then
     assert.dom(screen.getByText('Super Campagne')).exists();
+  });
+
+  module('when user is ADMIN', function () {
+    test('it should allow to update a campaign and redirect to the newly updated campaign', async function (assert) {
+      // given
+      const { user } = createAdmin();
+      await authenticateSession(user.id);
+      const campaign = server.create('campaign', { id: 1 });
+      const newName = 'New Name';
+      const newText = 'New text';
+
+      await visitScreen(`/campagnes/${campaign.id}/modification`);
+      await fillByLabel('* Nom de la campagne', newName);
+      await fillByLabel("Texte de la page d'accueil", newText);
+
+      // when
+      await clickByName('Modifier');
+
+      // then
+      assert.strictEqual(server.db.campaigns.find(1).name, newName);
+      assert.strictEqual(server.db.campaigns.find(1).customLandingPageText, newText);
+      assert.strictEqual(currentURL(), '/campagnes/1/parametres');
+    });
+  });
+
+  module('when user is a MEMBER and owner of the campaign', function () {
+    test('it should allow to see update campaign page', async function (assert) {
+      // given
+      const { user } = createMember();
+      await authenticateSession(user.id);
+      const campaign = server.create('campaign', { id: 1, name: 'Campagne des champs', ownerId: user.id });
+
+      // when
+      await visitScreen(`/campagnes/${campaign.id}/modification`);
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/1/modification');
+    });
+  });
+
+  module('when user is a MEMBER and not own the campaign', function () {
+    test('it should not allow to see update campaign page', async function (assert) {
+      // given
+      const otherUserId = server.create('user').id;
+      const { user } = createMember();
+      await authenticateSession(user.id);
+      const campaign = server.create('campaign', { id: 1, ownerId: otherUserId });
+
+      // when
+      const screen = await visitScreen(`/campagnes/${campaign.id}/parametres`);
+
+      // then
+      assert.dom(screen.queryByLabelText('Modifier')).doesNotExist();
+    });
+
+    test('it should redirect user to his campaigns', async function (assert) {
+      // given
+      const otherUserId = server.create('user').id;
+      const { user } = createMember();
+      await authenticateSession(user.id);
+      const campaign = server.create('campaign', { id: 1, ownerId: otherUserId });
+
+      // when
+      await visitScreen(`/campagnes/${campaign.id}/modification`);
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/les-miennes');
+    });
   });
 });

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -185,6 +185,66 @@ export function createMembershipByOrganizationIdAndUser(organizationId, user, ro
   return user;
 }
 
+export function createAdmin() {
+  const user = server.create('user', {
+    firstName: 'Harry',
+    lastName: 'Cover',
+    email: 'harry@cover.com',
+    pixOrgaTermsOfServiceAccepted: true,
+  });
+  const organization = server.create('organization', { name: 'BRO & Evil Associates' });
+
+  const membership = server.create('membership', {
+    organizationId: organization.id,
+    userId: user.id,
+    organizationRole: 'ADMIN',
+  });
+  user.memberships = [membership];
+
+  const userOrgaSettings = server.create('user-orga-setting', { user, organization });
+
+  const prescriber = server.create('prescriber', {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+    memberships: user.memberships,
+    userOrgaSettings: user.userOrgaSettings,
+  });
+
+  return { user, organization, membership, userOrgaSettings, prescriber };
+}
+
+export function createMember() {
+  const user = server.create('user', {
+    firstName: 'Harry',
+    lastName: 'Cover',
+    email: 'harry@cover.com',
+    pixOrgaTermsOfServiceAccepted: true,
+  });
+  const organization = server.create('organization', { name: 'BRO & Evil Associates' });
+
+  const membership = server.create('membership', {
+    organizationId: organization.id,
+    userId: user.id,
+    organizationRole: 'MEMBER',
+  });
+  user.memberships = [membership];
+
+  const userOrgaSettings = server.create('user-orga-setting', { user, organization });
+
+  const prescriber = server.create('prescriber', {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+    memberships: user.memberships,
+    userOrgaSettings: user.userOrgaSettings,
+  });
+
+  return { user, organization, membership, userOrgaSettings, prescriber };
+}
+
 export function createUserManagingStudents(role = 'MEMBER', type = 'SCO') {
   const user = server.create('user', {
     firstName: 'Harry',

--- a/orga/tests/unit/models/prescriber_test.js
+++ b/orga/tests/unit/models/prescriber_test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | prescriber', function (hooks) {
+  setupTest(hooks);
+
+  module('#isAdminOfTheCurrentOrganization', function () {
+    test('it should return true if prescriber is ADMIN of the current organization', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { name: 'Willow school' });
+      const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization }));
+      const membership = run(() => store.createRecord('membership', { organizationRole: 'ADMIN', organization }));
+      const memberships = [membership];
+      const model = run(() => store.createRecord('prescriber', { memberships, userOrgaSettings }));
+
+      // when / then
+      assert.true(model.isAdminOfTheCurrentOrganization);
+    });
+
+    test('it should return false if prescriber is MEMBER of the current organization', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { name: 'Willow school' });
+      const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization }));
+      const membership = run(() => store.createRecord('membership', { organizationRole: 'MEMBER', organization }));
+      const memberships = [membership];
+      const model = run(() => store.createRecord('prescriber', { memberships, userOrgaSettings }));
+
+      // when / then
+      assert.false(model.isAdminOfTheCurrentOrganization);
+    });
+
+    test('it should return false if prescriber is MEMBER of the current organization and ADMIN in another', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentOrganization = store.createRecord('organization', { id: 7, name: 'Willow school' });
+      const otherOrganization = store.createRecord('organization', { id: 123, name: 'Tanglewood school' });
+      const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization: currentOrganization }));
+      const membership = run(() =>
+        store.createRecord('membership', { organizationRole: 'MEMBER', currentOrganization })
+      );
+      const membership2 = run(() => store.createRecord('membership', { organizationRole: 'ADMIN', otherOrganization }));
+      const memberships = [membership, membership2];
+      const model = run(() => store.createRecord('prescriber', { memberships, userOrgaSettings }));
+
+      // when / then
+      assert.false(model.isAdminOfTheCurrentOrganization);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui n'importe quel membre Pix Orga peut modifier n'importe quelle campagne.
Cela pose soucis lorsqu'on essaie de retracer qui est responsable de la campagne pour des questions de RGPD.

Le but est de :
- restreindre les accès en lecture aux données perso, mais on ne peut pas traiter ce sujet tout de suite (en attente du sujet 'prescrit'.) 
- restreindre les actions.

## :robot: Solution
Ne plus permettre aux membres de modifier une campagne s'ils n'en sont pas propriétaire.
Cette PR porte principalement sur la modification, une autre PR suivra sur l'archivage et désarchivage. 

## :rainbow: Remarques
Dans un model ember il ne faut pas avoir un attribut qui représente une foreign key vers un autre model ET une relation vers cet autre model (ça pose des soucis côté mirage et sémantiquement ça n'a pas de sens).
_Exemple : dans le modèle Campaign on avait un `@attr('number') ownerId;` qui rentrait en conflit avec le `@belongsTo('user') owner;`._ 

## 💥 Attention
On cache le bouton pour archiver une campagne dans ce ticket, mais pas le bouton pour désarchiver. Les routes API ne sont pas encore protégées. Elles le seront dans la PR suivante. A merger ensemble idéalement.

## :100: Pour tester
**Premier scénario - Vous êtes un vilain hackeur qui aime faire les requêtes API sans passer par nos appli front**
- Se mettre sur le premier commit (avec un git rebase ou une suppression temporaire des autres commits)
- Lancer Pix Orga et l'API
- Se connecter avec `sco.membre@example.net` et cliquer sur une campagne qui ne vous appartient pas
- Tenter d'aller modifier une campagne et constater qu'on a une 403.

**Deuxième scénario - Vous êtes un membre Pix Orga**
- Remettre tous les commits de la PR
- Se connecter avec `sco.membre@example.net` et cliquer sur une campagne qui ne vous appartient pas
- Constater que dans l'onglet "Paramètres" vous ne voyez plus les boutons "Modifier" ou "Archiver"


- Tenter d'aller sur l'url `campagnes/{id-de-la-campagne-qui-ne-vous-appartient-pas}/modification` 
- Constater que vous n'arrivez pas à accéder à cette page


- Se créer une campagne 
- Aller sur les paramètres de cette campagne
- Constater que vous voyez les boutons "Modifier" ou "Archiver"


- Modifier cette campagne et constater que les changements sont effectués

**Troisième scénario - Vous êtes un admin Pix Orga**
- Se connecter avec `sco.admin@example.net`
- Constater que vous voyez les boutons "Modifier" ou "Archiver" sur n'importe quel campagne (toujours dans l'onglet "Paramètres")
- Vérifier que vous pouvez modifier n'importe quelle campagne
