### PR TITLE
[FEATURE] Suppression d'un RT non assigné dans Pix-Admin (PIX-4288).

### DIFF
--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -23,15 +23,23 @@
             <td>
               <Common::TickOrCross @isTrue={{badge.isAlwaysVisible}} />
             </td>
-            <td>
+            <td class="badges-table__actions">
               <PixButtonLink
                 @backgroundColor="transparent-light"
                 @isBorderVisible={{true}}
                 @route="authenticated.badges.badge"
                 @size="small"
                 @model={{badge.id}}
-                class="pix-button__secondary"
+                class="badges-table-actions__button"
               >Voir détail</PixButtonLink>
+              <PixButton
+                @size="small"
+                @backgroundColor="red"
+                @triggerAction={{fn this.toggleDisplayConfirm badge.id}}
+                class="badges-table-actions__button badges-table-actions__button--delete"
+              >
+                <FaIcon @icon="trash" />Supprimer
+              </PixButton>
             </td>
           </tr>
         {{/each}}
@@ -41,3 +49,12 @@
     <div class="table__empty content-text">Aucun résultat thématique associé</div>
   {{/if}}
 </div>
+
+<ConfirmPopup
+  @message="Êtes-vous sûr de vouloir supprimer ce résultat thématique ? (Uniquement si le RT n'a pas encore été assigné)"
+  @title="Suppression d'un résultat thématique"
+  @submitTitle="Supprimer"
+  @confirm={{fn this.deleteBadge this.badgeIdToDelete}}
+  @cancel={{this.toggleDisplayConfirm}}
+  @show={{this.displayConfirm}}
+/>

--- a/admin/app/components/target-profiles/badges.js
+++ b/admin/app/components/target-profiles/badges.js
@@ -1,8 +1,36 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class Badges extends Component {
+  @tracked displayConfirm = false;
+  @service store;
+  @service notifications;
+  badgeIdToDelete;
+
   get hasBadges() {
     const badges = this.args.badges;
     return badges && badges.length > 0;
+  }
+
+  @action
+  toggleDisplayConfirm(badgeId) {
+    this.displayConfirm = !this.displayConfirm;
+    this.badgeIdToDelete = badgeId;
+  }
+
+  @action
+  async deleteBadge() {
+    let badge;
+    try {
+      badge = this.store.peekRecord('badge', this.badgeIdToDelete);
+      await badge.destroyRecord();
+      this.notifications.success('Le résultat thématique a été supprimé avec succès.');
+    } catch (e) {
+      this.notifications.error(e.errors[0].detail);
+      badge.rollbackAttributes();
+    }
+    this.toggleDisplayConfirm();
   }
 }

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -20,8 +20,24 @@
     }
   }
 
-  &__actions,
   &__shortcoming {
     width: 140px;
+  }
+
+  &__actions {
+    width: 160px;
+  }
+}
+
+.badges-table-actions {
+
+  &__button {
+    width: 100%;
+
+    &--delete {
+      margin-top: 8px;
+      display: flex;
+      justify-content: space-between;
+    }
   }
 }

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -3,8 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, find, render } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import sinon from 'sinon';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 
 module('Integration | Component | TargetProfiles::Badges', function (hooks) {
   setupRenderingTest(hooks);
@@ -35,16 +35,10 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     assert.contains('Message');
     assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('tbody tr td:first-child').textContent, '1');
+    assert.strictEqual(find('tbody tr td:first-child').textContent, '1');
     assert.dom('tbody tr td:nth-child(2) img').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('alt'), 'My alt message');
