### PR TITLE
[FEATURE] Voir la tarification et le code de prépaiement sur la page de détails d'un candidat (PIX-4199)

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -93,6 +93,20 @@
               {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
             </span>
           </li>
+          {{#if @shouldDisplayPaymentOptions}}
+            <li class="certification-candidate-details-modal__row">
+              <span class="certification-candidate-details-modal__row__label">Tarification part Pix</span>
+              <span class="certification-candidate-details-modal__row__value" data-test-id="billing-mode-row">
+                {{if @candidate.billingMode @candidate.billingMode "-"}}
+              </span>
+            </li>
+            <li class="certification-candidate-details-modal__row">
+              <span class="certification-candidate-details-modal__row__label">Code de prépaiement</span>
+              <span class="certification-candidate-details-modal__row__value" data-test-id="prepayment-code-row">
+                {{if @candidate.prepaymentCode @candidate.prepaymentCode "-"}}
+              </span>
+            </li>
+          {{/if}}
           {{#if @displayComplementaryCertification}}
             <li class="certification-candidate-details-modal__row">
               <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -16,93 +16,93 @@
         <ul class="certification-candidate-details-modal__list">
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Nom</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="last-name-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.lastName @candidate.lastName "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Prénom</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="first-name-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.firstName @candidate.firstName "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Date de naissance</span>
             {{#if @candidate.birthdate}}
-              <span class="certification-candidate-details-modal__row__value" data-test-id="birth-date-row">
+              <span class="certification-candidate-details-modal__row__value">
                 {{moment-format @candidate.birthdate "DD/MM/YYYY"}}
               </span>
             {{else}}
-              <span class="certification-candidate-details-modal__row__value" data-test-id="birth-date-row">
+              <span class="certification-candidate-details-modal__row__value">
                 {{"-"}}
               </span>
             {{/if}}
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Sexe</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="sex-label-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.sexLabel @candidate.sexLabel "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Commune de naissance</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="birth-city-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.birthCity @candidate.birthCity "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Code postal de naissance</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="birth-postal-code-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Code INSEE de naissance</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="birth-insee-code-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Pays de naissance</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="birth-country-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.birthCountry @candidate.birthCountry "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">E-mail du destinataire des résultats
               (formateur, enseignant...)</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="result-recipient-email-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">E-mail de convocation</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="email-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.email @candidate.email "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Identifiant externe</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="external-id-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.externalId @candidate.externalId "-"}}
             </span>
           </li>
           <li class="certification-candidate-details-modal__row">
             <span class="certification-candidate-details-modal__row__label">Temps majoré (%)</span>
-            <span class="certification-candidate-details-modal__row__value" data-test-id="extra-time-row">
+            <span class="certification-candidate-details-modal__row__value">
               {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
             </span>
           </li>
           {{#if @shouldDisplayPaymentOptions}}
             <li class="certification-candidate-details-modal__row">
               <span class="certification-candidate-details-modal__row__label">Tarification part Pix</span>
-              <span class="certification-candidate-details-modal__row__value" data-test-id="billing-mode-row">
+              <span class="certification-candidate-details-modal__row__value">
                 {{if @candidate.billingMode @candidate.billingMode "-"}}
               </span>
             </li>
             <li class="certification-candidate-details-modal__row">
               <span class="certification-candidate-details-modal__row__label">Code de prépaiement</span>
-              <span class="certification-candidate-details-modal__row__value" data-test-id="prepayment-code-row">
+              <span class="certification-candidate-details-modal__row__value">
                 {{if @candidate.prepaymentCode @candidate.prepaymentCode "-"}}
               </span>
             </li>
@@ -110,10 +110,7 @@
           {{#if @displayComplementaryCertification}}
             <li class="certification-candidate-details-modal__row">
               <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
-              <span
-                class="certification-candidate-details-modal__row__value"
-                data-test-id="complementary-certifications-row"
-              >
+              <span class="certification-candidate-details-modal__row__value">
                 {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
               </span>
             </li>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -146,6 +146,7 @@
     @closeModal={{this.closeCertificationCandidateDetailsModal}}
     @candidate={{this.certificationCandidateInDetailsModal}}
     @displayComplementaryCertification={{@displayComplementaryCertification}}
+    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
   />
 {{/if}}
 

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -180,6 +180,120 @@ module('Integration | Component | certification-candidate-details-modal', functi
     });
   });
 
+  module('when @shouldDisplayPaymentOptions is true', function () {
+    test('it shows candidate details with payement options', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const candidate = store.createRecord('certification-candidate', {
+        firstName: 'Jean-Paul',
+        lastName: 'Candidat',
+        birthCity: 'Eu',
+        birthCountry: 'France',
+        email: 'jeanpauldeu@pix.fr',
+        resultRecipientEmail: 'suric@animal.fr',
+        externalId: '12345',
+        birthdate: '2000-12-25',
+        extraTimePercentage: 0.1,
+        birthInseeCode: 76255,
+        birthPostalCode: 76260,
+        sex: 'F',
+        complementaryCertifications: [],
+        billingMode: 'Prépayée',
+        prepaymentCode: 'prep123',
+      });
+
+      const closeModalStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('candidate', candidate);
+      this.set('displayComplementaryCertification', false);
+      this.set('shouldDisplayPaymentOptions', true);
+
+      // when
+      await render(hbs`
+      <CertificationCandidateDetailsModal
+        @closeModal={{this.closeModal}}
+        @candidate={{this.candidate}}
+        @displayComplementaryCertification={{this.displayComplementaryCertification}}
+        @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
+      />
+    `);
+
+      // then
+      assert.dom(screen.getByText('Détail du candidat')).exists();
+      assert.dom(screen.getByText('Jean-Paul')).exists();
+      assert.dom(screen.getByText('Candidat')).exists();
+      assert.dom(screen.getByText('Eu')).exists();
+      assert.dom(screen.getByText('76260')).exists();
+      assert.dom(screen.getByText('76255')).exists();
+      assert.dom(screen.getByText('Femme')).exists();
+      assert.dom(screen.getByText('France')).exists();
+      assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
+      assert.dom(screen.getByText('suric@animal.fr')).exists();
+      assert.dom(screen.getByText('12345')).exists();
+      assert.dom(screen.getByText('25/12/2000')).exists();
+      assert.dom(screen.getByText('10 %')).exists();
+      assert.dom(screen.getByText('Prépayée')).exists();
+      assert.dom(screen.getByText('prep123')).exists();
+    });
+  });
+
+  module('when @shouldDisplayPaymentOptions is false', function () {
+    test('it shows candidate details without payement options', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const candidate = store.createRecord('certification-candidate', {
+        firstName: 'Jean-Paul',
+        lastName: 'Candidat',
+        birthCity: 'Eu',
+        birthCountry: 'France',
+        email: 'jeanpauldeu@pix.fr',
+        resultRecipientEmail: 'suric@animal.fr',
+        externalId: '12345',
+        birthdate: '2000-12-25',
+        extraTimePercentage: 0.1,
+        birthInseeCode: 76255,
+        birthPostalCode: 76260,
+        sex: 'F',
+        complementaryCertifications: [],
+        billingMode: 'Prépayée',
+        prepaymentCode: 'prep123',
+      });
+
+      const closeModalStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('candidate', candidate);
+      this.set('displayComplementaryCertification', false);
+      this.set('shouldDisplayPaymentOptions', false);
+
+      // when
+      await render(hbs`
+      <CertificationCandidateDetailsModal
+        @closeModal={{this.closeModal}}
+        @candidate={{this.candidate}}
+        @displayComplementaryCertification={{this.displayComplementaryCertification}}
+        @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
+      />
+    `);
+
+      // then
+      assert.dom(screen.getByText('Détail du candidat')).exists();
+      assert.dom(screen.getByText('Jean-Paul')).exists();
+      assert.dom(screen.getByText('Candidat')).exists();
+      assert.dom(screen.getByText('Eu')).exists();
+      assert.dom(screen.getByText('76260')).exists();
+      assert.dom(screen.getByText('76255')).exists();
+      assert.dom(screen.getByText('Femme')).exists();
+      assert.dom(screen.getByText('France')).exists();
+      assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
+      assert.dom(screen.getByText('suric@animal.fr')).exists();
+      assert.dom(screen.getByText('12345')).exists();
+      assert.dom(screen.getByText('25/12/2000')).exists();
+      assert.dom(screen.getByText('10 %')).exists();
+      assert.dom(screen.queryByText('Prépayée')).doesNotExist();
+      assert.dom(screen.queryByText('prep123')).doesNotExist();
+    });
+  });
+
   module('when top close button is clicked', () => {
     test('it closes candidate details modal', async function (assert) {
       // given

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
-import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | certification-candidate-details-modal', function (hooks) {
@@ -45,7 +44,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       this.set('displayComplementaryCertification', true);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <CertificationCandidateDetailsModal
         @closeModal={{this.closeModal}}
         @candidate={{this.candidate}}
@@ -54,20 +53,20 @@ module('Integration | Component | certification-candidate-details-modal', functi
     `);
 
       // then
-      assert.contains('Détail du candidat');
-      assert.contains('Jean-Paul');
-      assert.contains('Candidat');
-      assert.contains('Eu');
-      assert.contains('76260');
-      assert.contains('76255');
-      assert.contains('Femme');
-      assert.contains('France');
-      assert.contains('jeanpauldeu@pix.fr');
-      assert.contains('suric@animal.fr');
-      assert.contains('12345');
-      assert.contains('25/12/2000');
-      assert.contains('10 %');
-      assert.contains('Pix+Edu, Pix+Droit');
+      assert.dom(screen.getByText('Détail du candidat')).exists();
+      assert.dom(screen.getByText('Jean-Paul')).exists();
+      assert.dom(screen.getByText('Candidat')).exists();
+      assert.dom(screen.getByText('Eu')).exists();
+      assert.dom(screen.getByText('76260')).exists();
+      assert.dom(screen.getByText('76255')).exists();
+      assert.dom(screen.getByText('Femme')).exists();
+      assert.dom(screen.getByText('France')).exists();
+      assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
+      assert.dom(screen.getByText('suric@animal.fr')).exists();
+      assert.dom(screen.getByText('12345')).exists();
+      assert.dom(screen.getByText('25/12/2000')).exists();
+      assert.dom(screen.getByText('10 %')).exists();
+      assert.dom(screen.getByText('Pix+Edu, Pix+Droit')).exists();
     });
 
     module('when candidate has missing data', () => {
@@ -93,7 +92,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         this.set('displayComplementaryCertification', true);
 
         // when
-        await render(hbs`
+        const screen = await renderScreen(hbs`
         <CertificationCandidateDetailsModal
           @closeModal={{this.closeModal}}
           @candidate={{this.candidate}}
@@ -102,19 +101,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       `);
 
         // then
-        assert.dom('[data-test-id="birth-postal-code-row"]').hasText('-');
-        assert.dom('[data-test-id="birth-insee-code-row"]').hasText('-');
-        assert.dom('[data-test-id="birth-city-row"]').hasText('-');
-        assert.dom('[data-test-id="result-recipient-email-row"]').hasText('-');
-        assert.dom('[data-test-id="email-row"]').hasText('-');
-        assert.dom('[data-test-id="external-id-row"]').hasText('-');
-        assert.dom('[data-test-id="extra-time-row"]').hasText('-');
-        assert.dom('[data-test-id="sex-label-row"]').hasText('-');
-        assert.dom('[data-test-id="birth-date-row"]').hasText('-');
-        assert.dom('[data-test-id="first-name-row"]').hasText('-');
-        assert.dom('[data-test-id="last-name-row"]').hasText('-');
-        assert.dom('[data-test-id="birth-country-row"]').hasText('-');
-        assert.dom('[data-test-id="complementary-certifications-row"]').hasText('-');
+        assert.strictEqual(screen.getAllByText('-').length, 13);
       });
     });
   });
@@ -154,7 +141,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       this.set('displayComplementaryCertification', false);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <CertificationCandidateDetailsModal
         @closeModal={{this.closeModal}}
         @candidate={{this.candidate}}
@@ -163,20 +150,20 @@ module('Integration | Component | certification-candidate-details-modal', functi
     `);
 
       // then
-      assert.contains('Détail du candidat');
-      assert.contains('Jean-Paul');
-      assert.contains('Candidat');
-      assert.contains('Eu');
-      assert.contains('76260');
-      assert.contains('76255');
-      assert.contains('Femme');
-      assert.contains('France');
-      assert.contains('jeanpauldeu@pix.fr');
-      assert.contains('suric@animal.fr');
-      assert.contains('12345');
-      assert.contains('25/12/2000');
-      assert.contains('10 %');
-      assert.notContains('Pix+Edu, Pix+Droit');
+      assert.dom(screen.getByText('Détail du candidat')).exists();
+      assert.dom(screen.getByText('Jean-Paul')).exists();
+      assert.dom(screen.getByText('Candidat')).exists();
+      assert.dom(screen.getByText('Eu')).exists();
+      assert.dom(screen.getByText('76260')).exists();
+      assert.dom(screen.getByText('76255')).exists();
+      assert.dom(screen.getByText('Femme')).exists();
+      assert.dom(screen.getByText('France')).exists();
+      assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
+      assert.dom(screen.getByText('suric@animal.fr')).exists();
+      assert.dom(screen.getByText('12345')).exists();
+      assert.dom(screen.getByText('25/12/2000')).exists();
+      assert.dom(screen.getByText('10 %')).exists();
+      assert.dom(screen.queryByText('Pix+Edu, Pix+Droit')).doesNotExist();
     });
   });
 
@@ -209,7 +196,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       this.set('shouldDisplayPaymentOptions', true);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <CertificationCandidateDetailsModal
         @closeModal={{this.closeModal}}
         @candidate={{this.candidate}}
@@ -266,7 +253,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       this.set('shouldDisplayPaymentOptions', false);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <CertificationCandidateDetailsModal
         @closeModal={{this.closeModal}}
         @candidate={{this.candidate}}
@@ -303,13 +290,13 @@ module('Integration | Component | certification-candidate-details-modal', functi
       this.set('candidate', candidate);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
         <CertificationCandidateDetailsModal
           @closeModal={{this.closeModal}}
           @candidate={{this.candidate}}
         />
       `);
-      await clickByLabel('Fermer la fenêtre de détail du candidat');
+      await click(screen.getByRole('button', { name: 'Fermer la fenêtre de détail du candidat' }));
 
       // then
       sinon.assert.calledOnce(closeModalStub);


### PR DESCRIPTION
## :unicorn: Problème
Pour faciliter les process de facturation des certifications payantes et le suivi des crédits de certification, 2 nouveaux champs vont être ajoutés lors de l’inscription d’un candidat en session : 

- Tarification part Pix

- Code de prépaiement

Il s’agit d’afficher ces informations sur la page de détails d’un candidat.

## :robot: Solution
Pour les centres de certification NON SCO, dans Pix Certif > page de détails de la session > onglet “Candidats” > pop-up “Voir le détail” : 

- afficher les champs “Tarification part Pix” et “Code de prépaiement”

## :rainbow: Remarques
Sous FT  ```FT_CERTIFICATION_BILLING```

## :100: Pour tester
- Activer le toggle ```FT_CERTIFICATION_BILLING```
- Se connecter sur ```pix-certif``` avec un centre de certification non-sco managing students
- Créer une session de certification
- Inscrire des candidats via l'import ods en précisant les modes de paiements
- Consulter les details des candidats (modale)
- Constater la présences des modes de paiements 

![image](https://user-images.githubusercontent.com/37305474/155989453-5f85db8c-0a2e-4dcf-9466-923c863cc271.png)
