### PR TITLE
[TECH] Utiliser la bonne erreur dans les tests de l'use-case add-tutorial-evaluation. 

### DIFF
--- a/api/tests/unit/domain/usecases/add-tutorial-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/add-tutorial-evaluation_test.js
@@ -1,6 +1,6 @@
 const { sinon, expect, domainBuilder, catchErr } = require('../../../test-helper');
 const addTutorialEvaluation = require('../../../../lib/domain/usecases/add-tutorial-evaluation');
-const LearningContentNotFoundError = require('../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | add-tutorial-evaluation', function () {
   let tutorialRepository;
@@ -38,7 +38,7 @@ describe('Unit | UseCase | add-tutorial-evaluation', function () {
       // Given
       tutorialRepository = {
         get: async () => {
-          throw new LearningContentNotFoundError();
+          throw new NotFoundError();
         },
       };
       const tutorialId = 'nonExistentTutorialId';
@@ -53,7 +53,7 @@ describe('Unit | UseCase | add-tutorial-evaluation', function () {
 
       // Then
       expect(tutorialEvaluationRepository.addEvaluation).to.not.have.been.called;
-      expect(result).to.be.instanceOf(LearningContentNotFoundError);
+      expect(result).to.be.instanceOf(NotFoundError);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La méthode `tutorialRepository.get` throw une `NotFoundError` et non pas une erreur `LearningContentResourceNotFound`.

## :robot: Solution
Pour être au plus prêt de l'implémentation dans les tests changer l'erreur par celle qui peut-être réellement levé.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
