### PR TITLE
[TECH] Ajouter les informations de suppresion sur une participation à une campagne (PIX-4435)

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -20,6 +20,8 @@ module.exports = function buildCampaignParticipation({
   pixScore,
   status = SHARED,
   isImproved = false,
+  deletedAt = null,
+  deletedBy = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   schoolingRegistrationId = _.isUndefined(schoolingRegistrationId)
@@ -42,6 +44,8 @@ module.exports = function buildCampaignParticipation({
     pixScore,
     status,
     isImproved,
+    deletedAt,
+    deletedBy,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'campaign-participations',

--- a/api/db/migrations/20220302101303_add-deletedat-deletedby-on-campaign-participations.js
+++ b/api/db/migrations/20220302101303_add-deletedat-deletedby-on-campaign-participations.js
@@ -1,0 +1,39 @@
+const TABLE_NAME = 'campaign-participations';
+const DELETEDAT_COLUMN = 'deletedAt';
+const DELETEDBY_COLUMN = 'deletedBy';
+const ISIMPROVED_COLUMN = 'isImproved';
+const USERID_COLUMN = 'userId';
+const CAMPAIGNID_COLUMN = 'campaignId';
+
+const NEW_CONSTRAINT_NAME = 'campaign_participations_campaignid_userid_isimproved_deleted';
+const OLD_CONSTRAINT_NAME = 'campaign_participations_campaignid_userid_isimproved';
+
+exports.up = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`DROP INDEX ${OLD_CONSTRAINT_NAME};`);
+
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dateTime(DELETEDAT_COLUMN);
+    table.bigInteger(DELETEDBY_COLUMN).index().references('users.id');
+  });
+
+  // eslint-disable-next-line knex/avoid-injections
+  return knex.raw(
+    `CREATE UNIQUE INDEX ${NEW_CONSTRAINT_NAME} ON "${TABLE_NAME}" ("${CAMPAIGNID_COLUMN}", "${USERID_COLUMN}" ) WHERE "${ISIMPROVED_COLUMN}" IS FALSE AND "${DELETEDAT_COLUMN}" IS NULL AND "${DELETEDBY_COLUMN}" IS NULL;`
+  );
+};
+
+exports.down = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`DROP INDEX ${NEW_CONSTRAINT_NAME};`);
+
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(DELETEDAT_COLUMN);
+    table.dropColumn(DELETEDBY_COLUMN);
+  });
+
+  // eslint-disable-next-line knex/avoid-injections
+  return knex.raw(
+    `CREATE UNIQUE INDEX ${OLD_CONSTRAINT_NAME} ON "${TABLE_NAME}" ("${CAMPAIGNID_COLUMN}", "${USERID_COLUMN}" ) WHERE "${ISIMPROVED_COLUMN}" IS FALSE;`
+  );
+};

--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -88,9 +88,11 @@ function _buildAssessmentAndAnswer({ databaseBuilder, userId, campaignParticipat
   });
 }
 
-function participateToAssessmentCampaign({ databaseBuilder, campaignId, user, schoolingRegistrationId, status, isImprovingOldParticipation = false }) {
+function participateToAssessmentCampaign({ databaseBuilder, campaignId, user, schoolingRegistrationId, status, isImprovingOldParticipation = false, deleted = false }) {
   const today = new Date();
   const sharedAt = status === SHARED ? today : null;
+  const deletedAt = deleted ? today : null;
+  const deletedBy = deleted ? 2 : null;
 
   const { id: userId } = user;
   const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
@@ -101,6 +103,8 @@ function participateToAssessmentCampaign({ databaseBuilder, campaignId, user, sc
     createdAt: user.createdAt,
     status,
     sharedAt,
+    deletedAt,
+    deletedBy,
   });
 
   _buildAssessmentAndAnswer({ databaseBuilder, userId, campaignParticipationId, status, hasSomeFailures: _.sample([true, false]) });

--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -325,6 +325,7 @@ function _buildUsers({ databaseBuilder, users }) {
 }
 
 function _buildParticipationsInDifferentStatus({ databaseBuilder, user }) {
+  participateToAssessmentCampaign({ databaseBuilder, campaignId: 1, user, schoolingRegistrationId: user.id, status: STARTED, deleted: true }); //started
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 2, user, schoolingRegistrationId: user.id, status: STARTED }); //started
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 12, user, schoolingRegistrationId: user.id, status: TO_SHARE }); //to share
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 13, user, schoolingRegistrationId: user.id, status: SHARED });//archived + shared

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -61,7 +61,7 @@ async function _createNewCampaignParticipation(queryBuilder, campaignParticipati
 
     return id;
   } catch (error) {
-    if (error.constraint === 'campaign_participations_campaignid_userid_isimproved') {
+    if (error.constraint === 'campaign_participations_campaignid_userid_isimproved_deleted') {
       throw new AlreadyExistingCampaignParticipationError(
         `User ${campaignParticipation.userId} has already a campaign participation with campaign ${campaignParticipation.campaignId}`
       );


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'EPIX suppression d'un prescrit, nous avons le besoin de pouvoir supprimer une participation.

## :robot: Solution
Ajouter deux colonnes deletedAt, deletedBy afin de savoir quand et qui à effectuer la suppression
Mettre à jour la contrainte existante avec ces informations deletedAt et deletedBy à null. Afin de garantir l'unicité de la participation.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à la BDD est vérifier que les colonnes sont présentes. Ainsi que l'utilisateur Jaune Attend a bien une participation supprimé