### PR TITLE
[FEATURE] Screen readers: prévenir des embed/texte alternatif (PIX-3917)

### DIFF
--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -4,6 +4,14 @@
     <div class="challenge-statement__instruction-section">
       <MarkdownToHtmlUnsafe @class="challenge-statement-instruction__text" @markdown={{this.challengeInstruction}} />
 
+      {{#if @challenge.hasValidEmbedDocument}}
+        <div class="sr-only">{{t "pages.challenge.statement.sr-only.embed"}}</div>
+      {{/if}}
+
+      {{#if @challenge.alternativeInstruction}}
+        <div class="sr-only">{{t "pages.challenge.statement.sr-only.alternative-instruction"}}</div>
+      {{/if}}
+
       {{#if this.isFocusedChallengeToggleEnabled}}
         <Challenge::Statement::Tooltip @challenge={{@challenge}} />
       {{/if}}

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -4,7 +4,6 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import sinon from 'sinon';
 
 describe('Integration | Component | ChallengeStatement', function () {
   setupIntlRenderingTest();
@@ -23,7 +22,7 @@ describe('Integration | Component | ChallengeStatement', function () {
                           @assessment={{this.assessment}}/>`);
   }
 
-  beforeEach(async function () {
+  beforeEach(function () {
     class currentUser extends Service {
       user = {
         hasSeenFocusedChallengeTooltip: false,
@@ -39,17 +38,6 @@ describe('Integration | Component | ChallengeStatement', function () {
    */
 
   describe('Instruction section:', function () {
-    let clock;
-    const februaryTheFifth = new Date(2017, 1, 5);
-
-    beforeEach(() => {
-      clock = sinon.useFakeTimers(februaryTheFifth);
-    });
-
-    afterEach(() => {
-      clock.restore();
-    });
-
     // Inspired from: https://github.com/emberjs/ember-mocha/blob/0790a78d7464655fee0c103d2fa960fa53a056ca/tests/setup-component-test-test.js#L118-L122
     it('should render challenge instruction if it exists', async function () {
       // given
@@ -162,6 +150,42 @@ describe('Integration | Component | ChallengeStatement', function () {
       // then
       expect(find('.tooltip__tag--regular')).to.exist;
       expect(find('.tooltip__tag--focused')).to.not.exist;
+    });
+
+    it('should have a screen reader only warning if challenge has an embed', async function () {
+      // given
+      addChallengeToContext(this, {
+        hasValidEmbedDocument: true,
+        id: 'rec_challenge',
+        instruction: 'La consigne de mon test',
+      });
+      addAssessmentToContext(this, { id: '267845' });
+
+      // when
+      await renderChallengeStatement(this);
+
+      // then
+      expect(find('.challenge-statement__instruction-section > .sr-only'))
+        .to.have.property('textContent')
+        .that.contains(this.intl.t('pages.challenge.statement.sr-only.embed'));
+    });
+
+    it('should have a screen reader only warning if challenge has an alternative instruction', async function () {
+      // given
+      addChallengeToContext(this, {
+        id: 'rec_challenge',
+        instruction: 'La consigne de mon test',
+        alternativeInstruction: 'La consigne alternative de mon test',
+      });
+      addAssessmentToContext(this, { id: '267845' });
+
+      // when
+      await renderChallengeStatement(this);
+
+      // then
+      expect(find('.challenge-statement__instruction-section > .sr-only'))
+        .to.have.property('textContent')
+        .that.contains(this.intl.t('pages.challenge.statement.sr-only.alternative-instruction'));
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -527,6 +527,10 @@
             "content": "To answer this question, feel free to search the internet or use an external application.",
             "title": "Free Mode"
           }
+        },
+        "sr-only": {
+          "embed": "This question uses a simulator.",
+          "alternative-instruction": "This question has an alternative instruction."
         }
       },
       "timed": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -527,6 +527,10 @@
             "content": "Vous êtes libre d’utiliser internet ou des applications pour répondre à cette question.",
             "title": "Mode Libre"
           }
+        },
+        "sr-only": {
+          "embed": "Cette épreuve contient un simulateur.",
+          "alternative-instruction": "Cette épreuve a une consigne alternative."
         }
       },
       "timed": {


### PR DESCRIPTION
## :unicorn: Problème
Les personnes utilisant un screen reader ne sont pas prévenues qu'il y a un embed ou une consigne alternative au moment de la lecture de la consigne.

## :robot: Solution
Ajouter des balises "screen reader only" dans le bloc de consigne pour prévenir qu'il y a un embed ou une consigne alternative.

## :rainbow: Remarques
On a supprimé un fake timer dans le test d'intégration du challenge statement, il ne semblait plus être utile, et il empêchait l'utilisation du `.only`.

## :100: Pour tester
Utiliser un screen reader sur un challenge avec embed et un challenge avec consigne alternative :
 - consigne alternative : challenges/challenge17pi5vGzgVX0oP/preview
 - embed : challenges/rec2dRKsI4aBIsayz/preview