### PR TITLE
[FEATURE] Rajouter le bouton "Effacer les filtres" sur la liste des campagnes (PIX-4070) 

### DIFF
--- a/orga/app/components/campaign/filter/filters.hbs
+++ b/orga/app/components/campaign/filter/filters.hbs
@@ -48,5 +48,10 @@
     <p class="campaign-filters__results">
       {{t "pages.campaigns-list.filter.results" total=@numResults}}
     </p>
+    <div class="campaign-filters__clear">
+      <PixButton @triggerAction={{@onClearFilters}} @isDisabled={{@isClearFiltersButtonDisabled}}>
+        {{t "pages.campaigns-list.filter.clear"}}
+      </PixButton>
+    </div>
   </div>
 </div>

--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -3,6 +3,8 @@
     @ownerNameFilter={{@ownerNameFilter}}
     @nameFilter={{@nameFilter}}
     @onFilter={{@onFilter}}
+    @onClearFilters={{@onClear}}
+    @isClearFiltersButtonDisabled={{@isClearFiltersButtonDisabled}}
     @isArchived={{@isArchived}}
     @onClickStatusFilter={{@onClickStatusFilter}}
     @numResults={{@campaigns.meta.rowCount}}

--- a/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
@@ -17,7 +17,8 @@ export default class AuthenticatedCampaignsListAllCampaignsController extends Co
 
   get isClearFiltersButtonDisabled() {
     const filtersAreEmpty = !this.name && !this.ownerName;
-    return filtersAreEmpty;
+    const activeCampainsDisplayed = this.status === null;
+    return filtersAreEmpty && activeCampainsDisplayed;
   }
 
   updateFilters(filters) {
@@ -27,8 +28,8 @@ export default class AuthenticatedCampaignsListAllCampaignsController extends Co
 
   @action
   clearFilters() {
-    this.name = null;
-    this.ownerName = null;
+    this.name = '';
+    this.ownerName = '';
     this.status = null;
   }
 

--- a/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
@@ -15,9 +15,21 @@ export default class AuthenticatedCampaignsListAllCampaignsController extends Co
     return this.status === 'archived';
   }
 
+  get isClearFiltersButtonDisabled() {
+    const filtersAreEmpty = !this.name && !this.ownerName;
+    return filtersAreEmpty;
+  }
+
   updateFilters(filters) {
     Object.keys(filters).forEach((filterKey) => (this[filterKey] = filters[filterKey]));
     this.pageNumber = null;
+  }
+
+  @action
+  clearFilters() {
+    this.name = null;
+    this.ownerName = null;
+    this.status = null;
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
@@ -15,9 +15,22 @@ export default class AuthenticatedCampaignsListMyCampaignsController extends Con
     return this.status === 'archived';
   }
 
+  get isClearFiltersButtonDisabled() {
+    const isSearchInputEmpty = !this.name;
+    const activeCampainsDisplayed = this.status === null;
+    return isSearchInputEmpty && activeCampainsDisplayed;
+  }
+
   updateFilters(filters) {
     Object.keys(filters).forEach((filterKey) => (this[filterKey] = filters[filterKey]));
     this.pageNumber = null;
+  }
+
+  @action
+  clearFilters() {
+    this.name = '';
+    this.ownerName = '';
+    this.status = null;
   }
 
   @action

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -27,7 +27,6 @@ export default class Campaign extends Model {
   @attr('number') participationsCount;
   @attr('number') sharedParticipationsCount;
   @attr('number') averageResult;
-  @attr('boolean') multipleSendings;
 
   @belongsTo('organization') organization;
   @belongsTo('target-profile') targetProfile;

--- a/orga/app/styles/components/campaign/filters.scss
+++ b/orga/app/styles/components/campaign/filters.scss
@@ -40,6 +40,11 @@
       border: none;
       margin: 0;
     }
