### PR TITLE
[BUGFIX] Réparer le design de la page de connexion à l'espace surveillant lors de l'apparition d'un message d'erreur (PIX-4323).

### DIFF
--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -37,13 +37,4 @@
   <p class="login-session-supervisor-form__description">
     Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif.
   </p>
-
-  <div class="login-session-supervisor-form__current-user-email">
-    <span><FaIcon @icon="user-circle" />
-      {{@currentUserEmail}}
-    </span>
-    <LinkTo class="login-session-supervisor-form__logout" @route="logout">
-      Changer de compte
-    </LinkTo>
-  </div>
 </div>

--- a/certif/app/styles/components/login-session-supervisor-form.scss
+++ b/certif/app/styles/components/login-session-supervisor-form.scss
@@ -1,19 +1,16 @@
 .login-session-supervisor-form {
   box-sizing: border-box;
   display: flex;
-  position: relative;
   flex-direction: column;
   align-items: center;
   background-color: white;
-  border-radius: 10px;
-  margin: 8px;
+  border-radius: 10px 10px 0 0;
   max-width: 463px;
-  height: 622px;
   padding: 32px 8px 16px;
   width: 100%;
 
   @include device-is('tablet') {
-    padding: 40px 60px;
+    padding: 40px 60px 10px 60px;
     margin: auto;
   }
 
@@ -61,33 +58,5 @@
     font-size: 0.8rem;
     margin: 0;
     text-align: center;
-  }
-
-  &__current-user-email {
-    display: flex;
-    flex-direction: column;
-    position: absolute;
-    border-radius: 0 0 10px 10px;
-    bottom: 0;
-    background: $grey-10;
-    align-items: center;
-    justify-content: center;
-    font-family: $roboto;
-    color: $blue-zodiac;
-    width: 100%;
-    font-size: 14px;
-    font-weight: normal;
-    height: 80px;
-    letter-spacing: 0.15px;
-    line-height: 22px;
-
-    svg {
-      margin-right: 8px;
-    }
-  }
-
-  &__logout {
-    margin-top: 4px;
-    color: $blue-zodiac;
   }
 }

--- a/certif/app/styles/pages/login-session-supervisor.scss
+++ b/certif/app/styles/pages/login-session-supervisor.scss
@@ -6,4 +6,37 @@
   background: $pix-certif-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   align-items: center;
+  justify-content: center;
+
+  .login-session-supervisor-page-content {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+
+    &__current-user-email {
+      display: flex;
+      flex-direction: column;
+      border-radius: 0 0 10px 10px;
+      background: $grey-10;
+      align-items: center;
+      justify-content: center;
+      font-family: $roboto;
+      color: $blue-zodiac;
+      width: 100%;
+      font-size: 14px;
+      font-weight: normal;
+      height: 80px;
+      letter-spacing: 0.15px;
+      line-height: 22px;
+
+      svg {
+        margin-right: 8px;
+      }
+    }
+
+    &__logout {
+      margin-top: 4px;
+      color: $blue-zodiac;
+    }
+  }
 }

--- a/certif/app/templates/login-session-supervisor.hbs
+++ b/certif/app/templates/login-session-supervisor.hbs
@@ -1,7 +1,15 @@
 {{page-title "Connexion à l'espace surveillant"}}
 <div class="login-session-supervisor-page">
-  <LoginSessionSupervisorForm
-    @onFormSubmit={{this.authenticateSupervisor}}
-    @currentUserEmail={{this.currentUserEmail}}
-  />
+  <div class="login-session-supervisor-page-content">
+    <LoginSessionSupervisorForm @onFormSubmit={{this.authenticateSupervisor}} />
+
+    <div class="login-session-supervisor-page-content__current-user-email">
+      <span><FaIcon @icon="user-circle" />
+        {{this.currentUserEmail}}
+      </span>
+      <LinkTo class="login-session-supervisor-page-content__logout" @route="logout">
+        Changer de compte
+      </LinkTo>
+    </div>
+  </div>
 </div>

--- a/certif/tests/acceptance/login-session-supervisor_test.js
+++ b/certif/tests/acceptance/login-session-supervisor_test.js
@@ -14,6 +14,7 @@ module('Acceptance | Login session supervisor', function (hooks) {
     const certificationPointOfContact = server.create('certification-point-of-contact', {
       firstName: 'Buffy',
       lastName: 'Summers',
+      email: 'toto@example.net',
       pixCertifTermsOfServiceAccepted: true,
       allowedCertificationCenterAccesses: [],
     });
@@ -22,13 +23,22 @@ module('Acceptance | Login session supervisor', function (hooks) {
     server.create('session-for-supervising', { id: 12345 });
   });
 
+  test('should display current user email and a change account button', async function (assert) {
+    // given
+    const screen = await visitScreen('/connexion-espace-surveillant');
+
+    // then
+    assert.dom(screen.getByText('toto@example.net')).exists();
+    assert.dom(screen.getByText('Changer de compte')).exists();
+  });
+
   module('When supervisor wants to change account', function () {
     test('it should redirect to logout page', async function (assert) {
       // given
       const screen = await visitScreen('/connexion-espace-surveillant');
 
       // when
-      await click(screen.getByText('Changer de compte'));
+      await click(screen.getByRole('link', { name: 'Changer de compte' }));
 
       // then
       assert.strictEqual(currentURL(), '/logout');

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -12,17 +12,12 @@ module('Integration | Component | login-session-supervisor-form', function (hook
   test('it should render supervisor login form', async function (assert) {
     // when
     this.onFormSubmit = sinon.stub();
-    this.currentUserEmail = 'toto@example.net';
-    const screen = await renderScreen(
-      hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} @currentUserEmail={{this.currentUserEmail}}/>`
-    );
+    const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}}/>`);
 
     // then
     assert.dom(screen.getByLabelText('Numéro de la session')).exists();
     assert.dom(screen.getByLabelText('Mot de passe de la session')).exists();
     assert.dom(screen.getByText('Surveiller la session')).exists();
-    assert.dom(screen.getByText('toto@example.net')).exists();
-    assert.dom(screen.getByText('Changer de compte')).exists();
   });
 
   module('On click on supervise button', function () {


### PR DESCRIPTION
## :unicorn: Problème
La page de connexion à l'espace surveillant voit son affichage cacher certains éléments lors de l'apparition d'un message d'erreur.

## :robot: Solution
Corriger l'affichage lorsqu'un message d'erreur apparaît.

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certifpro@example.net`
- Accéder à l'espace surveillant et cliquer sur "Surveiller la session" sans remplir le "Numéro de la session" et/ou le "Mot de passe de la session".
- Le message d'erreur apparaît et vérifier que tout le contenu se décale vers le bas sans cacher des éléments.
