### PR TITLE
[TECH] Supprimer la prévention des attaques par réponse utilisateur trop longue. 

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -2,7 +2,6 @@ const Joi = require('joi');
 const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { NotFoundError } = require('../../domain/errors');
-const { features } = require('../../config');
 
 exports.register = async (server) => {
   server.route([
@@ -15,7 +14,7 @@ exports.register = async (server) => {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                value: Joi.string().max(features.userAnswersMaxLength).allow('').allow(null),
+                value: Joi.string().allow('').allow(null),
                 result: Joi.string().allow(null),
                 'result-details': Joi.string().allow(null),
                 timeout: Joi.number().allow(null),

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -166,7 +166,6 @@ module.exports = (function () {
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
-      userAnswersMaxLength: _getNumber(process.env.USER_ANSWERS_MAX_LENGTH, 500),
     },
 
     featureToggles: {

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -33,7 +33,7 @@ describe('Unit | Application | Router | answer-router', function () {
       expect(response.statusCode).to.equal(201);
     });
 
-    it('should return BAD_REQUEST with message if answer length is too long (security issue)', async function () {
+    it('should return BAD_REQUEST with message if answer length is too long but does not (security issue)', async function () {
       // given
       sinon.stub(answerController, 'save').callsFake((request, h) => h.response().created());
       const httpTestServer = new HttpTestServer();
@@ -59,10 +59,7 @@ describe('Unit | Application | Router | answer-router', function () {
       const response = await httpTestServer.request('POST', '/api/answers', payload);
 
       // then
-      expect(response.statusCode).to.equal(400);
-      expect(response.result.errors[0].detail).to.equal(
-        '"data.attributes.value" length must be less than or equal to 500 characters long'
-      );
+      expect(response.statusCode).to.not.equal(400);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
La prévention des  attaques par réponse utilisateur trop longue, pour être correctement implémentée, doit limiter le nombre de caractères saisissable à 3 endroits:

1.  par l'équipe pédagogique dans une question du référentiel;
2. par l'utilisateur dans sa réponse;
3. par l'API lors de la réception de la réponse.

Seule la solution 3 a été [mise en place](https://github.com/1024pix/pix/pull/3949), et cela a occasionné de nombreux problèmes.
Même si la solution 1 et 2 étaient implémentés, la solution 3 complète n'est pas triviale, car l'utilisateur peut soumettre plusieurs réponses (ex: QCM), et celles-ci sont envoyées dans une même propriété JSON, en YAML.

## :robot: Solution
Supprimer la troisième solution incomplète car cela: 
- ajoute de la complexité au code API;
- en causant des régressions;
- alors que le risque est relativement faible te peu avéré pour l'instant.

## :rainbow: Remarques
Le test qui mettait en avant le comportement a été conservé.

## :100: Pour tester
Démarrer un test, récupérer le challengeId de la question courante dans le store Ember.

Dans l'onglet Network du navigateur, modifier l'appel POST précédent sur /api/answers avec le challengeId récupéré, et une chaîne [de plus de 500 caractères](http://www.unit-conversion.info/texttools/random-string-generator/) dans value.

Vérifiez que vous obtenez un statut HTTP passant (pas 4xx ou 5xx).
Vérifiez que la valeur est sauvegardée en BDD