### PR TITLE
[TECH] API : Logguer en pretty-print 👩‍💻 si la sortie standard est envoyée vers un terminal

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -40,6 +40,12 @@ function _removeTrailingSlashFromUrl(url) {
   return url.replace(/\/$/, '');
 }
 
+function _getLogForHumans() {
+  const processOutputingToTerminal = process.stdout.isTTY;
+  const forceJSONLogs = process.env.LOG_FOR_HUMANS === 'false';
+  return processOutputingToTerminal && !forceJSONLogs;
+}
+
 module.exports = (function () {
   const config = {
     rootPath: path.normalize(__dirname + '/..'),
@@ -73,7 +79,7 @@ module.exports = (function () {
     logging: {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
-      logForHumans: isFeatureEnabled(process.env.LOG_FOR_HUMANS),
+      logForHumans: _getLogForHumans(),
       enableLogKnexQueries: isFeatureEnabled(process.env.LOG_KNEX_QUERIES),
       enableLogStartingEventDispatch: isFeatureEnabled(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: isFeatureEnabled(process.env.LOG_ENDING_EVENT_DISPATCH),


### PR DESCRIPTION
## :unicorn: Problème

Les logs sont en pretty-print par défaut depuis l'ajout de `LOG_FOR_HUMANS=true` dans le `sample.env`
Certaines personnes ont pu ne pas être au courant

## :robot: Solution

Activer le pretty-print si la sortie standard est attachée à un terminal.
[Voir doc Node](https://nodejs.org/api/tty.html#ttyisattyfd)

Comme on veut pouvoir désactiver le pretty-print dans le cadre du développement local, par exemple pour mettre à jour la librairie de logging sans causer de régression sur le monitoring, il faut permettre de désactiver le pretty-print sans modifier le code.

## :rainbow: Remarques

Est-ce un problème de ne pas pouvoir forcer la variable à `false` quand on est dans un terminal ?

Même le [`isBooleanFeatureEnabledElseDefault()`](https://github.com/1024pix/pix/blob/4698ce953655270906e7056ed784a0fed1a562fb/api/lib/config.js#L18) ne répond pas à cette problématique...

On pourrait imaginer de tester si la variable est `!= null` et si c'est le cas ne pas utiliser `process.stdout.isTTY`.

## :100: Pour tester

### Local
Démarrer l'API sans avoir déclarer la variable `LOG_FOR_HUMANS` dans le fichier `.env`, vérifier que les logs ne sont pas en JSON.

Démarrer l'API sans avoir déclarer la variable `LOG_FOR_HUMANS` et en redirigeant la sortie standard vers un fichier :

```bash
npm start > api.log
```

Vérifier que les logs sont bien en JSON dans le fichier.

### Scalingo

Vérifier que
- `LOG_ENABLED=true`
- `LOG_FOR_HUMANS` n'est pas définie

Envoyer une requête HTTP en visitant https://api-pr4167.review.pix.fr/api/

Vérifier qu'elle apparaît en JSON dans l'onglet Logs

```
2022-03-09 09:47:05.689591988 +0100 CET [web-1] {"level":30,"time":1646815625688,"pid":23,"hostname":"pix-api-review-pr4167-web-1","queryParams":{},"req":{"id":"1646815625670:pix-api-review-pr4167-web-1:23:l0j7roh0:10000","method":"get","url":"/api","headers":{"host":"pix-api-review-pr4167.osc-fr1.scalingo.io","x-forwarded-proto":"https","x-real-ip":"171.33.105.206","x-forwarded-port":"443","x-forwarded-for":"88.172.56.105, 88.172.56.105, 171.33.105.206","connection":"close","x-forwarded-host":"api-pr4167.review.pix.fr","pix-application":"api","user-agent":"Mozilla/5.0 (X11; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0","accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8","accept-language":"en-US,en;q=0.5","accept-encoding":"gzip, deflate, br","dnt":"1","referer":"https://github.com/","upgrade-insecure-requests":"1","sec-fetch-dest":"document","sec-fetch-mode":"navigate","sec-fetch-site":"cross-site","sec-fetch-user":"?1","x-request-id":"e4ec8d46-e225-4d8d-86be-b4acb9363ae9"},"remoteAddress":"10.0.0.198","remotePort":45972,"version":"887efd85371a5c2fa7e78c48ec9f75a839775e14"},"res":{"statusCode":200,"headers":{"content-type":"application/json; charset=utf-8","vary":"origin","access-control-expose-headers":"WWW-Authenticate,Server-Authorization","cache-control":"no-cache","content-length":283,"accept-ranges":"bytes"}},"responseTime":17,"msg":"request completed"} 
```