### PR TITLE
[FEATURE] Ajoute les boutons de filtres sur le header des tutoriels v2 (PIX-4296)

### DIFF
--- a/mon-pix/app/components/tutorials/content.hbs
+++ b/mon-pix/app/components/tutorials/content.hbs
@@ -4,5 +4,15 @@
     <p class="user-tutorials-banner-v2__description">
       {{t "pages.user-tutorials-v2.description"}}
     </p>
+
+    <div class="user-tutorials-banner-v2__filters">
+      <PixButton @shape="rounded" class="user-tutorials-banner-v2-filters__button" @backgroundColor="transparent-light">
+        {{t "pages.user-tutorials-v2.recommended"}}
+      </PixButton>
+
+      <PixButton @shape="rounded" class="user-tutorials-banner-v2-filters__button" @backgroundColor="grey">
+        {{t "pages.user-tutorials-v2.saved"}}
+      </PixButton>
+    </div>
   </div>
 </header>

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -55,10 +55,11 @@
   margin: 0 24px;
   font-family: $font-roboto;
   font-weight: $font-light;
+  padding-bottom: 16px;
 
   @include device-is('desktop') {
     max-width: 1320px;
-    padding: 0 20px;
+    padding: 0 20px 16px 20px;
     margin: 0 auto;
   }
 
@@ -80,6 +81,20 @@
     font-size: 1rem;
     letter-spacing: 0.0093rem;
     line-height: 1.375rem;
+  }
+
+  &__filters {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+}
+
+.user-tutorials-banner-v2-filters__button {
+  height: 36px;
+
+  @include device-is('desktop') {
+    height: 44px;
   }
 }
 

--- a/mon-pix/tests/integration/components/tutorials/content_test.js
+++ b/mon-pix/tests/integration/components/tutorials/content_test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { find, render } from '@ember/test-helpers';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -14,5 +14,7 @@ describe('Integration | Component | Tutorials | Content', function () {
     // then
     expect(find('.user-tutorials-banner-v2__title')).to.exist;
     expect(find('.user-tutorials-banner-v2__description')).to.exist;
+    expect(find('.user-tutorials-banner-v2__filters')).to.exist;
+    expect(findAll('.user-tutorials-banner-v2__filters button')).to.have.lengthOf(2);
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1465,7 +1465,9 @@
     },
     "user-tutorials-v2": {
       "title": "My tutorials",
-      "description": "Improve with the help of tutorials suggested by the Pix users’ community."
+      "description": "Improve with the help of tutorials suggested by the Pix users’ community.",
+      "recommended": "Recommended",
+      "saved": "Saved"
     }
   }
 }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1465,7 +1465,9 @@
     },
     "user-tutorials-v2": {
       "title": "Mes tutos",
-      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix."
+      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",
+      "recommended": "Recommandés",
+      "saved": "Enregistrés"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les nouveaux boutons de filtre n'étaient pas encore présent sur la page des tutos v2.

## :robot: Solution
Ajouter les boutons "Recommandés" et "Enregistrés" sur la page.

## :rainbow: Remarques
RAS

## :100: Pour tester
Checker dans la Review App le comportement mobile/desktop
