### PR TITLE
[TECH] Migrer la colonne Answer.id de INTEGER en BIG INTEGER (Partie 1)

### DIFF
--- a/api/scripts/bigint/answer/create-migration-database-structure.js
+++ b/api/scripts/bigint/answer/create-migration-database-structure.js
@@ -1,0 +1,65 @@
+require('dotenv').config();
+const logger = require('../../../lib/infrastructure/logger');
+const { knex } = require('../../../db/knex-database-connection');
+
+async function createTemporaryTables(knex) {
+  await knex.schema.createTable('answers_bigint', (t) => {
+    t.bigInteger('id');
+    t.text('value');
+    t.string('result');
+    t.integer('assessmentId').unsigned();
+    t.string('challengeId');
+    t.dateTime('createdAt').defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').defaultTo(knex.fn.now());
+    t.integer('timeout');
+    t.text('resultDetails');
+    t.integer('timeSpent');
+    t.boolean('isFocusedOut').defaultTo(false);
+  });
+
+  await knex.schema.createTable('knowledge-elements_bigint', (table) => {
+    table.bigInteger('id');
+    table.string('source');
+    table.string('status');
+    table.dateTime('createdAt').defaultTo(knex.fn.now());
+    table.bigInteger('answerId').unsigned();
+    table.integer('assessmentId').unsigned();
+    table.string('skillId');
+    table.float('earnedPix').defaultTo(0);
+    table.integer('userId').unsigned();
+    table.string('competenceId');
+  });
+}
+
+async function createSettingsTable(knex) {
+  await knex.schema.createTable('bigint-migration-settings', (table) => {
+    table.string('tableName').primary();
+    table.integer('startsAtId').unsigned();
+    table.integer('endsAtId').unsigned();
+  });
+}
+
+async function createAnswersBigintMigrationDatabaseStructures(knex) {
+  await createTemporaryTables(knex);
+  await createSettingsTable(knex);
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  logger.info('Start script');
+  await createAnswersBigintMigrationDatabaseStructures(knex);
+  logger.info('End script');
+}
+
+if (isLaunchedFromCommandLine) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = { createAnswersBigintMigrationDatabaseStructures };

