### PR TITLE
[TECH] Empêcher d'initier une transaction du domaine en dehors du contrôleur.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -11,6 +11,7 @@ globals:
 
 plugins:
   - knex
+  - node
 
 rules:
   no-console: error

--- a/api/lib/.eslintrc.js
+++ b/api/lib/.eslintrc.js
@@ -1,3 +1,4 @@
+const path = require('path');
 module.exports = {
   extends: '../.eslintrc.yaml',
   rules: {
@@ -13,4 +14,20 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: 'domain/usecases/**',
+      rules: {
+        'node/no-restricted-require': [
+          'error',
+          [
+            {
+              name: path.resolve(__dirname, 'infrastructure/DomainTransaction**'),
+              message: "Don't use DomainTransaction in use-cases, use it in controller and scripts (ADR 9).",
+            },
+          ],
+        ],
+      },
+    },
+  ],
 };

--- a/api/lib/infrastructure/repositories/.eslintrc.yaml
+++ b/api/lib/infrastructure/repositories/.eslintrc.yaml
@@ -1,0 +1,8 @@
+extends:
+  - ../../.eslintrc.js
+
+rules:
+  no-restricted-syntax:
+    - error
+    - selector: "CallExpression[callee.object.name='DomainTransaction'][callee.property.name='execute']"
+      message: Don't initiate a DomainTransaction in repository, do it in controller and scripts (ADR 9).

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2697,6 +2697,33 @@
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true
     },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-i18n-json": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-json/-/eslint-plugin-i18n-json-3.1.0.tgz",
@@ -2766,6 +2793,49 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }

--- a/api/package.json
+++ b/api/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-i18n-json": "^3.1.0",
     "eslint-plugin-knex": "^0.2.1",
     "eslint-plugin-mocha": "^9.0.0",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-yml": "^0.11.0",
     "form-data": "^4.0.0",

--- a/docs/adr/0009-transaction-metier.md
+++ b/docs/adr/0009-transaction-metier.md
@@ -52,11 +52,14 @@ Or cette solution amène du couplage entre deux aspects fonctionnels distincts q
 
 ## Décision
 
-Englober le usecase dans une transaction métier.
+Englober le usecase dans une transaction métier, initiée:
+
+- soit depuis le controller;
+- soit depuis le script.
 
 ## Conséquences
 
-L'architecture applicative est légèrement différente.
+L'architecture applicative est légèrement différente, voir ci-dessous. Des règles de lint sont mises en place pour attirer l'attention du développeur.
 
 ### Architecture
 


### PR DESCRIPTION
## :unicorn: Problème
Les exemples d'uilisation de l'ADR 9 montrent que la transaction est initiée dans le controlleur, mais ne mentionne pas pourquoi.

## :robot: Solution
Clarifier l'intention dans l'ADR
RAF: recopier la règle knex/faker dans `repo/.eslintrc.yaml` pour éviter les régressions

## :rainbow: Remarques
Ajout de règles de lint pour prévenir les cas où une transaction du domaine est initiée dans un use-case ou un repository.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
