### PR TITLE
[FEATURE] Lister les tutos recommandés et enregistrés (PIX-4382)

### DIFF
--- a/api/lib/application/user-tutorials/index.js
+++ b/api/lib/application/user-tutorials/index.js
@@ -39,6 +39,30 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'GET',
+      path: '/api/users/tutorials/saved',
+      config: {
+        handler: userTutorialsController.findSaved,
+        tags: ['api', 'tutorials'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération des tutoriels enregistrés par l‘utilisateur courant\n',
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/users/tutorials/recommended',
+      config: {
+        handler: userTutorialsController.findRecommended,
+        tags: ['api', 'tutorials'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Récupération des tutoriels recommandés pour l‘utilisateur courant\n',
+        ],
+      },
+    },
+    {
       method: 'DELETE',
       path: '/api/users/tutorials/{tutorialId}',
       config: {

--- a/api/lib/application/user-tutorials/user-tutorials-controller.js
+++ b/api/lib/application/user-tutorials/user-tutorials-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 const userTutorialSerializer = require('../../infrastructure/serializers/jsonapi/user-tutorial-serializer');
+const tutorialSerializer = require('../../infrastructure/serializers/jsonapi/tutorial-serializer');
 const userTutorialRepository = require('../../infrastructure/repositories/user-tutorial-repository');
 
 module.exports = {
@@ -18,6 +19,22 @@ module.exports = {
     const userTutorials = await usecases.findUserTutorials({ userId });
 
     return h.response(userTutorialSerializer.serialize(userTutorials));
+  },
+
+  async findSaved(request, h) {
+    const { userId } = request.auth.credentials;
+
+    const userSavedTutorials = await usecases.findSavedTutorials({ userId });
+
+    return h.response(tutorialSerializer.serialize(userSavedTutorials));
+  },
+
+  async findRecommended(request, h) {
+    const { userId } = request.auth.credentials;
+
+    const userRecommendedTutorials = await usecases.findRecommendedTutorials({ userId });
+
+    return h.response(tutorialSerializer.serialize(userRecommendedTutorials));
   },
 
   async removeFromUser(request, h) {

--- a/api/lib/domain/usecases/find-recommended-tutorials.js
+++ b/api/lib/domain/usecases/find-recommended-tutorials.js
@@ -1,0 +1,26 @@
+module.exports = async function findRecommendedTutorials({
+  userId,
+  knowledgeElementRepository,
+  skillRepository,
+  tutorialRepository,
+}) {
+  const invalidatedKnowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
+
+  if (!invalidatedKnowledgeElements.length) {
+    return [];
+  }
+
+  const skills = await Promise.all(
+    invalidatedKnowledgeElements.map((invalidatedKnowledgeElement) => {
+      return skillRepository.get(invalidatedKnowledgeElement.skillId);
+    })
+  );
+
+  const tutorials = await Promise.all(
+    skills.map((skill) => {
+      return tutorialRepository.findByRecordIds(skill.tutorialIds);
+    })
+  );
+
+  return tutorials.flat();
+};

--- a/api/lib/domain/usecases/find-recommended-tutorials.js
+++ b/api/lib/domain/usecases/find-recommended-tutorials.js
@@ -10,17 +10,9 @@ module.exports = async function findRecommendedTutorials({
     return [];
   }
 
-  const skills = await Promise.all(
-    invalidatedKnowledgeElements.map((invalidatedKnowledgeElement) => {
-      return skillRepository.get(invalidatedKnowledgeElement.skillId);
-    })
-  );
+  const skills = await skillRepository.findOperativeByIds(invalidatedKnowledgeElements.map(({ skillId }) => skillId));
 
-  const tutorials = await Promise.all(
-    skills.map((skill) => {
-      return tutorialRepository.findByRecordIds(skill.tutorialIds);
-    })
-  );
+  const tutorials = await Promise.all(skills.map((skill) => tutorialRepository.findByRecordIds(skill.tutorialIds)));
 
   return tutorials.flat();
 };

--- a/api/lib/domain/usecases/find-saved-tutorials.js
+++ b/api/lib/domain/usecases/find-saved-tutorials.js
@@ -1,0 +1,21 @@
+module.exports = async function findSavedTutorials({
+  tutorialEvaluationRepository,
+  userTutorialRepository,
+  userId,
+} = {}) {
+  const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
+  const userTutorialsWithTutorial = await userTutorialRepository.findWithTutorial({ userId });
+  return userTutorialsWithTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
+};
+
+function _retrieveTutorialEvaluations(tutorialEvaluations) {
+  return (userTutorial) => {
+    const tutorialEvaluation = tutorialEvaluations.find(
+      (tutorialEvaluation) => tutorialEvaluation.tutorialId === userTutorial.tutorial.id
+    );
+    if (tutorialEvaluation) {
+      userTutorial.tutorial.tutorialEvaluation = tutorialEvaluation;
+    }
+    return userTutorial;
+  };
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -247,6 +247,8 @@ module.exports = injectDependencies(
     findPaginatedFilteredUsers: require('./find-paginated-filtered-users'),
     findPaginatedParticipationsForCampaignManagement: require('./find-paginated-participations-for-campaign-management'),
     findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),
+    findRecommendedTutorials: require('./find-recommended-tutorials'),
+    findSavedTutorials: require('./find-saved-tutorials'),
     findStudentsForEnrollment: require('./find-students-for-enrollment'),
     findTargetProfileBadges: require('./find-target-profile-badges'),
     findTargetProfileStages: require('./find-target-profile-stages'),

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -208,4 +208,22 @@ module.exports = {
   async findSnapshotForUsers(userIdsAndDates) {
     return _findSnapshotsForUsers(userIdsAndDates);
   },
+
+  async findInvalidatedAndDirectByUserId(userId) {
+    const invalidatedKnowledgeElements = await knex('knowledge-elements')
+      .where({
+        userId,
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+      })
+      .orderBy('createdAt', 'desc');
+
+    if (!invalidatedKnowledgeElements.length) {
+      return [];
+    }
+
+    return invalidatedKnowledgeElements.map(
+      (invalidatedKnowledgeElement) => new KnowledgeElement(invalidatedKnowledgeElement)
+    );
+  },
 };

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -2,10 +2,14 @@ const {
   expect,
   generateValidRequestAuthorizationHeader,
   mockLearningContent,
+  learningContentBuilder,
   databaseBuilder,
   knex,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const nock = require('nock');
 
 describe('Acceptance | Controller | user-tutorial-controller', function () {
   let server;
@@ -163,6 +167,177 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
           expectedUserTutorials.data[0].attributes['user-id']
         );
         expect(response.result.data[0].relationships).to.deep.equal(expectedUserTutorials.data[0].relationships);
+      });
+    });
+  });
+
+  describe('GET /api/users/tutorials/recommended', function () {
+    let options;
+    const userId = 4444;
+
+    beforeEach(async function () {
+      nock.cleanAll();
+      cache.flushAll();
+      options = {
+        method: 'GET',
+        url: '/api/users/tutorials/recommended',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+    });
+
+    describe('nominal case', function () {
+      it('should respond with a 200 and return tutorials recommended for user', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent([
+          {
+            id: 'recArea1',
+            titleFrFr: 'area1_Title',
+            color: 'specialColor',
+            competences: [
+              {
+                id: 'recCompetence1',
+                name: 'Fabriquer un meuble',
+                index: '1.1',
+                tubes: [
+                  {
+                    id: 'recTube1',
+                    skills: [
+                      {
+                        id: 'recSkill1',
+                        nom: '@web1',
+                        challenges: [],
+                        tutorialIds: ['tuto1', 'tuto2'],
+                        tutorials: [
+                          {
+                            id: 'tuto1',
+                            locale: 'en-us',
+                            duration: '00:00:54',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example.html',
+                            source: 'tuto.com',
+                            title: 'tuto1',
+                          },
+                          {
+                            id: 'tuto2',
+                            locale: 'en-us',
+                            duration: '00:01:51',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example2.html',
+                            source: 'tuto.com',
+                            title: 'tuto2',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recSkill2',
+                        nom: '@web2',
+                        challenges: [],
+                        tutorialIds: ['tuto3'],
+                        tutorials: [
+                          {
+                            id: 'tuto3',
+                            locale: 'fr-fr',
+                            duration: '00:03:31',
+                            format: 'vidéo',
+                            link: 'http://www.example.com/this-is-an-example3.html',
+                            source: 'tuto.com',
+                            title: 'tuto3',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recSkill3',
+                        nom: '@web3',
+                        challenges: [],
+                        tutorialIds: ['tuto4'],
+                        tutorials: [
+                          {
+                            id: 'tuto4',
+                            locale: 'fr-fr',
+                            duration: '00:04:38',
+                            format: 'vidéo',
+                            link: 'http://www.example.com/this-is-an-example4.html',
+                            source: 'tuto.com',
+                            title: 'tuto4',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+        mockLearningContent(learningContentObjects);
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          skillId: 'recSkill1',
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          status: KnowledgeElement.StatusType.VALIDATED,
+          source: KnowledgeElement.SourceType.INFERRED,
+          skillId: 'recSkill2',
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          skillId: 'recSkill3',
+        });
+
+        await databaseBuilder.commit();
+
+        const expectedUserTutorials = [
+          {
+            attributes: {
+              duration: '00:00:54',
+              format: 'video',
+              link: 'http://www.example.com/this-is-an-example.html',
+              source: 'tuto.com',
+              title: 'tuto1',
+            },
+            id: 'tuto1',
+            type: 'tutorials',
+          },
+          {
+            attributes: {
+              duration: '00:01:51',
+              format: 'video',
+              link: 'http://www.example.com/this-is-an-example2.html',
+              source: 'tuto.com',
+              title: 'tuto2',
+            },
+            id: 'tuto2',
+            type: 'tutorials',
+          },
+          {
+            attributes: {
+              duration: '00:04:38',
+              format: 'vidéo',
+              link: 'http://www.example.com/this-is-an-example4.html',
+              source: 'tuto.com',
+              title: 'tuto4',
+            },
+            id: 'tuto4',
+            type: 'tutorials',
+          },
+        ];
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal(expectedUserTutorials);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -2058,4 +2058,57 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       });
     });
   });
+
+  describe('#findInvalidatedAndDirectByUserId', function () {
+    it('should find invalidated & direct KE with given UserId', async function () {
+      // Given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildKnowledgeElement({
+        id: 1,
+        userId,
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        createdAt: new Date('2022-01-03'),
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        id: 2,
+        userId,
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        createdAt: new Date('2022-08-19'),
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        source: KnowledgeElement.SourceType.INFERRED,
+      });
+
+      await databaseBuilder.commit();
+
+      // When
+      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
+
+      // Then
+      expect(knowledgeElements).to.have.length(2);
+      expect(knowledgeElements[0]).to.be.instanceOf(KnowledgeElement);
+      expect(knowledgeElements[0].id).to.equal(2);
+    });
+
+    it('should return an empty list if there are no invalidated & direct KE', async function () {
+      // Given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // When
+      const knowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
+
+      // Then
+      expect(knowledgeElements).to.have.length(0);
+    });
+  });
 });

--- a/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
@@ -45,6 +45,25 @@ describe('Unit | Controller | User-tutorials', function () {
     });
   });
 
+  describe('#findRecommended', function () {
+    it('should call the expected usecase', async function () {
+      // given
+      const userId = 'userId';
+      sinon.stub(usecases, 'findRecommendedTutorials').returns([]);
+
+      const request = {
+        auth: { credentials: { userId } },
+      };
+
+      // when
+      await userTutorialsController.findRecommended(request, hFake);
+
+      // then
+      const findUserTutorialsArgs = usecases.findRecommendedTutorials.firstCall.args[0];
+      expect(findUserTutorialsArgs).to.have.property('userId', userId);
+    });
+  });
+
   describe('#removeFromUser', function () {
     it('should call the repository', async function () {
       // given

--- a/api/tests/unit/domain/usecases/find-recommended-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-recommended-tutorials_test.js
@@ -55,7 +55,7 @@ describe('Unit | UseCase | find-recommended-tutorials', function () {
       };
 
       const skillRepository = {
-        get: sinon.stub().resolves([]),
+        findOperativeByIds: sinon.stub().resolves([]),
       };
 
       const tutorialRepository = {
@@ -66,8 +66,7 @@ describe('Unit | UseCase | find-recommended-tutorials', function () {
       await findRecommendedTutorials({ userId, knowledgeElementRepository, skillRepository, tutorialRepository });
 
       // Then
-      expect(skillRepository.get.firstCall).to.have.been.calledWith('skill1');
-      expect(skillRepository.get.secondCall).to.have.been.calledWith('skill2');
+      expect(skillRepository.findOperativeByIds.firstCall).to.have.been.calledWith(['skill1', 'skill2']);
     });
 
     it('should return associated tutorials', async function () {
@@ -93,11 +92,10 @@ describe('Unit | UseCase | find-recommended-tutorials', function () {
         domainBuilder.buildSkill({ id: 'skill2', tutorialIds: ['tuto3', 'tuto4'] }),
       ];
       const skillRepository = {
-        get: sinon.stub(),
+        findOperativeByIds: sinon.stub(),
       };
 
-      skillRepository.get.onFirstCall().resolves(skills[0]);
-      skillRepository.get.onSecondCall().resolves(skills[1]);
+      skillRepository.findOperativeByIds.onFirstCall().resolves(skills);
 
       const expectedTutorials = [
         domainBuilder.buildTutorial({ id: 'tuto1' }),

--- a/api/tests/unit/domain/usecases/find-recommended-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-recommended-tutorials_test.js
@@ -1,0 +1,130 @@
+const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const findRecommendedTutorials = require('../../../../lib/domain/usecases/find-recommended-tutorials');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+
+describe('Unit | UseCase | find-recommended-tutorials', function () {
+  it('should find all KE related to a user', async function () {
+    // Given
+    const userId = 1;
+    const knowledgeElementRepository = {
+      findInvalidatedAndDirectByUserId: sinon.stub().resolves([]),
+    };
+
+    // When
+    await findRecommendedTutorials({ userId, knowledgeElementRepository });
+
+    // Then
+    expect(knowledgeElementRepository.findInvalidatedAndDirectByUserId).to.have.been.calledWith(userId);
+  });
+
+  describe('when there are no invalidated and direct KE', function () {
+    it('should return an empty array', async function () {
+      // Given
+      const userId = 1;
+      const knowledgeElementRepository = {
+        findInvalidatedAndDirectByUserId: sinon.stub().resolves([]),
+      };
+
+      // When
+      const tutorials = await findRecommendedTutorials({ userId, knowledgeElementRepository });
+
+      // Then
+      expect(tutorials).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when there are invalidated and direct KE', function () {
+    it('should find associated skills', async function () {
+      // Given
+      const userId = 1;
+      const invalidatedKnowledgeElements = [
+        domainBuilder.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          skillId: 'skill1',
+        }),
+        domainBuilder.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          skillId: 'skill2',
+        }),
+      ];
+
+      const knowledgeElementRepository = {
+        findInvalidatedAndDirectByUserId: sinon.stub().resolves(invalidatedKnowledgeElements),
+      };
+
+      const skillRepository = {
+        get: sinon.stub().resolves([]),
+      };
+
+      const tutorialRepository = {
+        findByRecordIds: sinon.stub(),
+      };
+
+      // When
+      await findRecommendedTutorials({ userId, knowledgeElementRepository, skillRepository, tutorialRepository });
+
+      // Then
+      expect(skillRepository.get.firstCall).to.have.been.calledWith('skill1');
+      expect(skillRepository.get.secondCall).to.have.been.calledWith('skill2');
+    });
+
+    it('should return associated tutorials', async function () {
+      // Given
+      const userId = 1;
+      const invalidatedKnowledgeElements = [
+        domainBuilder.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          skillId: 'skill1',
+        }),
+        domainBuilder.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          source: KnowledgeElement.SourceType.DIRECT,
+          skillId: 'skill2',
+        }),
+      ];
+      const knowledgeElementRepository = {
+        findInvalidatedAndDirectByUserId: sinon.stub().resolves(invalidatedKnowledgeElements),
+      };
+      const skills = [
+        domainBuilder.buildSkill({ id: 'skill1', tutorialIds: ['tuto1', 'tuto2'] }),
+        domainBuilder.buildSkill({ id: 'skill2', tutorialIds: ['tuto3', 'tuto4'] }),
+      ];
+      const skillRepository = {
+        get: sinon.stub(),
+      };
+
+      skillRepository.get.onFirstCall().resolves(skills[0]);
+      skillRepository.get.onSecondCall().resolves(skills[1]);
+
+      const expectedTutorials = [
+        domainBuilder.buildTutorial({ id: 'tuto1' }),
+        domainBuilder.buildTutorial({ id: 'tuto2' }),
+        domainBuilder.buildTutorial({ id: 'tuto3' }),
+        domainBuilder.buildTutorial({ id: 'tuto4' }),
+      ];
+
+      const tutorialRepository = {
+        findByRecordIds: sinon.stub(),
+      };
+
+      tutorialRepository.findByRecordIds.onFirstCall().resolves([expectedTutorials[0], expectedTutorials[1]]);
+      tutorialRepository.findByRecordIds.onSecondCall().resolves([expectedTutorials[2], expectedTutorials[3]]);
+
+      // When
+      const tutorials = await findRecommendedTutorials({
+        userId,
+        knowledgeElementRepository,
+        skillRepository,
+        tutorialRepository,
+      });
+
+      //Then
+      expect(tutorialRepository.findByRecordIds.firstCall).to.have.been.calledWith(['tuto1', 'tuto2']);
+      expect(tutorialRepository.findByRecordIds.secondCall).to.have.been.calledWith(['tuto3', 'tuto4']);
+      expect(tutorials).to.deep.equal(expectedTutorials);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-saved-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-saved-tutorials_test.js
@@ -1,0 +1,84 @@
+const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const findSavedTutorials = require('../../../../lib/domain/usecases/find-saved-tutorials');
+
+describe('Unit | UseCase | find-saved-tutorials', function () {
+  let tutorialEvaluationRepository;
+  let userTutorialRepository;
+  const userId = 'userId';
+
+  context('when there is no tutorial saved by current user', function () {
+    beforeEach(function () {
+      tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
+      userTutorialRepository = { findWithTutorial: sinon.spy(async () => []) };
+    });
+
+    it('should call the userTutorialRepository', async function () {
+      // When
+      await findSavedTutorials({ tutorialEvaluationRepository, userTutorialRepository, userId });
+
+      // Then
+      expect(userTutorialRepository.findWithTutorial).to.have.been.calledWith({ userId });
+    });
+
+    it('should return an empty array', async function () {
+      // When
+      const tutorials = await findSavedTutorials({
+        tutorialEvaluationRepository,
+        userTutorialRepository,
+        userId,
+      });
+
+      // Then
+      expect(tutorials).to.deep.equal([]);
+    });
+  });
+
+  context('when there is one tutorial saved by current user', function () {
+    it('should return user-tutorials with tutorials', async function () {
+      // Given
+      const userTutorialWithTutorial = domainBuilder.buildUserTutorialWithTutorial();
+      tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
+      userTutorialRepository = { findWithTutorial: sinon.spy(async () => [userTutorialWithTutorial]) };
+
+      // When
+      const tutorials = await findSavedTutorials({
+        tutorialEvaluationRepository,
+        userTutorialRepository,
+        userId,
+      });
+
+      // Then
+      expect(tutorials).to.deep.equal([userTutorialWithTutorial]);
+    });
+
+    context('when user has evaluated a tutorial', function () {
+      it('should return user-tutorials with tutorials', async function () {
+        // Given
+        const userId = 456;
+        const tutorial = domainBuilder.buildTutorial();
+        const userTutorialWithTutorial = domainBuilder.buildUserTutorialWithTutorial({ userId, tutorial });
+        const tutorialEvaluation = {
+          id: 123,
+          userId,
+          tutorialId: tutorial.id,
+        };
+        tutorialEvaluationRepository = { find: sinon.spy(async () => [tutorialEvaluation]) };
+        userTutorialRepository = { findWithTutorial: sinon.spy(async () => [{ ...userTutorialWithTutorial }]) };
+
+        // When
+        const tutorials = await findSavedTutorials({
+          tutorialEvaluationRepository,
+          userTutorialRepository,
+          userId,
+        });
+
+        // Then
+        const expectedUserTutorialWithTutorial = {
+          ...userTutorialWithTutorial,
+          tutorial: { ...tutorial, tutorialEvaluation },
+        };
+        expect(tutorials).to.deep.equal([expectedUserTutorialWithTutorial]);
+      });
+    });
+  });
+});

--- a/mon-pix/app/adapters/tutorial.js
+++ b/mon-pix/app/adapters/tutorial.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class Tutorial extends ApplicationAdapter {
+  urlForQuery(query, ...args) {
+    if (query.type) {
+      const { type } = query;
+      delete query.type;
+      return `${this.host}/${this.namespace}/users/tutorials/${type}`;
+    }
+    return super.urlForQuery(query, ...args);
+  }
+}

--- a/mon-pix/app/components/tutorials/cards.hbs
+++ b/mon-pix/app/components/tutorials/cards.hbs
@@ -1,0 +1,5 @@
+<div class="user-tutorials-content-v2__container">
+  {{#each @tutorials as |tutorial|}}
+    <Tutorials::Card @tutorial={{tutorial}} />
+  {{/each}}
+</div>

--- a/mon-pix/app/routes/user-tutorials-v2/recommended.js
+++ b/mon-pix/app/routes/user-tutorials-v2/recommended.js
@@ -8,4 +8,8 @@ export default class UserTutorialsRecommendedRoute extends Route {
   redirect() {
     if (!this.featureToggles.featureToggles.isNewTutorialsPageEnabled) this.router.replaceWith('user-tutorials');
   }
+
+  model() {
+    return this.store.query('tutorial', { type: 'recommended' }, { reload: true });
+  }
 }

--- a/mon-pix/app/routes/user-tutorials-v2/saved.js
+++ b/mon-pix/app/routes/user-tutorials-v2/saved.js
@@ -8,9 +8,7 @@ export default class UserTutorialsSavedRoute extends Route {
     if (!this.featureToggles.featureToggles.isNewTutorialsPageEnabled) this.router.replaceWith('user-tutorials');
   }
 
-  async model() {
-    const userTutorials = await this.store.findAll('user-tutorial', { reload: true });
-    userTutorials.sortBy('updatedAt').reverse();
-    return userTutorials;
+  model() {
+    return this.store.query('tutorial', { type: 'saved' }, { reload: true });
   }
 }

--- a/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
@@ -1,3 +1,5 @@
-{{#each @model as |tutorial|}}
-  <Tutorials::Card @tutorial={{tutorial}} />
-{{/each}}
+<div class="user-tutorials-content-v2__container">
+  {{#each @model as |tutorial|}}
+    <Tutorials::Card @tutorial={{tutorial}} />
+  {{/each}}
+</div>

--- a/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
@@ -1,0 +1,3 @@
+{{#each @model as |tutorial|}}
+  <Tutorials::Card @tutorial={{tutorial}} />
+{{/each}}

--- a/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
@@ -1,5 +1,1 @@
-<div class="user-tutorials-content-v2__container">
-  {{#each @model as |tutorial|}}
-    <Tutorials::Card @tutorial={{tutorial}} />
-  {{/each}}
-</div>
+<Tutorials::Cards @tutorials={{@model}} />

--- a/mon-pix/app/templates/user-tutorials-v2/saved.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/saved.hbs
@@ -1,7 +1,7 @@
 {{#if @model}}
   <div class="user-tutorials-content-v2__container">
-    {{#each @model as |userTutorial|}}
-      <Tutorials::Card @tutorial={{userTutorial.tutorial}} />
+    {{#each @model as |tutorial|}}
+      <Tutorials::Card @tutorial={{tutorial}} />
     {{/each}}
   </div>
 {{else}}

--- a/mon-pix/app/templates/user-tutorials-v2/saved.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/saved.hbs
@@ -1,9 +1,5 @@
 {{#if @model}}
-  <div class="user-tutorials-content-v2__container">
-    {{#each @model as |tutorial|}}
-      <Tutorials::Card @tutorial={{tutorial}} />
-    {{/each}}
-  </div>
+  <Tutorials::Cards @tutorials={{@model}} />
 {{else}}
   <Tutorials::SavedEmpty />
 {{/if}}

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -23,6 +23,8 @@ import loadUserRoutes from './routes/users/index';
 import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import postSharedCertifications from './routes/post-shared-certifications';
 import loadUserTutorialsRoutes from './routes/get-user-tutorials';
+import loadSavedTutorialsRoutes from './routes/get-saved-tutorials';
+import loadRecommendedTutorialsRoutes from './routes/get-recommended-tutorials';
 
 /* eslint max-statements: off */
 export default function () {
@@ -43,6 +45,8 @@ export default function () {
   loadUserRoutes(this);
   loadAccountRecoveryRoutes(this);
   loadUserTutorialsRoutes(this);
+  loadSavedTutorialsRoutes(this);
+  loadRecommendedTutorialsRoutes(this);
 
   this.get('/assessments/:id/competence-evaluations', getCompetenceEvaluationsByAssessment);
 

--- a/mon-pix/mirage/routes/get-recommended-tutorials.js
+++ b/mon-pix/mirage/routes/get-recommended-tutorials.js
@@ -1,0 +1,5 @@
+export default function index(config) {
+  config.get('/users/tutorials/recommended', (schema) => {
+    return schema.tutorials.all();
+  });
+}

--- a/mon-pix/mirage/routes/get-saved-tutorials.js
+++ b/mon-pix/mirage/routes/get-saved-tutorials.js
@@ -1,0 +1,5 @@
+export default function index(config) {
+  config.get('/users/tutorials/saved', (schema) => {
+    return schema.tutorials.all();
+  });
+}

--- a/mon-pix/tests/acceptance/user-tutorials-v2/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/recommended_test.js
@@ -1,0 +1,29 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { visit, findAll } from '@ember/test-helpers';
+import { authenticateByEmail } from '../../helpers/authentication';
+
+describe('Acceptance | User-tutorials-v2 | Recommended', function () {
+  setupApplicationTest();
+  setupMirage();
+  let user;
+
+  beforeEach(async function () {
+    user = server.create('user', 'withEmail');
+    server.create('feature-toggle', { id: 0, isNewTutorialsPageEnabled: true });
+    await authenticateByEmail(user);
+    await server.db.tutorials.remove();
+    server.create('tutorial');
+    server.create('tutorial');
+  });
+
+  describe('When there are recommended tutorials', () => {
+    it('should display tutorial cards', async function () {
+      await visit('/mes-tutos-v2/recommandes');
+      expect(findAll('.tutorial-card-v2')).to.exist;
+      expect(findAll('.tutorial-card-v2')).to.be.lengthOf(2);
+    });
+  });
+});

--- a/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
@@ -1,0 +1,25 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { visit, find } from '@ember/test-helpers';
+import { authenticateByEmail } from '../../helpers/authentication';
+
+describe('Acceptance | User-tutorials-v2 | Saved', function () {
+  setupApplicationTest();
+  setupMirage();
+  let user;
+
+  beforeEach(async function () {
+    user = server.create('user', 'withEmail');
+    server.create('feature-toggle', { id: 0, isNewTutorialsPageEnabled: true });
+    await authenticateByEmail(user);
+  });
+
+  describe('When there are tutorials saved', () => {
+    it('should display tutorial cards', async function () {
+      await visit('/mes-tutos-v2/enregistres');
+      expect(find('.tutorial-card-v2')).to.exist;
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/tutorials/cards_test.js
+++ b/mon-pix/tests/integration/components/tutorials/cards_test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { find, findAll, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+describe('Integration | Component | Tutorials | Cards', function () {
+  setupIntlRenderingTest();
+
+  it('renders no cards if there are no tutorials', async function () {
+    // given
+    const tutorials = [];
+    this.set('tutorials', tutorials);
+
+    // when
+    await render(hbs`<Tutorials::Cards @tutorials={{this.tutorials}} />`);
+
+    // then
+    expect(find('.user-tutorials-content-v2__container')).to.exist;
+    expect(findAll('.tutorial-card-v2').length).to.equal(0);
+  });
+
+  it('renders a list of cards if there are tutorials', async function () {
+    // given
+    const tutorial1 = {
+      title: 'Mon super tutoriel',
+      link: 'https://exemple.net/',
+      source: 'mon-tuto',
+      format: 'vidéo',
+      duration: '00:01:00',
+      isEvaluated: true,
+      isSaved: true,
+    };
+
+    const tutorial2 = {
+      title: 'Mon deuxième super tutoriel',
+      link: 'https://exemple2.net/',
+      source: 'mon-tuto-2',
+      format: 'vidéo',
+      duration: '00:02:00',
+      isEvaluated: true,
+      isSaved: true,
+    };
+    const tutorials = [tutorial1, tutorial2];
+    this.set('tutorials', tutorials);
+
+    // when
+    await render(hbs`<Tutorials::Cards @tutorials={{this.tutorials}} />`);
+
+    // then
+    expect(find('.user-tutorials-content-v2__container')).to.exist;
+    expect(findAll('.tutorial-card-v2').length).to.equal(2);
+  });
+});

--- a/mon-pix/tests/unit/adapters/tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/tutorial_test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapters | Tutorial', function () {
+  setupTest();
+
+  describe('#urlForQuery', () => {
+    let adapter;
+
+    beforeEach(function () {
+      adapter = this.owner.lookup('adapter:tutorial');
+      adapter.ajax = sinon.stub().resolves();
+    });
+
+    it('should build the tutorial url if no type in query', async function () {
+      // when
+      const query = {};
+      const url = await adapter.urlForQuery(query, 'tutorial');
+
+      // then
+      expect(url.endsWith('/tutorials')).to.be.true;
+    });
+
+    it('should build the tutorial type url', async function () {
+      // when
+      const query = { type: 'recommended' };
+      const url = await adapter.urlForQuery(query, 'tutorial');
+
+      // then
+      expect(url.endsWith('users/tutorials/recommended')).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Aucune donnée ne s'affiche sur page des tutos recommandés.

## :robot: Solution

Récupérer et afficher les tutos recommandés pour l'utilisateur.

## :rainbow: Remarques

 - Un nouveau endpoint pour les tutos enregistrés V2 a été créé
 - L'ordre des tutos n'est pas garantie
 - Il est possible qu'on affiche des tutos correspondants à des KE qui ont été invalidés puis validés par le user
 - On ne supprime pas les tutos en doublon
 - Locale pas gérée ?

À synchro avec #4132

## :100: Pour tester

Aller sur la page des tutos recommandés.
