### PR TITLE
[FEATURE] Mettre à jour le footer d'accessibilité de Pix Orga en "partiellement conforme" (PIX-4344).

### DIFF
--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -41,7 +41,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.dom(screen.getByText('Accessibilité : non conforme')).exists();
+    assert.dom(screen.getByText('Accessibilité : partiellement conforme')).exists();
     assert.dom('a[href="https://pix.fr/accessibilite-pix-orga"]').exists();
   });
 });

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -187,7 +187,7 @@
       "tooltip-text": "Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     },
     "footer": {
-      "a11y": "Accessibilité : non conforme",
+      "a11y": "Accessibilité : partiellement conforme",
       "copyrights": "©",
       "legal-notice": "Mentions légales",
       "pix": "Pix",


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'audit de Pix Orga, nous avons atteint les 50% d'accessibilité. Or actuellement, le footer de celui-ci indique que sommes toujours non conforme.

## :robot: Solution
Modifier le footer pour indiquer que nous sommes désormais "partiellement conforme".

## :rainbow: Remarques
Premier ticket fait en pair avec Emmy ❤️

## :100: Pour tester
Se connecter sur Pix Orga
Vérifier que le texte indique "partiellement conforme", il se trouve tout en bas de l'application à coté de "Mentions légales"
Rien ne change en anglais.
