### PR TITLE
[FEATURE] Utiliser seulement les données du prescrit côté Pix Orga (PIX-4387).

### DIFF
--- a/api/db/database-builder/factory/build-assessment-from-participation.js
+++ b/api/db/database-builder/factory/build-assessment-from-participation.js
@@ -1,10 +1,16 @@
 const buildAssessment = require('./build-assessment');
 const buildUser = require('./build-user');
 const buildCampaignParticipation = require('./build-campaign-participation');
+const buildSchoolingRegistration = require('./build-schooling-registration');
 
-module.exports = function buildAssessmentFromParticipation(campaignParticipation, participant) {
-  const userId = buildUser(participant).id;
-  const campaignParticipationId = buildCampaignParticipation({ ...campaignParticipation, userId }).id;
+module.exports = function buildAssessmentFromParticipation(campaignParticipation, schoolingRegistration, user) {
+  const userId = buildUser(user).id;
+  const schoolingRegistrationId = buildSchoolingRegistration(schoolingRegistration).id;
+  const campaignParticipationId = buildCampaignParticipation({
+    ...campaignParticipation,
+    userId,
+    schoolingRegistrationId,
+  }).id;
 
   return buildAssessment({ userId, campaignParticipationId });
 };

--- a/api/db/database-builder/factory/build-campaign-participation-with-schooling-registration.js
+++ b/api/db/database-builder/factory/build-campaign-participation-with-schooling-registration.js
@@ -3,8 +3,12 @@ const buildCampaignParticipation = require('./build-campaign-participation');
 const buildSchoolingRegistrationWithUser = require('./build-schooling-registration-with-user');
 
 module.exports = (schoolingRegistration, campaignParticipation, withAssessment) => {
-  const { userId } = buildSchoolingRegistrationWithUser(schoolingRegistration);
-  const campaignParticipationCreated = buildCampaignParticipation({ userId, ...campaignParticipation });
+  const { userId, id: schoolingRegistrationId } = buildSchoolingRegistrationWithUser(schoolingRegistration);
+  const campaignParticipationCreated = buildCampaignParticipation({
+    userId,
+    schoolingRegistrationId,
+    ...campaignParticipation,
+  });
   if (withAssessment) {
     buildAssessment({ userId, campaignParticipationId: campaignParticipationCreated.id });
   }

--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -319,7 +319,7 @@ function _buildParticipations({ databaseBuilder }) {
 function _buildUsers({ databaseBuilder, users }) {
   return users.map((user) => {
     const databaseUser = databaseBuilder.factory.buildUser.withRawPassword({ ...user, rawPassword: DEFAULT_PASSWORD });
-    databaseBuilder.factory.buildSchoolingRegistration({ ...user, id: databaseUser.id, userId: databaseUser.id, organizationId: PRO_COMPANY_ID });
+    databaseBuilder.factory.buildSchoolingRegistration({ firstName: user.firstName + '-Prescrit', lastName: user.lastName + '-Prescrit', id: databaseUser.id, userId: databaseUser.id, organizationId: PRO_COMPANY_ID });
     return databaseUser;
   });
 }
@@ -346,7 +346,7 @@ function _buildAssessmentParticipations({ databaseBuilder, users }) {
     const campaignParticipationId = participateToAssessmentCampaign({ databaseBuilder, campaignId: 1, user, schoolingRegistrationId: user.id, status: TO_SHARE });
     databaseBuilder.factory.buildBadgeAcquisition({ userId: user.id, badgeId: PRO_BASICS_BADGE_ID, campaignParticipationId });
   });
-  userIdsCompletedShared.forEach((user) => participateToAssessmentCampaign({ databaseBuilder, campaignId: 1, user, status: SHARED }));
+  userIdsCompletedShared.forEach((user) => participateToAssessmentCampaign({ databaseBuilder, campaignId: 1, user, schoolingRegistrationId: user.id, status: SHARED }));
   userIdsCompletedShared2.forEach((user) => {
     const campaignParticipationId = participateToAssessmentCampaign({ databaseBuilder, campaignId: 1, user, schoolingRegistrationId: user.id, status: SHARED });
     databaseBuilder.factory.buildBadgeAcquisition({ userId: user.id, badgeId: PRO_TOOLS_BADGE_ID, campaignParticipationId });
@@ -374,8 +374,8 @@ function _buildProfilesCollectionParticipations({ databaseBuilder, users }) {
   const certifRegularUser4 = { id: CERTIF_REGULAR_USER4_ID, createdAt: new Date('2022-02-06') };
   const certifRegularUser5 = { id: CERTIF_REGULAR_USER5_ID, createdAt: new Date('2022-02-07') };
 
-  [certifRegularUser1, certifRegularUser2, certifRegularUser3, certifRegularUser4, certifRegularUser5].map((certifUser) => {
-    databaseBuilder.factory.buildSchoolingRegistration({ ...certifUser, userId: certifUser.id, organizationId: PRO_COMPANY_ID });
+  [certifRegularUser1, certifRegularUser2, certifRegularUser3, certifRegularUser4, certifRegularUser5].map((certifUser, index) => {
+    databaseBuilder.factory.buildSchoolingRegistration({ lastName: `Certif${index}`, firstName: `User${index}`, id: certifUser.id, userId: certifUser.id, organizationId: PRO_COMPANY_ID });
   });
 
   [...userIdsNotShared, certifRegularUser4, certifRegularUser5].forEach((user) => participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 6, user, schoolingRegistrationId: user.id, status: TO_SHARE }));

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-repository.js
@@ -22,9 +22,9 @@ async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campa
   const [campaignAssessmentParticipation] = await knex
     .with('campaignAssessmentParticipation', (qb) => {
       qb.select([
-        'users.id AS userId',
-        knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-        knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+        'campaign-participations.userId',
+        'schooling-registrations.firstName',
+        'schooling-registrations.lastName',
         'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.campaignId',
         'campaign-participations.createdAt',
@@ -37,14 +37,11 @@ async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campa
       ])
         .from('campaign-participations')
         .join('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
-        .join('users', 'users.id', 'campaign-participations.userId')
-        .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-        .leftJoin('schooling-registrations', function () {
-          this.on('campaign-participations.userId', 'schooling-registrations.userId').andOn(
-            'campaigns.organizationId',
-            'schooling-registrations.organizationId'
-          );
-        })
+        .join(
+          'schooling-registrations',
+          'schooling-registrations.id',
+          'campaign-participations.schoolingRegistrationId'
+        )
         .where({
           'campaign-participations.id': campaignParticipationId,
         });

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -33,21 +33,15 @@ function _getParticipantsResultList(campaignId, targetProfile, filters) {
 
 function _getParticipations(qb, campaignId, targetProfile, filters) {
   qb.select(
-    knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-    knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+    'schooling-registrations.firstName',
+    'schooling-registrations.lastName',
     'campaign-participations.participantExternalId',
     'campaign-participations.masteryRate',
     'campaign-participations.id AS campaignParticipationId',
-    'users.id AS userId'
+    'campaign-participations.userId'
   )
     .from('campaign-participations')
-    .join('users', 'users.id', 'campaign-participations.userId')
-    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .leftJoin('schooling-registrations', function () {
-      this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' }).andOn({
-        'campaigns.organizationId': 'schooling-registrations.organizationId',
-      });
-    })
+    .join('schooling-registrations', 'schooling-registrations.id', 'campaign-participations.schoolingRegistrationId')
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.status', '=', SHARED)
     .where('campaign-participations.isImproved', '=', false)

--- a/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -20,22 +20,17 @@ const campaignParticipantActivityRepository = {
 function _buildCampaignParticipationByParticipant(qb, campaignId, filters) {
   qb.select(
     'campaign-participations.id AS campaignParticipationId',
-    'users.id AS userId',
-    knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-    knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+    'campaign-participations.userId',
+    'schooling-registrations.firstName',
+    'schooling-registrations.lastName',
     'campaign-participations.participantExternalId',
     'campaign-participations.sharedAt',
     'campaign-participations.status',
     'campaigns.type AS campaignType'
   )
     .from('campaign-participations')
-    .join('users', 'users.id', 'campaign-participations.userId')
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .leftJoin('schooling-registrations', function () {
-      this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' }).andOn({
-        'campaigns.organizationId': 'schooling-registrations.organizationId',
-      });
-    })
+    .join('schooling-registrations', 'schooling-registrations.id', 'campaign-participations.schoolingRegistrationId')
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
     .modify(_filterByDivisions, filters)

--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -10,22 +10,19 @@ module.exports = {
           'campaign-participations.*',
           'assessments.state',
           _assessmentRankByCreationDate(),
-          knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-          knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+          'schooling-registrations.firstName',
+          'schooling-registrations.lastName',
           'schooling-registrations.studentNumber',
           'schooling-registrations.division',
           'schooling-registrations.group',
         ])
           .from('campaign-participations')
-          .join('users', 'campaign-participations.userId', 'users.id')
           .join('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
-          .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-          .leftJoin('schooling-registrations', function () {
-            this.on('schooling-registrations.userId', 'campaign-participations.userId').andOn(
-              'schooling-registrations.organizationId',
-              'campaigns.organizationId'
-            );
-          })
+          .join(
+            'schooling-registrations',
+            'schooling-registrations.id',
+            'campaign-participations.schoolingRegistrationId'
+          )
           .where({ campaignId: campaignId, isImproved: false });
       })
       .from('campaignParticipationWithUserAndRankedAssessment')

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -55,17 +55,15 @@ module.exports = {
           'schooling-registrations.studentNumber',
           'schooling-registrations.division',
           'schooling-registrations.group',
-          knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-          knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+          'schooling-registrations.firstName',
+          'schooling-registrations.lastName',
         ])
           .from('campaign-participations')
-          .leftJoin('users', 'campaign-participations.userId', 'users.id')
-          .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
-          .leftJoin('schooling-registrations', function () {
-            this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' }).andOn({
-              'campaigns.organizationId': 'schooling-registrations.organizationId',
-            });
-          })
+          .join(
+            'schooling-registrations',
+            'schooling-registrations.id',
+            'campaign-participations.schoolingRegistrationId'
+          )
           .where({ campaignId, isImproved: false });
       })
       .from('campaignParticipationWithUser');

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -23,9 +23,9 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
   const [profile] = await knex
     .with('campaignProfile', (qb) => {
       qb.select([
-        'users.id AS userId',
-        knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-        knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+        'campaign-participations.userId',
+        'schooling-registrations.firstName',
+        'schooling-registrations.lastName',
         'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.campaignId',
         'campaign-participations.createdAt',
@@ -35,13 +35,11 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
         'campaign-participations.pixScore',
       ])
         .from('campaign-participations')
-        .leftJoin('users', 'campaign-participations.userId', 'users.id')
-        .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
-        .leftJoin('schooling-registrations', function () {
-          this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' }).andOn({
-            'campaigns.organizationId': 'schooling-registrations.organizationId',
-          });
-        })
+        .join(
+          'schooling-registrations',
+          'schooling-registrations.id',
+          'campaign-participations.schoolingRegistrationId'
+        )
         .where({
           campaignId,
           'campaign-participations.id': campaignParticipationId,

--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -12,27 +12,17 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
     const query = knex
       .select(
         'campaign-participations.id AS campaignParticipationId',
-        'users.id as userId',
-        knex.raw(
-          'COALESCE (LOWER("schooling-registrations"."firstName"), LOWER("users"."firstName")) AS "lowerFirstName"'
-        ),
-        knex.raw(
-          'COALESCE (LOWER("schooling-registrations"."lastName"), LOWER("users"."lastName")) AS "lowerLastName"'
-        ),
-        knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
-        knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
+        'campaign-participations.userId AS userId',
+        knex.raw('LOWER("schooling-registrations"."firstName") AS "lowerFirstName"'),
+        knex.raw('LOWER("schooling-registrations"."lastName") AS "lowerLastName"'),
+        'schooling-registrations.firstName AS firstName',
+        'schooling-registrations.lastName AS lastName',
         'campaign-participations.participantExternalId',
         'campaign-participations.sharedAt',
         'campaign-participations.pixScore AS pixScore'
       )
       .from('campaign-participations')
-      .join('users', 'users.id', 'campaign-participations.userId')
-      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-      .leftJoin('schooling-registrations', function () {
-        this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' }).andOn({
-          'campaigns.organizationId': 'schooling-registrations.organizationId',
-        });
-      })
+      .join('schooling-registrations', 'schooling-registrations.id', 'campaign-participations.schoolingRegistrationId')
       .where('campaign-participations.campaignId', '=', campaignId)
       .where('campaign-participations.isImproved', '=', false)
       .whereRaw('"campaign-participations"."sharedAt" IS NOT NULL')

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1163,9 +1163,9 @@ describe('Acceptance | API | Campaign Controller', function () {
   });
 
   describe('GET /api/campaigns/{id}/participants-activity', function () {
-    const participant1 = { firstName: 'John', lastName: 'McClane', id: 12, email: 'john.mclane@die.hard' };
-    const participant2 = { firstName: 'Holly', lastName: 'McClane', id: 13, email: 'holly.mclane@die.hard' };
-    const participant3 = { firstName: 'Mary', lastName: 'McClane', id: 14, email: 'mary.mclane@die.hard' };
+    const participant1 = { firstName: 'John', lastName: 'McClane', division: '5eme' };
+    const participant2 = { firstName: 'Holly', lastName: 'McClane', division: '4eme' };
+    const participant3 = { firstName: 'Mary', lastName: 'McClane', group: 'L1' };
 
     let campaign;
     let userId;
@@ -1174,7 +1174,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       userId = databaseBuilder.factory.buildUser().id;
       const organization = databaseBuilder.factory.buildOrganization();
 
-      campaign = databaseBuilder.factory.buildAssessmentCampaign({ organizationId: organization.id });
+      campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
 
       databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
 
@@ -1183,34 +1183,14 @@ describe('Acceptance | API | Campaign Controller', function () {
         campaignId: campaign.id,
       };
 
-      databaseBuilder.factory.buildAssessmentFromParticipation(campaignParticipation, participant1);
-      databaseBuilder.factory.buildSchoolingRegistration({
-        organizationId: organization.id,
-        division: '5eme',
-        firstName: 'John',
-        lastName: 'McClane',
-        userId: participant1.id,
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(participant1, campaignParticipation);
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(participant2, {
+        campaignId: campaign.id,
+        status: STARTED,
       });
-      databaseBuilder.factory.buildAssessmentFromParticipation(
-        { campaignId: campaign.id, status: STARTED },
-        participant2
-      );
-      databaseBuilder.factory.buildSchoolingRegistration({
-        organizationId: organization.id,
-        division: '4eme',
-        firstName: 'Holly',
-        lastName: 'McClane',
-        userId: participant2.id,
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(participant3, {
+        campaignId: campaign.id,
       });
-      databaseBuilder.factory.buildAssessmentFromParticipation({ campaignId: campaign.id }, participant3);
-      databaseBuilder.factory.buildSchoolingRegistration({
-        organizationId: organization.id,
-        group: 'L1',
-        firstName: 'Mary',
-        lastName: 'McClane',
-        userId: participant3.id,
-      });
-
       return databaseBuilder.commit();
     });
 

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -783,25 +783,29 @@ describe('Acceptance | API | Campaign Controller', function () {
             targetProfileId: targetProfile.id,
           });
 
-          const participantId1 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId1 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Barry',
-            lastName: 'White',
-            organizationId: organization.id,
-            userId: participantId1,
-            division: 'Division Barry',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Barry',
+              lastName: 'White',
+              organizationId: organization.id,
+              division: 'Division Barry',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
-          const participantId2 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId2 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Marvin',
-            lastName: 'Gaye',
-            organizationId: organization.id,
-            userId: participantId2,
-            division: 'Division Marvin',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Marvin',
+              lastName: 'Gaye',
+              organizationId: organization.id,
+              division: 'Division Marvin',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
           await databaseBuilder.commit();
 
@@ -842,35 +846,41 @@ describe('Acceptance | API | Campaign Controller', function () {
             targetProfileId: targetProfile.id,
           });
 
-          const participantId1 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId1 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Barry',
-            lastName: 'White',
-            organizationId: organization.id,
-            userId: participantId1,
-            division: 'Division Barry',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Barry',
+              lastName: 'White',
+              organizationId: organization.id,
+              division: 'Division Barry',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
-          const participantId2 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId2 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Marvin',
-            lastName: 'Gaye',
-            organizationId: organization.id,
-            userId: participantId2,
-            division: 'Division Marvin',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Marvin',
+              lastName: 'Gaye',
+              organizationId: organization.id,
+              division: 'Division Marvin',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
-          const participantId3 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId3 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Aretha',
-            lastName: 'Franklin',
-            organizationId: organization.id,
-            userId: participantId3,
-            division: 'Division Aretha',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Aretha',
+              lastName: 'Franklin',
+              organizationId: organization.id,
+              division: 'Division Aretha',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
           await databaseBuilder.commit();
 
@@ -914,25 +924,29 @@ describe('Acceptance | API | Campaign Controller', function () {
             targetProfileId: targetProfile.id,
           });
 
-          const participantId1 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId1 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Barry',
-            lastName: 'White',
-            organizationId: organization.id,
-            userId: participantId1,
-            group: 'L1',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Barry',
+              lastName: 'White',
+              organizationId: organization.id,
+              group: 'L1',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
-          const participantId2 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId2 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Marvin',
-            lastName: 'Gaye',
-            organizationId: organization.id,
-            userId: participantId2,
-            group: 'L2',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Marvin',
+              lastName: 'Gaye',
+              organizationId: organization.id,
+              group: 'L2',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
           await databaseBuilder.commit();
 
@@ -973,35 +987,41 @@ describe('Acceptance | API | Campaign Controller', function () {
             targetProfileId: targetProfile.id,
           });
 
-          const participantId1 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId1 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Barry',
-            lastName: 'White',
-            organizationId: organization.id,
-            userId: participantId1,
-            group: 'L1',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Barry',
+              lastName: 'White',
+              organizationId: organization.id,
+              group: 'L1',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
-          const participantId2 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId2 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Marvin',
-            lastName: 'Gaye',
-            organizationId: organization.id,
-            userId: participantId2,
-            group: 'L2',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Marvin',
+              lastName: 'Gaye',
+              organizationId: organization.id,
+              group: 'L2',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
-          const participantId3 = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: participantId3 });
-          databaseBuilder.factory.buildSchoolingRegistration({
-            firstName: 'Aretha',
-            lastName: 'Franklin',
-            organizationId: organization.id,
-            userId: participantId3,
-            group: 'L3',
-          });
+          databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+            {
+              firstName: 'Aretha',
+              lastName: 'Franklin',
+              organizationId: organization.id,
+              group: 'L3',
+            },
+            {
+              campaignId: campaign.id,
+            }
+          );
 
           await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-find-shared-participations_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-find-shared-participations_test.js
@@ -56,22 +56,26 @@ describe('Acceptance | API | Campaign Participations | Results', function () {
         campaignId: campaign.id,
       };
 
-      databaseBuilder.factory.buildAssessmentFromParticipation(campaignParticipation, participant1);
-      databaseBuilder.factory.buildSchoolingRegistration({
-        organizationId: organization.id,
-        division: '5eme',
-        firstName: 'John',
-        lastName: 'McClane',
-        userId: participant1.id,
-      });
-      databaseBuilder.factory.buildAssessmentFromParticipation(campaignParticipation, participant2);
-      databaseBuilder.factory.buildSchoolingRegistration({
-        organizationId: organization.id,
-        division: '4eme',
-        firstName: 'Holly',
-        lastName: 'McClane',
-        userId: participant2.id,
-      });
+      databaseBuilder.factory.buildAssessmentFromParticipation(
+        campaignParticipation,
+        {
+          organizationId: organization.id,
+          division: '5eme',
+          firstName: 'John',
+          lastName: 'McClane',
+        },
+        participant1
+      );
+      databaseBuilder.factory.buildAssessmentFromParticipation(
+        campaignParticipation,
+        {
+          organizationId: organization.id,
+          division: '4eme',
+          firstName: 'Holly',
+          lastName: 'McClane',
+        },
+        participant2
+      );
 
       return databaseBuilder.commit();
     });

--- a/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
+++ b/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
@@ -31,7 +31,7 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
   context('when requesting user is allowed to access campaign', function () {
     beforeEach(async function () {
       databaseBuilder.factory.buildMembership({ organizationId, userId });
-      databaseBuilder.factory.buildAssessmentFromParticipation({
+      databaseBuilder.factory.buildCampaignParticipation({
         participantExternalId: 'Ashitaka',
         campaignId,
       });
@@ -53,14 +53,13 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
       databaseBuilder.factory.buildMembership({ organizationId, userId });
 
       const participation1 = { participantExternalId: 'Yubaba', campaignId };
-      const participant1 = { id: 456, firstName: 'Chihiro', lastName: 'Ogino' };
-      databaseBuilder.factory.buildAssessmentFromParticipation(participation1, participant1);
-      databaseBuilder.factory.buildSchoolingRegistration({ userId: participant1.id, organizationId, division: '6eme' });
+      const participant1 = { firstName: 'Chihiro', lastName: 'Ogino', division: '6eme' };
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(participant1, participation1);
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: participant1.id, organizationId });
 
       const participation2 = { participantExternalId: 'Meï', campaignId };
-      const participant2 = { id: 457, firstName: 'Tonari', lastName: 'No Totoro' };
-      databaseBuilder.factory.buildAssessmentFromParticipation(participation2, participant2);
-      databaseBuilder.factory.buildSchoolingRegistration({ userId: participant2.id, organizationId, division: '5eme' });
+      const participant2 = { firstName: 'Tonari', lastName: 'No Totoro', division: '5eme' };
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(participant2, participation2);
 
       await databaseBuilder.commit();
     });

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -29,14 +29,13 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     let participant;
     let campaign;
     let campaignParticipation;
+    let schoolingRegistration;
     let writableStream;
     let csvPromise;
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const i18n = getI18n();
+    let i18n;
 
     beforeEach(async function () {
+      i18n = getI18n();
       organization = databaseBuilder.factory.buildOrganization({ showSkills: true });
       user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
@@ -56,7 +55,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
       });
       domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1] });
 
-      participant = databaseBuilder.factory.buildUser({ firstName: '@Jean', lastName: '=Bono' });
+      participant = databaseBuilder.factory.buildUser();
       const createdAt = new Date('2019-02-25T10:00:00Z');
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
@@ -101,14 +100,18 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         targetProfileId: targetProfile.id,
       });
 
