### PR TITLE
[TECH] Proposition: méthode .knex() sur la classe DomainTransaction

### DIFF
--- a/api/lib/infrastructure/DomainTransaction.js
+++ b/api/lib/infrastructure/DomainTransaction.js
@@ -5,6 +5,12 @@ class DomainTransaction {
     this.knexTransaction = knexTransaction;
   }
 
+  knex(...args) {
+    const builder = knex(...args);
+    if (this.knexTransaction != null) builder.transacting(this.knexTransaction);
+    return builder;
+  }
+
   static execute(lambda) {
     return knex.transaction((trx) => {
       return lambda(new DomainTransaction(trx));


### PR DESCRIPTION
## :unicorn: Problème

Actuellement dans les repositories utilisant du knex, lorsqu'on reçoit un paramètre `domainTransaction` **optionnel**, il n'y a pas de manière très élégante de le gérer.

On trouve principalement deux façons de faire :

#### Créer une référence qui contient soit la `knexTransaction`, soit à défaut l'objet knex :

```js
async function maMéthodeDeRepository(arg1, domainTransaction = DomainTransaction.emptyTransaction()) {
  const knexConn = domainTransaction.knexTransaction ?? knex;
  const result = await knexConn(MA_TABLE).select();
  // ...
}
```

#### Appeler la méthode `.transacting()` du builder uniquement si il y a une `knexTransaction` :

```js
async function maMéthodeDeRepository(arg1, domainTransaction = DomainTransaction.emptyTransaction()) {
  const query = knex(MA_TABLE).select();
  if (domainTransaction.knexTransaction) query.transacting(domainTransaction.knexTransaction);
  const result = await query;
  // ...
}
```

`.transacting()` lève une erreur si on l'appelle avec `null`/`undefined`, le `if` est donc obligatoire.

## :robot: Solution

Ajouter une méthode `.knex()` sur la classe `DomainTransaction` pour avoir une solution plus amicale avec le développeur :

```js
async function maMéthodeDeRepository(arg1, domainTransaction = DomainTransaction.emptyTransaction()) {
  const result = await domainTransaction.knex(MA_TABLE).select();
  // ...
}
```

## :rainbow: Remarques

N/A

## :100: Pour tester

Le `BadgeRepository` a servi de cobaye.

Il y a notamment [un test qui vérifie que la transaction est bien effective](https://github.com/1024pix/pix/blob/69b90c8388919184cd3ac9860bbc11dd94919714/api/tests/integration/domain/usecases/create-badge_test.js#L134).
