### PR TITLE
[FEATURE] Afficher des statistiques de participations à une campagne dans le détail d'une campagne dans Pix Admin(PIX-4362).

### DIFF
--- a/admin/app/components/campaigns/details.hbs
+++ b/admin/app/components/campaigns/details.hbs
@@ -1,6 +1,13 @@
 <section class="page-section">
-  <h1>{{@campaign.name}}</h1>
-
+  <div class="campaign-title">
+    <h1>{{@campaign.name}}</h1>
+    <PixTag @color={{"blue"}} @compact="true" class="campaign-title__tag">{{@campaign.totalParticipationsCount}}
+      participants</PixTag>
+    <PixTag @color={{"green"}} @compact="true">
+      {{@campaign.sharedParticipationsCount}}
+      {{if @campaign.isTypeAssessment "résultats" "profils"}}
+      reçus</PixTag>
+  </div>
   <p class="campaign__subtitle">
     Créée le
     {{moment-format @campaign.createdAt "DD/MM/YYYY"}}

--- a/admin/app/models/campaign.js
+++ b/admin/app/models/campaign.js
@@ -1,5 +1,4 @@
 import Model, { attr } from '@ember-data/model';
-
 export default class Campaign extends Model {
   @attr('string') name;
   @attr('string') title;
@@ -20,12 +19,8 @@ export default class Campaign extends Model {
   @attr('string') customResultPageText;
   @attr('string') customResultPageButtonText;
   @attr('string') customResultPageButtonUrl;
-
-  get isTypeProfilesCollection() {
-    return this.type === 'PROFILES_COLLECTION';
-  }
-
-  get isTypeAssessment() {
-    return this.type === 'ASSESSMENT';
-  }
+  @attr('number') sharedParticipationsCount;
+  @attr('number') totalParticipationsCount;
+  @attr('boolean') isTypeProfilesCollection;
+  @attr('boolean') isTypeAssessment;
 }

--- a/admin/app/styles/authenticated/campaigns/get.scss
+++ b/admin/app/styles/authenticated/campaigns/get.scss
@@ -8,3 +8,15 @@
   padding-inline: 0;
   margin: 0;
 }
+
+.campaign-title {
+  display: flex;
+
+  & h1 {
+    margin-right: 8px;
+  }
+
+  &__tag {
+    margin-right: 8px;
+  }
+}

--- a/admin/tests/integration/components/campaigns/details_test.js
+++ b/admin/tests/integration/components/campaigns/details_test.js
@@ -12,52 +12,79 @@ module('Integration | Component | Campaigns | details', function (hooks) {
     this.toggleEditMode = sinon.stub();
   });
 