-      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-        createdAt,
-        sharedAt: new Date('2019-03-01T23:04:05Z'),
-        participantExternalId: '+Mon mail pro',
-        campaignId: campaign.id,
-        userId: participant.id,
-        masteryRate: 0.67,
-      });
+      schoolingRegistration = { firstName: '@Jean', lastName: '=Bono' };
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+        schoolingRegistration,
+        {
+          createdAt,
+          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          participantExternalId: '+Mon mail pro',
+          campaignId: campaign.id,
+          userId: participant.id,
+          masteryRate: 0.67,
+        }
+      );
       databaseBuilder.factory.buildAssessment({
         campaignParticipationId: campaignParticipation.id,
         userId: participant.id,
@@ -152,8 +155,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         `${campaign.id};` +
         `"'${campaign.name}";` +
         `"'${targetProfile.name}";` +
-        `"'${participant.lastName}";` +
-        `"'${participant.firstName}";` +
+        `"'${schoolingRegistration.lastName}";` +
+        `"'${schoolingRegistration.firstName}";` +
         `"'${campaignParticipation.participantExternalId}";` +
         '1;' +
         '2019-02-25;' +

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -132,14 +132,18 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           title: null,
         });
 
-        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-          createdAt,
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
-          participantExternalId: '+Mon mail pro',
-          campaignId: campaign.id,
-          userId: participant.id,
-          pixScore: 52,
-        });
+        schoolingRegistration = { firstName: '@Jean', lastName: '=Bono' };
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          schoolingRegistration,
+          {
+            createdAt,
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            participantExternalId: '+Mon mail pro',
+            campaignId: campaign.id,
+            userId: participant.id,
+            pixScore: 52,
+          }
+        );
 
         await databaseBuilder.commit();
       });
