### PR TITLE
[TECH] Supprimer la colonne canCollectProfiles de la BDD (PIX-4364)

### DIFF
--- a/api/db/migrations/20220228150453_delete-can-collect-profile-column.js
+++ b/api/db/migrations/20220228150453_delete-can-collect-profile-column.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN = 'canCollectProfiles';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(COLUMN);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, async (table) => {
+    table.boolean(COLUMN).notNullable().defaultTo(false);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Le feature toggle est devenu obsolète, toute les organisations utilisent la collect de profile

## :robot: Solution
Retirer la colonne en base qui ne sert plus

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur Pix Orga que la collecte de profiles est toujours disponible sur une Organisation