### PR TITLE
[TECH] Migrer la colonne Answer.id de INTEGER en BIG INTEGER (Partie 4)

### DIFF
--- a/api/scripts/bigint/answer/copy-newly-inserted-rows-to-answerId-tmp-bigint-tables.js
+++ b/api/scripts/bigint/answer/copy-newly-inserted-rows-to-answerId-tmp-bigint-tables.js
@@ -1,0 +1,102 @@
+require('dotenv').config();
+const { knex } = require('../../../db/knex-database-connection');
+const { performance } = require('perf_hooks');
+const logger = require('../../../lib/infrastructure/logger');
+
+const copyNewlyInsertedRowsToAnswerIdTmpBigintTables = async () => {
+  const startTime = performance.now();
+
+  await knex.transaction(async (trx) => {
+    logger.debug('init bigint migration setting');
+
+    await knex.raw(`LOCK TABLE "answers" IN ACCESS EXCLUSIVE MODE`).transacting(trx);
+    await knex.raw(`LOCK TABLE "knowledge-elements" IN ACCESS EXCLUSIVE MODE;`).transacting(trx);
+    await knex
+      .raw(
+        `INSERT INTO "bigint-migration-settings"("tableName", "startsAtId", "endsAtId")
+               VALUES ('answers', (SELECT MAX(id) + 1 FROM "answers_bigint"), (SELECT MAX(id)
+               FROM "answers") )`
+      )
+      .transacting(trx);
+    await knex
+      .raw(
+        `INSERT INTO "bigint-migration-settings"("tableName", "startsAtId", "endsAtId")
+               VALUES ('knowledge-elements', (SELECT MAX(id) + 1 FROM "knowledge-elements_bigint"), (SELECT MAX(id)
+               FROM "knowledge-elements"))`
+      )
+      .transacting(trx);
+
+    logger.debug('Finish init bigint migration setting');
+
+    logger.debug('create triggers for answers_bigint and ke_bigint table');
+
+    await knex
+      .raw(
+        `CREATE OR REPLACE FUNCTION "insert_answers_in_answers_bigint"()
+                    RETURNS TRIGGER AS
+                    $$
+                    BEGIN
+                      INSERT INTO "answers_bigint" ("id", "value", "result", "assessmentId", "challengeId", timeout, "resultDetails", "timeSpent", "isFocusedOut")
+                      VALUES         (NEW."id"::BIGINT, NEW."value", NEW."result", NEW."assessmentId", NEW."challengeId", NEW."timeout", NEW."resultDetails", NEW."timeSpent", NEW."isFocusedOut");
+                     RETURN NEW;
+                    END
+                    $$ LANGUAGE plpgsql;`
+      )
+      .transacting(trx);
+
+    await knex
+      .raw(
+        `CREATE TRIGGER "trg_answers"
+                    AFTER INSERT ON "answers"
+                    FOR EACH ROW
+                    EXECUTE FUNCTION "insert_answers_in_answers_bigint"();`
+      )
+      .transacting(trx);
+
+    await knex
+      .raw(
+        `CREATE OR REPLACE FUNCTION "insert_knowledge-elements_in_knowledge-elements_bigint"()
+                    RETURNS TRIGGER AS
+                    $$
+                    BEGIN
+                       INSERT INTO "knowledge-elements_bigint"( id, source, status, "createdAt", "answerId", "assessmentId", "skillId", "earnedPix", "userId", "competenceId")
+                       VALUES ( NEW.id::BIGINT, NEW.source, NEW.status, NEW."createdAt", NEW."answerId", NEW."assessmentId", NEW."skillId", NEW."earnedPix", NEW."userId", NEW."competenceId");
+                      RETURN NEW;
+                    END
+                    $$ LANGUAGE plpgsql;`
+      )
+      .transacting(trx);
+
+    await knex
+      .raw(
+        `CREATE TRIGGER "trg_knowledge-elements"
+                    AFTER INSERT ON "knowledge-elements"
+                    FOR EACH ROW
+                    EXECUTE FUNCTION "insert_knowledge-elements_in_knowledge-elements_bigint"();`
+      )
+      .transacting(trx);
+  });
+  const endTime = performance.now();
+
+  logger.debug(`Call to copyNewlyInsertedRowsToAnswerIdTmpBigintTables took ${endTime - startTime} milliseconds`);
+  logger.debug('Finish adding triggers');
+};
+
+async function main() {
+  logger.info(`Start script ${__filename}... `);
+  await copyNewlyInsertedRowsToAnswerIdTmpBigintTables();
+  logger.info('End script: done successfully.');
+}
+
+const isLaunchedByCommandLine = require.main === module;
+if (isLaunchedByCommandLine) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = { copyNewlyInsertedRowsToAnswerIdTmpBigintTables };

