### PR TITLE
[FEATURE] Ne pas afficher les informations relatives aux cases de fin de test dans Pix Admin pour une session effectuée avec l'espace surveillant (PIX-4224).

### DIFF
--- a/admin/app/components/certifications/list.js
+++ b/admin/app/components/certifications/list.js
@@ -1,59 +1,64 @@
 import Component from '@glimmer/component';
 
 export default class CertificationList extends Component {
-  columns = [
-    {
-      propertyName: 'id',
-      title: 'Id',
-      routeName: 'authenticated.certifications.certification.informations',
-      sortPrecedence: 1,
-    },
-    {
-      propertyName: 'firstName',
-      title: 'Prénom',
-    },
-    {
-      propertyName: 'lastName',
-      title: 'Nom',
-    },
-    {
-      propertyName: 'Statut',
-      component: 'certifications/status',
-    },
+  get columns() {
+    const columns = [
+      {
+        propertyName: 'id',
+        title: 'Id',
+        routeName: 'authenticated.certifications.certification.informations',
+        sortPrecedence: 1,
+      },
+      {
+        propertyName: 'firstName',
+        title: 'Prénom',
+      },
+      {
+        propertyName: 'lastName',
+        title: 'Nom',
+      },
+      {
+        propertyName: 'Statut',
+        component: 'certifications/status',
+      },
 
-    {
-      propertyName: 'numberOfCertificationIssueReportsWithRequiredActionLabel',
-      title: 'Signalements impactants non résolus',
-      className: 'certification-list-page__cell--important',
-    },
-    {
-      propertyName: 'hasSeenEndTestScreenLabel',
-      title: 'Ecran de fin de test vu',
-      className: 'certification-list-page__cell--important',
-    },
-    {
-      propertyName: 'complementaryCertificationsLabel',
-      title: 'Autres certifications',
-    },
-    {
-      propertyName: 'pixScore',
-      title: 'Score',
-    },
-    {
-      propertyName: 'creationDate',
-      title: 'Début',
-    },
-    {
-      propertyName: 'completionDate',
-      title: 'Fin',
-    },
-    {
-      component: 'certifications/info-published',
-      useFilter: false,
-      mayBeHidden: false,
-      title: 'Publiée',
-    },
-  ];
+      {
+        propertyName: 'numberOfCertificationIssueReportsWithRequiredActionLabel',
+        title: 'Signalements impactants non résolus',
+        className: 'certification-list-page__cell--important',
+      },
+      {
+        propertyName: 'complementaryCertificationsLabel',
+        title: 'Autres certifications',
+      },
+      {
+        propertyName: 'pixScore',
+        title: 'Score',
+      },
+      {
+        propertyName: 'creationDate',
+        title: 'Début',
+      },
+      {
+        propertyName: 'completionDate',
+        title: 'Fin',
+      },
+      {
+        component: 'certifications/info-published',
+        useFilter: false,
+        mayBeHidden: false,
+        title: 'Publiée',
+      },
+    ];
+    if (this.args.displayHasSeenEndTestScreenColumn) {
+      columns.splice(5, 0, {
+        propertyName: 'hasSeenEndTestScreenLabel',
+        title: 'Ecran de fin de test vu',
+        className: 'certification-list-page__cell--important',
+      });
+    }
+    return columns;
+  }
 
   pageValues = [10, 25, 50];
 }

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -126,6 +126,11 @@ export default class Session extends Model {
     return statusToDisplayName[this.status];
   }
 
