### PR TITLE
[TECH] Bump pix UI sur Certif (PIX-4355)

### DIFF
--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -102,21 +102,19 @@
                   {{/unless}}
                   <div class="certification-candidates-actions__delete">
                     {{#if candidate.isLinked}}
-                      <PixTooltip
-                        @text="Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer."
-                        @position="left"
-                        @isInline={{true}}
-                        @id="tooltip-delete-student-button"
-                      >
-                        <PixIconButton
-                          @icon="trash-alt"
-                          class="certification-candidates-actions__delete-button--disabled"
-                          data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
-                          aria-label="Supprimer un candidat"
-                          aria-disabled="true"
-                          aria-describedby="tooltip-delete-student-button"
-                          @withBackground={{true}}
-                        />
+                      <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-student-button">
+                        <:triggerElement>
+                          <PixIconButton
+                            @icon="trash-alt"
+                            class="certification-candidates-actions__delete-button--disabled"
+                            data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
+                            aria-label="Supprimer un candidat"
+                            aria-disabled="true"
+                            aria-describedby="tooltip-delete-student-button"
+                            @withBackground={{true}}
+                          />
+                        </:triggerElement>
+                        <:tooltip>Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.</:tooltip>
                       </PixTooltip>
                     {{else}}
                       <PixIconButton

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -25,10 +25,10 @@
           @id="login-email"
           name="login"
           @label="Adresse e-mail"
-          @value={{this.email}}
           autocomplete="email"
           type="email"
           required="true"
+          {{on "input" this.setEmail}}
         />
       </div>
 
@@ -37,9 +37,9 @@
           @id="login-password"
           name="password"
           @label="Mot de passe"
-          @value={{this.password}}
           autocomplete="current-password"
           required="true"
+          {{on "input" this.setPassword}}
         />
       </div>
 

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -19,6 +19,16 @@ export default class LoginForm extends Component {
   }
 
   @action
+  setEmail(event) {
+    this.email = event.target.value;
+  }
+
+  @action
+  setPassword(event) {
+    this.password = event.target.value;
+  }
+
+  @action
   async authenticate(event) {
     event.preventDefault();
     const email = this.email ? this.email.trim() : '';

--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -18,7 +18,7 @@
   {{/if}}
 
   <form class="login-session-supervisor-form__form" {{on "submit" this.superviseSession}}>
-    <PixInput @id="session-id" @label="Numéro de la session" type="number" @value={{this.sessionId}} />
+    <PixInput @id="session-id" @label="Numéro de la session" type="number" {{on "input" this.setSessionId}} />
 
     <PixInputPassword
       @id="session-password"
@@ -26,7 +26,7 @@
       @information="Exemple : C-12345"
       @prefix="C-"
       placeholder="XXXXXX"
-      @value={{this.supervisorPassword}}
+      {{on "input" this.setSupervisorPassword}}
     />
 
     <PixButton @type="submit">

--- a/certif/app/components/login-session-supervisor-form.js
+++ b/certif/app/components/login-session-supervisor-form.js
@@ -4,9 +4,19 @@ import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 
 export default class LoginSessionSupervisorForm extends Component {
-  @tracked sessionId;
-  @tracked supervisorPassword;
   @tracked errorMessage = null;
+  sessionId;
+  supervisorPassword;
+
+  @action
+  setSupervisorPassword(event) {
+    this.supervisorPassword = event.target.value;
+  }
+
+  @action
+  setSessionId(event) {
+    this.sessionId = event.target.value;
+  }
 
   @action
   async superviseSession(event) {

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -16,20 +16,31 @@
         <th>
           <div class="session-finalization-reports-information-step__header_cancel">
             <span>Raison de l'abandon</span>
-            <PixTooltip
-              @id="tooltip-cancel-reason"
-              @text={{escapeHtml
-                "<ul><li>Abandon : Manque de temps ou départ prématuré :<ul><li>Le candidat n’a pas eu le temps de répondre à toutes ses questions</li><li>Le candidat est parti volontairement avant la fin du test</li></ul><li>Problème technique :<ul><li>Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la fin</li></ul></li></ul>"
-              }}
-              @position="left"
-              @isWide={{true}}
-            >
-              <FaIcon
-                @icon="info-circle"
-                tabindex="0"
-                aria-describedby="tooltip-cancel-reason"
-                aria-label="Raison de l'abandon"
-              />
+            <PixTooltip @id="tooltip-cancel-reason" @position="left" @isWide={{true}}>
+              <:triggerElement>
+                <FaIcon
+                  @icon="info-circle"
+                  tabindex="0"
+                  aria-describedby="tooltip-cancel-reason"
+                  aria-label="Raison de l'abandon"
+                />
+              </:triggerElement>
+              <:tooltip>
+                <ul>
+                  <li>Abandon : Manque de temps ou départ prématuré :
+                    <ul>
+                      <li>Le candidat n'a pas eu le temps de répondre à toutes ses questions</li>
+                      <li>Le candidat est parti volontairement avant la fin du test</li>
+                    </ul>
+                  </li>
+                  <li>Problème technique :
+                    <ul>
+                      <li>Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la
+                        fin</li>
+                    </ul>
+                  </li>
+                </ul>
+              </:tooltip>
             </PixTooltip>
           </div>
         </th>

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -60,6 +60,18 @@ export default class SessionParametersController extends Controller {
   removeSupervisorPasswordTooltip() {
     this.supervisorPasswordTooltipText = '';
   }
+
+  get isAccessCodeTooltipTextEmpty() {
+    return this.accessCodeTooltipText.length === 0;
+  }
+
+  get isSupervisorPasswordTooltipTextEmpty() {
+    return this.supervisorPasswordTooltipText.length === 0;
+  }
+
+  get isSessionNumberTooltipTextEmpty() {
+    return this.sessionNumberTooltipText.length === 0;
+  }
 }
 
 async function _waitForSeconds(timeoutInSeconds) {

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -24,7 +24,7 @@ $green-70: #006134;
     margin-bottom: 4px;
   }
 
-  &__checkbox {
+  &__checkbox[type="checkbox"] {
     width: 32px;
     height: 32px;
     margin-right: 16px;

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -5,15 +5,18 @@
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeSessionNumberTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
         {{#if (is-clipboard-supported)}}
-          <PixTooltip @id="tooltip-clipboard-button" @text={{this.sessionNumberTooltipText}} @isInline={{true}}>
-            <CopyButton
-              @clipboardText={{this.session.id}}
-              @success={{this.showSessionIdTooltip}}
-              @classNames="icon-button session-details-content__clipboard-button"
-              aria-label="Copier le code d'accès"
-            >
-              <FaIcon @icon="copy" prefix="fas" />
-            </CopyButton>
+          <PixTooltip @id="tooltip-clipboard-button" @isInline={{true}} @hide={{this.isSessionNumberTooltipTextEmpty}}>
+            <:triggerElement>
+              <CopyButton
+                @clipboardText={{this.session.id}}
+                @success={{this.showSessionIdTooltip}}
+                @classNames="icon-button session-details-content__clipboard-button"
+                aria-label="Copier le code d'accès"
+              >
+                <FaIcon @icon="copy" prefix="fas" />
+              </CopyButton>
+            </:triggerElement>
+            <:tooltip>{{this.sessionNumberTooltipText}}</:tooltip>
           </PixTooltip>
         {{/if}}
       </div>
@@ -27,15 +30,18 @@
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
         {{#if (is-clipboard-supported)}}
           {{! template-lint-disable no-duplicate-id }}
-          <PixTooltip @id="tooltip-clipboard-button" @text={{this.accessCodeTooltipText}} @isInline={{true}}>
-            <CopyButton
-              @clipboardText={{this.session.accessCode}}
-              @success={{this.showAccessCodeTooltip}}
-              @classNames="icon-button session-details-content__clipboard-button"
-              aria-label="Copier le code d'accès"
-            >
-              <FaIcon @icon="copy" prefix="fas" />
-            </CopyButton>
+          <PixTooltip @id="tooltip-clipboard-button" @isInline={{true}} @hide={{this.isAccessCodeTooltipTextEmpty}}>
+            <:triggerElement>
+              <CopyButton
+                @clipboardText={{this.session.accessCode}}
+                @success={{this.showAccessCodeTooltip}}
+                @classNames="icon-button session-details-content__clipboard-button"
+                aria-label="Copier le code d'accès"
+              >
+                <FaIcon @icon="copy" prefix="fas" />
+              </CopyButton>
+            </:triggerElement>
+            <:tooltip>{{this.accessCodeTooltipText}}</:tooltip>
           </PixTooltip>
         {{/if}}
       </div>
@@ -53,15 +59,22 @@
           </span>
           {{! template-lint-disable no-duplicate-id }}
           {{#if (is-clipboard-supported)}}
-            <PixTooltip @id="tooltip-clipboard-button" @text={{this.supervisorPasswordTooltipText}} @isInline={{true}}>
-              <CopyButton
-                @clipboardText={{this.session.supervisorPassword}}
-                @success={{this.showSupervisorPasswordTooltip}}
-                @classNames="icon-button session-details-content__clipboard-button"
-                aria-label="Copier le code d'accès"
-              >
-                <FaIcon @icon="copy" prefix="fas" />
-              </CopyButton>
+            <PixTooltip
+              @id="tooltip-clipboard-button"
+              @isInline={{true}}
+              @hide={{this.isSupervisorPasswordTooltipTextEmpty}}
+            >
+              <:triggerElement>
+                <CopyButton
+                  @clipboardText={{this.session.supervisorPassword}}
+                  @success={{this.showSupervisorPasswordTooltip}}
+                  @classNames="icon-button session-details-content__clipboard-button"
+                  aria-label="Copier le code d'accès"
+                >
+                  <FaIcon @icon="copy" prefix="fas" />
+                </CopyButton>
+              </:triggerElement>
+              <:tooltip>{{this.supervisorPasswordTooltipText}}</:tooltip>
             </PixTooltip>
           {{/if}}
         </div>

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -23,7 +23,7 @@ module.exports = function (defaults) {
       testGenerator: 'qunit',
     },
     sassOptions: {
-      includePaths: ['node_modules/pix-ui/addon/styles'],
+      includePaths: ['node_modules/@1024pix/pix-ui/addon/styles'],
     },
   });
 

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -93,9 +93,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.1.0.tgz",
-      "integrity": "sha512-9H9BG5up87GgPTqd4us9wuBf0s+H1stMwtdFYlqpYgTkKlZwpOobBQNdXxaYlJz0/voqjZVkh2lwnWsxp6taNw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.2.0.tgz",
+      "integrity": "sha512-C6No+292/eEZNFSmt4qTahJyh6e2UBDrvyy03pG7lmMBiOxiA1VnQzxL8wobBUXfWruu0JkSDuPCCR3dBQiA/Q==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -92,6 +92,21 @@
         }
       }
     },
+    "@1024pix/pix-ui": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.1.0.tgz",
+      "integrity": "sha512-9H9BG5up87GgPTqd4us9wuBf0s+H1stMwtdFYlqpYgTkKlZwpOobBQNdXxaYlJz0/voqjZVkh2lwnWsxp6taNw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.6.2",
+        "ember-cli-sass": "^10.0.1",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-click-outside": "^2.0.0",
+        "ember-prop-modifier": "^1.0.1",
+        "ember-truth-helpers": "^3.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -17071,6 +17086,16 @@
         "ember-cli-babel": "^7.23.1"
       }
     },
+    "ember-prop-modifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-prop-modifier/-/ember-prop-modifier-1.0.1.tgz",
+      "integrity": "sha512-IbWHOY1MtEFwA5oMC+54CiTh0TuhMDIE6Z+QyX9pYvIOpr+BJsDphujPw9697Dt/0EK3PE41ZWllI8G4Butd/w==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier": "^2.1.1"
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
@@ -23687,19 +23712,6 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v10.0.1",
-      "integrity": "sha512-s70SrvH6pvou93/p09FecOg7veMQi/nUDmzdc4Kt01pApoZ9muhgAM5wItK7M0hmtqTnnrajxzIqE1rP3O+aHA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
-        "ember-truth-helpers": "^3.0.0"
       }
     },
     "pkg-dir": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^13.1.0",
+    "@1024pix/pix-ui": "^13.2.0",
     "@ember/optional-features": "^2.0.0",
     "@fortawesome/ember-fontawesome": "^0.2.3",
     "@fortawesome/free-brands-svg-icons": "^5.15.3",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
+    "@1024pix/pix-ui": "^13.1.0",
     "@ember/optional-features": "^2.0.0",
     "@fortawesome/ember-fontawesome": "^0.2.3",
     "@fortawesome/free-brands-svg-icons": "^5.15.3",
@@ -96,7 +97,6 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.3.0",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v10.0.1",
     "prettier": "^2.5.1",
     "qunit-dom": "^1.6.0",
     "sass": "^1.32.8",

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, fillIn, click } from '@ember/test-helpers';
+import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession, invalidateSession } from 'ember-simple-auth/test-support';
 import {

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 
@@ -81,27 +81,13 @@ module('Acceptance | Session creation', function (hooks) {
 
       // then
       const session = server.schema.sessions.findBy({ date: sessionDate });
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.address, 'My address');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.room, 'My room');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.examiner, 'My examiner');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.description, 'My description');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.date, sessionDate);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.time, '13:45');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/sessions/${session.id}`);
+      assert.strictEqual(session.address, 'My address');
+      assert.strictEqual(session.room, 'My room');
+      assert.strictEqual(session.examiner, 'My examiner');
+      assert.strictEqual(session.description, 'My description');
+      assert.strictEqual(session.date, sessionDate);
+      assert.strictEqual(session.time, '13:45');
+      assert.strictEqual(currentURL(), `/sessions/${session.id}`);
     });
 
     test('it should go back to sessions list on cancel without creating any sessions', async function (assert) {
@@ -114,12 +100,8 @@ module('Acceptance | Session creation', function (hooks) {
 
       // then
       const actualSessionsCount = server.schema.sessions.all().length;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/liste');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(previousSessionsCount, actualSessionsCount);
+      assert.strictEqual(currentURL(), '/sessions/liste');
+      assert.strictEqual(previousSessionsCount, actualSessionsCount);
     });
   });
 });

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, fillIn, find } from '@ember/test-helpers';
+import { click, find, fillIn } from '@ember/test-helpers';
 import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { authenticateSession } from '../helpers/test-init';
 import sinon from 'sinon';

--- a/certif/tests/acceptance/session-update_test.js
+++ b/certif/tests/acceptance/session-update_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 

--- a/certif/tests/acceptance/supervisor-portal-access_test.js
+++ b/certif/tests/acceptance/supervisor-portal-access_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { fillIn, click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { authenticateSession } from '../helpers/test-init';

--- a/certif/tests/helpers/fill-in-focusout.js
+++ b/certif/tests/helpers/fill-in-focusout.js
@@ -1,0 +1,6 @@
+import { fillIn, blur } from '@ember/test-helpers';
+
+export default async function fillInFocusOut(selector, value) {
+  await fillIn(selector, value);
+  await blur(selector);
+}

--- a/certif/tests/helpers/fill-in-focusout.js
+++ b/certif/tests/helpers/fill-in-focusout.js
@@ -1,6 +1,0 @@
-import { fillIn, blur } from '@ember/test-helpers';
-
-export default async function fillInFocusOut(selector, value) {
-  await fillIn(selector, value);
-  await blur(selector);
-}

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { reject, resolve } from 'rsvp';

--- a/certif/tests/integration/components/session-finalization/examiner-global-comment-step_test.js
+++ b/certif/tests/integration/components/session-finalization/examiner-global-comment-step_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, click } from '@ember/test-helpers';
+import { render, click, fillIn } from '@ember/test-helpers';
 import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 


### PR DESCRIPTION
## :unicorn: Problème
On utilise une ancienne version de pix-ui. On à besoin de la version à jour pour utiliser la nouvelle modale

## :robot: Solution
Mettre à jour pix-ui

## :rainbow: Remarques
- Plusieurs breaking changes
- La version 11 a une regression, il y a donc une [correction sur pix-ui](https://github.com/1024pix/pix-ui/pull/198)

## :100: Pour tester
S'assurer que tout est ok 
- login certif
- login portail surveillant
- tooltips (en particulier sur les "copier presse-papiers" du details d'une session)
