### PR TITLE
[FEATURE] Mettre à jour le composant pour choisir un propriétaire de campagne (PIX-4410)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -28,20 +28,20 @@
   </div>
 
   <div class="form__field-with-info form__field">
-    <label class="label" for="campaign-owner">
-      <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-      {{t "pages.campaign-creation.owner.label"}}
-    </label>
-    <PixSelect
-      class="create-campaign__select"
+    <PixDropdown
       @id="campaign-owner"
-      @onChange={{this.onChangeCampaignOwner}}
       @options={{this.campaignOwnerOptions}}
-      placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+      @onSelect={{this.onChangeCampaignOwner}}
+      @selectedOption={{this.currentUserOptionId}}
       @isSearchable={{true}}
-      value={{this.currentUserFullName}}
-      required={{true}}
-      aria-required={{true}}
+      @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+      @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
+      @clearLabel={{t "pages.campaign-creation.owner.clear-label"}}
+      @expandLabel={{t "pages.campaign-creation.owner.expand-label"}}
+      @collapseLabel={{t "pages.campaign-creation.owner.collapse-label"}}
+      @pageSize={{10}}
+      @label={{t "pages.campaign-creation.owner.label"}}
+      @requiredLabel={{t "common.form.mandatory-fields-title"}}
     />
 
     <div class="form__field-info">

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -31,8 +31,11 @@ export default class CreateForm extends Component {
     this.campaign.ownerId = this.currentUser.prescriber.id;
   }
 
