### PR TITLE
[FEATURE] Permettre à l'équipe contenu d'utiliser la class sr-only dans les épreuves (PIX-4333).

### DIFF
--- a/mon-pix/app/components/markdown-to-html.js
+++ b/mon-pix/app/components/markdown-to-html.js
@@ -17,6 +17,10 @@ function modifyWhiteList() {
   };
 }
 
+function filterAccessibilityClass(value) {
+  return value === 'sr-only' ? `class="${value}"` : null;
+}
+
 export default class MarkdownToHtml extends Component {
   get options() {
     return {
@@ -30,6 +34,9 @@ export default class MarkdownToHtml extends Component {
     const unsafeHtml = converter.makeHtml(this.args.markdown);
     const html = xss(unsafeHtml, {
       whiteList: modifyWhiteList(),
+      onIgnoreTagAttr: (tag, name, value) => {
+        return name === 'class' ? filterAccessibilityClass(value) : null;
+      },
     });
     return htmlSafe(html);
   }

--- a/mon-pix/tests/unit/components/markdown-to-html_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html_test.js
@@ -73,4 +73,32 @@ describe('Unit | Component | markdown-to-html', function () {
       expect(component.html.string).to.equal(expectedHtml);
     });
   });
+
+  describe('when class is provided', () => {
+    it('should remove it', () => {
+      // given
+      const markdown = '<h1 class="foo">Test</h1>';
+
+      // when
+      component = createGlimmerComponent('component:markdown-to-html', { markdown });
+
+      // then
+      const expectedHtml = '<h1>Test</h1>';
+      expect(component.html.string).to.equal(expectedHtml);
+    });
+  });
+
+  describe('when accessibility class is provided', () => {
+    it('should keep it', () => {
+      // given
+      const markdown = '<h1 class="sr-only">Test</h1>';
+
+      // when
+      component = createGlimmerComponent('component:markdown-to-html', { markdown });
+
+      // then
+      const expectedHtml = '<h1 class="sr-only">Test</h1>';
+      expect(component.html.string).to.equal(expectedHtml);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'équipe contenu souhaite rendre les épreuves plus accessible. Pour cela, elle souhaite utiliser la class `sr-only`, qui permet au lecteur de lire un texte bien qu'il ne soit pas lisible sur la page. 
Cependant, l'équipe contenu ne peut pas le faire due au protection apporté sur le composant `MarkdownToHtml`. 

## :robot: Solution
Permettre l'utilisation de la class `sr-only` uniquement dans le composant `MarkdownToHtml`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier que le span du texte alternatif de l'épreuve `challenge17pi5vGzgVX0oP` contient bien la class `sr-only`.
