### PR TITLE
[TECH] Corriger les logs infinis lorsqu'on lance les tests unitaire en watch

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -127,7 +127,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
-    "test:api:unit": "TEST_DATABASE_URL=postgres://SHOULD_NOT_REACH_DB_IN_UNIT_TESTS REDIS_URL=redis://SHOULD_NOT_REACH_REDIS_IN_UNIT_TESTS npm run test:api:path -- tests/unit",
+    "test:api:unit": "TEST_DATABASE_URL=postgres://SHOULD_NOT_REACH_DB_IN_UNIT_TESTS REDIS_URL= npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on lance les tests unitaires en mode watch et qu'on fais un changement dans le code une liste de logs commence à défiler à l'infinis dans le terminal : 
![image](https://user-images.githubusercontent.com/38167520/155696813-6ad6802f-7f22-4287-b2a8-cf066eea1489.png)

## 🕵🏻 Enquête by JOP
> En fait comme on met une `REDIS_URL` dans l'environnement ça active la connexion à un serveur Redis.
> `temporary-storage/index.js` instancie un singleton dès le chargement du module, n'importe quel `require` direct ou indirecte de ce fichier va exécuter le code qui essaie de se connecter à Redis si la config donne une URL de connexion.

## :robot: Solution
Enlever le contenu de la variable `REDIS_URL` dans le script pour lancer les tests.

## :rainbow: Remarques
Voir : https://github.com/1024pix/pix/blob/dev/api/lib/infrastructure/temporary-storage/index.js
Lien du thread original sur le sujet : https://1024pix.slack.com/archives/C658LDBAQ/p1644501725012859 

## :100: Pour tester
Ouvrir un terminal et lancer les tests unitaires : 
- `npm run test:api:unit -- --watch` 
- Effectuer un changement dans le code qui relance les tests
- Constater qu'il n'y a que quelques logs et que mocha attends de nouveaux changements pour relancer les tests
<img width="714" alt="image" src="https://user-images.githubusercontent.com/38167520/155697113-37521807-d0a7-4eb9-a2b6-5f9f950bc018.png">

