### PR TITLE
[FEATURE] Pouvoir visualiser la "Tarification part Pix" dans la liste des candidats (PIX-4194)

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -163,6 +163,10 @@ class CertificationCandidate {
     }
   }
 
+  get translatedBillingMode() {
+    return CertificationCandidate.translateBillingMode(this.billingMode);
+  }
+
   isAuthorizedToStart() {
     return this.authorizedToStart;
   }

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -10,6 +10,7 @@ module.exports = {
       transform: function (certificationCandidate) {
         return {
           ...certificationCandidate,
+          billingMode: certificationCandidate.translatedBillingMode,
           isLinked: !_.isNil(certificationCandidate.userId),
         };
       },
@@ -30,6 +31,8 @@ module.exports = {
         'birthINSEECode',
         'birthPostalCode',
         'complementaryCertifications',
+        'billingMode',
+        'prepaymentCode',
       ],
     }).serialize(certificationCandidates);
   },

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -125,6 +125,8 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
           data: [
             {
               attributes: {
+                'billing-mode': '',
+                'prepayment-code': null,
                 'birth-city': student.birthCity,
                 birthdate: student.birthdate,
                 'first-name': student.firstName,

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -57,6 +57,8 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
         expectedCertificationCandidateAAttributes = {
           'first-name': certificationCandidateA.firstName,
           'last-name': certificationCandidateA.lastName,
+          'billing-mode': '',
+          'prepayment-code': null,
           birthdate: certificationCandidateA.birthdate,
           'birth-city': certificationCandidateA.birthCity,
           'birth-province-code': certificationCandidateA.birthProvinceCode,
@@ -75,6 +77,8 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
         expectedCertificationCandidateBAttributes = {
           'first-name': certificationCandidateB.firstName,
           'last-name': certificationCandidateB.lastName,
+          'billing-mode': '',
+          'prepayment-code': null,
           birthdate: certificationCandidateB.birthdate,
           'birth-city': certificationCandidateB.birthCity,
           'birth-province-code': certificationCandidateB.birthProvinceCode,

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -115,6 +115,8 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
           'birth-city': certificationCpfCity.name,
           'birth-country': certificationCpfCountry.commonName,
           'birth-province-code': null,
+          'billing-mode': '',
+          'prepayment-code': null,
           'result-recipient-email': certificationCandidate.resultRecipientEmail,
           email: certificationCandidate.email,
           'external-id': certificationCandidate.externalId,

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -602,4 +602,26 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
     });
   });
+
+  describe('get translatedBillingMode', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      { value: 'FREE', expectedTranslation: 'Gratuite' },
+      { value: 'PAID', expectedTranslation: 'Payante' },
+      { value: 'PREPAID', expectedTranslation: 'Prépayée' },
+      { value: 'Gratuite', expectedTranslation: 'FREE' },
+      { value: 'Payante', expectedTranslation: 'PAID' },
+      { value: 'Prépayée', expectedTranslation: 'PREPAID' },
+    ].forEach(({ value, expectedTranslation }) => {
+      it(`should return ${expectedTranslation} when ${value} is translated`, function () {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          billingMode: value,
+        });
+
+        // when/then
+        expect(certificationCandidate.translatedBillingMode).to.equal(expectedTranslation);
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -9,6 +9,7 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
   beforeEach(function () {
     certificationCandidate = domainBuilder.buildCertificationCandidate({
       schoolingRegistrationId: 1,
+      billingMode: 'PAID',
       complementaryCertifications: [
         domainBuilder.buildComplementaryCertification({
           id: 2,
@@ -28,6 +29,8 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
           attributes: {
             'first-name': certificationCandidate.firstName,
             'last-name': certificationCandidate.lastName,
+            'billing-mode': 'Payante',
+            'prepayment-code': null,
             'birth-city': certificationCandidate.birthCity,
             'birth-province-code': certificationCandidate.birthProvinceCode,
             'birth-insee-code': certificationCandidate.birthINSEECode,

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -52,6 +52,9 @@
               <th class="certification-candidates-table__external-id">Identifiant externe</th>
             {{/unless}}
             <th class="certification-candidates-table__column-time">Temps majoré</th>
+            {{#if @shouldDisplayPaymentOptions}}
+              <th class="certification-candidates-table__payment-options">Tarification part Pix</th>
+            {{/if}}
             {{#if @displayComplementaryCertification}}
               <th>Certifications complémentaires</th>
             {{/if}}
@@ -81,6 +84,12 @@
               <td data-test-id="panel-candidate__extraTimePercentage__{{candidate.id}}">{{format-percentage
                   candidate.extraTimePercentage
                 }}</td>
+              {{#if @shouldDisplayPaymentOptions}}
+                <td data-test-id="panel-candidate__paymentOptions__{{candidate.id}}">{{candidate.billingMode}}
+                  {{candidate.prepaymentCode}}
+                </td>
+              {{/if}}
+
               {{#if @displayComplementaryCertification}}
                 <td data-test-id="panel-candidate__complementaryCertifications__{{candidate.id}}">
                   {{if candidate.complementaryCertifications candidate.complementaryCertificationsList "-"}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -63,35 +63,28 @@
         <tbody>
           {{#each @certificationCandidates as |candidate|}}
             <tr>
-              <td data-test-id="panel-candidate__lastName__{{candidate.id}}">{{candidate.lastName}}</td>
-              <td data-test-id="panel-candidate__firstName__{{candidate.id}}">{{candidate.firstName}}</td>
-              <td data-test-id="panel-candidate__birthdate__{{candidate.id}}">{{moment-format
-                  candidate.birthdate
-                  "DD/MM/YYYY"
-                }}</td>
+              <td>{{candidate.lastName}}</td>
+              <td>{{candidate.firstName}}</td>
+              <td>{{moment-format candidate.birthdate "DD/MM/YYYY"}}</td>
               {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                <td data-test-id="panel-candidate__birthCity__{{candidate.id}}">{{candidate.birthCity}}</td>
-                <td data-test-id="panel-candidate__birthCountry__{{candidate.id}}">{{candidate.birthCountry}}</td>
+                <td>{{candidate.birthCity}}</td>
+                <td>{{candidate.birthCountry}}</td>
               {{/if}}
               {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                <td
-                  data-test-id="panel-candidate__result-recipient-email__{{candidate.id}}"
-                >{{candidate.resultRecipientEmail}}</td>
+                <td>{{candidate.resultRecipientEmail}}</td>
               {{/unless}}
               {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                <td data-test-id="panel-candidate__externalId__{{candidate.id}}">{{candidate.externalId}}</td>
+                <td>{{candidate.externalId}}</td>
               {{/unless}}
-              <td data-test-id="panel-candidate__extraTimePercentage__{{candidate.id}}">{{format-percentage
-                  candidate.extraTimePercentage
-                }}</td>
+              <td>{{format-percentage candidate.extraTimePercentage}}</td>
               {{#if @shouldDisplayPaymentOptions}}
-                <td data-test-id="panel-candidate__paymentOptions__{{candidate.id}}">{{candidate.billingMode}}
+                <td>{{candidate.billingMode}}
                   {{candidate.prepaymentCode}}
                 </td>
               {{/if}}
 
               {{#if @displayComplementaryCertification}}
-                <td data-test-id="panel-candidate__complementaryCertifications__{{candidate.id}}">
+                <td>
                   {{if candidate.complementaryCertifications candidate.complementaryCertificationsList "-"}}
                 </td>
               {{/if}}
@@ -116,8 +109,7 @@
                           <PixIconButton
                             @icon="trash-alt"
                             class="certification-candidates-actions__delete-button--disabled"
-                            data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
-                            aria-label="Supprimer un candidat"
+                            aria-label="Supprimer le candidat {{candidate.firstName}} {{candidate.lastName}}"
                             aria-disabled="true"
                             aria-describedby="tooltip-delete-student-button"
                             @withBackground={{true}}
@@ -129,9 +121,8 @@
                       <PixIconButton
                         @icon="trash-alt"
                         {{on "click" (fn this.deleteCertificationCandidate candidate)}}
-                        aria-label="Supprimer un candidat"
+                        aria-label="Supprimer le candidat {{candidate.firstName}} {{candidate.lastName}}"
                         class="certification-candidates-actions__delete-button"
-                        data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
                         @withBackground={{true}}
                       />
                     {{/if}}

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -7,6 +7,7 @@ import { alias } from '@ember/object/computed';
 
 export default class SessionsDetailsController extends Controller {
   @service currentUser;
+  @service featureToggles;
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -48,4 +48,14 @@ export default class CertificationCandidatesController extends Controller {
       this.currentUser.currentAllowedCertificationCenterAccess.hasHabilitations
     );
   }
+
+  get shouldDisplayPaymentOptions() {
+    return (
+      this._currentCertificationCenterIsNotSco() && this.featureToggles.featureToggles.isCertificationBillingEnabled
+    );
+  }
+
+  _currentCertificationCenterIsNotSco() {
+    return !this.currentUser.currentAllowedCertificationCenterAccess.isSco;
+  }
 }

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -16,6 +16,8 @@ export default class CertificationCandidate extends Model {
   @attr('boolean') isLinked;
   @attr('string') schoolingRegistrationId;
   @attr('string') sex;
+  @attr('string') billingMode;
+  @attr('string') prepaymentCode;
   @attr complementaryCertifications;
 
   get sexLabel() {

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isComplementaryCertificationSubscriptionEnabled;
+  @attr('boolean') isCertificationBillingEnabled;
 }

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -190,6 +190,11 @@
   box-sizing: content-box;
 }
 
+.certification-candidates-table__payment-options {
+  width: 100px;
+  box-sizing: content-box;
+}
+
 .certification-candidates-actions {
   position: relative;
   display: flex;

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -27,5 +27,6 @@
     @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
     @countries={{this.countries}}
     @displayComplementaryCertification={{this.shouldDisplayComplementaryCertifications}}
+    @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
   />
 {{/if}}

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -1,29 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | enrolled-candidates', function (hooks) {
   setupRenderingTest(hooks);
 
-  const CERTIFICATION_CANDIDATES_TABLE_SELECTOR = 'certification-candidates-table tbody';
-  const CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR = 'certification-candidates-actions__delete';
   const DELETE_BUTTON_SELECTOR = 'certification-candidates-actions__delete-button';
   const DELETE_BUTTON_DISABLED_SELECTOR = `${DELETE_BUTTON_SELECTOR}--disabled`;
-  const ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR = 'certification-candidates-add-button__text';
-  const ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR = 'enrolled-candidate__add-students';
-  const EXTERNAL_ID_COLUMN_SELECTOR = 'panel-candidate__externalId__';
-  const RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR = 'panel-candidate__result-recipient-email__';
-  const BIRTHDATE_COLUMN_SELECTOR = 'panel-candidate__birthdate__';
-  const LAST_NAME_COLUMN_SELECTOR = 'panel-candidate__lastName__';
-  const FIRST_NAME_COLUMN_SELECTOR = 'panel-candidate__firstName__';
-  const BIRTH_CITY_COLUMN_SELECTOR = 'panel-candidate__birthCity__';
-  const BIRTH_PROVINCE_CODE_COLUMN_SELECTOR = 'panel-candidate__birthProvinceCode__';
-  const BIRTH_COUNTRY_SELECTOR = 'panel-candidate__birthCountry__';
-  const EMAIL_SELECTOR = 'panel-candidate__email__';
-  const EXTRA_TIME_SELECTOR = 'panel-candidate__extraTimePercentage__';
-  const COMPLEMENTARY_CERTIFICATIONS_SELECTOR = 'panel-candidate__complementaryCertifications__';
-  const PAYMENT_OPTION_SELECTOR = 'panel-candidate__paymentOptions__';
 
   let store;
 
@@ -41,12 +25,10 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
       const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-      const certificationCandidates = [certificationCandidate];
-
-      this.set('certificationCandidates', certificationCandidates);
+      this.set('certificationCandidates', [certificationCandidate]);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
@@ -56,22 +38,18 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       `);
 
       // then
-      assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.externalId);
-      assert.dom(`[data-test-id=${BIRTHDATE_COLUMN_SELECTOR}${candidate.id}]`).hasText('28/04/2019');
-      assert.dom(`[data-test-id=${LAST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.lastName);
-      assert.dom(`[data-test-id=${FIRST_NAME_COLUMN_SELECTOR}${candidate.id}]`).hasText(candidate.firstName);
-      assert
-        .dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`)
-        .hasText(candidate.resultRecipientEmail);
-      assert.dom(`[data-test-id=${EXTRA_TIME_SELECTOR}${candidate.id}]`).hasText('3000 %');
-      assert
-        .dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`)
-        .hasText('Pix+Edu, Pix+Droit');
-      assert.dom(`[data-test-id=${BIRTH_CITY_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
-      assert.dom(`[data-test-id=${BIRTH_PROVINCE_CODE_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
-      assert.dom(`[data-test-id=${BIRTH_COUNTRY_SELECTOR}${candidate.id}]`).doesNotExist();
-      assert.dom(`[data-test-id=${EMAIL_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(screen.getByRole('cell', { name: certificationCandidate.externalId })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCandidate.lastName })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCandidate.firstName })).exists();
+      assert.dom(screen.getByRole('cell', { name: certificationCandidate.resultRecipientEmail })).exists();
+      assert.dom(screen.getByRole('cell', { name: '3000 %' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Pix+Edu, Pix+Droit' })).exists();
+      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCity })).doesNotExist();
+      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthProvinceCode })).doesNotExist();
+      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCountry })).doesNotExist();
+      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.email })).doesNotExist();
     });
+
     test('it displays a dash where there is no certification', async function (assert) {
       // given
       this.set('displayComplementaryCertification', true);
@@ -81,12 +59,10 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
       const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-      const certificationCandidates = [certificationCandidate];
-
-      this.set('certificationCandidates', certificationCandidates);
+      this.set('certificationCandidates', [certificationCandidate]);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
@@ -96,7 +72,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       `);
 
       // then
-      assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).hasText('-');
+      assert.dom(screen.getByRole('cell', { name: '-' })).exists();
     });
   });
 
@@ -111,12 +87,10 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
       const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-      const certificationCandidates = [certificationCandidate];
-
-      this.set('certificationCandidates', certificationCandidates);
+      this.set('certificationCandidates', [certificationCandidate]);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
@@ -126,8 +100,10 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       `);
 
       // then
-      assert.notContains('Certifications complémentaires');
-      assert.dom(`[data-test-id=${COMPLEMENTARY_CERTIFICATIONS_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(screen.queryByRole('columnheader', { name: 'Certifications complémentaires' })).doesNotExist();
+      assert
+        .dom(screen.queryByRole('cell', { name: certificationCandidate.complementaryCertificationsList }))
+        .doesNotExist();
     });
   });
 
@@ -139,30 +115,34 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     this.set('certificationCandidates', certificationCandidates);
 
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
         >
         </EnrolledCandidates>
-      `);
+    `);
 
     // then
-    assert.dom(`[aria-label="Voir le détail du candidat ${candidate.firstName} ${candidate.lastName}"]`).isVisible();
+    assert
+      .dom(
+        screen.getByRole('button', { name: `Voir le détail du candidat ${candidate.firstName} ${candidate.lastName}` })
+      )
+      .isVisible();
   });
 
   test('it display candidates with delete disabled button if linked', async function (assert) {
     // given
     const certificationCandidates = [
-      _buildCertificationCandidate({ isLinked: false }),
-      _buildCertificationCandidate({ isLinked: true }),
-      _buildCertificationCandidate({ isLinked: false }),
+      _buildCertificationCandidate({ firstName: 'Riri', lastName: 'Duck', isLinked: false }),
+      _buildCertificationCandidate({ firstName: 'Fifi', lastName: 'Duck', isLinked: true }),
+      _buildCertificationCandidate({ firstName: 'Loulou', lastName: 'Duck', isLinked: false }),
     ];
 
     this.set('certificationCandidates', certificationCandidates);
 
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
       <EnrolledCandidates
         @sessionId="1"
         @certificationCandidates={{this.certificationCandidates}}>
@@ -170,25 +150,14 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     `);
 
     // then
-    assert.dom(`.${CERTIFICATION_CANDIDATES_TABLE_SELECTOR} tr`).isVisible({ count: 3 });
     assert
-      .dom(`.${CERTIFICATION_CANDIDATES_TABLE_SELECTOR} tr .${CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR} button`)
-      .isVisible({ count: 3 });
-
-    assert
-      .dom(
-        `.${CERTIFICATION_CANDIDATES_TABLE_SELECTOR} tr:nth-child(1) .${CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR} button`
-      )
+      .dom(screen.getByRole('button', { name: 'Supprimer le candidat Riri Duck' }))
       .hasClass(DELETE_BUTTON_SELECTOR);
     assert
-      .dom(
-        `.${CERTIFICATION_CANDIDATES_TABLE_SELECTOR} tr:nth-child(2) .${CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR} button`
-      )
+      .dom(screen.getByRole('button', { name: 'Supprimer le candidat Fifi Duck' }))
       .hasClass(DELETE_BUTTON_DISABLED_SELECTOR);
     assert
-      .dom(
-        `.${CERTIFICATION_CANDIDATES_TABLE_SELECTOR} tr:nth-child(3) .${CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR} button`
-      )
+      .dom(screen.getByRole('button', { name: 'Supprimer le candidat Loulou Duck' }))
       .hasClass(DELETE_BUTTON_SELECTOR);
   });
 
@@ -206,7 +175,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       this.set('certificationCandidates', [certificationCandidate]);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
           <EnrolledCandidates
             @sessionId="1"
             @certificationCandidates={{certificationCandidates}}
@@ -216,8 +185,8 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         `);
 
       // then
-      assert.contains('Tarification part Pix');
-      assert.dom(`[data-test-id=${PAYMENT_OPTION_SELECTOR}${candidate.id}]`).hasText('Prepayée CODE01');
+      assert.dom(screen.queryByRole('columnheader', { name: 'Tarification part Pix' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Prepayée CODE01' })).exists();
     });
   });
 
@@ -235,7 +204,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       this.set('certificationCandidates', [certificationCandidate]);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
           <EnrolledCandidates
             @sessionId="1"
             @certificationCandidates={{certificationCandidates}}
@@ -245,8 +214,8 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         `);
 
       // then
-      assert.notContains('Tarification part Pix');
-      assert.dom(`[data-test-id=${PAYMENT_OPTION_SELECTOR}${candidate.id}]`).doesNotExist();
+      assert.dom(screen.queryByRole('columnheader', { name: 'Tarification part Pix' })).doesNotExist();
+      assert.dom(screen.queryByRole('cell', { name: 'Prepayée CODE01' })).doesNotExist();
     });
   });
 
@@ -274,22 +243,22 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         );
 
         // when
-        await render(hbs`
-        <EnrolledCandidates
-          @sessionId="1"
-          @certificationCandidates={{this.certificationCandidates}}
-          @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-        >
-        </EnrolledCandidates>
+        const screen = await renderScreen(hbs`
+          <EnrolledCandidates
+            @sessionId="1"
+            @certificationCandidates={{this.certificationCandidates}}
+            @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+          >
+          </EnrolledCandidates>
         `);
 
         // then
         if (multipleButtonVisible) {
-          assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
-          assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
+          assert.dom(screen.getByRole('link', { name: 'Ajouter des candidats' })).isVisible();
+          assert.dom(screen.queryByRole('button', { name: 'Ajouter un candidat' })).isNotVisible();
         } else {
-          assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
-          assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
+          assert.dom(screen.queryByRole('link', { name: 'Ajouter des candidats' })).isNotVisible();
+          assert.dom(screen.getByRole('button', { name: 'Ajouter un candidat' })).isVisible();
         }
       })
     );
@@ -310,31 +279,30 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     test(it, async function (assert) {
       // given
       const candidate = _buildCertificationCandidate({});
-      const certificationCandidates = [_buildCertificationCandidate({})];
 
-      this.set('certificationCandidates', certificationCandidates);
+      this.set('certificationCandidates', [candidate]);
       this.set(
         'shouldDisplayPrescriptionScoStudentRegistrationFeature',
         shouldDisplayPrescriptionScoStudentRegistrationFeature
       );
 
       // when
-      await render(hbs`
-      <EnrolledCandidates
-        @sessionId="1"
-        @certificationCandidates={{certificationCandidates}}
-        @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-      >
-      </EnrolledCandidates>
+      const screen = await renderScreen(hbs`
+        <EnrolledCandidates
+          @sessionId="1"
+          @certificationCandidates={{certificationCandidates}}
+          @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+        >
+        </EnrolledCandidates>
     `);
 
       // then
       if (shouldColumnsBeEmpty) {
-        assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
-        assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).doesNotExist();
+        assert.dom(screen.queryByRole('cell', { name: candidate.externalId })).doesNotExist();
+        assert.dom(screen.queryByRole('cell', { name: candidate.resultRecipientEmail })).doesNotExist();
       } else {
-        assert.dom(`[data-test-id=${EXTERNAL_ID_COLUMN_SELECTOR}${candidate.id}]`).exists();
-        assert.dom(`[data-test-id=${RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR}${candidate.id}]`).exists();
+        assert.dom(screen.getByRole('cell', { name: candidate.externalId })).exists();
+        assert.dom(screen.getByRole('cell', { name: candidate.resultRecipientEmail })).exists();
       }
     })
   );

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
@@ -78,6 +78,47 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
       assert.true(shouldDisplayComplementaryCertifications);
     });
   });
+
+  module('#get shouldDisplayPaymentOptions', function () {
+    test('should return false if feature toggle is false and center is not sco', function (assert) {
+      // given
+      _stubFeatureToggle(this, 'isCertificationBillingEnabled', false);
+      _stubCurrentCenter(this, store, { type: 'PRO' });
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      const shouldDisplayPaymentOptions = controller.shouldDisplayPaymentOptions;
+
+      // then
+      assert.false(shouldDisplayPaymentOptions);
+    });
+
+    test('should return false if feature toggle is true and center is sco', function (assert) {
+      // given
+      _stubFeatureToggle(this, 'isCertificationBillingEnabled', true);
+      _stubCurrentCenter(this, store, { type: 'SCO' });
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      const shouldDisplayPaymentOptions = controller.shouldDisplayPaymentOptions;
+
+      // then
+      assert.false(shouldDisplayPaymentOptions);
+    });
+
+    test('should return true if feature toggle is true and center is not SCO', function (assert) {
+      // given
+      _stubFeatureToggle(this, 'isCertificationBillingEnabled', true);
+      _stubCurrentCenter(this, store, { type: 'PRO' });
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      const shouldDisplayPaymentOptions = controller.shouldDisplayPaymentOptions;
+
+      // then
+      assert.true(shouldDisplayPaymentOptions);
+    });
+  });
 });
 
 function _stubFeatureToggle(controller, featureToggleName, featureToggleValue) {

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
@@ -42,7 +42,7 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
     test('should return false if feature toggle is false and center has complementary certifications', function (assert) {
       // given
       _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', false);
-      _stubCurrentCenterHabilitations(this, store, ['Pix+Droit']);
+      _stubCurrentCenter(this, store, { habilitations: ['Pix+Droit'] });
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 
       // when
@@ -55,7 +55,7 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
     test('should return false if feature toggle is true and center has no complementary certifications', function (assert) {
       // given
       _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', true);
-      _stubCurrentCenterHabilitations(this, store, []);
+      _stubCurrentCenter(this, store, { habilitations: [] });
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 
       // when
@@ -68,7 +68,7 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
     test('should return true if feature toggle is true and center has complementary certifications', function (assert) {
       // given
       _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', true);
-      _stubCurrentCenterHabilitations(this, store, ['Pix+Edu']);
+      _stubCurrentCenter(this, store, { habilitations: ['Pix+Edu'] });
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 
       // when
@@ -89,10 +89,11 @@ function _stubFeatureToggle(controller, featureToggleName, featureToggleValue) {
   controller.owner.register('service:feature-toggles', FeatureTogglesStub);
 }
 
-function _stubCurrentCenterHabilitations(controller, store, habilitations) {
+function _stubCurrentCenter(controller, store, properties) {
   const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-    habilitations,
+    ...properties,
   });
+
   class CurrentUserStub extends Service {
     currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
   }


### PR DESCRIPTION
## :unicorn: Problème
Pour faciliter les process de facturation des certifications payantes et le suivi des crédits de certification, 2 nouveaux champs vont être ajoutés lors de l’inscription d’un candidat en session : 

- Tarification part Pix

- Code de prépaiement

Si le code de prépaiement ne semble pas forcément pertinent à afficher dans le tableau des candidats sur la page de détails de la session, il semble important d’afficher l’option sélectionnée pour le champ “Tarification part Pix” pour que le référent puisse en un coup d’oeil vérifier cette information

## :robot: Solution
Pour les centres de certification NON SCO, dans Pix Certif > page de détails de la session > onglet “Candidats” : 

- ajouter une colonne “Tarification part Pix” après la colonne “Temps majoré”

## :rainbow: Remarques
:warning:  A mettre sous toggle pour ne pas impacter les centres avant finalisation de la fonctionnalité


## :100: Pour tester
- Activer le toggle FT_CERTIFICATION_BILLING
- Dans pix-certif, créer une session de certification dans un centre non SCO
- Importer des candidats via l'ods ( avec les colonnes de tarification )
- Constater que les options de paiement des candidats ajoutés sont bien présentes


![image](https://user-images.githubusercontent.com/37305474/154665283-3e1187f8-5cfa-4cd7-8d51-3c4e773e6d15.png)
