### PR TITLE
[FEATURE] Pouvoir sélectionner une thématique entièrement (PIX-3955)

### DIFF
--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -31,7 +31,7 @@
             <caption>{{t "pages.preselect-target-profile.table.caption"}}</caption>
             <thead>
               <tr>
-                <Table::Header @size="small" @align="center" scope="col">
+                <Table::Header @size="medium" @align="center" scope="col">
                   {{t "pages.preselect-target-profile.table.column.theme-name"}}
                 </Table::Header>
                 <Table::Header @size="small" @align="center" scope="col">
@@ -53,20 +53,32 @@
               {{#each competence.sortedThematics as |thematic|}}
                 {{#each thematic.tubes as |tube index|}}
                   <tr
-                    {{on "click" this.toggleInput}}
+                    {{on "click" this.toggleTubeInput}}
                     class="row-tube"
                     aria-label={{t "pages.preselect-target-profile.table.row-title"}}
                   >
                     {{#if (eq index 0)}}
                       <th
-                        class="row--not-clickable"
                         scope="row"
+                        class="th--clickable"
                         rowspan={{thematic.tubes.length}}
-                      >{{thematic.name}}</th>
+                        {{on "click" this.toggleThematicInput}}
+                      >
+                        <Input
+                          {{on "input" (fn this.updateSelectedThematics thematic.id)}}
+                          id="thematic-{{thematic.id}}"
+                          @type="checkbox"
+                        />
+                        <label for="thematic-{{thematic.id}}">
+                          {{thematic.name}}
+                        </label>
+                      </th>
                     {{/if}}
                     <td class="table__column--center">
                       <Input
                         {{on "input" (fn this.updateSelectedTubes tube.id)}}
+                        data-thematic={{thematic.id}}
+                        data-tube={{tube.id}}
                         id="tube-{{tube.id}}"
                         @type="checkbox"
                       />

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -37,8 +37,8 @@ export default class TubeList extends Component {
   }
 
   @action
-  toggleInput(event) {
-    const checkbox = event.currentTarget.querySelector('input');
+  toggleTubeInput(event) {
+    const checkbox = event.currentTarget.querySelector('[data-tube]');
     if (event.target.nodeName === 'TD') {
       checkbox.checked = !checkbox.checked;
       const evt = document.createEvent('HTMLEvents');
@@ -48,12 +48,63 @@ export default class TubeList extends Component {
   }
 
   @action
+  toggleThematicInput(event) {
+    const checkbox = event.currentTarget.querySelector('input');
+    if (event.target.nodeName === 'TH') {
+      checkbox.checked = !checkbox.checked;
+      const evt = document.createEvent('HTMLEvents');
+      evt.initEvent('input', false, true);
+      checkbox.dispatchEvent(evt);
+    }
+  }
+
+  _toggleCheckboxThematicByTubes(tube) {
+    const thematicId = tube.getAttribute('data-thematic');
+    const thematic = document.getElementById(`thematic-${thematicId}`);
+    const tubes = document.querySelectorAll(`[data-thematic="${thematicId}"]`);
+
+    if (Array.from(tubes).every((element) => element.checked)) {
+      thematic.indeterminate = false;
+      thematic.checked = true;
+    } else if (Array.from(tubes).some((element) => element.checked)) {
+      thematic.indeterminate = true;
+    } else {
+      thematic.indeterminate = false;
+      thematic.checked = false;
+    }
+  }
+
+  @action
   updateSelectedTubes(tubeId, event) {
-    const el = event.currentTarget;
-    if (el.checked) {
+    const tube = event.currentTarget;
+    this._toggleCheckboxThematicByTubes(tube);
+    if (tube.checked) {
       this.tubesSelected.pushObject(tubeId);
     } else {
       this.tubesSelected.removeObject(tubeId);
     }
+  }
+
+  @action
+  updateSelectedThematics(thematicId, event) {
+    const el = event.currentTarget;
+    const tubes = document.querySelectorAll(`[data-thematic="${thematicId}"]`);
+    const uniqueTubesSelected = new Set(this.tubesSelected);
+
+    if (el.checked) {
+      for (let i = 0; i < tubes.length; i++) {
+        const tubeId = tubes[i].getAttribute('data-tube');
+        tubes[i].checked = true;
+        uniqueTubesSelected.add(tubeId);
+      }
+    } else {
+      for (let i = 0; i < tubes.length; i++) {
+        const tubeId = tubes[i].getAttribute('data-tube');
+        tubes[i].checked = false;
+        uniqueTubesSelected.delete(tubeId);
+      }
+    }
+
+    this.tubesSelected = A([...new Set(uniqueTubesSelected)]);
   }
 }

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -68,6 +68,14 @@ tbody {
     background-color: white;
   }
 
+  th.th--clickable {
+    background-color: white;
+
+    &:hover {
+      background-color: $grey-15;
+    }
+  }
+
   td {
     font-family: $roboto;
     font-size: 0.875rem;
@@ -127,6 +135,10 @@ th::first-letter {
   &--small {
     width: 6%;
     max-width: 150px;
+  }
+
+  &--medium {
+    width: 15%;
   }
 
   &--wide {

--- a/orga/app/templates/authenticated/preselect-target-profile.hbs
+++ b/orga/app/templates/authenticated/preselect-target-profile.hbs
@@ -1,5 +1,6 @@
 {{page-title (t "pages.preselect-target-profile.title")}}
 
 <article class="preselect-target-profile">
+  <h1 class="page__title page-title">{{t "pages.preselect-target-profile.title"}}</h1>
   <Tube::List @areas={{this.model.areas}} @organization={{this.model.organization}} />
 </article>

--- a/orga/tests/integration/components/tube/list_test.js
+++ b/orga/tests/integration/components/tube/list_test.js
@@ -25,7 +25,7 @@ module('Integration | Component | tube:list', function (hooks) {
         practicalDescription: 'Description 2',
       },
     ];
-    const thematics = [{ tubes }];
+    const thematics = [{ id: 'thematicId', name: 'thematic1', tubes }];
     const competences = [
       {
         get sortedThematics() {
@@ -59,7 +59,8 @@ module('Integration | Component | tube:list', function (hooks) {
 
     // then
     assert.dom('.row-tube').exists({ count: 2 });
-    assert.dom(this.element.querySelector('.row-tube')).hasText('Titre 1 : Description 1');
+    assert.dom(this.element.querySelector('[for="tube-tubeId1"]')).hasText('Titre 1 : Description 1');
+    assert.dom(this.element.querySelector('[for="tube-tubeId2"]')).hasText('Titre 2 : Description 2');
   });
 
   test('it should disable the download button if not tube is selected', async function (assert) {
@@ -86,5 +87,49 @@ module('Integration | Component | tube:list', function (hooks) {
     // then
     assert.dom('.download-file__button').doesNotHaveClass('pix-button--disabled');
     assert.dom(`.download-file__button[download="${expectedAttr}"]`).exists();
+  });
+
+  test('Enable the download button if a thematic is selected', async function (assert) {
+    // given
+    this.set('areas', areas);
+
+    // when
+    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+    await clickByName('1 · Titre domaine');
+    await clickByName('thematic1');
+
+    // then
+    assert.dom('.download-file__button').doesNotHaveClass('pix-button--disabled');
+  });
+
+  test('Should check all tubes corresponding to the thematics if a thematic is selected', async function (assert) {
+    // given
+    this.set('areas', areas);
+
+    // when
+    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+    const tube1 = document.getElementById('tube-tubeId1');
+    const tube2 = document.getElementById('tube-tubeId2');
+    await clickByName('1 · Titre domaine');
+    await clickByName('thematic1');
+
+    // then
+    assert.dom(tube1).isChecked();
+    assert.dom(tube2).isChecked();
+  });
+
+  test('Should check the thematics if all corresponding tubes are selected', async function (assert) {
+    // given
+    this.set('areas', areas);
+
+    // when
+    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+    const thematic = document.getElementById('thematic-thematicId');
+    await clickByName('1 · Titre domaine');
+    await clickByName('Titre 1 : Description 1');
+    await clickByName('Titre 2 : Description 2');
+
+    // then
+    assert.dom(thematic).isChecked();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La sélection des thématiques n'étaient pas possible ce qui obligeait les utilisateurs à sélectionner les sujets un à un.

## :robot: Solution
Rendre possible la sélection des thématiques dans leur entièreté. 

## :100: Pour tester
Aller sur [/selection-sujets](https://orga-pr4093.review.pix.fr/selection-sujets), sélectionner une thématique et télécharger le fichier. 