+
+    @include device-is('mobile') {
+      justify-content: space-between;
+      border: none;
+    }
   }
 
   &__title {
@@ -50,6 +55,10 @@
   .search-input {
     height: 36px;
     width: 260px;
+
+    @include device-is('mobile') {
+      width: 100%;
+    }
   }
 
   &__type {
@@ -75,6 +84,10 @@
     border-left: 1px solid $grey-20;
     margin-left: 24px;
     padding: 2px 0 2px 24px;
+
+    @include device-is('mobile') {
+      border-left: none;
+    }
   }
 
   &__radio {
@@ -117,6 +130,11 @@
       &:hover {
         opacity: 1;
       }
+    }
+
+    @include device-is('mobile') {
+      flex-grow: 1;
+      justify-content: center;
     }
   }
 }

--- a/orga/app/styles/components/campaign/filters.scss
+++ b/orga/app/styles/components/campaign/filters.scss
@@ -32,6 +32,7 @@
   }
 
   > div:last-child {
+    display: flex;
     border-top: 1.2px solid $grey-15;
     margin-top: 20px;
 
@@ -68,6 +69,12 @@
     color: $grey-60;
     font-size: 0.875em;
     font-weight: 500;
+  }
+
+  &__clear {
+    border-left: 1px solid $grey-20;
+    margin-left: 24px;
+    padding: 2px 0 2px 24px;
   }
 
   &__radio {

--- a/orga/app/templates/authenticated/campaigns/list/all-campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns/list/all-campaigns.hbs
@@ -6,6 +6,8 @@
     @nameFilter={{this.name}}
     @ownerNameFilter={{this.ownerName}}
     @onFilter={{this.triggerFiltering}}
+    @onClear={{this.clearFilters}}
+    @isClearFiltersButtonDisabled={{this.isClearFiltersButtonDisabled}}
     @onClickCampaign={{this.goToCampaignPage}}
     @isArchived={{this.isArchived}}
     @onClickStatusFilter={{this.updateCampaignStatus}}

--- a/orga/app/templates/authenticated/campaigns/list/my-campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns/list/my-campaigns.hbs
@@ -6,6 +6,8 @@
     @nameFilter={{this.name}}
     @ownerNameFilter={{this.ownerName}}
     @onFilter={{this.triggerFiltering}}
+    @onClear={{this.clearFilters}}
+    @isClearFiltersButtonDisabled={{this.isClearFiltersButtonDisabled}}
     @onClickCampaign={{this.goToCampaignPage}}
     @isArchived={{this.isArchived}}
     @onClickStatusFilter={{this.updateCampaignStatus}}

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -69,28 +69,6 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
         assert.strictEqual(currentURL(), '/campagnes/1');
       });
 
-      module('When search input filters by name or owner are empty', function () {
-        test('it should display a disabled clear all filters button', async function (assert) {
-          // given
-          const user = createUserWithMembershipAndTermsOfServiceAccepted();
-          createPrescriberByUser(user);
-          await authenticateSession(user.id);
-
-          const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-          server.create('campaign', {
-            name: 'ma super campagne',
-            ownerFirstName: owner.firstName,
-            ownerLastName: owner.lastName,
-          });
-
-          // when
-          const screen = await visitScreen('/campagnes/toutes');
-
-          //then
-          assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasAttribute('disabled');
-        });
-      });
-
       module('When using owner filter', function () {
         test('it should update URL with owner first name filter', async function (assert) {
           // given
@@ -153,57 +131,6 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           assert.dom(screen.getByText('ma super campagne')).exists();
           assert.dom(screen.queryByLabelText('la campagne de Sara')).doesNotExist();
         });
-
-        module('With clear all filters button', function () {
-          test('it should display an enabled clear all filters button', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
-
-            const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-            server.create('campaign', {
-              name: 'ma super campagne',
-              ownerFirstName: owner.firstName,
-              ownerLastName: owner.lastName,
-            });
-            const screen = await visitScreen('/campagnes/toutes');
-
-            // when
-            await fillByLabel('Rechercher un propriétaire', 'Harry');
-
-            //then
-            assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasNoAttribute('disabled');
-          });
-
-          test('it should clear owner filter on click and display all active campaigns', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
-
-            const campaignName1 = 'ma super campagne';
-            const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-            server.create('campaign', {
-              name: campaignName1,
-              ownerFirstName: owner.firstName,
-              ownerLastName: owner.lastName,
-            });
-            const screen = await visitScreen('/campagnes/toutes');
-
-            // when
-            await fillByLabel('Rechercher un propriétaire', 'Harry');
-            await clickByName('Archivées');
-            await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
-
-            //then
-            assert
-              .dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-owner')))
-              .containsText('');
-            assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
-            assert.deepEqual(currentURL(), '/campagnes/toutes');
-          });
-        });
       });
 
       module('When using campaign filter', function () {
@@ -245,53 +172,6 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           // then
           assert.deepEqual(currentURL(), `/campagnes/toutes?name=${campaignName}`);
         });
