### PR TITLE
[TECH] Augmente le nombre de passes de bcrypt de 5 à 10

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -142,6 +142,8 @@ module.exports = (function () {
       passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',
     },
 
+    bcryptNumberOfSaltRounds: _getNumber(process.env.BCRYPT_NUMBER_OF_SALT_ROUNDS, 10),
+
     availableCharacterForCode: {
       letters: 'BCDFGHJKMPQRTVWXY',
       numbers: '2346789',
@@ -275,6 +277,8 @@ module.exports = (function () {
     config.mailing.sendinblue.templates.emailChangeTemplateId = 'test-email-change-template-id';
     config.mailing.sendinblue.templates.accountRecoveryTemplateId = 'test-account-recovery-template-id';
     config.mailing.sendinblue.templates.emailVerificationCodeTemplateId = 'test-email-verification-code-template-id';
+
+    config.bcryptNumberOfSaltRounds = 1;
 
     config.authentication.secret = 'test-jwt-key';
 

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -1,13 +1,12 @@
 const bcrypt = require('bcrypt');
+const { bcryptNumberOfSaltRounds } = require('../../config');
 const PasswordNotMatching = require('../errors').PasswordNotMatching;
 
-const NUMBER_OF_ROUNDS = 10;
-
 module.exports = {
-  hashPassword: (password) => bcrypt.hash(password, NUMBER_OF_ROUNDS),
+  hashPassword: (password) => bcrypt.hash(password, bcryptNumberOfSaltRounds),
 
   /* eslint-disable-next-line no-sync */
-  hashPasswordSync: (password) => bcrypt.hashSync(password, NUMBER_OF_ROUNDS),
+  hashPasswordSync: (password) => bcrypt.hashSync(password, bcryptNumberOfSaltRounds),
 
   checkPassword: async ({ password, passwordHash }) => {
     const matching = await bcrypt.compare(password, passwordHash);

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -1,13 +1,13 @@
 const bcrypt = require('bcrypt');
 const PasswordNotMatching = require('../errors').PasswordNotMatching;
 
-const NUMBER_OF_SALT_ROUNDS = 5;
+const NUMBER_OF_ROUNDS = 10;
 
 module.exports = {
-  hashPassword: (password) => bcrypt.hash(password, NUMBER_OF_SALT_ROUNDS),
+  hashPassword: (password) => bcrypt.hash(password, NUMBER_OF_ROUNDS),
 
   /* eslint-disable-next-line no-sync */
-  hashPasswordSync: (password) => bcrypt.hashSync(password, NUMBER_OF_SALT_ROUNDS),
+  hashPasswordSync: (password) => bcrypt.hashSync(password, NUMBER_OF_ROUNDS),
 
   checkPassword: async ({ password, passwordHash }) => {
     const matching = await bcrypt.compare(password, passwordHash);


### PR DESCRIPTION
## :unicorn: Problème
On a par défaut un nombre de passe bcrypt es à 5. C'est un peu juste vu la vitesse actuelle des CPUs.

## :robot: Solution
Pour ralentir les attaques par brute force, passer a un nombre de passe a 10 par défaut. En profiter pour le rendre configurable et le baisser dans les tests pour tenter d’accélérer tout ça.

Quelques tests de performance, en testant avec 100 itérations:
* 5 passes => 300ms
* 10 passes => 5s
* 11 passes => 10s
* 12 passes => 20s

## :rainbow: Remarques
Voici le code pour reproduire les tests de performances

```javascript
const bcrypt = require('bcrypt');
const NOMBRE_DE_PASSES = 10;
console.time('100-elements');                                                                                                                                    
for (let i = 0; i < 100; i++) { bcrypt.hashSync('pixloveyou', NOMBRE_DE_PASSES) }        
console.timeEnd('100-elements'); 
```


## :100: Pour tester
1. Créer un utilisateur 
2. Vérifier que on peut se connecter avec
3. Créer un utilisateur sur dev sans ce patch
4. Repasser sur cette branche
5. Vérifier qu'on peut se connecter avec
