### PR TITLE
[TECH] Afficher les logs de test si besoin dans les IDE (PIX-4334)

### DIFF
--- a/.vscode/sample.launch.json
+++ b/.vscode/sample.launch.json
@@ -33,6 +33,13 @@
       "request": "launch",
       "name": "api mocha all tests",
       "program": "${workspaceFolder}/api/node_modules/mocha/bin/_mocha",
+      "outputCapture": "std",
+      "env": {
+        "NODE_ENV": "test",
+        "LOG_FOR_HUMANS": "true",
+        "LOG_ENABLED": "true",
+        "LOG_LEVEL": "error"
+      },
       "args": [
         "-ui",
         "bdd",
@@ -43,9 +50,6 @@
         "--recursive",
         "${workspaceFolder}/api/tests"
       ],
-      "env": {
-        "NODE_ENV": "test"
-      },
       "internalConsoleOptions": "openOnSessionStart",
       "skipFiles": [
         "<node_internals>/**",
@@ -56,8 +60,12 @@
       "name": "api mocha current file",
       "type": "node",
       "request": "launch",
+      "outputCapture": "std",
       "env": {
-        "NODE_ENV": "test"
+        "NODE_ENV": "test",
+        "LOG_FOR_HUMANS": "true",
+        "LOG_ENABLED": "true",
+        "LOG_LEVEL": "error"
       },
       "program": "${workspaceRoot}/api/node_modules/mocha/bin/_mocha",
       "args": [

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -1,28 +1,30 @@
 const pino = require('pino');
 const { logging: logSettings } = require('../config');
 
-let transport;
-
+let prettyPrint;
 if (logSettings.logForHumans) {
-  const omitDay = 'h:MM:ss';
-
-  transport = {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-      translateTime: omitDay,
-      ignore: 'pid,hostname',
-    },
-  };
+  const pretty = require('pino-pretty');
+  const omitDay = 'HH:MM:ss';
+  prettyPrint = pretty({
+    sync: true,
+    colorize: true,
+    translateTime: omitDay,
+    ignore: 'pid,hostname',
+  });
 }
 
-const logger = pino({
-  level: logSettings.logLevel,
-  redact: ['req.headers.authorization'],
-  transport,
-  enabled: logSettings.enabled,
-});
+const logger = pino(
+  {
+    level: logSettings.logLevel,
+    redact: ['req.headers.authorization'],
+    enabled: logSettings.enabled,
+  },
+  prettyPrint
+);
 
+logger.error('ERROR logs enabled');
+logger.warn('WARN logs enabled');
+logger.info('INFO logs enabled');
 logger.debug('DEBUG logs enabled');
 logger.trace('TRACE logs enabled');
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -900,11 +900,57 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
+    "@types/hapi__catbox": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
+      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
+    },
+    "@types/hapi__hapi": {
+      "version": "20.0.10",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.10.tgz",
+      "integrity": "sha512-Nt/SY/20/JAlHhbgH616j0g18vsANR9OWoyMdQcytlW6o7TBN+wRgf0MB8AgzjYpuzQam5oTiqyED9WwHmQKYQ==",
+      "requires": {
+        "@hapi/boom": "^9.0.0",
+        "@hapi/iron": "^6.0.0",
+        "@hapi/podium": "^4.1.3",
+        "@types/hapi__catbox": "*",
+        "@types/hapi__mimos": "*",
+        "@types/hapi__shot": "*",
+        "@types/node": "*",
+        "joi": "^17.3.0"
+      }
+    },
+    "@types/hapi__mimos": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
+      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
+      "requires": {
+        "@types/mime-db": "*"
+      }
+    },
+    "@types/hapi__shot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
+      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/mime-db": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
+      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.16.tgz",
+      "integrity": "sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1159,6 +1205,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1202,6 +1249,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
       "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
       "requires": {
         "camelcase": "5.0.0",
         "chalk": "2.4.2",
@@ -1212,7 +1260,8 @@
         "camelcase": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "dev": true
         }
       }
     },
@@ -1663,6 +1712,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1960,6 +2010,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -2117,7 +2168,8 @@
     "dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -2515,7 +2567,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "8.2.0",
@@ -3057,7 +3110,8 @@
     "fast-safe-stringify": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==",
+      "dev": true
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -3117,11 +3171,6 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
-    },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "3.2.2",
@@ -3387,125 +3436,15 @@
       }
     },
     "hapi-pino": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.5.0.tgz",
-      "integrity": "sha512-p0phuePalD8965r6mboCBLIMWRO2vQAx+VSnXhTKxnF/4Sf+dk8Uze7109w9QfhlvGMqvBTEF6SxGStObBB/Lw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-9.1.2.tgz",
+      "integrity": "sha512-gUp/nc4TUOcb/K2uM1HtJP9b/dxLP8Lr8MRvFSvvjMvzhAwD5klRWyFUrtVr+uzwBgt7hdBaSRgxasx3kT3hFg==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
+        "@types/hapi__hapi": "^20.0.9",
         "abstract-logging": "^2.0.0",
