### PR TITLE
[BUGFIX] Corriger les messages d'erreur lors de l'accès à l'espace surveillant (PIX-4381).

### DIFF
--- a/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
+++ b/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
@@ -1,7 +1,10 @@
-const { SupervisorAccessNotAuthorizedError } = require('../../domain/errors');
+const {
+  SupervisorAccessNotAuthorizedError,
+  NotFoundError,
+  InvalidSessionSupervisingLoginError,
+} = require('../../domain/errors');
 const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
 const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository');
-const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
   async verifyBySessionId(request) {
@@ -14,7 +17,7 @@ module.exports = {
       await sessionRepository.get(sessionId);
     } catch (error) {
       if (error instanceof NotFoundError) {
-        throw new NotFoundError('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
+        throw new InvalidSessionSupervisingLoginError();
       }
       throw error;
     }

--- a/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
+++ b/api/lib/application/preHandlers/end-test-screen-removal-enabled.js
@@ -1,11 +1,22 @@
 const { SupervisorAccessNotAuthorizedError } = require('../../domain/errors');
 const endTestScreenRemovalService = require('../../domain/services/end-test-screen-removal-service');
+const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository');
+const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
   async verifyBySessionId(request) {
     let sessionId = request.params?.id;
     if (!sessionId) {
       sessionId = request.payload.data.attributes['session-id'];
+    }
+
+    try {
+      await sessionRepository.get(sessionId);
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw new NotFoundError('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
+      }
+      throw error;
     }
 
     const isEndTestScreenRemovalEnabled = await endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId(

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -973,7 +973,7 @@ class EmailModificationDemandNotFoundOrExpiredError extends DomainError {
   }
 }
 
-class InvalidSessionSupervisorPasswordError extends DomainError {
+class InvalidSessionSupervisingLoginError extends DomainError {
   constructor(message = 'Le numéro de session et/ou le mot de passe saisis sont incorrects.') {
     super(message);
   }
@@ -1100,7 +1100,7 @@ module.exports = {
   InvalidPasswordForUpdateEmailError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,
-  InvalidSessionSupervisorPasswordError,
+  InvalidSessionSupervisingLoginError,
   InvalidSkillSetError,
   InvalidTemporaryKeyError,
   InvalidVerificationCodeError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -974,7 +974,7 @@ class EmailModificationDemandNotFoundOrExpiredError extends DomainError {
 }
 
 class InvalidSessionSupervisorPasswordError extends DomainError {
-  constructor(message = 'Le mot de passe de la session ne correspond pas au numéro de la session.') {
+  constructor(message = 'Le numéro de session et/ou le mot de passe saisis sont incorrects.') {
     super(message);
   }
 }

--- a/api/lib/domain/usecases/supervise-session.js
+++ b/api/lib/domain/usecases/supervise-session.js
@@ -1,4 +1,4 @@
-const { SessionNotAccessible, InvalidSessionSupervisorPasswordError } = require('../errors');
+const { SessionNotAccessible, InvalidSessionSupervisingLoginError } = require('../errors');
 module.exports = async function superviseSession({
   sessionId,
   supervisorPassword,
@@ -8,7 +8,7 @@ module.exports = async function superviseSession({
 }) {
   const session = await sessionRepository.get(sessionId);
   if (!session.isSupervisable(supervisorPassword)) {
-    throw new InvalidSessionSupervisorPasswordError();
+    throw new InvalidSessionSupervisingLoginError();
   }
   if (!session.isAccessible()) {
     throw new SessionNotAccessible();

--- a/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
+++ b/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
@@ -2,7 +2,11 @@ const { catchErr, expect, sinon, hFake, domainBuilder } = require('../../../test
 const endTestScreenRemovalEnabled = require('../../../../lib/application/preHandlers/end-test-screen-removal-enabled');
 const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
 const sessionRepository = require('../../../../lib/infrastructure/repositories/sessions/session-repository');
-const { SupervisorAccessNotAuthorizedError, NotFoundError } = require('../../../../lib/domain/errors');
+const {
+  SupervisorAccessNotAuthorizedError,
+  NotFoundError,
+  InvalidSessionSupervisingLoginError,
+} = require('../../../../lib/domain/errors');
 
 describe('Unit | Pre-handler | end test screen removal', function () {
   describe('#verifyBySessionId', function () {
@@ -13,7 +17,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
 
     context('When POST', function () {
       describe('when session does not exist', function () {
-        it('should throw a NotFoundError', async function () {
+        it('should throw a InvalidSessionSupervisingLoginError', async function () {
           // given
           const request = {
             payload: {
@@ -26,7 +30,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
           const error = await catchErr(endTestScreenRemovalEnabled.verifyBySessionId)(request, hFake);
 
           // then
-          expect(error).to.be.an.instanceOf(NotFoundError);
+          expect(error).to.be.an.instanceOf(InvalidSessionSupervisingLoginError);
           expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
         });
       });
@@ -70,12 +74,12 @@ describe('Unit | Pre-handler | end test screen removal', function () {
       });
     });
     context('When GET', function () {
-      describe('when session does not exist', function () {
-        it('should throw a NotFoundError', async function () {
+      describe('when the session does not exist', function () {
+        it('should throw a InvalidSessionSupervisingLoginError', async function () {
           // given
           const request = {
-            payload: {
-              data: { attributes: { 'session-id': 8 } },
+            params: {
+              id: 8,
             },
           };
           sessionRepository.get.withArgs(8).throws(new NotFoundError());
@@ -84,7 +88,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
           const error = await catchErr(endTestScreenRemovalEnabled.verifyBySessionId)(request, hFake);
 
           // then
-          expect(error).to.be.an.instanceOf(NotFoundError);
+          expect(error).to.be.an.instanceOf(InvalidSessionSupervisingLoginError);
           expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
         });
       });

--- a/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
+++ b/api/tests/unit/application/preHandlers/end-test-screen-removal-enabled_test.js
@@ -1,15 +1,36 @@
-const { catchErr, expect, sinon, hFake } = require('../../../test-helper');
+const { catchErr, expect, sinon, hFake, domainBuilder } = require('../../../test-helper');
 const endTestScreenRemovalEnabled = require('../../../../lib/application/preHandlers/end-test-screen-removal-enabled');
 const endTestScreenRemovalService = require('../../../../lib/domain/services/end-test-screen-removal-service');
-const { SupervisorAccessNotAuthorizedError } = require('../../../../lib/domain/errors');
+const sessionRepository = require('../../../../lib/infrastructure/repositories/sessions/session-repository');
+const { SupervisorAccessNotAuthorizedError, NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Pre-handler | end test screen removal', function () {
   describe('#verifyBySessionId', function () {
     beforeEach(function () {
       sinon.stub(endTestScreenRemovalService, 'isEndTestScreenRemovalEnabledBySessionId');
+      sinon.stub(sessionRepository, 'get');
     });
 
     context('When POST', function () {
+      describe('when session does not exist', function () {
+        it('should throw a NotFoundError', async function () {
+          // given
+          const request = {
+            payload: {
+              data: { attributes: { 'session-id': 8 } },
+            },
+          };
+          sessionRepository.get.withArgs(8).throws(new NotFoundError());
+
+          // when
+          const error = await catchErr(endTestScreenRemovalEnabled.verifyBySessionId)(request, hFake);
+
+          // then
+          expect(error).to.be.an.instanceOf(NotFoundError);
+          expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
+        });
+      });
+
       describe('When session certification center is in the whitelist', function () {
         it('should return true', async function () {
           // given
@@ -18,6 +39,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
               data: { attributes: { 'session-id': 8 } },
             },
           };
+          sessionRepository.get.withArgs(8).resolves(domainBuilder.buildSession({ id: 8 }));
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(true);
 
           // when
@@ -36,6 +58,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
               data: { attributes: { 'session-id': 8 } },
             },
           };
+          sessionRepository.get.withArgs(8).resolves(domainBuilder.buildSession({ id: 8 }));
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
 
           // when
@@ -47,6 +70,25 @@ describe('Unit | Pre-handler | end test screen removal', function () {
       });
     });
     context('When GET', function () {
+      describe('when session does not exist', function () {
+        it('should throw a NotFoundError', async function () {
+          // given
+          const request = {
+            payload: {
+              data: { attributes: { 'session-id': 8 } },
+            },
+          };
+          sessionRepository.get.withArgs(8).throws(new NotFoundError());
+
+          // when
+          const error = await catchErr(endTestScreenRemovalEnabled.verifyBySessionId)(request, hFake);
+
+          // then
+          expect(error).to.be.an.instanceOf(NotFoundError);
+          expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
+        });
+      });
+
       describe('When session certification center is in the whitelist', function () {
         it('should return true', async function () {
           // given
@@ -55,6 +97,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
               id: 8,
             },
           };
+          sessionRepository.get.withArgs(8).resolves(domainBuilder.buildSession({ id: 8 }));
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(true);
 
           // when
@@ -73,6 +116,7 @@ describe('Unit | Pre-handler | end test screen removal', function () {
               id: 8,
             },
           };
+          sessionRepository.get.withArgs(8).resolves(domainBuilder.buildSession({ id: 8 }));
           endTestScreenRemovalService.isEndTestScreenRemovalEnabledBySessionId.withArgs(8).resolves(false);
 
           // when

--- a/api/tests/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/unit/domain/usecases/supervise-session_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const superviseSession = require('../../../../lib/domain/usecases/supervise-session');
-const { InvalidSessionSupervisorPasswordError, SessionNotAccessible } = require('../../../../lib/domain/errors');
+const { InvalidSessionSupervisingLoginError, SessionNotAccessible } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | supervise-session', function () {
   let sessionRepository;
@@ -15,7 +15,7 @@ describe('Unit | UseCase | supervise-session', function () {
     };
   });
 
-  it('should throw a InvalidSessionSupervisorPasswordError when the supervised password is wrong', async function () {
+  it('should throw a InvalidSessionSupervisingLoginError when the supervised password is wrong', async function () {
     // given
     const sessionId = 123;
     const supervisorPassword = 'NOT_MATCHING_SUPERVISOR_PASSWORD';
@@ -33,7 +33,7 @@ describe('Unit | UseCase | supervise-session', function () {
     });
 
     // then
-    expect(error).to.be.an.instanceOf(InvalidSessionSupervisorPasswordError);
+    expect(error).to.be.an.instanceOf(InvalidSessionSupervisingLoginError);
     expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
   });
 

--- a/api/tests/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/unit/domain/usecases/supervise-session_test.js
@@ -34,6 +34,7 @@ describe('Unit | UseCase | supervise-session', function () {
 
     // then
     expect(error).to.be.an.instanceOf(InvalidSessionSupervisorPasswordError);
+    expect(error.message).to.equal('Le numéro de session et/ou le mot de passe saisis sont incorrects.');
   });
 
   it('should throw a SessionNotAccessible when the session is not accessible', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Un message d'erreur mentionnant que le centre de certification n'est pas habilité à accéder à l'espace surveillant est affiché lorsque le numéro de session n'existe pas et/ou le mot de passe est incorrect

## :robot: Solution

### Espace surveillant
N'afficher le message "Cette session est organisée dans un centre de certification pour lequel l'espace surveillant n'a pas été activé par Pix." que lorsque 
- le numéro de session existe
- l'espace surveillant est désactivé

Le fait que le mot de passe soit valide n'a pas d'importance. 

### Autres cas
Afficher le message "Le numéro de session et/ou le mot de passe saisis sont incorrects." lorsque 
- le numéro de session n'existe pas
- et/ou le mot de passe est incorrect.


## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certif-success@example.net`.
- Entrer le numéro de session 11 et un mot de passe aléatoire.
- Vérifier que le message d'erreur "Cette session est organisée dans un centre de certification pour lequel l'espace surveillant n'a pas été activé par Pix." appraît.
- Entrer le numéro de session 666 et un mot de passe aléatoire et vérifier que le message d'erreur "Le numéro de session et/ou le mot de passe saisis sont incorrects." apparaît.
- Entrer le numéro de session 20000 et un mot de passe aléatoire et vérifier que le message d'erreur "Le numéro de session et/ou le mot de passe saisis sont incorrects." apparaît.
- Entrer le numéro de session 20000 et le mot de passe "9P9QM" et vérifier que l'on accède bien à l'espace surveillant.