### PR TITLE
[CLEAN] Nettoyage des return manquants coté API.

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -7,13 +7,19 @@ const {
   TARGET_PROFILE_PIX_DROIT_ID,
 } = require('./target-profiles-builder');
 const {
-  CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID,
-  CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID,
+  CERTIF_REGULAR_USER1_ID,
+  CERTIF_REGULAR_USER2_ID,
+  CERTIF_REGULAR_USER3_ID,
+  CERTIF_REGULAR_USER4_ID,
+  CERTIF_REGULAR_USER5_ID,
 } = require('./certification/users');
 const { PRO_BASICS_BADGE_ID, PRO_TOOLS_BADGE_ID } = require('./badges-builder');
 const { PRO_COMPANY_ID, PRO_POLE_EMPLOI_ID, PRO_MED_NUM_ID } = require('./organizations-pro-builder');
 const { DEFAULT_PASSWORD } = require('./users-builder');
-const { participateToAssessmentCampaign, participateToProfilesCollectionCampaign } = require('./campaign-participations-builder');
+const {
+  participateToAssessmentCampaign,
+  participateToProfilesCollectionCampaign,
+} = require('./campaign-participations-builder');
 const CampaignParticipationStatuses = require('../../../lib/domain/models/CampaignParticipationStatuses');
 const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;
 
@@ -43,7 +49,8 @@ function _buildCampaigns({ databaseBuilder }) {
     idPixLabel: 'identifiant entreprise',
     title: null,
     customLandingPageText: null,
-    customResultPageText: 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
+    customResultPageText:
+      'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
     customResultPageButtonUrl: 'https://pix.fr/',
     customResultPageButtonText: 'Voir Pix !',
     createdAt: new Date('2020-01-09'),
@@ -120,7 +127,8 @@ __Plus d'infos :)__
     assessmentMethod: 'SMART_RANDOM',
     idPixLabel: null,
     customLandingPageText: null,
-    customResultPageText: 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
+    customResultPageText:
+      'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
     customResultPageButtonUrl: 'https://pix.fr/',
     customResultPageButtonText: 'Voir Pix !',
     createdAt: new Date('2020-01-13'),
@@ -289,7 +297,6 @@ __Plus d'infos :)__
     customLandingPageText: null,
     createdAt: new Date('2020-01-04'),
   });
-
 }
 
 function _buildParticipations({ databaseBuilder }) {
@@ -375,7 +382,7 @@ function _buildProfilesCollectionParticipations({ databaseBuilder, users }) {
   const certifRegularUser4 = { id: CERTIF_REGULAR_USER4_ID, createdAt: new Date('2022-02-06') };
   const certifRegularUser5 = { id: CERTIF_REGULAR_USER5_ID, createdAt: new Date('2022-02-07') };
 
-  [certifRegularUser1, certifRegularUser2, certifRegularUser3, certifRegularUser4, certifRegularUser5].map((certifUser, index) => {
+  [certifRegularUser1, certifRegularUser2, certifRegularUser3, certifRegularUser4, certifRegularUser5].forEach((certifUser, index) => {
     databaseBuilder.factory.buildSchoolingRegistration({ lastName: `Certif${index}`, firstName: `User${index}`, id: certifUser.id, userId: certifUser.id, organizationId: PRO_COMPANY_ID });
   });
 

--- a/api/scripts/delete-user.js
+++ b/api/scripts/delete-user.js
@@ -73,13 +73,7 @@ class UserEraser {
         this.queryBuilder.delete_answers_from_assessment_ids(this.assessmentIds),
         this.queryBuilder.delete_competence_marks_from_assessment_ids(this.assessmentIds),
       ])
-      .then((queries) =>
-        Promise.all(
-          queries.map((query) => {
-            this.client.query_and_log(query);
-          })
-        )
-      )
+      .then((queries) => Promise.all(queries.map((query) => this.client.query_and_log(query))))
       .then(() => this.queryBuilder.delete_assessment_results_from_assessment_ids(this.assessmentIds))
       .then((query) => this.client.query_and_log(query));
   }

--- a/api/server.js
+++ b/api/server.js
@@ -81,7 +81,7 @@ const setupErrorHandling = function (server) {
 
 const setupAuthentication = function (server) {
   server.auth.scheme(authentication.schemeName, authentication.scheme);
-  authentication.strategies.map((strategy) => {
+  authentication.strategies.forEach((strategy) => {
     server.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration);
   });
   server.auth.default(authentication.defaultStrategy);

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -87,8 +87,11 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
       });
 
       targetProfile = databaseBuilder.factory.buildTargetProfile({ name: '+Profile 1' });
-      [skillWeb1, skillWeb2, skillWeb3].map((skill) => {
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill.id });
+      [skillWeb1, skillWeb2, skillWeb3].forEach((skill) => {
+        databaseBuilder.factory.buildTargetProfileSkill({
+          targetProfileId: targetProfile.id,
+          skillId: skill.id,
+        });
       });
 
       campaign = databaseBuilder.factory.buildCampaign({

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -55,9 +55,9 @@ class HttpTestServer {
 
   setupAuthentication() {
     this.hapiServer.auth.scheme(authentication.schemeName, authentication.scheme);
-    authentication.strategies.map((strategy) => {
-      this.hapiServer.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration);
-    });
+    authentication.strategies.forEach((strategy) =>
+      this.hapiServer.auth.strategy(strategy.name, authentication.schemeName, strategy.configuration)
+    );
     this.hapiServer.auth.default(authentication.defaultStrategy);
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs `return` étaient manquants dans le code de notre API. Ce problème est considéré comme Bloquant par SonarQube.
La plupart du temps, ce soucis était lié à l'utilisation d'un `map` plutot qu'un `forEach`.

## :robot: Solution
Remettre les `return` manquants ou mettre en `forEach`.

## :rainbow: Remarques
Ce problème est remonté via SonarQube.

## :100: Pour tester
- Tests OK
- Serveur se lance