### PR TITLE
[FEATURE] Nouveau design des cards de tutos (PIX-4299)

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,0 +1,32 @@
+<div class="tutorial-card-v2">
+
+  <div class="tutorial-card-v2__domain-border"></div>
+
+  <div class="tutorial-card-v2__content">
+    {{! template-lint-disable no-bare-strings }}
+    <div class="tutorial-card-v2-content__skill">
+      Mener une recherche et une veille d'information
+    </div>
+    <a target="_blank" rel="noopener noreferrer" href="{{@tutorial.link}}" class="tutorial-card-v2-content__link">
+      {{@tutorial.title}}
+    </a>
+    <div class="tutorial-card-v2-content__details">
+      {{@tutorial.source}}
+      •
+      {{@tutorial.format}}
+      •
+      {{moment-duration @tutorial.duration}}
+    </div>
+    <div class="tutorial-card-v2-content__actions">
+      <button class="tutorial-card-v2-content-actions__save" type="button">
+        <FaIcon @prefix="fas" @icon="bookmark" />
+        {{this.buttonLabel}}
+      </button>
+      <button class="tutorial-card-v2-content-actions__evaluate" type="button">
+        <FaIcon @prefix="fas" @icon="thumbs-up" />
+        {{t "pages.user-tutorials.list.tutorial.actions.evaluate.label"}}
+      </button>
+    </div>
+  </div>
+
+</div>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,13 +1,17 @@
-<div class="tutorial-card-v2">
-
+<article class="tutorial-card-v2">
   <div class="tutorial-card-v2__domain-border"></div>
-
   <div class="tutorial-card-v2__content">
     {{! template-lint-disable no-bare-strings }}
-    <div class="tutorial-card-v2-content__skill">
+    <p class="tutorial-card-v2-content__skill">
       Mener une recherche et une veille d'information
-    </div>
-    <a target="_blank" rel="noopener noreferrer" href="{{@tutorial.link}}" class="tutorial-card-v2-content__link">
+    </p>
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="{{@tutorial.link}}"
+      class="tutorial-card-v2-content__link"
+      title="{{@tutorial.title}}"
+    >
       {{@tutorial.title}}
     </a>
     <p class="tutorial-card-v2-content__details">
@@ -28,5 +32,4 @@
       </button>
     </div>
   </div>
-
-</div>
+</article>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -10,13 +10,13 @@
     <a target="_blank" rel="noopener noreferrer" href="{{@tutorial.link}}" class="tutorial-card-v2-content__link">
       {{@tutorial.title}}
     </a>
-    <div class="tutorial-card-v2-content__details">
+    <p class="tutorial-card-v2-content__details">
       {{@tutorial.source}}
       •
       {{@tutorial.format}}
       •
       {{moment-duration @tutorial.duration}}
-    </div>
+    </p>
     <div class="tutorial-card-v2-content__actions">
       <button class="tutorial-card-v2-content-actions__save" type="button">
         <FaIcon @prefix="fas" @icon="bookmark" />

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import buttonStatusTypes from 'mon-pix/utils/button-status-types';
+import { inject as service } from '@ember/service';
+
+export default class Card extends Component {
+  @service intl;
+
+  @tracked savingStatus = buttonStatusTypes.unrecorded;
+
+  constructor(owner, args) {
+    super(owner, args);
+    this.savingStatus = args.tutorial.isSaved ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
+    this.evaluationStatus = args.tutorial.isEvaluated ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
+  }
+
+  get buttonLabel() {
+    return this.savingStatus === buttonStatusTypes.recorded
+      ? this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.label')
+      : this.intl.t('pages.user-tutorials.list.tutorial.actions.save.label');
+  }
+}

