### PR TITLE
[FEATURE] Permettre d'identifier une organisation comme archivé (PIX-3816)

### DIFF
--- a/api/db/migrations/20220228135813_add-archived-at-and-archived-by-columns-on-organizations-table.js
+++ b/api/db/migrations/20220228135813_add-archived-at-and-archived-by-columns-on-organizations-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'organizations';
+const ARCHIVED_AT = 'archivedAt';
+const ARCHIVED_BY = 'archivedBy';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, async (table) => {
+    table.dateTime(ARCHIVED_AT).nullable();
+    table.bigInteger(ARCHIVED_BY).nullable().references('users.id');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(ARCHIVED_AT);
+    table.dropColumn(ARCHIVED_BY);
+  });
+};

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -106,7 +106,7 @@ async function _getCampaignToStart(campaignId, domainTransaction) {
       'campaigns.id',
       'campaigns.type',
       'idPixLabel',
-      'archivedAt',
+      'campaigns.archivedAt',
       'isManagingStudents AS isRestricted',
       'multipleSendings',
       'assessmentMethod',


### PR DESCRIPTION
## 🌈  Contexte

Aujourd'hui, il n'existe pas de manière propre d'archiver une organization. L'archivage est fait avec l'ajout d'un tag or, les tags n'ont pas été conçus pour ce cas d'usage.

## :unicorn: Problème

Nous ne pouvons pas identifier quand et par qui une organization a été archivée.

## :robot: Solution

Créer deux nouveaux champs en base :
- ‘organizations.archivedAt’ (type `datetime`)
- ‘organizations.archivedBy’ (type `bigint`)

On crée une migration, par défaut ces deux colonnes seront vides, elles seront remplies grâce à l'ajout de la fonctionnalité d'archivage d'organisation et suite au script qui nettoiera les anciennes données.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

1. Exécuter la migration (`npm run db:migrate`) 
2. Vérifier que les deux nouvelles colonnes existent dans la table `organizations`