### PR TITLE
[DOCS] Corrige un lien du CONTRIBUTING pour accéder au CHANGELOG

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,7 +70,7 @@ FEATURE | PR relative à une story
 BUGFIX | PR relative à une correction d'un bug
 TECH | PR relative à du code technique / d'infra
 
-Ce tag nous permet de générer automatiquement un fichier [CHANGELOG.md](./CHANGELOG.md) regroupant les modifications d'une version à l'autre. Il est possible d'utiliser d'autres tags mais le CHANGELOG les regroupera comme des modifications "Autres".
+Ce tag nous permet de générer automatiquement un fichier [CHANGELOG.md](../CHANGELOG.md) regroupant les modifications d'une version à l'autre. Il est possible d'utiliser d'autres tags mais le CHANGELOG les regroupera comme des modifications "Autres".
 
 Le titre de la PR originel (et donc son tag) reste dans tous les cas affiché dans chaque ligne du CHANGELOG.
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le fichier CONTRIBUTING, le lien vers le CHANGELOG était cassé.

## :robot: Solution
Correction du lien

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que le lien est maintenant correct :)
