### PR TITLE
[BUGFIX] Cacher la colonne écran de fin de test dans la feuille d'émargement quand le centre de certification à accès à l'espace surveillant (PIX-4376).

### DIFF
--- a/api/lib/domain/usecases/get-attendance-sheet.js
+++ b/api/lib/domain/usecases/get-attendance-sheet.js
@@ -17,7 +17,6 @@ module.exports = async function getAttendanceSheet({
   sessionRepository,
   sessionForAttendanceSheetRepository,
   endTestScreenRemovalService,
-  supervisorAccessRepository,
 }) {
   const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
   if (!hasMembership) {
@@ -27,8 +26,7 @@ module.exports = async function getAttendanceSheet({
   const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(
     sessionId
   );
-  const hasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({ sessionId });
-  const addEndTestScreenColumn = !isEndTestScreenRemovalEnabled || !hasSupervisorAccess;
+  const addEndTestScreenColumn = !isEndTestScreenRemovalEnabled;
 
   const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates(sessionId);
   const odsFilePath = _getAttendanceSheetTemplatePath(

--- a/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
+++ b/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
@@ -5,7 +5,6 @@ const readOdsUtils = require('../../../../../lib/infrastructure/utils/ods/read-o
 const sessionRepository = require('../../../../../lib/infrastructure/repositories/sessions/session-repository');
 const sessionForAttendanceSheetRepository = require('../../../../../lib/infrastructure/repositories/sessions/session-for-attendance-sheet-repository');
 const endTestScreenRemovalService = require('../../../../../lib/domain/services/end-test-screen-removal-service');
-const supervisorAccessRepository = require('../../../../../lib/infrastructure/repositories/supervisor-access-repository');
 const getAttendanceSheet = require('../../../../../lib/domain/usecases/get-attendance-sheet');
 
 describe('Integration | UseCases | getAttendanceSheet', function () {
@@ -60,7 +59,6 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
           endTestScreenRemovalService,
           sessionRepository,
           sessionForAttendanceSheetRepository,
-          supervisorAccessRepository,
         });
         await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
         const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
@@ -72,122 +70,59 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
     });
 
     context('when certification center does have the supervisor access enabled', function () {
-      context('when the session has supervisor access', function () {
-        const expectedOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_target.ods`;
-        const actualOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_actual.tmp.ods`;
+      const expectedOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_target.ods`;
+      const actualOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_actual.tmp.ods`;
 
-        beforeEach(async function () {
-          const certificationCenterName = 'Centre de certification';
-          databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
-          certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-            name: certificationCenterName,
-            type: 'SUP',
-            externalId: 'EXT1234',
-            isSupervisorAccessEnabled: true,
-          }).id;
+      beforeEach(async function () {
+        const certificationCenterName = 'Centre de certification';
+        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          name: certificationCenterName,
+          type: 'SUP',
+          externalId: 'EXT1234',
+          isSupervisorAccessEnabled: true,
+        }).id;
 
-          userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
 
-          sessionId = databaseBuilder.factory.buildSession({
-            id: 10,
-            certificationCenter: certificationCenterName,
-            certificationCenterId: certificationCenterId,
-            accessCode: 'ABC123DEF',
-            address: '3 rue des bibiches',
-            room: '28D',
-            examiner: 'Johnny',
-            date: '2020-07-05',
-            time: '14:30',
-            description: 'La super description',
-          }).id;
+        sessionId = databaseBuilder.factory.buildSession({
+          id: 10,
+          certificationCenter: certificationCenterName,
+          certificationCenterId: certificationCenterId,
+          accessCode: 'ABC123DEF',
+          address: '3 rue des bibiches',
+          room: '28D',
+          examiner: 'Johnny',
+          date: '2020-07-05',
+          time: '14:30',
+          description: 'La super description',
+        }).id;
 
-          databaseBuilder.factory.buildSupervisorAccess({ sessionId });
+        _createCertificationCandidatesForSession(sessionId);
 
-          _createCertificationCandidatesForSession(sessionId);
-
-          await databaseBuilder.commit();
-        });
-
-        afterEach(async function () {
-          await unlink(actualOdsFilePath);
-        });
-
-        it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
-          // when
-          const updatedOdsFileBuffer = await getAttendanceSheet({
-            userId,
-            sessionId,
-            endTestScreenRemovalService,
-            sessionRepository,
-            sessionForAttendanceSheetRepository,
-            supervisorAccessRepository,
-          });
-          await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
-          const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
-          const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
-
-          // then
-          expect(actualResult).to.deep.equal(expectedResult);
-        });
+        await databaseBuilder.commit();
       });
 
-      context('when the session does not have supervisor access', function () {
-        const expectedOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_target_with_fdt.ods`;
-        const actualOdsFilePath = `${__dirname}/non_sco_attendance_sheet_template_actual_with_fdt.tmp.ods`;
+      afterEach(async function () {
+        await unlink(actualOdsFilePath);
+      });
 
-        beforeEach(async function () {
-          const certificationCenterName = 'Centre de certification';
-          databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
-          certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-            name: certificationCenterName,
-            type: 'SUP',
-            externalId: 'EXT1234',
-            isSupervisorAccessEnabled: true,
-          }).id;
-
-          userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-
-          sessionId = databaseBuilder.factory.buildSession({
-            id: 10,
-            certificationCenter: certificationCenterName,
-            certificationCenterId: certificationCenterId,
-            accessCode: 'ABC123DEF',
-            address: '3 rue des bibiches',
-            room: '28D',
-            examiner: 'Johnny',
-            date: '2020-07-05',
-            time: '14:30',
-            description: 'La super description',
-          }).id;
-
-          _createCertificationCandidatesForSession(sessionId);
-
-          await databaseBuilder.commit();
+      it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
+        // when
+        const updatedOdsFileBuffer = await getAttendanceSheet({
+          userId,
+          sessionId,
+          endTestScreenRemovalService,
+          sessionRepository,
+          sessionForAttendanceSheetRepository,
         });
+        await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
+        const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
+        const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
 
-        afterEach(async function () {
-          await unlink(actualOdsFilePath);
-        });
-
-        it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
-          // when
-          const updatedOdsFileBuffer = await getAttendanceSheet({
-            userId,
-            sessionId,
-            endTestScreenRemovalService,
-            sessionRepository,
-            sessionForAttendanceSheetRepository,
-            supervisorAccessRepository,
-          });
-          await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
-          const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
-          const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
-
-          // then
-          expect(actualResult).to.deep.equal(expectedResult);
-        });
+        // then
+        expect(actualResult).to.deep.equal(expectedResult);
       });
     });
   });
@@ -244,7 +179,6 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
           endTestScreenRemovalService,
           sessionRepository,
           sessionForAttendanceSheetRepository,
-          supervisorAccessRepository,
         });
         await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
         const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
@@ -256,120 +190,58 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
     });
 
     context('when certification center does have the supervisor access enabled', function () {
-      context('when the session has supervisor access', function () {
-        const expectedOdsFilePath = `${__dirname}/sco_attendance_sheet_template_target.ods`;
-        const actualOdsFilePath = `${__dirname}/sco_attendance_sheet_template_actual.tmp.ods`;
+      const expectedOdsFilePath = `${__dirname}/sco_attendance_sheet_template_target.ods`;
+      const actualOdsFilePath = `${__dirname}/sco_attendance_sheet_template_actual.tmp.ods`;
 
-        beforeEach(async function () {
-          const certificationCenterName = 'Centre de certification';
-          databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
-          certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-            name: certificationCenterName,
-            type: 'SCO',
-            externalId: 'EXT1234',
-            isSupervisorAccessEnabled: true,
-          }).id;
+      beforeEach(async function () {
+        const certificationCenterName = 'Centre de certification';
+        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
+        certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          name: certificationCenterName,
+          type: 'SCO',
+          externalId: 'EXT1234',
+          isSupervisorAccessEnabled: true,
+        }).id;
 
-          userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+        userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
 
-          sessionId = databaseBuilder.factory.buildSession({
-            id: 10,
-            certificationCenter: certificationCenterName,
-            certificationCenterId: certificationCenterId,
-            accessCode: 'ABC123DEF',
-            address: '3 rue des bibiches',
-            room: '28D',
-            examiner: 'Johnny',
-            date: '2020-07-05',
-            time: '14:30',
-            description: 'La super description',
-          }).id;
-          _createCertificationCandidatesScoForSession(sessionId);
+        sessionId = databaseBuilder.factory.buildSession({
+          id: 10,
+          certificationCenter: certificationCenterName,
+          certificationCenterId: certificationCenterId,
+          accessCode: 'ABC123DEF',
+          address: '3 rue des bibiches',
+          room: '28D',
+          examiner: 'Johnny',
+          date: '2020-07-05',
+          time: '14:30',
+          description: 'La super description',
+        }).id;
+        _createCertificationCandidatesScoForSession(sessionId);
 
-          databaseBuilder.factory.buildSupervisorAccess({ sessionId });
-
-          await databaseBuilder.commit();
-        });
-
-        afterEach(async function () {
-          await unlink(actualOdsFilePath);
-        });
-
-        it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
-          // when
-          const updatedOdsFileBuffer = await getAttendanceSheet({
-            userId,
-            sessionId,
-            endTestScreenRemovalService,
-            sessionRepository,
-            sessionForAttendanceSheetRepository,
-            supervisorAccessRepository,
-          });
-          await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
-          const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
-          const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
-
-          // then
-          expect(actualResult).to.deep.equal(expectedResult);
-        });
+        await databaseBuilder.commit();
       });
 
-      context('when the session does not have supervisor access', function () {
-        const expectedOdsFilePath = `${__dirname}/sco_attendance_sheet_template_target_with_fdt.ods`;
-        const actualOdsFilePath = `${__dirname}/sco_attendance_sheet_template_actual_with_fdt.tmp.ods`;
+      afterEach(async function () {
+        await unlink(actualOdsFilePath);
+      });
 
-        beforeEach(async function () {
-          const certificationCenterName = 'Centre de certification';
-          databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
-          certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-            name: certificationCenterName,
-            type: 'SCO',
-            externalId: 'EXT1234',
-            isSupervisorAccessEnabled: true,
-          }).id;
-
-          userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-
-          sessionId = databaseBuilder.factory.buildSession({
-            id: 10,
-            certificationCenter: certificationCenterName,
-            certificationCenterId: certificationCenterId,
-            accessCode: 'ABC123DEF',
-            address: '3 rue des bibiches',
-            room: '28D',
-            examiner: 'Johnny',
-            date: '2020-07-05',
-            time: '14:30',
-            description: 'La super description',
-          }).id;
-          _createCertificationCandidatesScoForSession(sessionId);
-
-          await databaseBuilder.commit();
+      it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
+        // when
+        const updatedOdsFileBuffer = await getAttendanceSheet({
+          userId,
+          sessionId,
+          endTestScreenRemovalService,
+          sessionRepository,
+          sessionForAttendanceSheetRepository,
         });
+        await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
+        const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
+        const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
 
-        afterEach(async function () {
-          await unlink(actualOdsFilePath);
-        });
-
-        it('should return an attendance sheet with session data, certification candidates data prefilled', async function () {
-          // when
-          const updatedOdsFileBuffer = await getAttendanceSheet({
-            userId,
-            sessionId,
-            endTestScreenRemovalService,
-            sessionRepository,
-            sessionForAttendanceSheetRepository,
-            supervisorAccessRepository,
-          });
-          await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
-          const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
-          const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
-
-          // then
-          expect(actualResult).to.deep.equal(expectedResult);
-        });
+        // then
+        expect(actualResult).to.deep.equal(expectedResult);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans une précédente PR, la disparition de la colonne écran de fin de test dans la feuille d'émargement a été conditionnée par l'autorisation donnée à un centre de certification d'utiliser l'espace surveillant et au fait que la session se soit déroulé à travers l'espace surveillant. Cependant, cette dernière information ne peut être acquise que lorsque la session de certification a débuté. Ceci a entraîné l'apparition de la colonne écran de fin de test pour des centre ayant pourtant accès à l'espace surveillant.   

## :robot: Solution
Supprimer le code vérifiant que la session soit ou non effectuée via l'espace surveillant pour afficher/cacher la colonne écran  de fin de test. 

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certipro@example.net`.
- Créer une session de certification et y ajouter un candidat.
- Télécharger la feuille d'émargement et vérifier que la colonne "Ecran de fin de test vu" n'apparaît pas.
- Supprimer l'accès à l'espace surveillant pour le centre de certification PRO.
```
	scalingo -a pix-api-review-pr4085 --region osc-fr1 pgsql-console


	update "certification-centers" set "isSupervisorAccessEnabled"=false where id=2;
```


- Re-télécharger la feuille d'émargement et vérifier que la colonne apparaît.
