### PR TITLE
[FEATURE] Résoudre manuellement un signalement - API (PIX-4412).

### DIFF
--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -1,4 +1,11 @@
-const { SCO_COLLEGE_CERTIF_CENTER_ID, SCO_COLLEGE_CERTIF_CENTER_NAME, DROIT_CERTIF_CENTER_ID, DROIT_CERTIF_CENTER_NAME, SUP_CERTIF_CENTER_NAME, SUP_CERTIF_CENTER_ID } = require('./certification-centers-builder');
+const {
+  SCO_COLLEGE_CERTIF_CENTER_ID,
+  SCO_COLLEGE_CERTIF_CENTER_NAME,
+  DROIT_CERTIF_CENTER_ID,
+  DROIT_CERTIF_CENTER_NAME,
+  SUP_CERTIF_CENTER_NAME,
+  SUP_CERTIF_CENTER_ID,
+} = require('./certification-centers-builder');
 const { PIX_MASTER_ID } = require('./../users-builder');
 const EMPTY_SESSION_ID = 1;
 const STARTED_SESSION_ID = 2;
@@ -91,6 +98,7 @@ function certificationSessionsBuilder({ databaseBuilder }) {
     publishedAt: null,
     date, time,
     finalizedAt: new Date('2020-05-05T15:00:34Z'),
+    assignedCertificationOfficerName: 'Pix Master',
   });
 
   databaseBuilder.factory.buildSession({
@@ -153,11 +161,22 @@ function certificationSessionsBuilder({ databaseBuilder }) {
     finalizedAt: null,
     publishedAt: null,
   });
-  databaseBuilder.factory.buildSession({
-    certificationCenter, certificationCenterId,
-    finalizedAt: new Date('2018-01-01T00:00:00Z'),
+  const finalizedSession = databaseBuilder.factory.buildSession({
+    certificationCenter, certificationCenterId, address,
+    createdAt: new Date('2018-01-01T00:00:00Z'),
+    date: '2018-01-02',
+    finalizedAt: new Date('2018-01-03T00:00:00Z'),
     publishedAt: null,
   });
+  databaseBuilder.factory.buildFinalizedSession({
+    sessionId: finalizedSession.id,
+    certificationCenterName: certificationCenter,
+    isPublishable: true,
+    date: '2018-01-02', time,
+    finalizedAt: new Date('2018-01-03T00:00:00Z'),
+    publishedAt: null,
+  });
+
   databaseBuilder.factory.buildSession({
     certificationCenter, certificationCenterId,
     finalizedAt: new Date('2018-01-02T00:00:00Z'),

--- a/api/lib/application/certification-issue-reports/certification-issue-report-controller.js
+++ b/api/lib/application/certification-issue-reports/certification-issue-report-controller.js
@@ -11,4 +11,15 @@ module.exports = {
 
     return null;
   },
+
+  async manuallyResolve(request, h) {
+    const certificationIssueReportId = request.params.id;
+    const resolution = request.payload.data.resolution;
+    await usecases.manuallyResolveCertificationIssueReport({
+      certificationIssueReportId,
+      resolution,
+    });
+
+    return h.response().code(204);
+  },
 };

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const certificationIssueReportController = require('./certification-issue-report-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
+const securityPreHandlers = require('../security-pre-handlers');
 
 exports.register = async (server) => {
   server.route([
@@ -18,6 +19,34 @@ exports.register = async (server) => {
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n',
           '- Elle permet de supprimer un signalement',
+        ],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/certification-issue-reports/{id}',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationIssueReportId,
+          }),
+          payload: Joi.object({
+            data: {
+              resolution: Joi.string().max(255),
+            },
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRolePixMaster,
+            assign: 'hasRolePixMaster',
+          },
+        ],
+        handler: certificationIssueReportController.manuallyResolve,
+        tags: ['api', 'certification-issue-reports'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs PiXMaster authentifiés**\n',
+          '- Elle permet de résoudre manuellement un signalement',
         ],
       },
     },

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -333,6 +333,7 @@ module.exports = injectDependencies(
     improveCompetenceEvaluation: require('./improve-competence-evaluation'),
     linkUserToSessionCertificationCandidate: require('./link-user-to-session-certification-candidate')
       .linkUserToSessionCertificationCandidate,
+    manuallyResolveCertificationIssueReport: require('./manually-resolve-certification-issue-report'),
     neutralizeChallenge: require('./neutralize-challenge'),
     publishSession: require('./publish-session'),
     publishSessionsInBatch: require('./publish-sessions-in-batch'),

--- a/api/lib/domain/usecases/manually-resolve-certification-issue-report.js
+++ b/api/lib/domain/usecases/manually-resolve-certification-issue-report.js
@@ -1,0 +1,9 @@
+module.exports = async function manuallyResolveCertificationIssueReport({
+  certificationIssueReportId,
+  resolution,
+  certificationIssueReportRepository,
+}) {
+  const certificationIssueReport = await certificationIssueReportRepository.get(certificationIssueReportId);
+  certificationIssueReport.resolve(resolution);
+  await certificationIssueReportRepository.save(certificationIssueReport);
+};

--- a/api/tests/tooling/domain-builder/factory/build-finalized-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-finalized-session.js
@@ -8,6 +8,7 @@ module.exports = function buildFinalizedSession({
   finalizedAt = '2021-01-12',
   publishedAt = null,
   isPublishable = true,
+  assignedCertificationOfficerName = null,
 } = {}) {
   return new FinalizedSession({
     sessionId,
@@ -17,5 +18,6 @@ module.exports = function buildFinalizedSession({
     finalizedAt,
     publishedAt,
     isPublishable,
+    assignedCertificationOfficerName,
   });
 };

--- a/api/tests/unit/application/certification-issue-reports/certification-issue-report-controller_test.js
+++ b/api/tests/unit/application/certification-issue-reports/certification-issue-report-controller_test.js
@@ -28,4 +28,35 @@ describe('Unit | Controller | certification-issue-report-controller', function (
       expect(response).to.be.null;
     });
   });
+
+  describe('#manuallyResolve', function () {
+    it('should resolve certification issue report', async function () {
+      // given
+      const request = {
+        params: {
+          id: 100,
+        },
+        payload: {
+          data: {
+            resolution: 'resolved',
+          },
+        },
+      };
+      const manuallyResolveCertificationIssueReportStub = sinon.stub(
+        usecases,
+        'manuallyResolveCertificationIssueReport'
+      );
+      manuallyResolveCertificationIssueReportStub.resolves();
+
+      // when
+      const response = await certificationIssueReportController.manuallyResolve(request, hFake);
+
+      // then
+      expect(response.statusCode).to.deep.equal(204);
+      expect(manuallyResolveCertificationIssueReportStub).has.been.calledOnceWith({
+        certificationIssueReportId: 100,
+        resolution: 'resolved',
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
@@ -1,0 +1,29 @@
+const { expect, sinon } = require('../../../test-helper');
+const manuallyResolveCertificationIssueReport = require('../../../../lib/domain/usecases/manually-resolve-certification-issue-report');
+
+describe('Unit | UseCase | manually-resolve-certification-issue-report', function () {
+  it('should resolve and save certification issue report', async function () {
+    // given
+    const certificationIssueReportRepository = {
+      get: sinon.stub(),
+      save: sinon.stub(),
+    };
+    const resolution = 'issue solved';
+    const certificationIssueReportId = 1;
+    const expectedCertificationIssueReport = { resolve: sinon.stub() };
+    certificationIssueReportRepository.get.resolves(expectedCertificationIssueReport);
+    certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
+
+    // when
+    await manuallyResolveCertificationIssueReport({
+      resolution,
+      certificationIssueReportRepository,
+      certificationIssueReportId,
+    });
+
+    // then
+    expect(certificationIssueReportRepository.get).to.have.been.called;
+    expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
+    expect(expectedCertificationIssueReport.resolve).to.have.been.calledWith(resolution);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour le moment, il n’est pas possible pour le pôle certification d’indiquer qu'un signalement a été résolu, ce qui rend  complexe le suivi (c'est à dire savoir quels signalements ont déjà été traités, vs. lesquels restent à traiter pour une certification donnée).

## :robot: Solution
Permettre au pôle certification de résoudre manuellement un signalement : dans Pix Admin > page de détails d’une certification avec au moins 1 signalement impactant non résolu : 

- [ ] afficher un bouton “Résoudre le signalement” pour chaque signalement impactant non résolu
- [ ] cliquer sur ce bouton ouvre une pop-up avec comme titre “Résoudre le signalement”
  - [ ] un champ “Résolution” - facultatif
  - [ ] un bouton “Annuler” 
  - [ ] un bouton “Résoudre le signalement”

Une fois résolu:
- [ ] modifie l’icône devant le signalement concerné avec un check verte
- [ ] le bouton ““Résoudre le signalement” n’apparaît plus
- [ ] SI une résolution a été renseignée, ALORS elle s’affiche sous le signalement concerné sous le format “Résolution : xxxxxxxx” (sinon rien n'apparaît sous le signalement)
- [] met à jour le compteur de “Nombre de signalements impactants non résolus:” sur la page de détails d’une session
- [] met à jour le compteur de “Nombre de signalements impactants non résolus:” sur la liste des certifications

## :rainbow: Remarques

Ce ticket ne comporte que le back, à savoir la création de la route PATCH `/api/certification-issue-reports/${certificationIssueReportId}`

Ce ticket comporte une correction de seeds: 
- voir le nom d'un personne assignée sur un jury session;
- pouvoir s'assigner une session non assignée.

## :100: Pour tester
[Se connecter à Pix Admin](https://admin-pr4128.review.pix.fr/) et récupérer le token

### Cas passant

Vérifier que le signalement n'est pas résolu
```sql
SELECT
    r.id "reportId",
    r.category,
    r.description,
    r."resolvedAt",
    r.resolution
FROM "certification-issue-reports" r WHERE r.id = 107143
```

```
 reportId |         category         |       description        | resolvedAt | resolution 
----------+--------------------------+--------------------------+------------+------------
   107143 | CONNECTION_OR_END_SCREEN | Son ordinateur a explosé |            | 
```

Mettre à jour le signalement
```
curl --request PATCH 'https://certif-pr4128.review.pix.fr/api/certification-issue-reports/107143' -H 'authorization: Bearer <TOKEN>' --data '{"data" : { "resolution" : "resolved"} }' -H "content-type: application/json" 
```

Vérifier que le code retour est 204

Vérifier que le signalement est résolu en BDD 
```sql
SELECT
    r.id "reportId",
    r.category,
    r.description,
    r."resolvedAt",
    r.resolution
FROM "certification-issue-reports" r WHERE r.id = 107143;
```

```
 reportId |         category         | description |         resolvedAt         | resolution 
----------+--------------------------+-------------+----------------------------+------------
   107143 | CONNECTION_OR_END_SCREEN |             | 2022-02-24 11:15:09.392+00 | resolved
```


### Cas non passants

Mettre à jour un signalement sans authentification
```
curl --request PATCH 'https://certif-pr4128.review.pix.fr/api/certification-issue-reports/107143' -H 'authorization: Bearer INVALID_TOKEN' --data '{"data" : { "resolution" : "resolved"} }' -H "content-type: application/json" 
```

Vérifier que le code retour est 401

Mettre à jour un signalement inexistant
```
curl --request PATCH 'https://certif-pr4128.review.pix.fr/api/certification-issue-reports/666' -H 'authorization: Bearer <TOKEN>' --data '{"data" : { "resolution" : "resolved"} }' -H "content-type: application/json" 
```

Vérifier que le code retour est 404 et le message
```
{"errors":[{"status":"404","title":"Not Found","detail":"Le signalement n'existe pas"}]
```

Mettre à jour un signalement déjà résolu
```
curl --request PATCH 'https://certif-pr4128.review.pix.fr/api/certification-issue-reports/107143' -H 'authorization: Bearer <TOKEN>' --data '{"data" : { "resolution" : "resolved again"} }' -H "content-type: application/json" 
```

Vérifier que le code retour est 204 et la `resolution` + `resolvedAt` mis à jour en BDD
```
 reportId |         category         | description |        resolvedAt         |   resolution   
----------+--------------------------+-------------+---------------------------+----------------
   107143 | CONNECTION_OR_END_SCREEN |             | 2022-02-24 11:19:32.11+00 | resolved again
```


