### PR TITLE
[FEATURE] Afficher le propriétaire d'une campagne sur Pix Admin (PIX-4326).

### DIFF
--- a/admin/app/components/organizations/campaigns-section.hbs
+++ b/admin/app/components/organizations/campaigns-section.hbs
@@ -11,9 +11,10 @@
             <th>Code</th>
             <th>Type</th>
             <th>Nom</th>
-            <th>Créée le</th>
+            <th class="table__column--medium">Créée le</th>
             <th>Créée par</th>
-            <th>Archivée le</th>
+            <th>Propriétaire</th>
+            <th class="table__column--medium">Archivée le</th>
           </tr>
         </thead>
 
@@ -33,6 +34,7 @@
                 <td>{{campaign.name}}</td>
                 <td>{{moment-format campaign.createdAt "DD/MM/YYYY"}}</td>
                 <td>{{campaign.creatorFirstName}} {{campaign.creatorLastName}}</td>
+                <td>{{campaign.ownerFirstName}} {{campaign.ownerLastName}}</td>
                 <td>
                   {{#if campaign.archivedAt}}
                     {{moment-format campaign.archivedAt "DD/MM/YYYY"}}

--- a/admin/app/models/campaign.js
+++ b/admin/app/models/campaign.js
@@ -9,6 +9,8 @@ export default class Campaign extends Model {
   @attr('date') createdAt;
   @attr('string') creatorLastName;
   @attr('string') creatorFirstName;
+  @attr('string') ownerLastName;
+  @attr('string') ownerFirstName;
   @attr('string') organizationId;
   @attr('string') organizationName;
   @attr('string') targetProfileId;

--- a/admin/tests/integration/components/organizations/campaigns-section-test.js
+++ b/admin/tests/integration/components/organizations/campaigns-section-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | organizations/campaigns-section', function (hooks) {
@@ -8,16 +8,48 @@ module('Integration | Component | organizations/campaigns-section', function (ho
 
   module('when there is no campaigns', function () {
     test('it should display aucune campagne', async function (assert) {
+      // given
       this.set('campaigns', []);
 
       // when
-      await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await renderScreen(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+
       // then
-      assert.contains('Aucune campagne');
+      assert.dom(screen.getByText('Aucune campagne')).exists();
     });
   });
 
   module('when there are campaigns', function () {
+    test('it should display campaign columns', async function (assert) {
+      // given
+      const campaign = {
+        id: 1,
+        name: 'C1',
+        archivedAt: new Date('2021-01-01'),
+        type: 'ASSESSMENT',
+        code: '123',
+        createdAt: new Date('2021-01-02'),
+        creatorLastName: 'K',
+        creatorFirstName: 'K',
+      };
+      const campaigns = [campaign];
+      campaigns.meta = { rowCount: 1 };
+      this.set('campaigns', campaigns);
+
+      // when
+      const screen = await renderScreen(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+
+      // then
+      assert.dom(screen.getByText('ID')).exists();
+      assert.dom(screen.getByText('Code')).exists();
+      assert.dom(screen.getByText('Nom')).exists();
+      assert.dom(screen.getByText('Type')).exists();
+      assert.dom(screen.getByText('Créée le')).exists();
+      assert.dom(screen.getByText('Créée par')).exists();
+      assert.dom(screen.getByText('Propriétaire')).exists();
+      assert.dom(screen.getByText('Archivée le')).exists();
+    });
+
     test('it should display a list of campaigns', async function (assert) {
       const campaign1 = {
         id: 1,
@@ -42,8 +74,9 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       const campaigns = [campaign1, campaign2];
       campaigns.meta = { rowCount: 2 };
       this.set('campaigns', campaigns);
+
       // when
-      await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      await renderScreen(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
 
       // then
       assert.dom('[aria-label="campagne"]').exists({ count: 2 });
@@ -59,6 +92,8 @@ module('Integration | Component | organizations/campaigns-section', function (ho
         createdAt: new Date('2021-01-02'),
         creatorLastName: 'King',
         creatorFirstName: 'Karam',
+        ownerLastName: 'Di',
+        ownerFirstName: 'Amar',
       };
       const campaign2 = {
         id: 2,
@@ -67,30 +102,38 @@ module('Integration | Component | organizations/campaigns-section', function (ho
         type: 'PROFILE_COLLECTION',
         code: '456',
         createdAt: new Date('2021-01-04'),
-        creatorLastName: 'JJ',
-        creatorFirstName: 'AA',
+        creatorLastName: 'Elizabeth',
+        creatorFirstName: 'Queen',
+        ownerLastName: 'Credi',
+        ownerFirstName: 'Amer',
       };
       const campaigns = [campaign1, campaign2];
       campaigns.meta = { rowCount: 2 };
       this.set('campaigns', campaigns);
+
       // when
-      await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await renderScreen(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+
       // then
-      assert.contains('C1');
-      assert.contains('Évaluation');
-      assert.contains('123');
-      assert.contains('Karam King');
-      assert.contains('01/01/2021');
-      assert.contains('02/01/2021');
-      assert.contains('C2');
-      assert.contains('Collecte de profils');
-      assert.contains('123');
-      assert.contains('Karam King');
-      assert.contains('01/01/2021');
-      assert.contains('02/01/2021');
+      assert.dom(screen.getByText('C1')).exists();
+      assert.dom(screen.getByText('Évaluation')).exists();
+      assert.dom(screen.getByText('123')).exists();
+      assert.dom(screen.getByText('Karam King')).exists();
+      assert.dom(screen.getByText('Amar Di')).exists();
+      assert.dom(screen.getByText('01/01/2021')).exists();
+      assert.dom(screen.getByText('02/01/2021')).exists();
+
+      assert.dom(screen.getByText('C2')).exists();
+      assert.dom(screen.getByText('Collecte de profils')).exists();
+      assert.dom(screen.getByText('456')).exists();
+      assert.dom(screen.getByText('Queen Elizabeth')).exists();
+      assert.dom(screen.getByText('Amer Credi')).exists();
+      assert.dom(screen.getByText('03/01/2021')).exists();
+      assert.dom(screen.getByText('04/01/2021')).exists();
     });
 
     test('it should display - when there is no archivedAt date', async function (assert) {
+      // given
       const campaign = {
         id: 1,
         name: 'C1',
@@ -106,9 +149,10 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       this.set('campaigns', campaigns);
 
       // when
-      await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await renderScreen(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+
       // then
-      assert.contains('-');
+      assert.dom(screen.getByText('-')).exists();
     });
   });
 });

--- a/api/lib/domain/read-models/CampaignManagement.js
+++ b/api/lib/domain/read-models/CampaignManagement.js
@@ -1,5 +1,18 @@
 class CampaignManagement {
-  constructor({ id, code, name, createdAt, archivedAt, type, creatorLastName, creatorFirstName, creatorId } = {}) {
+  constructor({
+    id,
+    code,
+    name,
+    createdAt,
+    archivedAt,
+    type,
+    creatorLastName,
+    creatorFirstName,
+    creatorId,
+    ownerLastName,
+    ownerFirstName,
+    ownerId,
+  } = {}) {
     this.id = id;
     this.code = code;
     this.name = name;
@@ -9,6 +22,9 @@ class CampaignManagement {
     this.creatorLastName = creatorLastName;
     this.creatorFirstName = creatorFirstName;
     this.creatorId = creatorId;
+    this.ownerLastName = ownerLastName;
+    this.ownerFirstName = ownerFirstName;
+    this.ownerId = ownerId;
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-management-repository.js
@@ -43,11 +43,15 @@ module.exports = {
         createdAt: 'campaigns.createdAt',
         archivedAt: 'campaigns.archivedAt',
         type: 'campaigns.type',
-        creatorLastName: 'users.lastName',
-        creatorFirstName: 'users.firstName',
-        creatorId: 'users.id',
+        creatorLastName: 'creatorUser.lastName',
+        creatorFirstName: 'creatorUser.firstName',
+        creatorId: 'creatorUser.id',
+        ownerId: 'ownerUser.id',
+        ownerLastName: 'ownerUser.lastName',
+        ownerFirstName: 'ownerUser.firstName',
       })
-      .join('users', 'users.id', 'campaigns.creatorId')
+      .join('users AS creatorUser', 'creatorUser.id', 'campaigns.creatorId')
+      .join('users AS ownerUser', 'ownerUser.id', 'campaigns.ownerId')
       .where('organizationId', organizationId)
       .orderBy('campaigns.createdAt', 'DESC');
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-management-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-management-serializer.js
@@ -12,6 +12,9 @@ module.exports = {
         'creatorId',
         'creatorLastName',
         'creatorFirstName',
+        'ownerId',
+        'ownerLastName',
+        'ownerFirstName',
       ],
       meta,
     }).serialize(campaignManagement);

--- a/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -166,6 +166,10 @@ describe('Integration | Repository | Campaign-Management', function () {
     context('when the given organization has campaigns', function () {
       it('should return campaign with all attributes', async function () {
         // given
+        const owner = databaseBuilder.factory.buildUser({
+          lastName: 'Queen',
+          firstName: 'Elizabeth',
+        });
         const creator = databaseBuilder.factory.buildUser({
           lastName: 'King',
           firstName: 'Arthur',
@@ -178,6 +182,7 @@ describe('Integration | Repository | Campaign-Management', function () {
           archivedAt: new Date('2021-01-01'),
           type: 'ASSESSMENT',
           creatorId: creator.id,
+          ownerId: owner.id,
         });
         await databaseBuilder.commit();
 
@@ -198,6 +203,9 @@ describe('Integration | Repository | Campaign-Management', function () {
           creatorLastName: creator.lastName,
           creatorFirstName: creator.firstName,
           creatorId: creator.id,
+          ownerId: owner.id,
+          ownerFirstName: owner.firstName,
+          ownerLastName: owner.lastName,
         });
       });
 

--- a/api/tests/tooling/domain-builder/factory/build-campaign-management.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-management.js
@@ -11,6 +11,9 @@ module.exports = function buildCampaignManagement({
   creatorId = 2,
   creatorFirstName = 'Un prénom',
   creatorLastName = 'Un nom',
+  ownerId = 3,
+  ownerFirstName = 'Alain',
+  ownerLastName = 'Provist',
 } = {}) {
   return new CampaignManagement({
     id,
@@ -22,5 +25,8 @@ module.exports = function buildCampaignManagement({
     creatorId,
     creatorFirstName,
     creatorLastName,
+    ownerId,
+    ownerFirstName,
+    ownerLastName,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-management-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-management-serializer_test.js
@@ -27,6 +27,9 @@ describe('Unit | Serializer | JSONAPI | campaign-management-serializer', functio
             'creator-id': campaignManagement.creatorId,
             'creator-first-name': campaignManagement.creatorFirstName,
             'creator-last-name': campaignManagement.creatorLastName,
+            'owner-id': campaignManagement.ownerId,
+            'owner-first-name': campaignManagement.ownerFirstName,
+            'owner-last-name': campaignManagement.ownerLastName,
           },
         },
       });


### PR DESCRIPTION
## :unicorn: Problème
La notion de propriétaire d'une campagne a été ajouté sur Pix Orga (owner) mais les informations ne sont pas visibles sur Pix Admin, nécessaires pour le métier et le support.
## :robot: Solution
Afficher le propriétaire d'une campagne dans le tableaux des campagnes sur Pix Admin.

## :rainbow: Remarques
Réduction de certaines colonnes pour l'ajout de la colonne propriétaire.

## :100: Pour tester
- Se connecter sur Pix Admin
- Cliquer sur une organisation (random)
- Aller sur l'onglet "Campagnes"
- Constater la présence de l'onglet "Propriétaire" à droite de la colonne "Créée par"
( + Amusez-vous à changer en BDD le propriétaire d'une campagne pour voir des noms différents entre le créateur et le propriétaire )
