### PR TITLE
[FEATURE] Ajout de la traduction du message de présence non signalée en session de certification (PIX-3964)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -393,11 +393,11 @@ function _mapToHttpError(error) {
   }
 
   if (error instanceof DomainErrors.CandidateNotAuthorizedToJoinSessionError) {
-    return new HttpErrors.ForbiddenError(error.message);
+    return new HttpErrors.ForbiddenError(error.message, error.code);
   }
 
   if (error instanceof DomainErrors.CandidateNotAuthorizedToResumeCertificationTestError) {
-    return new HttpErrors.ForbiddenError(error.message);
+    return new HttpErrors.ForbiddenError(error.message, error.code);
   }
 
   if (error instanceof DomainErrors.SchoolingRegistrationCannotBeDissociatedError) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -981,15 +981,19 @@ class InvalidSessionSupervisorPasswordError extends DomainError {
 
 class CandidateNotAuthorizedToJoinSessionError extends DomainError {
   constructor(
-    message = 'Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.'
+    message = 'Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.',
+    code = 'CANDIDATE_NOT_AUTHORIZED_TO_JOIN_SESSION'
   ) {
-    super(message);
+    super(message, code);
   }
 }
 
 class CandidateNotAuthorizedToResumeCertificationTestError extends DomainError {
-  constructor(message = "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.") {
-    super(message);
+  constructor(
+    message = "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.",
+    code = 'CANDIDATE_NOT_AUTHORIZED_TO_RESUME_SESSION'
+  ) {
+    super(message, code);
   }
 }
 

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -337,7 +337,7 @@ describe('Unit | Application | ErrorManager', function () {
       await handle(params.request, params.h, params.error);
 
       // then
-      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
     });
 
     it('should instantiate ForbiddenError when CandidateNotAuthorizedToResumeCertificationTestError', async function () {
@@ -350,7 +350,7 @@ describe('Unit | Application | ErrorManager', function () {
       await handle(params.request, params.h, params.error);
 
       // then
-      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
     });
 
     it('should instantiate UnprocessableEntityError when UncancellableOrganizationInvitationError', async function () {

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -55,12 +55,20 @@ export default class CertificationJoiner extends Component {
       this.router.replaceWith('certifications.resume', newCertificationCourse.id);
     } catch (err) {
       newCertificationCourse.deleteRecord();
-      if (err.errors?.[0]?.status === '404') {
+      const statusCode = err.errors?.[0]?.status;
+      if (statusCode === '404') {
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.access-code-error');
-      } else if (err.errors?.[0]?.status === '412') {
+      } else if (statusCode === '412') {
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.session-not-accessible');
-      } else if (err.errors?.[0]?.status === '403') {
-        this.errorMessage = err.errors[0].detail;
+      } else if (statusCode === '403') {
+        const errorCode = err.errors?.[0]?.code;
+        if (errorCode === 'CANDIDATE_NOT_AUTHORIZED_TO_JOIN_SESSION') {
+          this.errorMessage = this.intl.t('pages.certification-start.error-messages.candidate-not-authorized-to-start');
+        } else if (errorCode === 'CANDIDATE_NOT_AUTHORIZED_TO_RESUME_SESSION') {
+          this.errorMessage = this.intl.t(
+            'pages.certification-start.error-messages.candidate-not-authorized-to-resume'
+          );
+        }
       } else {
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.generic');
       }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -302,7 +302,9 @@
       "error-messages": {
         "access-code-error": "This code does not exist or is no longer valid.",
         "generic": "An unexpected server error has occurred.",
-        "session-not-accessible": "The certification session is no longer available."
+        "session-not-accessible": "The certification session is no longer available.",
+        "candidate-not-authorized-to-start": "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator.",
+        "candidate-not-authorized-to-resume": "Please contact your invigilator to resume your certification test."
       },
       "first-title": "You are about to begin your certification test."
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -302,7 +302,9 @@
       "error-messages": {
         "access-code-error": "Ce code n’existe pas ou n’est plus valide.",
         "generic": "Une erreur serveur inattendue vient de se produire.",
-        "session-not-accessible": "La session de certification n'est plus accessible."
+        "session-not-accessible": "La session de certification n'est plus accessible.",
+        "candidate-not-authorized-to-start": "Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.",
+        "candidate-not-authorized-to-resume": "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test."
       },
       "first-title": "Vous allez commencer votre test de certification"
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans l'epix d'espace surveillant, nous avons mis en place une validation nécessaire de la présence d'un candidat dans la salle par le surveillant. En cas de présence non confirmée, le candidat ne peut pas commencer sa session de certification. Le message qui s'affiche est le suivant : 'Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.'
Il faut une traduction pour ce message d'erreur puis la mettre en place une fois celle-ci revenue.

## :robot: Solution
La traduction est revenue et est la suivante :  "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator."

## :100: Pour tester
- Créer une session de certification avec un centre qui a l'espace surveillant.
- Inscrire un candidat à cette session
- Se connecter à Pix App en anglais (?lang=en dans l'url) avec le candidat et essayer d'accéder à la session de certification avant d'avoir noté sa présence sur l'espace surveillant.
- Après avoir renseigné le code d'accès, constater l'affichage du message d'erreur "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator."
- Par contrainte technique liée à la gestion de cette erreur, on a également traduit le message d'erreur de reconnexion à la session. Pour l'afficher :
- Autoriser le candidat à se connecter à la session depuis l'espace surveillant.
- Commencer la certification puis quitter la page. 
- Se reconnecter à Pix App en anglais et essayer de réaccéder à la session comme expliqué au-dessus. Constater que le message est le suivant : "Please contact your invigilator to resume your certification test."
 
