### PR TITLE
[TECH] Remonter toutes les violations de lint.

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -22,7 +22,7 @@
     "build:uncached:assets": "cp dist/assets/pix-admin-*.css dist/assets/pix-admin.uncached.css && cp dist/assets/vendor-*.css dist/assets/vendor.uncached.css",
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint . --cache --cache-strategy content",
     "lint:js:uncached": "eslint .",

--- a/api/package.json
+++ b/api/package.json
@@ -125,7 +125,7 @@
     "db:prepare": "npm run db:delete && npm run db:create && npm run db:migrate",
     "db:seed": "knex --knexfile db/knexfile.js seed:run",
     "db:reset": "npm run db:prepare && npm run db:seed",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:dependencies": "depcheck",
     "lint:database": "NODE_ENV=test npm run db:prepare && schemalint --config tests/acceptance/database/configuration.js",
     "lint:file-and-directory-names": "ls-lint",

--- a/certif/package.json
+++ b/certif/package.json
@@ -25,7 +25,7 @@
     "build:uncached:assets": "cp dist/assets/pix-certif-*.css dist/assets/pix-certif.uncached.css && cp dist/assets/vendor-*.css dist/assets/vendor.uncached.css",
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint . --cache --cache-strategy content",
     "lint:js:uncached": "eslint .",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember server",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint . --cache --cache-strategy content",
     "lint:js:uncached": "eslint .",

--- a/orga/package.json
+++ b/orga/package.json
@@ -25,7 +25,7 @@
     "build:uncached:assets": "cp dist/assets/pix-orga-*.css dist/assets/pix-orga.uncached.css && cp dist/assets/vendor-*.css dist/assets/vendor.uncached.css",
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:js": "eslint . --cache --cache-strategy content",
     "lint:js:uncached": "eslint .",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
## :unicorn: Problème
Les commandes de lint js/scss/hbs... sont lancées en parallèle. Par contre le lint se stoppe dès la première erreur, donc on peut penser avoir une erreur sur un seul des types de lint alors qu'en réalité d'autres peuvent en avoir.

## :robot: Solution
Utiliser le paramètre [`--continue-on-error` de `npm-run-all`](https://github.com/mysticatea/npm-run-all/blob/master/docs/npm-run-all.md) qui permet de terminer les commandes avant de rejeter une erreur en sortie de la commande.

## :rainbow: Remarques
RAS

## :100: Pour tester
En local : faire des erreurs de lint sur différents types de fichiers et constater qu'elles ressortent toutes d'un coup par rapport à ce qu'on avait avant.
