### PR TITLE
[BUGFIX] Enlever le message du focus apparaissant sur certains challenges libres (PIX-4471)

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -33,6 +33,9 @@ export default class ChallengeRoute extends Route {
       });
     }
 
+    // WORKAROUND for PIX-4471 (wrongly displayed focusedout message)
+    if (assessment.lastQuestionState === 'focusedout') await assessment.reload();
+
     return RSVP.hash({
       assessment,
       challenge,

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -61,9 +61,6 @@ export default class ResumeRoute extends Route {
     if (userHasReachedCheckpoint && !userHasSeenCheckpoint) {
       return this._routeToCheckpoint(assessment);
     }
-    if (userHasReachedCheckpoint && userHasSeenCheckpoint) {
-      return this._routeToNextChallenge(assessment);
-    }
     return this._routeToNextChallenge(assessment);
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Le message de perte de focus (en bas du challenge) apparaît à tort suite à une perte de focus sur le challenge précédent.

Seule manière de reproduire pour le moment :

1. Faire un `npm run db:reset`
2. Se connecter avec `userpix1@example.net`
3. Reprendre la compétence “Mener une recherche et une veille d’information“
4. Faire un defocus et cliquer sur “Passer”
5. Sur la page du checkpoint, recharger la page
6. Cliquer sur “Continuer”

### Explication

Quand on est sur le checkpoint, il y a un décalage entre l'assessment dans ember-data et la BdD (`lastQuestionState` vaut `"asked"` dans ember-data et `"focusedout"` dans la BdD).

Si on rafraichit ember-data se resynchro avec la BdD et le `lastQuestionState` ne repasse jamais à `"asked"`...

## :robot: Solution

Contournement trouvé pour le moment : au moment de l'affichage d'une question, si l'assessment a un `lastQuestionState` à `"focusedout"` alors on le recharge pour en être sûr !

## :rainbow: Remarques

Il y a un 1er commit qui enlève un `if` qui ne servait à rien.

## :100: Pour tester

1. Faire un `npm run db:reset`
2. Se connecter avec `userpix1@example.net`
3. Reprendre la compétence “Mener une recherche et une veille d’information“
4. Faire un defocus et cliquer sur “Passer”
5. Sur la page du checkpoint, recharger la page
6. Cliquer sur “Continuer”

Le message de perte de focus ne doit pas s'afficher.