--- a/api/tests/acceptance/scripts/bigint/answer/copy-newly-inserted-rows-to-answerId-tmp-bigint-tables_test.js
+++ b/api/tests/acceptance/scripts/bigint/answer/copy-newly-inserted-rows-to-answerId-tmp-bigint-tables_test.js
@@ -1,0 +1,133 @@
+const {
+  createAnswersBigintMigrationDatabaseStructures,
+} = require('../../../../../scripts/bigint/answer/create-migration-database-structure');
+const {
+  copyAnswerKeDataToTemporaryTables,
+} = require('../../../../../scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint');
+const {
+  addConstraintsAndIndexesToAnswersKeBigintTemporaryTables,
+} = require('../../../../../scripts/bigint/answer/add-constraints-and-indexes-to-answers-ke-temporary-tables-with-bigint');
+const {
+  copyNewlyInsertedRowsToAnswerIdTmpBigintTables,
+} = require('../../../../../scripts/bigint/answer/copy-newly-inserted-rows-to-answerId-tmp-bigint-tables');
+
+const { expect, knex } = require('../../../../test-helper');
+
+const DatabaseBuilder = require('../../../../../db/database-builder/database-builder');
+const databaseBuilder = new DatabaseBuilder({ knex });
+
+describe('#copyNewlyInsertedRowsToAnswerIdTmpBigintTables', function () {
+  beforeEach(async function () {
+    // given
+    await knex.raw('DROP TABLE IF EXISTS "bigint-migration-settings"');
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
+    await knex.raw('DROP TABLE IF EXISTS "answers_bigint"');
+    await knex.raw('DROP TRIGGER IF EXISTS trg_answers ON answers');
+    await knex.raw('DROP TRIGGER IF EXISTS "trg_knowledge-elements" ON "knowledge-elements"');
+    await createAnswersBigintMigrationDatabaseStructures(knex);
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    const { id: firstAnswerId } = databaseBuilder.factory.buildAnswer({ assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId: firstAnswerId });
+    const { id: secondAnswerId } = databaseBuilder.factory.buildAnswer({ assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId: secondAnswerId });
+    await databaseBuilder.commit();
+    await copyAnswerKeDataToTemporaryTables();
+    await addConstraintsAndIndexesToAnswersKeBigintTemporaryTables();
+
+    // when
+    await copyNewlyInsertedRowsToAnswerIdTmpBigintTables();
+  });
+
+  it('should add triggers to answers and KE tables', async function () {
+    // then
+    const { rows: triggersByTable } = await knex.raw(
+      `SELECT  event_object_table AS table_name ,trigger_name
+             FROM information_schema.triggers
+             GROUP BY table_name , trigger_name
+             ORDER BY table_name ,trigger_name
+            `
+    );
+    expect(triggersByTable).to.deep.equal([
+      {
+        table_name: 'answers',
+        trigger_name: 'trg_answers',
+      },
+      {
+        table_name: 'knowledge-elements',
+        trigger_name: 'trg_knowledge-elements',
+      },
+    ]);
+  });
+
+  it('should copy newly inserted rows from base tables into bigint temporary tables', async function () {
+    // given
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    const { id: firstAnswerId } = databaseBuilder.factory.buildAnswer({ assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId: firstAnswerId });
+    const { id: secondAnswerId } = databaseBuilder.factory.buildAnswer({ assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId: secondAnswerId });
+    await databaseBuilder.commit();
+
+    // when then
+    const { rows: answersBigintCount } = await knex.raw(`SELECT COUNT(1) FROM "answers_bigint"`);
+    expect(answersBigintCount[0].count).to.equal(4);
+    const { rows: knowledgeElementsBigintCount } = await knex.raw(`SELECT COUNT(1) FROM "knowledge-elements_bigint"`);
+    expect(knowledgeElementsBigintCount[0].count).to.equal(4);
+  });
+
+  it('should persist last temporary table identifier into settings table', async function () {
+    const { answerBigIntMaxId } = await knex('answers_bigint').max('id as answerBigIntMaxId').first();
+    const { startsAtId: currentStartsAtId } = await knex('bigint-migration-settings')
+      .where({
+        tableName: 'answers',
+      })
+      .select('startsAtId')
+      .first();
+    const expectedStartsAtId = answerBigIntMaxId + 1;
+    expect(currentStartsAtId).to.equal(expectedStartsAtId);
+
+    const { knowledgeElementsBigintMaxId } = await knex('knowledge-elements_bigint')
+      .max('id as knowledgeElementsBigintMaxId')
+      .first();
+    const { startsAtId: currentStartsAtIdKe } = await knex('bigint-migration-settings')
+      .where({
+        tableName: 'knowledge-elements',
+      })
+      .select('startsAtId')
+      .first();
+    const expectedStartsAtIdKe = knowledgeElementsBigintMaxId + 1;
+    expect(currentStartsAtIdKe).to.equal(expectedStartsAtIdKe);
+  });
+
+  it('should persist last source table identifier into settings table', async function () {
+    const { answerMaxId } = await knex('answers').max('id as answerMaxId').first();
+    const { endsAtId: currentEndsAtId } = await knex('bigint-migration-settings')
+      .where({
+        tableName: 'answers',
+      })
+      .select('endsAtId')
+      .first();
+    const expectedEndsAtId = answerMaxId;
+    expect(currentEndsAtId).to.equal(expectedEndsAtId);
+
+    const { knowledgeElementsMaxId } = await knex('knowledge-elements').max('id as knowledgeElementsMaxId').first();
+    const { endsAtId: currentEndsAtIdKe } = await knex('bigint-migration-settings')
+      .where({
+        tableName: 'knowledge-elements',
+      })
+      .select('endsAtId')
+      .first();
+    const expectedEndsAtIdKe = knowledgeElementsMaxId;
+    expect(currentEndsAtIdKe).to.equal(expectedEndsAtIdKe);
+  });
+
+  afterEach(async function () {
+    await knex('knowledge-elements').delete();
+    await knex('answers').delete();
+    await knex('knowledge-elements_bigint').delete();
+    await knex('answers_bigint').delete();
+    await knex('assessments').delete();
+    await knex.raw('DROP TRIGGER IF EXISTS trg_answers ON answers');
+    await knex.raw('DROP TRIGGER IF EXISTS "trg_knowledge-elements" ON "knowledge-elements"');
+  });
+});

