### PR TITLE
[FEATURE] Possibilité de créer un RT avec un seuil d'une valeur de 0. (PIX-4392).

### DIFF
--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -107,7 +107,7 @@
             id="campaignParticipationThreshold"
             class="form-control"
             @type="number"
-            min="1"
+            min="0"
             max="100"
             @value={{this.badge.campaignThreshold}}
           />


### PR DESCRIPTION
## :unicorn: Problème

Nous souhaiterions pouvoir créer des RT avec un seuil nul afin de pouvoir donner des badges accessibles à tous. 

## :robot: Solution

Passage du minimum de 0 à 1 sur la valeur de l'input HTML correspondant.

## :rainbow: Remarques
N/A

## :100: Pour tester

Créer un RT avec un seuil d'une valeur de 0.