### PR TITLE
[BUGFIX] [A11Y] Permettre l'affichage des modales de Pix Certif avec le CSS désactivé (PIX-3910)

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -1,127 +1,112 @@
-<AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
-  <div class="certification-candidate-details-modal">
-    <div class="pix-modal__close-button">
-      <button aria-label="Fermer la fenêtre de détail du candidat" type="button" {{on "click" @closeModal}}>
-        Fermer
-        <img src="/icons/icon-close-modal.svg" alt="" role="presentation" width="24" height="24" />
-      </button>
-    </div>
+<PixModal @title="Détail du candidat" @onCloseButtonClick={{@closeModal}} class="certification-candidate-details-modal">
+  <:content>
+    <ul class="certification-candidate-details-modal__list">
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Nom</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.lastName @candidate.lastName "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Prénom</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.firstName @candidate.firstName "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Date de naissance</span>
+        {{#if @candidate.birthdate}}
+          <span class="certification-candidate-details-modal__row__value">
+            {{moment-format @candidate.birthdate "DD/MM/YYYY"}}
+          </span>
+        {{else}}
+          <span class="certification-candidate-details-modal__row__value">
+            {{"-"}}
+          </span>
+        {{/if}}
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Sexe</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.sexLabel @candidate.sexLabel "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Commune de naissance</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.birthCity @candidate.birthCity "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Code postal de naissance</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Code INSEE de naissance</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Pays de naissance</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.birthCountry @candidate.birthCountry "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">E-mail du destinataire des résultats (formateur,
+          enseignant...)</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">E-mail de convocation</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.email @candidate.email "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Identifiant externe</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.externalId @candidate.externalId "-"}}
+        </span>
+      </li>
+      <li class="certification-candidate-details-modal__row">
+        <span class="certification-candidate-details-modal__row__label">Temps majoré (%)</span>
+        <span class="certification-candidate-details-modal__row__value">
+          {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
+        </span>
+      </li>
+      {{#if @shouldDisplayPaymentOptions}}
+        <li class="certification-candidate-details-modal__row">
+          <span class="certification-candidate-details-modal__row__label">Tarification part Pix</span>
+          <span class="certification-candidate-details-modal__row__value">
+            {{if @candidate.billingMode @candidate.billingMode "-"}}
+          </span>
+        </li>
+        <li class="certification-candidate-details-modal__row">
+          <span class="certification-candidate-details-modal__row__label">Code de prépaiement</span>
+          <span class="certification-candidate-details-modal__row__value">
+            {{if @candidate.prepaymentCode @candidate.prepaymentCode "-"}}
+          </span>
+        </li>
+      {{/if}}
+      {{#if @displayComplementaryCertification}}
+        <li class="certification-candidate-details-modal__row">
+          <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
+          <span class="certification-candidate-details-modal__row__value">
+            {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
+          </span>
+        </li>
+      {{/if}}
+    </ul>
+  </:content>
 
-    <div class="pix-modal__container pix-modal__container--white">
-      <div class="certification-candidate-details-modal__title">
-        <h1>Détail du candidat</h1>
-      </div>
-
-      <div class="certification-candidate-details-modal__content">
-        <ul class="certification-candidate-details-modal__list">
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Nom</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.lastName @candidate.lastName "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Prénom</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.firstName @candidate.firstName "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Date de naissance</span>
-            {{#if @candidate.birthdate}}
-              <span class="certification-candidate-details-modal__row__value">
-                {{moment-format @candidate.birthdate "DD/MM/YYYY"}}
-              </span>
-            {{else}}
-              <span class="certification-candidate-details-modal__row__value">
-                {{"-"}}
-              </span>
-            {{/if}}
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Sexe</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.sexLabel @candidate.sexLabel "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Commune de naissance</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.birthCity @candidate.birthCity "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Code postal de naissance</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Code INSEE de naissance</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Pays de naissance</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.birthCountry @candidate.birthCountry "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">E-mail du destinataire des résultats
-              (formateur, enseignant...)</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">E-mail de convocation</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.email @candidate.email "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Identifiant externe</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.externalId @candidate.externalId "-"}}
-            </span>
-          </li>
-          <li class="certification-candidate-details-modal__row">
-            <span class="certification-candidate-details-modal__row__label">Temps majoré (%)</span>
-            <span class="certification-candidate-details-modal__row__value">
-              {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
-            </span>
-          </li>
-          {{#if @shouldDisplayPaymentOptions}}
-            <li class="certification-candidate-details-modal__row">
-              <span class="certification-candidate-details-modal__row__label">Tarification part Pix</span>
-              <span class="certification-candidate-details-modal__row__value">
-                {{if @candidate.billingMode @candidate.billingMode "-"}}
-              </span>
-            </li>
-            <li class="certification-candidate-details-modal__row">
-              <span class="certification-candidate-details-modal__row__label">Code de prépaiement</span>
-              <span class="certification-candidate-details-modal__row__value">
-                {{if @candidate.prepaymentCode @candidate.prepaymentCode "-"}}
-              </span>
-            </li>
-          {{/if}}
-          {{#if @displayComplementaryCertification}}
-            <li class="certification-candidate-details-modal__row">
-              <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
-              <span class="certification-candidate-details-modal__row__value">
-                {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
-              </span>
-            </li>
-          {{/if}}
-        </ul>
-
-        <div class="certification-candidate-details-modal__actions">
-          <PixButton @triggerAction={{@closeModal}}>Fermer</PixButton>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</AppModal>
+  <:footer>
+    <PixButton @triggerAction={{@closeModal}} aria-label="Fermer la modale de détail du candidat">Fermer</PixButton>
+  </:footer>
+</PixModal>
+>>>>>>> 485dad6333 (refactor(certif): use PixModal for candidate details modal)

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -106,7 +106,6 @@
   </:content>
 
   <:footer>
-    <PixButton @triggerAction={{@closeModal}} aria-label="Fermer la modale de détail du candidat">Fermer</PixButton>
+    <PixButton @triggerAction={{@closeModal}} aria-label="Fermer la fenêtre de détail du candidat">Fermer</PixButton>
   </:footer>
 </PixModal>
->>>>>>> 485dad6333 (refactor(certif): use PixModal for candidate details modal)

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -1,68 +1,62 @@
-<AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
-  <div class="add-issue-report-modal">
-    <div class="pix-modal__close-button">
-      <button type="button" data-test-id="finalize-session-modal__close-cross" {{on "click" @closeModal}}>Fermer
-        <img src="/icons/icon-close-modal.svg" alt="Fermer la fenêtre de confirmation" width="24" height="24" />
-      </button>
-    </div>
+<PixModal
+  class="add-issue-report-modal"
+  @title="Signalement du candidat : {{@report.firstName}} {{@report.lastName}}"
+  @onCloseButtonClick={{@closeModal}}
+>
+  <:content>
+    <form
+      id="add-issue-report-form"
+      {{on "submit" this.submitReport}}
+      class="pix-modal__container pix-modal__container--white"
+    >
+      <div class="add-issue-report-modal-content">
+        <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
+          @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+          @maxlength={{@maxlength}}
+        />
 
-    <form {{on "submit" this.submitReport}} class="pix-modal__container pix-modal__container--white">
-      <div class="add-issue-report-modal__title">
-        <h1>Signalement du candidat</h1>
-        <h3>{{@report.firstName}} {{@report.lastName}}</h3>
+        <IssueReportModal::LateOrLeavingCertificationIssueReportFields
+          @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+          @maxlength={{@maxlength}}
+        />
+
+        <IssueReportModal::FraudCertificationIssueReportFields
+          @fraudCategory={{this.fraudCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+        />
+
+        <IssueReportModal::InChallengeCertificationIssueReportFields
+          @inChallengeCategory={{this.inChallengeCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+          @maxlength={{@maxlength}}
+        />
+
+        <IssueReportModal::TechnicalProblemCertificationIssueReportFields
+          @technicalProblemCategory={{this.technicalProblemCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+          @maxlength={{@maxlength}}
+        />
+
+        <IssueReportModal::OtherCertificationIssueReportFields
+          @otherCategory={{this.otherCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+          @maxlength={{@maxlength}}
+        />
       </div>
 
-      <div class="add-issue-report-modal__content">
-        <div class="add-issue-report-modal-content">
-          <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
-            @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
+      {{#if this.showCategoryMissingError}}
+        <PixMessage @type="alert">Veuillez selectionner une catégorie</PixMessage>
+      {{/if}}
 
-          <IssueReportModal::LateOrLeavingCertificationIssueReportFields
-            @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
-
-          <IssueReportModal::FraudCertificationIssueReportFields
-            @fraudCategory={{this.fraudCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-          />
-
-          <IssueReportModal::InChallengeCertificationIssueReportFields
-            @inChallengeCategory={{this.inChallengeCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
-
-          <IssueReportModal::TechnicalProblemCertificationIssueReportFields
-            @technicalProblemCategory={{this.technicalProblemCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
-
-          <IssueReportModal::OtherCertificationIssueReportFields
-            @otherCategory={{this.otherCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
-        </div>
-
-        {{#if this.showCategoryMissingError}}
-          <PixMessage @type="alert">Veuillez selectionner une catégorie</PixMessage>
-        {{/if}}
-
-        {{#if this.showIssueReportSubmitError}}
-          <PixMessage @type="alert">Une erreur s'est produite lors de l'ajout du signalement. Merci de réessayer</PixMessage>
-        {{/if}}
-
-        <div class="add-issue-report-modal__actions">
-          <PixButton @triggerAction={{@closeModal}} @backgroundColor="transparent-light">Annuler</PixButton>
-          <PixButton @type="submit" aria-label="Ajouter le signalement">Valider</PixButton>
-        </div>
-      </div>
+      {{#if this.showIssueReportSubmitError}}
+        <PixMessage @type="alert">Une erreur s'est produite lors de l'ajout du signalement. Merci de réessayer</PixMessage>
+      {{/if}}
     </form>
-  </div>
-</AppModal>
+  </:content>
+  <:footer>
+    <PixButton @triggerAction={{@closeModal}} @backgroundColor="transparent-light">Annuler</PixButton>
+    <PixButton form="add-issue-report-form" @type="submit" aria-label="Ajouter le signalement">Valider</PixButton>
+  </:footer>
+</PixModal>

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -1,5 +1,5 @@
 <AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
-  <div class="add-issue-report-modal">
+  <div class="issue-report-modal">
     <div class="pix-modal__close-button">
       <button
         type="button"
@@ -12,18 +12,18 @@
     </div>
 
     <div class="pix-modal__container pix-modal__container--white">
-      <div class="add-issue-report-modal__title">
+      <div class="issue-report-modal__title">
         <h1>Signalement du candidat</h1>
         <h3>{{@report.firstName}} {{@report.lastName}}</h3>
       </div>
 
-      <div class="add-issue-report-modal__content">
+      <div class="issue-report-modal__content">
         <h2>Mes signalements ({{@report.certificationIssueReports.length}})</h2>
-        <div class="add-issue-report-modal__content--frame">
+        <div class="issue-report-modal__content--frame">
           <ul>
             {{#each @report.certificationIssueReports as |issueReport|}}
               <li>
-                <p class="add-issue-report-modal-content__category-label">
+                <p class="issue-report-modal-content__category-label">
                   {{issueReport.categoryCode}}&nbsp;{{issueReport.categoryLabel}}
                   <PixIconButton
                     @icon="trash"
@@ -33,7 +33,7 @@
                 </p>
                 {{#if issueReport.subcategoryLabel}}
                   <p
-                    class="add-issue-report-modal-content__subcategory-label"
+                    class="issue-report-modal-content__subcategory-label"
                   >{{issueReport.subcategoryCode}}&nbsp;{{issueReport.subcategoryLabel}}</p>
                 {{/if}}
               </li>

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -1,54 +1,38 @@
-<AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
-  <div class="issue-report-modal">
-    <div class="pix-modal__close-button">
-      <button
-        type="button"
-        aria-label="Fermer"
-        data-test-id="finalize-session-modal__close-cross"
-        {{on "click" @closeModal}}
-      >Fermer
-        <img src="/icons/icon-close-modal.svg" alt="Fermer la fenêtre de confirmation" width="24" height="24" />
-      </button>
+<PixModal
+  @title="Signalement du candidat : {{@report.firstName}} {{@report.lastName}}"
+  @onCloseButtonClick={{@closeModal}}
+  class="issue-report-modal"
+>
+  <:content>
+    <h2>Mes signalements ({{@report.certificationIssueReports.length}})</h2>
+    <div class="issue-report-modal__frame">
+      <ul>
+        {{#each @report.certificationIssueReports as |issueReport|}}
+          <li class="issue-report-modal__report">
+            <p class="issue-report-modal__category-label">
+              {{issueReport.categoryCode}}&nbsp;{{issueReport.categoryLabel}}
+              <PixIconButton
+                @icon="trash"
+                aria-label="Supprimer le signalement"
+                @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
+              />
+            </p>
+            {{#if issueReport.subcategoryLabel}}
+              <p
+                class="issue-report-modal__subcategory-label"
+              >{{issueReport.subcategoryCode}}&nbsp;{{issueReport.subcategoryLabel}}</p>
+            {{/if}}
+          </li>
+        {{/each}}
+      </ul>
+      <PixButton @triggerAction={{fn @onClickIssueReport @report}}>
+        <FaIcon @icon="plus" />
+        Ajouter un signalement
+      </PixButton>
     </div>
 
-    <div class="pix-modal__container pix-modal__container--white">
-      <div class="issue-report-modal__title">
-        <h1>Signalement du candidat</h1>
-        <h3>{{@report.firstName}} {{@report.lastName}}</h3>
-      </div>
-
-      <div class="issue-report-modal__content">
-        <h2>Mes signalements ({{@report.certificationIssueReports.length}})</h2>
-        <div class="issue-report-modal__content--frame">
-          <ul>
-            {{#each @report.certificationIssueReports as |issueReport|}}
-              <li>
-                <p class="issue-report-modal-content__category-label">
-                  {{issueReport.categoryCode}}&nbsp;{{issueReport.categoryLabel}}
-                  <PixIconButton
-                    @icon="trash"
-                    aria-label="Supprimer le signalement"
-                    @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
-                  />
-                </p>
-                {{#if issueReport.subcategoryLabel}}
-                  <p
-                    class="issue-report-modal-content__subcategory-label"
-                  >{{issueReport.subcategoryCode}}&nbsp;{{issueReport.subcategoryLabel}}</p>
-                {{/if}}
-              </li>
-            {{/each}}
-          </ul>
-          <PixButton @triggerAction={{fn @onClickIssueReport @report}}>
-            <FaIcon @icon="plus" />
-            Ajouter un signalement
-          </PixButton>
-        </div>
-
-        {{#if this.showDeletionError}}
-          <PixMessage @type="alert">Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer</PixMessage>
-        {{/if}}
-      </div>
-    </div>
-  </div>
-</AppModal>
+    {{#if this.showDeletionError}}
+      <PixMessage @type="alert">Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer</PixMessage>
+    {{/if}}
+  </:content>
+</PixModal>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,328 +1,332 @@
-<AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
-  <div class="new-certification-candidate-modal">
-    <div class="pix-modal__close-button">
-      <button aria-label="Fermer la fenêtre d'ajout d'un candidat" type="button" {{on "click" @closeModal}}>
-        Fermer
-        <img src="/icons/icon-close-modal.svg" alt="" role="presentation" width="24" height="24" />
-      </button>
-    </div>
+<PixModal @title="Ajouter un candidat" @onCloseButtonClick={{@closeModal}} class="new-certification-candidate-modal">
+  <:content>
+    <form
+      id="new-certification-candidate-form"
+      class="new-certification-candidate-modal__form"
+      {{on "submit" this.onFormSubmit}}
+    >
 
-    <div class="pix-modal__container pix-modal__container--white">
-      <div class="new-certification-candidate-modal__title">
-        <h1>Ajouter un candidat</h1>
+      <p class="new-certification-candidate-modal__form__required-fields-mention">
+        Les champs marqués de
+        <span class="required-field-indicator">*</span>
+        sont obligatoires.
+      </p>
+
+      <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
+        <label for="last-name" class="label">
+          <span class="required-field-indicator">*</span>
+          Nom de famille
+        </label>
+        <Input
+          id="last-name"
+          @type="text"
+          class="input"
+          @value={{@candidateData.lastName}}
+          {{on "input" (fn @updateCandidateData @candidateData "lastName")}}
+          {{did-insert this.focus}}
+          required
+        />
       </div>
 
-      <div class="new-certification-candidate-modal__content">
+      <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
+        <label for="first-name" class="label">
+          <span class="required-field-indicator">*</span>
+          Prénom
+        </label>
+        <Input
+          id="first-name"
+          @type="text"
+          class="input"
+          @value={{@candidateData.firstName}}
+          {{on "input" (fn @updateCandidateData @candidateData "firstName")}}
+          required
+        />
+      </div>
 
-        <form
-          id="new-certification-candidate-form"
-          class="new-certification-candidate-modal__form"
-          {{on "submit" this.onFormSubmit}}
-        >
-
-          <p class="new-certification-candidate-modal__form__required-fields-mention">
-            Les champs marqués de
+      <div class="new-certification-candidate-modal__form__field">
+        <fieldset>
+          <legend class="label">
             <span class="required-field-indicator">*</span>
-            sont obligatoires.
-          </p>
-
-          <div
-            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-          >
-            <label for="last-name" class="label">
-              <span class="required-field-indicator">*</span>
-              Nom de famille
-            </label>
-            <Input
-              id="last-name"
-              @type="text"
-              class="input"
-              @value={{@candidateData.lastName}}
-              {{on "input" (fn @updateCandidateData @candidateData "lastName")}}
-              {{did-insert this.focus}}
+            Sexe
+          </legend>
+          <div class="radio-button-container">
+            <input
+              type="radio"
+              id="female"
+              value="F"
+              name="sex"
               required
+              {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
-          </div>
-
-          <div
-            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-          >
-            <label for="first-name" class="label">
-              <span class="required-field-indicator">*</span>
-              Prénom
-            </label>
-            <Input
-              id="first-name"
-              @type="text"
-              class="input"
-              @value={{@candidateData.firstName}}
-              {{on "input" (fn @updateCandidateData @candidateData "firstName")}}
-              required
+            <label class="radio-button-label" for="female">Femme</label>
+            <input
+              type="radio"
+              id="male"
+              value="M"
+              name="sex"
+              {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
+            <label class="radio-button-label" for="male">Homme</label>
           </div>
-
-          <div class="new-certification-candidate-modal__form__field">
-            <fieldset>
-              <legend class="label">
-                <span class="required-field-indicator">*</span>
-                Sexe
-              </legend>
-              <div class="radio-button-container">
-                <input
-                  type="radio"
-                  id="female"
-                  value="F"
-                  name="sex"
-                  required
-                  {{on "click" (fn @updateCandidateData @candidateData "sex")}}
-                />
-                <label class="radio-button-label" for="female">Femme</label>
-                <input
-                  type="radio"
-                  id="male"
-                  value="M"
-                  name="sex"
-                  {{on "click" (fn @updateCandidateData @candidateData "sex")}}
-                />
-                <label class="radio-button-label" for="male">Homme</label>
-              </div>
-            </fieldset>
-          </div>
-
-          <div class="new-certification-candidate-modal__form__field">
-            <label for="birthdate" class="label">
-              <span class="required-field-indicator">*</span>
-              Date de naissance
-            </label>
-            <OneWayDateMask
-              required
-              @placeholder="dd/mm/yyyy"
-              @options={{hash inputFormat="dd/mm/yyyy" outputFormat="dd/mm/yyyy"}}
-              class="input"
-              id="birthdate"
-              @value={{this.maskedBirthdate}}
-              @update={{this.updateBirthdate}}
-            />
-          </div>
-
-          <div class="new-certification-candidate-modal__form__field">
-            <label for="birth-country" class="label">
-              <span class="required-field-indicator">*</span>
-              Pays de naissance
-            </label>
-            <PixSelect
-              id="birth-country"
-              class="birth-country-selector"
-              @options={{this.countryOptions}}
-              @onChange={{this.selectBirthCountry}}
-              @selectedOption={{this.defaultCountryOption}}
-              required
-            />
-          </div>
-
-          {{#if this.isBirthGeoCodeRequired}}
-            <div class="new-certification-candidate-modal__form__field">
-              <fieldset>
-                <legend class="label">
-                  <span class="required-field-indicator">*</span>
-                  Code géographique de naissance
-                </legend>
-                <div class="radio-button-container">
-                  <input
-                    type="radio"
-                    id="insee-code-choice"
-                    name="birth-geo-code-option"
-                    value="insee"
-                    checked="checked"
-                    {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
-                    required
-                  />
-                  <label class="radio-button-label" for="insee-code-choice">Code INSEE</label>
-                  <input
-                    type="radio"
-                    id="postal-code-choice"
-                    name="birth-geo-code-option"
-                    value="postal"
-                    {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
-                  />
-                  <label class="radio-button-label" for="postal-code-choice">Code postal</label>
-                </div>
-              </fieldset>
-            </div>
-          {{/if}}
-
-          {{#if this.isBirthInseeCodeRequired}}
-            <div class="new-certification-candidate-modal__form__field">
-              <label for="birth-insee-code" class="label">
-                <span class="required-field-indicator">*</span>
-                Code INSEE de naissance
-              </label>
-              <Input
-                id="birth-insee-code"
-                @type="text"
-                maxlength="5"
-                class="input"
-                @value={{@candidateData.birthInseeCode}}
-                required
-                {{on "input" (fn @updateCandidateData @candidateData "birthInseeCode")}}
-              />
-            </div>
-          {{/if}}
-
-          {{#if this.isBirthPostalCodeRequired}}
-            <div
-              class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-            >
-              <label for="birth-postal-code" class="label">
-                <span class="required-field-indicator">*</span>
-                Code postal de naissance
-              </label>
-              <Input
-                id="birth-postal-code"
-                @type="text"
-                maxlength="5"
-                class="input"
-                @value={{@candidateData.birthPostalCode}}
-                required
-                {{on "input" (fn @updateCandidateData @candidateData "birthPostalCode")}}
-              />
-            </div>
-          {{/if}}
-
-          {{#if this.isBirthCityRequired}}
-            <div
-              class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-            >
-              <label for="birth-city" class="label">
-                <span class="required-field-indicator">*</span>
-                Commune de naissance
-              </label>
-              <Input
-                id="birth-city"
-                @type="text"
-                class="input"
-                @value={{@candidateData.birthCity}}
-                required
-                {{on "input" (fn @updateCandidateData @candidateData "birthCity")}}
-              />
-            </div>
-          {{/if}}
-
-          <div class="new-certification-candidate-modal__form__field">
-            <label for="external-id" class="label">Identifiant externe</label>
-            <Input
-              id="external-id"
-              @type="text"
-              class="input"
-              @value={{@candidateData.externalId}}
-              {{on "input" (fn @updateCandidateData @candidateData "externalId")}}
-            />
-          </div>
-
-          <div class="new-certification-candidate-modal__form__field">
-            <label for="extra-time-percentage" class="label">Temps majoré (%)</label>
-            <Input
-              id="extra-time-percentage"
-              @type="number"
-              class="input {{if this.validation.email.hasError 'input--error'}}"
-              @value={{@candidateData.extraTimePercentage}}
-              {{on "input" (fn @updateCandidateData @candidateData "extraTimePercentage")}}
-            />
-          </div>
-
-          <div
-            id="recipient-email-container"
-            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-          >
-            <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur,
-              enseignant...)</label>
-            <Input
-              id="result-recipient-email"
-              @type="email"
-              class="input"
-              @value={{@candidateData.resultRecipientEmail}}
-              {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
-            />
-          </div>
-
-          <div
-            id="email-container"
-            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-          >
-            <label for="email" class="label">E-mail de convocation</label>
-            <Input
-              id="email"
-              @type="email"
-              class="input"
-              @value={{@candidateData.email}}
-              {{on "input" (fn @updateCandidateData @candidateData "email")}}
-            />
-          </div>
-
-          {{#if @shouldDisplayPaymentOptions}}
-            <div
-              class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
-            >
-              <label for="billing-mode" class="label">
-                <span class="required-field-indicator">*</span>
-                Tarification part Pix</label>
-              <PixSelect
-                id="billing-mode"
-                class="birth-country-selector"
-                @options={{this.billingModeOptions}}
-                @onChange={{fn @updateCandidateData @candidateData "billingMode"}}
-                @emptyOptionLabel={{"-- Choisissez --"}}
-                @emptyOptionNotSelectable={{true}}
-                required
-              />
-            </div>
-
-            <div
-              class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
-            >
-              <label for="prepayment-code" class="label">Code de prépaiement</label>
-              <Input
-                id="prepayment-code"
-                @type="text"
-                class="input"
-                @value={{@candidateData.prepaymentCode}}
-                {{on "input" (fn @updateCandidateData @candidateData "prepaymentCode")}}
-              />
-            </div>
-          {{/if}}
-
-          {{#if this.complementaryCertifications.length}}
-            <div class="new-certification-candidate-modal__form__field">
-              <span class="label">Certifications complémentaires</span>
-              <div class="complementary-certifications-checkbox-list">
-                <ul>
-                  {{#each this.complementaryCertifications as |complementaryCertification index|}}
-                    <li>
-                      <label for={{concat "complementaryCertification_" index}}>
-                        <Input
-                          @type="checkbox"
-                          id={{concat "complementaryCertification_" index}}
-                          {{on "input" (fn this.updateComplementaryCertifications complementaryCertification)}}
-                        />
-                        {{complementaryCertification.name}}
-                      </label>
-                    </li>
-                  {{/each}}
-                </ul>
-              </div>
-            </div>
-          {{/if}}
-
-          <div class="new-certification-candidate-modal__actions">
-            <PixButton @triggerAction={{@closeModal}} @backgroundColor="transparent-light">
-              Fermer
-            </PixButton>
-            <PixButton @type="submit">Ajouter le candidat</PixButton>
-          </div>
-
-        </form>
+        </fieldset>
       </div>
 
-    </div>
-  </div>
-</AppModal>
+      <div class="new-certification-candidate-modal__form__field">
+        <label for="birthdate" class="label">
+          <span class="required-field-indicator">*</span>
+          Date de naissance
+        </label>
+        <OneWayDateMask
+          required
+          @placeholder="dd/mm/yyyy"
+          @options={{hash inputFormat="dd/mm/yyyy" outputFormat="dd/mm/yyyy"}}
+          class="input"
+          id="birthdate"
+          @value={{this.maskedBirthdate}}
+          @update={{this.updateBirthdate}}
+        />
+      </div>
+
+      <div class="new-certification-candidate-modal__form__field">
+        <label for="birth-country" class="label">
+          <span class="required-field-indicator">*</span>
+          Pays de naissance
+        </label>
+        <PixSelect
+          id="birth-country"
+          class="birth-country-selector"
+          @options={{this.countryOptions}}
+          @onChange={{this.selectBirthCountry}}
+          @selectedOption={{this.defaultCountryOption}}
+          required
+        />
+      </div>
+
+      {{#if this.isBirthGeoCodeRequired}}
+        <div class="new-certification-candidate-modal__form__field">
+          <fieldset>
+            <legend class="label">
+              <span class="required-field-indicator">*</span>
+              Code géographique de naissance
+            </legend>
+            <div class="radio-button-container">
+              <input
+                type="radio"
+                id="insee-code-choice"
+                name="birth-geo-code-option"
+                value="insee"
+                checked="checked"
+                {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
+                required
+              />
+              <label class="radio-button-label" for="insee-code-choice">Code INSEE</label>
+              <input
+                type="radio"
+                id="postal-code-choice"
+                name="birth-geo-code-option"
+                value="postal"
+                {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
+              />
+              <label class="radio-button-label" for="postal-code-choice">Code postal</label>
+            </div>
+          </fieldset>
+        </div>
+      {{/if}}
+
+      {{#if this.isBirthInseeCodeRequired}}
+        <div class="new-certification-candidate-modal__form__field">
+          <label for="birth-insee-code" class="label">
+            <span class="required-field-indicator">*</span>
+            Code INSEE de naissance
+          </label>
+          <Input
+            id="birth-insee-code"
+            @type="text"
+            maxlength="5"
+            class="input"
+            @value={{@candidateData.birthInseeCode}}
+            required
+            {{on "input" (fn @updateCandidateData @candidateData "birthInseeCode")}}
+          />
+        </div>
+      {{/if}}
+
+      {{#if this.isBirthPostalCodeRequired}}
+        <div
+          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+        >
+          <label for="birth-postal-code" class="label">
+            <span class="required-field-indicator">*</span>
+            Code postal de naissance
+          </label>
+          <Input
+            id="birth-postal-code"
+            @type="text"
+            maxlength="5"
+            class="input"
+            @value={{@candidateData.birthPostalCode}}
+            required
+            {{on "input" (fn @updateCandidateData @candidateData "birthPostalCode")}}
+          />
+        </div>
+      {{/if}}
+
+      {{#if this.isBirthCityRequired}}
+        <div
+          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+        >
+          <label for="birth-city" class="label">
+            <span class="required-field-indicator">*</span>
+            Commune de naissance
+          </label>
+          <Input
+            id="birth-city"
+            @type="text"
+            class="input"
+            @value={{@candidateData.birthCity}}
+            required
+            {{on "input" (fn @updateCandidateData @candidateData "birthCity")}}
+          />
+        </div>
+      {{/if}}
+
+      <div class="new-certification-candidate-modal__form__field">
+        <label for="external-id" class="label">Identifiant externe</label>
+        <Input
+          id="external-id"
+          @type="text"
+          class="input"
+          @value={{@candidateData.externalId}}
+          {{on "input" (fn @updateCandidateData @candidateData "externalId")}}
+        />
+      </div>
+
+      {{#if this.complementaryCertifications.length}}
+        <div class="new-certification-candidate-modal__form__field">
+          <span class="label">Certifications complémentaires</span>
+          <div class="complementary-certifications-checkbox-list">
+            <ul>
+              {{#each this.complementaryCertifications as |complementaryCertification index|}}
+                <li>
+                  <label for={{concat "complementaryCertification_" index}}>
+                    <Input
+                      @type="checkbox"
+                      id={{concat "complementaryCertification_" index}}
+                      {{on "input" (fn this.updateComplementaryCertifications complementaryCertification)}}
+                    />
+                    {{complementaryCertification.name}}
+                  </label>
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+        </div>
+      {{/if}}
+      <div class="new-certification-candidate-modal__form__field">
+        <label for="extra-time-percentage" class="label">Temps majoré (%)</label>
+        <Input
+          id="extra-time-percentage"
+          @type="number"
+          class="input {{if this.validation.email.hasError 'input--error'}}"
+          @value={{@candidateData.extraTimePercentage}}
+          {{on "input" (fn @updateCandidateData @candidateData "extraTimePercentage")}}
+        />
+      </div>
+
+      <div
+        id="recipient-email-container"
+        class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+      >
+        <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur,
+          enseignant...)</label>
+        <Input
+          id="result-recipient-email"
+          @type="email"
+          class="input"
+          @value={{@candidateData.resultRecipientEmail}}
+          {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
+        />
+      </div>
+
+      <div
+        id="email-container"
+        class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+      >
+        <label for="email" class="label">E-mail de convocation</label>
+        <Input
+          id="email"
+          @type="email"
+          class="input"
+          @value={{@candidateData.email}}
+          {{on "input" (fn @updateCandidateData @candidateData "email")}}
+        />
+      </div>
+
+      {{#if @shouldDisplayPaymentOptions}}
+        <div
+          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+        >
+          <label for="billing-mode" class="label">
+            <span class="required-field-indicator">*</span>
+            Tarification part Pix</label>
+          <PixSelect
+            id="billing-mode"
+            class="birth-country-selector"
+            @options={{this.billingModeOptions}}
+            @onChange={{fn @updateCandidateData @candidateData "billingMode"}}
+            @emptyOptionLabel={{"-- Choisissez --"}}
+            @emptyOptionNotSelectable={{true}}
+            required
+          />
+        </div>
+
+        <div
+          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+        >
+          <label for="prepayment-code" class="label">Code de prépaiement</label>
+          <Input
+            id="prepayment-code"
+            @type="text"
+            class="input"
+            @value={{@candidateData.prepaymentCode}}
+            {{on "input" (fn @updateCandidateData @candidateData "prepaymentCode")}}
+          />
+        </div>
+      {{/if}}
+
+      {{#if this.complementaryCertifications.length}}
+        <div class="new-certification-candidate-modal__form__field">
+          <span class="label">Certifications complémentaires</span>
+          <div class="complementary-certifications-checkbox-list">
+            <ul>
+              {{#each this.complementaryCertifications as |complementaryCertification index|}}
+                <li>
+                  <label for={{concat "complementaryCertification_" index}}>
+                    <Input
+                      @type="checkbox"
+                      id={{concat "complementaryCertification_" index}}
+                      {{on "input" (fn this.updateComplementaryCertifications complementaryCertification)}}
+                    />
+                    {{complementaryCertification.name}}
+                  </label>
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+        </div>
+      {{/if}}
+    </form>
+  </:content>
+  <:footer>
+    <PixButton
+      aria-label="Fermer la modale d'ajout de candidat"
+      @triggerAction={{@closeModal}}
+      @backgroundColor="transparent-light"
+    >
+      Fermer
+    </PixButton>
+    <PixButton @type="submit" form="new-certification-candidate-form">
+      Ajouter le candidat
+    </PixButton>
+  </:footer>
+</PixModal>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -201,27 +201,6 @@
         />
       </div>
 
-      {{#if this.complementaryCertifications.length}}
-        <div class="new-certification-candidate-modal__form__field">
-          <span class="label">Certifications complémentaires</span>
-          <div class="complementary-certifications-checkbox-list">
-            <ul>
-              {{#each this.complementaryCertifications as |complementaryCertification index|}}
-                <li>
-                  <label for={{concat "complementaryCertification_" index}}>
-                    <Input
-                      @type="checkbox"
-                      id={{concat "complementaryCertification_" index}}
-                      {{on "input" (fn this.updateComplementaryCertifications complementaryCertification)}}
-                    />
-                    {{complementaryCertification.name}}
-                  </label>
-                </li>
-              {{/each}}
-            </ul>
-          </div>
-        </div>
-      {{/if}}
       <div class="new-certification-candidate-modal__form__field">
         <label for="extra-time-percentage" class="label">Temps majoré (%)</label>
         <Input

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,5 +1,5 @@
 <AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
-  <div class="new-certification-candidate-details-modal">
+  <div class="new-certification-candidate-modal">
     <div class="pix-modal__close-button">
       <button aria-label="Fermer la fenêtre d'ajout d'un candidat" type="button" {{on "click" @closeModal}}>
         Fermer
@@ -8,26 +8,26 @@
     </div>
 
     <div class="pix-modal__container pix-modal__container--white">
-      <div class="new-certification-candidate-details-modal__title">
+      <div class="new-certification-candidate-modal__title">
         <h1>Ajouter un candidat</h1>
       </div>
 
-      <div class="new-certification-candidate-details-modal__content">
+      <div class="new-certification-candidate-modal__content">
 
         <form
           id="new-certification-candidate-form"
-          class="new-certification-candidate-details-modal__form"
+          class="new-certification-candidate-modal__form"
           {{on "submit" this.onFormSubmit}}
         >
 
-          <p class="new-certification-candidate-details-modal__form__required-fields-mention">
+          <p class="new-certification-candidate-modal__form__required-fields-mention">
             Les champs marqués de
             <span class="required-field-indicator">*</span>
             sont obligatoires.
           </p>
 
           <div
-            class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
           >
             <label for="last-name" class="label">
               <span class="required-field-indicator">*</span>
@@ -45,7 +45,7 @@
           </div>
 
           <div
-            class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
           >
             <label for="first-name" class="label">
               <span class="required-field-indicator">*</span>
@@ -61,7 +61,7 @@
             />
           </div>
 
-          <div class="new-certification-candidate-details-modal__form__field">
+          <div class="new-certification-candidate-modal__form__field">
             <fieldset>
               <legend class="label">
                 <span class="required-field-indicator">*</span>
@@ -89,7 +89,7 @@
             </fieldset>
           </div>
 
-          <div class="new-certification-candidate-details-modal__form__field">
+          <div class="new-certification-candidate-modal__form__field">
             <label for="birthdate" class="label">
               <span class="required-field-indicator">*</span>
               Date de naissance
@@ -105,7 +105,7 @@
             />
           </div>
 
-          <div class="new-certification-candidate-details-modal__form__field">
+          <div class="new-certification-candidate-modal__form__field">
             <label for="birth-country" class="label">
               <span class="required-field-indicator">*</span>
               Pays de naissance
@@ -121,7 +121,7 @@
           </div>
 
           {{#if this.isBirthGeoCodeRequired}}
-            <div class="new-certification-candidate-details-modal__form__field">
+            <div class="new-certification-candidate-modal__form__field">
               <fieldset>
                 <legend class="label">
                   <span class="required-field-indicator">*</span>
@@ -152,7 +152,7 @@
           {{/if}}
 
           {{#if this.isBirthInseeCodeRequired}}
-            <div class="new-certification-candidate-details-modal__form__field">
+            <div class="new-certification-candidate-modal__form__field">
               <label for="birth-insee-code" class="label">
                 <span class="required-field-indicator">*</span>
                 Code INSEE de naissance
@@ -171,7 +171,7 @@
 
           {{#if this.isBirthPostalCodeRequired}}
             <div
-              class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+              class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
             >
               <label for="birth-postal-code" class="label">
                 <span class="required-field-indicator">*</span>
@@ -191,7 +191,7 @@
 
           {{#if this.isBirthCityRequired}}
             <div
-              class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+              class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
             >
               <label for="birth-city" class="label">
                 <span class="required-field-indicator">*</span>
@@ -208,7 +208,7 @@
             </div>
           {{/if}}
 
-          <div class="new-certification-candidate-details-modal__form__field">
+          <div class="new-certification-candidate-modal__form__field">
             <label for="external-id" class="label">Identifiant externe</label>
             <Input
               id="external-id"
@@ -219,7 +219,7 @@
             />
           </div>
 
-          <div class="new-certification-candidate-details-modal__form__field">
+          <div class="new-certification-candidate-modal__form__field">
             <label for="extra-time-percentage" class="label">Temps majoré (%)</label>
             <Input
               id="extra-time-percentage"
@@ -232,7 +232,7 @@
 
           <div
             id="recipient-email-container"
-            class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
           >
             <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur,
               enseignant...)</label>
@@ -247,7 +247,7 @@
 
           <div
             id="email-container"
-            class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+            class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
           >
             <label for="email" class="label">E-mail de convocation</label>
             <Input
@@ -292,7 +292,7 @@
           {{/if}}
 
           {{#if this.complementaryCertifications.length}}
-            <div class="new-certification-candidate-details-modal__form__field">
+            <div class="new-certification-candidate-modal__form__field">
               <span class="label">Certifications complémentaires</span>
               <div class="complementary-certifications-checkbox-list">
                 <ul>
@@ -313,7 +313,7 @@
             </div>
           {{/if}}
 
-          <div class="new-certification-candidate-details-modal__actions">
+          <div class="new-certification-candidate-modal__actions">
             <PixButton @triggerAction={{@closeModal}} @backgroundColor="transparent-light">
               Fermer
             </PixButton>

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -33,6 +33,7 @@
 @import "components/ember-cli-notifications-ie-fallback";
 @import "components/add-issue-report-modal";
 @import "components/certification-candidate-details-modal";
+@import "components/issue-report-modal";
 @import "components/layout/footer";
 @import "components/login-form";
 @import "components/login-session-supervisor-form.scss";

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -32,61 +32,8 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
 
-    h2 {
-      font-size: 0.875rem;
-    }
-
-    ul {
-      margin: 0;
-      padding: 0;
-
-      li {
-        list-style: none;
-        padding-bottom: 18px;
-      }
-    }
-
     input {
       outline: 2px transparent;
-    }
-
-    &--frame {
-      max-height: 50vh;
-      overflow-y: scroll;
-      background-color: $white;
-      border: 1px solid $grey-22;
-      border-radius: 4px;
-      padding: 24px;
-
-      button {
-        font-weight: 500;
-
-        svg {
-          margin-right: 8px;
-        }
-      }
-
-      .add-issue-report-modal-content__category-label {
-        font-family: $roboto;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        justify-content: space-between;
-        line-height: 32px;
-
-        svg {
-          font-size: 20px;
-          margin: 0;
-          padding: 0;
-        }
-      }
-
-      .add-issue-report-modal-content__subcategory-label {
-        font-family: $roboto;
-        color: $grey-50;
-        padding: 0 0 0 16px;
-        margin: 8px 0 0 0;
-      }
     }
 
     .add-issue-report-modal-content {

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -3,132 +3,89 @@
 .add-issue-report-modal {
   min-width: 650px;
   max-width: 650px;
+  margin: 100px auto; // to fix in pix UI
 
-  &__title {
-    font-family: $open-sans;
-    padding: 12px 32px;
-
-    h1 {
-      font-size: 1.25rem;
-      color: $grey-80;
-      margin: 0;
-      margin-bottom: 4px;
-    }
-
-    h3 {
-      font-size: 0.875rem;
-      color: $grey-50;
-      margin: 0;
-    }
+  input {
+    outline: 2px transparent;
   }
 
-  &__content {
-    font-size: 0.875rem;
-    color: $grey-70;
-    border-top: 1px solid $grey-20;
-    border-bottom: 1px solid $grey-20;
-    padding: 22px 32px;
-    background-color: $grey-10;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-
-    input {
-      outline: 2px transparent;
-    }
-
-    .add-issue-report-modal-content {
-
-      label[for^="subcategory-for-category"],
-      label[for^="text-area-for-category"] {
-        display: block;
-        margin-bottom: 4px;
-      }
-
-      .pix-select select {
-        width: 100%;
-      }
-
-      label[for^="text-area-for-category"] {
-        margin-top: 16px;
-      }
-
-      fieldset {
-        border: 0;
-        padding: 0;
-        margin: 0;
-        min-width: 0;
-        margin-bottom: 22px;
-
-        label[for^="input-radio-for-category"] span {
-          font-weight: bold;
-        }
-
-        input[id|="input-radio-for-category"] {
-          background-color: $communication-light;
-          transform: scale(1.2);
-          margin: 0;
-          cursor: pointer;
-
-          span {
-            font-weight: bold;
-          }
-        }
-
-        input[id|="input-for-category-in-challenge-question-number"] {
-          box-sizing: border-box;
-          margin-left: 8px;
-          border: 1.2px solid $blue-zodiac;
-          border-radius: 4px;
-          padding: 2px  8px;
-
-          &:focus {
-            outline: 2px solid $communication-dark;
-            -moz-outline-radius: 4px;
-            border-color: transparent;
-          }
-
-          &::placeholder {
-            color: transparent;
-          }
-
-          &:not(:placeholder-shown):invalid {
-            outline: 2px solid $information-dark;
-            -moz-outline-radius: 4px;
-            border: none;
-          }
-        }
-
-        label[for|="input-radio-for-category"] {
-          margin-left: 16px;
-          cursor: pointer;
-        }
-
-        label[for|="subcategory-for-category-in-challenge"] {
-          margin: 16px 0 8px;
-        }
-      }
-
-      div[class$="certification-issue-report-fields__details"] {
-        margin-top: 16px;
-        padding-left: 32px;
-
-        textarea {
-          box-shadow: none;
-          min-height: 82px;
-        }
-      }
-    }
+  label[for^="subcategory-for-category"],
+  label[for^="text-area-for-category"] {
+    display: block;
+    margin-bottom: 4px;
   }
 
-  &__actions {
-    background-color: $grey-10;
-    padding: 16px 32px;
-    display: flex;
-    justify-content: flex-end;
-    border-radius: 0 0 5px 5px;
+  .pix-select select {
+    width: 100%;
+  }
 
-    .pix-button {
+  label[for^="text-area-for-category"] {
+    margin-top: 16px;
+  }
+
+  fieldset {
+    border: 0;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+    margin-bottom: 22px;
+
+    label[for^="input-radio-for-category"] span {
+      font-weight: bold;
+    }
+
+    input[id|="input-radio-for-category"] {
+      background-color: $communication-light;
+      transform: scale(1.2);
+      margin: 0;
+      cursor: pointer;
+
+      span {
+        font-weight: bold;
+      }
+    }
+
+    input[id|="input-for-category-in-challenge-question-number"] {
+      box-sizing: border-box;
+      margin-left: 8px;
+      border: 1.2px solid $blue-zodiac;
+      border-radius: 4px;
+      padding: 2px  8px;
+
+      &:focus {
+        outline: 2px solid $communication-dark;
+        -moz-outline-radius: 4px;
+        border-color: transparent;
+      }
+
+      &::placeholder {
+        color: transparent;
+      }
+
+      &:not(:placeholder-shown):invalid {
+        outline: 2px solid $information-dark;
+        -moz-outline-radius: 4px;
+        border: none;
+      }
+    }
+
+    label[for|="input-radio-for-category"] {
       margin-left: 16px;
+      cursor: pointer;
+    }
+
+    label[for|="subcategory-for-category-in-challenge"] {
+      margin: 16px 0 8px;
+    }
+  }
+
+  div[class$="certification-issue-report-fields__details"] {
+    margin-top: 16px;
+    padding-left: 32px;
+
+    textarea {
+      box-shadow: none;
+      min-height: 82px;
     }
   }
 }

--- a/certif/app/styles/components/certification-candidate-details-modal.scss
+++ b/certif/app/styles/components/certification-candidate-details-modal.scss
@@ -1,33 +1,10 @@
 .certification-candidate-details-modal {
   min-width: 550px;
   max-width: 550px;
-
-  &__title {
-    font-family: $open-sans;
-    padding: 12px 32px;
-
-    h1 {
-      font-size: 1.25rem;
-      color: $grey-80;
-      margin: 0;
-      margin-bottom: 4px;
-    }
-  }
-
-  &__content {
-    font-size: 0.875rem;
-    color: $grey-70;
-    border-top: 1px solid $grey-20;
-    border-bottom: 1px solid $grey-20;
-    background-color: $grey-10;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-  }
+  margin: 100px auto; // to fix in pix UI
 
   &__list {
     max-width: 100%;
-    margin: 0;
-    padding: 0;
   }
 
   &__row {
@@ -52,22 +29,12 @@
     }
   }
 
-  &__actions {
-    background-color: $grey-10;
-    padding: 16px 32px;
-    display: flex;
+  .pix-modal__footer {
     justify-content: center;
-    border-radius: 0 0 5px 5px;
-
-    .button--showed-as-link {
-      font-family: $roboto;
-      text-decoration: none;
-      margin-right: 24px;
-      font-size: 0.875rem;
-
-      &:hover {
-        color: inherit;
-      }
-    }
   }
+}
+
+// Necessary to override Pix UI's per component css reset
+.pix-modal li.certification-candidate-details-modal__row {
+  padding: 8px 32px;
 }

--- a/certif/app/styles/components/issue-report-modal.scss
+++ b/certif/app/styles/components/issue-report-modal.scss
@@ -3,98 +3,53 @@
 .issue-report-modal {
   min-width: 650px;
   max-width: 650px;
+  margin: 100px auto; // to fix in pix UI
 
-  &__title {
-    font-family: $open-sans;
-    padding: 12px 32px;
+  h2 {
+    font-size: 0.875rem;
+  }
 
-    h1 {
-      font-size: 1.25rem;
-      color: $grey-80;
-      margin: 0;
-      margin-bottom: 4px;
-    }
+  &__frame {
+    max-height: 50vh;
+    overflow-y: scroll;
+    background-color: $white;
+    border: 1px solid $grey-22;
+    border-radius: 4px;
+    padding: 24px;
 
-    h3 {
-      font-size: 0.875rem;
-      color: $grey-50;
-      margin: 0;
+    button {
+      font-weight: 500;
+
+      svg {
+        margin-right: 8px;
+      }
     }
   }
 
-  &__content {
-    font-size: 0.875rem;
-    color: $grey-70;
-    border-top: 1px solid $grey-20;
-    border-bottom: 1px solid $grey-20;
-    padding: 22px 32px;
-    background-color: $grey-10;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+  &__category-label {
+    font-family: $roboto;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: space-between;
+    line-height: 32px;
 
-    h2 {
-      font-size: 0.875rem;
-    }
-
-    ul {
+    svg {
+      font-size: 20px;
       margin: 0;
       padding: 0;
-
-      li {
-        list-style: none;
-        padding-bottom: 18px;
-      }
-    }
-
-    &--frame {
-      max-height: 50vh;
-      overflow-y: scroll;
-      background-color: $white;
-      border: 1px solid $grey-22;
-      border-radius: 4px;
-      padding: 24px;
-
-      button {
-        font-weight: 500;
-
-        svg {
-          margin-right: 8px;
-        }
-      }
-
-      .issue-report-modal-content__category-label {
-        font-family: $roboto;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        justify-content: space-between;
-        line-height: 32px;
-
-        svg {
-          font-size: 20px;
-          margin: 0;
-          padding: 0;
-        }
-      }
-
-      .issue-report-modal-content__subcategory-label {
-        font-family: $roboto;
-        color: $grey-50;
-        padding: 0 0 0 16px;
-        margin: 8px 0 0 0;
-      }
     }
   }
 
-  &__actions {
-    background-color: $grey-10;
-    padding: 16px 32px;
-    display: flex;
-    justify-content: flex-end;
-    border-radius: 0 0 5px 5px;
-
-    .pix-button {
-      margin-left: 16px;
-    }
+  &__subcategory-label {
+    font-family: $roboto;
+    color: $grey-50;
+    padding: 0 0 0 16px;
+    margin: 8px 0 0 0;
   }
+}
+
+// Override Pix UI reset CSS
+.pix-modal.issue-report-modal li.issue-report-modal__report {
+  padding-bottom: 18px;
 }

--- a/certif/app/styles/components/issue-report-modal.scss
+++ b/certif/app/styles/components/issue-report-modal.scss
@@ -1,0 +1,100 @@
+/* stylelint-disable no-descending-specificity */
+
+.issue-report-modal {
+  min-width: 650px;
+  max-width: 650px;
+
+  &__title {
+    font-family: $open-sans;
+    padding: 12px 32px;
+
+    h1 {
+      font-size: 1.25rem;
+      color: $grey-80;
+      margin: 0;
+      margin-bottom: 4px;
+    }
+
+    h3 {
+      font-size: 0.875rem;
+      color: $grey-50;
+      margin: 0;
+    }
+  }
+
+  &__content {
+    font-size: 0.875rem;
+    color: $grey-70;
+    border-top: 1px solid $grey-20;
+    border-bottom: 1px solid $grey-20;
+    padding: 22px 32px;
+    background-color: $grey-10;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+
+    h2 {
+      font-size: 0.875rem;
+    }
+
+    ul {
+      margin: 0;
+      padding: 0;
+
+      li {
+        list-style: none;
+        padding-bottom: 18px;
+      }
+    }
+
+    &--frame {
+      max-height: 50vh;
+      overflow-y: scroll;
+      background-color: $white;
+      border: 1px solid $grey-22;
+      border-radius: 4px;
+      padding: 24px;
+
+      button {
+        font-weight: 500;
+
+        svg {
+          margin-right: 8px;
+        }
+      }
+
+      .issue-report-modal-content__category-label {
+        font-family: $roboto;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        justify-content: space-between;
+        line-height: 32px;
+
+        svg {
+          font-size: 20px;
+          margin: 0;
+          padding: 0;
+        }
+      }
+
+      .issue-report-modal-content__subcategory-label {
+        font-family: $roboto;
+        color: $grey-50;
+        padding: 0 0 0 16px;
+        margin: 8px 0 0 0;
+      }
+    }
+  }
+
+  &__actions {
+    background-color: $grey-10;
+    padding: 16px 32px;
+    display: flex;
+    justify-content: flex-end;
+    border-radius: 0 0 5px 5px;
+
+    .pix-button {
+      margin-left: 16px;
+    }
+  }
+}

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable no-descending-specificity */
 
-.new-certification-candidate-details-modal {
+.new-certification-candidate-modal {
   min-width: 576px;
   max-width: 576px;
 

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -3,33 +3,12 @@
 .new-certification-candidate-modal {
   min-width: 576px;
   max-width: 576px;
+  margin: 100px auto; // to fix in pix UI
 
   fieldset {
     margin: 0;
     border: 0;
     padding: 0;
-  }
-
-  &__title {
-    font-family: $open-sans;
-    padding: 12px 32px;
-
-    h1 {
-      font-size: 1.25rem;
-      color: $grey-80;
-      margin: 0;
-      margin-bottom: 4px;
-    }
-  }
-
-  &__content {
-    color: $grey-70;
-    border-top: 1px solid $grey-20;
-    border-bottom: 1px solid $grey-20;
-    background-color: $grey-10;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    padding: 8px 32px;
   }
 
   &__form {

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -319,7 +319,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
           @candidate={{this.candidate}}
         />
       `);
-      await click(screen.getByRole('button', { name: 'Fermer' }));
+      await click(screen.getByRole('button', { name: 'Fermer la modale de détail du candidat' }));
 
       // then
       sinon.assert.calledOnce(closeModalStub);

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -319,7 +319,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
           @candidate={{this.candidate}}
         />
       `);
-      await click(screen.getByRole('button', { name: 'Fermer la modale de détail du candidat' }));
+      await click(screen.getByRole('button', { name: 'Fermer la fenêtre de détail du candidat' }));
 
       // then
       sinon.assert.calledOnce(closeModalStub);

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
@@ -29,7 +30,7 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     this.set('onClickIssueReport', onClickIssueReportStub);
 
     // when
-    await render(hbs`
+    const { getByRole } = await render(hbs`
       <IssueReportModal::IssueReportsModal
         @report={{this.reportToEdit}}
         @closeModal={{this.closeIssueReportsModal}}
@@ -38,8 +39,8 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     `);
 
     // then
-    const reportModalTitleSelector = '.add-issue-report-modal__title h3';
-    assert.dom(reportModalTitleSelector).hasText('Lisa Monpud');
+    assert.dom(getByRole('heading', { name: 'Signalement du candidat' })).exists();
+    assert.dom(getByRole('heading', { name: 'Lisa Monpud' })).exists();
   });
 
   test('it should close modal onclick "Ajouter un signalement"', async function (assert) {
@@ -57,14 +58,14 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     this.set('closeIssueReportsModal', closeIssueReportsModalStub);
 
     // when
-    await render(hbs`
+    const { getByRole } = await render(hbs`
       <IssueReportModal::IssueReportsModal
         @report={{this.report}}
         @closeModal={{this.closeIssueReportsModal}}
         @onClickIssueReport={{this.onClickIssueReport}}
       />
     `);
-    await click('.add-issue-report-modal__content button');
+    await click(getByRole('button', { name: 'Ajouter un signalement' }));
 
     // then
     assert.ok(onClickIssueReportStub.calledOnceWith(report));

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -39,8 +39,7 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     `);
 
     // then
-    assert.dom(getByRole('heading', { name: 'Signalement du candidat' })).exists();
-    assert.dom(getByRole('heading', { name: 'Lisa Monpud' })).exists();
+    assert.dom(getByRole('heading', { name: 'Signalement du candidat : Lisa Monpud' })).exists();
   });
 
   test('it should close modal onclick "Ajouter un signalement"', async function (assert) {

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -224,7 +224,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
         />
       `);
 
-      await clickByLabel("Fermer la fenêtre d'ajout d'un candidat");
+      await clickByLabel('Fermer');
 
       // then
       sinon.assert.calledOnce(closeModalStub);


### PR DESCRIPTION
## ☕  Contexte

Suite à l’[audit accessibilité](https://docs.google.com/spreadsheets/d/1opOxK1nzON2PBjWrSAxx9gI5PPrUccWR/edit#gid=2021874496) de Pix Certif dans le cadre duquel l’app a obtenu le score de 40%, nous cherchons à améliorer notre % de conformité à 50%.

## :unicorn: Problème

Le composant actuellement utilisé pour les modales pose problème car elles ne s'affichent pas correctement lorsque les styles CSS sont désactivés. 

## :robot: Solution

Utiliser le composant `PixModal` de Pix UI pour les trois modales problématiques mentionnées dans l'audit de Tanaguru :

- [x] Détails du candidat
- [x] Ajouter un candidat
- [x] Ajouter un signalement (page de finalisation)
- [x] Signalement du candidat (page de finalisation)

## :rainbow: Remarques

- Hérite de la PR #4084
- La classe CSS du composant `NewCertificationCandidateModal` ne correspondait au nom du composant, ça a été corrigé au passage
- Les deux modales concernant les signalements du candidat partageaient un même fichier CSS. puisqu'avec l'utilisation de PixModal, il n'y a plus de code communs entre les deux, ils sont été séparés en deux fichiers.

## :100: Pour tester

Ouvrir les quatre modales et pour chacune : 
1. Vérifier le bon affichage 
2. Interagir (fermer, valider formulaire, etc.) et constater que tout fonctionne
3. Désactiver les styles css (par exemple avec l'extension [disable-HTML](https://chrome.google.com/webstore/detail/disable-html/lfhjgihpknekohffabeddfkmoiklonhm?hl=fr)) 
4. Constater que la modale est toujours affichée et utilisable
