### PR TITLE
[BUGFIX] Mettre le créateur de la campagne en propriétaire par défaut sur Pix Orga (PIX-4478).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -20,7 +20,7 @@ const { extractLocaleFromRequest } = require('../../infrastructure/utils/request
 
 module.exports = {
   async save(request, h) {
-    const { userId } = request.auth.credentials;
+    const { userId: creatorId } = request.auth.credentials;
     const {
       name,
       type,
@@ -41,8 +41,8 @@ module.exports = {
       title,
       idPixLabel,
       customLandingPageText,
-      creatorId: userId,
-      ownerId,
+      creatorId,
+      ownerId: _getOwnerId(ownerId, creatorId),
       organizationId,
       targetProfileId,
       multipleSendings,
@@ -232,4 +232,8 @@ function _validateFilters(filters) {
   if (typeof filters.code === 'undefined') {
     throw new MissingQueryParamError('filter.code');
   }
+}
+
+function _getOwnerId(ownerId, defaultOwnerId) {
+  return ownerId ? ownerId : defaultOwnerId;
 }

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -72,6 +72,56 @@ describe('Unit | Application | Controller | Campaign', function () {
       expect(response.source).to.equal(expectedResult);
       expect(response.statusCode).to.equal(201);
     });
+
+    it('should set the creator as the owner when no owner is provided', async function () {
+      // given
+      const connectedUserId = 1;
+      const request = {
+        auth: { credentials: { userId: connectedUserId } },
+        payload: {
+          data: {
+            attributes: {
+              name: 'name',
+              type: 'ASSESSMENT',
+              title: 'title',
+              'id-pix-label': 'idPixLabel',
+              'custom-landing-page-text': 'customLandingPageText',
+              'multiple-sendings': true,
+            },
+            relationships: {
+              'target-profile': { data: { id: '123' } },
+              organization: { data: { id: '456' } },
+            },
+          },
+        },
+        i18n: {
+          __: sinon.stub(),
+        },
+      };
+      const campaign = {
+        name: 'name',
+        type: 'ASSESSMENT',
+        title: 'title',
+        idPixLabel: 'idPixLabel',
+        customLandingPageText: 'customLandingPageText',
+        organizationId: 456,
+        targetProfileId: 123,
+        creatorId: 1,
+        ownerId: 1,
+        multipleSendings: true,
+      };
+
+      const expectedResult = Symbol('result');
+      const createdCampaign = Symbol('created campaign');
+      usecases.createCampaign.withArgs({ campaign }).resolves(createdCampaign);
+      campaignReportSerializer.serialize.withArgs(createdCampaign).returns(expectedResult);
+
+      // when
+      const response = await campaignController.save(request, hFake);
+
+      // then
+      expect(response.source).to.equal(expectedResult);
+    });
   });
 
   describe('#getCsvAssessmentResults', function () {


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga, quand une campagne est créée sans un propriétaire (de campagne), une erreur 500 est levée. 

## :robot: Solution
Mettre le créateur en propriétaire par défaut coté API.

## :rainbow: Remarques
Nous n'avons pas réussi à reproduire l'erreur de l'utilisateur. Néanmoins, en utilisant un curl de la requête, nous sommes tombé sur la même erreur que lui.
`Undefined binding(s) detected when compiling FIRST. Undefined column(s): [userId] query: select * from "memberships" where "organizationId" = ? and "userId" = ? limit ?`

## :100: Pour tester

- Se connecter sur Pix Orga 
- Ouvrir la console pour voir les requêtes
- Créer une campagne  url : `/campagnes/creation` ou bouton "Créer une campagne"
- Copier en curl la requête du `POST`
<img width="867" alt="Capture d’écran 2022-03-01 à 11 52 45" src="https://user-images.githubusercontent.com/58915422/156156218-8b2ee251-7ec3-4edd-8a6b-6b6b0d08f664.png">

- Enlever l'attribut `owner-id` du payload
- Lancer la requête curl dans votre terminal
- Vérifier que ça renvoie bien les données avec les détails de la campagne
