### PR TITLE
[FEATURE] MAJ du code d'accès à une session pour respecter les bonnes pratiques (PIX-4380)

### DIFF
--- a/api/db/database-builder/factory/build-session.js
+++ b/api/db/database-builder/factory/build-session.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 module.exports = function buildSession({
   id = databaseBuffer.getNextId(),
-  accessCode = 'ACC123',
+  accessCode = 'FMKP39',
   address = '3 rue des églantines',
   certificationCenter = 'Centre de certif Pix',
   certificationCenterId,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -142,6 +142,11 @@ module.exports = (function () {
       passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',
     },
 
+    availableCharacterForCode: {
+      letters: 'BCDFGHJKMPQRTVWXY',
+      numbers: '2346789',
+    },
+
     caching: {
       redisUrl: process.env.REDIS_URL,
       redisCacheKeyLockTTL: parseInt(process.env.REDIS_CACHE_KEY_LOCK_TTL, 10) || 60000,

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -1,11 +1,13 @@
 const _ = require('lodash');
+const config = require('../../config');
 
 const CREATED = 'created';
 const FINALIZED = 'finalized';
 const IN_PROCESS = 'in_process';
 const PROCESSED = 'processed';
 
-const availableCharactersForPasswordGeneration = '2346789BCDFGHJKMPQRTVWXY'.split('');
+const availableCharactersForPasswordGeneration =
+  `${config.availableCharacterForCode.numbers}${config.availableCharacterForCode.letters}`.split('');
 const NB_CHAR = 5;
 
 const statuses = {

--- a/api/lib/domain/services/session-code-service.js
+++ b/api/lib/domain/services/session-code-service.js
@@ -2,12 +2,12 @@ const _ = require('lodash');
 const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository');
 
 function _randomLetter() {
-  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXZ'.split('');
+  const letters = 'BCDFGHJKMPQRTVWXY'.split('');
   return _.sample(letters);
 }
 
 function _randomNumberCharacter() {
-  const numberCharacter = '0123456789'.split('');
+  const numberCharacter = '2346789'.split('');
   return _.sample(numberCharacter);
 }
 

--- a/api/lib/domain/services/session-code-service.js
+++ b/api/lib/domain/services/session-code-service.js
@@ -1,13 +1,14 @@
 const _ = require('lodash');
+const config = require('../../config');
 const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository');
 
 function _randomLetter() {
-  const letters = 'BCDFGHJKMPQRTVWXY'.split('');
+  const letters = config.availableCharacterForCode.letters.split('');
   return _.sample(letters);
 }
 
 function _randomNumberCharacter() {
-  const numberCharacter = '2346789'.split('');
+  const numberCharacter = config.availableCharacterForCode.numbers.split('');
   return _.sample(numberCharacter);
 }
 

--- a/api/lib/domain/services/verify-certificate-code-service.js
+++ b/api/lib/domain/services/verify-certificate-code-service.js
@@ -1,7 +1,10 @@
 const _ = require('lodash');
 const certificationCourseRepository = require('../../../lib/infrastructure/repositories/certification-course-repository');
 const { CertificateVerificationCodeGenerationTooManyTrials } = require('../../../lib/domain/errors');
-const availableCharacters = '2346789BCDFGHJKMPQRTVWXY'.split('');
+const config = require('../../config');
+
+const availableCharacters =
+  `${config.availableCharacterForCode.numbers}${config.availableCharacterForCode.letters}`.split('');
 const NB_CHAR = 8;
 const NB_OF_TRIALS = 1000;
 

--- a/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
@@ -25,6 +25,7 @@ describe('Integration | Repository | JurySession', function () {
         });
         certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ externalId: 'EXT_ID' }).id;
         sessionId = databaseBuilder.factory.buildSession({
+          accessCode: 'GHKM26',
           assignedCertificationOfficerId: assignedCertificationOfficer.id,
           certificationCenterId,
           juryComment: 'Les mecs ils font des sessions de certif dans le jardin ??',
@@ -48,7 +49,7 @@ describe('Integration | Repository | JurySession', function () {
           examiner: 'Ginette',
           date: '2020-01-15',
           time: '15:30:00',
-          accessCode: 'ACC123',
+          accessCode: 'GHKM26',
           description: 'La session se déroule dans le jardin',
           examinerGlobalComment: '',
           finalizedAt: null,

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -2,7 +2,7 @@ const Session = require('../../../../lib/domain/models/Session');
 
 const buildSession = function ({
   id = 123,
-  accessCode = 'ABCD123',
+  accessCode = 'BCDF234',
   address = '4 avenue du général perlimpimpim',
   certificationCenter = 'Centre de certif pix',
   certificationCenterId,

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 
 describe('Unit | Service | CodeSession', function () {
   describe('#isSessionCodeAvailable', function () {
-    it('should return a session code with 4 random capital letters and 2 random numbers', async function () {
+    it('should return a non ambiguous session code with 4 random capital letters and 2 random numbers', async function () {
       // given
       sinon.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
 
@@ -13,7 +13,7 @@ describe('Unit | Service | CodeSession', function () {
       const result = await sessionCodeService.getNewSessionCode();
 
       // then
-      expect(result).to.match(/[A-Z]{4}[0-9]{2}/);
+      expect(result).to.match(/[B,C,D,F,G,H,J,K,M,P,Q,R,T,V,W,X,Y]{4}[2,3,4,6,7,8,9]{2}/);
     });
 
     it('should return a new code if first code was not unique', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Le code d’accès à une session que le surveillant doit communiquer aux candidats pour lancer leur test de certification peut aujourd’hui comporter des O et des 0 ce qui entraîne des risques d’erreur lors de la dictée de ce code.

## :robot: Solution
MAJ les règles de génération de ce code pour respecter les bonnes pratiques.

## :rainbow: Remarques
On se base sur les caractères acceptés pour la génération du mot de passe surveillant.

Les caractères suivants sont désormais exclus:
```A,E,O,I,L,N,S,U,Z,0,1,5```


## :100: Pour tester
- Se connecter à pix-certif
- Créer une session
- Constater que le code d'accès à la session ne contient pas ```A,E,O,I,L,N,S,U,Z,0,1,5```