--- a/api/tests/acceptance/scripts/bigint/answer/create-migration-database-structure_test.js
+++ b/api/tests/acceptance/scripts/bigint/answer/create-migration-database-structure_test.js
@@ -6,9 +6,9 @@ const { expect, knex } = require('../../../../test-helper');
 describe('#createAnswersBigintMigrationDatabaseStructures', function () {
   it('should create temporary tables', async function () {
     // given
+    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
     await knex.raw('DROP TABLE IF EXISTS "answers_bigint"');
     await knex.raw('DROP TABLE IF EXISTS "bigint-migration-settings"');
-    await knex.raw('DROP TABLE IF EXISTS "knowledge-elements_bigint"');
 
     // when
     await createAnswersBigintMigrationDatabaseStructures(knex);


### PR DESCRIPTION
## :unicorn: Problème
Voir Partie 1 https://github.com/1024pix/pix/pull/3357
Voir Partie 2 https://github.com/1024pix/pix/pull/4127
Voir Partie 3 https://github.com/1024pix/pix/pull/4130

## :robot: Solution
Mettre en place des triggers pour recopier les données insérées par l’API au fil de l’eau. 
Cela va permettre de synchroniser les deux tables answer et ke avec leurs copies en BigInt.

## :rainbow: Remarques
Résultat sur un environnement iso prod: **78ms pour la mise en place des triggers.**
```
2022-02-14 20:05:21.942743427 +0100 CET [one-off-2378] Start script...
2022-02-14 20:05:22.019866304 +0100 CET [one-off-2378] number of rows answer table 686892528
2022-02-14 20:05:22.020702605 +0100 CET [one-off-2378] Call to addTriggersToAnswersKeBigintTemporaryTables took 77.6744384765625 milliseconds
2022-02-14 20:05:22.020706153 +0100 CET [one-off-2378] Finish adding triggers
2022-02-14 20:05:22.020707048 +0100 CET [one-off-2378]
2022-02-14 20:05:22.020707566 +0100 CET [one-off-2378] End script: copy done successfully
```

## :100: Pour tester
En local / RA


### Pré-requis
Supprimer les tables si elles existent déjà

```
DROP TABLE IF EXISTS "knowledge-elements_bigint";
DROP TABLE IF EXISTS "answers_bigint";
DROP TABLE IF EXISTS "bigint-migration-settings";
DROP TRIGGER IF EXISTS "trg_answers" on "answers";
DROP TRIGGER IF EXISTS "trg_knowledge-elements" on "knowledge-elements";
```

Exécuter les scripts
``` bash
node ./scripts/bigint/answer/create-migration-database-structure.js
node ./scripts/bigint/answer/copy-answers-ke-data-to-temporary-tables-with-bigint.js
node ./scripts/bigint/answer/add-constraints-and-indexes-to-answers-ke-temporary-tables-with-bigint.js
```

### Exécution

Installer les triggers.
```
LOG_LEVEL=debug node ./scripts/bigint/answer/copy-newly-inserted-rows-to-answerId-tmp-bigint-tables.js
```

Vérifier qu'ils sont installés
``` bash
psql postgresql://postgres@localhost:5432/pix
 \d answers

Triggers:
    trg_answers AFTER INSERT ON answers FOR EACH ROW EXECUTE FUNCTION insert_answers_in_answers_bigint

\d "knowledge-elements"
Triggers:
    "trg_knowledge-elements" AFTER INSERT ON "knowledge-elements" FOR EACH ROW EXECUTE FUNCTION "insert_knowled
ge-elements_in_knowledge-elements_bigint"()
```

ou
```sql
SELECT
    trg.tgname trg_name,
    p.prosrc   trg_src
FROM
    pg_trigger trg INNER JOIN pg_proc p ON p.oid = trg.tgfoid
WHERE 1=1
    AND trg.tgrelid = 'public.answers'::regclass
    AND trg.tgname = 'trg_answers'
```

Insérer des enregistrements dans la table answers et KE, par exemple en faisant un [parcours](https://app-pr4134.review.pix.fr/) avec `certif1@exmaple.net`

Vérifier qu'ils sont copiés dans les tables answer_bigint et knowledge-elements.
```sql
select count(1) from answers;
select count(1) from answers_bigint;
select * from answers order by "createdAt" DESC LIMIT 3;
select * from answers_bigint order by "createdAt" DESC LIMIT 3;

select * from "knowledge-elements" order by "createdAt" DESC LIMIT 3;
select * from "knowledge-elements_bigint" order by "createdAt" DESC LIMIT 3;
```

Vérifier que le paramétrage a été inséré
```sql
select * from "bigint-migration-settings";
```