-  test('should display campaign attributes', async function (assert) {
-    // given
-    this.campaign = {
-      type: 'ASSESSMENT',
-      code: 'MYCODE',
-      creatorFirstName: 'Jon',
-      creatorLastName: 'Snow',
-      organizationId: 2,
-      organizationName: 'My organization',
-      targetProfileId: 3,
-      targetProfileName: 'My target profile',
-      customLandingPageText: 'welcome',
-      customResultPageText: 'tadaaa',
-      customResultPageButtonText: 'Click here',
-      customResultPageButtonUrl: 'www.pix.fr',
-      createdAt: new Date('2020-02-01'),
-      archivedAt: new Date('2020-03-01'),
-    };
+  module('when campaign type is ASSESSMENT', function () {
+    test('should display campaign attributes', async function (assert) {
+      // given
+      this.campaign = {
+        type: 'ASSESSMENT',
+        code: 'MYCODE',
+        creatorFirstName: 'Jon',
+        creatorLastName: 'Snow',
+        organizationId: 2,
+        organizationName: 'My organization',
+        targetProfileId: 3,
+        targetProfileName: 'My target profile',
+        customLandingPageText: 'welcome',
+        customResultPageText: 'tadaaa',
+        customResultPageButtonText: 'Click here',
+        customResultPageButtonUrl: 'www.pix.fr',
+        createdAt: new Date('2020-02-01'),
+        archivedAt: new Date('2020-03-01'),
+      };
 
-    // when
-    await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // when
+      await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // expect
+      assert.contains('Créée le 01/02/2020 par Jon Snow');
+      assert.contains('Type : Évaluation');
+      assert.contains('Code : MYCODE');
+      assert.contains('My target profile');
+      assert.contains('My organization');
+      assert.contains('Archivée le 01/03/2020');
+      assert.contains('welcome');
+      assert.contains('tadaaa');
+      assert.contains('Click here');
+      assert.contains('www.pix.fr');
+    });
 
-    // expect
-    assert.contains('Créée le 01/02/2020 par Jon Snow');
-    assert.contains('Type : Évaluation');
-    assert.contains('Code : MYCODE');
-    assert.contains('My target profile');
-    assert.contains('My organization');
-    assert.contains('Archivée le 01/03/2020');
-    assert.contains('welcome');
-    assert.contains('tadaaa');
-    assert.contains('Click here');
-    assert.contains('www.pix.fr');
+    test('should display the number of shared results', async function (assert) {
+      // given
+      this.campaign = {
+        sharedParticipationsCount: 5,
+        isTypeAssessment: true,
+      };
+      // when
+      await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // then
+      assert.contains('5 résultats reçus');
+    });
   });
 
-  test('should display profile collection tag', async function (assert) {
-    // given
-    this.campaign = {
-      type: 'COLLECTION_PROFILE',
-    };
+  module('when campaign type is COLLECTION_PROFILE ', function () {
+    test('should display profile collection tag', async function (assert) {
+      // given
+      this.campaign = {
+        type: 'COLLECTION_PROFILE',
+      };
+      // when
+      await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
 
-    // when
-    await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // then
+      assert.contains('Collecte de profils');
+    });
 
-    // expect
-    assert.contains('Collecte de profils');
+    test('should display the number of shared profiles', async function (assert) {
+      // given
+      this.campaign = {
+        sharedParticipationsCount: 5,
+        isTypeAssessment: false,
+      };
+
+      // when
+      await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // then
+      assert.contains('5 profils reçus');
+    });
   });
 
   test('should call toggleEditMode function when the edit button is clicked', async function (assert) {
@@ -69,5 +96,18 @@ module('Integration | Component | Campaigns | details', function (hooks) {
 
     //then
     assert.ok(this.toggleEditMode.called);
+  });
+
+  test('should display total participants', async function (assert) {
+    // given
+    this.campaign = {
+      totalParticipationsCount: 10,
+      isTypeAssessment: false,
+    };
+
+    // when
+    await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+    // then
+    assert.contains('10 participants');
   });
 });

--- a/api/lib/domain/read-models/CampaignManagement.js
+++ b/api/lib/domain/read-models/CampaignManagement.js
@@ -10,9 +10,21 @@ class CampaignManagement {
     creatorLastName,
     creatorFirstName,
     creatorId,
+    organizationId,
+    organizationName,
+    targetProfileId,
+    targetProfileName,
+    title,
+    customLandingPageText,
+    customResultPageText,
+    customResultPageButtonText,
+    customResultPageButtonUrl,
     ownerLastName,
     ownerFirstName,
     ownerId,
+    shared,
+    started,
+    completed,
   } = {}) {
     this.id = id;
     this.code = code;
@@ -24,9 +36,28 @@ class CampaignManagement {
     this.creatorLastName = creatorLastName;
     this.creatorFirstName = creatorFirstName;
     this.creatorId = creatorId;
+    this.organizationId = organizationId;
+    this.organizationName = organizationName;
+    this.targetProfileId = targetProfileId;
+    this.targetProfileName = targetProfileName;
+    this.title = title;
+    this.customLandingPageText = customLandingPageText;
+    this.customResultPageText = customResultPageText;
+    this.customResultPageButtonText = customResultPageButtonText;
+    this.customResultPageButtonUrl = customResultPageButtonUrl;
     this.ownerLastName = ownerLastName;
     this.ownerFirstName = ownerFirstName;
     this.ownerId = ownerId;
+    this.sharedParticipationsCount = shared;
+    this.totalParticipationsCount = this.sharedParticipationsCount + (started || 0) + completed;
+  }
+
+  get isTypeProfilesCollection() {
+    return this.type === 'PROFILES_COLLECTION';
+  }
+
+  get isTypeAssessment() {
+    return this.type === 'ASSESSMENT';
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer.js
@@ -22,6 +22,10 @@ module.exports = {
         'customResultPageText',
         'customResultPageButtonText',
         'customResultPageButtonUrl',
+        'sharedParticipationsCount',
+        'totalParticipationsCount',
+        'isTypeProfilesCollection',
+        'isTypeAssessment',
       ],
       meta,
     }).serialize(campaignManagement);

--- a/api/tests/unit/domain/read-models/campaign/campaignManagment_test.js
+++ b/api/tests/unit/domain/read-models/campaign/campaignManagment_test.js
@@ -1,0 +1,30 @@
+const { expect } = require('../../../../test-helper');
+const CampaignManagement = require('../../../../../lib/domain/read-models/CampaignManagement');
+
+describe('campaignManagement', function () {
+  describe('#totalParticipationsCount', function () {
+    it('returns total participations count', function () {
+      const campaignManagement = new CampaignManagement({
+        id: 1,
+        name: 'Assessment101',
+        shared: 5,
+        started: 3,
+        completed: 2,
+      });
+
+      expect(campaignManagement.totalParticipationsCount).to.equal(10);
+    });
+
+    it('returns total participations count when started is undifined', function () {
+      const campaignManagement = new CampaignManagement({
+        id: 1,
+        name: 'Assessment101',
+        shared: 5,
+        started: undefined,
+        completed: 2,
+      });
+
+      expect(campaignManagement.totalParticipationsCount).to.equal(7);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-details-management-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-details-management-serializer_test.js
@@ -24,6 +24,10 @@ describe('Unit | Serializer | JSONAPI | campaign-details-management-serializer',
         customResultPageText: 'Finish',
         customResultPageButtonText: 'Click',
         customResultPageButtonUrl: 'www.pix.fr',
+        sharedParticipationsCount: 5,
+        totalParticipationsCount: 10,
+        isTypeProfilesCollection: false,
+        isTypeAssessment: true,
       };
 
       // when
@@ -52,6 +56,10 @@ describe('Unit | Serializer | JSONAPI | campaign-details-management-serializer',
             'custom-result-page-text': campaignManagement.customResultPageText,
             'custom-result-page-button-text': campaignManagement.customResultPageButtonText,
             'custom-result-page-button-url': campaignManagement.customResultPageButtonUrl,
+            'shared-participations-count': campaignManagement.sharedParticipationsCount,
+            'total-participations-count': campaignManagement.totalParticipationsCount,
+            'is-type-profiles-collection': false,
+            'is-type-assessment': true,
           },
         },
       });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans pix admin seul des informations primaires sont affichées. Les utilisateurs internes pix manquent d’informations. 

## :robot: Solution
Nous allons rajouter quelques indicateurs au sein de cette page de détail d’une campagne. les indicateurs sont  
- Nombre total de participations
- Le nombre de résultats reçus (total des participations SHARED)

## :rainbow: Remarques

## :100: Pour tester
- Se connecter dans Pix Admin -> Organizations -> campagnes 
- sélectionner une campagne puis constater que les nouvelles indicateurs `Nombre total de participations` et `Le nombre de résultats reçus` sont présents 
- Se connecter sur Pix Orga dans la même Organization puis sélectionner la même campagne, allez dans l’onglet activité et comparer les résultats. il faut que les 2 résultants soient identiques à ce qui est affiché coté Pix Admin