@@ -151,8 +155,8 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           `"${organization.name}";` +
           `${campaign.id};` +
           `"'${campaign.name}";` +
-          `"${participant.lastName}";` +
-          `"${participant.firstName}";` +
+          `"'${schoolingRegistration.lastName}";` +
+          `"'${schoolingRegistration.firstName}";` +
           `"'${campaignParticipation.participantExternalId}";` +
           '"Oui";' +
           '2019-03-01;' +
@@ -217,6 +221,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
           userId: participant.id,
+          schoolingRegistrationId: schoolingRegistration.id,
           pixScore: 52,
         });
 
@@ -298,6 +303,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
           userId: participant.id,
+          schoolingRegistrationId: schoolingRegistration.id,
           pixScore: 52,
         });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -37,7 +37,6 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
             ...participation,
             campaignId,
           },
-          {},
           participant
         );
         campaignParticipationId = assessment.campaignParticipationId;
@@ -235,9 +234,16 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         campaignId = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId }, [skill]).id;
         const userId = databaseBuilder.factory.buildUser().id;
 
+        const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          userId,
+          firstName: 'John',
+          lastName: 'Doe',
+        }).id;
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
           userId,
+          schoolingRegistrationId,
           sharedAt: new Date('2020-12-12'),
         }).id;
 
