### PR TITLE
[TECH] Ajout de deux modèles UserTutorial et UserTutorialWithTutorial sur l'api

### DIFF
--- a/api/lib/domain/models/UserTutorial.js
+++ b/api/lib/domain/models/UserTutorial.js
@@ -1,0 +1,9 @@
+class UserTutorial {
+  constructor({ id, userId, tutorialId } = {}) {
+    this.id = id;
+    this.userId = userId;
+    this.tutorialId = tutorialId;
+  }
+}
+
+module.exports = UserTutorial;

--- a/api/lib/domain/models/UserTutorialWithTutorial.js
+++ b/api/lib/domain/models/UserTutorialWithTutorial.js
@@ -1,0 +1,9 @@
+class UserTutorialWithTutorial {
+  constructor({ id, userId, tutorial } = {}) {
+    this.id = id;
+    this.userId = userId;
+    this.tutorial = tutorial;
+  }
+}
+
+module.exports = UserTutorialWithTutorial;

--- a/api/lib/domain/usecases/find-user-tutorials.js
+++ b/api/lib/domain/usecases/find-user-tutorials.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 module.exports = async function findUserTutorials({
   tutorialEvaluationRepository,
   userTutorialRepository,
@@ -7,18 +5,17 @@ module.exports = async function findUserTutorials({
 } = {}) {
   const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
   const userTutorialsWithTutorial = await userTutorialRepository.findWithTutorial({ userId });
-  _retrieveTutorialEvaluations(userTutorialsWithTutorial, tutorialEvaluations);
-  return userTutorialsWithTutorial;
+  return userTutorialsWithTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
 };
 
-function _retrieveTutorialEvaluations(savedTutorials, tutorialEvaluations) {
-  _.forEach(savedTutorials, (userTutorial) => {
-    const tutorialEvaluation = _.find(
-      tutorialEvaluations,
+function _retrieveTutorialEvaluations(tutorialEvaluations) {
+  return (userTutorial) => {
+    const tutorialEvaluation = tutorialEvaluations.find(
       (tutorialEvaluation) => tutorialEvaluation.tutorialId === userTutorial.tutorial.id
     );
     if (tutorialEvaluation) {
       userTutorial.tutorial.tutorialEvaluation = tutorialEvaluation;
     }
-  });
+    return userTutorial;
+  };
 }

--- a/api/lib/domain/usecases/find-user-tutorials.js
+++ b/api/lib/domain/usecases/find-user-tutorials.js
@@ -2,36 +2,23 @@ const _ = require('lodash');
 
 module.exports = async function findUserTutorials({
   tutorialEvaluationRepository,
-  tutorialRepository,
   userTutorialRepository,
   userId,
 } = {}) {
   const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
-  const userTutorials = await userTutorialRepository.find({ userId });
-  const tutorialsIds = userTutorials.map(({ tutorialId }) => tutorialId);
-  const savedTutorials = await tutorialRepository.findByRecordIds(tutorialsIds);
-
-  _retrieveTutorialEvaluations(savedTutorials, tutorialEvaluations);
-
-  return _.map(userTutorials, _buildUserTutorial(userId, savedTutorials));
+  const userTutorialsWithTutorial = await userTutorialRepository.findWithTutorial({ userId });
+  _retrieveTutorialEvaluations(userTutorialsWithTutorial, tutorialEvaluations);
+  return userTutorialsWithTutorial;
 };
 
 function _retrieveTutorialEvaluations(savedTutorials, tutorialEvaluations) {
-  _.forEach(savedTutorials, (tutorial) => {
+  _.forEach(savedTutorials, (userTutorial) => {
     const tutorialEvaluation = _.find(
       tutorialEvaluations,
-      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorial.id
+      (tutorialEvaluation) => tutorialEvaluation.tutorialId === userTutorial.tutorial.id
     );
     if (tutorialEvaluation) {
-      tutorial.tutorialEvaluation = tutorialEvaluation;
+      userTutorial.tutorial.tutorialEvaluation = tutorialEvaluation;
     }
   });
-}
-
-function _buildUserTutorial(userId, tutorials) {
-  function getTutorial(userTutorial) {
-    return _.find(tutorials, ({ id }) => id === userTutorial.tutorialId);
-  }
-
-  return (userTutorial) => ({ ...userTutorial, tutorial: getTutorial(userTutorial) });
 }

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -1,5 +1,8 @@
 const { knex } = require('../../../db/knex-database-connection');
+const Tutorial = require('../../domain/models/Tutorial');
 const UserTutorial = require('../../domain/models/UserTutorial');
+const UserTutorialWithTutorial = require('../../domain/models/UserTutorialWithTutorial');
+const tutorialDatasource = require('../datasources/learning-content/tutorial-datasource');
 
 module.exports = {
   async addTutorial({ userId, tutorialId }) {
@@ -14,6 +17,19 @@ module.exports = {
   async find({ userId }) {
     const userTutorials = await knex('user_tutorials').where({ userId });
     return userTutorials.map(_toDomain);
+  },
+
+  async findWithTutorial({ userId }) {
+    const userTutorials = await knex('user_tutorials').where({ userId });
+    return Promise.all(
+      userTutorials.map(async (userTutorial) => {
+        const tutorial = await tutorialDatasource.get(userTutorial.tutorialId);
+        return new UserTutorialWithTutorial({
+          ...userTutorial,
+          tutorial: new Tutorial(tutorial),
+        });
+      })
+    );
   },
 
   async removeFromUser(userTutorial) {

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -1,30 +1,29 @@
-const BookshelfUserTutorials = require('../orm-models/UserTutorials');
+const { knex } = require('../../../db/knex-database-connection');
 
 module.exports = {
   async addTutorial({ userId, tutorialId }) {
-    const userTutorial = await BookshelfUserTutorials.where({ userId, tutorialId }).fetch({ require: false });
-    if (userTutorial) {
-      return _toDomain(userTutorial);
+    const userTutorials = await knex('user_tutorials').where({ userId, tutorialId });
+    if (userTutorials.length) {
+      return _toDomain(userTutorials[0]);
     }
-    const rawUserTutorial = new BookshelfUserTutorials({ userId, tutorialId });
-    const savedUserTutorial = await rawUserTutorial.save();
-    return _toDomain(savedUserTutorial);
+    const savedUserTutorials = await knex('user_tutorials').insert({ userId, tutorialId }).returning('*');
+    return _toDomain(savedUserTutorials[0]);
   },
 
   async find({ userId }) {
-    const userTutorials = await BookshelfUserTutorials.where({ userId }).fetchAll();
+    const userTutorials = await knex('user_tutorials').where({ userId });
     return userTutorials.map(_toDomain);
   },
 
   async removeFromUser(userTutorial) {
-    return BookshelfUserTutorials.where(userTutorial).destroy({ require: false });
+    return knex('user_tutorials').where(userTutorial).delete();
   },
 };
 
-function _toDomain(bookshelfUserTutorial) {
+function _toDomain(userTutorial) {
   return {
-    id: bookshelfUserTutorial.get('id'),
-    tutorialId: bookshelfUserTutorial.get('tutorialId'),
-    userId: bookshelfUserTutorial.get('userId'),
+    id: userTutorial.id,
+    tutorialId: userTutorial.tutorialId,
+    userId: userTutorial.userId,
   };
 }

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -1,4 +1,5 @@
 const { knex } = require('../../../db/knex-database-connection');
+const UserTutorial = require('../../domain/models/UserTutorial');
 
 module.exports = {
   async addTutorial({ userId, tutorialId }) {
@@ -21,9 +22,9 @@ module.exports = {
 };
 
 function _toDomain(userTutorial) {
-  return {
+  return new UserTutorial({
     id: userTutorial.id,
     tutorialId: userTutorial.tutorialId,
     userId: userTutorial.userId,
-  };
+  });
 }

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -130,7 +130,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               id: '4242',
               attributes: {
                 'user-id': 4444,
-                'tutorial-id': 'tutorialId',
               },
               relationships: {
                 tutorial: {
@@ -162,9 +161,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
         expect(response.result.data[0].id).to.deep.equal(expectedUserTutorials.data[0].id);
         expect(response.result.data[0].attributes['user-id']).to.deep.equal(
           expectedUserTutorials.data[0].attributes['user-id']
-        );
-        expect(response.result.data[0].attributes['tutorial-id']).to.deep.equal(
-          expectedUserTutorials.data[0].attributes['tutorial-id']
         );
         expect(response.result.data[0].relationships).to.deep.equal(expectedUserTutorials.data[0].relationships);
       });

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -1,6 +1,8 @@
-const { expect, knex, databaseBuilder } = require('../../../test-helper');
+const { expect, knex, databaseBuilder, mockLearningContent } = require('../../../test-helper');
 const userTutorialRepository = require('../../../../lib/infrastructure/repositories/user-tutorial-repository');
 const UserTutorial = require('../../../../lib/domain/models/UserTutorial');
+const UserTutorialWithTutorial = require('../../../../lib/domain/models/UserTutorialWithTutorial');
+const Tutorial = require('../../../../lib/domain/models/Tutorial');
 
 describe('Integration | Infrastructure | Repository | user-tutorial-repository', function () {
   let userId;
@@ -70,15 +72,52 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
         expect(userTutorials[0]).to.have.property('tutorialId', tutorialId);
         expect(userTutorials[0]).to.have.property('userId', userId);
         expect(userTutorials[0]).to.be.instanceOf(UserTutorial);
+        expect(userTutorials[0].tutorialId).to.equal(tutorialId);
       });
     });
 
     context('when user has not saved tutorial', function () {
-      it('should empty array', async function () {
+      it('should return an empty list', async function () {
         const userTutorials = await userTutorialRepository.find({ userId });
 
         // then
         expect(userTutorials).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#findWithTutorial', function () {
+    context('when user has saved tutorials', function () {
+      it('should return user-tutorials belonging to given user', async function () {
+        // given
+        const tutorialId = 'recTutorial';
+
+        const learningContent = {
+          tutorials: [{ id: tutorialId }],
+        };
+        mockLearningContent(learningContent);
+
+        databaseBuilder.factory.buildUserTutorial({ tutorialId, userId });
+        await databaseBuilder.commit();
+
+        // when
+        const userTutorialsWithTutorials = await userTutorialRepository.findWithTutorial({ userId });
+
+        // then
+        expect(userTutorialsWithTutorials).to.have.length(1);
+        expect(userTutorialsWithTutorials[0]).to.have.property('userId', userId);
+        expect(userTutorialsWithTutorials[0]).to.be.instanceOf(UserTutorialWithTutorial);
+        expect(userTutorialsWithTutorials[0].tutorial).to.be.instanceOf(Tutorial);
+        expect(userTutorialsWithTutorials[0].tutorial.id).to.equal(tutorialId);
+      });
+    });
+
+    context('when user has not saved tutorial', function () {
+      it('should return an empty list', async function () {
+        const userTutorialsWithTutorials = await userTutorialRepository.findWithTutorial({ userId });
+
+        // then
+        expect(userTutorialsWithTutorials).to.deep.equal([]);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -1,7 +1,8 @@
 const { expect, knex, databaseBuilder } = require('../../../test-helper');
 const userTutorialRepository = require('../../../../lib/infrastructure/repositories/user-tutorial-repository');
+const UserTutorial = require('../../../../lib/domain/models/UserTutorial');
 
-describe('Integration | Infrastructure | Repository | userTutorialRepository', function () {
+describe('Integration | Infrastructure | Repository | user-tutorial-repository', function () {
   let userId;
 
   beforeEach(async function () {
@@ -26,10 +27,11 @@ describe('Integration | Infrastructure | Repository | userTutorialRepository', f
       const userTutorial = await userTutorialRepository.addTutorial({ userId, tutorialId });
 
       // then
-      const userTutorials = await knex('user_tutorials').where({ userId, tutorialId });
-      expect(userTutorial.id).to.deep.equal(userTutorials[0].id);
-      expect(userTutorial.userId).to.deep.equal(userTutorials[0].userId);
-      expect(userTutorial.tutorialId).to.deep.equal(userTutorials[0].tutorialId);
+      const savedUserTutorials = await knex('user_tutorials').where({ userId, tutorialId });
+      expect(userTutorial).to.be.instanceOf(UserTutorial);
+      expect(userTutorial.id).to.equal(savedUserTutorials[0].id);
+      expect(userTutorial.userId).to.equal(savedUserTutorials[0].userId);
+      expect(userTutorial.tutorialId).to.equal(savedUserTutorials[0].tutorialId);
     });
 
     context('when the tutorialId already exists in the user list', function () {
@@ -42,11 +44,12 @@ describe('Integration | Infrastructure | Repository | userTutorialRepository', f
         const userTutorial = await userTutorialRepository.addTutorial({ userId, tutorialId });
 
         // then
-        const userTutorials = await knex('user_tutorials').where({ userId, tutorialId });
-        expect(userTutorials).to.have.length(1);
-        expect(userTutorial.id).to.deep.equal(userTutorials[0].id);
-        expect(userTutorial.userId).to.deep.equal(userTutorials[0].userId);
-        expect(userTutorial.tutorialId).to.deep.equal(userTutorials[0].tutorialId);
+        const savedUserTutorials = await knex('user_tutorials').where({ userId, tutorialId });
+        expect(savedUserTutorials).to.have.length(1);
+        expect(userTutorial).to.be.instanceOf(UserTutorial);
+        expect(userTutorial.id).to.equal(savedUserTutorials[0].id);
+        expect(userTutorial.userId).to.equal(savedUserTutorials[0].userId);
+        expect(userTutorial.tutorialId).to.equal(savedUserTutorials[0].tutorialId);
       });
     });
   });
@@ -66,6 +69,7 @@ describe('Integration | Infrastructure | Repository | userTutorialRepository', f
         expect(userTutorials).to.have.length(1);
         expect(userTutorials[0]).to.have.property('tutorialId', tutorialId);
         expect(userTutorials[0]).to.have.property('userId', userId);
+        expect(userTutorials[0]).to.be.instanceOf(UserTutorial);
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-user-tutorial-with-tutorial.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-tutorial-with-tutorial.js
@@ -1,0 +1,15 @@
+const UserTutorialWithTutorial = require('../../../../lib/domain/models/UserTutorialWithTutorial');
+const buildTutorial = require('./build-tutorial');
+const buildUser = require('./build-user');
+
+module.exports = function buildUserTutorialWithTutorial({
+  id = 123,
+  userId = buildUser().id,
+  tutorial = buildTutorial(),
+} = {}) {
+  return new UserTutorialWithTutorial({
+    id,
+    userId,
+    tutorial,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -115,6 +115,7 @@ module.exports = {
   buildUserDetailsForAdmin: require('./build-user-details-for-admin'),
   buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserScorecard: require('./build-user-scorecard'),
+  buildUserTutorialWithTutorial: require('./build-user-tutorial-with-tutorial'),
   buildUserWithSchoolingRegistration: require('./build-user-with-schooling-registration'),
   buildValidation: require('./build-validation'),
   buildValidator: require('./build-validator'),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-tutorial-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-tutorial-serializer_test.js
@@ -33,18 +33,14 @@ describe('Unit | Serializer | JSONAPI | user-tutorial-serializer', function () {
   context('when there is user tutorial and tutorial', function () {
     it('should serialize', function () {
       // given
-      const userTutorial = {
-        id: 'userTutorialId',
-        userId: 'userId',
-        tutorial: domainBuilder.buildTutorial({ id: 'tutorialId' }),
-      };
-
+      const tutorial = domainBuilder.buildTutorial({ id: 'tutorialId' });
+      const userTutorialWithTutorial = domainBuilder.buildUserTutorialWithTutorial({ id: 123, userId: 456, tutorial });
       const expectedJsonUserTutorial = {
         data: {
           type: 'user-tutorials',
-          id: 'userTutorialId',
+          id: '123',
           attributes: {
-            'user-id': 'userId',
+            'user-id': 456,
           },
           relationships: {
             tutorial: {
@@ -71,7 +67,7 @@ describe('Unit | Serializer | JSONAPI | user-tutorial-serializer', function () {
         ],
       };
       // when
-      const json = serializer.serialize(userTutorial);
+      const json = serializer.serialize(userTutorialWithTutorial);
 
       // then
       expect(json).to.be.deep.equal(expectedJsonUserTutorial);


### PR DESCRIPTION
## :unicorn: Problème
Pas de modèle défini pour le modèle `UserTutorial`, alors que nous devons l'enrichir avec un `skillId` et un `Tutorial`.

## :robot: Solution
Créer deux modèles : 

- un modèle  `UserTutorial`
- un modèle `UserTutorialWithTutorial` : il contient un attribut tutorial qui est un objet du domaine `Tutorial`.

## :rainbow: Remarques
Cette PR n'a pas de numéro de ticket car on s'est aperçu que le ticket [PIX-4335](https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/33?modal=detail&selectedIssue=PIX-4335) nécessitait un petit refacto préalable
## :100: Pour tester
Vérifier que les tutos se chargent bien sur les pages : 

- [ ] Mes tutos
- [ ] Détail d'une compétence
- [ ] Correction d'une épreuve