### PR TITLE
[BUGFIX] Pouvoir revoir le détail des tutos enregistrés sur la route v2

### DIFF
--- a/api/lib/domain/models/TutorialWithUserSavedTutorial.js
+++ b/api/lib/domain/models/TutorialWithUserSavedTutorial.js
@@ -1,7 +1,7 @@
 const Tutorial = require('./Tutorial');
 
 class TutorialWithUserSavedTutorial extends Tutorial {
-  constructor(tutorial, userTutorial) {
+  constructor({ userTutorial, ...tutorial }) {
     super(tutorial);
     this.userTutorial = userTutorial;
   }

--- a/api/lib/domain/models/TutorialWithUserSavedTutorial.js
+++ b/api/lib/domain/models/TutorialWithUserSavedTutorial.js
@@ -1,0 +1,10 @@
+const Tutorial = require('./Tutorial');
+
+class TutorialWithUserSavedTutorial extends Tutorial {
+  constructor(tutorial, userTutorial) {
+    super(tutorial);
+    this.userTutorial = userTutorial;
+  }
+}
+
+module.exports = TutorialWithUserSavedTutorial;

--- a/api/lib/domain/usecases/find-saved-tutorials.js
+++ b/api/lib/domain/usecases/find-saved-tutorials.js
@@ -1,21 +1,17 @@
-module.exports = async function findSavedTutorials({
-  tutorialEvaluationRepository,
-  userTutorialRepository,
-  userId,
-} = {}) {
+module.exports = async function findSavedTutorials({ tutorialEvaluationRepository, tutorialRepository, userId } = {}) {
   const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
-  const tutorialWithUserTutorial = await userTutorialRepository.findWithTutorial({ userId });
-  return tutorialWithUserTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
+  const tutorialWithUserSavedTutorial = await tutorialRepository.findWithUserTutorialForCurrentUser({ userId });
+  return tutorialWithUserSavedTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
 };
 
 function _retrieveTutorialEvaluations(tutorialEvaluations) {
-  return (tutorialWithUserTutorial) => {
+  return (tutorialWithUserSavedTutorial) => {
     const tutorialEvaluation = tutorialEvaluations.find(
-      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorialWithUserTutorial.id
+      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorialWithUserSavedTutorial.id
     );
     if (tutorialEvaluation) {
-      tutorialWithUserTutorial.tutorialEvaluation = tutorialEvaluation;
+      tutorialWithUserSavedTutorial.tutorialEvaluation = tutorialEvaluation;
     }
-    return tutorialWithUserTutorial;
+    return tutorialWithUserSavedTutorial;
   };
 }

--- a/api/lib/domain/usecases/find-saved-tutorials.js
+++ b/api/lib/domain/usecases/find-saved-tutorials.js
@@ -1,17 +1,18 @@
 module.exports = async function findSavedTutorials({ tutorialEvaluationRepository, tutorialRepository, userId } = {}) {
   const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
   const tutorialWithUserSavedTutorial = await tutorialRepository.findWithUserTutorialForCurrentUser({ userId });
-  return tutorialWithUserSavedTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
+  return tutorialWithUserSavedTutorial.map(_setTutorialEvaluation(tutorialEvaluations));
 };
 
-function _retrieveTutorialEvaluations(tutorialEvaluations) {
+function _setTutorialEvaluation(tutorialEvaluations) {
   return (tutorialWithUserSavedTutorial) => {
     const tutorialEvaluation = tutorialEvaluations.find(
       (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorialWithUserSavedTutorial.id
     );
-    if (tutorialEvaluation) {
-      tutorialWithUserSavedTutorial.tutorialEvaluation = tutorialEvaluation;
-    }
-    return tutorialWithUserSavedTutorial;
+    if (!tutorialEvaluation) return tutorialWithUserSavedTutorial;
+    return {
+      ...tutorialWithUserSavedTutorial,
+      tutorialEvaluation,
+    };
   };
 }

--- a/api/lib/domain/usecases/find-saved-tutorials.js
+++ b/api/lib/domain/usecases/find-saved-tutorials.js
@@ -4,18 +4,18 @@ module.exports = async function findSavedTutorials({
   userId,
 } = {}) {
   const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
-  const userTutorialsWithTutorial = await userTutorialRepository.findWithTutorial({ userId });
-  return userTutorialsWithTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
+  const tutorialWithUserTutorial = await userTutorialRepository.findWithTutorial({ userId });
+  return tutorialWithUserTutorial.map(_retrieveTutorialEvaluations(tutorialEvaluations));
 };
 
 function _retrieveTutorialEvaluations(tutorialEvaluations) {
-  return (userTutorial) => {
+  return (tutorialWithUserTutorial) => {
     const tutorialEvaluation = tutorialEvaluations.find(
-      (tutorialEvaluation) => tutorialEvaluation.tutorialId === userTutorial.tutorial.id
+      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorialWithUserTutorial.id
     );
     if (tutorialEvaluation) {
-      userTutorial.tutorial.tutorialEvaluation = tutorialEvaluation;
+      tutorialWithUserTutorial.tutorialEvaluation = tutorialEvaluation;
     }
-    return userTutorial;
+    return tutorialWithUserTutorial;
   };
 }

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -4,6 +4,7 @@ const userTutorialRepository = require('./user-tutorial-repository');
 const tutorialEvaluationRepository = require('./tutorial-evaluation-repository');
 const tutorialDatasource = require('../datasources/learning-content/tutorial-datasource');
 const { NotFoundError } = require('../../domain/errors');
+const TutorialWithUserSavedTutorial = require('../../domain/models/TutorialWithUserSavedTutorial');
 const { FRENCH_FRANCE } = require('../../domain/constants').LOCALE;
 
 module.exports = {
@@ -17,6 +18,16 @@ module.exports = {
 
   async findByRecordIds(ids) {
     return _findByRecordIds({ ids });
+  },
+
+  async findWithUserTutorialForCurrentUser({ userId }) {
+    const userTutorials = await userTutorialRepository.find({ userId });
+    const tutorials = await tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId));
+
+    return tutorials.map((tutorial) => {
+      const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
+      return new TutorialWithUserSavedTutorial({ ...tutorial, userTutorial });
+    });
   },
 
   async get(id) {

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -21,6 +21,7 @@ module.exports = {
     return userSavedTutorials.map(_toDomain);
   },
 
+  // TODO delete when tutorial V2 becomes main version
   async findWithTutorial({ userId }) {
     const userSavedTutorials = await knex(TABLE_NAME).where({ userId });
     const tutorials = await tutorialDatasource.findByRecordIds(userSavedTutorials.map(({ tutorialId }) => tutorialId));

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -383,6 +383,139 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
     });
   });
 
+  describe('GET /api/users/tutorials/saved', function () {
+    let options;
+    const userId = 4444;
+
+    beforeEach(async function () {
+      nock.cleanAll();
+      cache.flushAll();
+      options = {
+        method: 'GET',
+        url: '/api/users/tutorials/saved',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+    });
+
+    describe('nominal case', function () {
+      it('should respond with a 200 and return tutorials saved for user', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent([
+          {
+            id: 'recArea1',
+            titleFrFr: 'area1_Title',
+            color: 'specialColor',
+            competences: [
+              {
+                id: 'recCompetence1',
+                name: 'Fabriquer un meuble',
+                index: '1.1',
+                tubes: [
+                  {
+                    id: 'recTube1',
+                    skills: [
+                      {
+                        id: 'recSkill1',
+                        nom: '@web1',
+                        challenges: [],
+                        tutorialIds: ['tuto1', 'tuto2'],
+                        tutorials: [
+                          {
+                            id: 'tuto1',
+                            locale: 'en-us',
+                            duration: '00:00:54',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example.html',
+                            source: 'tuto.com',
+                            title: 'tuto1',
+                          },
+                          {
+                            id: 'tuto2',
+                            locale: 'en-us',
+                            duration: '00:01:51',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example2.html',
+                            source: 'tuto.com',
+                            title: 'tuto2',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recSkill2',
+                        nom: '@web2',
+                        challenges: [],
+                        tutorialIds: ['tuto3'],
+                        tutorials: [
+                          {
+                            id: 'tuto3',
+                            locale: 'fr-fr',
+                            duration: '00:03:31',
+                            format: 'vidéo',
+                            link: 'http://www.example.com/this-is-an-example3.html',
+                            source: 'tuto.com',
+                            title: 'tuto3',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recSkill3',
+                        nom: '@web3',
+                        challenges: [],
+                        tutorialIds: ['tuto4'],
+                        tutorials: [
+                          {
+                            id: 'tuto4',
+                            locale: 'fr-fr',
+                            duration: '00:04:38',
+                            format: 'vidéo',
+                            link: 'http://www.example.com/this-is-an-example4.html',
+                            source: 'tuto.com',
+                            title: 'tuto4',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+        mockLearningContent(learningContentObjects);
+
+        databaseBuilder.factory.buildUserSavedTutorial({ id: 500, tutorialId: 'tuto1', userId });
+
+        await databaseBuilder.commit();
+
+        const expectedUserSavedTutorials = [
+          {
+            attributes: {
+              duration: '00:00:54',
+              format: 'video',
+              link: 'http://www.example.com/this-is-an-example.html',
+              source: 'tuto.com',
+              title: 'tuto1',
+            },
+            relationships: {
+              'user-tutorial': { data: { id: '500', type: 'user-tutorial' } },
+            },
+            id: 'tuto1',
+            type: 'tutorials',
+          },
+        ];
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal(expectedUserSavedTutorials);
+      });
+    });
+  });
+
   describe('DELETE /api/users/tutorials/{tutorialId}', function () {
     let options;
 

--- a/api/tests/tooling/domain-builder/factory/build-tutorial-with-user-saved-tutorial.js
+++ b/api/tests/tooling/domain-builder/factory/build-tutorial-with-user-saved-tutorial.js
@@ -4,7 +4,7 @@ const TutorialWithUserSavedTutorial = require('../../../../lib/domain/models/Tut
 
 module.exports = function buildTutorialWithUserSavedTutorial({
   tutorial = buildTutorial(),
-  userSavedTutorial = buildUserSavedTutorial(),
+  userTutorial = buildUserSavedTutorial(),
 } = {}) {
-  return new TutorialWithUserSavedTutorial(tutorial, userSavedTutorial);
+  return new TutorialWithUserSavedTutorial({ ...tutorial, userTutorial });
 };

--- a/api/tests/tooling/domain-builder/factory/build-tutorial-with-user-tutorial.js
+++ b/api/tests/tooling/domain-builder/factory/build-tutorial-with-user-tutorial.js
@@ -1,0 +1,10 @@
+const buildTutorial = require('./build-tutorial');
+const buildUserSavedTutorial = require('./build-user-saved-tutorial');
+const TutorialWithUserSavedTutorial = require('../../../../lib/domain/models/TutorialWithUserSavedTutorial');
+
+module.exports = function buildTutorialWithUserSavedTutorial({
+  tutorial = buildTutorial(),
+  userSavedTutorial = buildUserSavedTutorial(),
+} = {}) {
+  return new TutorialWithUserSavedTutorial(tutorial, userSavedTutorial);
+};

--- a/api/tests/tooling/domain-builder/factory/build-user-saved-tutorial.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-saved-tutorial.js
@@ -1,0 +1,15 @@
+const UserSavedTutorial = require('../../../../lib/domain/models/UserSavedTutorial');
+
+module.exports = function buildUserSavedTutorial({
+  id = 111,
+  userId = '4044',
+  tutorialId = '111',
+  skillId = '1212',
+} = {}) {
+  return new UserSavedTutorial({
+    id,
+    skillId,
+    userId,
+    tutorialId,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -112,6 +112,7 @@ module.exports = {
   buildThematic: require('./build-thematic'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),
+  buildTutorialWithUserTutorial: require('./build-tutorial-with-user-tutorial'),
   buildUser: require('./build-user'),
   buildUserCompetence: require('./build-user-competence'),
   buildUserDetailsForAdmin: require('./build-user-details-for-admin'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -112,7 +112,7 @@ module.exports = {
   buildThematic: require('./build-thematic'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),
-  buildTutorialWithUserTutorial: require('./build-tutorial-with-user-tutorial'),
+  buildTutorialWithUserSavedTutorial: require('./build-tutorial-with-user-saved-tutorial'),
   buildUser: require('./build-user'),
   buildUserCompetence: require('./build-user-competence'),
   buildUserDetailsForAdmin: require('./build-user-details-for-admin'),

--- a/api/tests/unit/domain/usecases/find-saved-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-saved-tutorials_test.js
@@ -3,28 +3,28 @@ const findSavedTutorials = require('../../../../lib/domain/usecases/find-saved-t
 
 describe('Unit | UseCase | find-saved-tutorials', function () {
   let tutorialEvaluationRepository;
-  let userTutorialRepository;
+  let tutorialRepository;
   const userId = 'userId';
 
   context('when there is no tutorial saved by current user', function () {
     beforeEach(function () {
       tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
-      userTutorialRepository = { findWithTutorial: sinon.spy(async () => []) };
+      tutorialRepository = { findWithUserTutorialForCurrentUser: sinon.spy(async () => []) };
     });
 
-    it('should call the userTutorialRepository', async function () {
+    it('should call the tutorialRepository', async function () {
       // When
-      await findSavedTutorials({ tutorialEvaluationRepository, userTutorialRepository, userId });
+      await findSavedTutorials({ tutorialEvaluationRepository, tutorialRepository, userId });
 
       // Then
-      expect(userTutorialRepository.findWithTutorial).to.have.been.calledWith({ userId });
+      expect(tutorialRepository.findWithUserTutorialForCurrentUser).to.have.been.calledWith({ userId });
     });
 
     it('should return an empty array', async function () {
       // When
       const tutorials = await findSavedTutorials({
         tutorialEvaluationRepository,
-        userTutorialRepository,
+        tutorialRepository,
         userId,
       });
 
@@ -36,43 +36,47 @@ describe('Unit | UseCase | find-saved-tutorials', function () {
   context('when there is one tutorial saved by current user', function () {
     it('should return tutorial with user-tutorials', async function () {
       // Given
-      const tutorialWithUserTutorial = domainBuilder.buildTutorialWithUserTutorial();
+      const tutorialWithUserSavedTutorial = domainBuilder.buildTutorialWithUserSavedTutorial();
       tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
-      userTutorialRepository = { findWithTutorial: sinon.spy(async () => [tutorialWithUserTutorial]) };
+      tutorialRepository = {
+        findWithUserTutorialForCurrentUser: sinon.spy(async () => [tutorialWithUserSavedTutorial]),
+      };
 
       // When
       const tutorials = await findSavedTutorials({
         tutorialEvaluationRepository,
-        userTutorialRepository,
+        tutorialRepository,
         userId,
       });
 
       // Then
-      expect(tutorials).to.deep.equal([tutorialWithUserTutorial]);
+      expect(tutorials).to.deep.equal([tutorialWithUserSavedTutorial]);
     });
 
     context('when user has evaluated a tutorial', function () {
       it('should return tutorial with user-tutorials', async function () {
         // Given
-        const tutorialWithUserTutorial = domainBuilder.buildTutorialWithUserTutorial();
+        const tutorialWithUserSavedTutorial = domainBuilder.buildTutorialWithUserSavedTutorial();
         const tutorialEvaluation = {
           id: 123,
-          userId: tutorialWithUserTutorial.userTutorial.userId,
-          tutorialId: tutorialWithUserTutorial.id,
+          userId: tutorialWithUserSavedTutorial.userTutorial.userId,
+          tutorialId: tutorialWithUserSavedTutorial.id,
         };
         tutorialEvaluationRepository = { find: sinon.spy(async () => [tutorialEvaluation]) };
-        userTutorialRepository = { findWithTutorial: sinon.spy(async () => [{ ...tutorialWithUserTutorial }]) };
+        tutorialRepository = {
+          findWithUserTutorialForCurrentUser: sinon.spy(async () => [tutorialWithUserSavedTutorial]),
+        };
 
         // When
         const tutorials = await findSavedTutorials({
           tutorialEvaluationRepository,
-          userTutorialRepository,
+          tutorialRepository,
           userId,
         });
 
         // Then
         const expectedTutorialWithUserTutorial = {
-          ...tutorialWithUserTutorial,
+          ...tutorialWithUserSavedTutorial,
           tutorialEvaluation,
         };
         expect(tutorials).to.deep.equal([expectedTutorialWithUserTutorial]);

--- a/api/tests/unit/domain/usecases/find-saved-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-saved-tutorials_test.js
@@ -34,11 +34,11 @@ describe('Unit | UseCase | find-saved-tutorials', function () {
   });
 
   context('when there is one tutorial saved by current user', function () {
-    it('should return user-tutorials with tutorials', async function () {
+    it('should return tutorial with user-tutorials', async function () {
       // Given
-      const userTutorialWithTutorial = domainBuilder.buildUserSavedTutorialWithTutorial();
+      const tutorialWithUserTutorial = domainBuilder.buildTutorialWithUserTutorial();
       tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
-      userTutorialRepository = { findWithTutorial: sinon.spy(async () => [userTutorialWithTutorial]) };
+      userTutorialRepository = { findWithTutorial: sinon.spy(async () => [tutorialWithUserTutorial]) };
 
       // When
       const tutorials = await findSavedTutorials({
@@ -48,22 +48,20 @@ describe('Unit | UseCase | find-saved-tutorials', function () {
       });
 
       // Then
-      expect(tutorials).to.deep.equal([userTutorialWithTutorial]);
+      expect(tutorials).to.deep.equal([tutorialWithUserTutorial]);
     });
 
     context('when user has evaluated a tutorial', function () {
-      it('should return user-tutorials with tutorials', async function () {
+      it('should return tutorial with user-tutorials', async function () {
         // Given
-        const userId = 456;
-        const tutorial = domainBuilder.buildTutorial();
-        const userTutorialWithTutorial = domainBuilder.buildUserSavedTutorialWithTutorial({ userId, tutorial });
+        const tutorialWithUserTutorial = domainBuilder.buildTutorialWithUserTutorial();
         const tutorialEvaluation = {
           id: 123,
-          userId,
-          tutorialId: tutorial.id,
+          userId: tutorialWithUserTutorial.userTutorial.userId,
+          tutorialId: tutorialWithUserTutorial.id,
         };
         tutorialEvaluationRepository = { find: sinon.spy(async () => [tutorialEvaluation]) };
-        userTutorialRepository = { findWithTutorial: sinon.spy(async () => [{ ...userTutorialWithTutorial }]) };
+        userTutorialRepository = { findWithTutorial: sinon.spy(async () => [{ ...tutorialWithUserTutorial }]) };
 
         // When
         const tutorials = await findSavedTutorials({
@@ -73,11 +71,11 @@ describe('Unit | UseCase | find-saved-tutorials', function () {
         });
 
         // Then
-        const expectedUserTutorialWithTutorial = {
-          ...userTutorialWithTutorial,
-          tutorial: { ...tutorial, tutorialEvaluation },
+        const expectedTutorialWithUserTutorial = {
+          ...tutorialWithUserTutorial,
+          tutorialEvaluation,
         };
-        expect(tutorials).to.deep.equal([expectedUserTutorialWithTutorial]);
+        expect(tutorials).to.deep.equal([expectedTutorialWithUserTutorial]);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
@@ -68,7 +68,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       expect(result).to.deep.equal(expectedSerializedResult);
     });
 
-    it('should return a serialized JSON data object, with userTutorial related to', function () {
+    it('should return a serialized JSON data object, with userSavedTutorial related to', function () {
       // given
       const userId = 456;
       const tutorialId = 123;


### PR DESCRIPTION
## :unicorn: Problème
Sur la page des tutos enregistrés v2, on n'affiche pas correctement les infos. Le problème vient du serializer de l'api qui "mange" les attributs, car ils ne sont pas iso avec la route tutorials/recommended

## :robot: Solution
Inverser la relation userTutorial => Tutorial par  Tutorial => UserTutorial

## :rainbow: Remarques
Sur la page des tutos v1 cette relation reste dans le sens userTutorial => Tutorial , et il faudra la supprimer quand la v1 sera devenue obsolète.

## :100: Pour tester
Aller sur pix app puis sur la page des tutos enregistrés et vérifier que le détail des tutos enregistrés s'affiche correctement.