### PR TITLE
[TECH] Ajout du feature toggle April Fool 2022

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -176,6 +176,7 @@ module.exports = (function () {
       ),
       isCertificationBillingEnabled: isFeatureEnabled(process.env.FT_CERTIFICATION_BILLING),
       isNewTutorialsPageEnabled: isFeatureEnabled(process.env.FT_NEW_TUTORIALS_PAGE),
+      isAprilFool2022Enabled: isFeatureEnabled(process.env.FT_IS_APRIL_FOOL2022_ENABLED),
     },
 
     infra: {

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -21,6 +21,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
         data: {
           id: '0',
           attributes: {
+            'is-april-fool2022-enabled': false,
             'is-certification-billing-enabled': false,
             'is-email-validation-enabled': false,
             'is-complementary-certification-subscription-enabled': false,

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -4,4 +4,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isEmailValidationEnabled;
   @attr('boolean') isEndTestScreenRemovalEnabled;
   @attr('boolean') isNewTutorialsPageEnabled;
+  @attr('boolean') isAprilFool2022Enabled;
 }


### PR DESCRIPTION
## 🐠 : Problème
A l'approche du 1er avril 2022, on démarre une discussion savoir si on fait quelque chose sur les applis Pix et si oui, que fait-on. Quelle que soit la solution que l'on choisira, on veut que celle-ci soit feature togglisée.
