### PR TITLE
[FEATURE] Trier les certifications par le plus grand nombre de signalements impactant non résolus dans Pix Admin (PIX-4407).

### DIFF
--- a/admin/app/components/certifications/list.js
+++ b/admin/app/components/certifications/list.js
@@ -7,7 +7,6 @@ export default class CertificationList extends Component {
         propertyName: 'id',
         title: 'Id',
         routeName: 'authenticated.certifications.certification.informations',
-        sortPrecedence: 1,
       },
       {
         propertyName: 'firstName',
@@ -26,6 +25,8 @@ export default class CertificationList extends Component {
         propertyName: 'numberOfCertificationIssueReportsWithRequiredActionLabel',
         title: 'Signalements impactants non résolus',
         className: 'certification-list-page__cell--important',
+        sortPrecedence: 1,
+        sortDirection: 'desc',
       },
       {
         propertyName: 'complementaryCertificationsLabel',

--- a/admin/tests/integration/components/certifications/list_test.js
+++ b/admin/tests/integration/components/certifications/list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, findAll, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | certifications/list', function (hooks) {
@@ -12,19 +12,35 @@ module('Integration | Component | certifications/list', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  test('should display many certifications', async function (assert) {
+  test('should display many certifications ordered by the most issues with required action count', async function (assert) {
     // given
     this.certifications = [
-      store.createRecord('jury-certification-summary', { id: 1 }),
-      store.createRecord('jury-certification-summary', { id: 2 }),
-      store.createRecord('jury-certification-summary', { id: 3 }),
+      store.createRecord('jury-certification-summary', {
+        id: 1,
+        numberOfCertificationIssueReportsWithRequiredActionLabel: 1,
+      }),
+      store.createRecord('jury-certification-summary', {
+        id: 2,
+        numberOfCertificationIssueReportsWithRequiredActionLabel: 3,
+      }),
+      store.createRecord('jury-certification-summary', {
+        id: 3,
+        numberOfCertificationIssueReportsWithRequiredActionLabel: 2,
+      }),
     ];
 
     // when
     await render(hbs`<Certifications::List @certifications={{certifications}} />`);
 
-    const $tableRows = this.element.querySelectorAll('tbody > tr');
-    assert.strictEqual($tableRows.length, 3);
+    const tableRows = findAll('tbody > tr');
+    assert.strictEqual(tableRows.length, 3);
+    const firstRow = 'tbody > tr:nth-child(1)';
+    const unresolvedImpactfulIssuesColumn = 'td:nth-child(5)';
+    assert.strictEqual(find(firstRow + ' > ' + unresolvedImpactfulIssuesColumn).innerText, '3');
+    const secondRow = 'tbody > tr:nth-child(2)';
+    assert.strictEqual(find(secondRow + ' > ' + unresolvedImpactfulIssuesColumn).innerText, '2');
+    const thirdRow = 'tbody > tr:nth-child(3)';
+    assert.strictEqual(find(thirdRow + ' > ' + unresolvedImpactfulIssuesColumn).innerText, '1');
   });
 
   test('should display number of certification issue reports with required action', async function (assert) {


### PR DESCRIPTION
# :unicorn: Problème
Dans Pix admin > liste des certifications d’une session, une colonne permet d’identifier les certifications pour lesquelles le pôle certif a une action à faire, car contient un (ou plusieurs) signalement impactant non résolu automatiquement. Le pôle certif doit parcourir toute la liste des certifications, à la recherche des certifications avec un nombre de signalement impactant non résolu > 1.

## :robot: Solution
Trier les certifications par le plus grand nombre de signalements impactant non résolus. 

## :rainbow: Remarques
- Par simplicité le tri a été fait dans le front

## :100: Pour tester
- Se connecter à Pix Admin,
- Aller sur la session 6.
- Aller dans l'onglet certifications.
- Vérifier que les certifications avec le plus de signalements impactant apparaissent bien en premier.
