### PR TITLE
[TECH] Eviter les conversions inutiles XML/texte dans l'export des candidats (PIX-4378).

### DIFF
--- a/api/lib/domain/services/session-xml-service.js
+++ b/api/lib/domain/services/session-xml-service.js
@@ -1,93 +1,87 @@
 const writeOdsUtils = require('../../infrastructure/utils/ods/write-ods-utils');
 const AddedCellOption = require('../../infrastructure/utils/ods/added-cell-option');
 // Placeholder in the template ODS file that helps us find the template candidate row in the file.
-const CANDIDATE_ROW_MARKER_PLACEHOLDER = 'COUNT';
+
 const INFORMATIVE_HEADER_ROW = 8;
 const TABLE_HEADER_ROW = 11;
 const TABLE_FIRST_ROW = 12;
 const GROUP_HEADER_ROW_HEIGHT_ROW_SPAN = 3;
 
-function getUpdatedXmlWithSessionData({ stringifiedXml, sessionTemplateValues, sessionData }) {
-  return writeOdsUtils.updateXmlSparseValues({
-    stringifiedXml,
-    templateValues: sessionTemplateValues,
-    dataToInject: sessionData,
-  });
+function getUpdatedXmlWithSessionData({ odsBuilder, sessionTemplateValues, sessionData }) {
+  return odsBuilder.withData(sessionData, sessionTemplateValues);
 }
 
-function getUpdatedXmlWithCertificationCandidatesData({ stringifiedXml, candidateTemplateValues, candidatesData }) {
-  return writeOdsUtils.updateXmlRows({
-    stringifiedXml,
+function getUpdatedXmlWithCertificationCandidatesData({ odsBuilder, candidateTemplateValues, candidatesData }) {
+  return odsBuilder.updateXmlRows({
     rowMarkerPlaceholder: CANDIDATE_ROW_MARKER_PLACEHOLDER,
     rowTemplateValues: candidateTemplateValues,
     dataToInject: candidatesData,
   });
 }
 
-function addColumnGroup({ stringifiedXml, groupHeaderLabel, columns }) {
-  stringifiedXml = _addColumnGroupHeader({
-    stringifiedXml,
-    headerLabel: groupHeaderLabel,
-    numberOfColumns: columns.length,
-  });
+// function addColumnGroup({ odsBuilder, groupHeaderLabel, columns }) {
+//   _addColumnGroupHeader({
+//     odsBuilder,
+//     headerLabel: groupHeaderLabel,
+//     numberOfColumns: columns.length,
+//   });
 
-  stringifiedXml = columns.reduce(_addColumn, stringifiedXml);
+//   stringifiedXml = columns.reduce(_addColumn, stringifiedXml);
 
-  return writeOdsUtils.incrementRowsColumnSpan({
-    stringifiedXml,
-    startLine: 0,
-    endLine: INFORMATIVE_HEADER_ROW - 1,
-    increment: columns.length,
-  });
-}
+//   return writeOdsUtils.incrementRowsColumnSpan({
+//     stringifiedXml,
+//     startLine: 0,
+//     endLine: INFORMATIVE_HEADER_ROW - 1,
+//     increment: columns.length,
+//   });
+// }
 
-function _addColumnGroupHeader({ stringifiedXml, headerLabel, numberOfColumns }) {
-  const headerLabelWords = headerLabel.split(' ');
+// function _addColumnGroupHeader({ stringifiedXml, headerLabel, numberOfColumns }) {
+//   const headerLabelWords = headerLabel.split(' ');
 
-  let addedCellOption = new AddedCellOption({
-    labels: [headerLabel],
-    rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
-    colspan: numberOfColumns,
-    positionOffset: 2,
-  });
+//   let addedCellOption = new AddedCellOption({
+//     labels: [headerLabel],
+//     rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
+//     colspan: numberOfColumns,
+//     positionOffset: 2,
+//   });
 
-  if (numberOfColumns === 1) {
-    addedCellOption = new AddedCellOption({
-      labels: headerLabelWords,
-      rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
-      colspan: numberOfColumns,
-      positionOffset: 2,
-    });
-  }
+//   if (numberOfColumns === 1) {
+//     addedCellOption = new AddedCellOption({
+//       labels: headerLabelWords,
+//       rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
+//       colspan: numberOfColumns,
+//       positionOffset: 2,
+//     });
+//   }
 
-  stringifiedXml = writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
-    stringifiedXml,
-    lineNumber: INFORMATIVE_HEADER_ROW,
-    cellToCopyLabel: '* Lieu de naissance',
-    addedCellOption,
-  });
+//   stringifiedXml = writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
+//     stringifiedXml,
+//     lineNumber: INFORMATIVE_HEADER_ROW,
+//     cellToCopyLabel: '* Lieu de naissance',
+//     addedCellOption,
+//   });
 
-  return stringifiedXml;
-}
+//   return stringifiedXml;
+// }
 
-function _addColumn(stringifiedXml, column) {
-  stringifiedXml = writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
-    stringifiedXml,
-    lineNumber: TABLE_HEADER_ROW,
-    cellToCopyLabel: 'Temps majoré ?',
-    addedCellOption: new AddedCellOption({ labels: column.headerLabel }),
-  });
+// function _addColumn(stringifiedXml, column) {
+//   stringifiedXml = writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
+//     stringifiedXml,
+//     lineNumber: TABLE_HEADER_ROW,
+//     cellToCopyLabel: 'Temps majoré ?',
+//     addedCellOption: new AddedCellOption({ labels: column.headerLabel }),
+//   });
 
-  return writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
-    stringifiedXml,
-    lineNumber: TABLE_FIRST_ROW,
-    cellToCopyLabel: 'EXTERNAL_ID',
-    addedCellOption: new AddedCellOption({ labels: column.placeholder }),
-  });
-}
+//   return writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
+//     stringifiedXml,
+//     lineNumber: TABLE_FIRST_ROW,
+//     cellToCopyLabel: 'EXTERNAL_ID',
+//     addedCellOption: new AddedCellOption({ labels: column.placeholder }),
+//   });
+// }
 
 module.exports = {
   getUpdatedXmlWithSessionData,
   getUpdatedXmlWithCertificationCandidatesData,
-  addColumnGroup,
 };

