### PR TITLE
[FEATURE] Afficher les cases de fin de test lors d'une finalisation de session qui n'a pas été effectuée avec l'espace surveillant (PIX-4223).

### DIFF
--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -21,7 +21,6 @@ const AGRI_SCO_MANAGING_STUDENT_NAME = 'Centre AGRI des Anne-Etoiles';
 const { PIX_EMPLOI_CLEA_BADGE_ID, PIX_DROIT_MAITRE_BADGE_ID, PIX_DROIT_EXPERT_BADGE_ID } = require('../badges-builder');
 
 function certificationCentersBuilder({ databaseBuilder }) {
-
   const cleaComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
     name: 'CléA Numérique',
   }).id;
@@ -74,6 +73,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     id: PRO_CERTIF_CENTER_ID,
     name: PRO_CERTIF_CENTER_NAME,
     type: 'PRO',
+    isSupervisorAccessEnabled: 'true',
   });
   databaseBuilder.factory.buildComplementaryCertificationHabilitation({
     certificationCenterId: PRO_CERTIF_CENTER_ID,

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -44,7 +44,7 @@ module.exports = {
 
   async get(request) {
     const sessionId = request.params.id;
-    const session = await usecases.getSession({ sessionId });
+    const { session } = await usecases.getSession({ sessionId });
     return sessionSerializer.serialize(session, true);
   },
 
@@ -262,7 +262,7 @@ module.exports = {
 
     const event = await usecases.finalizeSession({ sessionId, examinerGlobalComment, certificationReports });
     await events.eventDispatcher.dispatch(event);
-    const session = await usecases.getSession({ sessionId });
+    const { session } = await usecases.getSession({ sessionId });
 
     return sessionSerializer.serializeForFinalization(session);
   },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -44,8 +44,8 @@ module.exports = {
 
   async get(request) {
     const sessionId = request.params.id;
-    const { session } = await usecases.getSession({ sessionId });
-    return sessionSerializer.serialize(session, true);
+    const { session, hasSupervisorAccess } = await usecases.getSession({ sessionId });
+    return sessionSerializer.serialize(session, hasSupervisorAccess);
   },
 
   async save(request) {

--- a/api/lib/domain/usecases/get-session.js
+++ b/api/lib/domain/usecases/get-session.js
@@ -1,3 +1,8 @@
-module.exports = function getSession({ sessionId, sessionRepository }) {
-  return sessionRepository.get(sessionId);
+module.exports = async function getSession({ sessionId, sessionRepository, supervisorAccessRepository }) {
+  const session = await sessionRepository.get(sessionId);
+  const hasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({ sessionId });
+  return {
+    session,
+    hasSupervisorAccess,
+  };
 };

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -7,7 +7,7 @@ const { isValidDate } = require('../../utils/date-utils');
 const Session = require('../../../domain/models/Session');
 
 module.exports = {
-  serialize(sessions) {
+  serialize(sessions, hasSupervisorAccess) {
     const attributes = [
       'address',
       'room',
@@ -25,8 +25,15 @@ module.exports = {
       'certificationCandidates',
       'certificationReports',
       'supervisorPassword',
+      'hasSupervisorAccess',
     ];
     return new Serializer('session', {
+      transform(record) {
+        if (hasSupervisorAccess !== undefined) {
+          record.hasSupervisorAccess = hasSupervisorAccess;
+        }
+        return record;
+      },
       attributes,
       certificationCandidates: {
         ref: 'id',

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -150,7 +150,7 @@ describe('Unit | Controller | sessionController', function () {
         // given
         const foundSession = Symbol('foundSession');
         const serializedSession = Symbol('serializedSession');
-        usecases.getSession.withArgs({ sessionId }).resolves(foundSession);
+        usecases.getSession.withArgs({ sessionId }).resolves({ session: foundSession });
         sessionSerializer.serialize.withArgs(foundSession).resolves(serializedSession);
 
         // when

--- a/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
@@ -23,14 +23,19 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', function () {
           const stringifiedXml = '<xml>Some xml</xml>';
           const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
           const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
+
+          const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
           const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
           const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
+          const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
+
+          sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.resolves(false);
+          supervisorAccessRepository.sessionHasSupervisorAccess.resolves(false);
           sessionForAttendanceSheetRepository.getWithCertificationCandidates
             .withArgs(sessionId)
             .resolves(_buildSessionWithCandidate('SUP', false));
-          const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-          sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+
           const odsBuffer = Buffer.from('some ods file');
           sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
           sinon
@@ -63,66 +68,137 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', function () {
             sessionId,
             sessionRepository,
             endTestScreenRemovalService,
-            sessionForAttendanceSheetRepository: sessionForAttendanceSheetRepository,
+            sessionForAttendanceSheetRepository,
+            supervisorAccessRepository,
           });
 
           // then
           expect(result).to.deep.equal(odsBuffer);
         });
 
-        context("when session's center is in the end test screen removal whitelist", function () {
-          it('should return the attendance sheet without end test column', async function () {
-            // given
-            const userId = 'dummyUserId';
-            const sessionId = 'dummySessionId';
-            const stringifiedXml = '<xml>Some xml</xml>';
-            const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
-            const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
-            const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
-            endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(sessionId).resolves(true);
-            const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
-            sessionForAttendanceSheetRepository.getWithCertificationCandidates
-              .withArgs(sessionId)
-              .resolves(_buildSessionWithCandidate('SUP', true));
-            const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-            sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
-            const odsBuffer = Buffer.from('some ods file');
-            sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
-            sinon
-              .stub(writeOdsUtils, 'makeUpdatedOdsByContentXml')
-              .withArgs({
-                stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml,
-                odsFilePath: sinon.match('attendance_sheet_template.ods'),
-              })
-              .resolves(odsBuffer);
-            sinon
-              .stub(sessionXmlService, 'getUpdatedXmlWithSessionData')
-              .withArgs({
-                stringifiedXml,
-                sessionData: _buildAttendanceSheetSessionData('SUP', true),
-                sessionTemplateValues: ATTENDANCE_SHEET_SESSION_TEMPLATE_VALUES,
-              })
-              .returns(stringifiedSessionUpdatedXml);
-            sinon
-              .stub(sessionXmlService, 'getUpdatedXmlWithCertificationCandidatesData')
-              .withArgs({
-                stringifiedXml: stringifiedSessionUpdatedXml,
-                candidatesData: _buildAttendanceSheetCandidateDataWithExtraRows('SUP'),
-                candidateTemplateValues: NON_SCO_ATTENDANCE_SHEET_CANDIDATE_TEMPLATE_VALUES,
-              })
-              .returns(stringifiedSessionAndCandidatesUpdatedXml);
+        context('when the certification center has supervisor access', function () {
+          context('when the session has supervisor access', function () {
+            it('should return the attendance sheet without end test column', async function () {
+              // given
+              const userId = 'dummyUserId';
+              const sessionId = 'dummySessionId';
+              const stringifiedXml = '<xml>Some xml</xml>';
+              const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
+              const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
 
-            // when
-            const result = await getAttendanceSheet({
-              userId,
-              sessionId,
-              endTestScreenRemovalService,
-              sessionRepository,
-              sessionForAttendanceSheetRepository: sessionForAttendanceSheetRepository,
+              const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
+              const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
+              const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+              const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
+
+              sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+              endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(sessionId).resolves(true);
+              supervisorAccessRepository.sessionHasSupervisorAccess.withArgs({ sessionId }).resolves(true);
+              sessionForAttendanceSheetRepository.getWithCertificationCandidates
+                .withArgs(sessionId)
+                .resolves(_buildSessionWithCandidate('SUP', true));
+
+              const odsBuffer = Buffer.from('some ods file');
+              sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
+              sinon
+                .stub(writeOdsUtils, 'makeUpdatedOdsByContentXml')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml,
+                  odsFilePath: sinon.match('attendance_sheet_template.ods'),
+                })
+                .resolves(odsBuffer);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithSessionData')
+                .withArgs({
+                  stringifiedXml,
+                  sessionData: _buildAttendanceSheetSessionData('SUP', true),
+                  sessionTemplateValues: ATTENDANCE_SHEET_SESSION_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionUpdatedXml);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithCertificationCandidatesData')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionUpdatedXml,
+                  candidatesData: _buildAttendanceSheetCandidateDataWithExtraRows('SUP'),
+                  candidateTemplateValues: NON_SCO_ATTENDANCE_SHEET_CANDIDATE_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionAndCandidatesUpdatedXml);
+
+              // when
+              const result = await getAttendanceSheet({
+                userId,
+                sessionId,
+                endTestScreenRemovalService,
+                sessionRepository,
+                sessionForAttendanceSheetRepository,
+                supervisorAccessRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(odsBuffer);
             });
+          });
 
-            // then
-            expect(result).to.deep.equal(odsBuffer);
+          context('when the session does not have supervisor access', function () {
+            it('should return the attendance sheet with end test column', async function () {
+              // given
+              const userId = 'dummyUserId';
+              const sessionId = 'dummySessionId';
+              const stringifiedXml = '<xml>Some xml</xml>';
+              const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
+              const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
+
+              const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
+              const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+              const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
+              const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
+
+              sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+              endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.resolves(true);
+              supervisorAccessRepository.sessionHasSupervisorAccess.resolves(false);
+              sessionForAttendanceSheetRepository.getWithCertificationCandidates
+                .withArgs(sessionId)
+                .resolves(_buildSessionWithCandidate('SUP', false));
+
+              const odsBuffer = Buffer.from('some ods file');
+              sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
+              sinon
+                .stub(writeOdsUtils, 'makeUpdatedOdsByContentXml')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml,
+                  odsFilePath: sinon.match('non_sco_attendance_sheet_template_with_fdt.ods'),
+                })
+                .resolves(odsBuffer);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithSessionData')
+                .withArgs({
+                  stringifiedXml,
+                  sessionData: _buildAttendanceSheetSessionData('SUP', false),
+                  sessionTemplateValues: ATTENDANCE_SHEET_SESSION_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionUpdatedXml);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithCertificationCandidatesData')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionUpdatedXml,
+                  candidatesData: _buildAttendanceSheetCandidateDataWithExtraRows('SUP'),
+                  candidateTemplateValues: NON_SCO_ATTENDANCE_SHEET_CANDIDATE_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionAndCandidatesUpdatedXml);
+
+              // when
+              const result = await getAttendanceSheet({
+                userId,
+                sessionId,
+                sessionRepository,
+                endTestScreenRemovalService,
+                sessionForAttendanceSheetRepository,
+                supervisorAccessRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(odsBuffer);
+            });
           });
         });
       });
@@ -135,14 +211,19 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', function () {
           const stringifiedXml = '<xml>Some xml</xml>';
           const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
           const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
+
+          const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
           const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
-          endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.resolves(false);
           const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+          const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
+
+          sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+          endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.resolves(false);
+          supervisorAccessRepository.sessionHasSupervisorAccess.resolves(false);
           sessionForAttendanceSheetRepository.getWithCertificationCandidates
             .withArgs(sessionId)
             .resolves(_buildSessionWithCandidate('SCO', true));
-          const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-          sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+
           const odsBuffer = Buffer.from('some ods file');
           sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
           sinon
@@ -175,66 +256,136 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', function () {
             sessionId,
             endTestScreenRemovalService,
             sessionRepository,
-            sessionForAttendanceSheetRepository: sessionForAttendanceSheetRepository,
+            sessionForAttendanceSheetRepository,
+            supervisorAccessRepository,
           });
 
           // then
           expect(result).to.deep.equal(odsBuffer);
         });
 
-        context("when session's center is in the end test screen removal whitelist", function () {
-          it('should return the sco attendance sheet without end test column', async function () {
-            // given
-            const userId = 'dummyUserId';
-            const sessionId = 'dummySessionId';
-            const stringifiedXml = '<xml>Some xml</xml>';
-            const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
-            const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
-            const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
-            endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(sessionId).resolves(true);
-            const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
-            sessionForAttendanceSheetRepository.getWithCertificationCandidates
-              .withArgs(sessionId)
-              .resolves(_buildSessionWithCandidate('SCO', true));
-            const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-            sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
-            const odsBuffer = Buffer.from('some ods file');
-            sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
-            sinon
-              .stub(writeOdsUtils, 'makeUpdatedOdsByContentXml')
-              .withArgs({
-                stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml,
-                odsFilePath: sinon.match('sco_attendance_sheet_template.ods'),
-              })
-              .resolves(odsBuffer);
-            sinon
-              .stub(sessionXmlService, 'getUpdatedXmlWithSessionData')
-              .withArgs({
-                stringifiedXml,
-                sessionData: _buildAttendanceSheetSessionData('SCO', true),
-                sessionTemplateValues: ATTENDANCE_SHEET_SESSION_TEMPLATE_VALUES,
-              })
-              .returns(stringifiedSessionUpdatedXml);
-            sinon
-              .stub(sessionXmlService, 'getUpdatedXmlWithCertificationCandidatesData')
-              .withArgs({
-                stringifiedXml: stringifiedSessionUpdatedXml,
-                candidatesData: _buildAttendanceSheetCandidateDataWithExtraRows('SCO'),
-                candidateTemplateValues: SCO_ATTENDANCE_SHEET_CANDIDATE_TEMPLATE_VALUES,
-              })
-              .returns(stringifiedSessionAndCandidatesUpdatedXml);
+        context('when the certification center have supervisor access', function () {
+          context('when the session has supervisor access', function () {
+            it('should return the sco attendance sheet without end test column', async function () {
+              // given
+              const userId = 'dummyUserId';
+              const sessionId = 'dummySessionId';
+              const stringifiedXml = '<xml>Some xml</xml>';
+              const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
+              const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
 
-            // when
-            const result = await getAttendanceSheet({
-              userId,
-              sessionId,
-              endTestScreenRemovalService,
-              sessionRepository,
-              sessionForAttendanceSheetRepository: sessionForAttendanceSheetRepository,
+              const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
+              const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
+              const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+              const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
+
+              sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+              endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(sessionId).resolves(true);
+              supervisorAccessRepository.sessionHasSupervisorAccess.withArgs({ sessionId }).resolves(true);
+              sessionForAttendanceSheetRepository.getWithCertificationCandidates
+                .withArgs(sessionId)
+                .resolves(_buildSessionWithCandidate('SCO', true));
+
+              const odsBuffer = Buffer.from('some ods file');
+              sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
+              sinon
+                .stub(writeOdsUtils, 'makeUpdatedOdsByContentXml')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml,
+                  odsFilePath: sinon.match('sco_attendance_sheet_template.ods'),
+                })
+                .resolves(odsBuffer);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithSessionData')
+                .withArgs({
+                  stringifiedXml,
+                  sessionData: _buildAttendanceSheetSessionData('SCO', true),
+                  sessionTemplateValues: ATTENDANCE_SHEET_SESSION_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionUpdatedXml);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithCertificationCandidatesData')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionUpdatedXml,
+                  candidatesData: _buildAttendanceSheetCandidateDataWithExtraRows('SCO'),
+                  candidateTemplateValues: SCO_ATTENDANCE_SHEET_CANDIDATE_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionAndCandidatesUpdatedXml);
+
+              // when
+              const result = await getAttendanceSheet({
+                userId,
+                sessionId,
+                endTestScreenRemovalService,
+                sessionRepository,
+                sessionForAttendanceSheetRepository,
+                supervisorAccessRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(odsBuffer);
             });
+          });
+          context('when the session does not have supervisor access', function () {
+            it('should return the attendance sheet with end test column', async function () {
+              // given
+              const userId = 'dummyUserId';
+              const sessionId = 'dummySessionId';
+              const stringifiedXml = '<xml>Some xml</xml>';
+              const stringifiedSessionUpdatedXml = '<xml>Some updated session xml</xml>';
+              const stringifiedSessionAndCandidatesUpdatedXml = '<xml>Some updated session and candidates xml</xml>';
 
-            // then
-            expect(result).to.deep.equal(odsBuffer);
+              const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
+              const endTestScreenRemovalService = { isEndTestScreenRemovalEnabledBySessionId: sinon.stub() };
+              const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+              const supervisorAccessRepository = { sessionHasSupervisorAccess: sinon.stub() };
+
+              sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+              endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.resolves(true);
+              supervisorAccessRepository.sessionHasSupervisorAccess.resolves(false);
+              sessionForAttendanceSheetRepository.getWithCertificationCandidates
+                .withArgs(sessionId)
+                .resolves(_buildSessionWithCandidate('SCO', true));
+
+              const odsBuffer = Buffer.from('some ods file');
+              sinon.stub(readOdsUtils, 'getContentXml').resolves(stringifiedXml);
+              sinon
+                .stub(writeOdsUtils, 'makeUpdatedOdsByContentXml')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionAndCandidatesUpdatedXml,
+                  odsFilePath: sinon.match('sco_attendance_sheet_template_with_fdt.ods'),
+                })
+                .resolves(odsBuffer);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithSessionData')
+                .withArgs({
+                  stringifiedXml,
+                  sessionData: _buildAttendanceSheetSessionData('SCO', true),
+                  sessionTemplateValues: ATTENDANCE_SHEET_SESSION_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionUpdatedXml);
+              sinon
+                .stub(sessionXmlService, 'getUpdatedXmlWithCertificationCandidatesData')
+                .withArgs({
+                  stringifiedXml: stringifiedSessionUpdatedXml,
+                  candidatesData: _buildAttendanceSheetCandidateDataWithExtraRows('SCO'),
+                  candidateTemplateValues: SCO_ATTENDANCE_SHEET_CANDIDATE_TEMPLATE_VALUES,
+                })
+                .returns(stringifiedSessionAndCandidatesUpdatedXml);
+
+              // when
+              const result = await getAttendanceSheet({
+                userId,
+                sessionId,
+                endTestScreenRemovalService,
+                sessionRepository,
+                sessionForAttendanceSheetRepository,
+                supervisorAccessRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(odsBuffer);
+            });
           });
         });
       });

--- a/api/tests/unit/domain/usecases/get-session_test.js
+++ b/api/tests/unit/domain/usecases/get-session_test.js
@@ -1,9 +1,8 @@
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const getSession = require('../../../../lib/domain/usecases/get-session');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-session', function () {
-  const sessionId = 'sessionId';
   let sessionRepository;
 
   beforeEach(function () {
@@ -13,29 +12,26 @@ describe('Unit | UseCase | get-session', function () {
   });
 
   context('when the session exists', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const sessionToFind = Symbol('sessionToFind');
-
-    beforeEach(function () {
-      sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
-    });
-
     it('should get the session', async function () {
+      // given
+      const sessionId = 123;
+      const sessionToFind = domainBuilder.buildSession({ id: sessionId });
+      sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+
       // when
       const actualSession = await getSession({ sessionId, sessionRepository });
 
       // then
-      expect(actualSession).to.equal(sessionToFind);
+      expect(actualSession).to.deepEqualInstance(sessionToFind);
     });
   });
 
   context('when the session does not exist', function () {
-    beforeEach(function () {
-      sessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
-    });
-
     it('should throw an error the session', async function () {
+      // given
+      const sessionId = 123;
+      sessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
+
       // when
       const err = await catchErr(getSession)({ sessionId, sessionRepository });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
             'finalized-at': new Date('2020-02-17T14:23:56Z'),
             'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
             'published-at': new Date('2020-02-21T14:23:56Z'),
+            'supervisor-password': 'SOWHAT',
           },
           relationships: {
             'certification-candidates': {
@@ -63,17 +64,27 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
 
     context('when session does not have a link to an existing certification center', function () {
       it('should convert a Session model object into JSON API data including supervisor password', function () {
-        // given
-        const expectedJsonApiIncludingSupervisorPassword = {
-          ...expectedJsonApi,
-        };
-        expectedJsonApiIncludingSupervisorPassword.data.attributes['supervisor-password'] = 'SOWHAT';
-
         // when
         const json = serializer.serialize(modelSession);
 
         // then
-        expect(json).to.deep.equal(expectedJsonApiIncludingSupervisorPassword);
+        expect(json).to.deep.equal(expectedJsonApi);
+      });
+    });
+
+    context('when hasSupervisorAccess is provided', function () {
+      it('should add hasSupervisorAccess to the serialized session', function () {
+        // given
+        const expectedJsonApiIncludingHasSupervisorAccess = {
+          ...expectedJsonApi,
+        };
+        expectedJsonApiIncludingHasSupervisorAccess.data.attributes['has-supervisor-access'] = true;
+
+        // when
+        const json = serializer.serialize(modelSession, true);
+
+        // then
+        expect(json).to.deep.equal(expectedJsonApiIncludingHasSupervisorAccess);
       });
     });
   });

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -9,7 +9,6 @@ import isEmpty from 'lodash/isEmpty';
 import trim from 'lodash/trim';
 
 export default class SessionsFinalizeController extends Controller {
-  @service featureToggles;
   @service currentUser;
 
   @service notifications;
@@ -25,7 +24,7 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   get shouldDisplayHasSeenEndTestScreenCheckbox() {
-    return !this.currentUser.currentAllowedCertificationCenterAccess.isEndTestScreenRemovalEnabled;
+    return !this.session.hasSupervisorAccess;
   }
 
   get uncheckedHasSeenEndTestScreenCount() {

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -29,6 +29,7 @@ export default class Session extends Model {
   @attr('string') status;
   @attr('string') examinerGlobalComment;
   @attr('string') supervisorPassword;
+  @attr('boolean') hasSupervisorAccess;
   @attr() certificationCenterId;
   @hasMany('certificationReport') certificationReports;
 

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import Service from '@ember/service';
 import sinon from 'sinon';
 
 const FINALIZE_PATH = 'authenticated/sessions/finalize';
@@ -101,25 +100,13 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
   });
 
   module('#computed shouldDisplayHasSeenEndTestScreenCheckbox', function () {
-    test('it should return false if certification center has access to supervisor space', function (assert) {
+    test('it should return false if the session has supervisor access', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        id: 123,
-        name: 'Test certification center',
-        type: 'NOT_SCO',
-        isEndTestScreenRemovalEnabled: true,
-      });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       controller.model = store.createRecord('session', {
         certificationReports: [],
+        hasSupervisorAccess: true,
       });
 
       // when
@@ -129,25 +116,13 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       assert.false(result);
     });
 
-    test('it should return true if certification center has access to supervisor space', function (assert) {
+    test('it should return true if the session does not have supervisor access', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        id: 123,
-        name: 'Test certification center',
-        type: 'NOT_SCO',
-        isEndTestScreenRemovalEnabled: false,
-      });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       controller.model = store.createRecord('session', {
         certificationReports: [],
+        hasSupervisorAccess: false,
       });
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
L’espace surveillant permet de ne plus avoir à constater les écrans de FDT des candidats pour les surveillants. Donc nous avons retiré la colonne “écran de FDT vu” sur la page de finalisation d’une session. Au moment où nous allons activer l’espace surveillant pour tous nos centres de certification, il y a un risque élevé que certaines sessions organisées sans l’espace surveillant n’aient pas encore été finalisées par le centre de certification. Donc pour ces sessions où l'écran de FDT a pourtant été constaté, il n’y aurait pas de possibilité pour le référent du centre de retranscrire cette info sur la page de finalisation de session. 

## :robot: Solution
- Afficher les cases de fin de test pour une session non effectuée avec l'espace surveillant même si l'espace surveillant est activé pour le centre de certification.
- Avoir le même comportement pour la présence ou non de la colonne case de fin de test dans la feuille d'émargement.

## :100: Pour tester
- Avec l'espace surveillant désactivé.
- Se connecter à Pix Certif, créer une session et y inscrire un candidat.
- Passer la certification en allant au bout.
- Activer l'espace surveillant pour le centre de certification lié à la session.
- Finaliser la session et constaté que la case de fin de test est présent (ne pas la cocher).
- Vérifier que le message informant q'une case de fin de test n'a pas été coché apparaît dans la modale de confirmation de finalisation.
- Télécharger la feuille d'émargement et vérifier que la colonne case de fin de test est présente.
