### PR TITLE
[TECH] Configure le proxy API pour limiter le temps d'indispo

### DIFF
--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -16,6 +16,16 @@ log_format keyvalue
 # as we are about to override it in the server directive here below
 access_log off;
 
+upstream api {
+    <%
+    # We compute the API host from the front app name, examples:
+    #   pix-orga-integration       -> pix-api-integration.scalingo.io
+    #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
+    #   pix-orga-production        -> pix-api-production.scalingo.io
+    %>
+    server <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+}
+
 server {
   access_log logs/access.log keyvalue;
   server_name localhost;
@@ -66,14 +76,9 @@ server {
   }
 
   location /api/ {
-    <%
-    # We compute the API host from the front app name, examples:
-    #   pix-orga-integration       -> pix-api-integration.scalingo.io
-    #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
-    #   pix-orga-production        -> pix-api-production.scalingo.io
-    %>
-    proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+    proxy_pass https://api;
     proxy_redirect default;
+    proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
   }
 
   <% end %>


### PR DESCRIPTION
## :unicorn: Problème
Il peut arriver que le proxy API ait des problèmes en production. La configuration proxy_pass actuel fait que 2 backend upstreams sont crées (car scalingo a 2 adresses IP entrantes) et si une erreur apparait, le backend est désactivé pendant 10s. Il suffit de 2 erreurs d'affilés pour que les 2 backends ne renvoit plus rien pendant 10s. 

## :robot: Solution
Pour limiter des problèmes qui peuvent être très transitoire, on décide de configurer nous même le upstream et on configure le nombre d'erreurs avant désactivation a 3 et le temps avant le prochain réessai a 5s.
Ces chifres sont configurable via les variables d'environnement: `NGINX_UPSTREAM_MAX_FAILS` et `NGINX_UPSTREAM_FAIL_TIMEOUT`

## :rainbow: Remarques
Il est nécessaire de rajouter manuellement le header HOST.

## :100: Pour tester
Sur la review app, transformé en app front mon-pix, vérifier que le proxy fonctionne bien:
`curl -vvv https://pix-front-review-pr4097.osc-fr1.scalingo.io/api/`
