### PR TITLE
[FEATURE] Ajout pop-in de confirmation lorsqu'un surveillant quitte la surveillance d'une session (PIX-3801)

### DIFF
--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -1,14 +1,14 @@
 <div class="session-supervising-header">
-  <PixButtonLink
+  <PixButton
     aria-label="Quitter la surveillance de la session {{@session.id}}"
-    @route="login-session-supervisor"
     @size="small"
+    @triggerAction={{this.askUserToConfirmLeaving}}
     @backgroundColor="transparent-light"
     @isBorderVisible="true"
     class="session-supervising-header__quit"
   >
     <FaIcon @icon="sign-out-alt" />Quitter
-  </PixButtonLink>
+  </PixButton>
   <h1 class="session-supervising-header__title">Session {{@session.id}}</h1>
   <time class="session-supervising-header__date">
     {{moment-format @session.date "DD/MM/YYYY"}}
@@ -30,4 +30,22 @@
       {{@session.examiner}}
     </p>
   </div>
+
+  {{#if this.isConfirmationModalDisplayed}}
+    <SessionSupervising::ConfirmationModal
+      @closeConfirmationModal={{this.closeConfirmationModal}}
+      @actionOnConfirmation={{this.actionConfirmation}}
+      @candidate={{this.candidate}}
+      @modalCancelText={{this.modalCancelText}}
+      @modalConfirmationButtonText={{this.modalConfirmationText}}
+    >
+      <:instruction>
+        {{this.modalInstructionText}}
+      </:instruction>
+      <:description>
+        {{this.modalDescriptionText}}
+      </:description>
+    </SessionSupervising::ConfirmationModal>
+
+  {{/if}}
 </div>

--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class Header extends Component {
+  @tracked isConfirmationModalDisplayed = false;
+  @service router;
+
+  @action
+  askUserToConfirmLeaving() {
+    this.modalDescriptionText =
+      'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.';
+    this.modalCancelText = 'Annuler';
+    this.modalConfirmationText = `Quitter la surveillance`;
+    this.modalInstructionText = `Quitter la surveillance de la session ${this.args.session.id}`;
+    this.isConfirmationModalDisplayed = true;
+  }
+
+  @action
+  closeConfirmationModal() {
+    this.isConfirmationModalDisplayed = false;
+  }
+
+  @action
+  actionConfirmation() {
+    this.closeConfirmationModal();
+    return this.router.replaceWith('login-session-supervisor');
+  }
+}

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -33,28 +33,28 @@ module('Acceptance | Supervisor Portal', function (hooks) {
       await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/12345/surveiller');
+      assert.strictEqual(currentURL(), '/sessions/12345/surveiller');
     });
   });
 
   module('When supervisor is supervising a session', function () {
     module('When quit button is clicked', function () {
-      test('it should redirect to the supervisor authentication page', async function (assert) {
-        // given
-        const screen = await visitScreen('/connexion-espace-surveillant');
-        await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
-        await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
-        await click(screen.getByRole('button', { name: 'Surveiller la session' }));
+      module('When action is confirmed through the modal', function () {
+        test('it should redirect to the supervisor authentication page', async function (assert) {
+          // given
+          const screen = await visitScreen('/connexion-espace-surveillant');
+          await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
+          await fillIn(screen.getByLabelText('Mot de passe de la session'), '6789');
+          await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
-        // when
-        await click(screen.getByText('Quitter'));
+          // when
+          await click(screen.getByText('Quitter'));
 
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/connexion-espace-surveillant');
+          await click(screen.getByText('Quitter la surveillance'));
+
+          // then
+          assert.strictEqual(currentURL(), '/connexion-espace-surveillant');
+        });
       });
     });
   });

--- a/certif/tests/integration/components/session-supervising/header_test.js
+++ b/certif/tests/integration/components/session-supervising/header_test.js
@@ -1,6 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import sinon from 'sinon';
+
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | SessionSupervising::Header', function (hooks) {
@@ -14,7 +18,7 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
 
   test('it renders the session information', async function (assert) {
     // given
-    const sesionForSupervising = store.createRecord('session-for-supervising', {
+    const sessionForSupervising = store.createRecord('session-for-supervising', {
       id: 12345,
       date: '2020-01-01',
       time: '12:00:00',
@@ -24,10 +28,10 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       certificationCandidates: [],
     });
 
-    this.set('sessionForSupervising', sesionForSupervising);
+    this.set('sessionForSupervising', sessionForSupervising);
 
     // when
-    await render(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
+    await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
 
     // then
     assert.contains('12345');
@@ -35,5 +39,111 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
     assert.contains('Star Lord');
     assert.contains('01/01/2020');
     assert.contains('12:00');
+  });
+
+  module("when 'Quitter' button is clicked", function () {
+    test('it opens the confirmation modal', async function (assert) {
+      // given
+      const sessionForSupervising = store.createRecord('session-for-supervising', {
+        id: 12345,
+        date: '2020-01-01',
+        time: '12:00:00',
+        room: 'Salle 12',
+        examiner: 'Star Lord',
+        certificationCenterName: 'Knowhere',
+        certificationCandidates: [],
+      });
+
+      this.set('sessionForSupervising', sessionForSupervising);
+
+      // when
+      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
+
+      await click(screen.getByRole('button', { name: 'Quitter la surveillance de la session 12345' }));
+
+      // then
+      assert.dom(screen.getByText('Quitter la surveillance de la session 12345')).exists();
+      assert
+        .dom(
+          screen.getByText(
+            'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.'
+          )
+        )
+        .exists();
+    });
+  });
+
+  module('when confirmation modal closing button is clicked', function () {
+    test('it closes the confirmation modal', async function (assert) {
+      // given
+      const sessionForSupervising = store.createRecord('session-for-supervising', {
+        id: 12345,
+        date: '2020-01-01',
+        time: '12:00:00',
+        room: 'Salle 12',
+        examiner: 'Star Lord',
+        certificationCenterName: 'Knowhere',
+        certificationCandidates: [],
+      });
+
+      this.set('sessionForSupervising', sessionForSupervising);
+
+      // when
+      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
+
+      await click(screen.getByRole('button', { name: 'Quitter la surveillance de la session 12345' }));
+      await click(screen.getByRole('button', { name: 'Fermer la fenêtre de confirmation' }));
+
+      // then
+      assert.dom(screen.queryByText('Quitter la surveillance de la session 12345')).doesNotExist();
+      assert
+        .dom(
+          screen.queryByText(
+            'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.'
+          )
+        )
+        .doesNotExist();
+    });
+  });
+
+  module('when confirmation modal confirmation button is clicked', function () {
+    test('it closes the confirmation modal and redirect to "login-session-supervisor"', async function (assert) {
+      // given
+      const sessionForSupervising = store.createRecord('session-for-supervising', {
+        id: 12345,
+        date: '2020-01-01',
+        time: '12:00:00',
+        room: 'Salle 12',
+        examiner: 'Star Lord',
+        certificationCenterName: 'Knowhere',
+        certificationCandidates: [],
+      });
+
+      const replaceWithStub = sinon.stub();
+
+      class routerServiceStub extends Service {
+        replaceWith = replaceWithStub;
+      }
+      this.owner.register('service:router', routerServiceStub);
+
+      this.set('sessionForSupervising', sessionForSupervising);
+
+      // when
+      const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
+
+      await click(screen.getByRole('button', { name: 'Quitter la surveillance de la session 12345' }));
+
+      await click(screen.getByRole('button', { name: 'Quitter la surveillance' }));
+
+      // then
+      assert.dom(screen.queryByText('Quitter la surveillance de la session 12345')).doesNotExist();
+      assert
+        .dom(
+          screen.queryByText(
+            'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.'
+          )
+        )
+        .doesNotExist();
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible pour un surveillant de quitter la surveillance d’une session de certification en cliquant sur le bouton “quitter”.

Le surveillant peut cliquer par erreur sur le bouton, or aujourd’hui, il n’y a pas de confirmation nécessaire il quitte directement la session et est redirigé sur la page de connexion de l’espace surveillant.

## :robot: Solution
Ajouter une pop-up de confirmation lorsqu’un surveillant quitte la surveillance d’une session

## :100: Pour tester
- Se connecter à l'espace surveillant d'une session via ```pix-certif```
- Cliquer sur ```Quitter```
- Constater l'apparition d'une pop-in demandant confirmation

![image](https://user-images.githubusercontent.com/37305474/153615313-a2f2f440-1ddd-4ac4-aedf-aa783a4c1a04.png)

