### PR TITLE
[BUGFIX] Afficher le niveau de conformité a11y dans le footer de mon-pix (PIX-4347)

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -62,7 +62,7 @@
     "copyrights": "©",
     "error": "Erreur",
     "footer": {
-      "a11y": "Accessibilité",
+      "a11y": "Accessibilité : partiellement conforme",
       "data-protection-policy": "Politique de protection des données",
       "eula": "CGU",
       "help-center": "Centre d'aide",


### PR DESCRIPTION
## :unicorn: Problème
Le niveau de conformité des footers n'est pas uniforme à travers les applis.

## :robot: Solution
L'uniformiser en ajoutant l'info "partiellement conforme" dans le footer de mon-pix.

## :rainbow: Remarques
La traduction en anglais n'est pas nécessaire car cette contrainte légale ne s'applique qu'en France.

## :100: Pour tester
Vérifier que le "Accessibilité : partiellement conforme" est bien affiché dans le footer de Pix App.
