### PR TITLE
[FEATURE] Changer le nom des catégories pour les profils cibles (PIX-4365)

### DIFF
--- a/admin/app/components/campaigns/update.js
+++ b/admin/app/components/campaigns/update.js
@@ -88,7 +88,6 @@ export default class Update extends Component {
   }
 
   async _checkFormValidation() {
-    console.log(this.form.customResultPageButtonUrl);
     const { validations } = await this.form.validate();
     return validations.isValid;
   }

--- a/admin/app/components/target-profiles/category.js
+++ b/admin/app/components/target-profiles/category.js
@@ -1,21 +1,9 @@
 import Component from '@glimmer/component';
+import { categories } from '../../models/target-profile';
 
 export default class Category extends Component {
   get category() {
     const { category } = this.args;
-    switch (category) {
-      case 'COMPETENCES':
-        return 'Compétences Pix';
-      case 'SUBJECT':
-        return 'Thématique';
-      case 'DISCIPLINE':
-        return 'Disciplinaire';
-      case 'CUSTOM':
-        return 'Sur-mesure';
-      case 'PREDEFINED':
-        return 'Prédéfinie';
-      default:
-        return 'Autre';
-    }
+    return categories[category];
   }
 }

--- a/admin/app/components/target-profiles/create-target-profile-form.js
+++ b/admin/app/components/target-profiles/create-target-profile-form.js
@@ -1,39 +1,16 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { optionsCategoryList } from '../../models/target-profile';
 
 export default class UpdateTargetProfile extends Component {
   @service notifications;
 
   constructor() {
     super(...arguments);
-    this.optionsList = [
-      {
-        value: 'OTHER',
-        label: 'Autre',
-      },
-      {
-        value: 'COMPETENCES',
-        label: 'Compétences Pix',
-      },
-      {
-        value: 'DISCIPLINE',
-        label: 'Disciplinaire',
-      },
-      {
-        value: 'PREDEFINED',
-        label: 'Prédéfini',
-      },
-      {
-        value: 'CUSTOM',
-        label: 'Sur-mesure',
-      },
-      {
-        value: 'SUBJECT',
-        label: 'Thématique',
-      },
-    ];
+    this.optionsList = optionsCategoryList;
   }
+
   @action
   onCategoryChange(event) {
     this.args.targetProfile.category = event.target.value;

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { optionsCategoryList } from '../../models/target-profile';
 
 const Validations = buildValidations({
   name: {
@@ -63,32 +64,7 @@ export default class UpdateTargetProfile extends Component {
     this.form.comment = this.args.model.comment || null;
     this.form.category = this.args.model.category || null;
 
-    this.optionsList = [
-      {
-        value: 'OTHER',
-        label: 'Autre',
-      },
-      {
-        value: 'COMPETENCES',
-        label: 'Compétences Pix',
-      },
-      {
-        value: 'DISCIPLINE',
-        label: 'Disciplinaire',
-      },
-      {
-        value: 'PREDEFINED',
-        label: 'Prédéfini',
-      },
-      {
-        value: 'CUSTOM',
-        label: 'Sur-mesure',
-      },
-      {
-        value: 'SUBJECT',
-        label: 'Thématique',
-      },
-    ];
+    this.optionsList = this.optionsList = optionsCategoryList;
   }
 
   async _checkFormValidation() {

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -1,5 +1,19 @@
 import { memberAction } from 'ember-api-actions';
 import Model, { attr, hasMany } from '@ember-data/model';
+import map from 'lodash/map';
+
+export const categories = {
+  COMPETENCES: 'Les 16 compétences',
+  SUBJECT: 'Thématiques',
+  DISCIPLINE: 'Disciplinaires',
+  CUSTOM: 'Parcours sur-mesure',
+  PREDEFINED: 'Parcours prédéfinis',
+  OTHER: 'Autres',
+};
+
+export const optionsCategoryList = map(categories, function (key, value) {
+  return { value: value, label: key };
+});
 
 export default class TargetProfile extends Model {
   @attr('string') name;

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -62,7 +62,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
       // then
       assert.contains('Profil Cible Fantastix');
-      assert.contains('Thématique');
+      assert.contains('Thématiques');
       assert.dom('section').containsText('ID : 1');
       assert.dom('section').containsText('Public : Oui');
       assert.dom('section').containsText('Obsolète : Non');
@@ -223,7 +223,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
       await click('button[type=submit]');
 
       // then
-      assert.contains('Sur-mesure');
+      assert.contains('Parcours sur-mesure');
       assert.dom('Enregistrer').doesNotExist();
     });
   });

--- a/admin/tests/integration/components/target-profiles/category_test.js
+++ b/admin/tests/integration/components/target-profiles/category_test.js
@@ -11,7 +11,7 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     await render(hbs`<TargetProfiles::Category @category="COMPETENCES"/>`);
 
     // then
-    assert.contains('Compétences Pix');
+    assert.contains('Les 16 compétences');
   });
 
   test('it should display the tag for type SUBJECT', async function (assert) {
@@ -19,7 +19,7 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     await render(hbs`<TargetProfiles::Category @category="SUBJECT"/>`);
 
     // then
-    assert.contains('Thématique');
+    assert.contains('Thématiques');
   });
 
   test('it should display the tag for type DISCIPLINE', async function (assert) {
@@ -27,7 +27,7 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     await render(hbs`<TargetProfiles::Category @category="DISCIPLINE"/>`);
 
     // then
-    assert.contains('Disciplinaire');
+    assert.contains('Disciplinaires');
   });
 
   test('it should display the tag for type CUSTOM', async function (assert) {
@@ -35,7 +35,7 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     await render(hbs`<TargetProfiles::Category @category="CUSTOM"/>`);
 
     // then
-    assert.contains('Sur-mesure');
+    assert.contains('Parcours sur-mesure');
   });
 
   test('it should display the tag for type PREDEFINED', async function (assert) {
@@ -43,7 +43,7 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     await render(hbs`<TargetProfiles::Category @category="PREDEFINED"/>`);
 
     // then
-    assert.contains('Prédéfinie');
+    assert.contains('Parcours prédéfinis');
   });
 
   test('it should display the tag for type OTHER', async function (assert) {
@@ -51,6 +51,6 @@ module('Integration | Component | TargetProfiles::Category', function (hooks) {
     await render(hbs`<TargetProfiles::Category @category="OTHER"/>`);
 
     // then
-    assert.contains('Autre');
+    assert.contains('Autres');
   });
 });

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -3,9 +3,11 @@ import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
 import sinon from 'sinon';
+import { setupIntl, t } from 'ember-intl/test-support';
 
 module('Unit | Component | Campaign::CreateForm', (hooks) => {
   setupTest(hooks);
+  setupIntl(hooks);
 
   module('#categories', function () {
     module('when this a target profile without OTHER category', function () {
@@ -41,15 +43,15 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         const expectedOrder = [
           {
             name: 'PREDEFINED',
-            translation: 'Prédéfinie',
+            translation: t('pages.campaign-creation.tags.PREDEFINED'),
           },
           {
             name: 'CUSTOM',
-            translation: 'Sur-mesure',
+            translation: t('pages.campaign-creation.tags.CUSTOM'),
           },
           {
             name: 'SUBJECT',
-            translation: 'Thématique',
+            translation: t('pages.campaign-creation.tags.SUBJECT'),
           },
         ];
         assert.deepEqual(allCategories, expectedOrder);
@@ -95,19 +97,19 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         const expectedOrder = [
           {
             name: 'PREDEFINED',
-            translation: 'Prédéfinie',
+            translation: t('pages.campaign-creation.tags.PREDEFINED'),
           },
           {
             name: 'CUSTOM',
-            translation: 'Sur-mesure',
+            translation: t('pages.campaign-creation.tags.CUSTOM'),
           },
           {
             name: 'SUBJECT',
-            translation: 'Thématique',
+            translation: t('pages.campaign-creation.tags.SUBJECT'),
           },
           {
             name: 'OTHER',
-            translation: 'Autre',
+            translation: t('pages.campaign-creation.tags.OTHER'),
           },
         ];
         assert.deepEqual(allCategories, expectedOrder);

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -330,12 +330,12 @@
         "profiles-collection-info": "Une campagne de collecte de profils permet de récupérer le profil des participants : niveaux par compétence et score pix."
       },
       "tags": {
-        "COMPETENCES": "Compétences Pix",
-        "CUSTOM": "Sur-mesure",
-        "DISCIPLINE": "Disciplinaire",
-        "PREDEFINED": "Prédéfinie",
-        "OTHER": "Autre",
-        "SUBJECT": "Thématique"
+        "COMPETENCES": "Les 16 compétences",
+        "CUSTOM": "Parcours sur-mesure",
+        "DISCIPLINE": "Disciplinaires",
+        "PREDEFINED": "Parcours prédéfinis",
+        "OTHER": "Autres",
+        "SUBJECT": "Thématiques"
       },
       "tags-title": "Filtrer la recherche :",
       "target-profiles": {


### PR DESCRIPTION
## :unicorn: Problème
Le nom choisi pour les catégories des profils cibles n'était pas suffisamment explicite.

## :robot: Solution
Changer le noms des catégories dans le fichiers fr coté Orga et dans le fichier `category.js` coté Admin.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
**Côté Pix Orga**
- Aller sur PixOrga
- Créer une campagne de type "Campagne d'évaluation"
- Constater les nouveaux noms

**Côté Pix Admin**
- Aller sur PixAdmin
- Créer un nouveau profil cible
- Constater les nouveaux noms des catégories