--- a/api/lib/domain/services/session-xml-service.js
+++ b/api/lib/domain/services/session-xml-service.js
@@ -1,85 +1,23 @@
 const writeOdsUtils = require('../../infrastructure/utils/ods/write-ods-utils');
-const AddedCellOption = require('../../infrastructure/utils/ods/added-cell-option');
 // Placeholder in the template ODS file that helps us find the template candidate row in the file.
+const CANDIDATE_ROW_MARKER_PLACEHOLDER = 'COUNT';
 
-const INFORMATIVE_HEADER_ROW = 8;
-const TABLE_HEADER_ROW = 11;
-const TABLE_FIRST_ROW = 12;
-const GROUP_HEADER_ROW_HEIGHT_ROW_SPAN = 3;
-
-function getUpdatedXmlWithSessionData({ odsBuilder, sessionTemplateValues, sessionData }) {
-  return odsBuilder.withData(sessionData, sessionTemplateValues);
+function getUpdatedXmlWithSessionData({ stringifiedXml, sessionTemplateValues, sessionData }) {
+  return writeOdsUtils.updateXmlSparseValues({
+    stringifiedXml,
+    templateValues: sessionTemplateValues,
+    dataToInject: sessionData,
+  });
 }
 
-function getUpdatedXmlWithCertificationCandidatesData({ odsBuilder, candidateTemplateValues, candidatesData }) {
-  return odsBuilder.updateXmlRows({
+function getUpdatedXmlWithCertificationCandidatesData({ stringifiedXml, candidateTemplateValues, candidatesData }) {
+  return writeOdsUtils.updateXmlRows({
+    stringifiedXml,
     rowMarkerPlaceholder: CANDIDATE_ROW_MARKER_PLACEHOLDER,
     rowTemplateValues: candidateTemplateValues,
     dataToInject: candidatesData,
   });
 }
-
-// function addColumnGroup({ odsBuilder, groupHeaderLabel, columns }) {
-//   _addColumnGroupHeader({
-//     odsBuilder,
-//     headerLabel: groupHeaderLabel,
-//     numberOfColumns: columns.length,
-//   });
-
-//   stringifiedXml = columns.reduce(_addColumn, stringifiedXml);
-
-//   return writeOdsUtils.incrementRowsColumnSpan({
-//     stringifiedXml,
-//     startLine: 0,
-//     endLine: INFORMATIVE_HEADER_ROW - 1,
-//     increment: columns.length,
-//   });
-// }
-
-// function _addColumnGroupHeader({ stringifiedXml, headerLabel, numberOfColumns }) {
-//   const headerLabelWords = headerLabel.split(' ');
-
-//   let addedCellOption = new AddedCellOption({
-//     labels: [headerLabel],
-//     rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
-//     colspan: numberOfColumns,
-//     positionOffset: 2,
-//   });
-
-//   if (numberOfColumns === 1) {
-//     addedCellOption = new AddedCellOption({
-//       labels: headerLabelWords,
-//       rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
-//       colspan: numberOfColumns,
-//       positionOffset: 2,
-//     });
-//   }
-
-//   stringifiedXml = writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
-//     stringifiedXml,
-//     lineNumber: INFORMATIVE_HEADER_ROW,
-//     cellToCopyLabel: '* Lieu de naissance',
-//     addedCellOption,
-//   });
-
-//   return stringifiedXml;
-// }
-
-// function _addColumn(stringifiedXml, column) {
-//   stringifiedXml = writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
-//     stringifiedXml,
-//     lineNumber: TABLE_HEADER_ROW,
-//     cellToCopyLabel: 'Temps majoré ?',
-//     addedCellOption: new AddedCellOption({ labels: column.headerLabel }),
-//   });
-
-//   return writeOdsUtils.addCellToEndOfLineWithStyleOfCellLabelled({
-//     stringifiedXml,
-//     lineNumber: TABLE_FIRST_ROW,
-//     cellToCopyLabel: 'EXTERNAL_ID',
-//     addedCellOption: new AddedCellOption({ labels: column.placeholder }),
-//   });
-// }
 
 module.exports = {
   getUpdatedXmlWithSessionData,

--- a/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -28,7 +28,6 @@ module.exports = async function fillCandidatesImportSheet({
 }) {
   const template = await _getCandidatesImportTemplate();
 
-  // TODO ne pas manipuler l'ods builder depuis fill-candidates-import-sheet mais session-xml-service
   const odsBuilder = new writeOdsUtils.OdsUtilsBuilder(template);
   _addSession(odsBuilder, session);
   _addColumns({
@@ -38,10 +37,7 @@ module.exports = async function fillCandidatesImportSheet({
   });
   _addCandidateRows(odsBuilder, session.certificationCandidates);
 
-  return writeOdsUtils.makeUpdatedOdsByContentXml({
-    stringifiedXml: odsBuilder.build(),
-    odsFilePath: _getCandidatesImportTemplatePath(),
-  });
+  return odsBuilder.build({ templateFilePath: _getCandidatesImportTemplatePath() });
 };
 
 async function _getCandidatesImportTemplate() {

--- a/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -16,6 +16,11 @@ const billingValidatorList = Object.values(CertificationCandidate.BILLING_MODES)
   CertificationCandidate.translateBillingMode
 );
 
+const INFORMATIVE_HEADER_ROW = 8;
+const HEADER_ROW_SPAN = 3;
+const CANDIDATE_TABLE_HEADER_ROW = 11;
+const CANDIDATE_TABLE_FIRST_ROW = 12;
+
 module.exports = async function fillCandidatesImportSheet({
   session,
   certificationCenterHabilitations,
@@ -51,25 +56,41 @@ function _addSession(odsBuilder, session) {
 
 function _addColumns({ odsBuilder, certificationCenterHabilitations, isScoCertificationCenter }) {
   if (featureToggles.isCertificationBillingEnabled && !isScoCertificationCenter) {
-    odsBuilder.withTooltipOnCell({
-      targetCellAddress: "'Liste des candidats'.O13",
-      tooltipName: 'val-prepayment-code',
-      tooltipTitle: 'Code de prépaiement',
-      tooltipContentLines: [
-        "(Requis notamment dans le cas d'un achat de crédits combinés)",
-        'Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345',
-        'Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.',
-      ],
-    });
-
-    odsBuilder.withValidatorRestrictedList({
-      validatorName: 'billingModeValidator',
-      restrictedList: billingValidatorList,
-      allowEmptyCell: false,
-      tooltipTitle: 'Tarification part Pix',
-      tooltipContentLines: ['Options possibles :', ...billingValidatorList.map((option) => `- ${option}`)],
-    });
-    _addBillingColumns(odsBuilder);
+    odsBuilder
+      .withTooltipOnCell({
+        targetCellAddress: "'Liste des candidats'.O13",
+        tooltipName: 'val-prepayment-code',
+        tooltipTitle: 'Code de prépaiement',
+        tooltipContentLines: [
+          "(Requis notamment dans le cas d'un achat de crédits combinés)",
+          'Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345',
+          'Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.',
+        ],
+      })
+      .withValidatorRestrictedList({
+        validatorName: 'billingModeValidator',
+        restrictedList: billingValidatorList,
+        allowEmptyCell: false,
+        tooltipTitle: 'Tarification part Pix',
+        tooltipContentLines: ['Options possibles :', ...billingValidatorList.map((option) => `- ${option}`)],
+      })
+      .withColumnGroup({
+        groupHeaderLabel: 'Tarification',
+        columns: [
+          {
+            headerLabel: ['Tarification part Pix'],
+            placeholder: ['billingMode'],
+          },
+          {
+            headerLabel: ['Code de prépaiement'],
+            placeholder: ['prepaymentCode'],
+          },
+        ],
+        startsAt: INFORMATIVE_HEADER_ROW,
+        headerRowSpan: HEADER_ROW_SPAN,
+        tableHeaderRow: CANDIDATE_TABLE_HEADER_ROW,
+        tableFirstRow: CANDIDATE_TABLE_FIRST_ROW,
+      });
   }
   if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
     odsBuilder = _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations });
@@ -87,25 +108,13 @@ function _addComplementaryCertificationColumns({ odsBuilder, certificationCenter
     odsBuilder.withColumnGroup({
       groupHeaderLabel: 'Certification(s) complémentaire(s)',
       columns: habilitationColumns,
+      startsAt: INFORMATIVE_HEADER_ROW,
+      headerRowSpan: HEADER_ROW_SPAN,
+      tableHeaderRow: CANDIDATE_TABLE_HEADER_ROW,
+      tableFirstRow: CANDIDATE_TABLE_FIRST_ROW,
     });
   }
   return odsBuilder;
-}
-
-function _addBillingColumns(odsBuilder) {
-  return odsBuilder.withColumnGroup({
-    groupHeaderLabel: 'Tarification',
-    columns: [
-      {
-        headerLabel: ['Tarification part Pix'],
-        placeholder: ['billingMode'],
-      },
-      {
-        headerLabel: ['Code de prépaiement'],
-        placeholder: ['prepaymentCode'],
-      },
-    ],
-  });
 }
 
 function _addCandidateRows(odsBuilder, certificationCandidates) {

--- a/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -1,6 +1,5 @@
 const writeOdsUtils = require('../../utils/ods/write-ods-utils');
 const readOdsUtils = require('../../utils/ods/read-ods-utils');
-const sessionXmlService = require('../../../domain/services/session-xml-service');
 const { featureToggles } = require('../../../../lib/config');
 const {
   EXTRA_EMPTY_CANDIDATE_ROWS,
@@ -24,20 +23,18 @@ module.exports = async function fillCandidatesImportSheet({
 }) {
   const template = await _getCandidatesImportTemplate();
 
-  const templateWithSession = _addSession(template, session);
-  const templateWithSessionAndColumns = _addColumns({
-    stringifiedXml: templateWithSession,
+  // TODO ne pas manipuler l'ods builder depuis fill-candidates-import-sheet mais session-xml-service
+  const odsBuilder = new writeOdsUtils.OdsUtilsBuilder(template);
+  _addSession(odsBuilder, session);
+  _addColumns({
+    odsBuilder,
     certificationCenterHabilitations,
     isScoCertificationCenter,
   });
-
-  const templateWithSessionAndColumnsAndCandidates = _addCandidates(
-    templateWithSessionAndColumns,
-    session.certificationCandidates
-  );
+  _addCandidateRows(odsBuilder, session.certificationCandidates);
 
   return writeOdsUtils.makeUpdatedOdsByContentXml({
-    stringifiedXml: templateWithSessionAndColumnsAndCandidates,
+    stringifiedXml: odsBuilder.build(),
     odsFilePath: _getCandidatesImportTemplatePath(),
   });
 };
@@ -47,20 +44,14 @@ async function _getCandidatesImportTemplate() {
   return readOdsUtils.getContentXml({ odsFilePath: templatePath });
 }
 
-function _addSession(stringifiedXml, session) {
+function _addSession(odsBuilder, session) {
   const sessionData = SessionData.fromSession(session);
-  const templateWithSession = sessionXmlService.getUpdatedXmlWithSessionData({
-    stringifiedXml,
-    sessionData,
-    sessionTemplateValues: IMPORT_CANDIDATES_SESSION_TEMPLATE_VALUES,
-  });
-  return templateWithSession;
+  return odsBuilder.withData(sessionData, IMPORT_CANDIDATES_SESSION_TEMPLATE_VALUES);
 }
 
-function _addColumns({ stringifiedXml, certificationCenterHabilitations, isScoCertificationCenter }) {
+function _addColumns({ odsBuilder, certificationCenterHabilitations, isScoCertificationCenter }) {
   if (featureToggles.isCertificationBillingEnabled && !isScoCertificationCenter) {
-    stringifiedXml = writeOdsUtils.addTooltipOnCell({
-      stringifiedXml,
+    odsBuilder.withTooltipOnCell({
       targetCellAddress: "'Liste des candidats'.O13",
       tooltipName: 'val-prepayment-code',
       tooltipTitle: 'Code de prépaiement',
@@ -71,41 +62,38 @@ function _addColumns({ stringifiedXml, certificationCenterHabilitations, isScoCe
       ],
     });
 
-    stringifiedXml = writeOdsUtils.addValidatorRestrictedList({
-      stringifiedXml,
+    odsBuilder.withValidatorRestrictedList({
       validatorName: 'billingModeValidator',
       restrictedList: billingValidatorList,
       allowEmptyCell: false,
       tooltipTitle: 'Tarification part Pix',
       tooltipContentLines: ['Options possibles :', ...billingValidatorList.map((option) => `- ${option}`)],
     });
-    stringifiedXml = _addBillingColumns(stringifiedXml);
+    _addBillingColumns(odsBuilder);
   }
   if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-    stringifiedXml = _addComplementaryCertificationColumns(certificationCenterHabilitations, stringifiedXml);
+    odsBuilder = _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations });
   }
 
-  return stringifiedXml;
+  return odsBuilder;
 }
 
-function _addComplementaryCertificationColumns(certificationCenterHabilitations, updatedStringifiedXml) {
+function _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations }) {
   if (!_.isEmpty(certificationCenterHabilitations)) {
     const habilitationColumns = certificationCenterHabilitations.map(({ name }) => ({
       headerLabel: [name, '("oui" ou laisser vide)'],
       placeholder: [name],
     }));
-    updatedStringifiedXml = sessionXmlService.addColumnGroup({
-      stringifiedXml: updatedStringifiedXml,
+    odsBuilder.withColumnGroup({
       groupHeaderLabel: 'Certification(s) complémentaire(s)',
       columns: habilitationColumns,
     });
   }
-  return updatedStringifiedXml;
+  return odsBuilder;
 }
 
-function _addBillingColumns(updatedStringifiedXml) {
-  return sessionXmlService.addColumnGroup({
-    stringifiedXml: updatedStringifiedXml,
+function _addBillingColumns(odsBuilder) {
+  return odsBuilder.withColumnGroup({
     groupHeaderLabel: 'Tarification',
     columns: [
       {
@@ -120,12 +108,13 @@ function _addBillingColumns(updatedStringifiedXml) {
   });
 }
 
-function _addCandidates(updatedStringifiedXml, certificationCandidates) {
+function _addCandidateRows(odsBuilder, certificationCandidates) {
+  const CANDIDATE_ROW_MARKER_PLACEHOLDER = 'COUNT';
   const candidatesData = _getCandidatesData(certificationCandidates);
-  return sessionXmlService.getUpdatedXmlWithCertificationCandidatesData({
-    stringifiedXml: updatedStringifiedXml,
-    candidatesData,
-    candidateTemplateValues: IMPORT_CANDIDATES_TEMPLATE_VALUES,
+  return odsBuilder.updateXmlRows({
+    rowMarkerPlaceholder: CANDIDATE_ROW_MARKER_PLACEHOLDER,
+    rowTemplateValues: IMPORT_CANDIDATES_TEMPLATE_VALUES,
+    dataToInject: candidatesData,
   });
 }
 

--- a/api/lib/infrastructure/utils/ods/write-ods-utils.js
+++ b/api/lib/infrastructure/utils/ods/write-ods-utils.js
@@ -210,8 +210,16 @@ class OdsUtilsBuilder {
     return this;
   }
 
-  build() {
-    return _buildStringifiedXmlFromXmlDom(this.xmlDom);
+  async build({ templateFilePath }) {
+    const stringifiedXML = new XMLSerializer().serializeToString(this.xmlDom);
+    return this.generateODSBuffer({ stringifiedXML, templateFilePath });
+  }
+
+  async generateODSBuffer({ stringifiedXML, templateFilePath }) {
+    const inMemoryZippedTemplate = await loadOdsZip(templateFilePath);
+    await inMemoryZippedTemplate.file(CONTENT_XML_IN_ODS, stringifiedXML);
+    const odsBuffer = await inMemoryZippedTemplate.generateAsync({ type: 'nodebuffer' });
+    return odsBuffer;
   }
 }
 

--- a/api/lib/infrastructure/utils/ods/write-ods-utils.js
+++ b/api/lib/infrastructure/utils/ods/write-ods-utils.js
@@ -454,11 +454,27 @@ function _buildStringifiedXmlFromXmlDom(parsedXmlDom) {
   return new XMLSerializer().serializeToString(parsedXmlDom);
 }
 
+function updateXmlSparseValues({ stringifiedXml, templateValues, dataToInject }) {
+  const parsedXmlDom = _buildXmlDomFromXmlString(stringifiedXml);
+  const parsedXmlDomUpdated = _updateXmlDomWithData(parsedXmlDom, dataToInject, templateValues);
+  return _buildStringifiedXmlFromXmlDom(parsedXmlDomUpdated);
+}
+
+function _updateXmlDomWithData(parsedXmlDom, dataToInject, templateValues) {
+  const parsedXmlDomUpdated = _.cloneDeep(parsedXmlDom);
+  for (const { placeholder, propertyName } of templateValues) {
+    const targetXmlDomElement = _getXmlDomElementByText(parsedXmlDomUpdated, placeholder);
+    if (targetXmlDomElement) {
+      const newXmlValue = dataToInject[propertyName];
+      targetXmlDomElement.textContent = newXmlValue;
+    }
+  }
+  return parsedXmlDomUpdated;
+}
+
 module.exports = {
   makeUpdatedOdsByContentXml,
-  /*
   updateXmlSparseValues,
-*/
   updateXmlRows,
   addCellToEndOfLineWithStyleOfCellLabelled,
   incrementRowsColumnSpan,

--- a/api/lib/infrastructure/utils/ods/write-ods-utils.js
+++ b/api/lib/infrastructure/utils/ods/write-ods-utils.js
@@ -1,20 +1,223 @@
 const { loadOdsZip } = require('./common-ods-utils');
 const { DOMParser, XMLSerializer } = require('xmldom');
 const _ = require('lodash');
+const AddedCellOption = require('./added-cell-option');
 
 const CONTENT_XML_IN_ODS = 'content.xml';
+
+class OdsUtilsBuilder {
+  constructor(stringifiedXml) {
+    this.xmlDom = _buildXmlDomFromXmlString(stringifiedXml);
+  }
+
+  withData(dataToInject, templateValues) {
+    const intermediateXmlDom = _.cloneDeep(this.xmlDom);
+    for (const { placeholder, propertyName } of templateValues) {
+      const targetXmlDomElement = _getXmlDomElementByText(intermediateXmlDom, placeholder);
+      if (targetXmlDomElement) {
+        const newXmlValue = dataToInject[propertyName];
+        targetXmlDomElement.textContent = newXmlValue;
+      }
+    }
+
+    this.xmlDom = intermediateXmlDom;
+
+    return this;
+  }
+
+  withTooltipOnCell({ xmlDom, tooltipName, tooltipTitle, tooltipContentLines }) {
+    return this.withValidatorRestrictedList({
+      xmlDom,
+      validatorName: tooltipName,
+      allowEmptyCell: true,
+      tooltipTitle,
+      tooltipContentLines,
+    });
+  }
+
+  withValidatorRestrictedList({
+    validatorName,
+    restrictedList,
+    allowEmptyCell = true,
+    tooltipTitle,
+    tooltipContentLines,
+  }) {
+    const contentValidations = this.xmlDom.getElementsByTagName('table:content-validations').item(0);
+    const validator = this.xmlDom.createElement('table:content-validation');
+    validator.setAttribute('table:name', validatorName);
+    if (restrictedList?.length) {
+      validator.setAttribute(
+        'table:condition',
+        `of:cell-content-is-in-list(${restrictedList.map((val) => `"${val}"`).join(';')})`
+      );
+      validator.setAttribute('table:allow-empty-cell', allowEmptyCell);
+    }
+
+    const errorMessage = this.xmlDom.createElement('table:error-message');
+    errorMessage.setAttribute('table:display', 'true');
+    errorMessage.setAttribute('table:message-type', 'stop');
+
+    validator.appendChild(errorMessage);
+    contentValidations.appendChild(validator);
+
+    const helpMessage = this.xmlDom.createElement('table:help-message');
+    helpMessage.setAttribute('table:title', tooltipTitle);
+    helpMessage.setAttribute('table:display', 'true');
+
+    const helpMessageWithContent = tooltipContentLines.reduce((helpMessageAccumulator, line) => {
+      const paragraph = this.xmlDom.createElement('text:p');
+      paragraph.textContent = line;
+      helpMessageAccumulator.appendChild(paragraph);
+      return helpMessageAccumulator;
+    }, helpMessage);
+
+    validator.appendChild(helpMessageWithContent);
+
+    return this;
+  }
+
+  withColumnGroup({ groupHeaderLabel, columns }) {
+    this.withColumnGroupHeader({
+      headerLabel: groupHeaderLabel,
+      numberOfColumns: columns.length,
+    });
+
+    columns.forEach((col) => this._addColumn(col));
+
+    this.incrementRowsColumnSpan({
+      startLine: 0,
+      endLine: INFORMATIVE_HEADER_ROW - 1,
+      increment: columns.length,
+    });
+  }
+
+  incrementRowsColumnSpan({ startLine, endLine, increment }) {
+    const rows = Array.from(this.xmlDom.getElementsByTagName('table:table-row'));
+
+    for (let i = startLine; i <= endLine; i++) {
+      const element = Array.from(rows[i].getElementsByTagName('table:table-cell'))
+        .reverse()
+        .find((element) => element.hasAttribute('table:number-columns-spanned'));
+      if (element) {
+        element.setAttribute(
+          'table:number-columns-spanned',
+          parseInt(element.getAttribute('table:number-columns-spanned')) + increment
+        );
+      }
+    }
+
+    return this;
+  }
+
+  withColumnGroupHeader({ headerLabel, numberOfColumns }) {
+    const headerLabelWords = headerLabel.split(' ');
+
+    let addedCellOption = new AddedCellOption({
+      labels: [headerLabel],
+      rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
+      colspan: numberOfColumns,
+      positionOffset: 2,
+    });
+
+    if (numberOfColumns === 1) {
+      addedCellOption = new AddedCellOption({
+        labels: headerLabelWords,
+        rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
+        colspan: numberOfColumns,
+        positionOffset: 2,
+      });
+    }
+
+    this._withCellToEndOfLineWithStyleOfCellLabelled({
+      lineNumber: INFORMATIVE_HEADER_ROW,
+      cellToCopyLabel: '* Lieu de naissance',
+      addedCellOption,
+    });
+
+    return this;
+  }
+
+  _withCellToEndOfLineWithStyleOfCellLabelled({ lineNumber, cellToCopyLabel, addedCellOption }) {
+    const cellToCopy = _getXmlDomElementByText(this.xmlDom, cellToCopyLabel).parentNode;
+    const clonedCell = _deepCloneDomElement(cellToCopy);
+
+    _updateCellTextContent({ clonedCell, textContent: addedCellOption.labels });
+
+    if (addedCellOption.rowspan) {
+      clonedCell.setAttribute('table:number-rows-spanned', addedCellOption.rowspan);
+    }
+    if (addedCellOption.colspan) {
+      clonedCell.setAttribute('table:number-columns-spanned', addedCellOption.colspan);
+    }
+
+    const addedCellPositionOffset = addedCellOption.positionOffset ? addedCellOption.positionOffset : 1;
+    this.addCellToEndOfLine({
+      lineNumber,
+      cell: clonedCell,
+      positionOffset: addedCellPositionOffset,
+    });
+
+    if (addedCellOption.colspan && addedCellOption.colspan > 0) {
+      const coveredTableCell = this.xmlDom.createElement('table:covered-table-cell');
+      coveredTableCell.setAttribute('table:number-columns-repeated', addedCellOption.colspan - 1);
+      const coveredTableCellPositionOffset = addedCellOption.positionOffset ? addedCellOption.positionOffset : 1;
+      this.addCellToEndOfLine({
+        lineNumber,
+        cell: coveredTableCell,
+        positionOffset: coveredTableCellPositionOffset,
+      });
+    }
+  }
+
+  addCellToEndOfLine({ lineNumber, cell, positionOffset }) {
+    const line = Array.from(this.xmlDom.getElementsByTagName('table:table-row'))[lineNumber];
+    const lineChildNodes = Array.from(line.childNodes);
+    line.insertBefore(cell, lineChildNodes[lineChildNodes.length - positionOffset]);
+    return this;
+  }
+
+  _addColumn(column) {
+    this._withCellToEndOfLineWithStyleOfCellLabelled({
+      lineNumber: TABLE_HEADER_ROW,
+      cellToCopyLabel: 'Temps majoré ?',
+      addedCellOption: new AddedCellOption({ labels: column.headerLabel }),
+    });
+
+    this._withCellToEndOfLineWithStyleOfCellLabelled({
+      lineNumber: TABLE_FIRST_ROW,
+      cellToCopyLabel: 'EXTERNAL_ID',
+      addedCellOption: new AddedCellOption({ labels: column.placeholder }),
+    });
+  }
+
+  updateXmlRows({ rowMarkerPlaceholder, rowTemplateValues, dataToInject }) {
+    const { referenceRowElement, rowsContainerElement } = _getRefRowAndContainerDomElements(
+      this.xmlDom,
+      rowMarkerPlaceholder
+    );
+
+    const cloneRowElement = _deepCloneDomElement(referenceRowElement);
+    rowsContainerElement.removeChild(referenceRowElement);
+
+    _.each(dataToInject, (rowDataToInject) => {
+      const currentCloneRowElement = _deepCloneDomElement(cloneRowElement);
+      _updateXmlElementWithData(currentCloneRowElement, rowDataToInject, rowTemplateValues);
+      rowsContainerElement.appendChild(currentCloneRowElement);
+    });
+
+    return this;
+  }
+
+  build() {
+    return _buildStringifiedXmlFromXmlDom(this.xmlDom);
+  }
+}
 
 async function makeUpdatedOdsByContentXml({ stringifiedXml, odsFilePath }) {
   const zip = await loadOdsZip(odsFilePath);
   await zip.file(CONTENT_XML_IN_ODS, stringifiedXml);
   const odsBuffer = await zip.generateAsync({ type: 'nodebuffer' });
   return odsBuffer;
-}
-
-function updateXmlSparseValues({ stringifiedXml, templateValues, dataToInject }) {
-  const parsedXmlDom = _buildXmlDomFromXmlString(stringifiedXml);
-  const parsedXmlDomUpdated = _updateXmlDomWithData(parsedXmlDom, dataToInject, templateValues);
-  return _buildStringifiedXmlFromXmlDom(parsedXmlDomUpdated);
 }
 
 function updateXmlRows({ stringifiedXml, rowMarkerPlaceholder, rowTemplateValues, dataToInject }) {
@@ -179,18 +382,6 @@ function _buildXmlDomFromXmlString(stringifiedXml) {
   return new DOMParser().parseFromString(stringifiedXml);
 }
 
-function _updateXmlDomWithData(parsedXmlDom, dataToInject, templateValues) {
-  const parsedXmlDomUpdated = _.cloneDeep(parsedXmlDom);
-  for (const { placeholder, propertyName } of templateValues) {
-    const targetXmlDomElement = _getXmlDomElementByText(parsedXmlDomUpdated, placeholder);
-    if (targetXmlDomElement) {
-      const newXmlValue = dataToInject[propertyName];
-      targetXmlDomElement.textContent = newXmlValue;
-    }
-  }
-  return parsedXmlDomUpdated;
-}
-
 function _updateXmlElementWithData(xmlElement, dataToInject, templateValues) {
   for (const { placeholder, propertyName, validator } of templateValues) {
     const targetXmlDomElement = _getXmlDomElementByText(xmlElement, placeholder);
@@ -265,10 +456,13 @@ function _buildStringifiedXmlFromXmlDom(parsedXmlDom) {
 
 module.exports = {
   makeUpdatedOdsByContentXml,
+  /*
   updateXmlSparseValues,
+*/
   updateXmlRows,
   addCellToEndOfLineWithStyleOfCellLabelled,
   incrementRowsColumnSpan,
   addValidatorRestrictedList,
   addTooltipOnCell,
+  OdsUtilsBuilder,
 };

--- a/api/lib/infrastructure/utils/ods/write-ods-utils.js
+++ b/api/lib/infrastructure/utils/ods/write-ods-utils.js
@@ -53,13 +53,6 @@ class OdsUtilsBuilder {
       validator.setAttribute('table:allow-empty-cell', allowEmptyCell);
     }
 
-    const errorMessage = this.xmlDom.createElement('table:error-message');
-    errorMessage.setAttribute('table:display', 'true');
-    errorMessage.setAttribute('table:message-type', 'stop');
-
-    validator.appendChild(errorMessage);
-    contentValidations.appendChild(validator);
-
     const helpMessage = this.xmlDom.createElement('table:help-message');
     helpMessage.setAttribute('table:title', tooltipTitle);
     helpMessage.setAttribute('table:display', 'true');
@@ -73,20 +66,29 @@ class OdsUtilsBuilder {
 
     validator.appendChild(helpMessageWithContent);
 
+    const errorMessage = this.xmlDom.createElement('table:error-message');
+    errorMessage.setAttribute('table:display', 'true');
+    errorMessage.setAttribute('table:message-type', 'stop');
+
+    validator.appendChild(errorMessage);
+    contentValidations.appendChild(validator);
+
     return this;
   }
 
-  withColumnGroup({ groupHeaderLabel, columns }) {
+  withColumnGroup({ groupHeaderLabel, columns, startsAt, headerRowSpan, tableHeaderRow, tableFirstRow }) {
     this.withColumnGroupHeader({
       headerLabel: groupHeaderLabel,
       numberOfColumns: columns.length,
+      lineNumber: startsAt,
+      rowspan: headerRowSpan,
     });
 
-    columns.forEach((col) => this._addColumn(col));
+    columns.forEach((col) => this._addColumn(col, tableHeaderRow, tableFirstRow));
 
     this.incrementRowsColumnSpan({
       startLine: 0,
-      endLine: INFORMATIVE_HEADER_ROW - 1,
+      endLine: startsAt - 1,
       increment: columns.length,
     });
   }
@@ -109,12 +111,12 @@ class OdsUtilsBuilder {
     return this;
   }
 
-  withColumnGroupHeader({ headerLabel, numberOfColumns }) {
+  withColumnGroupHeader({ headerLabel, numberOfColumns, lineNumber, rowspan }) {
     const headerLabelWords = headerLabel.split(' ');
 
     let addedCellOption = new AddedCellOption({
       labels: [headerLabel],
-      rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
+      rowspan,
       colspan: numberOfColumns,
       positionOffset: 2,
     });
@@ -122,14 +124,14 @@ class OdsUtilsBuilder {
     if (numberOfColumns === 1) {
       addedCellOption = new AddedCellOption({
         labels: headerLabelWords,
-        rowspan: GROUP_HEADER_ROW_HEIGHT_ROW_SPAN,
+        rowspan,
         colspan: numberOfColumns,
         positionOffset: 2,
       });
     }
 
     this._withCellToEndOfLineWithStyleOfCellLabelled({
-      lineNumber: INFORMATIVE_HEADER_ROW,
+      lineNumber,
       cellToCopyLabel: '* Lieu de naissance',
       addedCellOption,
     });
@@ -176,15 +178,15 @@ class OdsUtilsBuilder {
     return this;
   }
 
-  _addColumn(column) {
+  _addColumn(column, tableHeaderRow, tableFirstRow) {
     this._withCellToEndOfLineWithStyleOfCellLabelled({
-      lineNumber: TABLE_HEADER_ROW,
+      lineNumber: tableHeaderRow,
       cellToCopyLabel: 'Temps majoré ?',
       addedCellOption: new AddedCellOption({ labels: column.headerLabel }),
     });
 
     this._withCellToEndOfLineWithStyleOfCellLabelled({
-      lineNumber: TABLE_FIRST_ROW,
+      lineNumber: tableFirstRow,
       cellToCopyLabel: 'EXTERNAL_ID',
       addedCellOption: new AddedCellOption({ labels: column.placeholder }),
     });


### PR DESCRIPTION
## :unicorn: Problème
L’utilitaire pour la mise à jour des ods fait plusieurs (126) fois appel à des conversions d'un type à l'autre.
- string to xml
- xml to string)
```
function foo(stringifiedXml)
   _buildXmlDomFromXmlString(stringifiedXml);
  // coeur de fonction
  _buildStringifiedXmlFromXmlDom(parsedXmlDom);
```

## :robot: Solution
Stocker la représentation XML native JS dans un objet, passé de fonction en fonction.
A la fin du traitement, demander une seule fois la sérialisation au format texte.
Utiliser le pattern Builder.

## :rainbow: Remarques
Seul l'export des candidats est impacté, reste la feuille d'émargement

## :100: Pour tester
Télécharger [le fichier candidat](https://certif-pr4091.review.pix.fr/sessions/11/candidats) de la session 11 de `certifsup@example.net` et vérifier l'absence de régressions

