### PR TITLE
[TECH] Permettre à certif-success de passer son cléA (PIX-4413)

### DIFF
--- a/api/db/database-builder/factory/build-badge-acquisition.js
+++ b/api/db/database-builder/factory/build-badge-acquisition.js
@@ -5,7 +5,7 @@ module.exports = function buildBadgeAcquisition({
   badgeId,
   userId,
   campaignParticipationId,
-  createdAt,
+  createdAt = new Date('2000-01-01'),
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'badge-acquisitions',

--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -16,6 +16,9 @@ const {
   CERTIF_REGULAR_USER5_ID,
   CERTIF_SCO_STUDENT_ID,
 } = require('./users');
+const {
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID } = require('./certification-centers-builder');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { BILLING_MODES } = require('../../../../lib/domain/models/CertificationCandidate');
 
@@ -202,8 +205,6 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
 
   // Candidates for a session with complementary certification subscriptions
   sessionId = COMPLEMENTARY_CERTIFICATIONS_SESSION_ID;
-  const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
-  const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+ Droit' });
   const john = databaseBuilder.factory.buildCertificationCandidate({
     firstName: 'John',
     lastName: 'Lennon',
@@ -213,8 +214,9 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildComplementaryCertificationSubscription({
     certificationCandidateId: john.id,
-    complementaryCertificationId: cleaComplementaryCertification.id,
+    complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
+
   const herbie = databaseBuilder.factory.buildCertificationCandidate({
     firstName: 'Herbie',
     lastName: 'Hancock',
@@ -224,7 +226,7 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildComplementaryCertificationSubscription({
     certificationCandidateId: herbie.id,
-    complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
+    complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
   const frank = databaseBuilder.factory.buildCertificationCandidate({
     firstName: 'Frank',
@@ -236,11 +238,11 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildComplementaryCertificationSubscription({
     certificationCandidateId: frank.id,
-    complementaryCertificationId: cleaComplementaryCertification.id,
+    complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildComplementaryCertificationSubscription({
     certificationCandidateId: frank.id,
-    complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
+    complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildCertificationCandidate({
     firstName: 'Britney',

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -17,28 +17,32 @@ const SCO_AGRI_EXTERNAL_ID = '1237457C';
 const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
 const AGRI_SCO_MANAGING_STUDENT_ID = 9;
 const AGRI_SCO_MANAGING_STUDENT_NAME = 'Centre AGRI des Anne-Etoiles';
+const CLEA_COMPLEMENTARY_CERTIFICATION_ID = 52;
+const PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID = 53;
 
 const { PIX_EMPLOI_CLEA_BADGE_ID, PIX_DROIT_MAITRE_BADGE_ID, PIX_DROIT_EXPERT_BADGE_ID } = require('../badges-builder');
 
 function certificationCentersBuilder({ databaseBuilder }) {
-  const cleaComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+  databaseBuilder.factory.buildComplementaryCertification({
     name: 'CléA Numérique',
-  }).id;
+    id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID,
-    complementaryCertificationId: cleaComplementaryCertificationId,
+    complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
-  const pixDroitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+  databaseBuilder.factory.buildComplementaryCertification({
     name: 'Pix+ Droit',
-  }).id;
+    id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+  });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_DROIT_MAITRE_BADGE_ID,
-    complementaryCertificationId: pixDroitComplementaryCertificationId,
+    complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_DROIT_EXPERT_BADGE_ID,
-    complementaryCertificationId: pixDroitComplementaryCertificationId,
+    complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
   databaseBuilder.factory.buildCertificationCenter({
@@ -77,7 +81,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildComplementaryCertificationHabilitation({
     certificationCenterId: PRO_CERTIF_CENTER_ID,
-    complementaryCertificationId: cleaComplementaryCertificationId,
+    complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
   databaseBuilder.factory.buildCertificationCenter({
@@ -87,11 +91,11 @@ function certificationCentersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildComplementaryCertificationHabilitation({
     certificationCenterId: SUP_CERTIF_CENTER_ID,
-    complementaryCertificationId: cleaComplementaryCertificationId,
+    complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildComplementaryCertificationHabilitation({
     certificationCenterId: SUP_CERTIF_CENTER_ID,
-    complementaryCertificationId: pixDroitComplementaryCertificationId,
+    complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
   databaseBuilder.factory.buildCertificationCenter({
@@ -101,7 +105,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildComplementaryCertificationHabilitation({
     certificationCenterId: DROIT_CERTIF_CENTER_ID,
-    complementaryCertificationId: pixDroitComplementaryCertificationId,
+    complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
   for (let i = 0; i < 200; i++) {
@@ -129,4 +133,6 @@ module.exports = {
   AGRI_SCO_MANAGING_STUDENT_NAME,
   SCO_LYCEE_CERTIF_CENTER_ID,
   SCO_LYCEE_CERTIF_CENTER_NAME,
+  CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+  PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
 };

--- a/api/db/seeds/data/certification/partner-certification-builder.js
+++ b/api/db/seeds/data/certification/partner-certification-builder.js
@@ -2,6 +2,7 @@ const Badge = require('../../../../lib/domain/models/Badge');
 const { CERTIFICATION_COURSE_SUCCESS_ID, CERTIFICATION_COURSE_FAILURE_ID } = require('./certification-courses-builder');
 const { PIX_DROIT_MAITRE_BADGE_ID } = require('../badges-builder');
 const { CERTIF_DROIT_USER5_ID } = require('./users');
+const { CLEA_COMPLEMENTARY_CERTIFICATION_ID, PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID } = require('./certification-centers-builder');
 
 function partnerCertificationBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildBadgeAcquisition({
@@ -11,6 +12,8 @@ function partnerCertificationBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, acquired: true, partnerKey: Badge.keys.PIX_EMPLOI_CLEA });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, acquired: true, partnerKey: Badge.keys.PIX_DROIT_MAITRE_CERTIF });
+  databaseBuilder.factory.buildComplementaryCertificationCourse({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID });
+  databaseBuilder.factory.buildComplementaryCertificationCourse({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID });
   databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_FAILURE_ID, acquired: false, partnerKey: Badge.keys.PIX_EMPLOI_CLEA });
 }
 

--- a/api/lib/domain/models/CleaCertificationScoring.js
+++ b/api/lib/domain/models/CleaCertificationScoring.js
@@ -13,16 +13,13 @@ function _isScoreOver75PercentOfExpectedScore(score, expectedScore) {
   return score >= _.floor(expectedScore * 0.75);
 }
 
-function _hasRequiredPixScoreForAtLeast75PercentOfCompetences({
-  maxReachablePixByCompetenceForClea,
-  cleaCompetenceMarks,
-}) {
+function _hasRequiredPixScoreForAtLeast75PercentOfCompetences({ expectedPixByCompetenceForClea, cleaCompetenceMarks }) {
   if (cleaCompetenceMarks.length === 0) return false;
 
   const countCompetencesWithRequiredPixScore = _(cleaCompetenceMarks)
-    .filter((cleaCompetenceMark) => {
-      const currentCompetenceScore = cleaCompetenceMark.score;
-      const expectedCompetenceScore = maxReachablePixByCompetenceForClea[cleaCompetenceMark.competenceId];
+    .filter(({ score, competenceId }) => {
+      const currentCompetenceScore = score;
+      const expectedCompetenceScore = expectedPixByCompetenceForClea[competenceId];
       return _isScoreOver75PercentOfExpectedScore(currentCompetenceScore, expectedCompetenceScore);
     })
     .size();
@@ -46,7 +43,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     reproducibilityRate,
     cleaCompetenceMarks,
     isBadgeAcquisitionStillValid = true,
-    maxReachablePixByCompetenceForClea,
+    expectedPixByCompetenceForClea,
     cleaBadgeKey,
   } = {}) {
     super({
@@ -58,13 +55,13 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     this.isBadgeAcquisitionStillValid = isBadgeAcquisitionStillValid;
     this.reproducibilityRate = reproducibilityRate;
     this.cleaCompetenceMarks = cleaCompetenceMarks;
-    this.maxReachablePixByCompetenceForClea = maxReachablePixByCompetenceForClea;
+    this.expectedPixByCompetenceForClea = expectedPixByCompetenceForClea;
 
     const schema = Joi.object({
       hasAcquiredBadge: Joi.boolean().required(),
       reproducibilityRate: Joi.number().required(),
       cleaCompetenceMarks: Joi.array().required(),
-      maxReachablePixByCompetenceForClea: Joi.object().required(),
+      expectedPixByCompetenceForClea: Joi.object().required(),
     }).unknown();
 
     validateEntity(schema, this);
@@ -76,7 +73,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
       hasAcquiredBadge: false,
       isBadgeAcquisitionStillValid: false,
       cleaCompetenceMarks: [],
-      maxReachablePixByCompetenceForClea: {},
+      expectedPixByCompetenceForClea: {},
       reproducibilityRate: 0,
       cleaBadgeKey: 'no_badge',
     });
@@ -99,7 +96,7 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
 
     return _hasRequiredPixScoreForAtLeast75PercentOfCompetences({
       cleaCompetenceMarks: this.cleaCompetenceMarks,
-      maxReachablePixByCompetenceForClea: this.maxReachablePixByCompetenceForClea,
+      expectedPixByCompetenceForClea: this.expectedPixByCompetenceForClea,
     });
   }
 }

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -20,17 +20,18 @@ module.exports = {
       return CleaCertificationScoring.buildNotEligible({ certificationCourseId });
     }
     const cleaSkills = await _getCleaSkills(cleaBadgeKey, skillRepository);
-    const maxReachablePixByCompetenceForClea = _getMaxReachablePixByCompetenceForClea(cleaSkills);
+    const expectedPixByCompetenceForClea = _getexpectedPixByCompetenceForClea(cleaSkills);
     const cleaCompetenceMarks = await _getCleaCompetenceMarks({
       certificationCourseId,
-      cleaCompetenceIds: Object.keys(maxReachablePixByCompetenceForClea),
+      cleaCompetenceIds: Object.keys(expectedPixByCompetenceForClea),
       domainTransaction,
     });
+
     return new CleaCertificationScoring({
       certificationCourseId,
       hasAcquiredBadge,
       cleaCompetenceMarks,
-      maxReachablePixByCompetenceForClea,
+      expectedPixByCompetenceForClea,
       reproducibilityRate,
       cleaBadgeKey,
     });
@@ -125,7 +126,7 @@ async function _getCleaSkills(cleaBadgeKey, skillRepository) {
   return skillRepository.findOperativeByIds(cleaSkillIds);
 }
 
-function _getMaxReachablePixByCompetenceForClea(cleaSkills) {
+function _getexpectedPixByCompetenceForClea(cleaSkills) {
   return _(cleaSkills)
     .groupBy('competenceId')
     .mapValues((skills) => _.sumBy(skills, 'pixValue'))

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -187,7 +187,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         context(
           'when user reproducibility rate is in between minimum repro rate and trusted repro rate (grey zone)',
           function () {
-            it('should build CleaCertificationScoring containing a hash of maxReachablePixByCompetenceForClea based on operative clea skills', async function () {
+            it('should build CleaCertificationScoring containing a hash of expectedPixByCompetenceForClea based on operative clea skills', async function () {
               // given
               const cleaSkill1Comp1 = domainBuilder.buildSkill({
                 id: 'recSkill1_1',
@@ -252,7 +252,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
                 });
 
               // then
-              expect(cleaCertificationScoring.maxReachablePixByCompetenceForClea).to.deep.equal({
+              expect(cleaCertificationScoring.expectedPixByCompetenceForClea).to.deep.equal({
                 recCompetence1: 9,
                 recCompetence2: 4,
                 recCompetence3: 2,

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
@@ -7,7 +7,7 @@ module.exports = function buildCleaCertificationScoring({
   isBadgeAcquisitionStillValid = true,
   reproducibilityRate = 50,
   cleaCompetenceMarks = [buildCompetenceMark()],
-  maxReachablePixByCompetenceForClea = { competence1: 51 },
+  expectedPixByCompetenceForClea = { competence1: 51 },
   cleaBadgeKey = 'some-clea_key',
 } = {}) {
   return new CleaCertificationScoring({
@@ -16,7 +16,7 @@ module.exports = function buildCleaCertificationScoring({
     isBadgeAcquisitionStillValid,
     reproducibilityRate,
     cleaCompetenceMarks,
-    maxReachablePixByCompetenceForClea,
+    expectedPixByCompetenceForClea,
     cleaBadgeKey,
   });
 };

--- a/api/tests/unit/domain/models/CleaCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationScoring_test.js
@@ -15,7 +15,7 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function () {
         hasAcquiredBadge: true,
         reproducibilityRate: 80,
         cleaCompetenceMarks: [1],
-        maxReachablePixByCompetenceForClea: { competence1: 1 },
+        expectedPixByCompetenceForClea: { competence1: 1 },
       };
     });
 
@@ -53,13 +53,13 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function () {
       );
     });
 
-    it('should throw an ObjectValidationError when maxReachablePixByCompetenceForClea is not valid', function () {
+    it('should throw an ObjectValidationError when expectedPixByCompetenceForClea is not valid', function () {
       // when
       expect(
         () =>
           new CleaCertificationScoring({
             ...validArguments,
-            maxReachablePixByCompetenceForClea: null,
+            expectedPixByCompetenceForClea: null,
           })
       ).to.throw(ObjectValidationError);
     });
@@ -178,7 +178,7 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function () {
           competenceId3 = 'competenceId3',
           competenceId4 = 'competenceId4';
 
-        const maxReachablePixByCompetenceForClea = {
+        const expectedPixByCompetenceForClea = {
           [competenceId1]: 20,
           [competenceId2]: 10,
           [competenceId3]: 15,
@@ -191,7 +191,7 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function () {
           withBadge: true,
           reproducibilityRate: 70,
           cleaCompetenceMarks,
-          maxReachablePixByCompetenceForClea,
+          expectedPixByCompetenceForClea,
         });
 
         // when
@@ -255,7 +255,7 @@ function _buildCleaCertificationScoringInGreyZoneAndAtLeast75PercentOfCertifiabl
     competenceId3 = 'competenceId3',
     competenceId4 = 'competenceId4';
 
-  const maxReachablePixByCompetenceForClea = {
+  const expectedPixByCompetenceForClea = {
     [competenceId1]: 20,
     [competenceId2]: 10,
     [competenceId3]: 15,
@@ -285,7 +285,7 @@ function _buildCleaCertificationScoringInGreyZoneAndAtLeast75PercentOfCertifiabl
     withBadge: true,
     reproducibilityRate: 70,
     cleaCompetenceMarks,
-    maxReachablePixByCompetenceForClea,
+    expectedPixByCompetenceForClea,
   });
 }
 
@@ -295,7 +295,7 @@ function _buildCleaCertificationScoringInGreyZoneAndLessThan75PercentOfCertifiab
     competenceId3 = 'competenceId3',
     competenceId4 = 'competenceId4';
 
-  const maxReachablePixByCompetenceForClea = {
+  const expectedPixByCompetenceForClea = {
     [competenceId1]: 18,
     [competenceId2]: 10,
     [competenceId3]: 15,
@@ -325,7 +325,7 @@ function _buildCleaCertificationScoringInGreyZoneAndLessThan75PercentOfCertifiab
     withBadge: true,
     reproducibilityRate: 70,
     cleaCompetenceMarks,
-    maxReachablePixByCompetenceForClea,
+    expectedPixByCompetenceForClea,
   });
 }
 
@@ -333,7 +333,7 @@ function _buildCleaCertificationScoring({
   withBadge = false,
   reproducibilityRate = 0,
   cleaCompetenceMarks = [domainBuilder.buildCompetenceMark()],
-  maxReachablePixByCompetenceForClea = { competence1: 1 },
+  expectedPixByCompetenceForClea = { competence1: 1 },
 }) {
   const certificationCourseId = 42;
 
@@ -342,7 +342,7 @@ function _buildCleaCertificationScoring({
     hasAcquiredBadge: withBadge,
     reproducibilityRate,
     cleaCompetenceMarks,
-    maxReachablePixByCompetenceForClea,
+    expectedPixByCompetenceForClea,
     cleaBadgeKey: 'pix_clea_badge_key',
   });
 }


### PR DESCRIPTION
## :unicorn: Problème
Suite à une reorganisation des certifs complementaires, et de l'algo les seeds ne permettaient plus de passer une certification complementaire (cléA).

## :robot: Solution
- Mettre du date d'obtention de badge AVANT la date de passage de certification
- Ajouter une certif complementaire cleA à certif-success (certification course 200)

## :rainbow: Remarques
+ refactos

## :100: Pour tester
UNIQUEMENT pour local ou review apps
Aller sur admin, puis sur la page de detail de la certification d'id 200 
Neutraliser un challenge de cette certification
=> Le challenge se neutralise correctement

-> 