-  get currentUserFullName() {
-    return this.currentUser.prescriber.fullName;
+  get currentUserOptionId() {
+    const currentUserOption = this.args.membersSortedByFullName.find(
+      (member) => member.get('fullName') === this.currentUser.prescriber.fullName
+    );
+    return currentUserOption.get('id');
   }
 
   get categories() {
@@ -174,9 +177,8 @@ export default class CreateForm extends Component {
   }
 
   @action
-  onChangeCampaignOwner(event) {
-    const newOwnerFullName = event.target.value;
-    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerFullName === member.fullName);
+  onChangeCampaignOwner(newOwnerId) {
+    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
     if (selectedMember) {
       this.campaign.ownerId = selectedMember.id;
     }

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -26,20 +26,20 @@
   </div>
 
   <div class="form__field-with-info form__field">
-    <label class="label" for="campaign-owner">
-      <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-      {{t "pages.campaign-modification.owner.label"}}
-    </label>
-    <PixSelect
-      class="update-campaign__select"
+    <PixDropdown
       @id="campaign-owner"
-      @onChange={{this.selectOwner}}
       @options={{this.campaignOwnerOptions}}
-      placeholder={{t "pages.campaign-modification.owner.placeholder"}}
+      @onSelect={{this.onChangeCampaignOwner}}
+      @selectedOption={{this.ownerIdOption}}
       @isSearchable={{true}}
-      value={{@campaign.ownerFullName}}
-      required={{true}}
-      aria-required={{true}}
+      @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+      @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
+      @clearLabel={{t "pages.campaign-creation.owner.clear-label"}}
+      @expandLabel={{t "pages.campaign-creation.owner.expand-label"}}
+      @collapseLabel={{t "pages.campaign-creation.owner.collapse-label"}}
+      @pageSize={{10}}
+      @label={{t "pages.campaign-creation.owner.label"}}
+      @requiredLabel={{t "common.form.mandatory-fields-title"}}
     />
     {{#if @campaign.errors.owner}}
       <div class="form__error error-message">

--- a/orga/app/components/campaign/update-form.js
+++ b/orga/app/components/campaign/update-form.js
@@ -24,10 +24,13 @@ export default class UpdateForm extends Component {
     return this.args.membersSortedByFullName.map((member) => ({ value: member.id, label: member.fullName }));
   }
 
+  get ownerIdOption() {
+    return this.args.campaign.ownerId.toString();
+  }
+
   @action
-  selectOwner(event) {
-    const newOwnerFullName = event.target.value;
-    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerFullName === member.fullName);
+  onChangeCampaignOwner(newOwnerId) {
+    const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
     if (selectedMember) {
       this.args.campaign.ownerId = selectedMember.id;
     }

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -1,11 +1,4 @@
-.create-campaign {
-
-  &__select {
-    width: 100%;
-  }
-}
-
-//enlever la flèche par défaut de la datalist sur chrome
+// enlève la flèche par défaut de la datalist sur chrome
 .campaign-target-profile::-webkit-calendar-picker-indicator {
   opacity: 0;
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -149,6 +149,21 @@
         }
       }
     },
+    "@1024pix/pix-ui": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.1.tgz",
+      "integrity": "sha512-DrybXGvlj29PxFSPVKX8nJdiry50H0kOKcDZGNCq5t6DTnaFu4zaFLA7QrnImjeORgo6oRNXpp1Mwr9jGwqpRg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.6.2",
+        "ember-cli-sass": "^10.0.1",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-click-outside": "^2.0.0",
+        "ember-prop-modifier": "^1.0.1",
+        "ember-truth-helpers": "^3.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
@@ -26687,20 +26702,6 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v13.0.0",
-      "integrity": "sha512-Pf+P0EJSkJBGZSjmURemsknxEc/qLg/VuiagrH5IQHWCl119cqKkUu0GYgJhipNQTMXvBWlyMA3tYn/bs8kQZA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
-        "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
       }
     },
     "pkg-dir": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
+    "@1024pix/pix-ui": "^13.3.1",
     "@ember/optional-features": "^2.0.0",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",
     "@formatjs/intl-locale": "^2.4.14",
@@ -101,7 +102,6 @@
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
     "patternomaly": "^1.3.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v13.0.0",
     "prettier": "^2.4.0",
     "query-string": "^7.0.0",
     "qunit-dom": "^1.6.0",

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -172,9 +172,7 @@ module('Acceptance | authentication', function (hooks) {
         await visit('/campagnes/creation');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/campagnes/creation');
+        assert.strictEqual(currentURL(), '/campagnes/creation');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
 

--- a/orga/tests/acceptance/campaign-creation_test.js
+++ b/orga/tests/acceptance/campaign-creation_test.js
@@ -9,11 +9,7 @@ import {
 } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
-import {
-  createUserWithMembershipAndTermsOfServiceAccepted,
-  createPrescriberByUser,
-  createMembershipByOrganizationIdAndUser,
-} from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -128,44 +124,6 @@ module('Acceptance | Campaign Creation', function (hooks) {
 
       // then
       assert.dom(screen.getByText('Harry Cover', { selector: 'dd' })).exists();
-    });
-
-    test('it should be possible to change default campaign owner', async function (assert) {
-      // given
-      const organization = server.create('organization', { name: 'BRO & Evil Associates' });
-
-      const currentUser = server.create('user', {
-        id: 7,
-        firstName: 'Coco',
-        lastName: 'Cover',
-        email: 'harry@cover.com',
-        pixOrgaTermsOfServiceAccepted: true,
-      });
-      currentUser.userOrgaSettings = server.create('user-orga-setting', { user: currentUser, organization });
-      const currentUserWithMembership = createMembershipByOrganizationIdAndUser(organization.id, currentUser);
-      createPrescriberByUser(currentUserWithMembership);
-
-      server.create('member-identity', {
-        id: currentUser.id,
-        firstName: currentUser.firstName,
-        lastName: currentUser.lastName,
-      });
-      server.create('member-identity', { firstName: 'Tom', lastName: 'Égérie' });
-
-      await authenticateSession(currentUser.id);
-
-      const screen = await visit('/campagnes/creation');
-
-      await fillByLabel('* Nom de la campagne', 'Ma Campagne');
-      await clickByName('Évaluer les participants');
-      await selectByLabelAndOption('Que souhaitez-vous tester ?', availableTargetProfiles[1].name);
-
-      // when
-      await selectByLabelAndOption(this.intl.t('pages.campaign-creation.owner.label'), 'Tom Égérie');
-      await clickByName('Créer la campagne');
-
-      // then
-      assert.dom(screen.getByText('Tom Égérie', { selector: 'dd' })).exists();
     });
 
     test('it should display error on global form when error 500 is returned from backend', async function (assert) {

--- a/orga/tests/acceptance/campaign-update_test.js
+++ b/orga/tests/acceptance/campaign-update_test.js
@@ -15,7 +15,7 @@ module('Acceptance | Campaign Update', function (hooks) {
     // given
     const { user } = createAdmin();
     await authenticateSession(user.id);
-    const campaign = server.create('campaign', { id: 1, name: 'Super Campagne' });
+    const campaign = server.create('campaign', { id: 1, name: 'Super Campagne', ownerId: user.id });
 
     // when
     const screen = await visitScreen(`/campagnes/${campaign.id}/modification`);
@@ -29,7 +29,7 @@ module('Acceptance | Campaign Update', function (hooks) {
       // given
       const { user } = createAdmin();
       await authenticateSession(user.id);
-      const campaign = server.create('campaign', { id: 1 });
+      const campaign = server.create('campaign', { id: 1, ownerId: user.id });
       const newName = 'New Name';
       const newText = 'New text';
 

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -80,6 +80,7 @@ export function createUserWithMembershipAndTermsOfServiceAccepted() {
     email: 'harry@cover.com',
     pixOrgaTermsOfServiceAccepted: true,
   });
+  server.create('member-identity', { id: user.id, firstName: 'Harry', lastName: 'Cover' });
   return _addUserToOrganization(user, { externalId: 'EXTBRO' });
 }
 

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -16,6 +16,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
+  const prescriber = EmberObject.create({ fullName: 'Adam Troisjour', id: 1 });
+  const defaultMembers = [prescriber];
+
   hooks.beforeEach(function () {
     this.createCampaignSpy = (event) => {
       event.preventDefault();
@@ -23,15 +26,20 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     this.cancelSpy = () => {};
     this.errors = {};
     class CurrentUserStub extends Service {
-      prescriber = EmberObject.create({ fullName: 'Adam Troisjour', id: 1 });
+      prescriber = prescriber;
     }
     this.owner.register('service:current-user', CurrentUserStub);
+    this.set('defaultMembers', defaultMembers);
   });
 
   test('it should contain inputs, attributes and validation button', async function (assert) {
     // when
     await renderScreen(
-      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
+      hbs`<Campaign::CreateForm
+        @onSubmit={{createCampaignSpy}}
+        @onCancel={{cancelSpy}}
+        @errors={{errors}}
+        @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
     // then
@@ -44,7 +52,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   test('it should display block information for owner', async function (assert) {
     // when
     const screen = await renderScreen(
-      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
+      hbs`<Campaign::CreateForm
+        @onSubmit={{createCampaignSpy}}
+        @onCancel={{cancelSpy}}
+        @errors={{errors}}
+        @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
     // then
@@ -55,17 +67,25 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   test("it should auto complete owner field with current user's full name", async function (assert) {
     // when
     const screen = await renderScreen(
-      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+      hbs`<Campaign::CreateForm
+        @onSubmit={{createCampaignSpy}}
+        @onCancel={{cancelSpy}}
+        @errors={{errors}}
+        @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
     // then
-    assert.dom(screen.getByLabelText('* ' + t('pages.campaign-creation.owner.label'))).hasValue('Adam Troisjour');
+    assert.dom(screen.getByTitle('Adam Troisjour')).exists();
   });
 
   test('[a11y] it should display a message that some inputs are required', async function (assert) {
     // when
     const screen = await renderScreen(
-      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}}  @errors={{errors}}/>`
+      hbs`<Campaign::CreateForm
+        @onSubmit={{createCampaignSpy}}
+        @onCancel={{cancelSpy}}
+        @errors={{errors}}
+        @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
     // then
@@ -74,15 +94,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   module('when user choose to create a campaign of type ASSESSMENT', function () {
     test('it should display fields for campaign title and target profile', async function (assert) {
-      // given
-      class CurrentUserStub extends Service {
-        prescriber = EmberObject.create({ id: 1 });
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
-
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
@@ -93,15 +111,16 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     test('it should display the purpose explanation of an assessment campaign', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        prescriber = EmberObject.create({ id: 1 });
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
       this.campaign = EmberObject.create({});
 
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @campaign={{campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
@@ -113,7 +132,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     test('it should not display multiple sendings field', async function (assert) {
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
 
       // then
@@ -124,10 +147,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     module('when there are several target profiles associated to the organization', function () {
       test('it should display the all category tags', async function (assert) {
         // given
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
           EmberObject.create({
             id: '4',
@@ -144,7 +163,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         ];
         // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}} @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
@@ -156,10 +179,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       test('it should display each category tags once', async function (assert) {
         // given
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
           EmberObject.create({
             id: '4',
@@ -180,9 +199,14 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             category: 'OTHER',
           }),
         ];
+
         // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}} @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
         // then
@@ -193,10 +217,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       test('it should display only the target profiles associated to the tag selected', async function (assert) {
         // given
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
           EmberObject.create({
             id: '4',
@@ -213,7 +233,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         ];
         // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}} @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
         await clickByName(t('pages.campaign-creation.tags.SUBJECT'));
@@ -227,14 +251,16 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     module('when there is no target profiles associated to the organization', function () {
       test('it should not display the category tags', async function (assert) {
         // given
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [];
+
         // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
@@ -246,10 +272,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     module('when the user chose a target profile', function () {
       test('it should display informations about target profile', async function (assert) {
         // given
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
           EmberObject.create({
             id: '1',
@@ -268,9 +290,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             hasStage: false,
           }),
         ];
+
         // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
         await selectByLabelAndOption(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
@@ -283,10 +311,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       test('it should display a message about result', async function (assert) {
         // given
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
           EmberObject.create({
             id: '1',
@@ -305,9 +329,15 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             hasStage: false,
           }),
         ];
+
         // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
         await selectByLabelAndOption(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
@@ -319,10 +349,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
     module('chevron', function () {
       test('should display chevron', async function (assert) {
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
+        // given
         this.targetProfiles = [
           EmberObject.create({
             id: '1',
@@ -330,21 +357,25 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
             description: 'description1',
           }),
         ];
+
+        // when
         await renderScreen(
-          hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+          hbs`<Campaign::CreateForm
+            @targetProfiles={{targetProfiles}}
+            @onSubmit={{createCampaignSpy}}
+            @onCancel={{cancelSpy}}
+            @errors={{errors}}
+            @membersSortedByFullName={{this.defaultMembers}} />`
         );
         await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
+        // then
         assert.dom(`[aria-label="${this.intl.t('pages.campaign-creation.target-profiles.chevron')}"]`).exists();
       });
     });
 
     module('when the user wants to clear the content of the target profile input', function (hooks) {
       hooks.beforeEach(function () {
-        class CurrentUserStub extends Service {
-          prescriber = EmberObject.create({ id: 1 });
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
         this.targetProfiles = [
           EmberObject.create({
             id: '1',
@@ -357,7 +388,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       module('when the target profile input is empty', function () {
         test('should not display the button to clear the input', async function (assert) {
           await renderScreen(
-            hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+            hbs`<Campaign::CreateForm
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{errors}}
+              @membersSortedByFullName={{this.defaultMembers}} />`
           );
           await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
@@ -368,7 +403,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       module('when the target profile input is filled', function () {
         test('should display the button to clear the input', async function (assert) {
           await renderScreen(
-            hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+            hbs`<Campaign::CreateForm
+              @targetProfiles={{targetProfiles}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{errors}}
+              @membersSortedByFullName={{this.defaultMembers}} />`
           );
           await clickByName(t('pages.campaign-creation.purpose.assessment'));
           await fillByLabel(`* ${t('pages.campaign-creation.target-profiles-list-label')}`, 'pro');
@@ -378,7 +418,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
         test('should clear the input after the click on the delete button', async function (assert) {
           await renderScreen(
-            hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+            hbs`<Campaign::CreateForm
+              @targetProfiles={{targetProfiles}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{errors}}
+              @membersSortedByFullName={{this.defaultMembers}} />`
           );
           await clickByName(t('pages.campaign-creation.purpose.assessment'));
           await fillByLabel(`* ${t('pages.campaign-creation.target-profiles-list-label')}`, 'pro');
@@ -389,7 +434,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
         test('should not display target profile informations after the click on the delete button', async function (assert) {
           await renderScreen(
-            hbs`<Campaign::CreateForm @targetProfiles={{targetProfiles}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+            hbs`<Campaign::CreateForm
+              @targetProfiles={{targetProfiles}}
+              @onSubmit={{createCampaignSpy}}
+              @onCancel={{cancelSpy}}
+              @errors={{errors}}
+              @membersSortedByFullName={{this.defaultMembers}} />`
           );
           await clickByName(t('pages.campaign-creation.purpose.assessment'));
           await selectByLabelAndOption(t('pages.campaign-creation.target-profiles-list-label'), 'targetProfile1');
@@ -403,14 +453,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   module('when user choose to create a campaign of type PROFILES_COLLECTION', () => {
     test('it should not display fields for campaign title and target profile', async function (assert) {
-      // given
-      class CurrentUserStub extends Service {
-        prescriber = EmberObject.create({ id: 1 });
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
 
@@ -420,14 +469,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     });
 
     test('it should display fields for enabling multiple sendings', async function (assert) {
-      // given
-      class CurrentUserStub extends Service {
-        prescriber = EmberObject.create({ id: 1 });
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
 
@@ -435,17 +483,19 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       assert.contains(t('pages.campaign-creation.multiple-sendings.question-label'));
       assert.contains(t('pages.campaign-creation.multiple-sendings.info'));
     });
+
     test('it should display the purpose explanation of a profiles collection campaign', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        prescriber = EmberObject.create({ id: 1 });
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
       this.campaign = EmberObject.create({});
 
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @campaign={{campaign}} @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @campaign={{campaign}}
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
 
@@ -459,7 +509,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     test('it should not display gdpr footnote', async function (assert) {
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
 
       // then
@@ -471,7 +525,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     test('it should not display gdpr footnote either', async function (assert) {
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.no'));
 
@@ -484,7 +542,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     test('it should display gdpr footnote', async function (assert) {
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.yes'));
 
@@ -499,7 +561,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     this.createCampaignSpy = sinon.stub();
 
     await renderScreen(
-      hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}} @targetProfiles={{this.targetProfiles}}/>`
+      hbs`<Campaign::CreateForm
+        @onSubmit={{createCampaignSpy}}
+        @onCancel={{cancelSpy}}
+        @errors={{errors}}
+        @targetProfiles={{this.targetProfiles}}
+        @membersSortedByFullName={{this.defaultMembers}} />`
     );
     await fillByLabel(`* ${t('pages.campaign-creation.name.label')}`, 'Ma campagne');
     await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -516,10 +583,6 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
   module('when there are errors', function () {
     test('it should display errors messages when the name, the campaign purpose and the external user id fields are empty', async function (assert) {
       // given
-      class CurrentUserStub extends Service {
-        prescriber = EmberObject.create({ id: 1 });
-      }
-      this.owner.register('service:current-user', CurrentUserStub);
       const campaign = EmberObject.create({
         errors: {
           name: [
@@ -544,7 +607,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.yes'));
 
@@ -569,7 +636,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
       // when
       await renderScreen(
-        hbs`<Campaign::CreateForm @onSubmit={{createCampaignSpy}} @onCancel={{cancelSpy}} @errors={{errors}}/>`
+        hbs`<Campaign::CreateForm
+          @onSubmit={{createCampaignSpy}}
+          @onCancel={{cancelSpy}}
+          @errors={{errors}}
+          @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
 

--- a/orga/tests/integration/components/campaign/update-form_test.js
+++ b/orga/tests/integration/components/campaign/update-form_test.js
@@ -9,7 +9,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.campaign = EmberObject.create({ name: 'campaign', isTypeAssessment: true });
+    this.campaign = EmberObject.create({ name: 'campaign', isTypeAssessment: true, ownerId: 666 });
     this.set('cancelSpy', () => {});
     this.set('updateCampaignSpy', (event) => event.preventDefault());
   });
@@ -27,7 +27,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
   module('When campaign type is ASSESSMENT', function () {
     test('it should display campaign title input', async function (assert) {
       // given
-      this.campaign = EmberObject.create({ isTypeAssessment: true });
+      this.campaign = EmberObject.create({ isTypeAssessment: true, ownerId: 666 });
 
       // when
       const screen = await renderScreen(
@@ -56,7 +56,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
 
     test('it should send campaign update action when submitted', async function (assert) {
       // given
-      this.campaign = EmberObject.create({ isTypeAssessment: true, ownerFullName: 'Jon Snow' });
+      this.campaign = EmberObject.create({ isTypeAssessment: true, ownerFullName: 'Jon Snow', ownerId: 666 });
       this.updateCampaignSpy = sinon.stub();
 
       await renderScreen(
@@ -86,7 +86,7 @@ module('Integration | Component | Campaign::UpdateForm', function (hooks) {
   module('When campaign type is not ASSESSMENT', function () {
     test('it should not display campaign title input', async function (assert) {
       // given
-      this.campaign = EmberObject.create({ isTypeAssessment: false });
+      this.campaign = EmberObject.create({ isTypeAssessment: false, ownerId: 666 });
 
       // when
       await renderScreen(

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -126,10 +126,10 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         { id: 7, fullName: 'Thierry Golo' },
       ];
       const component = await createGlimmerComponent('component:campaign/create-form', { membersSortedByFullName });
-      const event = { target: { value: 'Thierry Golo' } };
+      const newOwnerId = 7;
 
       //when
-      await component.onChangeCampaignOwner(event);
+      await component.onChangeCampaignOwner(newOwnerId);
 
       //then
       assert.deepEqual(component.campaign.ownerId, 7);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -297,6 +297,10 @@
       "owner": {
         "label": "Campaign owner",
         "placeholder": "Owner’s first and last name",
+        "search-placeholder": "Search for an owner",
+        "clear-label": "Clear the selection",
+        "expand-label": "Open the drop down list",
+        "collapse-label": "Close the drop down list",
         "title": "Campaign owner",
         "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign."
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -299,8 +299,8 @@
         "placeholder": "Owner’s first and last name",
         "search-placeholder": "Search for an owner",
         "clear-label": "Clear the selection",
-        "expand-label": "Open the drop down list",
-        "collapse-label": "Close the drop down list",
+        "expand-label": "Open the dropdown list",
+        "collapse-label": "Close the dropdown list",
         "title": "Campaign owner",
         "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign."
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -297,6 +297,10 @@
       "owner": {
         "label": "Propriétaire de la campagne",
         "placeholder": "Nom et prénom du propriétaire",
+        "search-placeholder": "Rechercher un propriétaire",
+        "clear-label": "Supprimer la sélection",
+        "expand-label": "Ouvrir le menu déroulant",
+        "collapse-label": "Réduire le menu déroulant",
         "title": "Propriétaire de la campagne",
         "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier ou archiver cette campagne."
       },


### PR DESCRIPTION
## :unicorn: Problème
Le champ qui permet de sélectionner un propriétaire d'une campagne (lors de la création ou modification), n'est pas des plus simple à utiliser : 
- aucune indication pour effacer le contenu du champ
- pour voir les autres propriétaires possible il faut effacer le contenu du champ et double cliquer dans l'input
- le champ est préremplis par défaut , ce qui peut poser soucis pour choisir un autre propriétaire

## :robot: Solution
Mettre à jour ce champ là en le remplacant par le composant Pix-UI PixDropdown. 

## :rainbow: Remarques
- Il manque des traductions pour la partie en anglais mais sinon la PR est ouvertes aux revues :) 
- Il faudra mettre à jour certaines parties des controllers si https://github.com/1024pix/pix/pull/4111 est mergée avant (les `.get` seront à supprimer)

## :100: Pour tester
Lancer l'API et Pix Orga
Faire des tests de non régression sur la création et la modification d'une campagne (sur la partie où on choisit un propriétaire d'une campagne). 