@@ -247,12 +253,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
           createdAt: new Date('2020-10-10'),
           state: Assessment.states.COMPLETED,
         });
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId,
-          userId,
-          firstName: 'John',
-          lastName: 'Doe',
-        });
+
         databaseBuilder.factory.buildSchoolingRegistration({
           organizationId: otherOrganizationId,
           userId,

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -37,25 +37,16 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
             ...participation,
             campaignId,
           },
+          {},
           participant
         );
         campaignParticipationId = assessment.campaignParticipationId;
         userId = assessment.userId;
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          {
-            campaignId,
-          },
-          {}
-        );
+        databaseBuilder.factory.buildAssessmentFromParticipation({ campaignId });
 
         const otherCampaign = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          {
-            campaignId: otherCampaign.id,
-          },
-          {}
-        );
+        databaseBuilder.factory.buildAssessmentFromParticipation({ campaignId: otherCampaign.id });
 
         await databaseBuilder.commit();
       });
@@ -145,14 +136,11 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         const skill1 = { id: 'skill1', status: 'actif' };
         mockLearningContent({ skills: [skill1] });
         campaignId = databaseBuilder.factory.buildAssessmentCampaign({}, [skill1]).id;
-        campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation(
-          {
-            status: STARTED,
-            sharedAt: null,
-            campaignId,
-          },
-          {}
-        ).campaignParticipationId;
+        campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation({
+          status: STARTED,
+          sharedAt: null,
+          campaignId,
+        }).campaignParticipationId;
 
         await databaseBuilder.commit();
       });

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -128,17 +128,16 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
 