--- a/api/tests/acceptance/scripts/bigint/answer/create-migration-database-structure_test.js
+++ b/api/tests/acceptance/scripts/bigint/answer/create-migration-database-structure_test.js
@@ -1,0 +1,42 @@
+const {
+  createAnswersBigintMigrationDatabaseStructures,
+} = require('../../../../../scripts/bigint/answer/create-migration-database-structure');
+const { expect, knex } = require('../../../../test-helper');
+
+describe('#createAnswersBigintMigrationDatabaseStructures', function () {
+  it('should create temporary tables', async function () {
+    // given
+    await knex.raw('DROP TABLE IF EXISTS "answers_bigint"');
+    await knex.raw('DROP TABLE IF EXISTS "bigint-migration-settings"');
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
+
+    // when
+    await createAnswersBigintMigrationDatabaseStructures(knex);
+
+    // then
+    const { rowCount: answersTableCount } = await knex.raw(
+      `SELECT COUNT(1) FROM information_schema.tables t WHERE t.table_type = 'BASE TABLE' AND t.table_name = 'answers_bigint'`
+    );
+    expect(answersTableCount).to.equal(1);
+
+    const { rowCount: knowledgeElementsTableCount } = await knex.raw(
+      `SELECT COUNT(1) FROM information_schema.tables t WHERE t.table_type = 'BASE TABLE' AND t.table_name = 'bigint-migration-settings'`
+    );
+    expect(knowledgeElementsTableCount).to.equal(1);
+  });
+  it('should create settings table', async function () {
+    // given
+    await knex.raw('DROP TABLE IF EXISTS "answers_bigint"');
+    await knex.raw('DROP TABLE IF EXISTS "bigint-migration-settings"');
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
+
+    // when
+    await createAnswersBigintMigrationDatabaseStructures(knex);
+
+    // then
+    const { rowCount: migrationSettingsTableCount } = await knex.raw(
+      `SELECT COUNT(1) FROM information_schema.tables t WHERE t.table_type = 'BASE TABLE' AND t.table_name = 'bigint-migration-settings'`
+    );
+    expect(migrationSettingsTableCount).to.equal(1);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

L'identifiant de la table Answer est de type Integer. Avec 70 7264 980 enregistrements actuellement, nous risquons de taper la limite des enregistrements possibles.

Ci-dessous le nombre d'insertion de ces deux dernières semaines:

<img width="1234" alt="Capture d’écran 2022-02-17 à 11 00 44" src="https://user-images.githubusercontent.com/10045497/154452260-288221dd-fede-4a6c-adb5-c214f929fedc.png">

Dans la continuité du chantier de migration de nos identifiants techniques de Integer à Bigint. Nous allons changer le type de de l’ID (clé primaire) de la table Answers.

Au vu de la quantité de données, les risques sont :

- nécessiter une (très importante) indispo de la plateforme
- corrompre ou perdre des données
- fracasser toutes les données / la plateforme

## :robot: Solution
Après avoir mener plusieurs tests dans un environnement proche de la production:
-  Application Scalingo [pix-int-to-bigint-test](https://dashboard.scalingo.com/apps/osc-secnum-fr1/pix-int-to-bigint-test/) Plan postgres 64g.
- Test de charge simulé par Artillery [pix-runner-performance-test](https://dashboard.scalingo.com/apps/osc-secnum-fr1/pix-runner-performance-test/)
- Collecte des statistiques avec l'application [pix-db-stats-int-to-bigint-test](https://dashboard.scalingo.com/apps/osc-secnum-fr1/pix-db-stats-int-to-bigint-test/)

L'objectif étant de minimiser l'indisponibilité de la plateforme en essayant de limiter les ressources ( mémoire, workers ...) lors de la création des indexes. Résultat du benchmark regroupé dans ce [fichier](https://docs.google.com/spreadsheets/d/1jhflHP4UOupr-SE53yHJlyp22A44SyEQSK9KMsp0R-E/edit#gid=0): 

<img width="1496" alt="Capture d’écran 2022-02-17 à 11 09 45" src="https://user-images.githubusercontent.com/10045497/154453967-e4d336eb-cb12-41a9-9b48-a487e002fbe8.png">

Nous somme venue à la conclusion que le temps de création d'un index était de 30min. En optimisant le tuning des workers et mémoire, on arrive à gagner 3 minutes mais pas plus à cause d'une autre ressource limitante I/O. Notre fournisseur Scalingo n'offre pas de moyen pour optimiser cette ressource, on se retrouve donc à faire avec cette contrainte.

Le choix s'est porté donc vers une solution avec downtime qui sera joué pendant la nuit et controlée afin de limiter le temps d'indisponibilité.

La démarche décidée avec @octo-topi, @jonathanperret et les captains est la suivante :

Partie 1: Une première migration knex qui migre directement le type de la colonne si l'environnement contient peu de données ( ex locale, recette ). Dans le cas inverse (ex production), opter pour une stratégie progressive avec des tables temporaires Answer et KE avec des identifiants de type Bigint. Ces deux tables temporaires n'auront pas de contraintes afin d'accélérer la copie de donnée. 

Les autres parties seront dans des PRs dédiées.

## :rainbow: Remarques
Un spécial merci à @octo-topi pour sa pédagogie, sa documentation et pour le suivi du chantier.

## :100: Pour tester

Supprimer les tables si elles existent déjà
```sql
DROP TABLE IF EXISTS "answers_bigint";
DROP TABLE IF EXISTS "bigint-migration-settings";
DROP TABLE IF EXISTS "knowledge-elements_bigint";
```

Exécuter le script
`node ./scripts/bigint/answer/create-migration-database-structure.js`

Vérifier la présence des deux tables temporaires :
- `answers_bigint`
- `knowledge-elements_bigint `

Vérifier la présence de la table de paramétrage
- `bigint-migration-settings`