+  @computed('hasSupervisorAccess')
+  get displayHasSeenEndTestScreenColumn() {
+    return !this.hasSupervisorAccess;
+  }
+
   getDownloadLink = memberAction({
     path: 'generate-results-download-link',
     type: 'get',

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -44,6 +44,7 @@ export default class Session extends Model {
   @attr() publishedAt;
   @attr() juryComment;
   @attr() juryCommentedAt;
+  @attr('boolean') hasSupervisorAccess;
 
   @hasMany('jury-certification-summary') juryCertificationSummaries;
   @belongsTo('user') assignedCertificationOfficer;

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -30,7 +30,10 @@
     </header>
 
     <div>
-      <Certifications::List @certifications={{this.model.juryCertificationSummaries}} />
+      <Certifications::List
+        @certifications={{this.model.juryCertificationSummaries}}
+        @displayHasSeenEndTestScreenColumn={{this.model.displayHasSeenEndTestScreenColumn}}
+      />
     </div>
   </div>
 </section>

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -85,13 +85,15 @@
             data-test-id="session-info__number-of-issue-report"
           >{{this.sessionModel.countCertificationIssueReports}}</div>
         </div>
-        <div class="row">
-          <div class="col">Nombre d'écrans de fin de test non renseignés :</div>
-          <div
-            class="col"
-            data-test-id="session-info__number-of-not-checked-end-screen"
-          >{{this.sessionModel.countNotCheckedEndScreen}}</div>
-        </div>
+        {{#unless this.sessionModel.hasSupervisorAccess}}
+          <div class="row">
+            <div class="col">Nombre d'écrans de fin de test non renseignés :</div>
+            <div
+              class="col"
+              data-test-id="session-info__number-of-not-checked-end-screen"
+            >{{this.sessionModel.countNotCheckedEndScreen}}</div>
+          </div>
+        {{/unless}}
         <div class="row">
           <div class="col">Certifications non terminées traitées automatiquement :</div>
           <div

--- a/admin/tests/integration/components/certifications/list_test.js
+++ b/admin/tests/integration/components/certifications/list_test.js
@@ -1,9 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
-import EmberObject from '@ember/object';
 
 module('Integration | Component | certifications/list', function (hooks) {
   setupRenderingTest(hooks);
@@ -16,20 +14,27 @@ module('Integration | Component | certifications/list', function (hooks) {
 
   test('should display many certifications', async function (assert) {
     // given
-    this.certifications = [EmberObject.create({ id: 1 }), EmberObject.create({ id: 2 }), EmberObject.create({ id: 3 })];
+    this.certifications = [
+      store.createRecord('jury-certification-summary', { id: 1 }),
+      store.createRecord('jury-certification-summary', { id: 2 }),
+      store.createRecord('jury-certification-summary', { id: 3 }),
+    ];
 
     // when
     await render(hbs`<Certifications::List @certifications={{certifications}} />`);
 
     const $tableRows = this.element.querySelectorAll('tbody > tr');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal($tableRows.length, 3);
+    assert.strictEqual($tableRows.length, 3);
   });
 
   test('should display number of certification issue reports with required action', async function (assert) {
     // given
-    this.certifications = [EmberObject.create({ id: 1, numberOfCertificationIssueReportsWithRequiredActionLabel: 2 })];
+    this.certifications = [
+      store.createRecord('jury-certification-summary', {
+        id: 1,
+        numberOfCertificationIssueReportsWithRequiredActionLabel: 2,
+      }),
+    ];
 
     // when
     await render(hbs`<Certifications::List @certifications={{certifications}} />`);
@@ -41,12 +46,10 @@ module('Integration | Component | certifications/list', function (hooks) {
 
   test('should display the complementary certifications if any', async function (assert) {
     // given
-    const juryCertificationSummaryProcessed = run(() => {
-      return store.createRecord('jury-certification-summary', {
-        cleaCertificationStatus: 'taken',
-        pixPlusDroitMaitreCertificationStatus: 'taken',
-        pixPlusDroitExpertCertificationStatus: 'not_taken',
-      });
+    const juryCertificationSummaryProcessed = store.createRecord('jury-certification-summary', {
+      cleaCertificationStatus: 'taken',
+      pixPlusDroitMaitreCertificationStatus: 'taken',
+      pixPlusDroitExpertCertificationStatus: 'not_taken',
     });
     this.certifications = [juryCertificationSummaryProcessed];
 
@@ -55,5 +58,41 @@ module('Integration | Component | certifications/list', function (hooks) {
 
     // then
     assert.contains('CléA Numérique Pix+ Droit Maître');
+  });
+
+  module('when displayHasSeenEndTestScreenColumn is true', function () {
+    test('it should display the "Ecran de fin de test vu" column', async function (assert) {
+      // given
+      const juryCertificationSummaryProcessed = store.createRecord('jury-certification-summary', {
+        hasSeenEndTestScreen: true,
+      });
+      this.certifications = [juryCertificationSummaryProcessed];
+
+      // when
+      await render(
+        hbs`<Certifications::List @certifications={{certifications}} @displayHasSeenEndTestScreenColumn={{true}}/>`
+      );
+
+      // then
+      assert.contains('Ecran de fin de test vu');
+    });
+  });
+
+  module('when displayHasSeenEndTestScreenColumn is false', function () {
+    test('it should not display the "Ecran de fin de test vu" column', async function (assert) {
+      // given
+      const juryCertificationSummaryProcessed = store.createRecord('jury-certification-summary', {
+        hasSeenEndTestScreen: true,
+      });
+      this.certifications = [juryCertificationSummaryProcessed];
+
+      // when
+      await render(
+        hbs`<Certifications::List @certifications={{certifications}} @displayHasSeenEndTestScreenColumn={{false}}/>`
+      );
+
+      // then
+      assert.notContains('Ecran de fin de test vu');
+    });
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -28,9 +28,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/sessions/${session.id}`);
+      assert.strictEqual(currentURL(), `/sessions/${session.id}`);
       assert.dom('.session-info__details div:nth-child(1) div:last-child').hasText(session.certificationCenterName);
       assert
         .dom('.session-info__details div:nth-child(1) div:last-child a')
@@ -57,12 +55,8 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('[data-test-id="session-info__examiner-comment"]'), undefined);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('[data-test-id="session-info__number-of-not-checked-end-screen"]'), undefined);
+      assert.strictEqual(find('[data-test-id="session-info__examiner-comment"]'), null);
+      assert.strictEqual(find('[data-test-id="session-info__number-of-not-checked-end-screen"]'), null);
     });
 
     test('it does not render the "M\'assigner la session" button', async function (assert) {
@@ -116,6 +110,19 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       assert.dom('[data-test-id="session-info__number-of-started-or-error-certifications"]').hasText('0');
     });
 
+    module('when the session has supervisor access', function () {
+      test('it should not display the number of not checked end test screens', async function (assert) {
+        // given
+        session.update({ hasSupervisorAccess: true });
+
+        // when
+        await visit(`/sessions/${session.id}`);
+
+        // when
+        assert.notContains("Nombre d'écrans de fin de test non renseignés");
+      });
+    });
+
     test('it renders the examinerGlobalComment if any', async function (assert) {
       // when
       await visit(`/sessions/${session.id}`);
@@ -132,9 +139,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('[data-test-id="session-info__examiner-comment"]'), undefined);
+      assert.strictEqual(find('[data-test-id="session-info__examiner-comment"]'), null);
     });
 
     module('when results have not yet been sent to prescriber', function () {
@@ -149,9 +154,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         const buttonSendResultsToCandidates = this.element.querySelector(
           '.session-info__actions .row button:nth-child(3)'
         );
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(buttonSendResultsToCandidates.innerHTML.trim(), 'Résultats transmis au prescripteur');
+        assert.strictEqual(buttonSendResultsToCandidates.innerHTML.trim(), 'Résultats transmis au prescripteur');
       });
     });
 

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -433,4 +433,28 @@ module('Unit | Model | session', function (hooks) {
       });
     });
   });
+
+  module('#displayHasSeenEndTestScreenColumn', function () {
+    test('should display false when hasSupervisorAccess is true', function (assert) {
+      // given
+      const session = store.createRecord('session', { hasSupervisorAccess: true });
+
+      // when
+      const displayHasSeenEndTestScreenColumn = session.displayHasSeenEndTestScreenColumn;
+
+      // then
+      assert.false(displayHasSeenEndTestScreenColumn);
+    });
+
+    test('should display true when hasSupervisorAccess is false', function (assert) {
+      // given
+      const session = store.createRecord('session', { hasSupervisorAccess: false });
+
+      // when
+      const displayHasSeenEndTestScreenColumn = session.displayHasSeenEndTestScreenColumn;
+
+      // then
+      assert.true(displayHasSeenEndTestScreenColumn);
+    });
+  });
 });

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -176,15 +176,11 @@ module('Unit | Model | session', function (hooks) {
     });
 
     test('it should count 6 certification issue reports', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionWithCertificationIssueReports.countCertificationIssueReports, 6);
+      assert.strictEqual(sessionWithCertificationIssueReports.countCertificationIssueReports, 6);
     });
 
     test('it should count 0 certification issue report', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionWithoutCertificationIssueReport.countCertificationIssueReports, 0);
+      assert.strictEqual(sessionWithoutCertificationIssueReport.countCertificationIssueReports, 0);
     });
   });
 
@@ -212,15 +208,11 @@ module('Unit | Model | session', function (hooks) {
     });
 
     test('it should count 6 certification issue reports ', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionWithCertificationIssueReports.countCertificationIssueReportsWithActionRequired, 6);
+      assert.strictEqual(sessionWithCertificationIssueReports.countCertificationIssueReportsWithActionRequired, 6);
     });
 
     test('it should count 0 certification issue report ', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionWithoutCertificationIssueReport.countCertificationIssueReportsWithActionRequired, 0);
+      assert.strictEqual(sessionWithoutCertificationIssueReport.countCertificationIssueReportsWithActionRequired, 0);
     });
   });
 
@@ -242,16 +234,12 @@ module('Unit | Model | session', function (hooks) {
 
     test('it should count 1 unchecked box if only one box (unchecked)', function (assert) {
       const countNotCheckedEndScreen = sessionWithOneUncheckedEndScreen.countNotCheckedEndScreen;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countNotCheckedEndScreen, 1);
+      assert.strictEqual(countNotCheckedEndScreen, 1);
     });
 
     test('it should count 0 unchecked box if only one box (checked)', function (assert) {
       const countNotCheckedEndScreen = sessionWithOneCheckedEndScreen.countNotCheckedEndScreen;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countNotCheckedEndScreen, 0);
+      assert.strictEqual(countNotCheckedEndScreen, 0);
     });
   });
 
@@ -269,9 +257,7 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countStartedAndInErrorCertifications, 1);
+      assert.strictEqual(countStartedAndInErrorCertifications, 1);
     });
 
     test('it should take into account in error certifications', function (assert) {
@@ -287,9 +273,7 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countStartedAndInErrorCertifications, 1);
+      assert.strictEqual(countStartedAndInErrorCertifications, 1);
     });
 
     test('it should ignore validated certifications', function (assert) {
@@ -305,9 +289,7 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countStartedAndInErrorCertifications, 0);
+      assert.strictEqual(countStartedAndInErrorCertifications, 0);
     });
 
     test('it should ignore rejected certifications', function (assert) {
@@ -323,9 +305,7 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countStartedAndInErrorCertifications, 0);
+      assert.strictEqual(countStartedAndInErrorCertifications, 0);
     });
 
     test('it should ignore cancelled certifications', function (assert) {
@@ -341,9 +321,7 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countStartedAndInErrorCertifications, 0);
+      assert.strictEqual(countStartedAndInErrorCertifications, 0);
     });
 
     test('it should return a sum of started and in error certifications', function (assert) {
@@ -367,9 +345,7 @@ module('Unit | Model | session', function (hooks) {
       const countStartedAndInErrorCertifications = session.countStartedAndInErrorCertifications;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countStartedAndInErrorCertifications, 3);
+      assert.strictEqual(countStartedAndInErrorCertifications, 3);
     });
   });
 
@@ -385,9 +361,7 @@ module('Unit | Model | session', function (hooks) {
       const countCertificationsFlaggedAsAborted = session.countCertificationsFlaggedAsAborted;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(countCertificationsFlaggedAsAborted, 1);
+      assert.strictEqual(countCertificationsFlaggedAsAborted, 1);
     });
   });
 
@@ -429,9 +403,7 @@ module('Unit | Model | session', function (hooks) {
         const displayStatus = session.displayStatus;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(displayStatus, 'Créée');
+        assert.strictEqual(displayStatus, 'Créée');
       });
     });
 
@@ -444,9 +416,7 @@ module('Unit | Model | session', function (hooks) {
         const displayStatus = session.displayStatus;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(displayStatus, 'Finalisée');
+        assert.strictEqual(displayStatus, 'Finalisée');
       });
     });
 
@@ -459,9 +429,7 @@ module('Unit | Model | session', function (hooks) {
         const displayStatus = session.displayStatus;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(displayStatus, 'Résultats transmis par Pix');
+        assert.strictEqual(displayStatus, 'Résultats transmis par Pix');
       });
     });
   });

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -37,7 +37,7 @@ module.exports = {
 
   async getJurySession(request) {
     const sessionId = request.params.id;
-    const jurySession = await usecases.getJurySession({ sessionId });
+    const { jurySession } = await usecases.getJurySession({ sessionId });
 
     return jurySessionSerializer.serialize(jurySession);
   },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -37,9 +37,9 @@ module.exports = {
 
   async getJurySession(request) {
     const sessionId = request.params.id;
-    const { jurySession } = await usecases.getJurySession({ sessionId });
+    const { jurySession, hasSupervisorAccess } = await usecases.getJurySession({ sessionId });
 
-    return jurySessionSerializer.serialize(jurySession);
+    return jurySessionSerializer.serialize(jurySession, hasSupervisorAccess);
   },
 
   async get(request) {

--- a/api/lib/domain/usecases/get-jury-session.js
+++ b/api/lib/domain/usecases/get-jury-session.js
@@ -1,3 +1,8 @@
-module.exports = function getJurySession({ sessionId, jurySessionRepository }) {
-  return jurySessionRepository.get(sessionId);
+module.exports = async function getJurySession({ sessionId, jurySessionRepository, supervisorAccessRepository }) {
+  const jurySession = await jurySessionRepository.get(sessionId);
+  const hasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({ sessionId });
+  return {
+    jurySession,
+    hasSupervisorAccess,
+  };
 };

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -3,10 +3,10 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serializeForPaginatedList(jurySessionsForPaginatedList) {
     const { jurySessions, pagination } = jurySessionsForPaginatedList;
-    return this.serialize(jurySessions, pagination);
+    return this.serialize(jurySessions, undefined, pagination);
   },
 
-  serialize(jurySessions, meta) {
+  serialize(jurySessions, hasSupervisorAccess, meta) {
     return new Serializer('sessions', {
       attributes: [
         'certificationCenterName',
@@ -28,6 +28,7 @@ module.exports = {
         'juryComment',
         'juryCommentAuthorId',
         'juryCommentedAt',
+        'hasSupervisorAccess',
         // included
         'assignedCertificationOfficer',
         'juryCommentAuthor',
@@ -57,6 +58,9 @@ module.exports = {
       transform(jurySession) {
         const transformedJurySession = Object.assign({}, jurySession);
         transformedJurySession.status = jurySession.status;
+        if (hasSupervisorAccess !== undefined) {
+          transformedJurySession.hasSupervisorAccess = hasSupervisorAccess;
+        }
         return transformedJurySession;
       },
       typeForAttribute: function (attribute) {

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Controller | session-controller-get-jury-session', functi
         certificationCenterId: certificationCenter.id,
         certificationCenter: certificationCenter.name,
       });
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId: expectedJurySession.id });
       databaseBuilder.factory.buildSession();
       options = {
         method: 'GET',
@@ -73,6 +74,7 @@ describe('Acceptance | Controller | session-controller-get-jury-session', functi
           expectedJurySession.resultsSentToPrescriberAt
         );
         expect(response.result.data.attributes['published-at']).to.equal(expectedJurySession.publishedAt);
+        expect(response.result.data.attributes['has-supervisor-access']).to.be.true;
         expect(parseInt(response.result.included[0].id)).to.equal(expectedJurySession.assignedCertificationOfficerId);
         expect(response.result.included[0].attributes['first-name']).to.equal('Pix');
         expect(response.result.included[0].attributes['last-name']).to.equal('Doe');

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -119,7 +119,7 @@ describe('Unit | Controller | sessionController', function () {
         // given
         const foundJurySession = Symbol('foundSession');
         const serializedJurySession = Symbol('serializedSession');
-        usecases.getJurySession.withArgs({ sessionId }).resolves(foundJurySession);
+        usecases.getJurySession.withArgs({ sessionId }).resolves({ jurySession: foundJurySession });
         jurySessionSerializer.serialize.withArgs(foundJurySession).resolves(serializedJurySession);
 
         // when

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -119,8 +119,11 @@ describe('Unit | Controller | sessionController', function () {
         // given
         const foundJurySession = Symbol('foundSession');
         const serializedJurySession = Symbol('serializedSession');
-        usecases.getJurySession.withArgs({ sessionId }).resolves({ jurySession: foundJurySession });
-        jurySessionSerializer.serialize.withArgs(foundJurySession).resolves(serializedJurySession);
+        const hasSupervisorAccess = true;
+        usecases.getJurySession
+          .withArgs({ sessionId })
+          .resolves({ jurySession: foundJurySession, hasSupervisorAccess });
+        jurySessionSerializer.serialize.withArgs(foundJurySession, hasSupervisorAccess).resolves(serializedJurySession);
 
         // when
         const response = await sessionController.getJurySession(request, hFake);

--- a/api/tests/unit/domain/usecases/get-jury-session_test.js
+++ b/api/tests/unit/domain/usecases/get-jury-session_test.js
@@ -1,9 +1,8 @@
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const getJurySession = require('../../../../lib/domain/usecases/get-jury-session');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-jury-session', function () {
-  const sessionId = 'sessionId';
   let jurySessionRepository;
 
   beforeEach(function () {
@@ -13,29 +12,26 @@ describe('Unit | UseCase | get-jury-session', function () {
   });
 
   context('when the session exists', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const sessionToFind = Symbol('sessionToFind');
-
-    beforeEach(function () {
-      jurySessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
-    });
-
     it('should get the session', async function () {
+      // given
+      const sessionId = 123;
+      const sessionToFind = domainBuilder.buildJurySession({ id: sessionId });
+      jurySessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+
       // when
       const actualSession = await getJurySession({ sessionId, jurySessionRepository });
 
       // then
-      expect(actualSession).to.equal(sessionToFind);
+      expect(actualSession).to.deepEqualInstance(sessionToFind);
     });
   });
 
   context('when the session does not exist', function () {
-    beforeEach(function () {
-      jurySessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
-    });
-
     it('should throw an error the session', async function () {
+      // given
+      const sessionId = 123;
+      jurySessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
+
       // when
       const err = await catchErr(getJurySession)({ sessionId, jurySessionRepository });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -15,7 +15,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
       serializer.serializeForPaginatedList(parameter);
 
       // then
-      expect(serializer.serialize).to.have.been.calledWithExactly(jurySessions, pagination);
+      expect(serializer.serialize).to.have.been.calledWithExactly(jurySessions, undefined, pagination);
       serializer.serialize = restore;
     });
   });
@@ -178,6 +178,77 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               attributes: { 'first-name': 'Phil', 'last-name': 'Hippo' },
             },
           ],
+        };
+        expect(json).to.deep.equal(expectedJsonAPI);
+      });
+    });
+
+    context('when the session has supervisor access', function () {
+      it('should convert a Session model object into JSON API data with hasSupervisorAccess', function () {
+        // given
+        const hasSupervisorAccess = true;
+        const session = domainBuilder.buildJurySession({
+          id: 1,
+          certificationCenterName: 'someCenterName',
+          certificationCenterType: 'someCenterType',
+          certificationCenterId: 'someCenterId',
+          certificationCenterExternalId: 'someCenterExternalId',
+          address: 'someAddress',
+          room: 'someRoom',
+          examiner: 'someExaminer',
+          date: '2017-01-20',
+          time: '14:30',
+          accessCode: 'someAccessCode',
+          description: 'someDescription',
+          examinerGlobalComment: 'someComment',
+          finalizedAt: new Date('2020-02-17T14:23:56Z'),
+          resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
+          publishedAt: new Date('2020-02-21T14:23:56Z'),
+        });
+
+        // when
+        const json = serializer.serialize(session, hasSupervisorAccess);
+
+        // then
+        const expectedJsonAPI = {
+          data: {
+            type: 'sessions',
+            id: '1',
+            attributes: {
+              'certification-center-name': 'someCenterName',
+              'certification-center-type': 'someCenterType',
+              'certification-center-id': 'someCenterId',
+              'certification-center-external-id': 'someCenterExternalId',
+              address: 'someAddress',
+              room: 'someRoom',
+              examiner: 'someExaminer',
+              date: '2017-01-20',
+              time: '14:30',
+              'access-code': 'someAccessCode',
+              status: 'processed',
+              description: 'someDescription',
+              'examiner-global-comment': 'someComment',
+              'finalized-at': new Date('2020-02-17T14:23:56Z'),
+              'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
+              'published-at': new Date('2020-02-21T14:23:56Z'),
+              'jury-comment': null,
+              'jury-commented-at': null,
+              'has-supervisor-access': true,
+            },
+            relationships: {
+              'jury-certification-summaries': {
+                links: {
+                  related: '/api/admin/sessions/1/jury-certification-summaries',
+                },
+              },
+              'assigned-certification-officer': {
+                data: null,
+              },
+              'jury-comment-author': {
+                data: null,
+              },
+            },
+          },
         };
         expect(json).to.deep.equal(expectedJsonAPI);
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect, sinon } = require('../../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-session-serializer');
 
 describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
@@ -21,150 +21,235 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
   });
 
   describe('#serialize()', function () {
-    let modelSession;
-
-    beforeEach(function () {
-      modelSession = {
-        id: 1,
-        certificationCenterName: 'someCenterName',
-        certificationCenterType: 'someCenterType',
-        certificationCenterId: 'someCenterId',
-        certificationCenterExternalId: 'someCenterExternalId',
-        address: 'someAddress',
-        room: 'someRoom',
-        examiner: 'someExaminer',
-        date: '2017-01-20',
-        time: '14:30',
-        accessCode: 'someAccessCode',
-        status: 'someStatus',
-        description: 'someDescription',
-        examinerGlobalComment: 'someComment',
-        finalizedAt: new Date('2020-02-17T14:23:56Z'),
-        resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
-        publishedAt: new Date('2020-02-21T14:23:56Z'),
-        juryComment: 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
-        juryCommentedAt: new Date('2021-02-21T14:23:56Z'),
-      };
-    });
-
     context('when there is an assigned certification officer', function () {
       it('should convert a Session model object into JSON API data with included officer', function () {
         // given
-        const expectedResult = _buildExpectedJsonAPI(
-          [
+        const assignedCertificationOfficer = domainBuilder.buildCertificationOfficer({
+          id: 2,
+          firstName: 'Jean',
+          lastName: 'de la Flûte',
+        });
+        const session = domainBuilder.buildJurySession({
+          id: 1,
+          certificationCenterName: 'someCenterName',
+          certificationCenterType: 'someCenterType',
+          certificationCenterId: 'someCenterId',
+          certificationCenterExternalId: 'someCenterExternalId',
+          address: 'someAddress',
+          room: 'someRoom',
+          examiner: 'someExaminer',
+          date: '2017-01-20',
+          time: '14:30',
+          accessCode: 'someAccessCode',
+          description: 'someDescription',
+          examinerGlobalComment: 'someComment',
+          finalizedAt: new Date('2020-02-17T14:23:56Z'),
+          assignedCertificationOfficer,
+        });
+
+        // when
+        const json = serializer.serialize(session);
+
+        // then
+        const expectedJsonAPI = {
+          data: {
+            type: 'sessions',
+            id: '1',
+            attributes: {
+              'certification-center-name': 'someCenterName',
+              'certification-center-type': 'someCenterType',
+              'certification-center-id': 'someCenterId',
+              'certification-center-external-id': 'someCenterExternalId',
+              address: 'someAddress',
+              room: 'someRoom',
+              examiner: 'someExaminer',
+              date: '2017-01-20',
+              time: '14:30',
+              'access-code': 'someAccessCode',
+              status: 'in_process',
+              description: 'someDescription',
+              'examiner-global-comment': 'someComment',
+              'finalized-at': new Date('2020-02-17T14:23:56Z'),
+              'published-at': null,
+              'results-sent-to-prescriber-at': null,
+              'jury-comment': null,
+              'jury-commented-at': null,
+            },
+            relationships: {
+              'jury-certification-summaries': {
+                links: {
+                  related: '/api/admin/sessions/1/jury-certification-summaries',
+                },
+              },
+              'jury-comment-author': {
+                data: null,
+              },
+              'assigned-certification-officer': {
+                data: { id: '2', type: 'user' },
+              },
+            },
+          },
+          included: [
             {
               type: 'user',
               id: '2',
               attributes: { 'first-name': 'Jean', 'last-name': 'de la Flûte' },
             },
           ],
-          {
-            'assigned-certification-officer': {
-              data: { id: '2', type: 'user' },
-            },
-          }
-        );
-        modelSession.assignedCertificationOfficer = {
-          id: 2,
-          firstName: 'Jean',
-          lastName: 'de la Flûte',
         };
-
-        // when
-        const json = serializer.serialize(modelSession, { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 });
-
-        // then
-        expect(json).to.deep.equal(expectedResult);
+        expect(json).to.deep.equal(expectedJsonAPI);
       });
     });
 
     context('when there is a jury comment', function () {
       it('should convert a Session model object into JSON API data with included comment', function () {
         // given
-        const expectedResult = _buildExpectedJsonAPI(
-          [
+        const juryCommentAuthor = domainBuilder.buildCertificationOfficer({
+          id: 3,
+          firstName: 'Phil',
+          lastName: 'Hippo',
+        });
+        const session = domainBuilder.buildJurySession({
+          id: 1,
+          certificationCenterName: 'someCenterName',
+          certificationCenterType: 'someCenterType',
+          certificationCenterId: 'someCenterId',
+          certificationCenterExternalId: 'someCenterExternalId',
+          address: 'someAddress',
+          room: 'someRoom',
+          examiner: 'someExaminer',
+          date: '2017-01-20',
+          time: '14:30',
+          accessCode: 'someAccessCode',
+          description: 'someDescription',
+          examinerGlobalComment: 'someComment',
+          finalizedAt: new Date('2020-02-17T14:23:56Z'),
+          juryComment: 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
+          juryCommentedAt: new Date('2021-02-21T14:23:56Z'),
+          juryCommentAuthor,
+        });
+
+        // when
+        const json = serializer.serialize(session);
+
+        // then
+        const expectedJsonAPI = {
+          data: {
+            type: 'sessions',
+            id: '1',
+            attributes: {
+              'certification-center-name': 'someCenterName',
+              'certification-center-type': 'someCenterType',
+              'certification-center-id': 'someCenterId',
+              'certification-center-external-id': 'someCenterExternalId',
+              address: 'someAddress',
+              room: 'someRoom',
+              examiner: 'someExaminer',
+              date: '2017-01-20',
+              time: '14:30',
+              'access-code': 'someAccessCode',
+              status: 'finalized',
+              description: 'someDescription',
+              'examiner-global-comment': 'someComment',
+              'finalized-at': new Date('2020-02-17T14:23:56Z'),
+              'results-sent-to-prescriber-at': null,
+              'published-at': null,
+              'jury-comment': 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
+              'jury-commented-at': new Date('2021-02-21T14:23:56Z'),
+            },
+            relationships: {
+              'jury-certification-summaries': {
+                links: {
+                  related: '/api/admin/sessions/1/jury-certification-summaries',
+                },
+              },
+              'assigned-certification-officer': {
+                data: null,
+              },
+              'jury-comment-author': {
+                data: { id: '3', type: 'user' },
+              },
+            },
+          },
+          included: [
             {
               type: 'user',
               id: '3',
               attributes: { 'first-name': 'Phil', 'last-name': 'Hippo' },
             },
           ],
-          {
-            'jury-comment-author': {
-              data: { id: '3', type: 'user' },
-            },
-          }
-        );
-
-        modelSession.juryCommentAuthor = {
-          id: 3,
-          firstName: 'Phil',
-          lastName: 'Hippo',
         };
-
-        // when
-        const json = serializer.serialize(modelSession, { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 });
-
-        // then
-        expect(json).to.deep.equal(expectedResult);
+        expect(json).to.deep.equal(expectedJsonAPI);
       });
     });
 
     context('when there is neither assigned certification officer nor jury comment', function () {
       it('should convert a Session model object into JSON API data', function () {
         // given
-        const expectedResult = _buildExpectedJsonAPI();
+        const session = domainBuilder.buildJurySession({
+          id: 1,
+          certificationCenterName: 'someCenterName',
+          certificationCenterType: 'someCenterType',
+          certificationCenterId: 'someCenterId',
+          certificationCenterExternalId: 'someCenterExternalId',
+          address: 'someAddress',
+          room: 'someRoom',
+          examiner: 'someExaminer',
+          date: '2017-01-20',
+          time: '14:30',
+          accessCode: 'someAccessCode',
+          description: 'someDescription',
+          examinerGlobalComment: 'someComment',
+          finalizedAt: new Date('2020-02-17T14:23:56Z'),
+          resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
+          publishedAt: new Date('2020-02-21T14:23:56Z'),
+        });
 
         // when
-        const json = serializer.serialize(modelSession, { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 });
+        const json = serializer.serialize(session);
 
         // then
-        expect(json).to.deep.equal(expectedResult);
+        const expectedJsonAPI = {
+          data: {
+            type: 'sessions',
+            id: '1',
+            attributes: {
+              'certification-center-name': 'someCenterName',
+              'certification-center-type': 'someCenterType',
+              'certification-center-id': 'someCenterId',
+              'certification-center-external-id': 'someCenterExternalId',
+              address: 'someAddress',
+              room: 'someRoom',
+              examiner: 'someExaminer',
+              date: '2017-01-20',
+              time: '14:30',
+              'access-code': 'someAccessCode',
+              status: 'processed',
+              description: 'someDescription',
+              'examiner-global-comment': 'someComment',
+              'finalized-at': new Date('2020-02-17T14:23:56Z'),
+              'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
+              'published-at': new Date('2020-02-21T14:23:56Z'),
+              'jury-comment': null,
+              'jury-commented-at': null,
+            },
+            relationships: {
+              'jury-certification-summaries': {
+                links: {
+                  related: '/api/admin/sessions/1/jury-certification-summaries',
+                },
+              },
+              'assigned-certification-officer': {
+                data: null,
+              },
+              'jury-comment-author': {
+                data: null,
+              },
+            },
+          },
+        };
+        expect(json).to.deep.equal(expectedJsonAPI);
       });
     });
   });
 });
-
-function _buildExpectedJsonAPI(included, relationships = {}) {
-  const expectedJsonAPI = {
-    data: {
-      type: 'sessions',
-      id: '1',
-      attributes: {
-        'certification-center-name': 'someCenterName',
-        'certification-center-type': 'someCenterType',
-        'certification-center-id': 'someCenterId',
-        'certification-center-external-id': 'someCenterExternalId',
-        address: 'someAddress',
-        room: 'someRoom',
-        examiner: 'someExaminer',
-        date: '2017-01-20',
-        time: '14:30',
-        'access-code': 'someAccessCode',
-        status: 'someStatus',
-        description: 'someDescription',
-        'examiner-global-comment': 'someComment',
-        'finalized-at': new Date('2020-02-17T14:23:56Z'),
-        'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
-        'published-at': new Date('2020-02-21T14:23:56Z'),
-        'jury-comment': 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
-        'jury-commented-at': new Date('2021-02-21T14:23:56Z'),
-      },
-      relationships: {
-        ...relationships,
-        'jury-certification-summaries': {
-          links: {
-            related: '/api/admin/sessions/1/jury-certification-summaries',
-          },
-        },
-      },
-    },
-    meta: { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 },
-  };
-
-  if (included) {
-    expectedJsonAPI.included = included;
-  }
-
-  return expectedJsonAPI;
-}


### PR DESCRIPTION
## :unicorn: Problème
L’espace surveillant permet de ne plus avoir à constater les écrans de FDT des candidats pour les surveillants. Donc nous avons retiré la colonne “Ecran de FDT vu” sur la page de finalisation d’une session. Une fois une session ayant utilisé l’espace surveillant finalisée, le pôle certif voit toujours les infos liées à la case de FDT dans Pix Admin pour cette session, ce qui n’est pas pertinent.

## :robot: Solution
- Cacher le champ "Nombre d'écrans de fin de test non renseignés" dans la page de détail d'une session.
- Retirer la colonne "Ecran de fin de test vu" dans la liste des certifications.

## :100: Pour tester
- Se connecter à Pix Admin
- Aller sur la session 5 (effectuée via  l'espace surveillant)
- Constater que le champ "Nombre d'écrans de fin de test non renseignés" n'est pas affiché
- Aller dans l'onglet "Certifications" et vérifier que la colonne "Ecran de fin de test vu" n'est pas affcihée
- Aller sur la session 6 (pas effectuée via  l'espace surveillant)
- Constater que les champs précédents sont présents.