### PR TITLE
[FEATURE] Mettre à jour la durée de conservation des documents sur la page de finalisation d'une session (PIX-4356)

### DIFF
--- a/certif/app/components/session-finalization/formbuilder-link-step.hbs
+++ b/certif/app/components/session-finalization/formbuilder-link-step.hbs
@@ -12,7 +12,7 @@
   </div>
   <p class="session-finalization-formbuilder-link-step__sub-text">
     Il n'est plus obligatoire de nous transmettre la feuille d'émargement et le PV d'incident scannés. En revanche, ces
-    deux documents doivent être conservés par votre établissement pendant une durée de 2 ans et pouvoir être fournis à
+    deux documents doivent être conservés par votre établissement pendant une durée de 5 ans et pouvoir être fournis à
     Pix en cas de besoin.
   </p>
 </div>

--- a/certif/tests/integration/components/formbuilder-link-step_test.js
+++ b/certif/tests/integration/components/formbuilder-link-step_test.js
@@ -20,10 +20,9 @@ module('Integration | Component | SessionFinalization::FormbuilderLinkStep', fun
       "Cette étape, facultative, vous permet de nous transmettre tout document que vous jugerez utile de nous communiquer pour le traitement des sessions (capture d'écran d'un problème technique, PV de fraude...). Pour cela, suivez ce lien"
     );
     assert.contains(
-      "Il n'est plus obligatoire de nous transmettre la feuille d'émargement et le PV d'incident scannés. En revanche, ces deux documents doivent être conservés par votre établissement pendant une durée de 2 ans et pouvoir être fournis à Pix en cas de besoin."
+      "Il n'est plus obligatoire de nous transmettre la feuille d'émargement et le PV d'incident scannés. En revanche, ces deux documents doivent être conservés par votre établissement pendant une durée de 5 ans et pouvoir être fournis à Pix en cas de besoin."
     );
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(this.element.querySelector('a').getAttribute('href'), formBuilderLinkUrl);
+
+    assert.strictEqual(this.element.querySelector('a').getAttribute('href'), formBuilderLinkUrl);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cahier des charges des centres de certification Pix, il est demandé aux centres de conserver tous les documents liés à une session de certification (feuille d'émargement, PV d’incident) pendant un certain nombre d’années. 

Si cette durée de conservation était de 2 ans auparavant, elle est passée à 5 ans lors d’une mise à jour du cahier des charges. Mais cette durée, qui apparait également sur la page de finalisation d’une session, est restée à 2 ans  sur cette page ce qui créé une incohérence pour nos utilisateurs.

## :robot: Solution
Mettre à jour la durée de conservation des documents sur la page de finalisation de session dans Pix Certif > Etape 2 pour 5 ans (au lieu de 2 ans) 


## :100: Pour tester

- Constater lors de la finalisation d'une session que la durée de conservation des documents est passée de 2 à 5 ans

![image](https://user-images.githubusercontent.com/37305474/153382037-11aecc3e-f735-4cd4-b09e-56346e2ee439.png)