-        const { userId } = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-        });
-
-        databaseBuilder.factory.buildSchoolingRegistration({
-          firstName: 'Joe',
-          lastName: 'Le taxi',
-          organizationId: campaign.organizationId,
-          userId,
-        });
-
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          {
+            firstName: 'Joe',
+            lastName: 'Le taxi',
+            organizationId: campaign.organizationId,
+          },
+          {
+            campaignId: campaign.id,
+          }
+        );
         await databaseBuilder.commit();
 
         const learningContent = [
@@ -170,53 +169,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         expect(participations[0]).to.include({
           firstName: 'Joe',
           lastName: 'Le taxi',
-        });
-      });
-    });
-
-    context('when there are no schooling registrations', function () {
-      beforeEach(async function () {
-        campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
-        const { id: userId } = databaseBuilder.factory.buildUser({
-          firstName: 'Jane',
-          lastName: 'Le uber',
-        });
-        databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          userId,
-        });
-
-        await databaseBuilder.commit();
-
-        const learningContent = [
-          {
-            id: 'recArea1',
-            competences: [
-              {
-                id: 'recCompetence1',
-                tubes: [
-                  {
-                    id: 'recTube1',
-                    skills: [{ id: 'Skill1', name: '@Acquis1', challenges: [] }],
-                  },
-                ],
-              },
-            ],
-          },
-        ];
-        const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
-        mockLearningContent(learningContentObjects);
-      });
-
-      it('returns the name from the schooling registration', async function () {
-        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
-          campaignId: campaign.id,
-        });
-
-        expect(participations).to.have.lengthOf(1);
-        expect(participations[0]).to.include({
-          firstName: 'Jane',
-          lastName: 'Le uber',
         });
       });
     });
@@ -338,12 +290,12 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignParticipation,
           true
         );
-        databaseBuilder.factory.buildCampaignParticipationWithUser(
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
           { firstName: 'Jiji', lastName: 'Le riquiqui', organizationId },
           campaignParticipation,
           true
         );
-        databaseBuilder.factory.buildCampaignParticipationWithUser(
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
           { firstName: 'Jojo', lastName: 'le rococo', organizationId },
           campaignParticipation,
           true

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -394,8 +394,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
         };
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation, {});
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation, {});
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation);
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation);
 
         await databaseBuilder.commit();
 
@@ -442,7 +442,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           };
 
           for (let i = 0; i < 11; i++) {
-            databaseBuilder.factory.buildAssessmentFromParticipation(participation, {});
+            databaseBuilder.factory.buildAssessmentFromParticipation(participation);
           }
 
           await databaseBuilder.commit();
@@ -488,11 +488,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           participantExternalId: 'The good',
           campaignId: campaign.id,
         };
-
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, {
           organizationId: campaign.organizationId,
-          userId: 1,
           division: 'Good Guys Team',
         });
 
@@ -500,11 +497,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           participantExternalId: 'The bad',
           campaignId: campaign.id,
         };
-
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, {
           organizationId: campaign.organizationId,
-          userId: 2,
           division: 'Bad Guys Team',
         });
 
@@ -513,10 +507,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
         };
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, { id: 3 });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, {
           organizationId: campaign.organizationId,
-          userId: 3,
           division: 'Ugly Guys Team',
         });
 
@@ -752,22 +744,26 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           threshold: 25,
         });
         databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold: 75 });
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { masteryRate: 0, participantExternalId: 'Juste Before', campaignId: campaign.id },
-          { id: 1 }
-        );
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { masteryRate: 0.25, participantExternalId: 'Stage Reached Boundary IN', campaignId: campaign.id },
-          { id: 2 }
-        );
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { masteryRate: 0.74, participantExternalId: 'Stage Reached Boundary OUT', campaignId: campaign.id },
-          { id: 3 }
-        );
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { masteryRate: 0.75, participantExternalId: 'Just After', campaignId: campaign.id },
-          { id: 4 }
-        );
+        databaseBuilder.factory.buildAssessmentFromParticipation({
+          masteryRate: 0,
+          participantExternalId: 'Juste Before',
+          campaignId: campaign.id,
+        });
+        databaseBuilder.factory.buildAssessmentFromParticipation({
+          masteryRate: 0.25,
+          participantExternalId: 'Stage Reached Boundary IN',
+          campaignId: campaign.id,
+        });
+        databaseBuilder.factory.buildAssessmentFromParticipation({
+          masteryRate: 0.74,
+          participantExternalId: 'Stage Reached Boundary OUT',
+          campaignId: campaign.id,
+        });
+        databaseBuilder.factory.buildAssessmentFromParticipation({
+          masteryRate: 0.75,
+          participantExternalId: 'Just After',
+          campaignId: campaign.id,
+        });
         await databaseBuilder.commit();
 
         // when
@@ -837,10 +833,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
         };
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, {
           organizationId: campaign.organizationId,
-          userId: 1,
           group: 'Bad Puns Team',
         });
 
@@ -849,10 +843,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
         };
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, {
           organizationId: campaign.organizationId,
-          userId: 2,
           group: 'Royal Guard',
         });
 
