### PR TITLE
[TRANSLATION] Change a translation on certification joiner (PIX-4409)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -235,7 +235,7 @@
           "birth-date": "Date of birth",
           "birth-day": "Day (DD)",
           "birth-month": "Month (MM)",
-          "birth-name": "Given name",
+          "birth-name": "Last name (given at birth)",
           "birth-year": "Year (YYYY)",
           "first-name": "First name",
           "session-number": "Session number"


### PR DESCRIPTION
## :unicorn: Problème
Suite à une recette fonctionnelle sur le ticket 3964, on a remarqué une erreur de traduction sur la page de connexion à une certification. Le terme Nom de famille est traduit par Given name, ce qui peut entrainer des incompréhensions. 

## :robot: Solution
Changer la traduction par Last name (given at birth).

## :100: Pour tester
- Se connecter à Pix App en version anglaise en suivant le lien https://app-pr4113.review.pix.org/?lang=en
- Accéder à la page de connexion à une certification en cliquant sur Certification
- Constater que le champ suivant la présence du champ Last name (given at birth)