### PR TITLE
[TECH] Génère le fichier cron.json conditionnellement au moment du build 

### DIFF
--- a/api/cron.json
+++ b/api/cron.json
@@ -1,7 +1,0 @@
-{
-  "jobs": [
-    {
-      "command": "20 5 * * * npm run cache:refresh"
-    }
-  ]
-}

--- a/api/package.json
+++ b/api/package.json
@@ -121,7 +121,7 @@
     "manual-lint:json": "eslint --cache --cache-strategy content --fix --ext .json translations/",
     "postdeploy": "npm run db:migrate",
     "preinstall": "npx check-engine",
-    "scalingo-postbuild": "echo 'nothing to do'",
+    "scalingo-postbuild": "node scripts/generate-cron > cron.json",
     "start": "node bin/www",
     "start:watch": "nodemon bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",

--- a/api/sample.env
+++ b/api/sample.env
@@ -64,6 +64,15 @@ FT_NEW_TUTORIALS_PAGE
 # default: none
 REDIS_URL=redis://localhost:6379
 
+# Cache reload schedule
+#
+# If not present, the cron.json file will not generated
+#
+# presence: optional
+# type: crontab
+# default: none
+# sample (everyday at 06:30 UTC): CACHE_RELOAD_TIME=30 6 * * *
+
 # =========
 # DATABASES
 # =========

--- a/api/scripts/generate-cron.js
+++ b/api/scripts/generate-cron.js
@@ -1,0 +1,10 @@
+const cronContent = {
+  jobs: [],
+};
+
+if (process.env.CACHE_RELOAD_TIME) {
+  cronContent.jobs.push({
+    command: `${process.env.CACHE_RELOAD_TIME} npm run cache:refresh`,
+  });
+}
+console.log(JSON.stringify(cronContent));


### PR DESCRIPTION
## :unicorn: Problème
Le fichier cron.json ajouté dans #4010 ne permet pas de rendre le cron paramétrable, que le cron soit présent ou pour changer la programmation.

## :robot: Solution
Au moment du build de l'application par scalingo, générer le contenu du fichier cron.json conditionnellement.

## :100: Pour tester
1. Setter la variable `CACHE_RELOAD_TIME`, lancer `npm run build` et vérifier que fichier cron.json contient une commande
2. Ne pas Setter la variable `CACHE_RELOAD_TIME`, lancer `npm run build` et vérifier que fichier cron.json ne contient pas de commande
3. Sur scalingo, il est possible de vérifier la présence ou non des cron en faisant `scalingo --app XXXX-my-app cron-tasks`