+    assert.strictEqual(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
+    assert.strictEqual(find('tbody tr td:nth-child(2) img').getAttribute('alt'), 'My alt message');
     assert.contains('My key');
     assert.contains('My title');
     assert.contains('My message');

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -1,8 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, render } from '@ember/test-helpers';
+import { click, find, render } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+import sinon from 'sinon';
 
 module('Integration | Component | TargetProfiles::Badges', function (hooks) {
   setupRenderingTest(hooks);
@@ -60,5 +62,56 @@ module('Integration | Component | TargetProfiles::Badges', function (hooks) {
     // then
     assert.dom('table').doesNotExist();
     assert.contains('Aucun résultat thématique associé');
+  });
+
+  module('when deleting a badge', function (hooks) {
+    let badge;
+
+    hooks.beforeEach(async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+      badge = store.push({
+        data: {
+          id: 'badgeId',
+          type: 'badge',
+          attributes: {
+            key: 'My key',
+            title: 'My title',
+            message: 'My message',
+            imageUrl: 'data:,',
+            altMessage: 'My alt message',
+          },
+        },
+      });
+      badge.destroyRecord = sinon.stub();
+      this.set('badges', [badge]);
+
+      // when
+      await render(hbs`<TargetProfiles::Badges @badges={{this.badges}} />`);
+      await clickByLabel('Supprimer');
+    });
+
+    test('should open confirm modal', function (assert) {
+      // then
+      assert.dom('.modal-dialog').exists();
+      assert.contains("Suppression d'un résultat thématique");
+      assert.contains('Êtes-vous sûr de vouloir supprimer ce résultat thématique ?');
+    });
+
+    test('should close confirm modal on click on cancel', async function (assert) {
+      // when
+      await click('.modal-footer > button.btn-secondary');
+
+      // then
+      assert.dom('.modal-dialog').doesNotExist();
+    });
+
+    test('should delete the badge on confirmation click', async function (assert) {
+      // when
+      await click('.modal-footer > button.btn-primary');
+
+      // then
+      assert.ok(badge.destroyRecord.called);
+    });
   });
 });

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -17,4 +17,11 @@ module.exports = {
 
     return h.response(badgeSerializer.serialize(updatedBadge)).code(204);
   },
+
+  async deleteUnassociatedBadge(request, h) {
+    const badgeId = request.params.id;
+    await usecases.deleteUnassociatedBadge({ badgeId });
+
+    return h.response().code(204);
+  },
 };

--- a/api/lib/application/badges/index.js
+++ b/api/lib/application/badges/index.js
@@ -71,6 +71,29 @@ exports.register = async function (server) {
         ],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/admin/badges/{id}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRolePixMaster,
+            assign: 'hasRolePixMaster',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.badgeId,
+          }),
+        },
+        handler: badgesController.deleteUnassociatedBadge,
+        tags: ['api', 'badges'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+            '- Elle permet de supprimer un résultat thématique non assigné.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -986,8 +986,14 @@ class SchoolingRegistrationCannotBeDissociatedError extends DomainError {
   }
 }
 
