### PR TITLE
[BUGFIX] Neutraliser les questions auxquelles les candidats n'ont pas pu répondre à cause d'une régression (PIX-4368).

### DIFF
--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -18,7 +18,7 @@ function certificationSessionsBuilder({ databaseBuilder }) {
   const address = 'Anne-Star Street';
   const room = 'Salle Anne';
   const examiner = 'Anne';
-  const date = '2020-03-04';
+  const date = '2020-01-31';
   const time = '15:00';
 
   databaseBuilder.factory.buildSession({

--- a/api/scripts/neutralize-answers-after-invalid-challenges.js
+++ b/api/scripts/neutralize-answers-after-invalid-challenges.js
@@ -1,0 +1,98 @@
+'use strict';
+require('dotenv').config({ path: `${__dirname}/../.env` });
+const _ = require('lodash');
+const bluebird = require('bluebird');
+
+const { knex } = require('../db/knex-database-connection');
+const logger = require('../lib/infrastructure/logger');
+
+const challengeRepository = require('../lib/infrastructure/repositories/challenge-repository');
+const certificationAssessmentRepository = require('../lib/infrastructure/repositories/certification-assessment-repository');
+const usecases = require('../lib/domain/usecases/index');
+const events = require('../lib/domain/events');
+
+const extractLengthyChallenges = async () => {
+  const challenges = await challengeRepository.findValidated();
+  const lengthyChallenges = _.remove(challenges, function (challenge) {
+    return challenge.validator.solution.value.length >= 500;
+  });
+
+  if (lengthyChallenges.length === 0) {
+    throw new Error('No challenges found, ending process');
+  }
+
+  logger.info(`${lengthyChallenges.length} challenges found`);
+  logger.debug(lengthyChallenges);
+
+  return lengthyChallenges;
+};
+
+const extractAnswers = async (lengthyChallenges, exposure) => {
+  const answers = await knex
+    .from('sessions')
+    .select('certification-courses.id AS certificationCourseId', 'answers.challengeId')
+    .innerJoin('certification-courses', 'certification-courses.sessionId', 'sessions.id')
+    .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+    .innerJoin('answers', 'answers.assessmentId', 'assessments.id')
+    .whereRaw('"certification-courses"."createdAt"::DATE = ?', exposure.date)
+    .where('answers.result', '<>', 'ok')
+    .whereBetween('answers.createdAt', exposure.window)
+    .whereIn('answers.challengeId', lengthyChallenges);
+
+  if (answers.length === 0) {
+    throw new Error('No answers found, ending process');
+  }
+  logger.info(`${answers.length} answers found`);
+  logger.debug(answers);
+  return answers;
+};
+
+const getServiceUser = async () => {
+  const AUTOMATED_DATA_CORRECTION_ACCOUNT_EMAIL = 'service+pix@pix.fr';
+  const user = await knex
+    .from('users')
+    .select('users.id')
+    .innerJoin('users_pix_roles', 'users_pix_roles.user_id', 'users.id')
+    .innerJoin('pix_roles', 'pix_roles.id', 'users_pix_roles.pix_role_id')
+    .where('users.email', '=', AUTOMATED_DATA_CORRECTION_ACCOUNT_EMAIL)
+    .where('pix_roles.name', '=', 'PIX_MASTER')
+    .first();
+
+  if (!user) {
+    throw new Error(`No user ${AUTOMATED_DATA_CORRECTION_ACCOUNT_EMAIL} found, ending process`);
+  }
+  return user.id;
+};
+
+const neutralizeAnswers = async function (answers, userId) {
+  logger.info('Neutralization has started');
+  await bluebird.mapSeries(answers, async (answer) => {
+    const event = await usecases.neutralizeChallenge({
+      certificationAssessmentRepository,
+      certificationCourseId: answer.certificationCourseId,
+      challengeRecId: answer.challengeId,
+      juryId: userId,
+    });
+    await events.eventDispatcher.dispatch(event);
+  });
+  logger.info('Neutralization has ended');
+};
+
+const main = async () => {
+  const lengthyChallenges = await extractLengthyChallenges();
+
+  const exposure = {
+    date: '2022-02-10',
+    window: ['2022-02-10 09:50:00.000000 +00:00', '2022-02-10 18:00:00.000000 +00:00'],
+  };
+
+  const answers = await extractAnswers(lengthyChallenges, exposure);
+
+  const userId = await getServiceUser();
+
+  if (process.env.PROCEED === 'YES') {
+    await neutralizeAnswers(answers, userId);
+  }
+};
+
+module.exports = { neutralizeAnswers, main };

--- a/api/scripts/run-neutralize-answers-after-invalid-challenges.js
+++ b/api/scripts/run-neutralize-answers-after-invalid-challenges.js
@@ -1,0 +1,21 @@
+// Usage
+// LOG_LEVEL=<LEVEL> PROCEED=<CHOICE> node scripts/run-neutralize-answers-after-invalid-challenges.js
+//
+// - LEVEL=debug is the most verbose one
+// - PROCEED : No changes are made unless PROCEED environment variable is set to YES : PROCEED=YES node scripts/run-neutralize-answers-after-invalid-challenges.js
+'use strict';
+require('dotenv').config({ path: `${__dirname}/../.env` });
+const logger = require('../lib/infrastructure/logger');
+const { main } = require('./neutralize-answers-after-invalid-challenges');
+
+(async () => {
+  try {
+    logger.info('Script has started');
+    await main();
+    logger.info('Script has ended');
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+  process.exit(0);
+})();

--- a/api/tests/acceptance/scripts/neutralize-answers-after-invalid-challenges_test.js
+++ b/api/tests/acceptance/scripts/neutralize-answers-after-invalid-challenges_test.js
@@ -1,0 +1,45 @@
+const { expect, sinon, catchErr } = require('../../test-helper');
+const usecases = require('../../../lib/domain/usecases/index');
+const { eventDispatcher } = require('../../../lib/domain/events/');
+const ChallengeNeutralized = require('../../../lib/domain/events/ChallengeNeutralized');
+const { neutralizeAnswers } = require('../../../scripts/neutralize-answers-after-invalid-challenges');
+
+describe('Acceptance | Scripts | neutralize-answers-after-invalid-challenges.js', function () {
+  describe('#neutralizeAnswers', function () {
+    it('should call neutralizeChallengeUseCase', async function () {
+      // given
+      const answers = [
+        {
+          certificationCourseId: null,
+          challengeId: null,
+        },
+      ];
+      const userId = 1;
+      const neutralizeChallengeUseCaseStub = sinon.stub(usecases, 'neutralizeChallenge').rejects();
+
+      // when
+      await catchErr(neutralizeAnswers)(answers, userId);
+
+      // then
+      expect(neutralizeChallengeUseCaseStub).to.have.been.calledOnce;
+    });
+    it('should call eventDispatcher', async function () {
+      // given
+      const answers = [
+        {
+          certificationCourseId: null,
+          challengeId: null,
+        },
+      ];
+      const userId = 1;
+      sinon.stub(usecases, 'neutralizeChallenge').returns(new ChallengeNeutralized({}));
+      const eventDispatcherStub = sinon.stub(eventDispatcher, 'dispatch').rejects();
+
+      // when
+      await catchErr(neutralizeAnswers)(answers, userId);
+
+      // then
+      expect(eventDispatcherStub).to.have.been.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Régression suite à #3949 sur la période du 10/02
- 11h01 - v3.165.0: https://1024pix.slack.com/archives/CVAMDQYHY/p1644487291838009
- 18h41 - v3.167.0 : https://1024pix.slack.com/archives/CVAMDQYHY/p1644514894379229

## :robot: Solution
Rétablir le service avec la solution de contournement #4073
 
Neutraliser les questions auxquelles les utlisateurs n'ont pas pu répondre:
- bonne réponse de plus de 500 caractères
- réponse soumise entre les deux MEP
- question que le candidat a dû passer

Prendre en compte les questions entre 10/02:
- 10:50 (MEP 11:01)
- 19:00 (MEP 18h41)

Aucune session n'a été publiée pour l'instant.

Utilisater le code du controller associée à la route de neutralisation, qui lance le scoring.

A exécuter en production:
1 - vérifier les données `LOG_LEVEL=info node scripts/run-neutralize-answers-after-invalid-challenges.js`
2 - modifier les données `PROCEED=YES node scripts/run-neutralize-answers-after-invalid-challenges.js`

En cas d'erreur sur la vérification des données, récupérer les données en question `LOG_LEVEL=debug node scripts/run-neutralize-answers-after-invalid-challenges.js`

## :rainbow: Remarques
Pas de test d'acceptance du script, à l'image de la route.
Uniquemement un test d'intégration du script.

## :100: Pour tester
N'ayant pas de base de données identiques à la production, les tests se feront en local sur les données de seeds.

### composant `extractAnswers`
Extraire les réponses de `Anne failure` à la session 5:
- créer les seeds en BBD
- configurer les paramètres d'entrée
```js
const seedsChallenges = ['recG8nWow8yP7P3WA', 'rec89GEKgYFZ1vqHr'];
const seedsDate = '2020-01-31';
const exposure = {
    date: seedsDate,
    window: [`${seedsDate} 00:00:00.000000 +00:00`, `${seedsDate} 23:59:59.000000 +00:00`],
};
```
- exécuter `const answers = await extractAnswers(seedsChallenges, exposure);`
- vérifier que les réponses retournées correspondent à celles en BDD
```sql
SELECT
    cc.id "certificationCourseId",
    cc."firstName",
    cc."lastName",
    ans."createdAt" "answeredAt",
    ans.result
FROM sessions s
         INNER JOIn "certification-centers" crt ON crt.id = s."certificationCenterId"
         INNER JOIN "certification-courses" cc ON cc."sessionId" = s.id
         INNER JOIN assessments ass ON ass."certificationCourseId" = cc.id
         INNER JOIN answers ans on ans."assessmentId" = ass.id
WHERE 1 = 1
    AND s."date" = '2020-01-31'
    AND ans.result <> 'ok'
   AND ans."challengeId" IN ('recG8nWow8yP7P3WA', 'rec89GEKgYFZ1vqHr');
```
![image](https://user-images.githubusercontent.com/56302715/153703947-3aeec74d-cd62-47bf-999f-5ad34690ca06.png)


Vérifier, en exécutant la requête sur `pix-datawarehouse-production` que le nombre de réponses obtenues est cohérente avec celle obtenue dans Datadog sur la route `POST /answers` avec une réponse `400` (10,856 réponses sur Datadog).

:warning: 
En fait la comparaison n'est pas possible car un candidat peut soumettre plusieurs fois la réponse si elle est rejetée.
Le nombre de questions persistées (result <>ok sur ces challenges) est de 7 640, soit moins que les 10 856 réponses rejetées sur Datadog.

### composant  `neutralizeAnswers`
Neutraliser les réponses de `Anne sucess` à la session 5:
- créer les seeds en BBD
- remplacer le paramètre answers par 
```js
  const answers = [
    {
      certificationCourseId: 106994,
      challengeId: 'recG8nWow8yP7P3WA',
    },
    {
      certificationCourseId: 106994,
      challengeId: 'rec89GEKgYFZ1vqHr',
    },
  ];
```
- exécuter `await neutralizeAnswers(answers, 199)`
- vérifier que les challenges sont neutralisés
```sql
SELECT
    cc.id,
    cc."courseId" "certificationCourseId",
    cc."challengeId",
    cc."isNeutralized",
    cc."updatedAt",
    'certification-challenges=>',
    cc.*
FROM "certification-challenges" cc
WHERE 1=1
     AND cc."courseId" = 106994
     AND cc."challengeId" IN ('recG8nWow8yP7P3WA', 'rec89GEKgYFZ1vqHr')
     AND cc."isNeutralized" IS TRUE
;
```
![image](https://user-images.githubusercontent.com/56302715/153703598-43c789b4-ba34-4212-b2e0-dc960f455b8e.png)

- vérifier que le scoring a été exécuté
```sql
SELECT
    'center=>',
    crt.name "centerName",
    'session=>',
    s.id     "sessionId",
    --s."publishedAt" ,
    'course=>',
    cc.id    "certificationCourseId",
    cc."firstName",
    cc."lastName",
    cc."userId",
    u.email,
    cc."lastName",
    cc.birthdate,
    --cc.*,
    'assessments=>',
    ass.id,
    ass.type,
    ass.state,
    'assessments-results=>',
    asr."pixScore",
    asr.emitter,
    asr.status,
    asr."createdAt"
FROM sessions s
         INNER JOIN "certification-centers" crt ON crt.id = s."certificationCenterId"
         INNER JOIN "certification-courses" cc ON cc."sessionId" = s.id
         INNER JOIN users u ON u.id = cc."userId"
         INNER JOIN assessments ass ON ass."certificationCourseId" = cc.id
         INNER JOIN "assessment-results" asr ON asr."assessmentId" = ass.id
WHERE 1 = 1
  AND s.id = 5
  AND cc."userId" = 104
ORDER BY s.id, cc."userId", asr."createdAt"
;
```
![image](https://user-images.githubusercontent.com/56302715/153703557-1d6323ce-75ef-4512-ad4c-e5db535285f0.png)


