### PR TITLE
[FEATURE] Permettre de rattacher à nouveau un membre Pix Certif qui a été désactivé par le passé (PIX-4013).

### DIFF
--- a/api/db/migrations/20220221103255_update-unique-constraint-on-certification-center-memberships.js
+++ b/api/db/migrations/20220221103255_update-unique-constraint-on-certification-center-memberships.js
@@ -1,0 +1,15 @@
+exports.up = async function (knex) {
+  await knex.schema.table('certification-center-memberships', function (table) {
+    table.dropUnique(['userId', 'certificationCenterId']);
+  });
+  return knex.raw(
+    'CREATE UNIQUE INDEX "certification-center-memberships_userid_certificationcenterid_disabledAt_unique" ON "certification-center-memberships" ("userId", "certificationCenterId") WHERE "disabledAt" IS NULL;'
+  );
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('certification-center-memberships', function (table) {
+    table.dropUnique(null, 'certification-center-memberships_userid_certificationcenterid_disabledAt_unique');
+    table.unique(['userId', 'certificationCenterId']);
+  });
+};

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -42,7 +42,10 @@ function _toDomain(certificationCenterMembershipDTO) {
 
 module.exports = {
   async findByUserId(userId) {
-    const certificationCenterMemberships = await BookshelfCertificationCenterMembership.where({ userId }).fetchAll({
+    const certificationCenterMemberships = await BookshelfCertificationCenterMembership.where({
+      userId,
+      disabledAt: null,
+    }).fetchAll({
       withRelated: ['certificationCenter'],
     });
 

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -129,6 +129,7 @@ module.exports = {
       .where({
         userId,
         certificationCenterId,
+        disabledAt: null,
       })
       .first();
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -123,6 +123,52 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(associatedCertificationCenter.id).to.equal(expectedCertificationCenter.id);
       expect(associatedCertificationCenter.name).to.equal(expectedCertificationCenter.name);
     });
+
+    context('when the certification center membership is disabled', function () {
+      it('should return an empty array', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          userId,
+          certificationCenterId,
+          disabledAt: new Date(),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userId);
+
+        // then
+        expect(certificationCenterMemberships).to.deep.equal([]);
+      });
+    });
+
+    context('when an user has a disabled membership and a not disabled one', function () {
+      it('should return the not disabled membership', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          userId,
+          certificationCenterId,
+          disabledAt: new Date(),
+        });
+        const notDisabledMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+          userId,
+          certificationCenterId,
+          disabledAt: null,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userId);
+
+        // then
+        expect(certificationCenterMemberships.length).to.equal(1);
+        expect(certificationCenterMemberships[0].id).to.equal(notDisabledMembership.id);
+      });
+    });
   });
 
   describe('#findActiveByCertificationCenterIdSortedById', function () {

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -362,13 +362,35 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(hasMembership).to.be.false;
     });
 
-    it('should return true if user has membership in given certification center', async function () {
+    it('should return false if user has a disabled membership in given certification center', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       databaseBuilder.factory.buildCertificationCenterMembership({
         userId,
         certificationCenterId,
+        disabledAt: new Date(),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const hasMembership = await certificationCenterMembershipRepository.isMemberOfCertificationCenter({
+        userId,
+        certificationCenterId,
+      });
+
+      // then
+      expect(hasMembership).to.be.false;
+    });
+
+    it('should return true if user has a not disabled membership in given certification center', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+        disabledAt: null,
       });
       await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -54,6 +54,24 @@ describe('Integration | Repository | Certification Center Membership', function 
       expect(createdCertificationCenterMembership).to.be.an.instanceOf(CertificationCenterMembership);
     });
 
+    context('when there is already a disabled membership for the same user and certification center', function () {
+      it('should add a new membership in database', async function () {
+        // given
+        databaseBuilder.factory.buildMembership({ userId, certificationCenterId, disabledAt: new Date() });
+        await databaseBuilder.commit();
+        const countCertificationCenterMembershipsBeforeCreate = await BookshelfCertificationCenterMembership.count();
+
+        // when
+        await certificationCenterMembershipRepository.save({ userId, certificationCenterId });
+
+        // then
+        const countCertificationCenterMembershipsAfterCreate = await BookshelfCertificationCenterMembership.count();
+        expect(countCertificationCenterMembershipsAfterCreate).to.equal(
+          countCertificationCenterMembershipsBeforeCreate + 1
+        );
+      });
+    });
+
     context('Error cases', function () {
       beforeEach(async function () {
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });


### PR DESCRIPTION
## :unicorn: Problème
Depuis Pix Admin, dans la page de détail d'un centre de certification, il est possible d'ajouter et de désactiver des membres. Cependant, lorsqu'on tente d'ajouter un membre qui été désactivé auparavant, une erreur est renvoyée.

## :robot: Solution
- Modifier la contrainte d'unicité afin de permettre de rattacher à nouveau un membre désactivé.
- Effectuer les modifications de code nécessaires pour ne prendre en compte que les membres actifs (non désactivés)

## :100: Pour tester
- Se connecter à Pix Admin,
- Aller sur la page de détail d'un centre de certification.
- Ajouter un membre au centre par son email
- Désactiver ce membre
- Le rajouter de nouveau et vérifier que le membre est bien ajouté.
- Tenter de la rajouter à nouveau, sans le désactiver au préalable, et vérifier qu'une erreur apparaît.