--- a/mon-pix/app/components/tutorials/content.hbs
+++ b/mon-pix/app/components/tutorials/content.hbs
@@ -19,7 +19,7 @@
 <article class="user-tutorials-content-v2">
   <div class="user-tutorials-content-v2__container">
     {{#each @userTutorials as |userTutorial|}}
-      <TutorialItem @tutorial={{userTutorial.tutorial}} />
+      <Tutorials::Card @tutorial={{userTutorial.tutorial}} />
     {{/each}}
   </div>
 </article>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -92,6 +92,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/timed-challenge-instructions';
 @import 'components/timeout-gauge';
 @import 'components/tooltip';
+@import 'components/tutorial-card';
 @import 'components/tutorial-item';
 @import 'components/tutorial-panel';
 @import 'components/user-account';

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -1,11 +1,11 @@
 .tutorial-card-v2 {
+  display: flex;
   min-height: 170px;
   background: $white;
   border-radius: 8px;
   box-shadow: 0 2px 5px 0 rgba($grey-90, 0.06);
   padding: 16px;
   gap: 12px;
-  display: flex;
 
   &__domain-border {
     width: 3px;
@@ -21,9 +21,10 @@
 }
 
 .tutorial-card-v2-content {
+
   &__skill {
-    margin-bottom: 16px;
-    width: 274px;
+    margin: 0 0 16px 0;
+    width: 100%;
     color: $grey-50;
     font-family: $font-roboto;
     font-size: 0.813rem;
@@ -34,11 +35,17 @@
   }
 
   &__link {
+    display: -webkit-box;
     margin-bottom: 4px;
     color: $grey-90;
     font-size: 1rem;
     font-family: $font-open-sans;
     font-weight: $font-semi-bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    width: 100%;
 
     @include device-is('tablet') {
       font-size: 1.125rem;
@@ -47,12 +54,6 @@
     &:hover,
     &:focus {
       color: $blue;
-    }
-
-    &::after {
-      @include external-link;
-
-      margin-left: 8px;
     }
   }
 

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -1,0 +1,125 @@
+.tutorial-card-v2 {
+  min-height: 170px;
+  background: $white;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px 0 rgba($grey-90, 0.06);
+  padding: 16px;
+  gap: 12px;
+  display: flex;
+
+  &__domain-border {
+    width: 3px;
+    background: $yellow;
+    border-radius: 2px;
+  }
+
+  &__content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.tutorial-card-v2-content {
+  &__skill {
+    margin-bottom: 16px;
+    width: 274px;
+    color: $grey-50;
+    font-family: $font-roboto;
+    font-size: 0.8125rem;
+    font-weight: normal;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  &__link {
+    margin-bottom: 4px;
+    color: $grey-90;
+    font-size: 1rem;
+    font-family: $font-open-sans;
+    font-weight: $font-semi-bold;
+
+    &:hover,
+    &:focus {
+      color: $blue;
+    }
+
+    &::after {
+      @include external-link;
+
+      margin-left: 8px;
+    }
+  }
+
+  &__details {
+    height: 24px;
+    color: $grey-50;
+    font-size: 0.8125rem;
+    font-family: $font-roboto;
+    font-weight: $font-normal;
+    line-height: 1.5rem;
+  }
+
+  &__actions {
+    align-items: end;
+    display: flex;
+    flex: 1;
+    gap: 13px;
+  }
+}
+
+.tutorial-card-v2-content-actions {
+
+  &__save {
+    font-size: 0.813rem;
+    font-weight: $font-medium;
+    color: $grey-50;
+    letter-spacing: 0.028rem;
+    background: transparent;
+    border: none;
+    padding: 0;
+    display: block;
+
+    svg {
+      margin-right: 4px;
+    }
+
+    &:hover {
+      filter: brightness(70%);
+      cursor: pointer;
+    }
+
+    &:disabled {
+      color: $grey-30;
+      filter: brightness(90%);
+      cursor: auto;
+    }
+  }
+
+  &__evaluate {
+    font-size: 0.813rem;
+    font-weight: $font-medium;
+    color: $grey-50;
+    letter-spacing: 0.028rem;
+    background: transparent;
+    border: none;
+    padding: 0;
+    display: block;
+
+    svg {
+      margin-right: 4px;
+    }
+
+    &:hover {
+      filter: brightness(70%);
+      cursor: pointer;
+    }
+
+    &:disabled {
+      color: $grey-30;
+      filter: brightness(90%);
+      cursor: auto;
+    }
+  }
+}

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -26,7 +26,7 @@
     width: 274px;
     color: $grey-50;
     font-family: $font-roboto;
-    font-size: 0.8125rem;
+    font-size: 0.813rem;
     font-weight: normal;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -39,6 +39,10 @@
     font-size: 1rem;
     font-family: $font-open-sans;
     font-weight: $font-semi-bold;
+
+    @include device-is('tablet') {
+      font-size: 1.125rem;
+    }
 
     &:hover,
     &:focus {
@@ -55,10 +59,11 @@
   &__details {
     height: 24px;
     color: $grey-50;
-    font-size: 0.8125rem;
+    font-size: 0.813rem;
     font-family: $font-roboto;
     font-weight: $font-normal;
     line-height: 1.5rem;
+    margin: 0;
   }
 
   &__actions {
@@ -71,32 +76,7 @@
 
 .tutorial-card-v2-content-actions {
 
-  &__save {
-    font-size: 0.813rem;
-    font-weight: $font-medium;
-    color: $grey-50;
-    letter-spacing: 0.028rem;
-    background: transparent;
-    border: none;
-    padding: 0;
-    display: block;
-
-    svg {
-      margin-right: 4px;
-    }
-
-    &:hover {
-      filter: brightness(70%);
-      cursor: pointer;
-    }
-
-    &:disabled {
-      color: $grey-30;
-      filter: brightness(90%);
-      cursor: auto;
-    }
-  }
-
+  &__save,
   &__evaluate {
     font-size: 0.813rem;
     font-weight: $font-medium;

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+describe('Integration | Component | Tutorials | Card', function () {
+  setupIntlRenderingTest();
+
+  it('renders component', async function () {
+    // given
+    this.set('tutorial', {
+      title: 'Mon super tutoriel',
+      link: 'https://exemple.net',
+      source: 'mon-tuto',
+      format: 'vidéo',
+      duration: '00:01:00',
+      isEvaluated: true,
+      isSaved: true,
+    });
+
+    // when
+    await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+
+    // then
+    expect(find('.tutorial-card-v2')).to.exist;
+    expect(find('.tutorial-card-v2__domain-border')).to.exist;
+    expect(find('.tutorial-card-v2__content')).to.exist;
+    expect(find('.tutorial-card-v2-content__skill')).to.exist;
+    expect(find('.tutorial-card-v2-content__link')).to.exist;
+    expect(find('.tutorial-card-v2-content__details')).to.exist;
+    expect(find('.tutorial-card-v2-content__spacer')).to.exist;
+    expect(find('.tutorial-card-v2-content__actions')).to.exist;
+    expect(find('.tutorial-card-v2-content-actions__save')).to.exist;
+    expect(find('.tutorial-card-v2-content-actions__evaluate')).to.exist;
+  });
+});

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -11,7 +11,7 @@ describe('Integration | Component | Tutorials | Card', function () {
     // given
     this.set('tutorial', {
       title: 'Mon super tutoriel',
-      link: 'https://exemple.net',
+      link: 'https://exemple.net/',
       source: 'mon-tuto',
       format: 'vidéo',
       duration: '00:01:00',
@@ -26,12 +26,20 @@ describe('Integration | Component | Tutorials | Card', function () {
     expect(find('.tutorial-card-v2')).to.exist;
     expect(find('.tutorial-card-v2__domain-border')).to.exist;
     expect(find('.tutorial-card-v2__content')).to.exist;
-    expect(find('.tutorial-card-v2-content__skill')).to.exist;
-    expect(find('.tutorial-card-v2-content__link')).to.exist;
-    expect(find('.tutorial-card-v2-content__details')).to.exist;
-    expect(find('.tutorial-card-v2-content__spacer')).to.exist;
+    expect(find('.tutorial-card-v2-content__skill'))
+      .to.have.property('textContent')
+      .that.contains("Mener une recherche et une veille d'information");
+    expect(find('.tutorial-card-v2-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
+    expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
+    expect(find('.tutorial-card-v2-content__details'))
+      .to.have.property('textContent')
+      .that.contains('mon-tuto')
+      .and.contains('vidéo')
+      .and.contains('une minute');
     expect(find('.tutorial-card-v2-content__actions')).to.exist;
-    expect(find('.tutorial-card-v2-content-actions__save')).to.exist;
+    expect(find('.tutorial-card-v2-content-actions__save'))
+      .to.have.property('textContent')
+      .that.contains(this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.label'));
     expect(find('.tutorial-card-v2-content-actions__evaluate')).to.exist;
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le design des items de tutoriels était l'ancien.

## :robot: Solution
Mise à jour du design et changement de nom (item => card) en suivant la maquette https://share.goabstract.com/050bd943-c309-4c7c-83eb-90a58ce8649d.

## :rainbow: Remarques
Pas trouvé de solution pour faire un ellipsis et afficher l'icône "lien externe" à la fois. La hauteur des cards peut varier si on dépasse deux lignes dans le titre d'un tuto.

## :100: Pour tester
Enregistrer quelques tutos dans la RA et vérifier le design.