-
-        module('With clear all filters button', function () {
-          test('it should display an enabled clear all filters button when search input is filled', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
-
-            const campaignName = 'CampagneV2';
-            server.create('campaign', { name: campaignName });
-            const screen = await visitScreen('/campagnes/toutes');
-
-            // when
-            await fillByLabel('Rechercher une campagne', campaignName);
-
-            //then
-            assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasNoAttribute('disabled');
-          });
-
-          test('it should clear campaign filter on click and display all active campaigns', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
-            const campaignName1 = 'ma super campagne';
-
-            const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-            server.create('campaign', {
-              name: campaignName1,
-              ownerFirstName: owner.firstName,
-              ownerLastName: owner.lastName,
-            });
-            const screen = await visitScreen('/campagnes/toutes');
-
-            // when
-            await fillByLabel('Rechercher une campagne', campaignName1);
-            await clickByName('Archivées');
-            await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
-
-            //then
-            assert
-              .dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name')))
-              .containsText('');
-            assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
-            assert.deepEqual(currentURL(), '/campagnes/toutes');
-          });
-        });
       });
 
       module('When using campaign and owner filters', function () {
@@ -329,63 +209,35 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
           assert.notContains('Evaluation');
           assert.notContains('la campagne de Sara');
         });
+      });
 
