### PR TITLE
[FEATURE] Voir si une organisation est archivée et qui a fait l'action d'archivage dans Pix Admin (PIX-4186).

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -166,6 +166,15 @@
           </ul>
         {{/if}}
 
+        {{#if @organization.archivistFullName}}
+          <PixMessage class="organization-information-section__archived-message" @type="warning">
+            Archivée le
+            {{@organization.archivedFormattedDate}}
+            par
+            {{@organization.archivistFullName}}.
+          </PixMessage>
+        {{/if}}
+
         <div class="organization-information-section__content">
           <div class="organization-information-section__details">
             <p>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -2,6 +2,7 @@ import { memberAction } from 'ember-api-actions';
 import Model, { hasMany, attr } from '@ember-data/model';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { equal } from '@ember/object/computed';
+import dayjs from 'dayjs';
 
 export default class Organization extends Model {
   @attr() name;
@@ -17,6 +18,8 @@ export default class Organization extends Model {
   @attr() createdBy;
   @attr('string') documentationUrl;
   @attr('boolean') showSkills;
+  @attr() archivistFullName;
+  @attr() archivedAt;
 
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;
@@ -28,6 +31,10 @@ export default class Organization extends Model {
   async hasMember(userEmail) {
     const memberships = await this.memberships;
     return !!memberships.findBy('user.email', userEmail);
+  }
+
+  get archivedFormattedDate() {
+    return dayjs(this.archivedAt).format('DD/MM/YYYY');
   }
 
   attachTargetProfiles = memberAction({

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -6,6 +6,10 @@
     justify-content: space-between;
   }
 
+  &__archived-message {
+    margin-bottom: 16px;
+  }
+
   &__details {
     overflow: hidden;
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11407,6 +11407,12 @@
         "time-zone": "^1.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
+      "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/admin/package.json
+++ b/admin/package.json
@@ -48,6 +48,7 @@
     "babel-eslint": "^10.1.0",
     "bootstrap": "^4.6.0",
     "broccoli-asset-rev": "^3.0.0",
+    "dayjs": "^1.10.8",
     "ember-ajax": "^5.0.0",
     "ember-api-actions": "^0.2.9",
     "ember-auto-import": "^1.12.0",
@@ -117,6 +118,5 @@
   },
   "ember": {
     "edition": "octane"
-  },
-  "dependencies": {}
+  }
 }

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
@@ -13,9 +14,10 @@ module('Integration | Component | organizations/information-section', function (
     this.organization = EmberObject.create({ type: 'SUP', isManagingStudents: false });
 
     // when
-    await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+    const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
     // then
+    assert.dom(screen.queryByText('Archivée le', { exact: false })).doesNotExist();
     assert.dom('.organization__information').exists();
   });
 
@@ -99,6 +101,22 @@ module('Integration | Component | organizations/information-section', function (
     assert.contains('CFA');
     assert.contains('PRIVE');
     assert.contains('AGRICULTURE');
+  });
+
+  module('when organization is archived', function () {
+    test('it should display who archived it', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const archivedAt = new Date('2022-02-22');
+      const organization = store.createRecord('organization', { archivistFullName: 'Rob Lochon', archivedAt });
+      this.set('organization', organization);
+
+      // when
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+
+      // expect
+      assert.dom(screen.getByText('Archivée le 22/02/2022 par Rob Lochon.')).exists();
+    });
   });
 
   module('Edit organization', function (hooks) {

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | organization', function (hooks) {
+  setupTest(hooks);
+
+  test('it formats the archived date', function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('organization', { archivedAt: new Date('2022-02-22') }));
+
+    // when
+    const archivedFormattedDate = model.archivedFormattedDate;
+
+    // then
+    assert.strictEqual(archivedFormattedDate, '22/02/2022');
+  });
+});

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -17,6 +17,8 @@ const buildOrganization = function buildOrganization({
   showNPS = false,
   formNPSUrl = null,
   showSkills = false,
+  archivedBy = null,
+  archivedAt = null,
 } = {}) {
   const values = {
     id,
@@ -35,6 +37,8 @@ const buildOrganization = function buildOrganization({
     showNPS,
     formNPSUrl,
     showSkills,
+    archivedBy,
+    archivedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -4,6 +4,7 @@ const { DEFAULT_PASSWORD } = require('./users-builder');
 const PRO_COMPANY_ID = 1;
 const PRO_POLE_EMPLOI_ID = 4;
 const PRO_MED_NUM_ID = 5;
+const PRO_ARCHIVED_ID = 15;
 
 function organizationsProBuilder({ databaseBuilder }) {
 
@@ -100,6 +101,48 @@ function organizationsProBuilder({ databaseBuilder }) {
     userId: proUser1.id,
     organizationId: PRO_MED_NUM_ID,
     organizationRole: Membership.roles.ADMIN,
+  });
+
+  /* ARCHIVÉE */
+  const pixMaster = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Clément',
+    lastName: 'Tine',
+    email: 'pix.master@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+  const membership1 = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Colette',
+    lastName: 'Stérole',
+    email: 'coco.role@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+  const membership2 = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Mick',
+    lastName: 'Émmaousse',
+    email: 'mimi.lasouris@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+
+  const archivedAt = new Date('2022-02-02');
+
+  databaseBuilder.factory.buildOrganization({
+    id: PRO_ARCHIVED_ID,
+    type: 'PRO',
+    name: 'Orga archivée',
+    archivedAt,
+    archivedBy: pixMaster.id,
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: membership1.id,
+    organizationId: PRO_ARCHIVED_ID,
+    organizationRole: Membership.roles.ADMIN,
+    disabledAt: archivedAt,
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: membership2.id,
+    organizationId: PRO_ARCHIVED_ID,
+    organizationRole: Membership.roles.MEMBER,
+    disabledAt: archivedAt,
   });
 }
 

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -22,12 +22,14 @@ const {
 const moment = require('moment');
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
+const organizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/organization-for-admin-serializer');
 
 module.exports = {
-  getOrganizationDetails: (request) => {
+  async getOrganizationDetails(request) {
     const organizationId = request.params.id;
 
-    return usecases.getOrganizationDetails({ organizationId }).then(organizationSerializer.serialize);
+    const organizationDetails = await usecases.getOrganizationDetails({ organizationId });
+    return organizationForAdminSerializer.serialize(organizationDetails);
   },
 
   create: (request) => {

--- a/api/lib/domain/models/OrganizationForAdmin.js
+++ b/api/lib/domain/models/OrganizationForAdmin.js
@@ -1,0 +1,49 @@
+class OrganizationForAdmin {
+  constructor({
+    id,
+    name,
+    type,
+    logoUrl,
+    externalId,
+    provinceCode,
+    isManagingStudents,
+    credit,
+    email,
+    documentationUrl,
+    createdBy,
+    showNPS,
+    formNPSUrl,
+    showSkills,
+    archivedAt,
+    archivistFirstName,
+    archivistLastName,
+    tags = [],
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+    this.logoUrl = logoUrl;
+    this.externalId = externalId;
+    this.provinceCode = provinceCode;
+    this.isManagingStudents = isManagingStudents;
+    this.credit = credit;
+    this.email = email;
+    this.documentationUrl = documentationUrl;
+    this.createdBy = createdBy;
+    this.showNPS = showNPS;
+    this.formNPSUrl = formNPSUrl;
+    this.showSkills = showSkills;
+    this.archivedAt = archivedAt;
+    this.archivistFirstName = archivistFirstName;
+    this.archivistLastName = archivistLastName;
+    this.tags = tags;
+  }
+
+  get archivistFullName() {
+    return this.archivistFirstName && this.archivistLastName
+      ? `${this.archivistFirstName} ${this.archivistLastName}`
+      : null;
+  }
+}
+
+module.exports = OrganizationForAdmin;

--- a/api/lib/domain/usecases/get-organization-details.js
+++ b/api/lib/domain/usecases/get-organization-details.js
@@ -1,3 +1,3 @@
-module.exports = function getOrganizationDetails({ organizationId, organizationRepository }) {
-  return organizationRepository.get(organizationId);
+module.exports = function getOrganizationDetails({ organizationId, organizationForAdminRepository }) {
+  return organizationForAdminRepository.get(organizationId);
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -85,6 +85,7 @@ const dependencies = {
   membershipRepository: require('../../infrastructure/repositories/membership-repository'),
   obfuscationService: require('../../domain/services/obfuscation-service'),
   organizationMemberIdentityRepository: require('../../infrastructure/repositories/organization-member-identity-repository'),
+  organizationForAdminRepository: require('../../infrastructure/repositories/organization-for-admin-repository'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
   organizationInvitedUserRepository: require('../../infrastructure/repositories/organization-invited-user-repository'),

--- a/api/lib/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/organization-for-admin-repository.js
@@ -1,0 +1,73 @@
+const { NotFoundError } = require('../../domain/errors');
+const OrganizationForAdmin = require('../../domain/models/OrganizationForAdmin');
+const Tag = require('../../domain/models/Tag');
+const { knex } = require('../../../db/knex-database-connection');
+
+function _toDomain(rawOrganization) {
+  const organization = new OrganizationForAdmin({
+    id: rawOrganization.id,
+    name: rawOrganization.name,
+    type: rawOrganization.type,
+    logoUrl: rawOrganization.logoUrl,
+    externalId: rawOrganization.externalId,
+    provinceCode: rawOrganization.provinceCode,
+    isManagingStudents: Boolean(rawOrganization.isManagingStudents),
+    credit: rawOrganization.credit,
+    email: rawOrganization.email,
+    documentationUrl: rawOrganization.documentationUrl,
+    createdBy: rawOrganization.createdBy,
+    showNPS: rawOrganization.showNPS,
+    formNPSUrl: rawOrganization.formNPSUrl,
+    showSkills: rawOrganization.showSkills,
+    archivedAt: rawOrganization.archivedAt,
+    archivistFirstName: rawOrganization.archivistFirstName,
+    archivistLastName: rawOrganization.archivistLastName,
+  });
+
+  organization.tags = rawOrganization.tags || [];
+
+  return organization;
+}
+
+module.exports = {
+  async get(id) {
+    const organization = await knex('organizations')
+      .select({
+        id: 'organizations.id',
+        name: 'organizations.name',
+        type: 'organizations.type',
+        logoUrl: 'organizations.logoUrl',
+        externalId: 'organizations.externalId',
+        provinceCode: 'organizations.provinceCode',
+        isManagingStudents: 'organizations.isManagingStudents',
+        credit: 'organizations.credit',
+        email: 'organizations.email',
+        documentationUrl: 'organizations.documentationUrl',
+        createdBy: 'organizations.createdBy',
+        showNPS: 'organizations.showNPS',
+        formNPSUrl: 'organizations.formNPSUrl',
+        showSkills: 'organizations.showSkills',
+        archivedAt: 'organizations.archivedAt',
+        archivistFirstName: 'users.firstName',
+        archivistLastName: 'users.lastName',
+      })
+      .leftJoin('users', 'users.id', 'organizations.archivedBy')
+      .where('organizations.id', id)
+      .first();
+
+    if (!organization) {
+      throw new NotFoundError(`Not found organization for ID ${id}`);
+    }
+
+    const tags = await knex('tags')
+      .select('tags.*')
+      .join('organization-tags', 'organization-tags.tagId', 'tags.id')
+      .where('organization-tags.organizationId', organization.id);
+
+    organization.tags = tags.map((tag) => {
+      return new Tag(tag);
+    });
+
+    return _toDomain(organization);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js
@@ -1,0 +1,65 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(organizations, meta) {
+    return new Serializer('organizations', {
+      attributes: [
+        'name',
+        'type',
+        'logoUrl',
+        'externalId',
+        'provinceCode',
+        'isManagingStudents',
+        'credit',
+        'email',
+        'documentationUrl',
+        'createdBy',
+        'showNPS',
+        'formNPSUrl',
+        'showSkills',
+        'archivedAt',
+        'archivistFullName',
+        'tags',
+        'memberships',
+        'students',
+        'targetProfiles',
+      ],
+      memberships: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/organizations/${parent.id}/memberships`;
+          },
+        },
+      },
+      students: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/organizations/${parent.id}/students`;
+          },
+        },
+      },
+      targetProfiles: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/organizations/${parent.id}/target-profiles`;
+          },
+        },
+      },
+      tags: {
+        ref: 'id',
+        included: true,
+        attributes: ['id', 'name'],
+      },
+      meta,
+    }).serialize(organizations);
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -1,0 +1,157 @@
+const { catchErr, expect, domainBuilder, databaseBuilder } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
+const organizationForAdminRepository = require('../../../../lib/infrastructure/repositories/organization-for-admin-repository');
+
+describe('Integration | Repository | Organization-for-admin', function () {
+  describe('#get', function () {
+    it('should return a organization for admin by provided id', async function () {
+      // given
+      const pixMasterUserId = databaseBuilder.factory.buildUser().id;
+
+      const insertedOrganization = databaseBuilder.factory.buildOrganization({
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        logoUrl: 'some logo url',
+        credit: 154,
+        externalId: '100',
+        provinceCode: '75',
+        isManagingStudents: 'true',
+        email: 'sco.generic.account@example.net',
+        documentationUrl: 'https://pix.fr/',
+        createdBy: pixMasterUserId,
+        showNPS: true,
+        formNPSUrl: 'https://pix.fr/',
+        showSkills: false,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationForAdmin = await organizationForAdminRepository.get(insertedOrganization.id);
+
+      // then
+      const expectedOrganizationForAdmin = new OrganizationForAdmin({
+        id: insertedOrganization.id,
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        logoUrl: 'some logo url',
+        credit: 154,
+        externalId: '100',
+        provinceCode: '75',
+        isManagingStudents: true,
+        email: 'sco.generic.account@example.net',
+        students: [],
+        targetProfileShares: [],
+        organizationInvitations: [],
+        tags: [],
+        documentationUrl: 'https://pix.fr/',
+        createdBy: insertedOrganization.createdBy,
+        showNPS: true,
+        formNPSUrl: 'https://pix.fr/',
+        showSkills: false,
+        archivedAt: null,
+        archivistFirstName: null,
+        archivistLastName: null,
+      });
+      expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
+    });
+
+    it('should throw when organization is not found', async function () {
+      // given
+      const nonExistentId = 10083;
+
+      // when
+      const error = await catchErr(organizationForAdminRepository.get)(nonExistentId);
+
+      // then
+      expect(error).to.be.an.instanceof(NotFoundError);
+      expect(error.message).to.equal('Not found organization for ID 10083');
+    });
+
+    describe('when the organization has associated tags', function () {
+      it('should return an organization with associated tags', async function () {
+        // given
+        const insertedOrganization = databaseBuilder.factory.buildOrganization();
+        const tag1 = databaseBuilder.factory.buildTag({ name: 'PRO' });
+        databaseBuilder.factory.buildOrganizationTag({
+          organizationId: insertedOrganization.id,
+          tagId: tag1.id,
+        });
+        const tag2 = databaseBuilder.factory.buildTag({ name: 'SCO' });
+        databaseBuilder.factory.buildOrganizationTag({
+          organizationId: insertedOrganization.id,
+          tagId: tag2.id,
+        });
+        databaseBuilder.factory.buildOrganizationTag();
+        await databaseBuilder.commit();
+
+        // when
+        const organization = await organizationForAdminRepository.get(insertedOrganization.id);
+
+        // then
+        const expectedTags = [domainBuilder.buildTag({ ...tag1 }), domainBuilder.buildTag({ ...tag2 })];
+        expect(organization.tags).to.deep.equal(expectedTags);
+        expect(organization.tags).to.have.lengthOf(2);
+      });
+    });
+
+    describe('when the organization is archived', function () {
+      it('should return its archived details', async function () {
+        // given
+        const pixMasterUser = databaseBuilder.factory.buildUser();
+        const archivist = databaseBuilder.factory.buildUser();
+        const archivedAt = new Date('2022-02-02');
+
+        const insertedOrganization = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          name: 'Organization of the dark side',
+          logoUrl: 'some logo url',
+          credit: 154,
+          externalId: '100',
+          provinceCode: '75',
+          isManagingStudents: 'true',
+          email: 'sco.generic.account@example.net',
+          documentationUrl: 'https://pix.fr/',
+          createdBy: pixMasterUser.id,
+          showNPS: true,
+          formNPSUrl: 'https://pix.fr/',
+          showSkills: false,
+          archivedBy: archivist.id,
+          archivedAt,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganizationForAdmin = await organizationForAdminRepository.get(insertedOrganization.id);
+
+        // then
+        const expectedOrganizationForAdmin = new OrganizationForAdmin({
+          id: insertedOrganization.id,
+          type: 'SCO',
+          name: 'Organization of the dark side',
+          logoUrl: 'some logo url',
+          credit: 154,
+          externalId: '100',
+          provinceCode: '75',
+          isManagingStudents: true,
+          email: 'sco.generic.account@example.net',
+          students: [],
+          targetProfileShares: [],
+          organizationInvitations: [],
+          tags: [],
+          documentationUrl: 'https://pix.fr/',
+          createdBy: insertedOrganization.createdBy,
+          showNPS: true,
+          formNPSUrl: 'https://pix.fr/',
+          showSkills: false,
+          archivedAt,
+          archivistFirstName: archivist.firstName,
+          archivistLastName: archivist.lastName,
+        });
+        expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -202,7 +202,7 @@ describe('Integration | Repository | Organization', function () {
       });
     });
 
-    describe('when a target profile is shared with the organisation', function () {
+    describe('when a target profile is shared with the organization', function () {
       let insertedOrganization;
       let sharedProfile;
 

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -30,6 +30,8 @@ describe('Integration | Repository | UserOrgaSettings', function () {
     'createdAt',
     'updatedAt',
     'createdBy',
+    'archivedAt',
+    'archivedBy',
   ];
 
   let user;

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -16,7 +16,15 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', fun
       // given
       const externalId = '1234567A';
       const organization = databaseBuilder.factory.buildOrganization({ externalId });
-      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt', 'email', 'tags', 'createdBy']);
+      const expectedOrganization = _.omit(organization, [
+        'createdAt',
+        'updatedAt',
+        'email',
+        'tags',
+        'createdBy',
+        'archivedBy',
+        'archivedAt',
+      ]);
 
       await databaseBuilder.commit();
 

--- a/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
@@ -1,0 +1,49 @@
+const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
+
+function buildOrganizationForAdmin({
+  id = 123,
+  name = 'Lycée Luke Skywalker',
+  type = 'SCO',
+  logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+  externalId = 'OrganizationIdLinksToExternalSource',
+  provinceCode = '2A',
+  isManagingStudents = false,
+  credit = 500,
+  email = 'jesuistonpere@example.net',
+  createdAt = new Date('2018-01-12T01:02:03Z'),
+  targetProfileShares = [],
+  tags = [],
+  createdBy,
+  documentationUrl = 'https://pix.fr',
+  showNPS = false,
+  formNPSUrl = 'https://pix.fr',
+  showSkills = false,
+  archivedAt = null,
+  archivistFirstName = null,
+  archivistLastName = null,
+} = {}) {
+  return new OrganizationForAdmin({
+    id,
+    name,
+    type,
+    logoUrl,
+    externalId,
+    provinceCode,
+    isManagingStudents,
+    credit,
+    email,
+    createdAt,
+    targetProfileShares,
+    tags,
+    createdBy,
+    documentationUrl,
+    showNPS,
+    formNPSUrl,
+    showSkills,
+    archivedAt,
+    archivistFirstName,
+    archivistLastName,
+  });
+}
+
+module.exports = buildOrganizationForAdmin;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -72,6 +72,7 @@ module.exports = {
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildMembership: require('./build-membership'),
   buildOrganization: require('./build-organization'),
+  buildOrganizationForAdmin: require('./build-organization-for-admin'),
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationTag: require('./build-organization-tag'),
   buildParticipationForCampaignManagement: require('./build-participation-for-campaign-management'),

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -20,6 +20,7 @@ const campaignManagementSerializer = require('../../../../lib/infrastructure/ser
 const campaignReportSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-report-serializer');
 const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 const organizationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
+const organizationForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer');
 const TargetProfileForSpecifierSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer');
 const userWithSchoolingRegistrationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
 const organizationAttachTargetProfilesSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-attach-target-profiles-serializer');
@@ -39,18 +40,19 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const organizationId = 1234;
       const request = { params: { id: organizationId } };
 
-      sinon.stub(usecases, 'getOrganizationDetails');
-      sinon.stub(organizationSerializer, 'serialize');
-      usecases.getOrganizationDetails.resolves();
-      organizationSerializer.serialize.returns();
+      const organizationDetails = Symbol('organizationDetails');
+      const organizationDetailsSerialized = Symbol('organizationDetailsSerialized');
+      sinon.stub(usecases, 'getOrganizationDetails').withArgs({ organizationId }).resolves(organizationDetails);
+      sinon
+        .stub(organizationForAdminSerializer, 'serialize')
+        .withArgs(organizationDetails)
+        .returns(organizationDetailsSerialized);
 
       // when
-      await organizationController.getOrganizationDetails(request, hFake);
+      const result = await organizationController.getOrganizationDetails(request, hFake);
 
       // then
-      expect(usecases.getOrganizationDetails).to.have.been.calledOnce;
-      expect(usecases.getOrganizationDetails).to.have.been.calledWith({ organizationId });
-      expect(organizationSerializer.serialize).to.have.been.calledOnce;
+      expect(result).to.equal(organizationDetailsSerialized);
     });
   });
 

--- a/api/tests/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/unit/domain/models/OrganizationForAdmin_test.js
@@ -1,0 +1,22 @@
+const { expect } = require('../../../test-helper');
+const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
+
+describe('Unit | Domain | Models | OrganizationForAdmin', function () {
+  describe('#archivistFullName', function () {
+    it('should return the full name of user who archived the organization', function () {
+      // given
+      const organization = new OrganizationForAdmin({ archivistFirstName: 'Sarah', archivistLastName: 'Visseuse' });
+
+      // when / then
+      expect(organization.archivistFullName).equal('Sarah Visseuse');
+    });
+
+    it('should return null if organization is not archived', function () {
+      // given
+      const organization = new OrganizationForAdmin({ archivistFirstName: null, archivistLastName: null });
+
+      // when / then
+      expect(organization.archivistFullName).to.be.null;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-organization-details_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-details_test.js
@@ -3,25 +3,23 @@ const getOrganizationDetails = require('../../../../lib/domain/usecases/get-orga
 const Organization = require('../../../../lib/domain/models/Organization');
 
 describe('Unit | UseCase | get-organization-details', function () {
-  it('should return the Organization matching the given organization ID', function () {
+  it('should return the Organization matching the given organization ID', async function () {
     // given
     const organizationId = 1234;
     const foundOrganization = domainBuilder.buildOrganization({
       id: organizationId,
       email: 'sco.generic.account@example.net',
     });
-    const organizationRepository = {
+    const organizationForAdminRepository = {
       get: sinon.stub().resolves(foundOrganization),
     };
 
     // when
-    const promise = getOrganizationDetails({ organizationId, organizationRepository });
+    const organization = await getOrganizationDetails({ organizationId, organizationForAdminRepository });
 
     // then
-    return promise.then((organization) => {
-      expect(organizationRepository.get).to.have.been.calledWith(organizationId);
-      expect(organization).to.be.an.instanceOf(Organization);
-      expect(organization).to.deep.equal(foundOrganization);
-    });
+    expect(organizationForAdminRepository.get).to.have.been.calledWith(organizationId);
+    expect(organization).to.be.an.instanceOf(Organization);
+    expect(organization).to.deep.equal(foundOrganization);
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -1,0 +1,101 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer');
+
+describe('Unit | Serializer | organization-for-admin-serializer', function () {
+  describe('#serialize', function () {
+    it('should return a JSON API serialized organization', function () {
+      // given
+      const tags = [
+        domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
+        domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
+      ];
+      const organization = domainBuilder.buildOrganizationForAdmin({
+        email: 'sco.generic.account@example.net',
+        tags,
+        createdBy: 10,
+        documentationUrl: 'https://pix.fr/',
+        archivistFirstName: 'John',
+        archivistLastName: 'Doe',
+      });
+      const meta = { some: 'meta' };
+
+      // when
+      const serializedOrganization = serializer.serialize(organization, meta);
+
+      // then
+      expect(serializedOrganization).to.deep.equal({
+        data: {
+          type: 'organizations',
+          id: organization.id.toString(),
+          attributes: {
+            name: organization.name,
+            type: organization.type,
+            'logo-url': organization.logoUrl,
+            'external-id': organization.externalId,
+            'province-code': organization.provinceCode,
+            'is-managing-students': organization.isManagingStudents,
+            credit: organization.credit,
+            email: organization.email,
+            'created-by': organization.createdBy,
+            'documentation-url': organization.documentationUrl,
+            'show-nps': organization.showNPS,
+            'form-nps-url': organization.formNPSUrl,
+            'show-skills': organization.showSkills,
+            'archived-at': organization.archivedAt,
+            'archivist-full-name': organization.archivistFullName,
+          },
+          relationships: {
+            memberships: {
+              links: {
+                related: `/api/organizations/${organization.id}/memberships`,
+              },
+            },
+            students: {
+              links: {
+                related: `/api/organizations/${organization.id}/students`,
+              },
+            },
+            'target-profiles': {
+              links: {
+                related: `/api/organizations/${organization.id}/target-profiles`,
+              },
+            },
+            tags: {
+              data: [
+                {
+                  id: tags[0].id.toString(),
+                  type: 'tags',
+                },
+                {
+                  id: tags[1].id.toString(),
+                  type: 'tags',
+                },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              id: tags[0].id,
+              name: tags[0].name,
+            },
+            id: tags[0].id.toString(),
+            type: 'tags',
+          },
+          {
+            attributes: {
+              id: tags[1].id,
+              name: tags[1].name,
+            },
+            id: tags[1].id.toString(),
+            type: 'tags',
+          },
+        ],
+        meta: {
+          some: 'meta',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌈  Contexte
Aujourd'hui, il n'existe pas de manière propre d'archiver une organisation. L'archivage est fait avec l'ajout d'un tag (obsolète). Or, les tags n'ont pas été conçus pour ce cas d'usage.

## :unicorn: Problème
Nous ne pouvons pas identifier quand et par qui une organisation a été archivée sur Pix Admin.

## :robot: Solution
Ajouter une phrase dans les détails d'une organisation dans Pix Admin `Archivée le {archivedAt} par {users.fullName}`

## :rainbow: Remarques
Ajout de la librairie DayJs

## :100: Pour tester
1 - Se rendre sur [PixAdmin](https://admin-pr4157.review.pix.fr/)
2 - Se connecter en tant que `pixmaster@example.net`
3 - Ouvrez les détails de l'orga avec id `15`
4 - Vérifiez que le message d'archivage est bien affiché
5 - Ouvrez les détails d'une autre orga non archivée
6 - Vérifiez qu'aucun message d'archivage n'apparaisse