### PR TITLE
[BUGFIX] Corriger le problème de cochage/décochage de la présence d'un candidat dans l'espace surveillant (PIX-4317).

### DIFF
--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -28,6 +28,7 @@ export default class CertificationCandidateForSupervising extends Model {
     type: 'post',
     urlType: 'updateAuthorizedToStart',
     before(authorizedToStart) {
+      this.authorizedToStart = authorizedToStart;
       return {
         'authorized-to-start': authorizedToStart,
       };

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -141,6 +141,36 @@ module('Acceptance | Session supervising', function (hooks) {
     assert.true(find('input[type="checkbox"]').checked);
   });
 
+  test('when supervisor checks and unchecks the candidate, it should update authorizedToStart', async function (assert) {
+    // given
+    const sessionId = 12345;
+    this.sessionForSupervising = server.create('session-for-supervising', {
+      id: sessionId,
+      certificationCandidates: [
+        server.create('certification-candidate-for-supervising', {
+          id: 123,
+          firstName: 'John',
+          lastName: 'Doe',
+          birthdate: '1984-05-28',
+          extraTimePercentage: '8',
+          authorizedToStart: false,
+        }),
+      ],
+    });
+
+    const firstVisit = await visitScreen('/connexion-espace-surveillant');
+    await fillIn(firstVisit.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+    await fillIn(firstVisit.getByLabelText('Mot de passe de la session'), '6789');
+    await click(firstVisit.getByRole('button', { name: 'Surveiller la session' }));
+
+    // when
+    await click(firstVisit.getByRole('checkbox', { name: 'Doe John' }));
+    await click(firstVisit.getByRole('checkbox', { name: 'Doe John' }));
+
+    // then
+    assert.false(server.schema.certificationCandidateForSupervisings.find(123).authorizedToStart);
+  });
+
   test('when supervisor allow to resume test, it should display a success notification', async function (assert) {
     // given
     const sessionId = 12345;


### PR DESCRIPTION
## :unicorn: Problème
Le cochage/décochage de la présence d'un candidat dans l'espace surveillant n'était pas bien pris en compte. En effet, après analyse, il semble que la valeur du champ `authorizedToStart` n'est pas mis à jour, en adéquation avec la case à cocher, lors de chaque clique.

## :robot: Solution
Corréler l'état de la variable `authorizedToStart` avec celle de la case à cocher à chaque clique.

## :100: Pour tester
- Se connecter à Pix Certif
- Créer une session et y ajouter un candidat
- Se rendre sur l'espace surveillant
- Cocher et décocher la présence du candidat et vérifier que statut de la case à cocher ne change pas entre chaque rechargement automatique du model.