-        "pino": "^6.0.0",
-        "pino-pretty": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "joycon": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
-          "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
-        },
-        "pino": {
-          "version": "6.13.4",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.4.tgz",
-          "integrity": "sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==",
-          "requires": {
-            "fast-redact": "^3.0.0",
-            "fast-safe-stringify": "^2.0.8",
-            "flatstr": "^1.0.12",
-            "pino-std-serializers": "^3.1.0",
-            "process-warning": "^1.0.0",
-            "quick-format-unescaped": "^4.0.3",
-            "sonic-boom": "^1.0.2"
-          }
-        },
-        "pino-pretty": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.8.0.tgz",
-          "integrity": "sha512-mhQfHG4rw5ZFpWL44m0Utjo4GC2+HMfdNvxyA8lLw0sIqn6fCf7uQe6dPckUcW/obly+OQHD7B/MTso6LNizYw==",
-          "requires": {
-            "@hapi/bourne": "^2.0.0",
-            "args": "^5.0.1",
-            "chalk": "^4.0.0",
-            "dateformat": "^4.5.1",
-            "fast-safe-stringify": "^2.0.7",
-            "jmespath": "^0.15.0",
-            "joycon": "^2.2.5",
-            "pump": "^3.0.0",
-            "readable-stream": "^3.6.0",
-            "rfdc": "^1.3.0",
-            "split2": "^3.1.1",
-            "strip-json-comments": "^3.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "get-caller-file": "^2.0.5",
+        "pino": "^7.0.0"
       }
     },
     "hapi-sentry": {
@@ -3569,7 +3508,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -4241,11 +4181,6 @@
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
     "joi": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
@@ -4573,7 +4508,8 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -5194,7 +5130,8 @@
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
-      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -5988,11 +5925,6 @@
         }
       }
     },
-    "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -6598,7 +6530,8 @@
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -6949,15 +6882,6 @@
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true
     },
-    "sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7272,6 +7196,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -34,7 +34,7 @@
     "fast-levenshtein": "^3.0.0",
     "file-type": "^16.5.3",
     "hapi-i18n": "^3.0.1",
-    "hapi-pino": "^8.5.0",
+    "hapi-pino": "^9.1.2",
     "hapi-sentry": "^3.2.0",
     "hapi-swagger": "^14.2.4",
     "hash-int": "^1.0.0",

--- a/api/sample.env
+++ b/api/sample.env
@@ -349,7 +349,7 @@ LOG_ENDING_EVENT_DISPATCH=true
 # Sample output: [8:27:12] INFO: Connected to server
 # presence: optional
 # type: String
-# LOG_FOR_HUMANS=true
+LOG_FOR_HUMANS=true
 
 
 # =================

--- a/api/sample.env
+++ b/api/sample.env
@@ -343,7 +343,7 @@ LOG_ENDING_EVENT_DISPATCH=true
 # - color logs
 # - display time of the day in HH:MM:SS format
 # - skip process id and hostname
-#
+# - synchronous logs (decrease performance)
 # Do NOT use if logs are to be processed by a log processing pipeline
 #
 # Sample output: [8:27:12] INFO: Connected to server


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’on lance un test via Webstorm/intellij, les logs sont parfois tronqués
Le logger pino est par défaut en asynchrone. Lorsqu’on lance les tests avec webstorm, le process peut s’arreter avant que tout les logs se soient affichés

## :robot: Solution
Passer les logs en synchrone lorsque LOG_FOR_HUMAN=true

## :rainbow: Remarques
On pourrait aussi rediriger les logs sur l'executable pino-pretty 
`mocha | pino-pretty` mais cela demande une configuration qui n'est pas compatible avec nvm
En bonus, bump de hapi-pino

## :100: Pour tester

### Log requête via hapi-pino
Ouvrir un test d'acceptance, ex `account-recovery-route-get_test.js`
Ajouter dans la configuration de run `LOG_ENABLED=true`
Exécuter et vérifier le message
```
{"level":50,"time":1644325836934,"pid":31377,"hostname":"OCTO-TOPI","msg":"ERROR logs enabled"}
{"level":40,"time":1644325836935,"pid":31377,"hostname":"OCTO-TOPI","msg":"WARN logs enabled"}
{"level":30,"time":1644325836935,"pid":31377,"hostname":"OCTO-TOPI","msg":"INFO logs enabled"}
{"level":30,"time":1644325840228,"pid":31377,"hostname":"OCTO-TOPI","queryParams":{},"req":{"id":"1644325840203:OCTO-TOPI:31377:kze55e7h:10000","method":"get","url":"/api/account-recovery/FfgpFXgyuO062nPUPwcb8Wy3KcgkqR2p2GyEuGVaNI4=","headers":{"user-agent":"shot","host":"OCTO-TOPI:0"},"remoteAddress":"127.0.0.1","remotePort":"","version":"development"},"res":{"statusCode":200,"headers":{"content-type":"application/json; charset=utf-8","vary":"origin","access-control-expose-headers":"WWW-Authenticate,Server-Authorization","cache-control":"no-cache","content-length":128,"accept-ranges":"bytes"}},"responseTime":25,"msg":"request completed"}

```

### Erreur
Lever une exceptionAjouter la config  `LOG_FOR_HUMANS=true;LOG_ENABLED=false`
Verifier que l'erreur apparait dans les logs

![image](https://user-images.githubusercontent.com/3769147/152993408-fcd69928-ff3d-4cb7-84a5-8ca97dc9ea6a.png)
