### PR TITLE
[BUGFIX] : correction de la lecture des réponses du checkpoint (PIX-3918)

### DIFF
--- a/mon-pix/app/templates/components/result-item.hbs
+++ b/mon-pix/app/templates/components/result-item.hbs
@@ -1,7 +1,6 @@
 <div class="result-item">
   {{#if this.resultItem}}
     <div class="result-item__icon" title="{{this.resultTooltip}}">
-      <span class="sr-only">{{this.resultTooltip}}</span>
       <FaIcon @icon={{this.resultItem.icon}} class={{concat "result-item__icon--" this.resultItem.color}} />
     </div>
 
@@ -10,6 +9,7 @@
     </div>
 
     <div class="result-item__correction">
+      <span class="sr-only">{{this.resultTooltip}}</span>
       {{#if this.validationImplementedForChallengeType}}
         <button
           {{on "click" (fn @openAnswerDetails @answer)}}


### PR DESCRIPTION
## :unicorn: Problème
Quand on écoute la page de checkpoint, on a d'abord le résultat avant la question."Réponse Ok" "Quelle est la date de ...."Pour une meilleure compréhension, il faudrait inverser cette lecture."Quelle est la date de ..." "Réponse OK"

## :robot: Solution
Délacer la balise sr-only après l'intitulé de la question

## :rainbow: Remarques
L'accesssibilité ces génial

## :100: Pour tester
Démarer une compétence, arriver au premier checkpoint, et utiliser un screen reader pour écouter l'écran