### PR TITLE
[TECH] Migrer la colonne Answer.id de INTEGER en BIG INTEGER (Partie 2)

### DIFF
--- a/api/scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint.js
+++ b/api/scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint.js
@@ -1,0 +1,60 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const { knex } = require('../../../db/knex-database-connection');
+const logger = require('../../../lib/infrastructure/logger');
+
+const copyAnswerKeDataToTemporaryTables = async () => {
+  logger.debug('Start copy answers and knowledge-elements data');
+  const startTime = performance.now();
+
+  await knex.transaction(async (trx) => {
+    await knex
+      .raw(
+        `INSERT INTO "answers_bigint"
+    (id, value, result, "assessmentId", "challengeId", timeout, "resultDetails", "timeSpent", "isFocusedOut")
+    SELECT
+    a.id, a.value, a.result, a."assessmentId", a."challengeId", a.timeout, a."resultDetails", a."timeSpent", a."isFocusedOut"
+    FROM "answers" a`
+      )
+      .transacting(trx);
+
+    await knex
+      .raw(
+        `INSERT INTO "knowledge-elements_bigint"
+    ( id, source, status, "createdAt", "answerId", "assessmentId", "skillId", "earnedPix", "userId", "competenceId")
+    SELECT
+    ke.id, ke.source, ke.status, ke."createdAt", ke."answerId", ke."assessmentId", ke."skillId", ke."earnedPix", ke."userId", ke."competenceId"
+    FROM "knowledge-elements" ke`
+      )
+      .transacting(trx);
+  });
+  const endTime = performance.now();
+
+  logger.debug(`Call to copyAnswerKeDataToTemporaryTables took ${endTime - startTime} milliseconds`);
+  logger.debug('Finish copy');
+};
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  try {
+    logger.debug('Start script... ');
+    await copyAnswerKeDataToTemporaryTables();
+    logger.debug('End script: copy done successfully.');
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+}
+
+if (isLaunchedFromCommandLine) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      logger.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = { copyAnswerKeDataToTemporaryTables };

--- a/api/tests/acceptance/scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint_test.js
+++ b/api/tests/acceptance/scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint_test.js
@@ -1,0 +1,68 @@
+const {
+  createAnswersBigintMigrationDatabaseStructures,
+} = require('../../../../../scripts/bigint/answer/create-migration-database-structure');
+const {
+  copyAnswerKeDataToTemporaryTables,
+} = require('../../../../../scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint');
+const { expect, knex } = require('../../../../test-helper');
+
+const DatabaseBuilder = require('../../../../../db/database-builder/database-builder');
+const databaseBuilder = new DatabaseBuilder({ knex });
+
+describe('#copyAnswerKeDataToTemporaryTables', function () {
+  it('should copy data from tables to temporary tables', async function () {
+    // given
+    await knex.raw('DROP TABLE IF EXISTS "bigint-migration-settings"');
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
+    await knex.raw('DROP TABLE IF EXISTS "answers_bigint"');
+    await createAnswersBigintMigrationDatabaseStructures(knex);
+
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    const { id: firstAnswerId } = databaseBuilder.factory.buildAnswer({ assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId: firstAnswerId });
+    const { id: secondAnswerId } = databaseBuilder.factory.buildAnswer({ assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId: secondAnswerId });
+
+    await databaseBuilder.commit();
+
+    // when
+    await copyAnswerKeDataToTemporaryTables();
+
+    // then
+    const { rows: answersBigintCount } = await knex.raw(`SELECT COUNT(1) FROM "answers_bigint"`);
+    expect(answersBigintCount[0].count).to.equal(2);
+    const { rows: knowledgeElementsBigintCount } = await knex.raw(`SELECT COUNT(1) FROM "knowledge-elements_bigint"`);
+    expect(knowledgeElementsBigintCount[0].count).to.equal(2);
+  });
+  it('should copy both tables or nothing', async function () {
+    // given
+    await knex.raw('DROP TABLE IF EXISTS "bigint-migration-settings"');
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
+    await knex.raw('DROP TABLE IF EXISTS "answers_bigint"');
+    await createAnswersBigintMigrationDatabaseStructures(knex);
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
+
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    databaseBuilder.factory.buildAnswer({ assessmentId });
+    await databaseBuilder.commit();
+
+    // when
+    let error;
+    try {
+      await copyAnswerKeDataToTemporaryTables();
+    } catch (err) {
+      error = err;
+    }
+
+    // then
+    expect(error.message).to.have.string('relation "knowledge-elements_bigint" does not exist');
+    const { rows: answersBigintCount } = await knex.raw(`SELECT COUNT(1) FROM "answers_bigint"`);
+    expect(answersBigintCount[0].count).to.equal(0);
+  });
+
+  afterEach(async function () {
+    await knex('knowledge-elements').delete();
+    await knex('answers').delete();
+    await knex('assessments').delete();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Voir https://github.com/1024pix/pix/pull/3357

## :robot: Solution
Copier les données de la table answer et knowledge-element vers les deux tables intermédiaires answer_bigint, knowledge-element.
Les tables intermédiaires answer_bigint, knowledge-element ne disposent pas de contraintes afin d'accélérer la copie de donnée.

## :rainbow: Remarques
Selon les temps de réponses, la copie avec l'instruction "insert into" sera remplacé par un restore de la table via un dump plus rapide. 
En cas de problème lors de l'exécution du script, le rollback effectué par knex assure un retour à la normale car la copie est dans une transaction isolée.
Pas de reprise de donnée prévue pour le moment.

Résultat sur une environnement iso prod: **4h pour la copie de donnée**


## :100: Pour tester


### Pré-requis
Supprimer les tables si elles existent déjà

```
DROP TABLE IF EXISTS "answers_bigint";
DROP TABLE IF EXISTS "bigint-migration-settings";
DROP TABLE IF EXISTS "knowledge-elements_bigint";
```

Exécuter le script
`node ./scripts/bigint/answer/create-migration-database-structure.js`


### Exécuter
Exécuter
`LOG_LEVEL=debug node ./scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint.js`

Vérifier que le log en contient pas d'erreur
```
2022-02-17 22:58:46.982230808 +0100 CET [one-off-9205] {"level":30,"time":1645135126981,"pid":24,"hostname":"pix-int-to-bigint-test-one-off-9205","msg":"Start copy answers and knowledge-elements data"}
2022-02-18 03:05:27.857993973 +0100 CET [one-off-9205] {"level":30,"time":1645149927857,"pid":24,"hostname":"pix-int-to-bigint-test-one-off-9205","msg":"Call to copyAnswerKeDataToTemporaryTables took 14800875.221370697 milliseconds"}
2022-02-18 03:05:27.858004976 +0100 CET [one-off-9205] {"level":30,"time":1645149927857,"pid":24,"hostname":"pix-int-to-bigint-test-one-off-9205","msg":"Finish copy"}
2022-02-18 03:05:27.858006164 +0100 CET [one-off-9205] {"level":30,"time":1645149927857,"pid":24,"hostname":"pix-int-to-bigint-test-one-off-9205","msg":"End script: copy done successfully."}
2022-02-18 03:05:28.382207472 +0100 CET [manager] container [one-off-9205] (620ec508cc40e1029534b56c) has stopped
```

Vérifier que toutes les données ont été copiées:
- de la table `answers` vers `answers_bigint`
- de la table `knowledge-elements` vers `knowledge-elements_bigint`

