### PR TITLE
[FEATURE] Empêcher les membres de PixOrga d'archiver ou de désarchiver une campagne s'ils n'en sont pas propriétaires (PIX-4318)

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -208,6 +208,7 @@ exports.register = async function (server) {
       method: 'PUT',
       path: '/api/campaigns/{id}/archive',
       config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
         validate: {
           params: Joi.object({
             id: identifiersType.campaignId,

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -224,6 +224,7 @@ exports.register = async function (server) {
       method: 'DELETE',
       path: '/api/campaigns/{id}/archive',
       config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
         validate: {
           params: Joi.object({
             id: identifiersType.campaignId,

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1344,4 +1344,48 @@ describe('Acceptance | API | Campaign Controller', function () {
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('PUT /api/campaigns/{id}/archive', function () {
+    it('should return 200 when user is admin in organization', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const campaign = databaseBuilder.factory.buildAssessmentCampaign({ organizationId: organization.id });
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationRole: 'ADMIN', organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/api/campaigns/${campaign.id}/archive`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403 when user is not owner of the campaign', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const campaign = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+        creatorId: databaseBuilder.factory.buildUser({ id: 3 }).id,
+        ownerId: databaseBuilder.factory.buildUser({ id: 2 }).id,
+      });
+      const userId = databaseBuilder.factory.buildUser({ id: 1 }).id;
+      databaseBuilder.factory.buildMembership({ userId, organizationRole: 'MEMBER', organizationId: organization.id });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/api/campaigns/${campaign.id}/archive`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -396,19 +396,6 @@ describe('Unit | Application | Router | campaign-router ', function () {
   });
 
   describe('DELETE /api/campaigns/{id}/archive', function () {
-    it('should return 200', async function () {
-      // given
-      sinon.stub(campaignController, 'unarchiveCampaign').callsFake((request, h) => h.response('ok').code(200));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('DELETE', '/api/campaigns/1/archive');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
     it('should return 400 with an invalid campaign id', async function () {
       // given
       const httpTestServer = new HttpTestServer();

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -382,19 +382,6 @@ describe('Unit | Application | Router | campaign-router ', function () {
   });
 
   describe('PUT /api/campaigns/{id}/archive', function () {
-    it('should return 200', async function () {
-      // given
-      sinon.stub(campaignController, 'archiveCampaign').callsFake((request, h) => h.response('ok').code(200));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PUT', '/api/campaigns/1/archive');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
     it('should return 400 with an invalid campaign id', async function () {
       // given
       const httpTestServer = new HttpTestServer();

--- a/orga/app/components/campaign/header/archived-banner.hbs
+++ b/orga/app/components/campaign/header/archived-banner.hbs
@@ -4,8 +4,14 @@
       <FaIcon class="campaign-archived-banner__icon" @icon="archive" />
       <span>{{t "pages.campaign.archived"}}</span>
     </div>
-    <PixButton @triggerAction={{this.unarchiveCampaign}} @backgroundColor="transparent-dark" @isBorderVisible={{true}}>
-      {{t "pages.campaign.actions.unarchive"}}
-    </PixButton>
+    {{#if this.displayUnarchiveButton}}
+      <PixButton
+        @triggerAction={{this.unarchiveCampaign}}
+        @backgroundColor="transparent-dark"
+        @isBorderVisible={{true}}
+      >
+        {{t "pages.campaign.actions.unarchive"}}
+      </PixButton>
+    {{/if}}
   </div>
 {{/if}}

--- a/orga/app/components/campaign/header/archived-banner.js
+++ b/orga/app/components/campaign/header/archived-banner.js
@@ -6,6 +6,7 @@ export default class CampaignArchivedBanner extends Component {
   @service store;
   @service notifications;
   @service intl;
+  @service currentUser;
 
   @action
   async unarchiveCampaign() {
@@ -15,5 +16,13 @@ export default class CampaignArchivedBanner extends Component {
     } catch (err) {
       this.notifications.error(this.intl.t('api-errors-messages.global'));
     }
+  }
+
+  get displayUnarchiveButton() {
+    const isCurrentUserAdmin = this.currentUser.prescriber.isAdminOfTheCurrentOrganization;
+    const isCurrentUserOwnerOfTheCampaign = parseInt(this.currentUser.prescriber.id) === this.args.campaign.ownerId;
+    const isCurrentUserAllowedToUnarchiveCampaign = isCurrentUserAdmin || isCurrentUserOwnerOfTheCampaign;
+
+    return isCurrentUserAllowedToUnarchiveCampaign;
   }
 }

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -47,7 +47,7 @@ export default class CampaignView extends Component {
       const campaign = this.store.peekRecord('campaign', campaignId);
       await campaign.archive();
     } catch (err) {
-      this.notifications.error(this.intl.t('api-error-messages.global-error'));
+      this.notifications.error(this.intl.t('api-errors-messages.global'));
     }
   }
 }

--- a/orga/app/styles/components/campaign/header/archived-banner.scss
+++ b/orga/app/styles/components/campaign/header/archived-banner.scss
@@ -10,6 +10,7 @@
   flex-flow: row nowrap;
   align-items: center;
   justify-content: space-between;
+  min-height: 60px;
 
   &__text {
     display: flex;

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -307,6 +307,12 @@ export default function () {
 
   this.patch('/campaigns/:id');
 
+  this.put('/campaigns/:id/archive', (schema, request) => {
+    const id = request.params.id;
+    const campaign = schema.campaigns.findBy({ id });
+    return campaign.update({ isArchived: true });
+  });
+
   this.get('/organizations/:id/target-profiles', (schema) => {
     return schema.targetProfiles.all();
   });

--- a/orga/tests/acceptance/campaign-parameters_test.js
+++ b/orga/tests/acceptance/campaign-parameters_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import authenticateSession from '../helpers/authenticate-session';
+import { createAdmin } from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import setupIntl from '../helpers/setup-intl';
+
+module('Acceptance | Campaign Parameters', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  test('it should allow to archive a campaign when user is admin', async function (assert) {
+    // given
+    const { user } = createAdmin();
+    await authenticateSession(user.id);
+    const campaign = server.create('campaign', { id: 1, isArchived: false });
+
+    const screen = await visitScreen(`/campagnes/${campaign.id}/parametres`);
+
+    // when
+    await clickByName('Archiver');
+
+    // then
+    assert.dom(screen.getByText(this.intl.t('pages.campaign.archived'))).exists();
+  });
+
+  test('it should display error notification when something bad happened', async function (assert) {
+    // given
+    const { user } = createAdmin();
+    await authenticateSession(user.id);
+    const campaign = server.create('campaign', { id: 1, isArchived: false });
+    this.server.put('/campaigns/:id/archive', {}, 500);
+
+    const screen = await visitScreen(`/campagnes/${campaign.id}/parametres`);
+
+    // when
+    await clickByName('Archiver');
+
+    // then
+    assert.dom(screen.getByText(this.intl.t('api-errors-messages.global'))).exists();
+  });
+});

--- a/orga/tests/integration/components/campaign/header/archived-banner_test.js
+++ b/orga/tests/integration/components/campaign/header/archived-banner_test.js
@@ -1,9 +1,10 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { clickByName } from '@1024pix/ember-testing-library';
-import { render } from '@ember/test-helpers';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
 
 module('Integration | Component | Campaign::Header::ArchivedBanner', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -17,48 +18,145 @@ module('Integration | Component | Campaign::Header::ArchivedBanner', function (h
   module('When campaign is active', () => {
     test('it should not display unarchive banner', async function (assert) {
       // given
+      class CurrentUserStub extends Service {
+        prescriber = { isAdminOfTheCurrentOrganization: true };
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
       this.campaign = store.createRecord('campaign', {
         id: 1,
         isArchived: false,
       });
 
       // when
-      await render(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+      const screen = await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
 
       // then
-      assert.notContains('Désarchiver la campagne');
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign.archived'))).doesNotExist();
+      assert.dom(screen.queryByText(this.intl.t('pages.campaign.actions.unarchive'))).doesNotExist();
     });
   });
 
   module('When campaign is archived', () => {
-    test('it should display unarchive banner', async function (assert) {
-      // given
-      this.campaign = store.createRecord('campaign', {
-        id: 1,
-        isArchived: true,
+    module('When user is admin', () => {
+      test('it should display archive informations and button', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { isAdminOfTheCurrentOrganization: true };
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        this.campaign = store.createRecord('campaign', {
+          id: 1,
+          isArchived: true,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.archived'))).exists();
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.actions.unarchive'))).exists();
       });
 
-      // when
-      await render(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+      test('it should unarchive campaign on button click', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { isAdminOfTheCurrentOrganization: true };
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        this.campaign = store.createRecord('campaign', {
+          id: 1,
+          isArchived: true,
+          unarchive: sinon.stub(),
+        });
 
-      // then
-      assert.contains('Désarchiver la campagne');
+        // when
+        await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+        await clickByName('Désarchiver la campagne');
+
+        // then
+        assert.ok(this.campaign.unarchive.calledOnce);
+      });
     });
 
-    test('it should unarchive campaign on button click', async function (assert) {
-      // given
-      this.campaign = store.createRecord('campaign', {
-        id: 1,
-        isArchived: true,
-        unarchive: sinon.stub(),
+    module('When user is member and own the campaign', () => {
+      test('it should display archive informations and button', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = EmberObject.create({ isAdminOfTheCurrentOrganization: false, id: 109 });
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        this.campaign = store.createRecord('campaign', {
+          id: 1,
+          isArchived: true,
+          ownerId: 109,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.archived'))).exists();
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.actions.unarchive'))).exists();
       });
 
-      // when
-      await render(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
-      await clickByName('Désarchiver la campagne');
+      test('it should unarchive campaign on button click', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = EmberObject.create({ isAdminOfTheCurrentOrganization: false, id: 109 });
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        this.campaign = store.createRecord('campaign', {
+          id: 1,
+          isArchived: true,
+          ownerId: 109,
+          unarchive: sinon.stub(),
+        });
 
-      // then
-      assert.ok(this.campaign.unarchive.calledOnce);
+        // when
+        await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+        await clickByName('Désarchiver la campagne');
+
+        // then
+        assert.ok(this.campaign.unarchive.calledOnce);
+      });
+    });
+
+    module('When user does not own campaign and is a member', () => {
+      test('it should display archive informations', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { isAdminOfTheCurrentOrganization: false };
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        this.campaign = store.createRecord('campaign', {
+          id: 1,
+          isArchived: true,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.archived'))).exists();
+      });
+
+      test('it should not be possible to unarchive', async function (assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { isAdminOfTheCurrentOrganization: false };
+        }
+        this.owner.register('service:currentUser', CurrentUserStub);
+        this.campaign = store.createRecord('campaign', {
+          id: 1,
+          isArchived: true,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<Campaign::Header::ArchivedBanner @campaign={{campaign}}/>`);
+
+        // then
+        assert.dom(screen.queryByText(this.intl.t('pages.campaign.actions.unarchive'))).doesNotExist();
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui n'importe quel membre Pix Orga peut désarchiver n'importe quelle campagne sur l'application et archiver n'importe qu'elle campagne en ligne de commande.
Cela pose soucis lorsqu'on essaie de retracer qui est responsable de l'archivage et désarchivage de la campagne pour des questions de RGPD.

Le but est de :
- restreindre les accès en lecture aux données perso, mais on ne peut pas traiter ce sujet tout de suite (en attente du sujet 'prescrit'.) 
- restreindre les actions.

## :robot: Solution
Ne plus permettre aux membres d'archiver ou désarchiver une campagne s'ils n'en sont pas propriétaires.

## :rainbow: Remarques
Première partie de la restriction des droits des membres Pix Orga : https://github.com/1024pix/pix/pull/4032

## :100: Pour tester
**Premier scénario - Vous êtes un vilain hackeur qui aime faire les requêtes API sans passer par nos appli front**
- Soit faire les requêtes en POSTMAN
- Soit supprimer la partie `afterModel` dans `orga/app/routes/authenticated/campaigns/update.js` et la condition `{{#if this.displayUnarchiveButton}}` dans `orga/app/components/campaign/header/archived-banner.hbs`
- Puis lancer l'API et Pix Orga
- Se connecter avec `sco.membre@example.net` et cliquer sur une campagne qui ne vous appartient pas
- Cliquez sur le bouton "Archiver" (qui devrait apparaître suite à vos suppressions de code)
- Constater que rien ne se passe , l'API retourne une erreur
- Aller sur une campagne déjà archivée (ou archivez en une avec le compte `sco.admin@example.net` et reconnectez vous en tant que membre)
- Cliquez sur le bouton "Désarchiver"
- Constater que rien ne se passe , l'API retourne une erreur

**Deuxième scénario - Vous êtes un membre Pix Orga**
- Se connecter avec `sco.membre@example.net` et cliquer sur une campagne qui ne vous appartient pas
- Constater qu'il n'y a pas de bouton "Archiver"
- Aller sur une campagne déjà archivée (ou archivez en une avec le compte `sco.admin@example.net` et reconnectez vous en tant que membre)
- Constater qu'il n'y a pas de bouton "Désarchiver" mais qu'il y a quand même la bannière d'information expliquant que la campagne est archivée

**Troisième scénario - Vous êtes un admin Pix Orga**
- Se connecter avec `admin.membre@example.net` et cliquer sur une campagne qui ne vous appartient pas
- Constater qu'il y a le bouton "Archiver"
- Cliquez sur le bouton
- Constater que la campagne devient archivée
- Constater qu'il y a le bouton "Désarchiver"
- Cliquez sur le bouton
- Constater que la campagne est bien désarchivée

