### PR TITLE
[TECH] Ajout d'un script pour connaitre l'éligibilité CléA pour une session (PIX-4369)

### DIFF
--- a/api/scripts/check-clea-elligibility.js
+++ b/api/scripts/check-clea-elligibility.js
@@ -1,0 +1,50 @@
+'use strict';
+require('dotenv').config();
+const bluebird = require('bluebird');
+const logger = require('../lib/infrastructure/logger');
+const certificationBadgesService = require('../lib/domain/services/certification-badges-service');
+const { knex } = require('../db/knex-database-connection');
+
+/**
+ * Usage: node scripts/check-clea-elligibility.js 456
+ */
+async function main() {
+  logger.info("Début du script de verification d'éligibilité à la certification CléA Numérique");
+  try {
+    const sessionId = process.argv[2];
+    const userIds = await _getUserIdsBySessionId(sessionId);
+    const eligibilities = await _checkCleaElligibility(userIds);
+    logger.info(`CléA Eligibilities for session ${sessionId}`);
+    logger.info(_displayEligibilities(eligibilities));
+
+    logger.info('Fin du script');
+  } catch (err) {
+    logger.error(err.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      logger.error(err.message);
+      process.exit(1);
+    });
+}
+
+module.exports = {};
+
+function _displayEligibilities(eligibilities) {
+  return eligibilities.map(({ userId, eligible }) => `user: ${userId} ${eligible ? '✅' : '❌'}`);
+}
+async function _getUserIdsBySessionId(sessionId) {
+  const result = await knex.select('userId').from('certification-courses').where({ sessionId });
+  return result?.map(({ userId }) => userId);
+}
+async function _checkCleaElligibility(userIds) {
+  return bluebird.mapSeries(userIds, async (userId) => {
+    const eligible = await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId });
+    return { userId, eligible };
+  });
+}


### PR DESCRIPTION
## :unicorn: Problème
On ne peux pas/difficilement avoir accés aux éligibilités CléA des candidats d'une session

## :robot: Solution
Ajouter un script qui donne l'éligibilité de chaque candidat d'une session

## :rainbow: Remarques
Exécuter en production avant release
``` shell
scalingo --region osc-secnum-fr1 -a pix-api-production run bash --file ./scripts/check-clea-elligibility.js
cp /tmp/uploads/* ./scripts/
node ./scripts/check-clea-elligibility.js 84447
```

On obtient
``` shell
{"level":30,"time":1644940122939,"pid":41,"hostname":"pix-api-production-one-off-9307","msg":"Début du script de verification d'éligibilité à la certification CléA Numérique"}
{"level":30,"time":1644940123881,"pid":41,"hostname":"pix-api-production-one-off-9307","msg":"CléA Eligibilities for session 84447"}
(..)
{"level":30,"time":1644940123882,"pid":41,"hostname":"pix-api-production-one-off-9307","msg":"Fin du script"}
```

## :100: Pour tester
`node scripts/check-clea-elligibility.js idsession`