### PR TITLE
[BUGFIX] Neutraliser les questions auxquelles les candidats n'ont pas pu répondre à cause d'une régression - v2 (PIX-4368). 

### DIFF
--- a/api/scripts/neutralize-answers-after-invalid-challenges.js
+++ b/api/scripts/neutralize-answers-after-invalid-challenges.js
@@ -11,11 +11,9 @@ const events = require('../lib/domain/events');
 
 const extractAnswers = async (lengthyChallengeId, exposure) => {
   const answers = await knex
-    .from('sessions')
-    .select('certification-courses.id AS certificationCourseId', 'answers.challengeId')
-    .innerJoin('certification-courses', 'certification-courses.sessionId', 'sessions.id')
-    .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-    .innerJoin('answers', 'answers.assessmentId', 'assessments.id')
+    .from('answers')
+    .select('assessments.certificationCourseId AS certificationCourseId', 'answers.challengeId')
+    .innerJoin('assessments', 'assessments.id', 'answers.assessmentId')
     .where('answers.result', '<>', 'ok')
     .where('answers.id', '>', exposure.lastAnswerIdBeforeRegression)
     .where('answers.id', '<', exposure.firstAnswerIdAfterRegression)

--- a/api/scripts/neutralize-answers-after-invalid-challenges.js
+++ b/api/scripts/neutralize-answers-after-invalid-challenges.js
@@ -72,6 +72,9 @@ const main = async () => {
 
   if (process.env.PROCEED === 'YES') {
     await neutralizeAnswers(answers, userId);
+  } else {
+    logger.info('Answers have not been neutralized.');
+    logger.info('To actually neutralize, set PROCEED env variable value to YES');
   }
 };
 


### PR DESCRIPTION
## :unicorn: Problème
La solution proposée dans #4081 a plusieurs inconvénients:
- elle utilise la dernière release du référentiel pour déterminer les questions candidates, or le référentiel est différent de celui en place le 10/02;
- elle inclut des réponses à des questions dont la bonne réponse fait moins de 500 caractères.


## :robot: Solution
En se basant sur les données de monitoring, on peut obtenir les information nécessaires:
- 9 549 requêtes HTTP en erreur = 9 549 réponses rejetées
- 1 004 réponses provenant de certifications
- 1 000 réponses concernant l'épreuve `challengeId=receQkwO1dvjQc2S3`
 
Les 4 autres épreuves ne sont pas concernées, la bonne réponse faisant moins de 500 caractères.

## :rainbow: Remarques
Neutraliser les questions sur  `challengeId=receQkwO1dvjQc2S3`
Pour accélérer la requête, ne pas mentionner une plage de date mais une plage sur `answers.id`

## :100: Pour tester

### script complet
Créer un utilisateur ayant passé une certification sur ce challenge (voir commit `WIP TO DROP`)
```
npm run db:reset
```

Lancer le script
```
 LOG_LEVEL=info PROCEED=YES node scripts/run-neutralize-answers-after-invalid-challenges.js
```

Vérifier les messages
```
[13:04:47] INFO: Script has started
[13:04:47] INFO: 3 answers found
[13:04:47] INFO: Neutralization has started
[13:04:50] INFO: Neutralization has ended
[13:04:50] INFO: Script has ended
```

Vérifier la neutralisation
```
SELECT
    cc.id,
    cc."courseId" "certificationCourseId",
    cc."challengeId",
    cc."isNeutralized",
    cc."updatedAt",
    'certification-challenges=>',
    cc.*
FROM "certification-challenges" cc
WHERE 1=1
     AND cc."courseId" = 108509
     AND cc."challengeId" = 'receQkwO1dvjQc2S3'
     AND cc."isNeutralized" IS TRUE;
```
![image](https://user-images.githubusercontent.com/56302715/154071163-ff232b78-6b3a-45df-8754-9eec08470c8d.png)

Vérfier le scoring
```sql
SELECT
    'assessments=>',
    ass.id,
    ass.type,
    ass.state,
    'assessments-results=>',
    asr."pixScore",
    asr.emitter,
    asr.status,
    asr."createdAt"
FROM sessions s
         INNER JOIN "certification-centers" crt ON crt.id = s."certificationCenterId"
         INNER JOIN "certification-courses" cc ON cc."sessionId" = s.id
         INNER JOIN users u ON u.id = cc."userId"
         INNER JOIN assessments ass ON ass."certificationCourseId" = cc.id
         INNER JOIN "assessment-results" asr ON asr."assessmentId" = ass.id
WHERE 1 = 1
    AND ass.id = 108510
ORDER BY s.id, cc."userId", asr."createdAt";
```
![image](https://user-images.githubusercontent.com/56302715/154071046-16b0b258-738e-4ad4-a919-48744a8a285f.png)


### composant `extractAnswers`
Exécuter le script en local pour obtenir la requête knex
`DEBUG=knex.* LOG_LEVEL=info node scripts/run-neutralize-answers-after-invalid-challenges.js `

Récupérer la requête et l'exécuter sur une instance avec des données de production.
Vérifier que le nombre de réponses renvoyées est similaire à  `1 000`

Ce nombre est 1 036, il y a des assessment qui ne font pas l'objets d'erreur 400, ex `44091888`
Ce sont des réponses KO sur une longueur de texte < 500 caractères.