### PR TITLE
[BUGFIX] Neutraliser les questions auxquelles les candidats n'ont pas pu répondre à cause d'une régression - v3 (PIX-4389).

### DIFF
--- a/api/scripts/neutralize-answers-after-invalid-challenges.js
+++ b/api/scripts/neutralize-answers-after-invalid-challenges.js
@@ -15,6 +15,7 @@ const extractAnswers = async (lengthyChallengeId, exposure) => {
     .select('assessments.certificationCourseId AS certificationCourseId', 'answers.challengeId')
     .innerJoin('assessments', 'assessments.id', 'answers.assessmentId')
     .where('answers.result', '<>', 'ok')
+    .where('assessments.type', '=', 'CERTIFICATION')
     .where('answers.id', '>', exposure.lastAnswerIdBeforeRegression)
     .where('answers.id', '<', exposure.firstAnswerIdAfterRegression)
     .where('answers.challengeId', '=', lengthyChallengeId);


### PR DESCRIPTION
## :unicorn: Problème
La solution proposée dans #4089 tente de neutraliser les réponses hors certification et sort en erreur

``` json
{"level":50,"time":1644935607754,"pid":73,"hostname":"pix-api-production-one-off-8238","err":{"type":"NotFoundError","message":"L'assessment de certification avec un certificationCourseId de null n'existe pas ou son accès est restreint","stack":"Error: L'assessment de certification avec un certificationCourseId de null n'existe pas ou son accès est restreint\n    at Object.getByCertificationCourseId (/app/lib/infrastructure/repositories/certification-assessment-repository.js:90:13)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async neutralizeChallenge (/app/lib/domain/usecases/neutralize-challenge.js:9:35)\n    at async /app/scripts/neutralize-answers-after-invalid-challenges.js:50:19"},"msg":"L'assessment de certification avec un certificationCourseId de null n'existe pas ou son accès est restreint"}
```

## :robot: Solution
Restreindre aux certifications

## :rainbow: Remarques

Régression dû à un refacto de #4089 

Pour exécuter en production sans attendre de release

```shell
scalingo --region osc-secnum-fr1 -a pix-api-production run bash --file ./scripts/run-neutralize-answers-after-invalid-challenges.js --file ./scripts/neutralize-answers-after-invalid-challenges.js
cp /tmp/uploads/* ./scripts/

LOG_LEVEL=info PROCEED=YES node ./scripts/run-neutralize-answers-after-invalid-challenges.js

{"level":30,"time":1644939176134,"pid":54,"hostname":"pix-api-production-one-off-7432","msg":"1036 answers found"}
{"level":30,"time":1644939176138,"pid":54,"hostname":"pix-api-production-one-off-7432","msg":"Neutralization has started"}
{"level":30,"time":1644939176138,"pid":54,"hostname":"pix-api-production-one-off-7432","msg":"Neutralization has started"}
{"level":30,"time":1644939177023,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"ChallengeNeutralized","event_content":{"certificationCourseId":929613,"juryId":144175},"event_handler_name":"handleCertificationRescoring","msg":"EventDispatcher : Event dispatch started"}
{"level":30,"time":1644939177501,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"ChallengeNeutralized","event_content":{"certificationCourseId":929613,"juryId":144175},"event_handler_name":"handleCertificationRescoring","event_handling_duration":477.57178115844727,"msg":"EventDispatcher : Event dispatched successfully"}
{"level":30,"time":1644939177502,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"CertificationRescoringCompleted","event_content":{"certificationCourseId":929613,"userId":XXX,"reproducibilityRate":72},"event_handler_name":"handleCleaCertificationScoring","msg":"EventDispatcher : Event dispatch started"}
{"level":30,"time":1644939177504,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"CertificationRescoringCompleted","event_content":{"certificationCourseId":929613,"userId":XXX,"reproducibilityRate":72},"event_handler_name":"handleCleaCertificationScoring","event_handling_duration":2.3846588134765625,"msg":"EventDispatcher : Event dispatched successfully"}
(...15 minutes...)
{"level":30,"time":1644940282978,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"CertificationRescoringCompleted","event_content":{"certificationCourseId":936836,"userId":XX,"reproducibilityRate":77},"event_handler_name":"handleCleaCertificationScoring","msg":"EventDispatcher : Event dispatch started"}
{"level":30,"time":1644940282979,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"CertificationRescoringCompleted","event_content":{"certificationCourseId":936836,"userId":XX,"reproducibilityRate":77},"event_handler_name":"handleCleaCertificationScoring","event_handling_duration":0.9329147338867188,"msg":"EventDispatcher : Event dispatched successfully"}
{"level":30,"time":1644940282979,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"CertificationRescoringCompleted","event_content":{"certificationCourseId":936836,"userId":XX,"reproducibilityRate":77},"event_handler_name":"handlePixPlusCertificationsScoring","msg":"EventDispatcher : Event dispatch started"}
{"level":30,"time":1644940283359,"pid":54,"hostname":"pix-api-production-one-off-7432","user_id":"-","request_id":"-","event_name":"CertificationRescoringCompleted","event_content":{"certificationCourseId":936836,"userId":XX,"reproducibilityRate":77},"event_handler_name":"handlePixPlusCertificationsScoring","event_handling_duration":379.1695137023926,"msg":"EventDispatcher : Event dispatched successfully"}
{"level":30,"time":1644940283359,"pid":54,"hostname":"pix-api-production-one-off-7432","msg":"Neutralization has ended"}
{"level":30,"time":1644940283359,"pid":54,"hostname":"pix-api-production-one-off-7432","msg":"Script has ended"}
```

## :100: Pour tester
Modifier pour utiliser des id de seeds
