### PR TITLE
[BUGFIX] sauvegarder une description à la création d'un profile cible (PIX-4285)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -16,6 +16,7 @@ module.exports = {
       imageUrl: json.data.attributes['image-url'],
       skillIds: json.data.attributes['skill-ids'],
       comment: json.data.attributes['comment'],
+      description: json.data.attributes['description'],
       category: json.data.attributes['category'],
     };
   },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -37,4 +37,44 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       return expect(serializedTargetProfile).to.deep.equal(expectedTargetProfile);
     });
   });
+
+  describe('#deserialize', function () {
+    it('should deserialize JSONAPI to target profile', function () {
+      // given
+
+      const json = {
+        data: {
+          id: '12',
+          type: 'target-profiles',
+          attributes: {
+            name: 'Les compétences de BRO 2.0',
+            'is-public': false,
+            'owner-organization-id': 12,
+            'skill-ids': ['skillId1', 'skillIds2'],
+            'image-url': 'superImage.png',
+            comment: 'Interesting comment',
+            description: 'Amazing description',
+            category: 'OTHER',
+          },
+        },
+      };
+
+      const expectTargetProfileObject = {
+        ownerOrganizationId: 12,
+        name: 'Les compétences de BRO 2.0',
+        isPublic: false,
+        imageUrl: 'superImage.png',
+        skillIds: ['skillId1', 'skillIds2'],
+        comment: 'Interesting comment',
+        description: 'Amazing description',
+        category: 'OTHER',
+      };
+
+      // when
+      const deserializedTargetProfile = serializer.deserialize(json);
+
+      // then
+      return expect(deserializedTargetProfile).to.deep.equal(expectTargetProfileObject);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on créait un profil cible avec une description, la description n'était pas prise en compte à la sauvegarde.

## :robot: Solution
Ajouter l'attribut manquant au deserializer

## :rainbow: Remarques


## :100: Pour tester
- Aller sur Pix Admin 
- Créer un profil cible avec une description et enregistrer
- Constater que le profil cible a bien une description 