@@ -861,10 +853,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           campaignId: campaign.id,
         };
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, { id: 3 });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, {
           organizationId: campaign.organizationId,
-          userId: 3,
           group: 'Adoptive Brother',
         });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -9,22 +9,22 @@ describe('Integration | Repository | Campaign Participant activity', function ()
   describe('#findPaginatedByCampaignId', function () {
     let campaign;
 
-    context('When there is an assessment for another campaign', function () {
+    context('When there is participations for another campaign', function () {
       beforeEach(async function () {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+        campaign = databaseBuilder.factory.buildCampaign();
         const otherCampaign = databaseBuilder.factory.buildCampaign();
 
-        databaseBuilder.factory.buildAssessmentFromParticipation({
+        databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'The good',
           campaignId: campaign.id,
         });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation({
+        databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'The bad',
           campaignId: otherCampaign.id,
         });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation({
+        databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'The ugly',
           campaignId: campaign.id,
         });
@@ -44,10 +44,10 @@ describe('Integration | Repository | Campaign Participant activity', function ()
     context('When there are several participations for the same participant', function () {
       it('Returns one CampaignParticipantActivity with the most recent participation (isImproved = false)', async function () {
         //Given
-        const campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+        const campaign = databaseBuilder.factory.buildCampaign();
         const user = databaseBuilder.factory.buildUser();
 
-        databaseBuilder.factory.buildAssessmentFromParticipation({
+        databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'The bad',
           campaignId: campaign.id,
           status: STARTED,
@@ -55,7 +55,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           isImproved: true,
         });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation({
+        databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'The good',
           campaignId: campaign.id,
           status: STARTED,
@@ -127,22 +127,22 @@ describe('Integration | Repository | Campaign Participant activity', function ()
     });
 
     context('order', function () {
-      it('should return participants activities ordered by last name then first name asc (including schooling registration data)', async function () {
+      it('should return participants activities ordered by last name then first name asc from schooling-registration', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({ organizationId });
+        campaign = databaseBuilder.factory.buildCampaign({ organizationId });
         const campaignParticipation = { campaignId: campaign.id };
         databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
           { firstName: 'Jaja', lastName: 'Le raplapla', organizationId },
           campaignParticipation,
           true
         );
-        databaseBuilder.factory.buildCampaignParticipationWithUser(
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
           { firstName: 'jiji', lastName: 'Le riquiqui', organizationId },
           campaignParticipation,
           true
         );
-        databaseBuilder.factory.buildCampaignParticipationWithUser(
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
           { firstName: 'Jojo', lastName: 'Le rococo', organizationId },
           campaignParticipation,
           true
@@ -167,37 +167,21 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('when there is a filter on division', function () {
       it('returns participants which have the correct division', async function () {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
-
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The good', campaignId: campaign.id },
-          { id: 1 }
+        campaign = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, division: 'Good Guys Team' },
+          { participantExternalId: 'The good', campaignId: campaign.id }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          userId: 1,
-          division: 'Good Guys Team',
-        });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The bad', campaignId: campaign.id },
-          { id: 2 }
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, division: 'Bad Guys Team' },
+          { participantExternalId: 'The bad', campaignId: campaign.id }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          userId: 2,
-          division: 'Bad Guys Team',
-        });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The ugly', campaignId: campaign.id },
-          { id: 3 }
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, division: 'Ugly Guys Team' },
+          { participantExternalId: 'The ugly', campaignId: campaign.id }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          userId: 3,
-          division: 'Ugly Guys Team',
-        });
 
         await databaseBuilder.commit();
 
@@ -218,19 +202,17 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('when there is a filter on status', function () {
       it('returns participants which have the correct status', async function () {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+        campaign = databaseBuilder.factory.buildCampaign({});
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The good', campaignId: campaign.id, status: STARTED },
-          { id: 1 }
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId },
+          { participantExternalId: 'The good', campaignId: campaign.id, status: STARTED }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 1 });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The bad', campaignId: campaign.id, status: TO_SHARE },
-          { id: 2 }
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId },
+          { participantExternalId: 'The bad', campaignId: campaign.id, status: TO_SHARE }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: campaign.organizationId, userId: 2 });
 
         await databaseBuilder.commit();
 
@@ -251,36 +233,22 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('when there is a filter on group', function () {
       it('returns participants which have the correct group', async function () {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+        campaign = databaseBuilder.factory.buildCampaign();
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The good', campaignId: campaign.id },
-          { id: 1 }
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, group: 'L1' },
+          { participantExternalId: 'The good', campaignId: campaign.id }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          userId: 1,
-          group: 'L1',
-        });
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The bad', campaignId: campaign.id, status: 'STARTED' },
-          { id: 2 }
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, group: 'T1' },
+          { participantExternalId: 'The bad', campaignId: campaign.id, status: 'STARTED' }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          userId: 2,
-          group: 'T1',
-        });
-        databaseBuilder.factory.buildAssessmentFromParticipation(
-          { participantExternalId: 'The ugly', campaignId: campaign.id, status: 'STARTED' },
-          { id: 3 }
+
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, group: 'T2' },
+          { participantExternalId: 'The ugly', campaignId: campaign.id, status: 'STARTED' }
         );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          userId: 3,
-          group: 'T2',
-        });
 
         await databaseBuilder.commit();
 
@@ -301,11 +269,11 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('pagination', function () {
       beforeEach(async function () {
-        campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+        campaign = databaseBuilder.factory.buildCampaign();
 
         const participation = { campaignId: campaign.id };
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation);
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation);
+        databaseBuilder.factory.buildCampaignParticipation(participation);
+        databaseBuilder.factory.buildCampaignParticipation(participation);
 
         await databaseBuilder.commit();
       });
@@ -332,7 +300,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
       context('when there are zero rows', function () {
         beforeEach(async function () {
-          campaign = databaseBuilder.factory.buildAssessmentCampaign({});
+          campaign = databaseBuilder.factory.buildCampaign();
 
           await databaseBuilder.commit();
         });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -11,17 +11,24 @@ describe('Integration | Repository | Campaign Participation Info', function () {
       let campaignParticipation1;
       let campaign1;
       beforeEach(async function () {
-        const userId = databaseBuilder.factory.buildUser({
-          firstName: 'First',
-          lastName: 'Last',
-        }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
 
         campaign1 = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
 
-        campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign1.id,
-          userId,
-        });
+        campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          {
+            firstName: 'First',
+            lastName: 'Last',
+            division: null,
+            group: null,
+            userId,
+          },
+          {
+            campaignId: campaign1.id,
+            userId,
+          },
+          false
+        );
 
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation1.id,
@@ -32,10 +39,17 @@ describe('Integration | Repository | Campaign Participation Info', function () {
 
         const campaign2 = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
 
-        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign2.id,
-          userId,
-        });
+        const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation(
+          {
+            firstName: 'First',
+            lastName: 'Last',
+            userId,
+          },
+          {
+            campaignId: campaign2.id,
+            userId,
+          }
+        );
 
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation2.id,
@@ -80,14 +94,17 @@ describe('Integration | Repository | Campaign Participation Info', function () {
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
 
-        const user1Id = databaseBuilder.factory.buildUser({ firstName: 'The', lastName: 'Narrator' }).id;
-        const user2Id = databaseBuilder.factory.buildUser({ firstName: 'Tyler', lastName: 'Durden' }).id;
+        const user1Id = databaseBuilder.factory.buildUser().id;
+        const user2Id = databaseBuilder.factory.buildUser().id;
 
-        campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          userId: user1Id,
-          sharedAt: new Date(),
-        });
+        campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { firstName: 'The', lastName: 'Narrator', division: null, group: null },
+          {
+            campaignId: campaign.id,
+            userId: user1Id,
+            sharedAt: new Date(),
+          }
+        );
 
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation1.id,
@@ -95,12 +112,15 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           state: 'started',
         });
 
-        campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          userId: user2Id,
-          status: STARTED,
-          sharedAt: null,
-        });
+        campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { firstName: 'Tyler', lastName: 'Durden', division: null, group: null },
+          {
+            campaignId: campaign.id,
+            userId: user2Id,
+            status: STARTED,
+            sharedAt: null,
+          }
+        );
 
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation2.id,
@@ -158,13 +178,16 @@ describe('Integration | Repository | Campaign Participation Info', function () {
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
 
-        const userId = databaseBuilder.factory.buildUser({ firstName: 'The', lastName: 'Narrator' }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
 
-        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          userId,
-          sharedAt: new Date(),
-        });
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { firstName: 'The', lastName: 'Narrator', division: null, group: null },
+          {
+            campaignId: campaign.id,
+            userId,
+            sharedAt: new Date(),
+          }
+        );
 
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation.id,
@@ -214,11 +237,18 @@ describe('Integration | Repository | Campaign Participation Info', function () {
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
 
-        const userId = databaseBuilder.factory.buildUser({ firstName: 'The', lastName: 'Narrator' }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+          firstName: 'The',
+          lastName: 'Narrator',
+          division: null,
+          group: null,
+        }).id;
 
         campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
+          schoolingRegistrationId,
           sharedAt: new Date(),
           isImproved: true,
         });
@@ -226,6 +256,7 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
+          schoolingRegistrationId,
           sharedAt: new Date(),
           isImproved: false,
         });
@@ -277,23 +308,24 @@ describe('Integration | Repository | Campaign Participation Info', function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const userId = databaseBuilder.factory.buildUser().id;
         campaign = databaseBuilder.factory.buildCampaign({ organizationId });
-        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          userId,
-        }).id;
-        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
-        databaseBuilder.factory.buildSchoolingRegistration({
+        const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
           organizationId,
           userId,
           firstName: 'John',
           lastName: 'Doe',
-        });
+        }).id;
         databaseBuilder.factory.buildSchoolingRegistration({
           organizationId: otherOrganizationId,
           userId,
           firstName: 'Jane',
           lastName: 'Doe',
         });
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId,
+          schoolingRegistrationId,
+        }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
 
         await databaseBuilder.commit();
       });