-        module('With clear all filters button', function () {
-          test('it should display an enabled clear all filters button when campaign and owner search inputs are filled', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
+      module('With clear all filters button', function () {
+        test('it should clear archived, campaign and owner filter on click and display all active campaigns', async function (assert) {
+          // given
+          const user = createUserWithMembershipAndTermsOfServiceAccepted();
+          createPrescriberByUser(user);
+          await authenticateSession(user.id);
+          const campaignName1 = 'ma super campagne';
 
-            const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-            server.create('campaign', {
-              name: 'ma super campagne',
-              ownerFirstName: owner.firstName,
-              ownerLastName: owner.lastName,
-            });
-
-            await visitScreen('/campagnes/toutes');
-
-            // when
-            const screen = await visitScreen('/campagnes/toutes');
-            await fillByLabel('Rechercher un propriétaire', 'Harry');
-            await fillByLabel('Rechercher une campagne', 'campagne');
-
-            //then
-            assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasNoAttribute('disabled');
+          const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
+          server.create('campaign', {
+            name: campaignName1,
+            ownerFirstName: owner.firstName,
+            ownerLastName: owner.lastName,
           });
+          const screen = await visitScreen('/campagnes/toutes');
 
-          test('it should clear campaign and owner filter on click and display all active campaigns', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
-            const campaignName1 = 'ma super campagne';
+          // when
+          await fillByLabel('Rechercher une campagne', campaignName1);
+          await fillByLabel('Rechercher un propriétaire', owner.firstName);
+          await clickByName('Archivées');
+          await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
 
-            const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-            server.create('campaign', {
-              name: campaignName1,
-              ownerFirstName: owner.firstName,
-              ownerLastName: owner.lastName,
-            });
-            const screen = await visitScreen('/campagnes/toutes');
-
-            // when
-            await fillByLabel('Rechercher une campagne', campaignName1);
-            await fillByLabel('Rechercher un propriétaire', owner.firstName);
-            await clickByName('Archivées');
-            await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
-
-            //then
-            assert
-              .dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-owner')))
-              .containsText('');
-            assert
-              .dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name')))
-              .containsText('');
-            assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
-            assert.deepEqual(currentURL(), '/campagnes/toutes');
-          });
+          //then
+          assert.dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-owner'))).containsText('');
+          assert.dom(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name'))).containsText('');
+          assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
+          assert.deepEqual(currentURL(), '/campagnes/toutes');
         });
       });
     });

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -24,14 +24,14 @@ module('Acceptance | campaigns/all-campaigns ', function (hooks) {
   });
 
   module('When prescriber is logged in', function () {
-    test('it should be accessible and prescriber redirected to his campaigns list', async function (assert) {
+    test('it should be accessible', async function (assert) {
       // given
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
       createPrescriberByUser(user);
       await authenticateSession(user.id);
 
       // when
-      await visitScreen('/campagnes');
+      await visitScreen('/campagnes/toutes');
 
       // then
       assert.deepEqual(currentURL(), '/campagnes/toutes');

--- a/orga/tests/acceptance/campaign-list-my-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-my-campaigns_test.js
@@ -89,52 +89,6 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
         assert.deepEqual(currentURL(), '/campagnes/1');
       });
 
-      module('When campaign filter is empty', function () {
-        test('it should display a disabled clear all filters button', async function (assert) {
-          // given
-          const user = createUserWithMembershipAndTermsOfServiceAccepted();
-          createPrescriberByUser(user);
-          await authenticateSession(user.id);
-
-          const campaignName = 'CampagneV2';
-          server.create('campaign', {
-            name: campaignName,
-            ownerId: user.id,
-            ownerLastName: user.lastName,
-            ownerFirstName: user.firstName,
-          });
-
-          // when
-          const screen = await visitScreen('/campagnes/les-miennes');
-
-          // then
-          assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasAttribute('disabled');
-        });
-      });
-
-      module('When search input filter by campaign name is empty', function () {
-        test('it should display a disabled clear all filters button', async function (assert) {
-          // given
-          const user = createUserWithMembershipAndTermsOfServiceAccepted();
-          createPrescriberByUser(user);
-          await authenticateSession(user.id);
-
-          const owner = server.create('user', { firstName: 'Harry', lastName: 'Gole' });
-          server.create('campaign', {
-            name: 'ma super campagne',
-            ownerId: user.id,
-            ownerFirstName: owner.firstName,
-            ownerLastName: owner.lastName,
-          });
-
-          // when
-          const screen = await visitScreen('/campagnes/les-miennes');
-
-          // then
-          assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasAttribute('disabled');
-        });
-      });
-
       module('When using campaign filter', function () {
         test('it should filter campaigns by campaign name', async function (assert) {
           // given
@@ -187,29 +141,7 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
         });
 
         module('With clear all filters button', function () {
-          test('it should display an enabled clear all filters button', async function (assert) {
-            // given
-            const user = createUserWithMembershipAndTermsOfServiceAccepted();
-            createPrescriberByUser(user);
-            await authenticateSession(user.id);
-
-            server.create('campaign', {
-              name: 'ma super campagne',
-              ownerId: user.id,
-              ownerLastName: user.lastName,
-              ownerFirstName: user.firstName,
-            });
-
-            const screen = await visitScreen('/campagnes/les-miennes');
-
-            // when
-            await fillByLabel('Rechercher une campagne', 'ma super campagne');
-
-            //then
-            assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasNoAttribute('disabled');
-          });
-
-          test("it should clear campaign filter on click and display active owner's campaigns", async function (assert) {
+          test("it should clear campaign filters on click and display active owner's campaigns", async function (assert) {
             // given
             const user = createUserWithMembershipAndTermsOfServiceAccepted();
             createPrescriberByUser(user);

--- a/orga/tests/integration/components/campaign/filter/filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/filters_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import hbs from 'htmlbars-inline-precompile';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
 
 module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -9,7 +10,7 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
   hooks.beforeEach(function () {
     this.set('triggerFilteringSpy', () => {});
     this.set('onClickStatusFilterSpy', () => {});
-    this.set('onClickClearFiltersSpy', () => {});
+    this.set('onClickClearFiltersSpy', sinon.stub());
   });
 
   test('it should display filters', async function (assert) {
@@ -31,18 +32,24 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
     assert.dom(screen.getByText('1 campagne')).exists();
   });
 
-  test('it should display reset filters button', async function (assert) {
-    // when
-    const screen = await renderScreen(
-      hbs`<Campaign::Filter::Filters
+  module('With clear all filters button', function () {
+    test('it should reset all filters on button clear filters click', async function (assert) {
+      // when
+      await renderScreen(
+        hbs`<Campaign::Filter::Filters
         @onFilter={{this.triggerFilteringSpy}}
         @onClickStatusFilter={{this.onClickStatusFilterSpy}}
         @onClearFilters={{this.onClickClearFiltersSpy}}
         @numResults={{1}} />`
-    );
+      );
 
-    // then
-    assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).exists();
+      // When
+      await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
+
+      // then
+      sinon.assert.called(this.onClickClearFiltersSpy);
+      assert.ok(true);
+    });
   });
 
   module('when showing current user campaign list', function () {

--- a/orga/tests/integration/components/campaign/filter/filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/filters_test.js
@@ -9,6 +9,7 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
   hooks.beforeEach(function () {
     this.set('triggerFilteringSpy', () => {});
     this.set('onClickStatusFilterSpy', () => {});
+    this.set('onClickClearFiltersSpy', () => {});
   });
 
   test('it should display filters', async function (assert) {
@@ -17,6 +18,7 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
       hbs`<Campaign::Filter::Filters
         @onFilter={{this.triggerFilteringSpy}}
         @onClickStatusFilter={{this.onClickStatusFilterSpy}}
+        @onClearFilters={{this.onClickClearFiltersSpy}}
         @numResults={{1}} />`
     );
 
@@ -29,6 +31,20 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
     assert.dom(screen.getByText('1 campagne')).exists();
   });
 
+  test('it should display reset filters button', async function (assert) {
+    // when
+    const screen = await renderScreen(
+      hbs`<Campaign::Filter::Filters
+        @onFilter={{this.triggerFilteringSpy}}
+        @onClickStatusFilter={{this.onClickStatusFilterSpy}}
+        @onClearFilters={{this.onClickClearFiltersSpy}}
+        @numResults={{1}} />`
+    );
+
+    // then
+    assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).exists();
+  });
+
   module('when showing current user campaign list', function () {
     test('it should not show creator input', async function (assert) {
       // given / when
@@ -36,6 +52,7 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
         hbs`<Campaign::Filter::Filters
         @onFilter={{this.triggerFilteringSpy}}
         @onClickStatusFilter={{this.onClickStatusFilterSpy}}
+        @onClearFilters={{this.onClickClearFiltersSpy}}
         @numResults={{1}}
         @listOnlyCampaignsOfCurrentUser={{true}} />`
       );
@@ -51,6 +68,7 @@ module('Integration | Component | Campaign::Filter::Filters', function (hooks) {
       hbs`<Campaign::Filter::Filters
         @onFilter={{this.triggerFilteringSpy}}
         @onClickStatusFilter={{this.onClickStatusFilterSpy}}
+        @onClearFilters={{this.onClickClearFiltersSpy}}
         @numResults={{1}} />`
     );
 

--- a/orga/tests/integration/components/campaign/list_test.js
+++ b/orga/tests/integration/components/campaign/list_test.js
@@ -283,5 +283,61 @@ module('Integration | Component | Campaign::List', function (hooks) {
         assert.dom(screen.queryByLabelText('Dupont Alice')).doesNotExist();
       });
     });
+
+    module('clear filters button', function () {
+      test('it should be disabled when isClearFiltersButtonDisabled returns true which means that filters are empty', async function (assert) {
+        // given
+        this.set('isClearFiltersButtonDisabled', true);
+
+        const campaigns = [
+          { name: 'campagne 1', code: 'AAAAAA111', ownerFullName: 'Dupont Alice' },
+          { name: 'campagne 2', code: 'BBBBBB222', ownerFullName: 'Dupont Alice' },
+        ];
+        campaigns.meta = {
+          rowCount: 2,
+        };
+        this.set('campaigns', campaigns);
+        this.set('listOnlyCampaignsOfCurrentUser', true);
+
+        // when
+        const screen = await renderScreen(hbs`<Campaign::List
+                    @campaigns={{this.campaigns}}
+                    @onFilter={{this.triggerFilteringSpy}}
+                    @onClickCampaign={{this.goToCampaignPageSpy}}
+                    @onClickStatusFilter={{this.onClickStatusFilterSpy}}
+                    @listOnlyCampaignsOfCurrentUser={{this.listOnlyCampaignsOfCurrentUser}}
+                    @isClearFiltersButtonDisabled={{this.isClearFiltersButtonDisabled}}/>`);
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasAttribute('disabled');
+      });
+
+      test('it should be enabled when isClearFiltersButtonDisabled returns false which means that one or some filters are used', async function (assert) {
+        // given
+        this.set('isClearFiltersButtonDisabled', false);
+
+        const campaigns = [
+          { name: 'campagne 1', code: 'AAAAAA111', ownerFullName: 'Dupont Alice' },
+          { name: 'campagne 2', code: 'BBBBBB222', ownerFullName: 'Dupont Alice' },
+        ];
+        campaigns.meta = {
+          rowCount: 2,
+        };
+        this.set('campaigns', campaigns);
+        this.set('listOnlyCampaignsOfCurrentUser', true);
+
+        // when
+        const screen = await renderScreen(hbs`<Campaign::List
+                    @campaigns={{this.campaigns}}
+                    @onFilter={{this.triggerFilteringSpy}}
+                    @onClickCampaign={{this.goToCampaignPageSpy}}
+                    @onClickStatusFilter={{this.onClickStatusFilterSpy}}
+                    @listOnlyCampaignsOfCurrentUser={{this.listOnlyCampaignsOfCurrentUser}}
+                    @isClearFiltersButtonDisabled={{this.isClearFiltersButtonDisabled}}/>`);
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasNoAttribute('disabled');
+      });
+    });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/list/all-campaigns_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list/all-campaigns_test.js
@@ -72,4 +72,53 @@ module('Unit | Controller | authenticated/campaigns/list/all-campaigns', functio
       assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.campaign', 123));
     });
   });
+
+  module('#action clearFilters', function () {
+    test('it should set params to initial empty values', async function (assert) {
+      // given
+      controller.status = 'archived';
+      controller.name = 'a name';
+      controller.ownerName = 'an owner bame';
+
+      // when
+      await controller.clearFilters();
+
+      // then
+      assert.strictEqual(controller.status, null);
+      assert.strictEqual(controller.name, '');
+      assert.strictEqual(controller.ownerName, '');
+    });
+  });
+
+  module('#get isClearFiltersButtonDisabled', function () {
+    module('when status is not archived', function () {
+      test('it should returns true', function (assert) {
+        // given
+        controller.status = null;
+        controller.name = '';
+        controller.ownerName = '';
+
+        // when
+        const isClearFiltersButtonDisabled = controller.isClearFiltersButtonDisabled;
+
+        // then
+        assert.true(isClearFiltersButtonDisabled);
+      });
+    });
+
+    module('when filters are not empty', function () {
+      test('it should returns false', function (assert) {
+        // given
+        controller.status = 'archived';
+        controller.name = 'Some';
+        controller.ownerName = '';
+
+        // when
+        const isClearFiltersButtonDisabled = controller.isClearFiltersButtonDisabled;
+
+        // then
+        assert.false(isClearFiltersButtonDisabled);
+      });
+    });
+  });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/list/my-campaigns_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list/my-campaigns_test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/campaigns/list/all-campaigns', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let controller;
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/campaigns/list/my-campaigns');
+  });
+
+  module('#action clearFilters', function () {
+    test('it should set params to initial empty values', async function (assert) {
+      // given
+      controller.status = 'archived';
+      controller.name = 'a name';
+      controller.ownerName = 'an owner bame';
+
+      // when
+      await controller.clearFilters();
+
+      // then
+      assert.strictEqual(controller.status, null);
+      assert.strictEqual(controller.name, '');
+      assert.strictEqual(controller.ownerName, '');
+    });
+  });
+
+  module('#get isClearFiltersButtonDisabled', function () {
+    module('when status is not archived', function () {
+      test('it should returns true', function (assert) {
+        // given
+        controller.status = null;
+        controller.name = '';
+        controller.ownerName = '';
+
+        // when
+        const isClearFiltersButtonDisabled = controller.isClearFiltersButtonDisabled;
+
+        // then
+        assert.true(isClearFiltersButtonDisabled);
+      });
+    });
+
+    module('when filters are not empty', function () {
+      test('it should returns false', function (assert) {
+        // given
+        controller.status = 'archived';
+        controller.name = 'Some';
+        controller.ownerName = '';
+
+        // when
+        const isClearFiltersButtonDisabled = controller.isClearFiltersButtonDisabled;
+
+        // then
+        assert.false(isClearFiltersButtonDisabled);
+      });
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -513,6 +513,7 @@
       },
       "no-campaign": "No campaign. To start, click on 'Create a campaign'.",
       "filter": {
+        "clear": "Clear filters",
         "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du propriétaire. Des boutons permettent de filtrer les campagnes actives et archivées.",
         "title": "Filters",
         "by-owner": "Search for an owner",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -513,6 +513,7 @@
       },
       "no-campaign": "Aucune campagne, pour commencer cliquez sur le bouton 'Créer une campagne'.",
       "filter": {
+        "clear": "Effacer les filtres",
         "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du propriétaire. Des boutons permettent de filtrer les campagnes actives et archivées.",
         "title": "Filtres",
         "by-owner": "Rechercher un propriétaire",


### PR DESCRIPTION
## :unicorn: Problème
Il n'existait pas encore de possibilité pour l'utilisateur de vider les champs de recherche par propriétaire ou nom de campagne en un seul click.

## :robot: Solution
Un bouton "Effacer les recherches" a été ajouté. Lorsque l'utilisateur clique sur le bouton, les champs sont vidés et la liste des campagnes actives (l'un des filtres) s'affichent sans filtre de nom de campagne ou propriétaire de campagne ou status archivé.

## :rainbow: Remarques
Le bouton **"Effacer les filtres"** ne devient actif que lorsque l'utilisateur commence à taper une recherche, s'il filtre avec le bouton archiver, cela n'a pas d'impact.
Par contre, s'il clique sur  **"Effacer les filtres"*, le filtre par status archivées n'est plus actif et l'utilisateur voit toutes ses campagnes actives.

## :100: Pour tester
- Se connecter avec par exemple le compte `pro.admin@example.net`
- Aller sur la page campagne, les campagnes de l'utilisateur s'affichent par défaut.
- Vérifier que le bouton **"Effacer les filtres"** est visible mais en status disabled
- Vérifier que lorsque l'on commence à taper une lettre dans le champ de recherche, le bouton devient actif
- Cliquer sur le bouton, et vérifier que les champs de recherche se vident et que l'utilisateur voit la liste de ses campagnes
- Recommencer en sélectionnant les campagnes archivées puis en faisant une recherche.
- Cliquer sur le bouton **"Effacer les filtres"** et vérifier que l'utilisateur voit maintenant toutes ses campagnes **actives**

Faire la même chose sur la page "Toutes les campagnes".

