### PR TITLE
[FEATURE] Pouvoir indiquer la tarification de la part Pix d'un candidat dans la modal d'ajout (PIX-4198).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -165,6 +165,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CertificationCandidatePersonalInfoWrongFormat) {
     return new HttpErrors.BadRequestError("Un ou plusieurs champs d'informations d'identité sont au mauvais format.");
   }
+  if (error instanceof DomainErrors.CertificationCandidateAddError) {
+    return new HttpErrors.UnprocessableEntityError(error.message);
+  }
   if (error instanceof DomainErrors.CertificationCandidatesImportError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -440,6 +440,26 @@ class CertificationCandidateForbiddenDeletionError extends DomainError {
   }
 }
 
+class CertificationCandidateAddError extends DomainError {
+  constructor(message = 'Candidat de certification invalide.') {
+    super(message);
+  }
+
+  static fromInvalidCertificationCandidateError(error) {
+    let message = 'Candidat de certification invalide.';
+
+    if (error.why === 'not_a_billing_mode') {
+      message = `Le champ “Tarification part Pix” ne peut contenir qu'une des valeurs suivantes: Gratuite, Payante ou Prépayée.`;
+    } else if (error.why === 'prepayment_code_null') {
+      message = `Le champ “Code de prépaiement” est obligatoire puisque l’option “Prépayée” a été sélectionnée pour ce candidat.`;
+    } else if (error.why === 'prepayment_code_not_null') {
+      message = `Le champ “Code de prépaiement” doit rester vide puisque l’option “Prépayée” n'a pas été sélectionnée pour ce candidat.`;
+    }
+
+    return new CertificationCandidateAddError(message);
+  }
+}
+
 class CertificationCandidatesImportError extends DomainError {
   constructor({ message = "Quelque chose s'est mal passé. Veuillez réessayer", code = null } = {}) {
     super(message, code);
@@ -1059,12 +1079,13 @@ module.exports = {
   CertificateVerificationCodeGenerationTooManyTrials,
   NoCertificationAttestationForDivisionError,
   CertificationBadgeForbiddenDeletionError,
-  CertificationCandidateForbiddenDeletionError,
+  CertificationCandidateAddError,
   CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateCreationOrUpdateError,
   CertificationCandidateDeletionError,
+  CertificationCandidateForbiddenDeletionError,
   CertificationCandidateMultipleUserLinksWithinSessionError,
   CertificationCandidatePersonalInfoFieldMissingError,
   CertificationCandidatePersonalInfoWrongFormat,

--- a/api/lib/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/lib/domain/usecases/add-certification-candidate-to-session.js
@@ -1,6 +1,7 @@
 const {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CpfBirthInformationValidationError,
+  CertificationCandidateAddError,
 } = require('../errors');
 
 module.exports = async function addCertificationCandidateToSession({
@@ -13,7 +14,12 @@ module.exports = async function addCertificationCandidateToSession({
   certificationCpfCityRepository,
 }) {
   certificationCandidate.sessionId = sessionId;
-  certificationCandidate.validate();
+
+  try {
+    certificationCandidate.validate();
+  } catch (error) {
+    throw CertificationCandidateAddError.fromInvalidCertificationCandidateError(error);
+  }
 
   const duplicateCandidates = await certificationCandidateRepository.findBySessionIdAndPersonalInfo({
     sessionId,

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -494,4 +494,75 @@ describe('Unit | Domain | Errors', function () {
   it('should export an SchoolingRegistrationCannotBeDissociatedError', function () {
     expect(errors.SchoolingRegistrationCannotBeDissociatedError).to.exist;
   });
+
+  describe('CertificationCandidateAddError', function () {
+    context('#fromInvalidCertificationCandidateError', function () {
+      it('should return a CertificationCandidateAddError', function () {
+        // given
+        const invalidCertificationCandidateError = {
+          key: 'someKey',
+          why: 'someWhy',
+        };
+
+        // when
+        const error = errors.CertificationCandidateAddError.fromInvalidCertificationCandidateError(
+          invalidCertificationCandidateError,
+          {},
+          1
+        );
+
+        // then
+        expect(error).to.be.instanceOf(errors.CertificationCandidateAddError);
+      });
+
+      context('when err.why is known', function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        [
+          {
+            why: 'not_a_billing_mode',
+            message: `Le champ “Tarification part Pix” ne peut contenir qu'une des valeurs suivantes: Gratuite, Payante ou Prépayée.`,
+          },
+          {
+            why: 'prepayment_code_null',
+            message: `Le champ “Code de prépaiement” est obligatoire puisque l’option “Prépayée” a été sélectionnée pour ce candidat.`,
+          },
+          {
+            why: 'prepayment_code_not_null',
+            message: `Le champ “Code de prépaiement” doit rester vide puisque l’option “Prépayée” n'a pas été sélectionnée pour ce candidat.`,
+          },
+        ].forEach(({ why, message }) => {
+          it(`message should be "${message}" when why is "${why}"`, async function () {
+            // given
+            const invalidCertificationCandidateError = { why };
+
+            // when
+            const error = errors.CertificationCandidateAddError.fromInvalidCertificationCandidateError(
+              invalidCertificationCandidateError
+            );
+
+            // then
+            expect(error.message).to.equal(message);
+          });
+        });
+      });
+
+      context('when err.why is unknown', function () {
+        it('should display generic message', function () {
+          // given
+          const invalidCertificationCandidateError = {
+            key: 'someKey',
+            why: 'unknown',
+          };
+
+          // when
+          const error = errors.CertificationCandidateAddError.fromInvalidCertificationCandidateError(
+            invalidCertificationCandidateError
+          );
+
+          // then
+          expect(error.message).to.contain('Candidat de certification invalide.');
+        });
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -3,8 +3,8 @@ const addCertificationCandidateToSession = require('../../../../lib/domain/useca
 const { CpfBirthInformationValidation } = require('../../../../lib/domain/services/certification-cpf-service');
 const {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
-  InvalidCertificationCandidate,
   CpfBirthInformationValidationError,
+  CertificationCandidateAddError,
 } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | add-certification-candidate-to-session', function () {
@@ -28,7 +28,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
   });
 
   context('when certification candidate does not pass JOI validation', function () {
-    it('should throw an InvalidCertificationCandidate error', async function () {
+    it('should throw an CertificationCandidateAddError error', async function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
         birthdate: 'WrongDateFormat',
@@ -47,7 +47,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
       });
 
       // then
-      expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      expect(err).to.be.instanceOf(CertificationCandidateAddError);
       expect(certificationCandidateRepository.saveInSession).not.to.have.been.called;
     });
   });

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -157,5 +157,6 @@
     @candidateData={{this.newCandidate}}
     @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
     @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
+    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
   />
 {{/if}}

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -33,6 +33,13 @@ export default class EnrolledCandidates extends Component {
 
   @action
   addCertificationCandidateInStaging() {
+    let addedAttributes = {};
+    if (this.args.shouldDisplayPaymentOptions) {
+      addedAttributes = {
+        billingMode: '',
+        prepaymentCode: '',
+      };
+    }
     this.newCandidate = EmberObject.create({
       firstName: '',
       lastName: '',
@@ -46,6 +53,7 @@ export default class EnrolledCandidates extends Component {
       birthInseeCode: '',
       sex: '',
       extraTimePercentage: '',
+      ...addedAttributes,
     });
   }
 
@@ -150,6 +158,8 @@ export default class EnrolledCandidates extends Component {
       email: this._trimOrUndefinedIfFalsy(certificationCandidateData.email),
       resultRecipientEmail: this._trimOrUndefinedIfFalsy(certificationCandidateData.resultRecipientEmail),
       extraTimePercentage: certificationCandidateData.extraTimePercentage,
+      billingMode: certificationCandidateData.billingMode,
+      prepaymentCode: this._trimOrUndefinedIfFalsy(certificationCandidateData.prepaymentCode),
       complementaryCertifications: certificationCandidateData.complementaryCertifications,
     });
   }

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -259,6 +259,38 @@
             />
           </div>
 
+          {{#if @shouldDisplayPaymentOptions}}
+            <div
+              class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+            >
+              <label for="billing-mode" class="label">
+                <span class="required-field-indicator">*</span>
+                Tarification part Pix</label>
+              <PixSelect
+                id="billing-mode"
+                class="birth-country-selector"
+                @options={{this.billingModeOptions}}
+                @onChange={{fn @updateCandidateData @candidateData "billingMode"}}
+                @emptyOptionLabel={{"-- Choisissez --"}}
+                @emptyOptionNotSelectable={{true}}
+                required
+              />
+            </div>
+
+            <div
+              class="new-certification-candidate-details-modal__form__field new-certification-candidate-details-modal__form__field-double"
+            >
+              <label for="prepayment-code" class="label">Code de prépaiement</label>
+              <Input
+                id="prepayment-code"
+                @type="text"
+                class="input"
+                @value={{@candidateData.prepaymentCode}}
+                {{on "input" (fn @updateCandidateData @candidateData "prepaymentCode")}}
+              />
+            </div>
+          {{/if}}
+
           {{#if this.complementaryCertifications.length}}
             <div class="new-certification-candidate-details-modal__form__field">
               <span class="label">Certifications complémentaires</span>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -132,6 +132,14 @@ export default class NewCertificationCandidateModal extends Component {
     return FRANCE_INSEE_CODE;
   }
 
+  get billingModeOptions() {
+    return [
+      { label: 'Gratuite', value: 'FREE' },
+      { label: 'Payante', value: 'PAID' },
+      { label: 'Prépayée', value: 'PREPAID' },
+    ];
+  }
+
   _isFranceSelected() {
     return this.selectedCountryInseeCode === FRANCE_INSEE_CODE;
   }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -65,7 +65,17 @@ export default function () {
 
   this.post('/sessions/:id/certification-candidates', function (schema, request) {
     const sessionId = request.params.id;
-    return schema.certificationCandidates.create({ sessionId });
+    const requestBody = JSON.parse(request.requestBody);
+    const translateBillingMode = (billingMode) => {
+      if (billingMode === 'FREE') return 'Gratuite';
+      if (billingMode === 'PAID') return 'Payante';
+      if (billingMode === 'PREPAID') return 'Prépayée';
+    };
+    return schema.certificationCandidates.create({
+      ...requestBody.data.attributes,
+      sessionId,
+      billingMode: translateBillingMode(requestBody.data.attributes['billing-mode']),
+    });
   });
 
   this.post('/certification-reports/:id/certification-issue-reports', function (schema, request) {

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -315,6 +315,34 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             // then
             assert.dom('table tbody tr').exists({ count: 1 });
           });
+
+          module('when shouldDisplayPaymentOptions is true', function () {
+            test('it should add a new candidate with billing information', async function (assert) {
+              // given
+              server.create('feature-toggle', { id: 0, isCertificationBillingEnabled: true });
+              allowedCertificationCenterAccess.update({ type: 'SUP' });
+
+              const screen = await visitScreen(`/sessions/${session.id}/candidats`);
+              await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
+              await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
+              await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
+              await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
+              await click(screen.getByLabelText('Homme'));
+              await fillIn(screen.getByLabelText('* Pays de naissance'), '99100');
+              await click(screen.getByLabelText('Code INSEE'));
+              await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
+              await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
+              await fillIn(screen.getByLabelText('* Tarification part Pix'), 'PREPAID');
+              await fillIn(screen.getByLabelText('Code de prépaiement'), '12345');
+
+              // when
+              await click(screen.getByRole('button', { name: 'Ajouter le candidat' }));
+
+              // then
+              assert.dom('table tbody tr').exists({ count: 1 });
+              assert.contains('Prépayée 12345');
+            });
+          });
         });
       });
     });

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -76,6 +76,71 @@ module('Integration | Component | new-certification-candidate-modal', function (
     assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
   });
 
+  module('when shouldDisplayPaymentOptions is true', function () {
+    test('it shows candidate form with billing information', async function (assert) {
+      // given
+      const shouldDisplayPaymentOptions = true;
+      const closeModalStub = sinon.stub();
+      const updateCandidateStub = sinon.stub();
+      const updateCandidateWithEventStub = sinon.stub();
+      this.set('shouldDisplayPaymentOptions', shouldDisplayPaymentOptions);
+      this.set('closeModal', closeModalStub);
+      this.set('updateCandidateStub', updateCandidateStub);
+      this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
+      this.set('countries', []);
+      this.set('candidateData', [
+        {
+          firstName: '',
+          lastName: '',
+          birthdate: '',
+          birthCity: '',
+          birthCountry: '',
+          email: '',
+          externalId: '',
+          resultRecipientEmail: '',
+          birthPostalCode: '',
+          birthInseeCode: '',
+          sex: '',
+          extraTimePercentage: '',
+          billingMode: '',
+          prepaymentCode: '',
+        },
+      ]);
+
+      // when
+      const screen = await renderScreen(hbs`
+        <NewCertificationCandidateModal
+          @closeModal={{this.closeModal}}
+          @countries={{this.countries}}
+          @updateCandidateData={{this.updateCandidateStub}}
+          @updateCandidateDataWithEvent={{this.updateCandidateStub}}
+          @candidateData={{this.candidateData}}
+          @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
+        />
+      `);
+
+      // then
+      assert.dom(screen.getByLabelText('* Nom de famille')).exists();
+      assert.dom(screen.getByLabelText('* Nom de famille')).isFocused();
+      assert.dom(screen.getByLabelText('* Prénom')).exists();
+      assert.dom(screen.getByLabelText('Homme')).exists();
+      assert.dom(screen.getByLabelText('Femme')).exists();
+      assert.dom(screen.getByLabelText('* Date de naissance')).exists();
+      assert.dom(screen.getByLabelText('* Pays de naissance')).exists();
+      assert.dom(screen.getByLabelText('Code INSEE')).exists();
+      assert.dom(screen.getByLabelText('Code postal')).exists();
+      assert.dom(screen.getByLabelText('* Code INSEE de naissance')).exists();
+      assert.dom(screen.getByLabelText('Identifiant externe')).exists();
+      assert.dom(screen.getByLabelText('Temps majoré (%)')).exists();
+      assert.dom(screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)')).exists();
+      assert.dom(screen.getByLabelText('E-mail de convocation')).exists();
+      assert.dom(screen.getByLabelText('Certif complémentaire 1')).exists();
+      assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
+      assert.dom(screen.getByLabelText('* Tarification part Pix')).exists();
+      assert.dom(screen.getByLabelText('Code de prépaiement')).exists();
+    });
+  });
+
   test('it shows a countries list with France selected as default', async function (assert) {
     // given
     const closeModalStub = sinon.stub();

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -76,8 +76,12 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
       assert.equal(component.args.certificationCandidates.length, 1);
     });
   });
+
   module('#addCertificationCandidateInStaging', function () {
     test('should add an empty new candidate', async function (assert) {
+      // given
+      component.args.shouldDisplayPaymentOptions = false;
+
       const newCandidate = EmberObject.create({
         firstName: '',
         lastName: '',
@@ -98,6 +102,36 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
 
       // then
       assert.deepEqual(component.newCandidate, newCandidate);
+    });
+
+    module('when shouldDisplayPaymentOptions is true', function () {
+      test('it should add billing information', async function (assert) {
+        // given
+        component.args.shouldDisplayPaymentOptions = true;
+
+        const newCandidate = EmberObject.create({
+          firstName: '',
+          lastName: '',
+          birthdate: '',
+          birthCity: '',
+          birthCountry: 'FRANCE',
+          email: '',
+          externalId: '',
+          resultRecipientEmail: '',
+          birthPostalCode: '',
+          birthInseeCode: '',
+          sex: '',
+          extraTimePercentage: '',
+          billingMode: '',
+          prepaymentCode: '',
+        });
+
+        // when
+        await component.addCertificationCandidateInStaging();
+
+        // then
+        assert.deepEqual(component.newCandidate, newCandidate);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les pôles métiers en charge de la facturation des certifications payantes doivent pouvoir identifier simplement les candidats pour lesquels le centre de certification doit être facturé par Pix. Pour cela nous devons permettre à un centre de certification de renseigner les informations de facturation lors de l'ajout d'un candidat.

## :robot: Solution
- Ajouter les champs "Tarification part Pix" et "Code de prépaiement" à la modale d'ajout d'un candidat.

## :100: Pour tester
- Se connecter à Pix Certif sur un centre NON SCO
- Créer une session
- Ajouter une candidat via la modale alors que le fetaure toggle `FT_CERTIFICATION_BILLING` est off
- Vérifier que l'ajout de candidat réussit
- Activer le toggle `FT_CERTIFICATION_BILLING`
- Voir que les champs `Tarification part Pix` et `Code de prépaiment` apparaissent sur la modale
- Ajouter un candidat avec:
    - La tarification "Gratuite" et un code de prépaiement => constater une erreur.
    - La tarification "Payante" et un code de prépaiement => constater une erreur. 
    - La tarification "Prépayée" sans code de prépaiement => constater une erreur.
- Tester l'ajout de candidat dans les cas passants 