-class BadgeForbiddenDeletionError extends DomainError {
+class AcquiredBadgeForbiddenDeletionError extends DomainError {
   constructor(message = 'Il est interdit de supprimer un résultat thématique déjà acquis par un utilisateur.') {
+    super(message);
+  }
+}
+
+class CertificationBadgeForbiddenDeletionError extends DomainError {
+  constructor(message = 'Il est interdit de supprimer un résultat thématique lié à une certification.') {
     super(message);
   }
 }
@@ -996,6 +1002,7 @@ module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
   AccountRecoveryUserAlreadyConfirmEmail,
+  AcquiredBadgeForbiddenDeletionError,
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
   AlreadyExistingMembershipError,
@@ -1016,13 +1023,13 @@ module.exports = {
   AuthenticationMethodAlreadyExistsError,
   AuthenticationKeyForPoleEmploiTokenExpired,
   UncancellableOrganizationInvitationError,
-  BadgeForbiddenDeletionError,
   CampaignCodeError,
   CancelledOrganizationInvitationError,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   CertificateVerificationCodeGenerationTooManyTrials,
   NoCertificationAttestationForDivisionError,
+  CertificationBadgeForbiddenDeletionError,
   CertificationCandidateForbiddenDeletionError,
   CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -986,6 +986,12 @@ class SchoolingRegistrationCannotBeDissociatedError extends DomainError {
   }
 }
 
+class BadgeForbiddenDeletionError extends DomainError {
+  constructor(message = 'Il est interdit de supprimer un résultat thématique déjà acquis par un utilisateur.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -1010,6 +1016,7 @@ module.exports = {
   AuthenticationMethodAlreadyExistsError,
   AuthenticationKeyForPoleEmploiTokenExpired,
   UncancellableOrganizationInvitationError,
+  BadgeForbiddenDeletionError,
   CampaignCodeError,
   CancelledOrganizationInvitationError,
   CandidateNotAuthorizedToJoinSessionError,

--- a/api/lib/domain/usecases/delete-unassociated-badge.js
+++ b/api/lib/domain/usecases/delete-unassociated-badge.js
@@ -1,0 +1,11 @@
+const { BadgeForbiddenDeletionError } = require('../errors');
+
+module.exports = async function deleteUnassociatedBadge({ badgeId, badgeRepository }) {
+  const isAssociated = await badgeRepository.isAssociated(badgeId);
+
+  if (isAssociated) {
+    throw new BadgeForbiddenDeletionError();
+  }
+
+  return badgeRepository.delete(badgeId);
+};

--- a/api/lib/domain/usecases/delete-unassociated-badge.js
+++ b/api/lib/domain/usecases/delete-unassociated-badge.js
@@ -1,16 +1,19 @@
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 const { AcquiredBadgeForbiddenDeletionError, CertificationBadgeForbiddenDeletionError } = require('../errors');
 
 module.exports = async function deleteUnassociatedBadge({ badgeId, badgeRepository }) {
-  const isAssociated = await badgeRepository.isAssociated(badgeId);
-  const isRelatedToCertification = await badgeRepository.isRelatedToCertification(badgeId);
+  return DomainTransaction.execute(async (domainTransaction) => {
+    const isAssociated = await badgeRepository.isAssociated(badgeId, domainTransaction);
+    const isRelatedToCertification = await badgeRepository.isRelatedToCertification(badgeId, domainTransaction);
 
-  if (isAssociated) {
-    throw new AcquiredBadgeForbiddenDeletionError();
-  }
+    if (isAssociated) {
+      throw new AcquiredBadgeForbiddenDeletionError();
+    }
 
-  if (isRelatedToCertification) {
-    throw new CertificationBadgeForbiddenDeletionError();
-  }
+    if (isRelatedToCertification) {
+      throw new CertificationBadgeForbiddenDeletionError();
+    }
 
-  return badgeRepository.delete(badgeId);
+    return badgeRepository.delete(badgeId, domainTransaction);
+  });
 };

--- a/api/lib/domain/usecases/delete-unassociated-badge.js
+++ b/api/lib/domain/usecases/delete-unassociated-badge.js
@@ -1,10 +1,15 @@
-const { BadgeForbiddenDeletionError } = require('../errors');
+const { AcquiredBadgeForbiddenDeletionError, CertificationBadgeForbiddenDeletionError } = require('../errors');
 
 module.exports = async function deleteUnassociatedBadge({ badgeId, badgeRepository }) {
   const isAssociated = await badgeRepository.isAssociated(badgeId);
+  const isRelatedToCertification = await badgeRepository.isRelatedToCertification(badgeId);
 
   if (isAssociated) {
-    throw new BadgeForbiddenDeletionError();
+    throw new AcquiredBadgeForbiddenDeletionError();
+  }
+
+  if (isRelatedToCertification) {
+    throw new CertificationBadgeForbiddenDeletionError();
   }
 
   return badgeRepository.delete(badgeId);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -206,6 +206,7 @@ module.exports = injectDependencies(
     createUserFromPoleEmploi: require('./create-user-from-pole-emploi'),
     deleteCertificationIssueReport: require('./delete-certification-issue-report'),
     deleteSessionJuryComment: require('./delete-session-jury-comment'),
+    deleteUnassociatedBadge: require('./delete-unassociated-badge'),
     deleteUnlinkedCertificationCandidate: require('./delete-unlinked-certification-candidate'),
     deneutralizeChallenge: require('./deneutralize-challenge'),
     disableMembership: require('./disable-membership'),

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -46,6 +46,11 @@ module.exports = {
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
   },
 
+  async isAssociated(badgeId) {
+    const associatedBadge = await knex('badge-acquisitions').where({ badgeId }).first();
+    return !!associatedBadge;
+  },
+
   async get(id) {
     const bookshelfBadge = await BookshelfBadge.where('id', id).fetch({
       withRelated: ['badgeCriteria', 'skillSets'],
@@ -82,6 +87,15 @@ module.exports = {
     if (result.length) {
       throw new AlreadyExistingEntityError(`The badge key ${key} already exists`);
     }
+    return true;
+  },
+
+  async delete(badgeId) {
+    await knex.transaction(async (trx) => {
+      await trx('badge-criteria').where({ badgeId }).del();
+      return trx('badges').where({ id: badgeId }).del();
+    });
+
     return true;
   },
 };

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -51,6 +51,15 @@ module.exports = {
     return !!associatedBadge;
   },
 
+  async isRelatedToCertification(badgeId) {
+    const partnerCertificationBadge = await knex('partner-certifications')
+      .join('badges', 'partnerKey', 'key')
+      .where('badges.id', badgeId)
+      .first();
+    const complementaryCertificationBadge = await knex('complementary-certification-badges').where({ badgeId }).first();
+    return !!(partnerCertificationBadge || complementaryCertificationBadge);
+  },
+
   async get(id) {
     const bookshelfBadge = await BookshelfBadge.where('id', id).fetch({
       withRelated: ['badgeCriteria', 'skillSets'],
@@ -93,6 +102,7 @@ module.exports = {
   async delete(badgeId) {
     await knex.transaction(async (trx) => {
       await trx('badge-criteria').where({ badgeId }).del();
+      await trx('skill-sets').where({ badgeId }).del();
       return trx('badges').where({ id: badgeId }).del();
     });
 

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -291,4 +291,52 @@ describe('Acceptance | API | Badges', function () {
       expect(response.statusCode).to.equal(204);
     });
   });
+
+  describe('DELETE /api/admin/badges/{id}', function () {
+    beforeEach(async function () {
+      userId = (await insertUserWithRolePixMaster()).id;
+    });
+
+    afterEach(async function () {
+      await knex('badge-acquisitions').delete();
+      await knex('badges').delete();
+    });
+
+    it('should delete the existing badge if not associated to a badge acquisition', async function () {
+      // given
+      badge = databaseBuilder.factory.buildBadge({ id: 1 });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'DELETE',
+        url: `/api/admin/badges/${badge.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should not delete the existing badge if associated to a badge acquisition', async function () {
+      // given
+      badge = databaseBuilder.factory.buildBadge({ id: 1 });
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badge.id, userId });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'DELETE',
+        url: `/api/admin/badges/${badge.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/delete-unassociated-badge_test.js
+++ b/api/tests/unit/domain/usecases/delete-unassociated-badge_test.js
@@ -1,0 +1,52 @@
+const { sinon, expect, catchErr } = require('../../../test-helper');
+
+const deleteUnassociatedBadge = require('../../../../lib/domain/usecases/delete-unassociated-badge');
+const { BadgeForbiddenDeletionError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | delete-unassociated-badge', function () {
+  let badgeId;
+  let badgeRepository;
+
+  beforeEach(async function () {
+    badgeId = 'badgeId';
+    badgeRepository = {
+      isAssociated: sinon.stub(),
+      delete: sinon.stub(),
+    };
+  });
+
+  context('When the badge is not associated to a badge acquisition', function () {
+    beforeEach(function () {
+      badgeRepository.isAssociated.withArgs(badgeId).resolves(false);
+      badgeRepository.delete.withArgs(badgeId).resolves(true);
+    });
+
+    it('should delete the badge', async function () {
+      // when
+      const response = await deleteUnassociatedBadge({
+        badgeId,
+        badgeRepository,
+      });
+
+      // then
+      expect(response).to.deep.equal(true);
+    });
+  });
+
+  context('When the badge is associated to a badge acquisition', function () {
+    beforeEach(function () {
+      badgeRepository.isAssociated.withArgs(badgeId).resolves(true);
+    });
+
+    it('should throw a forbidden deletion error', async function () {
+      // when
+      const err = await catchErr(deleteUnassociatedBadge)({
+        badgeId,
+        badgeRepository,
+      });
+
+      // then
+      expect(err).to.be.instanceOf(BadgeForbiddenDeletionError);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

En cas d'erreur de saisie lors de la création d'un RT ou si celui-ci venait à ne plus être valable, il n'est pas possible de le supprimer dans le cas où il n'a pas encore été assigné au minimum à un utilisateur. 

## :robot: Solution

Création d'une route dédiée dans l'api à la suppression d'un RT non assigné.
Ajout d'un bouton de suppression dans pix-admin dans le tableau des RT

## :rainbow: Remarques
N/A

## :100: Pour tester

Pour vérifier qu'il est possible de supprimer un RT non assigné: 
- Créer un RT dans pix-admin et le supprimer par la suite

Pour vérifier qu'il n'est PAS possible de supprimer un RT assigné à un utilisateur:
- Réaliser la campagne `PDJGBD246` et tenter de supprimer le RT une fois la campagne terminée.