@@ -313,11 +345,6 @@ describe('Integration | Repository | Campaign Participation Info', function () {
       beforeEach(async function () {
         const userId = databaseBuilder.factory.buildUser().id;
         campaign = databaseBuilder.factory.buildCampaign();
-        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-          campaignId: campaign.id,
-          userId,
-        }).id;
-        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'started' });
         schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({
           organizationId: campaign.organizationId,
           userId,
@@ -325,6 +352,13 @@ describe('Integration | Repository | Campaign Participation Info', function () {
           division: '6eme',
           group: 'G1',
         });
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId,
+          schoolingRegistrationId: schoolingRegistration.id,
+        }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'started' });
+
         databaseBuilder.factory.buildSchoolingRegistration({
           userId,
           studentNumber: 'Yippee Ki Yay',

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -16,21 +16,13 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('return the creation date, the sharing date and the participantExternalId', async function () {
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
-        databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'Freddy', lastName: 'Krugger' },
-          { campaignId },
-          false
-        );
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'Jason', lastName: 'Voorhees' },
-          {
-            campaignId,
-            createdAt: new Date('2020-01-01'),
-            sharedAt: new Date('2020-01-02'),
-            participantExternalId: 'Friday the 13th',
-          },
-          false
-        );
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          createdAt: new Date('2020-01-01'),
+          sharedAt: new Date('2020-01-02'),
+          participantExternalId: 'Friday the 13th',
+        });
 
         await databaseBuilder.commit();
 
@@ -48,11 +40,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('return the campaignParticipationId and campaignId', async function () {
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'Jason', lastName: 'Voorhees' },
-          { campaignId },
-          false
-        );
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
 
         await databaseBuilder.commit();
 
@@ -69,16 +57,12 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('return the campaignParticipationId sharing status', async function () {
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'Jason', lastName: 'Voorhees' },
-          {
-            campaignId,
-            createdAt: new Date('2020-01-01'),
-            sharedAt: new Date('2020-01-02'),
-            participantExternalId: 'Friday the 13th',
-          },
-          false
-        );
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          createdAt: new Date('2020-01-01'),
+          sharedAt: new Date('2020-01-02'),
+          participantExternalId: 'Friday the 13th',
+        });
 
         await databaseBuilder.commit();
 
@@ -89,38 +73,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
         });
 
         expect(campaignProfile.isShared).to.equal(true);
-      });
-    });
-
-    context('user infos', function () {
-      beforeEach(function () {
-        mockLearningContent({ areas: [], competences: [], skills: [] });
-      });
-
-      it('return the first name and last name of the participant', async function () {
-        const campaignId = databaseBuilder.factory.buildCampaign().id;
-
-        databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'Viggo', lastName: 'Tarasov' },
-          { campaignId },
-          false
-        );
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'John', lastName: 'Shaft' },
-          { campaignId },
-          false
-        );
-
-        await databaseBuilder.commit();
-
-        const campaignProfile = await CampaignProfileRepository.findProfile({
-          campaignId,
-          campaignParticipationId: campaignParticipation.id,
-          locale,
-        });
-
-        expect(campaignProfile.firstName).to.equal('John');
-        expect(campaignProfile.lastName).to.equal('Shaft');
       });
     });
 
@@ -210,11 +162,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('return the number of competences', async function () {
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'John', lastName: 'Shaft' },
-          { campaignId },
-          false
-        );
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
 
         await databaseBuilder.commit();
 
@@ -230,11 +178,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('return the competences data according to given locale', async function () {
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'John', lastName: 'Shaft' },
-          { campaignId },
-          false
-        );
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId });
 
         await databaseBuilder.commit();
 
