### PR TITLE
[TECH] Permettre la gestion de la longueur max des réponses via variable d'env

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { NotFoundError } = require('../../domain/errors');
-const USER_ANSWERS_MAX_LENGTH = 500;
+const { features } = require('../../config');
 
 exports.register = async (server) => {
   server.route([
@@ -15,7 +15,7 @@ exports.register = async (server) => {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                value: Joi.string().max(USER_ANSWERS_MAX_LENGTH).allow('').allow(null),
+                value: Joi.string().max(features.userAnswersMaxLength).allow('').allow(null),
                 result: Joi.string().allow(null),
                 'result-details': Joi.string().allow(null),
                 timeout: Joi.number().allow(null),

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -159,6 +159,7 @@ module.exports = (function () {
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
+      userAnswersMaxLength: _getNumber(process.env.USER_ANSWERS_MAX_LENGTH, 500),
     },
 
     featureToggles: {

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -1,6 +1,7 @@
 const { expect, HttpTestServer, sinon } = require('../../../test-helper');
 const moduleUnderTest = require('../../../../lib/application/answers');
 const answerController = require('../../../../lib/application/answers/answer-controller');
+const { features } = require('../../../../lib/config');
 
 describe('Unit | Application | Router | answer-router', function () {
   describe('POST /api/answers', function () {
@@ -37,8 +38,7 @@ describe('Unit | Application | Router | answer-router', function () {
       sinon.stub(answerController, 'save').callsFake((request, h) => h.response().created());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
-      const USER_ANSWERS_MAX_LENGTH = 500;
-      const value = 'X'.repeat(USER_ANSWERS_MAX_LENGTH + 1);
+      const value = 'X'.repeat(features.userAnswersMaxLength + 1);
 
       const payload = {
         data: {


### PR DESCRIPTION
## :unicorn: Problème
Pour le moment si besoin de modifier la longueur max des réponses, il faut relivrer.

## :robot: Solution
Rendre modifiable ce nombre via variable d'environnement pour pouvoir la modifier au runtime.

## :rainbow: Remarques
See #3949

## :100: Pour tester
Mettre la variable d'env `USER_ANSWERS_MAX_LENGTH` dans la RA avec une valeur faible (< 10) et constater les erreurs 400.
