### PR TITLE
[BUGFIX] Corrige la création du modèle Challenge lorsque le skill associé n'existe pas

### DIFF
--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -100,7 +100,7 @@ function _toDomainCollection({ challengeDataObjects, skills }) {
 }
 
 function _toDomain({ challengeDataObject, skillDataObject }) {
-  const skill = skillAdapter.fromDatasourceObject(skillDataObject);
+  const skill = skillDataObject ? skillAdapter.fromDatasourceObject(skillDataObject) : null;
 
   const solution = solutionAdapter.fromDatasourceObject(challengeDataObject);
 

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -1,0 +1,29 @@
+const { expect, sinon } = require('../../../test-helper');
+const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
+const challengeDatasource = require('../../../../lib/infrastructure/datasources/learning-content/challenge-datasource');
+const skillDatasource = require('../../../../lib/infrastructure/datasources/learning-content/skill-datasource');
+
+describe('Unit | Repository | challenge-repository', function () {
+  beforeEach(function () {
+    sinon.stub(challengeDatasource, 'get');
+    sinon.stub(skillDatasource, 'get');
+  });
+
+  describe('#get', function () {
+    it('returns a challenge by id with a skill', async function () {
+      challengeDatasource.get.resolves({});
+      skillDatasource.get.resolves({});
+      const challenge = await challengeRepository.get('myid');
+      expect(challenge).to.be.ok;
+      expect(challenge.skill).to.be.ok;
+    });
+
+    it('returns a challenge by id with no skill', async function () {
+      challengeDatasource.get.resolves({});
+      skillDatasource.get.resolves(null);
+      const challenge = await challengeRepository.get('myid');
+      expect(challenge).to.be.ok;
+      expect(challenge.skill).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans #4040, une épreuve n'est associé qu'a un seul acquis. Mais le code gérait un cas particulier ou l'acquis pouvais ne pas exister.

## :robot: Solution
Gérer le cas ou l'acquis associé n'existe pas.

## :rainbow: Remarques
Ce cas ne devrait pas arriver coté référentiel, une investigation est en cours, pour l'instant on reproduit le comportement précédent.

## :100: Pour tester
1. Avec le référentiel de production
2. lancer node
 ```javascript 
require('dotenv').config();
const challengeRepository = require('./lib/infrastructure/repositories/challenge-repository')
challengeRepository.findOperativeHavingLocale('fr-fr').then(() => { console.log('ok')} )
```
3. Si tout se passe bien, c'est que patch est bon.