### PR TITLE
[FEATURE] Modifier le titre du fichier d'extraction de sujets sélectionnés (PIX-4170)

### DIFF
--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -8,7 +8,11 @@
       <PixButtonLink
         class="download-file__button"
         @href={{this.downloadURL}}
-        download={{t "pages.preselect-target-profile.download-filename"}}
+        download={{t
+          "pages.preselect-target-profile.download-filename"
+          organizationName=@organization.name
+          date=this.formattedCurrentDate
+        }}
       >
         {{t
           "pages.preselect-target-profile.download"

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
+import moment from 'moment';
 import Component from '@glimmer/component';
 
 export default class TubeList extends Component {
@@ -21,6 +22,10 @@ export default class TubeList extends Component {
 
   get fileSize() {
     return (this.file.size / 1024).toFixed(2);
+  }
+
+  get formattedCurrentDate() {
+    return moment().format('YYYY-MM-DD-HHmm');
   }
 
   get downloadURL() {

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -1,7 +1,15 @@
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class PreselectTargetProfileRoute extends Route {
-  model() {
-    return this.store.query('area', {});
+  @service currentUser;
+
+  async model() {
+    const organization = this.currentUser.organization;
+    const areas = await this.store.query('area', {});
+    return {
+      organization,
+      areas,
+    };
   }
 }

--- a/orga/app/templates/authenticated/preselect-target-profile.hbs
+++ b/orga/app/templates/authenticated/preselect-target-profile.hbs
@@ -1,5 +1,5 @@
 {{page-title (t "pages.preselect-target-profile.title")}}
 
 <article class="preselect-target-profile">
-  <Tube::List @areas={{@model}} />
+  <Tube::List @areas={{this.model.areas}} @organization={{this.model.organization}} />
 </article>

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -616,9 +616,9 @@
       }
     },
     "preselect-target-profile": {
-      "no-tube-selected": "Download topics selection (JSON, { fileSize }kb)",
-      "download": "Download topics selection ({ numberOfTubesSelected }) (JSON, { fileSize }kb)",
-      "download-filename": "topic-selection.json",
+      "no-tube-selected": "Download topics selection (JSON, { fileSize }kB)",
+      "download": "Download topics selection ({ numberOfTubesSelected }) (JSON, { fileSize }kB)",
+      "download-filename": "topic-selection-{ organizationName }-{ date }.json",
       "title": "Topic selection",
       "table": {
         "caption": "Topic selection",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -618,7 +618,7 @@
     "preselect-target-profile": {
       "no-tube-selected": "Télécharger la sélection des sujets (JSON, { fileSize }ko)",
       "download": "Télécharger la sélection des sujets ({ numberOfTubesSelected }) (JSON, { fileSize }ko)",
-      "download-filename": "selection-sujets.json",
+      "download-filename": "selection-sujets-{ organizationName }-{ date }.json",
       "title": "Sélection des sujets",
       "table": {
         "caption": "Sélection des sujets",


### PR DESCRIPTION
## :unicorn: Problème
Le fichier généré lors de l'extraction de sujets possédait toujours le même nom ce qui pouvait poser problème pour différencier les fichiers.

## :robot: Solution
Ajouter dans le nom du fichier le nom de l'organisation et la date.

## :100: Pour tester
Aller sur la page /selection-sujets et télécharger le fichier.