### PR TITLE
[FEATURE] Permettre de déplacer une méthode de connexion GAR d'un user à un autre (PIX-4043)

### DIFF
--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -57,6 +57,23 @@ export default class UserAdapter extends ApplicationAdapter {
       return this.ajax(url, 'POST', payload);
     }
 
+    if (snapshot.adapterOptions && snapshot.adapterOptions.reassignGarAuthenticationMethod) {
+      const payload = {
+        data: {
+          data: {
+            attributes: {
+              'user-id': snapshot.adapterOptions.targetUserId,
+              'identity-provider': 'GAR',
+            },
+          },
+        },
+      };
+      const url =
+        this.urlForUpdateRecord(snapshot.id) +
+        `/authentication-methods/${snapshot.adapterOptions.targetUserId}/reassign`;
+      return this.ajax(url, 'PUT', payload);
+    }
+
     return super.updateRecord(...arguments);
   }
 }

--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -68,9 +68,10 @@ export default class UserAdapter extends ApplicationAdapter {
           },
         },
       };
+
       const url =
         this.urlForUpdateRecord(snapshot.id) +
-        `/authentication-methods/${snapshot.adapterOptions.targetUserId}/reassign`;
+        `/authentication-methods/${snapshot.adapterOptions.authenticationMethodId}/reassign`;
       return this.ajax(url, 'PUT', payload);
     }
 

--- a/admin/app/components/users/user-detail-personal-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information.hbs
@@ -10,6 +10,7 @@
     @user={{@user}}
     @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
     @addPixAuthenticationMethod={{@addPixAuthenticationMethod}}
