### PR TITLE
[BUGFIX] Filtrer les tutoriels inexistants sur la page des tuto

### DIFF
--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -21,15 +21,14 @@ module.exports = {
 
   async findWithTutorial({ userId }) {
     const userTutorials = await knex('user_tutorials').where({ userId });
-    return Promise.all(
-      userTutorials.map(async (userTutorial) => {
-        const tutorial = await tutorialDatasource.get(userTutorial.tutorialId);
-        return new UserTutorialWithTutorial({
-          ...userTutorial,
-          tutorial: new Tutorial(tutorial),
-        });
-      })
-    );
+    const tutorials = await tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId));
+    return tutorials.map((tutorial) => {
+      const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
+      return new UserTutorialWithTutorial({
+        ...userTutorial,
+        tutorial: new Tutorial(tutorial),
+      });
+    });
   },
 
   async removeFromUser(userTutorial) {

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -114,6 +114,21 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
 
     context('when user has not saved tutorial', function () {
       it('should return an empty list', async function () {
+        mockLearningContent({ tutorials: [] });
+
+        const userTutorialsWithTutorials = await userTutorialRepository.findWithTutorial({ userId });
+
+        // then
+        expect(userTutorialsWithTutorials).to.deep.equal([]);
+      });
+    });
+
+    context('when user has saved a tutorial not available anymore', function () {
+      it('should return an empty list', async function () {
+        mockLearningContent({ tutorials: [] });
+        databaseBuilder.factory.buildUserTutorial({ tutorialId: 'recTutorial', userId });
+        await databaseBuilder.commit();
+
         const userTutorialsWithTutorials = await userTutorialRepository.findWithTutorial({ userId });
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Une erreur 500 survient sur la page des tutos si l'utilisateur a sauvegardé un tutoriel qui a été supprimé.

## :robot: Solution
Filtrer la liste des tutoriels récupérés à des tutoriels existants obligatoirement.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la page des tutos s'affiche correctement si un tutorialId innexistant est rempli dans la table user_tutorials.