@@ -373,11 +317,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('throws an NotFoundError error', async function () {
         const campaignId = databaseBuilder.factory.buildCampaign({ id: 1 }).id;
 
-        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipationWithUser(
-          { firstName: 'John', lastName: 'Shaft' },
-          { id: 3, campaignId },
-          false
-        ).id;
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ id: 3, campaignId }).id;
 
         await databaseBuilder.commit();
         const error = await catchErr(CampaignProfileRepository.findProfile)({

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -54,14 +54,14 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
     it('should return participants data summary only for the given campaign id', async function () {
       // given
       const campaignParticipation1 = { campaignId };
-      databaseBuilder.factory.buildCampaignParticipationWithUser(
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
         { firstName: 'Lise', lastName: 'Quesnel' },
         campaignParticipation1,
         false
       );
       const campaignId2 = databaseBuilder.factory.buildCampaign().id;
       const campaignParticipation2 = { campaignId: campaignId2 };
-      databaseBuilder.factory.buildCampaignParticipationWithUser(
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
         { firstName: 'Benjamin', lastName: 'Petetot' },
         campaignParticipation2,
         false
@@ -78,7 +78,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       expect(names).exactlyContainInOrder(['Lise']);
     });
 
-    it('should return participants data summary ordered by last name then first name asc (including schooling registration data)', async function () {
+    it('should return participants data summary ordered by last name then first name asc from schooling-registration', async function () {
       // given
       const campaignParticipation = { campaignId };
       databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
@@ -86,12 +86,12 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         campaignParticipation,
         false
       );
-      databaseBuilder.factory.buildCampaignParticipationWithUser(
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
         { firstName: 'Jiji', lastName: 'Le riquiqui', organizationId },
         campaignParticipation,
         false
       );
-      databaseBuilder.factory.buildCampaignParticipationWithUser(
+      databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
         { firstName: 'Jojo', lastName: 'Le rococo', organizationId },
         campaignParticipation,
         false
@@ -200,29 +200,38 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
 
     describe('when there is a filter on division', function () {
       beforeEach(async function () {
+        const { id: schoolingRegistrationId1 } = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          division: 'Barry',
+        });
         const participation1 = {
           participantExternalId: "Can't get Enough Of Your Love, Baby",
           campaignId,
+          schoolingRegistrationId: schoolingRegistrationId1,
         };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 1, division: 'Barry' });
-
+        const { id: schoolingRegistrationId2 } = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          division: 'White',
+        });
         const participation2 = {
           participantExternalId: "You're The First, The last, My Everything",
           campaignId,
+          schoolingRegistrationId: schoolingRegistrationId2,
         };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 2, division: 'White' });
-
+        const { id: schoolingRegistrationId3 } = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          division: 'Marvin Gaye',
+        });
         const participation3 = {
           participantExternalId: "Ain't No Mountain High Enough",
           campaignId,
+          schoolingRegistrationId: schoolingRegistrationId3,
         };
-
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, { id: 3 });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 3, division: 'Marvin Gaye' });
+        databaseBuilder.factory.buildCampaignParticipation(participation3);
 
         await databaseBuilder.commit();
       });
@@ -247,29 +256,38 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
 
     describe('when there is a filter on group', function () {
       beforeEach(async function () {
+        const { id: schoolingRegistrationId1 } = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          group: 'Barry',
+        });
         const participation1 = {
           participantExternalId: "Can't get Enough Of Your Love, Baby",
           campaignId,
+          schoolingRegistrationId: schoolingRegistrationId1,
         };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 1, group: 'Barry' });
-
+        const { id: schoolingRegistrationId2 } = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          group: 'White',
+        });
         const participation2 = {
           participantExternalId: "You're The First, The last, My Everything",
           campaignId,
+          schoolingRegistrationId: schoolingRegistrationId2,
         };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
 
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 2, group: 'White' });
-
+        const { id: schoolingRegistrationId3 } = databaseBuilder.factory.buildSchoolingRegistration({
+          organizationId,
+          group: 'Marvin Gaye',
+        });
         const participation3 = {
           participantExternalId: "Ain't No Mountain High Enough",
           campaignId,
+          schoolingRegistrationId: schoolingRegistrationId3,
         };
-
-        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, { id: 3 });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 3, group: 'Marvin Gaye' });
+        databaseBuilder.factory.buildCampaignParticipation(participation3);
 
         await databaseBuilder.commit();
       });

--- a/high-level-tests/e2e/cypress/fixtures/campaign-participations.json
+++ b/high-level-tests/e2e/cypress/fixtures/campaign-participations.json
@@ -6,6 +6,7 @@
     "participantExternalId": "Le parricide",
     "sharedAt": "2019-04-22T06:00:00Z",
     "userId": 4,
+    "schoolingRegistrationId": 5,
     "validatedSkillsCount": 1,
     "masteryRate": 0.5
   },
@@ -14,33 +15,38 @@
     "campaignId": 1,
     "status": "TO_SHARE",
     "participantExternalId": "Le régicide",
-    "userId": 5
+    "userId": 5,
+    "schoolingRegistrationId": 6
   },
   {
     "id": 3,
     "campaignId": 1,
     "status": "STARTED",
     "participantExternalId": "La reine",
-    "userId": 6
+    "userId": 6,
+    "schoolingRegistrationId": 7
   },
   {
     "id": 4,
     "campaignId": 4,
     "status": "STARTED",
     "participantExternalId": "La reine",
-    "userId": 6
+    "userId": 6,
+    "schoolingRegistrationId": 7
   },
   {
     "id": 5,
     "campaignId": 4,
     "status": "STARTED",
     "participantExternalId": "La régicide",
-    "userId": 5
+    "userId": 5,
+    "schoolingRegistrationId": 6
   },
   {
     "id": 6,
     "campaignId": 2,
     "status": "TO_SHARE",
-    "userId": 5
+    "userId": 5,
+    "schoolingRegistrationId": 6
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/schooling-registrations.json
+++ b/high-level-tests/e2e/cypress/fixtures/schooling-registrations.json
@@ -33,5 +33,26 @@
     "birthdate": "2010-10-10",
     "organizationId": 2,
     "userId": 12
+  },
+  {
+    "id": 5,
+    "firstName": "Tyrion",
+    "lastName": "Lannister",
+    "organizationId": 1,
+    "userId": 4
+  },
+  {
+    "id": 6,
+    "firstName": "Jaime",
+    "lastName": "Lannister",
+    "organizationId": 1,
+    "userId": 5
+  },
+  {
+    "id": 7,
+    "firstName": "Cersei",
+    "lastName": "Lannister",
+    "organizationId": 1,
+    "userId": 6
   }
 ]

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -8,6 +8,7 @@ Given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'target-profiles');
   cy.task('db:fixture', 'target-profiles_skills');
   cy.task('db:fixture', 'campaigns');
+  cy.task('db:fixture', 'schooling-registrations');
   cy.task('db:fixture', 'campaign-participations');
   cy.task('db:fixture', 'certification-centers');
   cy.task('db:fixture', 'sessions');
@@ -16,7 +17,6 @@ Given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'answers');
   cy.task('db:fixture', 'knowledge-elements');
   cy.task('db:fixture', 'users_pix_roles');
-  cy.task('db:fixture', 'schooling-registrations');
   cy.task('db:fixture', 'certification-center-memberships');
   cy.task('db:fixture', 'certification-candidates');
 });


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'à maintenant on utilisait encore comme fallback les informations de l'utilisateur côté Pix Orga. Or, désormais, toute personne participant à une campagne est un prescrit. On veut donc récupérer exclusivement les informations du prescrit.

## :robot: Solution
Supprimer le code non nécéssaire.

## :rainbow: Remarques
On fait moins de jointures, potentiellement les requêtes sont plus rapides.

## :100: Pour tester
Aller dans Pix Orga, et se balader dans les pages :
- page activité d’une campagne
- page résultats d’une campagne d'évaluation
- page résultats d’une campagne de collecte
- page individuelle d’une campagne de collecte
- page individuelle d’une campagne d'évaluation
- export des résultats de campagne d'évaluation
- export des résultats de campagne de collecte
Et vérifier que ce sont les bonnes informations récupérées, celle du prescrit.