+    @reassignGarAuthenticationMethod={{@reassignGarAuthenticationMethod}}
   />
 </section>
 

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -76,13 +76,13 @@
         {{#if @user.hasPoleEmploiAuthenticationMethod}}
           <FaIcon
             @icon="check-circle"
-            aria-label="L'utilisateur a une méthode de connexion avec Pôle Emploi"
+            aria-label="L'utilisateur a une méthode de connexion Pôle Emploi"
             class="authentication-method__check"
           />
         {{else}}
           <FaIcon
             @icon="times-circle"
-            aria-label="L'utilisateur n'a pas de méthode de connexion avec Pôle Emploi"
+            aria-label="L'utilisateur n'a pas de méthode de connexion Pôle Emploi"
             class="authentication-method__uncheck"
           />
         {{/if}}
@@ -104,11 +104,15 @@
       <td class="authentication-method__name-column">Médiacentre</td>
       <td>
         {{#if @user.hasGarAuthenticationMethod}}
-          <FaIcon @icon="check-circle" class="authentication-method__check" />
+          <FaIcon
+            @icon="check-circle"
+            aria-label="L'utilisateur a une méthode de connexion Médiacentre"
+            class="authentication-method__check"
+          />
         {{else}}
           <FaIcon
             @icon="times-circle"
-            aria-label="L'utilisateur n'a pas de méthode de connexion avec GAR"
+            aria-label="L'utilisateur n'a pas de méthode de connexion Médiacentre"
             class="authentication-method__uncheck"
           />
         {{/if}}

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -124,6 +124,13 @@
           >Supprimer</PixButton>
         {{/if}}
       </td>
+      <td>
+        {{#if @user.hasGarAuthenticationMethod}}
+          <PixButton @triggerAction={{this.toggleReassignGarAuthenticationMethodModal}} @size="small">
+            Déplacer cette méthode de connexion
+          </PixButton>
+        {{/if}}
+      </td>
     </tr>
   </tbody>
 </table>
@@ -134,4 +141,11 @@
   @showAlreadyExistingEmailError={{this.showAlreadyExistingEmailError}}
   @toggleAddAuthenticationMethodModal={{this.toggleAddAuthenticationMethodModal}}
   @submitAddingPixAuthenticationMethod={{this.submitAddingPixAuthenticationMethod}}
+/>
+
+<Users::UserDetailPersonalInformation::ReassignGarAuthenticationMethodModal
+  @showReassignGarAuthenticationMethodModal={{this.showReassignGarAuthenticationMethodModal}}
+  @targetUserId={{this.targetUserId}}
+  @toggleReassignGarAuthenticationMethodModal={{this.toggleReassignGarAuthenticationMethodModal}}
+  @submitReassignGarAuthenticationMethod={{this.submitReassignGarAuthenticationMethod}}
 />

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -54,12 +54,7 @@ export default class AuthenticationMethod extends Component {
   @action
   async submitReassignGarAuthenticationMethod(event) {
     event.preventDefault();
-    try {
-      await this.args.reassignGarAuthenticationMethod(this.targetUserId);
-      this.notifications.success(`La méthode de connexion a bien été déplacé vers l'utilisateur ${this.targetUserId}`);
-      this.showReassignGarAuthenticationMethodModal = false;
-    } catch (response) {
-      console.log(response.errors);
-    }
+    await this.args.reassignGarAuthenticationMethod(this.targetUserId);
+    this.showReassignGarAuthenticationMethodModal = false;
   }
 }

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -7,7 +7,9 @@ export default class AuthenticationMethod extends Component {
   @service notifications;
 
   @tracked showAddAuthenticationMethodModal = false;
+  @tracked showReassignGarAuthenticationMethodModal = false;
   @tracked newEmail = '';
+  @tracked targetUserId = '';
   @tracked showAlreadyExistingEmailError = false;
 
   @action
@@ -18,9 +20,14 @@ export default class AuthenticationMethod extends Component {
   }
 
   @action
+  toggleReassignGarAuthenticationMethodModal() {
+    this.showReassignGarAuthenticationMethodModal = !this.showReassignGarAuthenticationMethodModal;
+    this.targetUserId = '';
+  }
+
+  @action
   async submitAddingPixAuthenticationMethod(event) {
     event.preventDefault();
-
     try {
       await this.args.addPixAuthenticationMethod(this.newEmail);
       this.notifications.success(`${this.newEmail} a bien été rajouté aux méthodes de connexion de l'utilisateur`);
@@ -41,6 +48,18 @@ export default class AuthenticationMethod extends Component {
         this.newEmail = '';
         this.showAlreadyExistingEmailError = false;
       }
+    }
+  }
+
+  @action
+  async submitReassignGarAuthenticationMethod(event) {
+    event.preventDefault();
+    try {
+      await this.args.reassignGarAuthenticationMethod(this.targetUserId);
+      this.notifications.success(`La méthode de connexion a bien été déplacé vers l'utilisateur ${this.targetUserId}`);
+      this.showReassignGarAuthenticationMethodModal = false;
+    } catch (response) {
+      console.log(response.errors);
     }
   }
 }

--- a/admin/app/components/users/user-detail-personal-information/reassign-gar-authentication-method-modal.hbs
+++ b/admin/app/components/users/user-detail-personal-information/reassign-gar-authentication-method-modal.hbs
@@ -1,0 +1,31 @@
+<Modal::Dialog
+  @title="Déplacer la méthode de connexion"
+  @display={{@showReassignGarAuthenticationMethodModal}}
+  @close={{@toggleReassignGarAuthenticationMethodModal}}
+>
+  <form {{on "submit" @submitReassignGarAuthenticationMethod}}>
+    <Modal::Body class="reassign-gar-authentication-method-modal__form-body">
+      <p class="reassign-gar-authentication-method-modal__form-body__information">
+        Vous vous apprêtez à déplacer la méthode Médiacentre sur un autre utilisateur. Cela signifie qu'elle n'existera
+        plus pour cet utilisateur.
+      </p>
+      <PixInput
+        @id="user-id-for-reassign-authentication-method"
+        @label="Id de l'utilisateur à qui vous souhaitez ajouter la méthode de connexion"
+        @value={{@targetUserId}}
+        type="number"
+        required
+      />
+    </Modal::Body>
+
+    <Modal::Footer>
+      <PixButton
+        @size="small"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{@toggleReassignGarAuthenticationMethodModal}}
+      >Annuler</PixButton>
+      <PixButton @type="submit" @size="small">Valider le déplacement</PixButton>
+    </Modal::Footer>
+  </form>
+</Modal::Dialog>

--- a/admin/app/controllers/authenticated/users/get.js
+++ b/admin/app/controllers/authenticated/users/get.js
@@ -12,4 +12,9 @@ export default class GetController extends Controller {
   async addPixAuthenticationMethod(newEmail) {
     await this.model.save({ adapterOptions: { addPixAuthenticationMethod: true, newEmail } });
   }
+
+  @action
+  async reassignGarAuthenticationMethod(targetUserId) {
+    await this.model.save({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId } });
+  }
 }

--- a/admin/app/controllers/authenticated/users/get.js
+++ b/admin/app/controllers/authenticated/users/get.js
@@ -1,7 +1,20 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class GetController extends Controller {
+  @service notifications;
+
+  METHOD_REASSIGN_IMPOSSIBLE = "L'utilisateur a déjà une méthode de connexion Médiacentre.";
+  BAD_REQUEST = 'Cette requête est impossible';
+
+  ERROR_MESSAGES = {
+    DEFAULT: 'Une erreur est survenue.',
+    STATUS_422: this.METHOD_REASSIGN_IMPOSSIBLE,
+    STATUS_400: this.BAD_REQUEST,
+    STATUS_404: "Cet utilisateur n'existe pas.",
+  };
+
   @action
   async removeAuthenticationMethod(type) {
     await this.model.save({ adapterOptions: { removeAuthenticationMethod: true, type } });
@@ -15,6 +28,39 @@ export default class GetController extends Controller {
 
   @action
   async reassignGarAuthenticationMethod(targetUserId) {
-    await this.model.save({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId } });
+    try {
+      await this.model.save({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId } });
+      this.notifications.success(`La méthode de connexion a bien été déplacé vers l'utilisateur ${targetUserId}`);
+      this.send('refreshModel');
+      this.notifications.success("L'utilisateur n'a plus de méthode de connexion Médiacentre");
+    } catch (error) {
+      this._handleResponseError(error);
+    }
+  }
+
+  _handleResponseError({ errors }) {
+    let errorMessages = [];
+
+    if (errors) {
+      errorMessages = errors.map((error) => {
+        switch (error.status) {
+          case '400':
+            return this.ERROR_MESSAGES.STATUS_400;
+          case '404':
+            return this.ERROR_MESSAGES.STATUS_404;
+          case '422':
+            return this.ERROR_MESSAGES.STATUS_422;
+          default:
+            return this.ERROR_MESSAGES.DEFAULT;
+        }
+      });
+    } else {
+      errorMessages.push(this.ERROR_MESSAGES.DEFAULT);
+    }
+
+    const uniqueErrorMessages = new Set(errorMessages);
+    uniqueErrorMessages.forEach((errorMessage) => {
+      this.notifications.error(errorMessage);
+    });
   }
 }

--- a/admin/app/controllers/authenticated/users/get.js
+++ b/admin/app/controllers/authenticated/users/get.js
@@ -28,14 +28,24 @@ export default class GetController extends Controller {
 
   @action
   async reassignGarAuthenticationMethod(targetUserId) {
+    const authenticationMethodId = this._getGARauthenticationMethodId();
     try {
-      await this.model.save({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId } });
+      await this.model.save({
+        adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId, authenticationMethodId },
+      });
       this.notifications.success(`La méthode de connexion a bien été déplacé vers l'utilisateur ${targetUserId}`);
       this.send('refreshModel');
       this.notifications.success("L'utilisateur n'a plus de méthode de connexion Médiacentre");
     } catch (error) {
       this._handleResponseError(error);
     }
+  }
+
+  _getGARauthenticationMethodId() {
+    const authenticationMethods = this.model.authenticationMethods.filter(
+      (authenticationMethod) => authenticationMethod.identityProvider === 'GAR'
+    );
+    return authenticationMethods[0].get('id');
   }
 
   _handleResponseError({ errors }) {

--- a/admin/app/styles/components/users/user-detail-personal-information/authentication-method.scss
+++ b/admin/app/styles/components/users/user-detail-personal-information/authentication-method.scss
@@ -34,11 +34,20 @@
   }
 }
 
-.add-authentication-method-modal__form-body {
+.add-authentication-method-modal__form-body,
+.reassign-gar-authentication-method-modal__form-body {
   margin-bottom: 16px;
 
   label[for="new-email-for-adding-authentication-method"] {
     height: 18px;
     bottom: calc(-18px - 4px - 6px);
+  }
+}
+
+.reassign-gar-authentication-method-modal__form-body {
+
+  p {
+    padding: 0;
+    margin-bottom: 40px;
   }
 }

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -12,5 +12,6 @@
     @user={{@model}}
     @removeAuthenticationMethod={{this.removeAuthenticationMethod}}
     @addPixAuthenticationMethod={{this.addPixAuthenticationMethod}}
+    @reassignGarAuthenticationMethod={{this.reassignGarAuthenticationMethod}}
   />
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -250,6 +250,13 @@ export default function () {
     return user;
   });
 
+  this.put('/admin/users/:userId/authentication-methods/:id/reassign', (schema, request) => {
+    const userId = request.params.userId;
+    const user = schema.users.findBy({ id: userId });
+    user.update({ authenticationMethods: [] });
+    return user;
+  });
+
   this.get('feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -250,7 +250,7 @@ export default function () {
     return user;
   });
 
-  this.put('/admin/users/:userId/authentication-methods/:id/reassign', (schema, request) => {
+  this.put('/admin/users/:userId/authentication-methods/:authenticationMethodId/reassign', (schema, request) => {
     const userId = request.params.userId;
     const user = schema.users.findBy({ id: userId });
     user.update({ authenticationMethods: [] });

--- a/admin/tests/acceptance/authenticated/users/authentication-method_test.js
+++ b/admin/tests/acceptance/authenticated/users/authentication-method_test.js
@@ -87,7 +87,10 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
 
       // then
       assert.dom(screen.getByText("La méthode de connexion a bien été déplacé vers l'utilisateur 1")).exists();
+      assert.dom(screen.getByText("L'utilisateur n'a plus de méthode de connexion Médiacentre")).exists();
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec GAR")).exists();
+      assert.dom(screen.queryByText('Valider le déplacement')).doesNotExist();
+      //
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/users/authentication-method_test.js
+++ b/admin/tests/acceptance/authenticated/users/authentication-method_test.js
@@ -1,63 +1,93 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { createAuthenticateSession } from '../../../helpers/test-init';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | authenticated/users | authentication-method', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('should be possible to add a new Pix Authentication Method', async function (assert) {
-    // given
-    const currentUser = server.create('user');
-    await createAuthenticateSession({ userId: currentUser.id });
+  module('when adding Pix authentication method', function () {
+    test("should display Pix authentication method with email's information", async function (assert) {
+      // given
+      const currentUser = server.create('user');
+      await createAuthenticateSession({ userId: currentUser.id });
 
-    const firstName = 'Alice';
-    const lastName = 'Merveille';
-    const garAuthenticationMethod = server.create('authentication-method', { identityProvider: 'GAR' });
-    const userToAddNewEmail = server.create('user', {
-      firstName,
-      lastName,
-      authenticationMethods: [garAuthenticationMethod],
+      const firstName = 'Alice';
+      const lastName = 'Merveille';
+      const garAuthenticationMethod = server.create('authentication-method', { identityProvider: 'GAR' });
+      const userToAddNewEmail = server.create('user', {
+        firstName,
+        lastName,
+        authenticationMethods: [garAuthenticationMethod],
+      });
+
+      // when
+      const screen = await visitScreen(`/users/${userToAddNewEmail.id}`);
+      await clickByName('Ajouter une adresse e-mail');
+      await fillByLabel('Nouvelle adresse e-mail', 'nouvel-email@example.net');
+      await clickByName("Enregistrer l'adresse e-mail");
+
+      // then
+      assert.notContains('Nouvelle adresse e-mail');
+      assert.dom(
+        screen.getByText(`nouvel-email@example.net a bien été rajouté aux méthodes de connexion de l'utilisateur`)
+      );
+      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec adresse e-mail")).exists();
     });
 
-    // when
-    await visit(`/users/${userToAddNewEmail.id}`);
-    await clickByName('Ajouter une adresse e-mail');
-    await fillByLabel('Nouvelle adresse e-mail', 'nouvel-email@example.net');
-    await clickByName("Enregistrer l'adresse e-mail");
+    test('should stay on modal if email already existing for an other user', async function (assert) {
+      // given
+      const currentUser = server.create('user');
+      await createAuthenticateSession({ userId: currentUser.id });
 
-    // then
-    assert.notContains('Nouvelle adresse e-mail');
-    assert.contains(`nouvel-email@example.net a bien été rajouté aux méthodes de connexion de l'utilisateur`);
-    assert.dom('tr[data-test-email] svg.authentication-method__check').exists();
+      const firstName = 'Alice';
+      const lastName = 'Merveille';
+      const garAuthenticationMethod = server.create('authentication-method', { identityProvider: 'GAR' });
+      const userToAddNewEmail = server.create('user', {
+        firstName,
+        lastName,
+        authenticationMethods: [garAuthenticationMethod],
+      });
+      server.create('user', { email: 'nouvel-email@example.net' });
+
+      // when
+      const screen = await visitScreen(`/users/${userToAddNewEmail.id}`);
+      await clickByName('Ajouter une adresse e-mail');
+      await fillByLabel('Nouvelle adresse e-mail', 'nouvel-email@example.net');
+      await clickByName("Enregistrer l'adresse e-mail");
+
+      // then
+      assert.dom(screen.getByText('Nouvelle adresse e-mail')).exists();
+      assert.dom(screen.getByText('Cette adresse e-mail est déjà utilisée')).exists();
+    });
   });
 
-  test('should stay on modal if email already existing for an other user', async function (assert) {
-    // given
-    const currentUser = server.create('user');
-    await createAuthenticateSession({ userId: currentUser.id });
+  module('when reassign Gar authentication method', function () {
+    test('should remove Gar authentication method information', async function (assert) {
+      // given
+      const currentUser = server.create('user');
+      await createAuthenticateSession({ userId: currentUser.id });
 
-    const firstName = 'Alice';
-    const lastName = 'Merveille';
-    const garAuthenticationMethod = server.create('authentication-method', { identityProvider: 'GAR' });
-    const userToAddNewEmail = server.create('user', {
-      firstName,
-      lastName,
-      authenticationMethods: [garAuthenticationMethod],
+      const firstName = 'Alice';
+      const lastName = 'Merveille';
+      const garAuthenticationMethod = server.create('authentication-method', { identityProvider: 'GAR' });
+      const user = server.create('user', {
+        firstName,
+        lastName,
+        authenticationMethods: [garAuthenticationMethod],
+      });
+
+      // when
+      const screen = await visitScreen(`/users/${user.id}`);
+      await clickByName('Déplacer cette méthode de connexion');
+      await fillByLabel("Id de l'utilisateur à qui vous souhaitez ajouter la méthode de connexion", 1);
+      await clickByName('Valider le déplacement');
+
+      // then
+      assert.dom(screen.getByText("La méthode de connexion a bien été déplacé vers l'utilisateur 1")).exists();
+      assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec GAR")).exists();
     });
-    server.create('user', { email: 'nouvel-email@example.net' });
-
-    // when
-    await visit(`/users/${userToAddNewEmail.id}`);
-    await clickByName('Ajouter une adresse e-mail');
-    await fillByLabel('Nouvelle adresse e-mail', 'nouvel-email@example.net');
-    await clickByName("Enregistrer l'adresse e-mail");
-
-    // then
-    assert.contains('Nouvelle adresse e-mail');
-    assert.contains('Cette adresse e-mail est déjà utilisée');
   });
 });

--- a/admin/tests/acceptance/authenticated/users/authentication-method_test.js
+++ b/admin/tests/acceptance/authenticated/users/authentication-method_test.js
@@ -88,9 +88,8 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
       // then
       assert.dom(screen.getByText("La méthode de connexion a bien été déplacé vers l'utilisateur 1")).exists();
       assert.dom(screen.getByText("L'utilisateur n'a plus de méthode de connexion Médiacentre")).exists();
-      assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec GAR")).exists();
+      assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion Médiacentre")).exists();
       assert.dom(screen.queryByText('Valider le déplacement')).doesNotExist();
-      //
     });
   });
 });

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import sinon from 'sinon';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | users | user-detail-personal-information/authentication-method', function (hooks) {
@@ -11,79 +10,69 @@ module('Integration | Component | users | user-detail-personal-information/authe
   module('When user has authentication methods', function () {
     test('should display user’s email authentication method', async function (assert) {
       // given
-      this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
       this.set('user', { hasEmailAuthenticationMethod: true });
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
-          @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
         />`);
 
       // then
-      assert.dom('tr[data-test-email] svg').hasClass('authentication-method__check');
+      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec adresse e-mail")).exists();
     });
 
     test('should display user’s username authentication method', async function (assert) {
       // given
-      this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
       this.set('user', { hasUsernameAuthenticationMethod: true });
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
-          @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
         />`);
 
       // then
-      assert.dom('tr[data-test-username] svg').hasClass('authentication-method__check');
+      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec identifiant")).exists();
     });
 
     test('should display user’s Pole Emploi authentication method', async function (assert) {
       // given
-      this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
       this.set('user', { hasPoleEmploiAuthenticationMethod: true });
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
-          @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
         />`);
 
       // then
-      assert.dom('tr[data-test-pole-emploi] svg').hasClass('authentication-method__check');
+      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Pôle Emploi")).exists();
     });
 
     test('should display user’s gar authentication method', async function (assert) {
       // given
-      this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
       this.set('user', { hasGarAuthenticationMethod: true });
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
-          @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
         />`);
 
       // then
-      assert.dom('tr[data-test-gar] svg').hasClass('authentication-method__check');
+      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Médiacentre")).exists();
     });
 
     module('When user has only one authentication method', function () {
       test('it should not display a remove authentication method link', async function (assert) {
         // given
-        this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
         this.set('user', { hasOnlyOneAuthenticationMethod: true });
 
         // when
         await render(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
-          @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
         />`);
 
         // then
@@ -93,7 +82,6 @@ module('Integration | Component | users | user-detail-personal-information/authe
       module('When user does not have pix authentication method', function () {
         test('it should display add authentication method button', async function (assert) {
           // given
-          this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
           this.set('user', {
             isAllowedToAddEmailAuthenticationMethod: true,
             hasOnlyOneAuthenticationMethod: true,
@@ -101,28 +89,25 @@ module('Integration | Component | users | user-detail-personal-information/authe
           });
 
           // when
-          await render(hbs`
+          const screen = await renderScreen(hbs`
           <Users::UserDetailPersonalInformation::AuthenticationMethod
             @user={{this.user}}
-            @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
           />`);
 
           // then
-          assert.contains('Ajouter une adresse e-mail');
+          assert.dom(screen.getByRole('button', { name: 'Ajouter une adresse e-mail' })).exists();
         });
       });
 
       module('When user has a pix authentication method', function () {
         test('it should not display add authentication method button', async function (assert) {
           // given
-          this.set('toggleDisplayRemoveAuthenticationMethodModal', sinon.spy());
           this.set('user', { hasOnlyOneAuthenticationMethod: true, hasPixAuthenticationMethod: true });
 
           // when
           await render(hbs`
           <Users::UserDetailPersonalInformation::AuthenticationMethod
             @user={{this.user}}
-            @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
           />`);
 
           // then

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | users | user-detail-personal-information/authentication-method', function (hooks) {
   setupRenderingTest(hooks);
@@ -127,6 +128,24 @@ module('Integration | Component | users | user-detail-personal-information/authe
           // then
           assert.notContains('Ajouter une adresse e-mail');
         });
+      });
+    });
+
+    module('When user has gar authentication method', function () {
+      test('it should display reassign authentication method button', async function (assert) {
+        // given
+        this.set('user', {
+          hasGarAuthenticationMethod: true,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`
+          <Users::UserDetailPersonalInformation::AuthenticationMethod
+            @user={{this.user}}
+          />`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/users/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/users/get_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/users/get', function (hooks) {
+  setupTest(hooks);
+
+  module('#reassignGarAuthenticationMethod', function () {
+    test('should display good error message when an 422 error occurred', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated.users.get');
+
+      const targetUserId = 2;
+      controller.model = { save: sinon.stub() };
+      controller.send = sinon.stub();
+
+      controller.model.save
+        .withArgs({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId } })
+        .rejects({ errors: [{ status: '422' }] });
+
+      controller.notifications = {
+        success: sinon.stub(),
+        error: sinon.stub(),
+      };
+
+      controller.notifications.error.resolves();
+
+      // when
+      await controller.reassignGarAuthenticationMethod(targetUserId);
+
+      // then
+      sinon.assert.calledWith(controller.notifications.error, controller.ERROR_MESSAGES.STATUS_422);
+      assert.ok(true);
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/users/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/users/get_test.js
@@ -11,18 +11,18 @@ module('Unit | Controller | authenticated/users/get', function (hooks) {
       const controller = this.owner.lookup('controller:authenticated.users.get');
 
       const targetUserId = 2;
+      const authenticationMethodId = 10;
+
       controller.model = { save: sinon.stub() };
+      controller._getGARauthenticationMethodId = sinon.stub().returns(authenticationMethodId);
       controller.send = sinon.stub();
-
       controller.model.save
-        .withArgs({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId } })
+        .withArgs({ adapterOptions: { reassignGarAuthenticationMethod: true, targetUserId, authenticationMethodId } })
         .rejects({ errors: [{ status: '422' }] });
-
       controller.notifications = {
         success: sinon.stub(),
         error: sinon.stub(),
       };
-
       controller.notifications.error.resolves();
 
       // when

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -66,6 +66,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AuthenticationKeyForPoleEmploiTokenExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.AuthenticationMethodAlreadyExistsError) {
+    return new HttpErrors.UnprocessableEntityError(error.message);
+  }
   if (error instanceof DomainErrors.UserHasAlreadyLeftSCO) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -780,6 +780,35 @@ exports.register = async function (server) {
         tags: ['api', 'user', 'authentication-methods'],
       },
     },
+    {
+      method: 'PUT',
+      path: '/api/admin/users/{userId}/authentication-methods/{authenticationMethodId}/reassign',
+      config: {
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+            authenticationMethodId: identifiersType.authenticationMethodId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'user-id': identifiersType.userId,
+                'identity-provider': Joi.string().valid('GAR').required(),
+              },
+            },
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRolePixMaster,
+            assign: 'hasRolePixMaster',
+          },
+        ],
+        handler: userController.reassignAuthenticationMethods,
+        notes: ["- Permet à un administrateur de déplacer une méthode de connexion GAR d'un utilisateur à un autre"],
+        tags: ['api', 'administration', 'user', 'authentication-method'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -310,4 +310,18 @@ module.exports = {
     });
     return h.response(userDetailsForAdminSerializer.serialize(userUpdated)).created();
   },
+
+  async reassignAuthenticationMethods(request, h) {
+    const originUserId = request.params.userId;
+    const targetUserId = request.payload.data.attributes['user-id'];
+    const identityProvider = request.payload.data.attributes['identity-provider'];
+
+    if (identityProvider === 'GAR') {
+      await usecases.reassignGarAuthenticationMethod({
+        originUserId,
+        targetUserId,
+      });
+      return h.response().code(204);
+    }
+  },
 };

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -25,6 +25,7 @@ function _assignValueToExport(array, implementationType) {
 const typesPositiveInteger32bits = [
   'answerId',
   'assessmentId',
+  'authenticationMethodId',
   'badgeId',
   'badgeCriterionId',
   'campaignId',

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -354,6 +354,7 @@ module.exports = injectDependencies(
     superviseSession: require('./supervise-session'),
     unarchiveCampaign: require('./unarchive-campaign'),
     unpublishSession: require('./unpublish-session'),
+    reassignGarAuthenticationMethod: require('./reassign-gar-authentication-method'),
     updateBadge: require('./update-badge'),
     updateCampaign: require('./update-campaign'),
     updateCampaignDetailsManagement: require('./update-campaign-details-management'),

--- a/api/lib/domain/usecases/reassign-gar-authentication-method.js
+++ b/api/lib/domain/usecases/reassign-gar-authentication-method.js
@@ -1,0 +1,37 @@
+const { AuthenticationMethodAlreadyExistsError, AuthenticationMethodNotFoundError } = require('../errors');
+const AuthenticationMethod = require('../models/AuthenticationMethod');
+
+module.exports = async function reassignGarAuthenticationMethod({
+  originUserId,
+  targetUserId,
+  userRepository,
+  authenticationMethodRepository,
+}) {
+  const garIdentityProvider = AuthenticationMethod.identityProviders.GAR;
+
+  await userRepository.get(originUserId);
+  const hasGarAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+    userId: originUserId,
+    identityProvider: garIdentityProvider,
+  });
+
+  if (!hasGarAuthenticationMethod)
+    throw new AuthenticationMethodNotFoundError(`L'utilisateur ${originUserId} n'a pas de méthode de connexion GAR.`);
+
+  await userRepository.get(targetUserId);
+  const hasAlreadyGarAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+    userId: targetUserId,
+    identityProvider: garIdentityProvider,
+  });
+
+  if (hasAlreadyGarAuthenticationMethod)
+    throw new AuthenticationMethodAlreadyExistsError(
+      `L'utilisateur ${targetUserId} a déjà une méthode de connexion GAR.`
+    );
+
+  await authenticationMethodRepository.updateAuthenticationMethodUserId({
+    originUserId,
+    identityProvider: garIdentityProvider,
+    targetUserId,
+  });
+};

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -243,4 +243,10 @@ module.exports = {
     }
     return _toDomain(authenticationMethodDTO);
   },
+
+  async updateAuthenticationMethodUserId({ originUserId, identityProvider, targetUserId }) {
+    await knex(AUTHENTICATION_METHODS_TABLE)
+      .where({ userId: originUserId, identityProvider })
+      .update({ userId: targetUserId, updatedAt: new Date() });
+  },
 };

--- a/api/tests/acceptance/application/users/reassign-authentication-methods-route-put_test.js
+++ b/api/tests/acceptance/application/users/reassign-authentication-methods-route-put_test.js
@@ -1,0 +1,89 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRolePixMaster,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+
+describe('Acceptance | Route | Users', function () {
+  describe('PUT /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}/reassign', function () {
+    let server;
+    let pixMaster;
+
+    beforeEach(async function () {
+      server = await createServer();
+      pixMaster = await insertUserWithRolePixMaster();
+    });
+
+    it('should return 204 HTTP status code', async function () {
+      // given
+      const originUserId = databaseBuilder.factory.buildUser().id;
+      const targetUserId = databaseBuilder.factory.buildUser().id;
+      const authenticationMethodId = databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: originUserId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/api/admin/users/${originUserId}/authentication-methods/${authenticationMethodId}/reassign`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(pixMaster.id),
+        },
+        payload: {
+          data: {
+            attributes: {
+              'user-id': targetUserId,
+              'identity-provider': AuthenticationMethod.identityProviders.GAR,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return 422 HTTP status code when target user has already a GAR authentication method', async function () {
+      // given
+      const originUserId = databaseBuilder.factory.buildUser().id;
+      const targetUserId = databaseBuilder.factory.buildUser().id;
+      const authenticationMethodId = databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: originUserId,
+      }).id;
+
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: targetUserId,
+        externalIdentifier: 'externalId2',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/api/admin/users/${originUserId}/authentication-methods/${authenticationMethodId}/reassign`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(pixMaster.id),
+        },
+        payload: {
+          data: {
+            attributes: {
+              'user-id': targetUserId,
+              'identity-provider': AuthenticationMethod.identityProviders.GAR,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.result.errors[0].detail).to.equal(
+        `L'utilisateur ${targetUserId} a déjà une méthode de connexion GAR.`
+      );
+    });
+  });
+});

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -744,6 +744,14 @@ describe('Integration | API | Controller Error', function () {
         "L'élève Paul Preboist a été inscrit avec un code pays de naissance invalide. Veuillez corriger ses informations sur l'espace PixOrga de l'établissement ou contacter le support Pix"
       );
     });
+
+    it('responds UnprocessableEntity when a AuthenticationMethodAlreadyExistsError occurs', async function () {
+      routeHandler.throws(new DomainErrors.AuthenticationMethodAlreadyExistsError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
+      expect(responseDetail(response)).to.equal('Authentication method already exists.');
+    });
   });
 
   context('should respond 401 Unauthorized', function () {

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -900,4 +900,38 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       expect(authenticationMethods).to.be.empty;
     });
   });
+
+  describe('#updateAuthenticationMethodUserId', function () {
+    let clock;
+    const now = new Date('2022-02-16');
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers(now);
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('should update authentication method user id', async function () {
+      // given
+      const originUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: originUserId });
+
+      const targetUserId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      await authenticationMethodRepository.updateAuthenticationMethodUserId({
+        originUserId,
+        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        targetUserId,
+      });
+
+      // then
+      const authenticationMethodUpdated = await knex('authentication-methods').select();
+      expect(authenticationMethodUpdated[0].userId).to.equal(targetUserId);
+      expect(authenticationMethodUpdated[0].updatedAt).to.deep.equal(now);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/reassign-gar-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/reassign-gar-authentication-method_test.js
@@ -1,0 +1,121 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+const reassignGarAuthenticationMethod = require('../../../../lib/domain/usecases/reassign-gar-authentication-method');
+const {
+  AuthenticationMethodNotFoundError,
+  AuthenticationMethodAlreadyExistsError,
+} = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | reassign-gar-authentication-method', function () {
+  let authenticationMethodRepository, userRepository;
+
+  beforeEach(function () {
+    userRepository = {
+      get: sinon.stub(),
+    };
+    authenticationMethodRepository = {
+      updateAuthenticationMethodUserId: sinon.stub(),
+      findOneByUserIdAndIdentityProvider: sinon.stub(),
+    };
+  });
+
+  context('when no gar authentication method exists for origin user', function () {
+    it('should not update gar authentication method user id', async function () {
+      // given
+      const originUser = domainBuilder.buildUser({ id: 1 });
+
+      userRepository.get.withArgs(originUser.id).resolves(originUser);
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+        .withArgs({ userId: originUser.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+        .resolves(null);
+
+      // when
+      const error = await catchErr(reassignGarAuthenticationMethod)({
+        originUserId: originUser.id,
+        userRepository,
+        authenticationMethodRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AuthenticationMethodNotFoundError);
+      expect(error.message).to.equal("L'utilisateur 1 n'a pas de méthode de connexion GAR.");
+    });
+  });
+
+  context('when target user has already gar authentication method', function () {
+    it('should not update gar authentication method user id', async function () {
+      // given
+      const garIdentityProvider = AuthenticationMethod.identityProviders.GAR;
+
+      const originUser = domainBuilder.buildUser({ id: 1 });
+      const garAuthenticationMethodFromOriginUser = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: originUser.id,
+      });
+      const targetUser = domainBuilder.buildUser({ id: 2 });
+      const garAuthenticationMethodFromTargetUser = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+        userId: targetUser.id,
+      });
+
+      userRepository.get.withArgs(originUser.id).resolves(originUser);
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+        .withArgs({ userId: originUser.id, identityProvider: garIdentityProvider })
+        .resolves(garAuthenticationMethodFromOriginUser);
+
+      userRepository.get.withArgs(targetUser.id).resolves(targetUser);
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+        .withArgs({ userId: targetUser.id, identityProvider: garIdentityProvider })
+        .resolves(garAuthenticationMethodFromTargetUser);
+
+      // when
+      const error = await catchErr(reassignGarAuthenticationMethod)({
+        originUserId: originUser.id,
+        targetUserId: targetUser.id,
+        userRepository,
+        authenticationMethodRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AuthenticationMethodAlreadyExistsError);
+      expect(error.message).to.equal("L'utilisateur 2 a déjà une méthode de connexion GAR.");
+    });
+  });
+
+  it('should update gar authentication method user id', async function () {
+    // given
+    const garIdentityProvider = AuthenticationMethod.identityProviders.GAR;
+
+    const originUser = domainBuilder.buildUser({ id: 1 });
+    const garAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+      userId: originUser.id,
+    });
+    const targetUser = domainBuilder.buildUser({ id: 2 });
+    domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+      userId: targetUser.id,
+    });
+
+    userRepository.get.withArgs(originUser.id).resolves(originUser);
+    authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+      .withArgs({ userId: originUser.id, identityProvider: garIdentityProvider })
+      .resolves(garAuthenticationMethod);
+
+    userRepository.get.withArgs(targetUser.id).resolves(targetUser);
+    authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+      .withArgs({ userId: targetUser.id, identityProvider: garIdentityProvider })
+      .resolves(null);
+
+    // when
+    await reassignGarAuthenticationMethod({
+      originUserId: originUser.id,
+      targetUserId: targetUser.id,
+      userRepository,
+      authenticationMethodRepository,
+    });
+
+    // then
+    expect(authenticationMethodRepository.updateAuthenticationMethodUserId).to.have.been.calledOnceWith({
+      originUserId: originUser.id,
+      identityProvider: garIdentityProvider,
+      targetUserId: targetUser.id,
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
0n a beaucoup de users qui ont des compte en doublons, ou même plus. Ils se créent des comptes avec des méthodes de connexion différentes par exemple

**Exemple** : un élève n'écoute pas les instructions du prof et va se créer un compte avec adresse email, alors que son prof lui dit de passer par le GAR. Ou un user avec adresse email qui a déjà un compte Pix bien rempli, devient demandeur d’emploi et aimerait donc utiliser ce compte pour passer le parcours pix emploi. Ils doit nous contacter pour rajouter la connexion pole emploi sur son compte email. 

## :robot: Solution
Sur la page de détails d'un utilisateur ayant une connexion GAR, un bouton permet de déplacer la méthode à un autre utilisateur en fournissant son id

## :rainbow: Remarques
On a GAR méthode et médiacentre comme termes, ce qui peut amener de la confusion... A voir.

## :100: Pour tester

Se connecter sur https://admin-pr4090.review.pix.fr/ avec le compte pixmaster@example.net et cliquer sur l'icône de gestion des utilisateurs. (Tips : il est possible de récupérer en allant voir la liste des membres d'une organisation par exemple http://localhost:4202/organizations/6/team).
- aller sur la page d'un utilisateur n'ayant pas d'accès GAR, par exemple http://localhost:4202/users/4 et vérifier que le bouton `Déplacer cette méthode de connexion` n'est pas visible
- aller sur la page d'un utilisateur ayant un accès GAR, par exemple http://localhost:4202/users/100005 et vérifier que le bouton `Déplacer cette méthode de connexion` est visible.
- Cliquez dessus, une modale apparaît. 
- Cliquez sur Annuler, la modale disparaît.
- Cliquez sur `Déplacer cette méthode de connexion` 

- entrer un id très grand, par exemple, `5747946536936396`, cliquez sur `Valider le déplacement` et vérifier qu'un message d'erreur apparait (correspond à une erreur 400 en réponse d'api)
- entrer l'id d'un utilisateur ayant une métode GAR (voir en base de données) cliquez sur `Valider le déplacement` et vérifier qu'un message d'erreur apparait `L'utilisateur a déjà une méthode de connexion Médiacentre` (correspond à une erreur 422 en réponse d'api)
-  entrer l'id d'un utilisateur n'ayant une métode GAR (voir en base de données) cliquez sur `Valider le déplacement` et vérifier que deux notification de succès apparaissent et que l'utilisateur n'a plus la méthode connexion GAR ni le bouton visible.
