### PR TITLE
[FEATURE] Permettre de désactiver pour tous la visualisation des acquis dans l'export CSV de campagnes via un script (PIX-4106).

### DIFF
--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -32,6 +32,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     externalId: null,
     provinceCode: null,
     email: null,
+    showSkills: true,
   });
 
   databaseBuilder.factory.buildMembership({

--- a/api/scripts/prod/hide-skills-in-csv-export.js
+++ b/api/scripts/prod/hide-skills-in-csv-export.js
@@ -1,0 +1,18 @@
+const { knex } = require('../../db/knex-database-connection');
+
+async function hideSkills() {
+  await knex('organizations').where('showSkills', true).update({ showSkills: false });
+}
+
+module.exports = {
+  hideSkills,
+};
+
+if (require.main === module) {
+  hideSkills()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/api/tests/integration/scripts/prod/hide-skills-in-csv-export_test.js
+++ b/api/tests/integration/scripts/prod/hide-skills-in-csv-export_test.js
@@ -1,0 +1,26 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { hideSkills } = require('../../../../scripts/prod/hide-skills-in-csv-export');
+
+describe('hideSkills', function () {
+  it('should update showSkills to false', async function () {
+    databaseBuilder.factory.buildOrganization({ showSkills: true });
+    await databaseBuilder.commit();
+
+    await hideSkills();
+
+    const { showSkills } = await knex('organizations').first();
+
+    expect(showSkills).to.be.false;
+  });
+
+  it('should not update showSkills', async function () {
+    databaseBuilder.factory.buildOrganization({ showSkills: false });
+    await databaseBuilder.commit();
+
+    await hideSkills();
+
+    const { showSkills } = await knex('organizations').first();
+
+    expect(showSkills).to.be.false;
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On veut décommisionner la visualisation des acquis dans Pix Orga, sauf que les acquis sont présents dans l'export CSV des résultats de campagne.

On ne sait pas à quelle fin ceux-ci sont utilisés.

## :robot: Solution
On désactive cette visualisation pour tout le monde. Si personne ne revient vers nous, tout est good. Si en revanche, certaines organisations reviennent vers nous, on réactive la fonctionnalité de manière ponctuelle, et on analyse à quelle fin ces organisations ont besoin de la visualisation des acquis.

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer le script sur la review app, et vérifier qu'après, tous les `showsSkills` sont à false.
