### PR TITLE
[TECH] Supprimer les étapes de checkout inutiles dans les GitHub actions. 

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -8,9 +8,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2.4.0
-
       - name: Block Autosquash Commits
         uses: xt0rted/block-autosquash-commits-action@v2
         with:

--- a/.github/workflows/jira-transition-to-dev-in-progress.yaml
+++ b/.github/workflows/jira-transition-to-dev-in-progress.yaml
@@ -8,9 +8,6 @@ jobs:
     name: Transition Issue
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
       - name: Login
         uses: atlassian/gajira-login@master
         env:

--- a/.github/workflows/jira-transition-to-review.yaml
+++ b/.github/workflows/jira-transition-to-review.yaml
@@ -10,9 +10,6 @@ jobs:
     if: >
       contains(github.event.pull_request.labels.*.name, ':eyes: Tech Review Needed')
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
       - name: Login
         uses: atlassian/gajira-login@master
         env:

--- a/.github/workflows/on-dev-merge.yaml
+++ b/.github/workflows/on-dev-merge.yaml
@@ -8,9 +8,6 @@ jobs:
     name: Transition Issue
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
       - name: Login
         uses: atlassian/gajira-login@master
         env:


### PR DESCRIPTION
## :unicorn: Problème
Nous avons des étapes de checkout inutile dans des GitHub Actions. Cette étape permet de récupérer le code dans le container utiliser pour l'action dans le but de s'en servir. Cette étape prend 3s dans plusieurs GitHub Actions alors qu'on ne se sert pas ensuite du code.

## :robot: Solution
Supprimer ces étapes. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
