### PR TITLE
[FEATURE] Création d'un script de rattachement des catégories aux profils cibles (PIX-4357)

### DIFF
--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const bluebird = require('bluebird');
 
-const { checkCsvExtensionFile, parseCsvWithHeader } = require('./helpers/csvHelpers');
+const { parseCsvWithHeader } = require('./helpers/csvHelpers');
 
 const Membership = require('../lib/domain/models/Membership');
 
@@ -78,10 +78,6 @@ async function main() {
 
   try {
     const filePath = process.argv[2];
-
-    console.log('Check csv extension file... ');
-    checkCsvExtensionFile(filePath);
-    console.log('ok');
 
     console.log('Reading and parsing csv data file... ');
     const csvData = await parseCsvWithHeader(filePath);

--- a/api/scripts/create-sco-certification-centers.js
+++ b/api/scripts/create-sco-certification-centers.js
@@ -1,4 +1,4 @@
-const { checkCsvExtensionFile, parseCsvWithHeader } = require('./helpers/csvHelpers');
+const { parseCsvWithHeader } = require('./helpers/csvHelpers');
 
 const Bookshelf = require('../lib/infrastructure/bookshelf');
 
@@ -21,10 +21,6 @@ async function main() {
 
   try {
     const filePath = process.argv[2];
-
-    console.log('Check csv extension file... ');
-    checkCsvExtensionFile(filePath);
-    console.log('ok');
 
     console.log('Reading and parsing csv data file... ');
     const csvData = await parseCsvWithHeader(filePath);

--- a/api/scripts/prod/select-category-for-target-profiles.js
+++ b/api/scripts/prod/select-category-for-target-profiles.js
@@ -1,0 +1,87 @@
+#! /usr/bin/env node
+require('dotenv').config();
+const bluebird = require('bluebird');
+const groupBy = require('lodash/groupBy');
+const sum = require('lodash/sum');
+const has = require('lodash/has');
+const negate = require('lodash/negate');
+
+const { readCsvFile, parseCsvData } = require('../helpers/csvHelpers');
+const { categories } = require('../../lib/domain/models/TargetProfile');
+const { knex } = require('../../db/knex-database-connection');
+
+const TARGET_PROFILE_ID_COLUMN = 'targetProfileId';
+const CATEGORY_COLUMN = 'category';
+
+async function main() {
+  console.log('Starting script select-category-for-target-profiles');
+
+  console.log('Reading csv file... ');
+  const filePath = process.argv[2];
+  const csvData = await readCsvFile(filePath);
+  console.log('✅ ok');
+
+  console.log('Setting categories on target profiles...');
+  const { totalUpdatedRows, invalidCategories } = await setCategoriesToTargetProfiles(csvData);
+  if (invalidCategories.length > 0) {
+    console.log(`⚠️ Les catégories "${invalidCategories.join(', ')}" ne sont pas supportées`);
+  }
+  console.log(`✅ ${totalUpdatedRows} target profiles were updated.`);
+}
+
+async function setCategoriesToTargetProfiles(csvData) {
+  const parsedCsvData = await parseCsvData(csvData, {
+    header: true,
+    delimiter: ',',
+    skipEmptyLines: true,
+  });
+
+  const firstRow = parsedCsvData[0];
+  if (!has(firstRow, CATEGORY_COLUMN) || !has(firstRow, TARGET_PROFILE_ID_COLUMN)) {
+    throw new Error(`Les colonnes "${CATEGORY_COLUMN}" et "${TARGET_PROFILE_ID_COLUMN}" sont obligatoires`);
+  }
+
+  const targetProfilesGroupedByCategory = groupBy(parsedCsvData, CATEGORY_COLUMN);
+  const parsedCategories = Object.keys(targetProfilesGroupedByCategory);
+
+  const invalidCategories = parsedCategories.filter(negate(_isSupportedCategory));
+  const validCategories = parsedCategories.filter(_isSupportedCategory);
+
+  const result = await bluebird.mapSeries(validCategories, function (category) {
+    return setCategoryToTargetProfiles(
+      category,
+      targetProfilesGroupedByCategory[category].map((row) => row[TARGET_PROFILE_ID_COLUMN])
+    );
+  });
+
+  return { totalUpdatedRows: sum(result), invalidCategories };
+}
+
+if (require.main === module) {
+  main()
+    .then(function () {
+      console.log('🎉 Everything went fine !');
+      process.exit(0);
+    })
+    .catch(function (error) {
+      console.error('❌ Something went wrong...');
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+async function setCategoryToTargetProfiles(category, targetProfileIds) {
+  return knex('target-profiles').whereIn('id', targetProfileIds).update({
+    category,
+  });
+}
+
+function _isSupportedCategory(category) {
+  const supportedCategories = Object.values(categories);
+  return supportedCategories.includes(category);
+}
+
+module.exports = {
+  setCategoriesToTargetProfiles,
+  setCategoryToTargetProfiles,
+};

--- a/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
+++ b/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
@@ -51,12 +51,20 @@ describe('Integration | Scripts | select-category-for-target-profiles.js', funct
   });
 
   describe('#setCategoriesToTargetProfiles', function () {
-    it('should log categories that are not supported', async function () {
+    it('should return categories that are not supported', async function () {
       const { invalidCategories } = await setCategoriesToTargetProfiles(`targetProfileId,category
 1,WRONG
 2,BAD`);
 
       expect(invalidCategories).deep.equal(['WRONG', 'BAD']);
+    });
+
+    it('should return target profiles that are not valid', async function () {
+      const { invalidTargetProfiles } = await setCategoriesToTargetProfiles(`targetProfileId,category
+,COMPETENCES
+yolo,COMPETENCES`);
+
+      expect(invalidTargetProfiles).deep.equal(['', 'yolo']);
     });
 
     it('should not set categories that are not supported', async function () {

--- a/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
+++ b/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
@@ -1,0 +1,108 @@
+const { expect, databaseBuilder, knex, catchErr } = require('../../../test-helper');
+const {
+  setCategoriesToTargetProfiles,
+  setCategoryToTargetProfiles,
+} = require('../../../../scripts/prod/select-category-for-target-profiles');
+const { categories } = require('../../../../lib/domain/models/TargetProfile');
+
+describe('Integration | Scripts | select-category-for-target-profiles.js', function () {
+  let firstTargetProfileId;
+  let secondTargetProfileId;
+  let otherTargetProfileId;
+
+  beforeEach(async function () {
+    firstTargetProfileId = databaseBuilder.factory.buildTargetProfile({ category: null }).id;
+    secondTargetProfileId = databaseBuilder.factory.buildTargetProfile({ category: null }).id;
+    otherTargetProfileId = databaseBuilder.factory.buildTargetProfile({ category: null }).id;
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async function () {
+    await knex('target-profiles').delete();
+  });
+
+  describe('#setCategoryToTargetProfiles', function () {
+    it('should set category on target profiles', async function () {
+      const targetProfilesId = [firstTargetProfileId, secondTargetProfileId];
+
+      await setCategoryToTargetProfiles(categories.COMPETENCES, targetProfilesId);
+
+      const targetProfilesCategories = await knex('target-profiles')
+        .select('category')
+        .whereIn('id', targetProfilesId)
+        .distinct('category');
+      expect(targetProfilesCategories).deep.equal([{ category: categories.COMPETENCES }]);
+    });
+
+    it('should not set category on other target profiles', async function () {
+      const targetProfilesId = [firstTargetProfileId, secondTargetProfileId];
+
+      await setCategoryToTargetProfiles(categories.COMPETENCES, targetProfilesId);
+
+      const { category } = await knex('target-profiles').where({ id: otherTargetProfileId }).first();
+      expect(category).equal(null);
+    });
+
+    it('should skip non existing ids', async function () {
+      const targetProfilesId = [456];
+
+      await expect(setCategoryToTargetProfiles(categories.COMPETENCES, targetProfilesId)).to.be.fulfilled;
+    });
+  });
+
+  describe('#setCategoriesToTargetProfiles', function () {
+    it('should log categories that are not supported', async function () {
+      const { invalidCategories } = await setCategoriesToTargetProfiles(`targetProfileId,category
+1,WRONG
+2,BAD`);
+
+      expect(invalidCategories).deep.equal(['WRONG', 'BAD']);
+    });
+
+    it('should not set categories that are not supported', async function () {
+      await setCategoriesToTargetProfiles(`targetProfileId,category
+${firstTargetProfileId},WRONG`);
+
+      const { category } = await knex('target-profiles').where({ id: firstTargetProfileId }).first();
+      expect(category).equal(null);
+    });
+
+    it('should throw an error if the category column is missing', async function () {
+      const error = await catchErr(setCategoriesToTargetProfiles)(`targetProfileId,missing
+1,COMPETENCES`);
+
+      expect(error.message).equal('Les colonnes "category" et "targetProfileId" sont obligatoires');
+    });
+
+    it('should throw an error if the target profile id column is missing', async function () {
+      const error = await catchErr(setCategoriesToTargetProfiles)(`missing,category
+1,COMPETENCES`);
+
+      expect(error.message).equal('Les colonnes "category" et "targetProfileId" sont obligatoires');
+    });
+
+    it('should update target profiles with different categories', async function () {
+      const csvData = `targetProfileId,category
+${firstTargetProfileId},DISCIPLINE
+${secondTargetProfileId},COMPETENCES`;
+
+      await setCategoriesToTargetProfiles(csvData);
+
+      const targetProfiles = await knex('target-profiles').select(['id', 'category']).whereNotNull('category');
+      expect(targetProfiles).deep.equal([
+        { id: firstTargetProfileId, category: categories.DISCIPLINE },
+        { id: secondTargetProfileId, category: categories.COMPETENCES },
+      ]);
+    });
+
+    it('should return total updated rows', async function () {
+      const csvData = `targetProfileId,category
+${firstTargetProfileId},DISCIPLINE
+${secondTargetProfileId},DISCIPLINE`;
+
+      const { totalUpdatedRows } = await setCategoriesToTargetProfiles(csvData);
+
+      expect(totalUpdatedRows).equal(2);
+    });
+  });
+});

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -3,27 +3,30 @@ const { NotFoundError, FileValidationError } = require('../../../../lib/domain/e
 const {
   checkCsvExtensionFile,
   parseCsv,
+  readCsvFile,
   parseCsvWithHeader,
   checkCsvHeader,
 } = require('../../../../scripts/helpers/csvHelpers');
 
 describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
-  const notExistFilePath = 'notExist.file';
+  const notExistFilePath = 'notExist.csv';
   const badExtensionFilePath = `${__dirname}/files/bad_extension.html`;
   const validFilePath = `${__dirname}/files/valid-organizations-test.csv`;
   const utf8FilePath = `${__dirname}/files/utf8_excel-test.csv`;
   const withHeaderFilePath = `${__dirname}/files/withHeader-test.csv`;
 
-  describe('#checkCsvExtensionFile', function () {
+  describe('#readCsvFile', function () {
     it('should throw a NotFoundError when file does not exist', async function () {
       // when
-      const error = await catchErr(checkCsvExtensionFile)(notExistFilePath);
+      const error = await catchErr(readCsvFile)(notExistFilePath);
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal(`File ${notExistFilePath} not found!`);
     });
+  });
 
+  describe('#checkCsvExtensionFile', function () {
     it('should throw a FileValidationError when file extension is not ".csv"', async function () {
       // when
       const error = await catchErr(checkCsvExtensionFile)(badExtensionFilePath);


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'ajout de la catégorisation des profil cibles, c'est fastidieux de tous les mettre à jour un par un pour les pôles métiers.

## :robot: Solution
On crée un script qui permet de catégoriser un ensemble de profils cible à partir d'un fichier CSV.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Faire un fichier csv avec le contenu suivant : 
```csv
targetProfileId,category
1,COMPETENCES
2,DISCIPLINE
```
- Executer la commande suivante `node api/scripts/prod/select-category-for-target-profiles.js [chemin/vers/le/fichier/csv]`
- Constater que les deux profils cibles ont été mis à jour avec la bonne catégorie
