### PR TITLE
[TECH] Corriger les erreurs pole emploi suite à la mise en place du refresh token (PIX-4259)

### DIFF
--- a/api/lib/application/pole-emplois/pole-emploi-controller.js
+++ b/api/lib/application/pole-emplois/pole-emploi-controller.js
@@ -8,7 +8,7 @@ module.exports = {
 
     const { userId, idToken } = await usecases.createUserFromPoleEmploi({ authenticationKey });
 
-    const accessToken = tokenService.createAccessTokenFromUser(userId, 'pole_emploi_connect').accessToken;
+    const accessToken = tokenService.createAccessTokenForPoleEmploi(userId);
     await userRepository.updateLastLoggedAt({ userId });
 
     const response = {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -209,6 +209,7 @@ module.exports = (function () {
       },
       poleEmploiSendingsLimit: _getNumber(process.env.POLE_EMPLOI_SENDING_LIMIT, 100),
       poleEmploiIdentityProvider: process.env.POLE_EMPLOI_IDENTITY_PROVIDER || 'POLE_EMPLOI',
+      accessTokenLifespanMs: ms(process.env.POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN || '7d'),
     },
 
     temporaryStorage: {

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -19,6 +19,11 @@ function createAccessTokenFromUser(userId, source) {
   return { accessToken, expirationDelaySeconds };
 }
 
+function createAccessTokenForPoleEmploi(userId) {
+  const expirationDelaySeconds = settings.poleEmploi.accessTokenLifespanMs / 1000;
+  return _createAccessToken({ userId, source: 'pole_emploi_connect', expirationDelaySeconds });
+}
+
 function createAccessTokenForSaml(userId) {
   const expirationDelaySeconds = settings.saml.accessTokenLifespanMs / 1000;
   return _createAccessToken({ userId, source: 'external', expirationDelaySeconds });
@@ -185,6 +190,7 @@ async function extractPayloadFromPoleEmploiIdToken(idToken) {
 
 module.exports = {
   createAccessTokenFromUser,
+  createAccessTokenForPoleEmploi,
   createAccessTokenForSaml,
   createAccessTokenFromApplication,
   createTokenForCampaignResults,

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -108,7 +108,6 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
     await authenticationMethodRepository.create({ authenticationMethod });
   }
   const pixAccessToken = tokenService.createAccessTokenForPoleEmploi(authenticatedUserId);
-
   await userRepository.updateLastLoggedAt({ userId: authenticatedUserId });
   return pixAccessToken;
 }

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -107,7 +107,7 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
     });
     await authenticationMethodRepository.create({ authenticationMethod });
   }
-  const pixAccessToken = tokenService.createAccessTokenFromUser(authenticatedUserId, 'pole_emploi_connect').accessToken;
+  const pixAccessToken = tokenService.createAccessTokenForPoleEmploi(authenticatedUserId);
 
   await userRepository.updateLastLoggedAt({ userId: authenticatedUserId });
   return pixAccessToken;
@@ -124,7 +124,7 @@ async function _getPixAccessTokenFromPoleEmploiUser({
     authenticationComplement,
     userId: user.id,
   });
-  const pixAccessToken = tokenService.createAccessTokenFromUser(user.id, 'pole_emploi_connect').accessToken;
+  const pixAccessToken = tokenService.createAccessTokenForPoleEmploi(user.id);
 
   await userRepository.updateLastLoggedAt({ userId: user.id });
   return pixAccessToken;

--- a/api/sample.env
+++ b/api/sample.env
@@ -561,3 +561,8 @@ REFRESH_TOKEN_LIFESPAN=7d
 # default: '7d'
 SAML_ACCESS_TOKEN_LIFESPAN=7d
 
+# Pole emploi access token lifespan
+# presence: optional
+# type: String
+# default: '7d'
+POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN=7d

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -65,7 +65,7 @@ describe('Unit | Controller | pole-emplois-controller', function () {
       const request = { query: { 'authentication-key': 'abcde' } };
       const userId = 7;
       sinon.stub(usecases, 'createUserFromPoleEmploi').resolves({ userId, idToken: 1 });
-      sinon.stub(tokenService, 'createAccessTokenFromUser').resolves('an access token');
+      sinon.stub(tokenService, 'createAccessTokenForPoleEmploi').resolves('an access token');
       sinon.stub(userRepository, 'updateLastLoggedAt');
 
       // when
@@ -86,10 +86,7 @@ describe('Unit | Controller | pole-emplois-controller', function () {
         .withArgs({ authenticationKey: 'abcde' })
         .resolves({ userId, idToken });
       sinon.stub(userRepository, 'updateLastLoggedAt');
-      sinon
-        .stub(tokenService, 'createAccessTokenFromUser')
-        .withArgs(userId, 'pole_emploi_connect')
-        .returns({ accessToken, expirationDelaySeconds: 1000 });
+      sinon.stub(tokenService, 'createAccessTokenForPoleEmploi').withArgs(userId).returns(accessToken);
 
       // when
       const result = await poleEmploiController.createUser(request, hFake);

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -35,6 +35,26 @@ describe('Unit | Domain | Service | Token Service', function () {
     });
   });
 
+  describe('#createAccessTokenForPoleEmploi', function () {
+    it('should create access token with user id and source', function () {
+      // given
+      const userId = 123;
+      settings.authentication.secret = 'a secret';
+      settings.poleEmploi.accessTokenLifespanMs = 1000;
+      const accessToken = 'valid access token';
+      const firstParameter = { user_id: userId, source: 'pole_emploi_connect' };
+      const secondParameter = 'a secret';
+      const thirdParameter = { expiresIn: 1 };
+      sinon.stub(jsonwebtoken, 'sign').withArgs(firstParameter, secondParameter, thirdParameter).returns(accessToken);
+
+      // when
+      const result = tokenService.createAccessTokenForPoleEmploi(userId);
+
+      // then
+      expect(result).to.be.deep.equal(accessToken);
+    });
+  });
+
   describe('#createIdTokenForUserReconciliation', function () {
     it('should return a valid idToken with firstName, lastName, samlId', function () {
       // given

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -31,7 +31,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     };
 
     tokenService = {
-      createAccessTokenFromUser: sinon.stub().returns(),
+      createAccessTokenForPoleEmploi: sinon.stub().returns(),
     };
 
     authenticationMethodRepository = {
@@ -93,7 +93,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should call authenticate pole emploi user with code, redirectUri and clientId parameters', async function () {
       // given
       _fakePoleEmploiAPI({ authenticationService });
-      tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+      tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
       // when
       await authenticatePoleEmploiUser({
@@ -121,7 +121,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should call get pole emploi user info with id token parameter', async function () {
       // given
       _fakePoleEmploiAPI({ authenticationService });
-      tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+      tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
       // when
       await authenticatePoleEmploiUser({
@@ -142,11 +142,11 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       expect(authenticationService.getPoleEmploiUserInfo).to.have.been.calledWith('idToken');
     });
 
-    it('should call tokenService createAccessTokenFromUser function with external source and user parameters', async function () {
+    it('should call tokenService createAccessTokenForPoleEmploi function with user id', async function () {
       // given
       const user = new User({ id: 1, firstName: 'Tuck', lastName: 'Morris' });
       user.externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
-      tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+      tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
       _fakePoleEmploiAPI({ authenticationService });
       userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: 1 });
@@ -167,16 +167,14 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       });
 
       // then
-      expect(tokenService.createAccessTokenFromUser).to.have.been.calledWith(1, 'pole_emploi_connect');
+      expect(tokenService.createAccessTokenForPoleEmploi).to.have.been.calledWith(1);
     });
 
     it('should return accessToken and idToken', async function () {
       // given
       const { poleEmploiTokens } = _fakePoleEmploiAPI({ authenticationService });
       const authenticatedUserId = 1;
-      tokenService.createAccessTokenFromUser
-        .withArgs(authenticatedUserId, 'pole_emploi_connect')
-        .returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+      tokenService.createAccessTokenForPoleEmploi.withArgs(authenticatedUserId).returns('access-token');
 
       // when
       const result = await authenticatePoleEmploiUser({
@@ -204,7 +202,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should save last logged at date', async function () {
       // given
       _fakePoleEmploiAPI({ authenticationService });
-      tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+      tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
       // when
       await authenticatePoleEmploiUser({
@@ -230,7 +228,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         // given
         userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: 1 });
         const { poleEmploiTokens } = _fakePoleEmploiAPI({ authenticationService });
-        tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+        tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
         // when
         await authenticatePoleEmploiUser({
@@ -265,7 +263,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         // given
         userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: 123 });
         _fakePoleEmploiAPI({ authenticationService });
-        tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+        tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
         // when
         await authenticatePoleEmploiUser({
@@ -293,7 +291,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           // given
           const { poleEmploiTokens } = _fakePoleEmploiAPI({ authenticationService });
           userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
-          tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+          tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
           // when
           await authenticatePoleEmploiUser({
@@ -336,7 +334,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
               externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
             })
           );
-          tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 666 });
+          tokenService.createAccessTokenForPoleEmploi.returns('access-token');
 
           // when
           await authenticatePoleEmploiUser({


### PR DESCRIPTION
## :unicorn: Problème
Suite à la réduction de la durée de l'access token à 20min, de nombreuses erreurs 401 ont été relevées par les utilisateurs Pole Emploi. En effet, on créé un access token pour ces derniers de 20min mais sans refresh token, ce qui avait pour conséquence de les déconnecter.

## :robot: Solution
Comme pour le GAR, créer un token spécifique pour nos utilisateurs externes.

## :rainbow: Remarques
RAS

## :100: Pour tester
Tester les scénario Pole Emploi, (voir https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1949663259/Int+gration+P+le+Emploi+-+Pix)
