### PR TITLE
[BUGFIX] Sauvegarder l'identifiant externe du participant au démarrage de campagne (PIX-4366).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -33,6 +33,7 @@ async function _createNewCampaignParticipation(queryBuilder, campaignParticipati
         userId: campaignParticipation.userId,
         status: campaignParticipation.status,
         schoolingRegistrationId: campaignParticipation.schoolingRegistrationId,
+        participantExternalId: campaignParticipation.participantExternalId,
       })
       .returning('id');
 


### PR DESCRIPTION
## :unicorn: Problème
On ne sauvegarde plus l'identifiant externe du participant au démarrage de campagne suite à un bug envoyé récemment en production.

## :robot: Solution
Corriger ça.

## :rainbow: Remarques
RAS

## :100: Pour tester
Démarrer la campagne 'PROCOMP51' et aller voir dans Pix Orga si l'identifiant externe s'affiche correctement dans cette campagne.