### PR TITLE
[FEATURE] Résoudre manuellement un signalement - Admin (PIX-4466).

### DIFF
--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -24,8 +24,7 @@
     </div>
     {{#if (and @issueReport.isImpactful @issueReport.resolvedAt)}}
       <div class="certification-issue-report__details__resolution-message">
-        Résolution :
-        {{#if @issueReport.resolution}}{{@issueReport.resolution}}{{else}}-{{/if}}
+        Résolution : {{#if @issueReport.resolution}}{{@issueReport.resolution}}{{else}}-{{/if}}
       </div>
     {{/if}}
   </div>

--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -24,17 +24,13 @@
     </div>
     {{#if (and @issueReport.isImpactful @issueReport.resolvedAt)}}
       <div class="certification-issue-report__details__resolution-message">
-        Résolution : {{#if @issueReport.resolution}}{{@issueReport.resolution}}{{else}}-{{/if}}
+        Résolution :
+        {{#if @issueReport.resolution}}{{@issueReport.resolution}}{{else}}-{{/if}}
       </div>
     {{/if}}
   </div>
   {{#if @issueReport.canBeResolved}}
-    <PixButton
-      @size="small"
-      @backgroundColor="transparent-light"
-      @isBorderVisible={{true}}
-      @triggerAction={{this.toggleResolveModal}}
-    >Résoudre
+    <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Résoudre
     </PixButton>
   {{/if}}
   {{#if this.showResolveModal}}

--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -29,7 +29,7 @@
       </div>
     {{/if}}
   </div>
-  {{#if (and @issueReport.isImpactful (not @issueReport.resolvedAt))}}
+  {{#if @issueReport.canBeResolved}}
     <PixButton @size="small" @backgroundColor="transparent-light" @isBorderVisible={{true}}>Résoudre
     </PixButton>
   {{/if}}

--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -30,8 +30,8 @@
     {{/if}}
   </div>
   {{#if @issueReport.canBeResolved}}
-    <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Résoudre
-    </PixButton>
+    <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Résoudre le
+      signalement</PixButton>
   {{/if}}
   {{#if this.showResolveModal}}
     <Certifications::IssueReports::ResolveIssueReportModal

--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -30,7 +30,20 @@
     {{/if}}
   </div>
   {{#if @issueReport.canBeResolved}}
-    <PixButton @size="small" @backgroundColor="transparent-light" @isBorderVisible={{true}}>Résoudre
+    <PixButton
+      @size="small"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @triggerAction={{this.toggleResolveModal}}
+    >Résoudre
     </PixButton>
+  {{/if}}
+  {{#if this.showResolveModal}}
+    <Certifications::IssueReports::ResolveIssueReportModal
+      @toggleResolveModal={{this.toggleResolveModal}}
+      @issueReport={{@issueReport}}
+      @resolveIssueReport={{@resolveIssueReport}}
+      @closeResolveModal={{this.closeResolveModal}}
+    />
   {{/if}}
 </li>

--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -29,4 +29,8 @@
       </div>
     {{/if}}
   </div>
+  {{#if (and @issueReport.isImpactful (not @issueReport.resolvedAt))}}
+    <PixButton @size="small" @backgroundColor="transparent-light" @isBorderVisible={{true}}>Résoudre
+    </PixButton>
+  {{/if}}
 </li>

--- a/admin/app/components/certifications/issue-report.js
+++ b/admin/app/components/certifications/issue-report.js
@@ -1,0 +1,20 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+export default class CertificationIssueReport extends Component {
+  @service notifications;
+
+  @tracked showResolveModal = false;
+
+  @action
+  toggleResolveModal() {
+    this.showResolveModal = !this.showResolveModal;
+  }
+
+  @action
+  closeResolveModal() {
+    this.showResolveModal = false;
+  }
+}

--- a/admin/app/components/certifications/issue-reports.hbs
+++ b/admin/app/components/certifications/issue-reports.hbs
@@ -5,7 +5,7 @@
   </h2>
   <ul class="certification-issue-reports__list">
     {{#each @impactfulCertificationIssueReports as |issueReport|}}
-      <Certifications::IssueReport @issueReport={{issueReport}} />
+      <Certifications::IssueReport @issueReport={{issueReport}} @resolveIssueReport={{@resolveIssueReport}} />
     {{/each}}
   </ul>
 {{/if}}

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -1,0 +1,7 @@
+<PixModal @title="Résoudre un signalement" @onCloseButtonClick={{@toggleResolveModal}}>
+  <:footer>
+    <PixButton @type="submit" @size="small" {{on "click" this.resolve}}>
+      Ok
+    </PixButton>
+  </:footer>
+</PixModal>

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -1,7 +1,17 @@
 <PixModal @title="Résoudre un signalement" @onCloseButtonClick={{@toggleResolveModal}}>
   <:footer>
+    <PixInput
+      @id="label"
+      @label="Motif"
+      type="text"
+      maxLength="255"
+      {{on "change" this.onChangeLabel}}
+    />
     <PixButton @type="submit" @size="small" {{on "click" this.resolve}}>
       Ok
+    </PixButton>
+    <PixButton @type="submit" @size="small" {{on "click" @toggleResolveModal}}>
+      Annuler
     </PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -1,17 +1,23 @@
 <PixModal @title="Résoudre un signalement" @onCloseButtonClick={{@toggleResolveModal}}>
-  <:footer>
-    <PixInput
-      @id="label"
-      @label="Motif"
+  <:content>
+    <PixTextarea
+      @id="resolve-reason"
+      @label="Résolution"
       type="text"
       maxLength="255"
       {{on "change" this.onChangeLabel}}
     />
-    <PixButton @type="submit" @size="small" {{on "click" this.resolve}}>
-      Ok
-    </PixButton>
-    <PixButton @type="submit" @size="small" {{on "click" @toggleResolveModal}}>
+  </:content>
+
+  <:footer>
+    <PixButton
+      @type="submit"
+      @size="small"
+      class="pix-button--background-transparent-light"
+      {{on "click" @toggleResolveModal}}
+    >
       Annuler
     </PixButton>
+    <PixButton @size="small" @triggerAction={{this.resolve}}>Résoudre le signalement</PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
@@ -1,13 +1,21 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class CertificationIssueReportModal extends Component {
   @service notifications;
 
+  @tracked label = null;
+
   @action
   resolve() {
-    this.args.resolveIssueReport(this.args.issueReport, 'resolved!');
+    this.args.resolveIssueReport(this.args.issueReport, this.label);
     this.args.closeResolveModal();
+  }
+
+  @action
+  onChangeLabel(event) {
+    this.label = event.target.value;
   }
 }

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
@@ -1,0 +1,13 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class CertificationIssueReportModal extends Component {
+  @service notifications;
+
+  @action
+  resolve() {
+    this.args.resolveIssueReport(this.args.issueReport, 'resolved!');
+    this.args.closeResolveModal();
+  }
+}

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -84,7 +84,7 @@ export default class CertificationInformationsController extends Controller {
       await issueReport.resolve(resolutionLabel);
       this.notifications.success('Le signalement a été résolu.');
     } catch (error) {
-      this.notifications.error('Une erreur est survenue :\n' + error.errors[0].detail);
+      this.notifications.error('Une erreur est survenue :\n' + error?.errors[0]?.detail);
     }
     await this.certification.reload();
   }

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -11,6 +11,7 @@ import find from 'lodash/find';
 import ENV from 'pix-admin/config/environment';
 
 import { tracked } from '@glimmer/tracking';
+
 const PIX_COUNT_BY_LEVEL = 8;
 
 export default class CertificationInformationsController extends Controller {
@@ -75,6 +76,12 @@ export default class CertificationInformationsController extends Controller {
 
   get isModifyButtonDisabled() {
     return this.editingCandidateResults || this.certification.wasRegisteredBeforeCPF;
+  }
+
+  @action
+  async resolveIssueReport(issueReport, resolutionLabel) {
+    await issueReport.resolve(resolutionLabel);
+    await this.certification.reload();
   }
 
   @action

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -80,7 +80,12 @@ export default class CertificationInformationsController extends Controller {
 
   @action
   async resolveIssueReport(issueReport, resolutionLabel) {
-    await issueReport.resolve(resolutionLabel);
+    try {
+      await issueReport.resolve(resolutionLabel);
+      this.notifications.success('Le signalement a été résolu.');
+    } catch (error) {
+      this.notifications.error('Une erreur est survenue :\n' + error.errors[0].detail);
+    }
     await this.certification.reload();
   }
 

--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
 import isNull from 'lodash/isNull';
 
 export const certificationIssueReportCategories = {
@@ -125,4 +126,12 @@ export default class CertificationIssueReportModel extends Model {
   get canBeResolved() {
     return this.isImpactful && !this.isResolved;
   }
+
+  resolve = memberAction({
+    type: 'patch',
+    before(resolution) {
+      const payload = { data: { resolution } };
+      return payload;
+    },
+  });
 }

--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
+import isNull from 'lodash/isNull';
 
 export const certificationIssueReportCategories = {
   OTHER: 'OTHER',
@@ -115,5 +116,13 @@ export default class CertificationIssueReportModel extends Model {
 
   get subcategoryCode() {
     return subcategoryToCode[this.subcategory];
+  }
+
+  get isResolved() {
+    return !isNull(this.resolvedAt);
+  }
+
+  get canBeResolved() {
+    return this.isImpactful && !this.isResolved;
   }
 }

--- a/admin/app/styles/components/certification-issue-reports.scss
+++ b/admin/app/styles/components/certification-issue-reports.scss
@@ -26,6 +26,10 @@
   &__list {
     padding-left: 0;
 
+    button:last-of-type {
+      margin-left: auto;
+    }
+
     &--last {
       margin-bottom: 0;
     }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -169,6 +169,7 @@
           @hasUnimpactfulIssueReports={{this.hasUnimpactfulIssueReports}}
           @impactfulCertificationIssueReports={{this.impactfulCertificationIssueReports}}
           @unimpactfulCertificationIssueReports={{this.unimpactfulCertificationIssueReports}}
+          @resolveIssueReport={{this.resolveIssueReport}}
         />
       </div>
     </section>

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -443,6 +443,53 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           .exists();
       });
     });
+
+    module('when Resolve button is clicked on issue report', function () {
+      test('it should open resolution modal', async function (assert) {
+        // given
+        const certificationIssueReport = this.server.create('certification-issue-report', {
+          category: 'OTHER',
+          description: 'Un signalement impactant',
+          isImpactful: true,
+          resolvedAt: null,
+        });
+        certification.update({ certificationIssueReports: [certificationIssueReport] });
+
+        await visit(`/certifications/${certification.id}`);
+        this.server.patch(`/certification-issue-reports/${certificationIssueReport.id}`, () => new Response({}), 204);
+
+        // when
+        await clickByLabel('Résoudre');
+
+        // then
+        assert.contains('Résoudre un signalement');
+      });
+      module('and Resolve button is clicked', function () {
+        test('it should do foo', async function (assert) {
+          // given
+          const certificationIssueReport = this.server.create('certification-issue-report', {
+            category: 'OTHER',
+            description: 'Un signalement impactant',
+            isImpactful: true,
+            resolvedAt: null,
+          });
+          certification.update({ certificationIssueReports: [certificationIssueReport] });
+
+          await visit(`/certifications/${certification.id}`);
+          this.server.patch(`/certification-issue-reports/${certificationIssueReport.id}`, () => new Response({}), 204);
+
+          // when
+          await clickByLabel('Résoudre');
+          await clickByLabel('OK');
+
+          // then
+          assert.ok(true);
+          assert.contains('resolved!');
+          // assert.dom('.certification-issue-report__resolution-status--resolved').exists();
+          // assert.dom('.certification-issue-report__resolution-status--unresolved').doesNotExist();
+        });
+      });
+    });
   });
 
   module('when go to user detail button is clicked', function () {

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
 import { fillByLabel, clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
@@ -443,11 +443,11 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                 );
 
                 const screen = await visitScreen(`/certifications/${certification.id}`);
-                await clickByName('Résoudre');
-                await fillByLabel('Motif', 'Fraude');
+                await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(0));
+                await fillByLabel('Résolution', 'Fraude');
 
                 // when
-                await clickByName('Ok');
+                await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(1));
 
                 // then
                 assert.dom(screen.getByText('Le signalement a été résolu.')).exists();
@@ -472,15 +472,16 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
               );
 
               const screen = await visitScreen(`/certifications/${certification.id}`);
-              await clickByName('Résoudre');
-              await fillByLabel('Motif', 'Fraude');
+
+              await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(0));
+              await fillByLabel('Résolution', 'Fraude');
 
               // when
-              await clickByName('Ok');
+              await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(1));
 
               // then
-              assert.dom(screen.getByText('error')).exists();
-              assert.dom('.certification-issue-report__details').not.containsText('Fraud');
+              assert.dom(screen.getByText(/une erreur est survenue/i)).exists();
+              assert.dom(screen.queryByLabelText('Fraud')).doesNotExist();
             });
           });
         });

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -2,15 +2,15 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-import EmberObject from '@ember/object';
 
 module('Integration | Component | certifications/issue-report', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('when the issue is impactful and not resolved', function () {
+  module('when the issue has not been resolved yet', function () {
     test('it should display resolve button', async function (assert) {
       // Given
-      const issueReport = EmberObject.create({ isImpactful: true, resolvedAt: null });
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
       this.set('issueReport', issueReport);
 
       // When
@@ -21,24 +21,11 @@ module('Integration | Component | certifications/issue-report', function (hooks)
     });
   });
 
-  module('when the issue is not impactful', function () {
+  module('when the issue has already been resolved', function () {
     test('it should not display resolve button', async function (assert) {
       // Given
-      const issueReport = EmberObject.create({ isImpactful: false, resolvedAt: null });
-      this.set('issueReport', issueReport);
-
-      // When
-      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
-
-      // Then
-      assert.dom(screen.queryByText('Résoudre')).doesNotExist();
-    });
-  });
-
-  module('when the issue is impactful and resolved', function () {
-    test('it should not display resolve button', async function (assert) {
-      // Given
-      const issueReport = EmberObject.create({
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
         isImpactful: true,
         resolvedAt: new Date('2020-01-01'),
       });

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | certifications/issue-report', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('when the issue is impactful and not resolved', function () {
+    test('it should display resolve button', async function (assert) {
+      // Given
+      const issueReport = EmberObject.create({ isImpactful: true, resolvedAt: null });
+      this.set('issueReport', issueReport);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // Then
+      assert.dom(screen.getByRole('button', { name: 'Résoudre' })).exists();
+    });
+  });
+
+  module('when the issue is not impactful', function () {
+    test('it should not display resolve button', async function (assert) {
+      // Given
+      const issueReport = EmberObject.create({ isImpactful: false, resolvedAt: null });
+      this.set('issueReport', issueReport);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // Then
+      assert.dom(screen.queryByText('Résoudre')).doesNotExist();
+    });
+  });
+
+  module('when the issue is impactful and resolved', function () {
+    test('it should not display resolve button', async function (assert) {
+      // Given
+      const issueReport = EmberObject.create({
+        isImpactful: true,
+        resolvedAt: new Date('2020-01-01'),
+      });
+      this.set('issueReport', issueReport);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // Then
+      assert.dom(screen.queryByText('Résoudre')).doesNotExist();
+    });
+  });
+});

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
       // Then
-      assert.dom(screen.getByRole('button', { name: 'Résoudre' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
     });
   });
 
@@ -35,7 +35,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
       // Then
-      assert.dom(screen.queryByText('Résoudre')).doesNotExist();
+      assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 
 module('Integration | Component | certifications/issue-reports/resolve-issue-report-modal', function (hooks) {
@@ -13,27 +13,55 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
     const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
     this.set('issueReport', issueReport);
 
+    this.toggleResolveModal = sinon.stub().returns();
+    this.resolveIssueReport = sinon.stub().resolves();
+    this.closeResolveModal = sinon.stub().returns();
+
     // When
-    const screen = await renderScreen(
-      hbs`<Certifications::IssueReports::ResolveIssueReportModal @issueReport={{this.issueReport}}/>`
-    );
+    const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
 
     // Then
     assert.dom(screen.getByRole('button', { name: 'Ok' })).exists();
   });
+  module('when clicking on Cancel button', function () {
+    test('it should close the modal', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+      this.set('issueReport', issueReport);
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
 
+      await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+      // When
+      await clickByName('Annuler');
+
+      // Then
+      sinon.assert.calledOnce(this.toggleResolveModal);
+      assert.ok(true);
+    });
+  });
   module('when clicking on OK button', function () {
     test('it should close the modal', async function (assert) {
       // Given
       const store = this.owner.lookup('service:store');
       const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
       this.set('issueReport', issueReport);
-      this.toggleResolveModal = sinon.stub();
-      this.toggleResolveModal.resolves();
-      this.resolveIssueReport = sinon.stub();
-      this.resolveIssueReport.resolves();
-      this.closeResolveModal = sinon.stub();
-      this.closeResolveModal.resolves();
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
 
       await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
                    @toggleResolveModal={{this.toggleResolveModal}}
@@ -49,18 +77,16 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
       sinon.assert.calledOnce(this.closeResolveModal);
       assert.ok(true);
     });
+
     module('when no label has been keyed', function () {
-      test('it should call resolveIssueReport with issue-report and resolved! label', async function (assert) {
+      test('it should call resolveIssueReport with issue-report and no label', async function (assert) {
         // Given
         const store = this.owner.lookup('service:store');
         const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
         this.set('issueReport', issueReport);
-        this.toggleResolveModal = sinon.stub();
-        this.toggleResolveModal.resolves();
-        this.resolveIssueReport = sinon.stub();
-        this.resolveIssueReport.resolves();
-        this.closeResolveModal = sinon.stub();
-        this.closeResolveModal.resolves();
+        this.toggleResolveModal = sinon.stub().returns();
+        this.resolveIssueReport = sinon.stub().resolves();
+        this.closeResolveModal = sinon.stub().returns();
 
         await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
                    @toggleResolveModal={{this.toggleResolveModal}}
@@ -73,7 +99,37 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
         await clickByName('Ok');
 
         // Then
-        sinon.assert.calledWith(this.resolveIssueReport, this.issueReport, 'resolved!');
+        sinon.assert.calledWith(this.resolveIssueReport, this.issueReport);
+        assert.ok(true);
+      });
+    });
+    module('when a label has been keyed', function () {
+      test('it should call resolveIssueReport with issue-report and keyed label', async function (assert) {
+        // Given
+        const store = this.owner.lookup('service:store');
+        const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+        this.set('issueReport', issueReport);
+        this.toggleResolveModal = sinon.stub().returns();
+        this.resolveIssueReport = sinon.stub().resolves();
+        this.closeResolveModal = sinon.stub().returns();
+
+        await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+        // When
+        await fillByLabel('Motif', 'This is a fraud, its certification has been revoked');
+        await clickByName('Ok');
+
+        // Then
+        sinon.assert.calledWith(
+          this.resolveIssueReport,
+          this.issueReport,
+          'This is a fraud, its certification has been revoked'
+        );
         assert.ok(true);
       });
     });

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -26,7 +26,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
     // Then
-    assert.dom(screen.getByRole('button', { name: 'Ok' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
   });
   module('when clicking on Cancel button', function () {
     test('it should close the modal', async function (assert) {
@@ -53,7 +53,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
       assert.ok(true);
     });
   });
-  module('when clicking on OK button', function () {
+  module('when clicking on "Résoudre le signalement" button', function () {
     test('it should close the modal', async function (assert) {
       // Given
       const store = this.owner.lookup('service:store');
@@ -71,7 +71,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
       // When
-      await clickByName('Ok');
+      await clickByName('Résoudre le signalement');
 
       // Then
       sinon.assert.calledOnce(this.closeResolveModal);
@@ -96,7 +96,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
         // When
-        await clickByName('Ok');
+        await clickByName('Résoudre le signalement');
 
         // Then
         sinon.assert.calledWith(this.resolveIssueReport, this.issueReport);
@@ -121,8 +121,8 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
         // When
-        await fillByLabel('Motif', 'This is a fraud, its certification has been revoked');
-        await clickByName('Ok');
+        await fillByLabel('Résolution', 'This is a fraud, its certification has been revoked');
+        await clickByName('Résoudre le signalement');
 
         // Then
         sinon.assert.calledWith(

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -1,0 +1,81 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
+
+module('Integration | Component | certifications/issue-reports/resolve-issue-report-modal', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display resolve button', async function (assert) {
+    // Given
+    const store = this.owner.lookup('service:store');
+    const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+    this.set('issueReport', issueReport);
+
+    // When
+    const screen = await renderScreen(
+      hbs`<Certifications::IssueReports::ResolveIssueReportModal @issueReport={{this.issueReport}}/>`
+    );
+
+    // Then
+    assert.dom(screen.getByRole('button', { name: 'Ok' })).exists();
+  });
+
+  module('when clicking on OK button', function () {
+    test('it should close the modal', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+      this.set('issueReport', issueReport);
+      this.toggleResolveModal = sinon.stub();
+      this.toggleResolveModal.resolves();
+      this.resolveIssueReport = sinon.stub();
+      this.resolveIssueReport.resolves();
+      this.closeResolveModal = sinon.stub();
+      this.closeResolveModal.resolves();
+
+      await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+      // When
+      await clickByName('Ok');
+
+      // Then
+      sinon.assert.calledOnce(this.closeResolveModal);
+      assert.ok(true);
+    });
+    module('when no label has been keyed', function () {
+      test('it should call resolveIssueReport with issue-report and resolved! label', async function (assert) {
+        // Given
+        const store = this.owner.lookup('service:store');
+        const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+        this.set('issueReport', issueReport);
+        this.toggleResolveModal = sinon.stub();
+        this.toggleResolveModal.resolves();
+        this.resolveIssueReport = sinon.stub();
+        this.resolveIssueReport.resolves();
+        this.closeResolveModal = sinon.stub();
+        this.closeResolveModal.resolves();
+
+        await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+        // When
+        await clickByName('Ok');
+
+        // Then
+        sinon.assert.calledWith(this.resolveIssueReport, this.issueReport, 'resolved!');
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import map from 'lodash/map';
+import ENV from 'pix-admin/config/environment';
 
 import {
   certificationIssueReportCategories,
@@ -11,6 +12,7 @@ import {
   categoryToCode,
   subcategoryToCode,
 } from 'pix-admin/models/certification-issue-report';
+import sinon from 'sinon';
 
 module('Unit | Model | certification issue report', function (hooks) {
   setupTest(hooks);
@@ -114,6 +116,33 @@ module('Unit | Model | certification issue report', function (hooks) {
 
       // when / then
       assert.true(model.canBeResolved);
+    });
+  });
+
+  module('#resolve', function () {
+    test('it should call API with resolution label', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('certification-issue-reports');
+      sinon.stub(adapter, 'ajax');
+      adapter.ajax.resolves({});
+
+      const model = run(() =>
+        store.createRecord('certification-issue-report', {
+          id: 1,
+          isImpactful: true,
+          resolvedAt: null,
+        })
+      );
+      // when
+      model.resolve('resolved!');
+
+      // then
+      const url = `${ENV.APP.API_HOST}/api/certification-issue-reports/${model.id}`;
+      const payload = { data: { data: { resolution: 'resolved!' } } };
+
+      sinon.assert.calledWith(adapter.ajax, url, 'PATCH', payload);
+      assert.ok(true);
     });
   });
 });

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -26,9 +26,7 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.categoryLabel, categoryToLabel[model.category]);
+      assert.strictEqual(model.categoryLabel, categoryToLabel[model.category]);
     }
   });
 
@@ -43,9 +41,7 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
+      assert.strictEqual(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
     }
   });
 
@@ -60,9 +56,7 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.categoryCode, categoryToCode[model.category]);
+      assert.strictEqual(model.categoryCode, categoryToCode[model.category]);
     }
   });
 
@@ -77,9 +71,7 @@ module('Unit | Model | certification issue report', function (hooks) {
 
     // when / then
     for (const model of models) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.subcategoryCode, subcategoryToCode[model.subcategory]);
+      assert.strictEqual(model.subcategoryCode, subcategoryToCode[model.subcategory]);
     }
   });
 
@@ -90,8 +82,38 @@ module('Unit | Model | certification issue report', function (hooks) {
     const model = run(() => store.createRecord('certification-issue-report', { subcategory: null }));
 
     // when / then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.subcategoryLabel, '');
+    assert.strictEqual(model.subcategoryLabel, '');
+  });
+  module('#canBeResolved', function () {
+    test('it should return false is the issue is impactful and already resolved', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const model = run(() =>
+        store.createRecord('certification-issue-report', {
+          isImpactful: true,
+          resolvedAt: new Date('2020-01-01'),
+          resolution: 'resolved',
+        })
+      );
+
+      // when / then
+      assert.false(model.canBeResolved);
+    });
+    test('it should return true is the issue is impactful and not resolved yet', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const model = run(() =>
+        store.createRecord('certification-issue-report', {
+          isImpactful: true,
+          resolvedAt: null,
+          resolution: null,
+        })
+      );
+
+      // when / then
+      assert.true(model.canBeResolved);
+    });
   });
 });

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -37,25 +37,134 @@ const CERTIFICATION_COURSE_FAILURE_ID = 403;
 function certificationCoursesBuilder({ databaseBuilder }) {
   // Each certification tests present the same questions
   _.each([
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: TO_FINALIZE_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'ABC123' },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: TO_FINALIZE_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'DEF456' },
-    { userId: CERTIF_SCO_STUDENT_ID, sessionId: PUBLISHED_SCO_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID, candidateData: CANDIDATE_SCO_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'GHI789' },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'JKL159' },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'MNO753' },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: 'A regardé son téléphone pendant le test', hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'PQR741' },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: 'Son ordinateur a explosé', hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'STU852' },
-    { userId: CERTIF_REGULAR_USER5_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_STARTED, examinerComment: 'Elle a pas finis sa certif', hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'VWX963' },
-    { id: CERTIFICATION_COURSE_SUCCESS_ID, userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'YZA147' },
-    { id: CERTIFICATION_COURSE_FAILURE_ID, userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'BCD258' },
+    {
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: TO_FINALIZE_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      examinerComment: null,
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+      verificationCode: 'ABC123',
+    },
+    {
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: TO_FINALIZE_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      examinerComment: null,
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+      verificationCode: 'DEF456',
+    },
+    {
+      userId: CERTIF_SCO_STUDENT_ID,
+      sessionId: PUBLISHED_SCO_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID,
+      candidateData: CANDIDATE_SCO_DATA_SUCCESS,
+      examinerComment: null,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+      verificationCode: 'GHI789',
+    },
+    {
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: NO_PROBLEM_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      examinerComment: null,
+      hasSeenEndTestScreen: true,
+      isPublished: false,
+      verificationCode: 'JKL159',
+    },
+    {
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: NO_PROBLEM_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      examinerComment: null,
+      hasSeenEndTestScreen: true,
+      isPublished: false,
+      verificationCode: 'MNO753',
+    },
+    {
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: PROBLEMS_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      examinerComment: 'A regardé son téléphone pendant le test',
+      hasSeenEndTestScreen: true,
+      isPublished: false,
+      verificationCode: 'PQR741',
+    },
+    {
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: PROBLEMS_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      examinerComment: 'Son ordinateur a explosé',
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+      verificationCode: 'STU852',
+    },
+    {
+      userId: CERTIF_REGULAR_USER5_ID,
+      sessionId: PROBLEMS_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_STARTED,
+      examinerComment: 'Elle a pas fini sa certif',
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+      verificationCode: 'VWX963',
+    },
+    {
+      id: CERTIFICATION_COURSE_SUCCESS_ID,
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: PUBLISHED_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+      verificationCode: 'YZA147',
+    },
+    {
+      id: CERTIFICATION_COURSE_FAILURE_ID,
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: PUBLISHED_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+      verificationCode: 'BCD258',
+    },
   ], (certificationCourseData) => {
     _buildCertificationCourse(databaseBuilder, certificationCourseData);
   });
 }
 
-function _buildCertificationCourse(databaseBuilder, { id, assessmentId, userId, sessionId, candidateData, examinerComment, hasSeenEndTestScreen, isPublished, verificationCode }) {
+function _buildCertificationCourse(databaseBuilder, {
+  id,
+  assessmentId,
+  userId,
+  sessionId,
+  candidateData,
+  examinerComment,
+  hasSeenEndTestScreen,
+  isPublished,
+  verificationCode,
+}) {
   const createdAt = new Date('2020-01-31T00:00:00Z');
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-    ...candidateData, id, createdAt, isPublished, isV2Certification: true, examinerComment, hasSeenEndTestScreen, sessionId, userId, verificationCode,
+    ...candidateData,
+    id,
+    createdAt,
+    isPublished,
+    isV2Certification: true,
+    examinerComment,
+    hasSeenEndTestScreen,
+    sessionId,
+    userId,
+    verificationCode,
   }).id;
   if (examinerComment) {
     databaseBuilder.factory.buildCertificationIssueReport({
@@ -84,7 +193,12 @@ function _buildCertificationCourse(databaseBuilder, { id, assessmentId, userId, 
     campaignParticipationId: null, isImproving: false, createdAt,
   });
   _.each(CERTIFICATION_CHALLENGES_DATA, (challenge) => {
-    databaseBuilder.factory.buildCertificationChallenge({ ...challenge, courseId: certificationCourseId, associatedSkillId: null, createdAt });
+    databaseBuilder.factory.buildCertificationChallenge({
+      ...challenge,
+      courseId: certificationCourseId,
+      associatedSkillId: null,
+      createdAt,
+    });
   });
 }
 
@@ -102,4 +216,4 @@ module.exports = {
   ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID,
   CERTIFICATION_COURSE_FAILURE_ID,
   CERTIFICATION_COURSE_SUCCESS_ID,
-} ;
+};

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -170,12 +170,12 @@ function _buildCertificationCourse(databaseBuilder, {
     databaseBuilder.factory.buildCertificationIssueReport({
       certificationCourseId,
       category: CertificationIssueReportCategories.OTHER,
-      description: examinerComment,
+      description: examinerComment + ' (deuxième fois)',
     });
     databaseBuilder.factory.buildCertificationIssueReport({
       certificationCourseId,
       category: CertificationIssueReportCategories.OTHER,
-      description: examinerComment,
+      description: examinerComment + ' (première fois)',
       resolvedAt: '2020-05-01T00:00:00Z',
     });
     databaseBuilder.factory.buildCertificationIssueReport({

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -32,7 +32,7 @@ exports.register = async (server) => {
           }),
           payload: Joi.object({
             data: {
-              resolution: Joi.string().max(255),
+              resolution: Joi.string().max(255).allow(null).optional(),
             },
           }),
         },

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -1,6 +1,7 @@
 const { expect, HttpTestServer, sinon } = require('../../../test-helper');
 const certificationIssueReportController = require('../../../../lib/application/certification-issue-reports/certification-issue-report-controller');
 
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/certification-issue-reports');
 
 describe('Unit | Application | Certifications Issue Report | Route', function () {
@@ -16,5 +17,51 @@ describe('Unit | Application | Certifications Issue Report | Route', function ()
 
     // then
     expect(response.statusCode).to.equal(200);
+  });
+
+  describe('PATCH /api/certification-issue-reports/{id}', function () {
+    context('when user is pixmaster', function () {
+      context('when no resolution is given', function () {
+        it('should return 204', async function () {
+          // given
+          sinon.stub(certificationIssueReportController, 'manuallyResolve').callsFake((_, h) => h.response().code(204));
+          sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
+          securityPreHandlers.checkUserHasRolePixMaster.callsFake((_, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+          const payload = {
+            data: {
+              resolution: null,
+            },
+          };
+          // when
+          const response = await httpTestServer.request('PATCH', '/api/certification-issue-reports/1', payload);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+        });
+      });
+    });
+
+    context('when user is not pixmaster', function () {
+      it('should throw 403', async function () {
+        // given
+        sinon.stub(certificationIssueReportController, 'manuallyResolve').callsFake((_, h) => h.response().code(204));
+        sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
+        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = {
+          data: {},
+        };
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/certification-issue-reports/1', payload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Voir #4128 

## :robot: Solution
Voir #4128 

## :rainbow: Remarques
Le motif de résolution étant optionnel, l'API a été modifiée pour le permettre

## :100: Pour tester
Se connecter à [PixAdmin](https://admin-pr4162.review.pix.fr/)

Pour passer le signalement à "Non résolu" entre les tests
```sql
UPDATE "certification-issue-reports" r
SET "resolvedAt" = NULL, resolution = NULL
WHERE r.id = 107193;
```

### Résolution sans motif
Atteindre la session de certification n°6 pour [AnneNormale5](https://admin-pr4162.review.pix.fr/certifications/107192)
Cliquer sur "Résoudre le signalement", puis dans la modale sur "Résoudre"
Vérifier
- l'apparition du message "Le signalement a été résolu."
- que le signalement est résolu dans l'IHM
- que l'enregistrement a bien été mis à jour en BDD

```sql
SELECT
    'course=>',
   c."firstName",
    c."lastName",
    'report=>',
    r.category,
    r.description,
    r."resolvedAt",
    r.resolution
FROM "certification-issue-reports" r
    INNER JOIN "certification-courses" c ON c.id = r."certificationCourseId"
    INNER JOIN "sessions" s ON s.id = c."sessionId"
WHERE 1=1
    AND s.id = 6
    AND r.id = 107193
ORDER BY s.id, r.category, r.description
;
```

### Résolution avec motif
Idem que ci-dessus, mais entrer un motif.

### Résolution en erreur
Idem que ci-dessus, mais forcer l'API à renvoyer un 500

Vérifier
- l'apparition du message "'Une erreur est survenue" + stacktrace
- que le signalement n'est pas résolu dans l'IHM
- que l'enregistrement n'a pas été mis à jour en BDD

