### PR TITLE
[FEATURE] Afficher le niveau définitif d'une certification Pix+Edu (PIX-4494).

### DIFF
--- a/api/db/database-builder/factory/build-partner-certification.js
+++ b/api/db/database-builder/factory/build-partner-certification.js
@@ -1,13 +1,16 @@
 const databaseBuffer = require('../database-buffer');
-const buildBadge = require('./build-badge');
 const buildCertificationCourse = require('./build-certification-course');
 const _ = require('lodash');
 
-module.exports = function buildPartnerCertification({ certificationCourseId, partnerKey, acquired = true }) {
+module.exports = function buildPartnerCertification({
+  certificationCourseId,
+  partnerKey,
+  temporaryPartnerKey,
+  acquired = true,
+}) {
   certificationCourseId = _.isUndefined(certificationCourseId) ? buildCertificationCourse().id : certificationCourseId;
-  partnerKey = partnerKey ? partnerKey : buildBadge().key;
   return databaseBuffer.objectsToInsert.push({
     tableName: 'partner-certifications',
-    values: { certificationCourseId, partnerKey, acquired },
+    values: { certificationCourseId, partnerKey, temporaryPartnerKey, acquired },
   });
 };

--- a/api/db/migrations/20220303094934_add-column-temporary-partner-key-in-partner-certifications-and-populate-it.js
+++ b/api/db/migrations/20220303094934_add-column-temporary-partner-key-in-partner-certifications-and-populate-it.js
@@ -1,4 +1,3 @@
-const bluebird = require('bluebird');
 const {
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
@@ -7,49 +6,32 @@ const {
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
 } = require('../../lib/domain/models/Badge').keys;
 
+const pixEduBadges = [
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+]
+  .map((badge) => `'${badge}'`)
+  .join(',');
+
 exports.up = async function (knex) {
   await knex.schema.alterTable('partner-certifications', function (table) {
     table.string('partnerKey').nullable().alter();
     table.string('temporaryPartnerKey').references('badges.key').nullable();
   });
 
-  const partnerCertificationsToUpdate = await knex('partner-certifications')
-    .select('certificationCourseId', 'partnerKey')
-    .whereIn('partnerKey', [
-      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-    ]);
-
-  await bluebird.mapSeries(partnerCertificationsToUpdate, async function ({ partnerKey, certificationCourseId }) {
-    await knex('partner-certifications').where({ partnerKey, certificationCourseId }).update({
-      temporaryPartnerKey: partnerKey,
-      partnerKey: null,
-    });
-  });
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(
+    `UPDATE "partner-certifications" SET "temporaryPartnerKey" = "partnerKey", "partnerKey" = NULL WHERE "partnerKey" IN (${pixEduBadges})`
+  );
 };
 
 exports.down = async function (knex) {
-  const partnerCertificationsToUpdate = await knex('partner-certifications')
-    .select('certificationCourseId', 'temporaryPartnerKey')
-    .whereIn('temporaryPartnerKey', [
-      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-    ]);
-
-  await bluebird.mapSeries(
-    partnerCertificationsToUpdate,
-    async function ({ temporaryPartnerKey, certificationCourseId }) {
-      await knex('partner-certifications').where({ temporaryPartnerKey, certificationCourseId }).update({
-        partnerKey: temporaryPartnerKey,
-        temporaryPartnerKey: null,
-      });
-    }
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(
+    `UPDATE "partner-certifications" SET "partnerKey" = "temporaryPartnerKey" WHERE "temporaryPartnerKey" IN (${pixEduBadges})`
   );
 
   await knex.schema.alterTable('partner-certifications', function (table) {

--- a/api/db/migrations/20220303094934_add-column-temporary-partner-key-in-partner-certifications-and-populate-it.js
+++ b/api/db/migrations/20220303094934_add-column-temporary-partner-key-in-partner-certifications-and-populate-it.js
@@ -1,0 +1,59 @@
+const bluebird = require('bluebird');
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+} = require('../../lib/domain/models/Badge').keys;
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable('partner-certifications', function (table) {
+    table.string('partnerKey').nullable().alter();
+    table.string('temporaryPartnerKey').references('badges.key').nullable();
+  });
+
+  const partnerCertificationsToUpdate = await knex('partner-certifications')
+    .select('certificationCourseId', 'partnerKey')
+    .whereIn('partnerKey', [
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    ]);
+
+  await bluebird.mapSeries(partnerCertificationsToUpdate, async function ({ partnerKey, certificationCourseId }) {
+    await knex('partner-certifications').where({ partnerKey, certificationCourseId }).update({
+      temporaryPartnerKey: partnerKey,
+      partnerKey: null,
+    });
+  });
+};
+
+exports.down = async function (knex) {
+  const partnerCertificationsToUpdate = await knex('partner-certifications')
+    .select('certificationCourseId', 'temporaryPartnerKey')
+    .whereIn('temporaryPartnerKey', [
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    ]);
+
+  await bluebird.mapSeries(
+    partnerCertificationsToUpdate,
+    async function ({ temporaryPartnerKey, certificationCourseId }) {
+      await knex('partner-certifications').where({ temporaryPartnerKey, certificationCourseId }).update({
+        partnerKey: temporaryPartnerKey,
+        temporaryPartnerKey: null,
+      });
+    }
+  );
+
+  await knex.schema.alterTable('partner-certifications', function (table) {
+    table.dropColumn('temporaryPartnerKey');
+    table.string('partnerKey').notNullable().alter();
+  });
+};

--- a/api/lib/domain/models/CertificationAttestation.js
+++ b/api/lib/domain/models/CertificationAttestation.js
@@ -54,23 +54,24 @@ class CertificationAttestation {
   }
 
   getAcquiredCleaCertification() {
-    return this.acquiredPartnerCertificationKeys.find((key) => key === PIX_EMPLOI_CLEA || key === PIX_EMPLOI_CLEA_V2);
+    return this.acquiredPartnerCertificationKeys.find(
+      ({ partnerKey }) => partnerKey === PIX_EMPLOI_CLEA || partnerKey === PIX_EMPLOI_CLEA_V2
+    )?.partnerKey;
   }
 
   getAcquiredPixPlusDroitCertification() {
     return this.acquiredPartnerCertificationKeys.find(
-      (key) => key === PIX_DROIT_MAITRE_CERTIF || key === PIX_DROIT_EXPERT_CERTIF
-    );
+      ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF || partnerKey === PIX_DROIT_EXPERT_CERTIF
+    )?.partnerKey;
   }
 
   getAcquiredPixPlusEduCertification() {
-    return this.acquiredPartnerCertificationKeys.find(
-      (key) =>
-        key === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE ||
-        key === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME ||
-        key === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME ||
-        key === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE ||
-        key === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+    return (
+      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) ||
+      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME) ||
+      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME) ||
+      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) ||
+      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT)
     );
   }
 
@@ -80,26 +81,45 @@ class CertificationAttestation {
       return null;
     }
 
-    if (acquiredPixPlusEduCertification === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) {
+    const { partnerKey, temporaryPartnerKey } = acquiredPixPlusEduCertification;
+    if (
+      partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE ||
+      temporaryPartnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
+    ) {
       return 'Initié (entrée dans le métier)';
     }
     if (
       [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
-        acquiredPixPlusEduCertification
+        partnerKey
+      ) ||
+      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
+        temporaryPartnerKey
       )
     ) {
       return 'Confirmé';
     }
-    if (acquiredPixPlusEduCertification === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) {
+    if (
+      partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE ||
+      temporaryPartnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
+    ) {
       return 'Avancé';
     }
-    if (acquiredPixPlusEduCertification === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT) {
+    if (
+      partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT ||
+      temporaryPartnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+    ) {
       return 'Expert';
     }
   }
 
   hasAcquiredAnyComplementaryCertifications() {
     return this.acquiredPartnerCertificationKeys.length > 0;
+  }
+
+  _findByPartnerKeyOrTemporaryPartnerKey(key) {
+    return this.acquiredPartnerCertificationKeys.find(
+      ({ partnerKey, temporaryPartnerKey }) => partnerKey === key || temporaryPartnerKey === key
+    );
   }
 }
 

--- a/api/lib/domain/models/CertificationAttestation.js
+++ b/api/lib/domain/models/CertificationAttestation.js
@@ -26,7 +26,7 @@ class CertificationAttestation {
     deliveredAt,
     certificationCenter,
     pixScore,
-    acquiredPartnerCertificationKeys,
+    acquiredPartnerCertifications,
     resultCompetenceTree = null,
     verificationCode,
     maxReachableLevelOnCertificationDate,
@@ -42,7 +42,7 @@ class CertificationAttestation {
     this.deliveredAt = deliveredAt;
     this.certificationCenter = certificationCenter;
     this.pixScore = pixScore;
-    this.acquiredPartnerCertificationKeys = acquiredPartnerCertificationKeys;
+    this.acquiredPartnerCertifications = acquiredPartnerCertifications;
     this.resultCompetenceTree = resultCompetenceTree;
     this.verificationCode = verificationCode;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
@@ -54,13 +54,13 @@ class CertificationAttestation {
   }
 
   getAcquiredCleaCertification() {
-    return this.acquiredPartnerCertificationKeys.find(
+    return this.acquiredPartnerCertifications.find(
       ({ partnerKey }) => partnerKey === PIX_EMPLOI_CLEA || partnerKey === PIX_EMPLOI_CLEA_V2
     )?.partnerKey;
   }
 
   getAcquiredPixPlusDroitCertification() {
-    return this.acquiredPartnerCertificationKeys.find(
+    return this.acquiredPartnerCertifications.find(
       ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF || partnerKey === PIX_DROIT_EXPERT_CERTIF
     )?.partnerKey;
   }
@@ -113,11 +113,11 @@ class CertificationAttestation {
   }
 
   hasAcquiredAnyComplementaryCertifications() {
-    return this.acquiredPartnerCertificationKeys.length > 0;
+    return this.acquiredPartnerCertifications.length > 0;
   }
 
   _findByPartnerKeyOrTemporaryPartnerKey(key) {
-    return this.acquiredPartnerCertificationKeys.find(
+    return this.acquiredPartnerCertifications.find(
       ({ partnerKey, temporaryPartnerKey }) => partnerKey === key || temporaryPartnerKey === key
     );
   }

--- a/api/lib/domain/models/PartnerCertificationScoring.js
+++ b/api/lib/domain/models/PartnerCertificationScoring.js
@@ -3,12 +3,14 @@ const { validateEntity } = require('../validators/entity-validator');
 const { NotImplementedError } = require('../errors');
 
 class PartnerCertificationScoring {
-  constructor({ certificationCourseId, partnerKey } = {}) {
+  constructor({ certificationCourseId, partnerKey, temporaryPartnerKey = null } = {}) {
     this.certificationCourseId = certificationCourseId;
     this.partnerKey = partnerKey;
+    this.temporaryPartnerKey = temporaryPartnerKey;
     const schema = Joi.object({
       certificationCourseId: Joi.number().integer().required(),
-      partnerKey: Joi.string().required(),
+      partnerKey: Joi.string().allow(null).required(),
+      temporaryPartnerKey: Joi.string().allow(null).required(),
     });
     validateEntity(schema, this);
   }

--- a/api/lib/domain/models/PixPlusEduCertificationScoring.js
+++ b/api/lib/domain/models/PixPlusEduCertificationScoring.js
@@ -4,7 +4,8 @@ class PixPlusEduCertificationScoring extends PartnerCertificationScoring {
   constructor({ certificationCourseId, certifiableBadgeKey, reproducibilityRate, hasAcquiredPixCertification } = {}) {
     super({
       certificationCourseId,
-      partnerKey: certifiableBadgeKey,
+      partnerKey: null,
+      temporaryPartnerKey: certifiableBadgeKey,
     });
 
     this.reproducibilityRate = reproducibilityRate;

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -15,53 +15,54 @@ class CertifiedBadgeImage {
     this.levelName = levelName;
   }
 
-  static fromPartnerKey(partnerKey) {
-    if (partnerKey === PIX_DROIT_MAITRE_CERTIF) {
+  static fromPartnerKey(partnerKey, temporaryPartnerKey) {
+    const badgeKey = partnerKey || temporaryPartnerKey;
+    const isTemporaryBadge = !partnerKey;
+
+    if (badgeKey === PIX_DROIT_MAITRE_CERTIF) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
-        isTemporaryBadge: false,
+        isTemporaryBadge,
       });
     }
 
-    if (partnerKey === PIX_DROIT_EXPERT_CERTIF) {
+    if (badgeKey === PIX_DROIT_EXPERT_CERTIF) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
-        isTemporaryBadge: false,
+        isTemporaryBadge,
       });
     }
 
-    if (partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) {
+    if (badgeKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
-        isTemporaryBadge: true,
+        isTemporaryBadge,
         levelName: 'Initié (entrée dans le métier)',
       });
     }
 
     if (
-      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
-        partnerKey
-      )
+      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(badgeKey)
     ) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
-        isTemporaryBadge: true,
+        isTemporaryBadge,
         levelName: 'Confirmé',
       });
     }
 
-    if (partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) {
+    if (badgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
-        isTemporaryBadge: true,
+        isTemporaryBadge,
         levelName: 'Avancé',
       });
     }
 
-    if (partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT) {
+    if (badgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT) {
       return new CertifiedBadgeImage({
         path: 'https://images.pix.fr/badges/Pix_plus_Edu-4-Expert-certif.svg',
-        isTemporaryBadge: true,
+        isTemporaryBadge,
         levelName: 'Expert',
       });
     }

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -15,22 +15,23 @@ class CertifiedBadgeImage {
     this.levelName = levelName;
   }
 
+  static finalFromPath(path) {
+    return new CertifiedBadgeImage({
+      path,
+      isTemporaryBadge: false,
+    });
+  }
+
   static fromPartnerKey(partnerKey, temporaryPartnerKey) {
     const badgeKey = partnerKey || temporaryPartnerKey;
     const isTemporaryBadge = !partnerKey;
 
     if (badgeKey === PIX_DROIT_MAITRE_CERTIF) {
-      return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
-        isTemporaryBadge,
-      });
+      return CertifiedBadgeImage.finalFromPath('https://images.pix.fr/badges-certifies/pix-droit/maitre.svg');
     }
 
     if (badgeKey === PIX_DROIT_EXPERT_CERTIF) {
-      return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
-        isTemporaryBadge,
-      });
+      return CertifiedBadgeImage.finalFromPath('https://images.pix.fr/badges-certifies/pix-droit/expert.svg');
     }
 
     if (badgeKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) {

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -30,9 +30,9 @@ module.exports = {
     }
 
     const competenceTree = await competenceTreeRepository.get();
-    const acquiredPartnerCertificationKeys = await _getAcquiredPartnerCertificationKeys(certificationCourseDTO.id);
+    const acquiredPartnerCertifications = await _getAcquiredPartnerCertification(certificationCourseDTO.id);
 
-    return _toDomain(certificationCourseDTO, competenceTree, acquiredPartnerCertificationKeys);
+    return _toDomain(certificationCourseDTO, competenceTree, acquiredPartnerCertifications);
   },
 
   async findByDivisionForScoIsManagingStudentsOrganization({ organizationId, division }) {
@@ -139,7 +139,7 @@ function _filterMostRecentCertificationCoursePerSchoolingRegistration(DTOs) {
   return mostRecent;
 }
 
-async function _getAcquiredPartnerCertificationKeys(certificationCourseId) {
+async function _getAcquiredPartnerCertification(certificationCourseId) {
   const handledBadgeKeys = [
     PIX_EMPLOI_CLEA,
     PIX_EMPLOI_CLEA_V2,
@@ -158,15 +158,10 @@ async function _getAcquiredPartnerCertificationKeys(certificationCourseId) {
     .whereIn('partnerKey', handledBadgeKeys)
     .orWhereIn('temporaryPartnerKey', handledBadgeKeys);
 
-  return partnerCertifications.map(({ partnerKey, temporaryPartnerKey }) => {
-    return {
-      partnerKey,
-      temporaryPartnerKey,
-    };
-  });
+  return partnerCertifications;
 }
 
-function _toDomain(certificationCourseDTO, competenceTree, acquiredPartnerCertificationKeys) {
+function _toDomain(certificationCourseDTO, competenceTree, acquiredPartnerCertifications) {
   const competenceMarks = _.compact(certificationCourseDTO.competenceMarks).map(
     (competenceMark) => new CompetenceMark({ ...competenceMark })
   );
@@ -181,6 +176,6 @@ function _toDomain(certificationCourseDTO, competenceTree, acquiredPartnerCertif
   return new CertificationAttestation({
     ...certificationCourseDTO,
     resultCompetenceTree,
-    acquiredPartnerCertificationKeys,
+    acquiredPartnerCertifications,
   });
 }

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -152,12 +152,18 @@ async function _getAcquiredPartnerCertificationKeys(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
   ];
   const partnerCertifications = await knex
-    .select('partnerKey')
+    .select('partnerKey', 'temporaryPartnerKey')
     .from('partner-certifications')
     .where({ certificationCourseId, acquired: true })
-    .whereIn('partnerKey', handledBadgeKeys);
+    .whereIn('partnerKey', handledBadgeKeys)
+    .orWhereIn('temporaryPartnerKey', handledBadgeKeys);
 
-  return partnerCertifications.map((partnerCertification) => partnerCertification.partnerKey);
+  return partnerCertifications.map(({ partnerKey, temporaryPartnerKey }) => {
+    return {
+      partnerKey,
+      temporaryPartnerKey,
+    };
+  });
 }
 
 function _toDomain(certificationCourseDTO, competenceTree, acquiredPartnerCertificationKeys) {

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -46,19 +46,28 @@ module.exports = {
     );
 
     const exists = await knex
-      .select('acquired')
+      .select('*')
       .from('partner-certifications')
       .where({
         certificationCourseId: partnerCertificationScoring.certificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
       })
+      .orWhere({
+        certificationCourseId: partnerCertificationScoring.certificationCourseId,
+        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
+      })
       .first();
 
     if (exists) {
       return partnerCertificationToSave
-        .where({
-          certificationCourseId: partnerCertificationScoring.certificationCourseId,
-          partnerKey: partnerCertificationScoring.partnerKey,
+        .query(function (qb) {
+          qb.where({
+            certificationCourseId: partnerCertificationScoring.certificationCourseId,
+            partnerKey: partnerCertificationScoring.partnerKey,
+          }).orWhere({
+            certificationCourseId: partnerCertificationScoring.certificationCourseId,
+            temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
+          });
         })
         .save(null, { transacting: domainTransaction.knexTransaction, method: 'update' });
     }
@@ -67,8 +76,8 @@ module.exports = {
   },
 };
 
-function _adaptModelToDB({ certificationCourseId, partnerKey, acquired }) {
-  return { certificationCourseId, partnerKey, acquired };
+function _adaptModelToDB({ certificationCourseId, partnerKey, temporaryPartnerKey, acquired }) {
+  return { certificationCourseId, partnerKey, temporaryPartnerKey, acquired };
 }
 
 async function _getAcquiredCleaBadgeKey(userId, certificationCourseId, domainTransaction) {

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -133,13 +133,18 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
   ];
   const results = await knex
-    .select('partnerKey')
+    .select('partnerKey', 'temporaryPartnerKey')
     .from('partner-certifications')
     .where({ certificationCourseId, acquired: true })
     .whereIn('partnerKey', handledBadgeKeys)
+    .orWhereIn('temporaryPartnerKey', handledBadgeKeys)
     .orderBy('partnerKey');
 
-  return _.compact(_.map(results, ({ partnerKey }) => CertifiedBadgeImage.fromPartnerKey(partnerKey)));
+  return _.compact(
+    _.map(results, ({ partnerKey, temporaryPartnerKey }) =>
+      CertifiedBadgeImage.fromPartnerKey(partnerKey, temporaryPartnerKey)
+    )
+  );
 }
 
 function _toDomain({ certificationCourseDTO, competenceTree, cleaCertificationResult, certifiedBadgeImages }) {

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -109,13 +109,18 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
   ];
   const results = await knex
-    .select('partnerKey')
+    .select('partnerKey', 'temporaryPartnerKey')
     .from('partner-certifications')
     .where({ certificationCourseId, acquired: true })
     .whereIn('partnerKey', handledBadgeKeys)
+    .orWhereIn('temporaryPartnerKey', handledBadgeKeys)
     .orderBy('partnerKey');
 
-  return _.compact(_.map(results, ({ partnerKey }) => CertifiedBadgeImage.fromPartnerKey(partnerKey)));
+  return _.compact(
+    _.map(results, ({ partnerKey, temporaryPartnerKey }) =>
+      CertifiedBadgeImage.fromPartnerKey(partnerKey, temporaryPartnerKey)
+    )
+  );
 }
 
 function _toDomain(shareableCertificateDTO, competenceTree, cleaCertificationResult, certifiedBadgeImages) {

--- a/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
+++ b/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
@@ -109,11 +109,14 @@ class AttestationViewModel {
     let pixPlusEduTemporaryBadgeMessage;
     if (certificate.getAcquiredPixPlusEduCertification()) {
       hasAcquiredPixPlusEduCertification = true;
-      pixPlusEduCertificationImagePath = getImagePathByBadgeKey(certificate.getAcquiredPixPlusEduCertification());
-      pixPlusEduTemporaryBadgeMessage = toArrayOfFixedLengthStringsConservingWords(
-        `Vous avez obtenu le niveau “${certificate.getPixPlusEduBadgeDisplayName()}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
-        45
-      );
+      const { partnerKey, temporaryPartnerKey } = certificate.getAcquiredPixPlusEduCertification();
+      pixPlusEduCertificationImagePath = getImagePathByBadgeKey(partnerKey || temporaryPartnerKey);
+      if (!partnerKey) {
+        pixPlusEduTemporaryBadgeMessage = toArrayOfFixedLengthStringsConservingWords(
+          `Vous avez obtenu le niveau “${certificate.getPixPlusEduBadgeDisplayName()}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
+          45
+        );
+      }
     }
 
     const sortedCompetenceTree = sortBy(certificate.resultCompetenceTree.areas, 'code');

--- a/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
+++ b/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
@@ -111,7 +111,7 @@ class AttestationViewModel {
       hasAcquiredPixPlusEduCertification = true;
       const { partnerKey, temporaryPartnerKey } = certificate.getAcquiredPixPlusEduCertification();
       pixPlusEduCertificationImagePath = getImagePathByBadgeKey(partnerKey || temporaryPartnerKey);
-      if (!partnerKey) {
+      if (temporaryPartnerKey && !partnerKey) {
         pixPlusEduTemporaryBadgeMessage = toArrayOfFixedLengthStringsConservingWords(
           `Vous avez obtenu le niveau “${certificate.getPixPlusEduBadgeDisplayName()}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
           45

--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -322,14 +322,16 @@ function _renderPixPlusCertificationCertification(viewModel, page, embeddedImage
     });
     yCoordinate -= 15;
 
-    viewModel.pixPlusEduTemporaryBadgeMessage?.forEach((text, index) => {
-      page.drawText(text, {
-        x: 350,
-        y: yCoordinate - index * 10,
-        size: 7,
-        color: rgb(37 / 255, 56 / 255, 88 / 255),
+    if (viewModel.pixPlusEduTemporaryBadgeMessage.length) {
+      viewModel.pixPlusEduTemporaryBadgeMessage.forEach((text, index) => {
+        page.drawText(text, {
+          x: 350,
+          y: yCoordinate - index * 10,
+          size: 7,
+          color: rgb(37 / 255, 56 / 255, 88 / 255),
+        });
       });
-    });
+    }
   }
 }
 

--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -322,7 +322,7 @@ function _renderPixPlusCertificationCertification(viewModel, page, embeddedImage
     });
     yCoordinate -= 15;
 
-    viewModel.pixPlusEduTemporaryBadgeMessage.forEach((text, index) => {
+    viewModel.pixPlusEduTemporaryBadgeMessage?.forEach((text, index) => {
       page.drawText(text, {
         x: 350,
         y: yCoordinate - index * 10,

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -341,7 +341,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
             deliveredAt: new Date('2021-05-05'),
             certificationCenter: 'Centre des poules bien dodues',
             pixScore: 51,
-            acquiredPartnerCertificationKeys: [badgeKey],
+            acquiredPartnerCertificationKeys: [{ partnerKey: badgeKey, temporaryPartnerKey: null }],
             sessionId: 789,
           };
           await _buildValidCertificationAttestation(certificationAttestationData);
@@ -391,7 +391,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [PIX_DROIT_MAITRE_CERTIF],
+        acquiredPartnerCertificationKeys: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, temporaryPartnerKey: null }],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -63,7 +63,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
       await _buildIncomplete(certificationAttestationData);
@@ -92,7 +92,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
       await _buildCancelled(certificationAttestationData);
@@ -121,7 +121,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
@@ -150,7 +150,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
       await _buildRejected(certificationAttestationData);
@@ -183,7 +183,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
@@ -216,7 +216,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
 
@@ -296,7 +296,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
         sessionId: 789,
       };
       await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
@@ -341,7 +341,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
             deliveredAt: new Date('2021-05-05'),
             certificationCenter: 'Centre des poules bien dodues',
             pixScore: 51,
-            acquiredPartnerCertificationKeys: [{ partnerKey: badgeKey, temporaryPartnerKey: null }],
+            acquiredPartnerCertifications: [{ partnerKey: badgeKey, temporaryPartnerKey: null }],
             sessionId: 789,
           };
           await _buildValidCertificationAttestation(certificationAttestationData);
@@ -391,7 +391,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredPartnerCertificationKeys: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, temporaryPartnerKey: null }],
+        acquiredPartnerCertifications: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, temporaryPartnerKey: null }],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -16,26 +16,20 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
   const PARTNER_CERTIFICATIONS_TABLE_NAME = 'partner-certifications';
 
   describe('#save', function () {
-    let partnerCertificationScoring;
-
-    beforeEach(function () {
-      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
-      partnerCertificationScoring = domainBuilder.buildCleaCertificationScoring({
-        certificationCourseId,
-      });
-      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.partnerKey });
-
-      return databaseBuilder.commit();
-    });
-
     afterEach(async function () {
       await knex(PARTNER_CERTIFICATIONS_TABLE_NAME).delete();
       await knex('certification-courses').delete();
       await knex('badges').delete();
     });
 
-    it('should insert the certification partner in db if it does not already exists', async function () {
+    it('should insert the certification partner in db if it does not already exists by partnerKey', async function () {
       // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      const partnerCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+        certificationCourseId,
+      });
+      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.partnerKey });
+      await databaseBuilder.commit();
       sinon.stub(partnerCertificationScoring, 'isAcquired').returns(true);
 
       // when
@@ -51,8 +45,13 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
       });
     });
 
-    it('should update the existing certification partner if it exists', async function () {
+    it('should update the existing certification partner if it exists by partnerKey', async function () {
       // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      const partnerCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+        certificationCourseId,
+      });
+      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.partnerKey });
       databaseBuilder.factory.buildPartnerCertification({
         certificationCourseId: partnerCertificationScoring.certificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
@@ -70,6 +69,58 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         certificationCourseId: partnerCertificationScoring.certificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: false,
+      });
+    });
+
+    it('should insert the certification partner in db if it does not already exists by temporaryPartnerKey', async function () {
+      // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      const partnerCertificationScoring = domainBuilder.buildPixPlusEduCertificationScoring({
+        certificationCourseId,
+      });
+      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.temporaryPartnerKey });
+      await databaseBuilder.commit();
+      sinon.stub(partnerCertificationScoring, 'isAcquired').returns(true);
+
+      // when
+      await partnerCertificationScoringRepository.save({ partnerCertificationScoring });
+
+      // then
+      const partnerCertificationSaved = await knex(PARTNER_CERTIFICATIONS_TABLE_NAME).select();
+      expect(partnerCertificationSaved).to.have.length(1);
+      expect(partnerCertificationSaved[0]).to.deep.equal({
+        certificationCourseId: partnerCertificationScoring.certificationCourseId,
+        partnerKey: null,
+        acquired: true,
+        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
+      });
+    });
+
+    it('should update the existing certification partner if it exists by temporaryPartnerKey', async function () {
+      // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+      const partnerCertificationScoring = domainBuilder.buildPixPlusEduCertificationScoring({
+        certificationCourseId,
+      });
+      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.temporaryPartnerKey });
+      databaseBuilder.factory.buildPartnerCertification({
+        certificationCourseId: partnerCertificationScoring.certificationCourseId,
+        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
+      });
+      await databaseBuilder.commit();
+      sinon.stub(partnerCertificationScoring, 'isAcquired').returns(false);
+
+      // when
+      await partnerCertificationScoringRepository.save({ partnerCertificationScoring });
+
+      // then
+      const partnerCertificationSaved = await knex(PARTNER_CERTIFICATIONS_TABLE_NAME).select();
+      expect(partnerCertificationSaved).to.have.length(1);
+      expect(partnerCertificationSaved[0]).to.deep.equal({
+        certificationCourseId: partnerCertificationScoring.certificationCourseId,
+        partnerKey: null,
+        acquired: false,
+        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -37,13 +37,14 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
 
       // then
       const partnerCertificationSaved = await knex(PARTNER_CERTIFICATIONS_TABLE_NAME).select();
-      expect(partnerCertificationSaved).to.have.length(1);
-      expect(partnerCertificationSaved[0]).to.deep.equal({
-        certificationCourseId: partnerCertificationScoring.certificationCourseId,
-        partnerKey: partnerCertificationScoring.partnerKey,
-        acquired: true,
-        temporaryPartnerKey: null,
-      });
+      expect(partnerCertificationSaved).to.deep.equal([
+        {
+          certificationCourseId: partnerCertificationScoring.certificationCourseId,
+          partnerKey: partnerCertificationScoring.partnerKey,
+          acquired: true,
+          temporaryPartnerKey: null,
+        },
+      ]);
     });
 
     it('should update the existing certification partner if it exists by partnerKey', async function () {

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -42,6 +42,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         certificationCourseId: partnerCertificationScoring.certificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: true,
+        temporaryPartnerKey: null,
       });
     });
 
@@ -69,6 +70,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         certificationCourseId: partnerCertificationScoring.certificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: false,
+        temporaryPartnerKey: null,
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -510,9 +510,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         ...privateCertificateData,
       });
 
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate.certifiedBadgeImages).to.deep.equal(expectedPrivateCertificate.certifiedBadgeImages);
     });
 
     it('should get the certified badge images of pixPlusDroitMaitre and pixPlusDroitExpert when those certifications were acquired', async function () {

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -9,8 +9,13 @@ const {
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const privateCertificateRepository = require('../../../../lib/infrastructure/repositories/private-certificate-repository');
 const PrivateCertificate = require('../../../../lib/domain/models/PrivateCertificate');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+} = require('../../../../lib/domain/models/Badge').keys;
 const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | Private Certificate', function () {
@@ -461,6 +466,155 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         );
       });
     });
+
+    it('should get the certified badge image of pixPlusDroitMaitre when this certifications was acquired', async function () {
+      // given
+      const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+      mockLearningContent(learningContentObjects);
+
+      const userId = databaseBuilder.factory.buildUser().id;
+      const privateCertificateData = {
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'ABCDF-G',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: null,
+        commentForCandidate: null,
+        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+        certifiedBadgeImages: [
+          domainBuilder.buildCertifiedBadgeImage.notTemporary({
+            path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+          }),
+        ],
+      };
+
+      const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
+        privateCertificateData,
+        acquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
+        notAcquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
+      });
+
+      // when
+      const privateCertificate = await privateCertificateRepository.get(certificateId);
+
+      // then
+      const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.started({
+        id: certificateId,
+        ...privateCertificateData,
+      });
+
+      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
+        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
+      );
+    });
+
+    it('should get the certified badge images of pixPlusDroitMaitre and pixPlusDroitExpert when those certifications were acquired', async function () {
+      // given
+      const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+      mockLearningContent(learningContentObjects);
+
+      const userId = databaseBuilder.factory.buildUser().id;
+      const privateCertificateData = {
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'ABCDE-F',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: null,
+        commentForCandidate: null,
+        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+        certifiedBadgeImages: [
+          domainBuilder.buildCertifiedBadgeImage.notTemporary({
+            path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+          }),
+          domainBuilder.buildCertifiedBadgeImage.notTemporary({
+            path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+          }),
+        ],
+      };
+
+      const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
+        privateCertificateData,
+        acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF],
+        notAcquiredBadges: [],
+      });
+
+      // when
+      const privateCertificate = await privateCertificateRepository.get(certificateId);
+
+      // then
+      const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.started({
+        id: certificateId,
+        ...privateCertificateData,
+      });
+
+      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
+        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
+      );
+    });
+
+    it('should get the certified badge image when there is temporary partner key and no partner key', async function () {
+      // given
+      const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+      mockLearningContent(learningContentObjects);
+
+      const userId = databaseBuilder.factory.buildUser().id;
+      const privateCertificateData = {
+        firstName: 'Sarah Michelle',
+        lastName: 'Gellar',
+        birthdate: '1977-04-14',
+        birthplace: 'Saint-Ouen',
+        isPublished: true,
+        userId,
+        date: new Date('2020-01-01'),
+        verificationCode: 'ABCDF-G',
+        maxReachableLevelOnCertificationDate: 5,
+        deliveredAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+        pixScore: null,
+        commentForCandidate: null,
+        cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+        certifiedBadgeImages: [
+          domainBuilder.buildCertifiedBadgeImage.temporary({
+            path: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+            levelName: 'Initié (entrée dans le métier)',
+          }),
+        ],
+      };
+
+      const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
+        privateCertificateData,
+        temporaryAcquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
+        acquiredBadges: [],
+        notAcquiredBadges: [],
+      });
+
+      // when
+      const privateCertificate = await privateCertificateRepository.get(certificateId);
+
+      // then
+      const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.started({
+        id: certificateId,
+        ...privateCertificateData,
+      });
+
+      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
+        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
+      );
+    });
   });
 
   describe('#findByUserId', function () {
@@ -729,6 +883,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
   privateCertificateData,
   acquiredBadges,
   notAcquiredBadges,
+  temporaryAcquiredBadges,
 }) {
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
   const sessionId = databaseBuilder.factory.buildSession({
@@ -763,6 +918,14 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     databaseBuilder.factory.buildPartnerCertification({
       certificationCourseId: certificateId,
       partnerKey: badgeKey,
+      acquired: true,
+    });
+  });
+  temporaryAcquiredBadges?.forEach((badgeKey) => {
+    databaseBuilder.factory.buildBadge({ key: badgeKey });
+    databaseBuilder.factory.buildPartnerCertification({
+      certificationCourseId: certificateId,
+      temporaryPartnerKey: badgeKey,
       acquired: true,
     });
   });

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -8,8 +8,14 @@ const {
 } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const shareableCertificateRepository = require('../../../../lib/infrastructure/repositories/shareable-certificate-repository');
-const { PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2, PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } =
-  require('../../../../lib/domain/models/Badge').keys;
+const {
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+} = require('../../../../lib/domain/models/Badge').keys;
+const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | Shareable Certificate', function () {
   const minimalLearningContent = [
@@ -455,6 +461,58 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         ]);
       });
 
+      it('should get the certified badge image when there is temporary partner key and no partner key', async function () {
+        // given
+        const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
+        mockLearningContent(learningContentObjects);
+
+        const userId = databaseBuilder.factory.buildUser().id;
+        const shareableCertificateData = {
+          firstName: 'Sarah Michelle',
+          lastName: 'Gellar',
+          birthdate: '1977-04-14',
+          birthplace: 'Saint-Ouen',
+          isPublished: true,
+          userId,
+          date: new Date('2020-01-01'),
+          verificationCode: 'ABCDF-G',
+          maxReachableLevelOnCertificationDate: 5,
+          deliveredAt: new Date('2021-05-05'),
+          certificationCenter: 'Centre des poules bien dodues',
+          pixScore: null,
+          commentForCandidate: null,
+          cleaCertificationResult: domainBuilder.buildCleaCertificationResult.notTaken(),
+          certifiedBadgeImages: [
+            domainBuilder.buildCertifiedBadgeImage.temporary({
+              path: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+              levelName: 'Initié (entrée dans le métier)',
+            }),
+          ],
+        };
+
+        const { certificateId } = await _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
+          shareableCertificateData,
+          temporaryAcquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
+          acquiredBadges: [],
+          notAcquiredBadges: [],
+        });
+
+        // when
+        const shareableCertificate = await shareableCertificateRepository.getByVerificationCode(
+          shareableCertificateData.verificationCode
+        );
+
+        // then
+        const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
+          id: certificateId,
+          ...shareableCertificateData,
+        });
+
+        expect(_.omit(shareableCertificate, ['resultCompetenceTree'])).to.deep.equal(
+          _.omit(expectedShareableCertificate, ['resultCompetenceTree'])
+        );
+      });
+
       it('should only take into account acquired ones', async function () {
         // given
         const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
@@ -551,6 +609,7 @@ async function _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
   shareableCertificateData,
   acquiredBadges,
   notAcquiredBadges,
+  temporaryAcquiredBadges,
 }) {
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
   const sessionId = databaseBuilder.factory.buildSession({
@@ -584,6 +643,14 @@ async function _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
     databaseBuilder.factory.buildPartnerCertification({
       certificationCourseId: certificateId,
       partnerKey: badgeKey,
+      acquired: true,
+    });
+  });
+  temporaryAcquiredBadges?.forEach((badgeKey) => {
+    databaseBuilder.factory.buildBadge({ key: badgeKey });
+    databaseBuilder.factory.buildPartnerCertification({
+      certificationCourseId: certificateId,
+      temporaryPartnerKey: badgeKey,
       acquired: true,
     });
   });

--- a/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -29,7 +29,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
+      acquiredPartnerCertifications: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full.pdf';
 
@@ -56,7 +56,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [{ temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE }],
+      acquiredPartnerCertifications: [{ temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full_edu.pdf';
 
@@ -83,14 +83,14 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
+      acquiredPartnerCertifications: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
     });
     const certificateWithCleaAndPixPlusDroitExpert = domainBuilder.buildCertificationAttestation({
       id: 2,
       firstName: 'Harry',
       lastName: 'Covert',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
+      acquiredPartnerCertifications: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
     });
     const certificateWithoutCleaNorPixPlusDroit = domainBuilder.buildCertificationAttestation({
       ...certificateWithCleaAndPixPlusDroitMaitre,
@@ -99,7 +99,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       lastName: 'Decaffé',
       cleaCertificationImagePath: null,
       pixPlusDroitCertificationImagePath: null,
-      acquiredPartnerCertificationKeys: [],
+      acquiredPartnerCertifications: [],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_several_pages.pdf';
 

--- a/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -29,7 +29,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [PIX_EMPLOI_CLEA, PIX_DROIT_MAITRE_CERTIF],
+      acquiredPartnerCertificationKeys: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full.pdf';
 
@@ -56,7 +56,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
+      acquiredPartnerCertificationKeys: [{ temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full_edu.pdf';
 
@@ -83,14 +83,14 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [PIX_EMPLOI_CLEA, PIX_DROIT_MAITRE_CERTIF],
+      acquiredPartnerCertificationKeys: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
     });
     const certificateWithCleaAndPixPlusDroitExpert = domainBuilder.buildCertificationAttestation({
       id: 2,
       firstName: 'Harry',
       lastName: 'Covert',
       resultCompetenceTree,
-      acquiredPartnerCertificationKeys: [PIX_EMPLOI_CLEA, PIX_DROIT_EXPERT_CERTIF],
+      acquiredPartnerCertificationKeys: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
     });
     const certificateWithoutCleaNorPixPlusDroit = domainBuilder.buildCertificationAttestation({
       ...certificateWithCleaAndPixPlusDroitMaitre,

--- a/api/tests/tooling/domain-builder/factory/build-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-attestation.js
@@ -14,7 +14,7 @@ module.exports = function buildCertificationAttestation({
   pixScore = 123,
   maxReachableLevelOnCertificationDate = 5,
   verificationCode = 'P-SOMECODE',
-  acquiredPartnerCertificationKeys = [],
+  acquiredPartnerCertifications = [],
   resultCompetenceTree = null,
 } = {}) {
   return new CertificationAttestation({
@@ -31,7 +31,7 @@ module.exports = function buildCertificationAttestation({
     pixScore,
     maxReachableLevelOnCertificationDate,
     verificationCode,
-    acquiredPartnerCertificationKeys,
+    acquiredPartnerCertifications,
     resultCompetenceTree,
   });
 };

--- a/api/tests/unit/domain/models/CertificationAttestation_test.js
+++ b/api/tests/unit/domain/models/CertificationAttestation_test.js
@@ -30,7 +30,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_EMPLOI_CLEA badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE', PIX_EMPLOI_CLEA],
+        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA }],
       });
 
       // when
@@ -43,7 +43,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_EMPLOI_CLEA_V2 badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE', PIX_EMPLOI_CLEA_V2],
+        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA_V2 }],
       });
 
       // when
@@ -56,7 +56,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no clea badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE_1', 'OTHER_BADGE_2'],
+        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
       });
 
       // when
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_DROIT_MAITRE_CERTIF badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE', PIX_DROIT_MAITRE_CERTIF],
+        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
       });
 
       // when
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_DROIT_EXPERT_CERTIF badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE', PIX_DROIT_EXPERT_CERTIF],
+        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
       });
 
       // when
@@ -97,7 +97,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no Pix+ Droit badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE_1', 'OTHER_BADGE_2'],
+        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
       });
 
       // when
@@ -120,14 +120,14 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return the acquired ${badgeKey} badge`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredPartnerCertificationKeys: ['OTHER_BADGE', badgeKey],
+          acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { temporaryPartnerKey: badgeKey }],
         });
 
         // when
         const acquiredPixPlusEduCertification = certificationAttestation.getAcquiredPixPlusEduCertification();
 
         // expect
-        expect(acquiredPixPlusEduCertification).to.deep.equal(badgeKey);
+        expect(acquiredPixPlusEduCertification).to.deep.equal({ temporaryPartnerKey: badgeKey });
       });
     });
 
@@ -160,7 +160,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return ${expectedDisplayName} for badge key ${badgeKey}`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredPartnerCertificationKeys: [badgeKey],
+          acquiredPartnerCertificationKeys: [{ partnerKey: badgeKey }],
         });
 
         // when

--- a/api/tests/unit/domain/models/CertificationAttestation_test.js
+++ b/api/tests/unit/domain/models/CertificationAttestation_test.js
@@ -30,7 +30,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_EMPLOI_CLEA badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA }],
+        acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA }],
       });
 
       // when
@@ -43,7 +43,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_EMPLOI_CLEA_V2 badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA_V2 }],
+        acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA_V2 }],
       });
 
       // when
@@ -56,7 +56,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no clea badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
+        acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
       });
 
       // when
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_DROIT_MAITRE_CERTIF badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
+        acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
       });
 
       // when
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_DROIT_EXPERT_CERTIF badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
+        acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
       });
 
       // when
@@ -97,7 +97,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no Pix+ Droit badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
+        acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
       });
 
       // when
@@ -120,7 +120,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return the acquired ${badgeKey} badge`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredPartnerCertificationKeys: [{ partnerKey: 'OTHER_BADGE' }, { temporaryPartnerKey: badgeKey }],
+          acquiredPartnerCertifications: [{ partnerKey: 'OTHER_BADGE' }, { temporaryPartnerKey: badgeKey }],
         });
 
         // when
@@ -134,7 +134,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no Pix+ Edu badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: ['OTHER_BADGE_1', 'OTHER_BADGE_2'],
+        acquiredPartnerCertifications: ['OTHER_BADGE_1', 'OTHER_BADGE_2'],
       });
 
       // when
@@ -160,7 +160,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return ${expectedDisplayName} for badge key ${badgeKey}`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredPartnerCertificationKeys: [{ partnerKey: badgeKey }],
+          acquiredPartnerCertifications: [{ partnerKey: badgeKey }],
         });
 
         // when
@@ -176,7 +176,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return true if certified badge images for attestation is not empty', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [PIX_EMPLOI_CLEA],
+        acquiredPartnerCertifications: [PIX_EMPLOI_CLEA],
       });
 
       // when
@@ -190,7 +190,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return false if certified badge images for attestation is empty', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredPartnerCertificationKeys: [],
+        acquiredPartnerCertifications: [],
       });
 
       // when

--- a/api/tests/unit/domain/models/PartnerCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/PartnerCertificationScoring_test.js
@@ -24,9 +24,9 @@ describe('Unit | Domain | Models | PartnerCertificationScoring', function () {
       );
     });
 
-    it('should throw an ObjectValidationError when partnerKey is not valid', function () {
+    it('should not throw an ObjectValidationError when partnerKey is null', function () {
       // when
-      expect(() => new PartnerCertificationScoring({ ...validArguments, partnerKey: null })).to.throw(
+      expect(() => new PartnerCertificationScoring({ ...validArguments, partnerKey: null })).to.not.throw(
         ObjectValidationError
       );
     });

--- a/api/tests/unit/domain/models/PixPlusEduCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/PixPlusEduCertificationScoring_test.js
@@ -1,6 +1,25 @@
 const { expect, domainBuilder } = require('../../../test-helper');
+const PixPlusEduCertificationScoring = require('../../../../lib/domain/models/PixPlusEduCertificationScoring');
 
 describe('Unit | Domain | Models | PixPlusEduCertificationScoring', function () {
+  context('#constructor', function () {
+    it('set partnerKey and temporaryPartnerKey', function () {
+      // given
+      const reproducibilityRate = domainBuilder.buildReproducibilityRate({ value: 71 });
+
+      // when
+      const pixPlusEduCertificationScoring = new PixPlusEduCertificationScoring({
+        certificationCourseId: 1,
+        certifiableBadgeKey: 'BADGE',
+        reproducibilityRate,
+        hasAcquiredPixCertification: false,
+      });
+
+      // then
+      expect(pixPlusEduCertificationScoring.temporaryPartnerKey).to.equal('BADGE');
+      expect(pixPlusEduCertificationScoring.partnerKey).to.be.null;
+    });
+  });
   context('#isAcquired', function () {
     it('returns true when Pix+ Edu certification is acquired and reproducibility rate is over 70', function () {
       // given

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -10,13 +10,16 @@ const {
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
 } = require('../../../../lib/domain/models/Badge').keys;
 
-const badgeInfos = {
+const pixPlusDroitBadgesInfos = {
   [PIX_DROIT_MAITRE_CERTIF]: {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
   },
   [PIX_DROIT_EXPERT_CERTIF]: {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
   },
+};
+
+const pixPlusEduBadgesInfos = {
   [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]: {
     path: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
     levelName: 'Initié (entrée dans le métier)',
@@ -41,26 +44,33 @@ const badgeInfos = {
 
 describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
   describe('#fromPartnerKey', function () {
-    for (const badgeKey in badgeInfos) {
-      it(`returns not temporary badge image for partner key ${badgeKey}`, function () {
-        // when
-        const result = CertifiedBadgeImage.fromPartnerKey(badgeKey);
+    context('when badge is final', function () {
+      const badges = { ...pixPlusDroitBadgesInfos, ...pixPlusEduBadgesInfos };
+      for (const badgeKey in badges) {
+        it(`returns final badge image for partner key ${badgeKey}`, function () {
+          // when
+          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey);
 
-        // then
-        const { path, levelName } = badgeInfos[badgeKey];
+          // then
+          const { path, levelName } = badges[badgeKey];
 
-        expect(result).to.deepEqualInstance(new CertifiedBadgeImage({ path, levelName, isTemporaryBadge: false }));
-      });
+          expect(result).to.deepEqualInstance(new CertifiedBadgeImage({ path, levelName, isTemporaryBadge: false }));
+        });
+      }
+    });
+    context('when badge is temporary', function () {
+      const badges = { ...pixPlusEduBadgesInfos };
+      for (const badgeKey in badges) {
+        it(`returns temporary badge image for temporary partner key ${badgeKey}`, function () {
+          // when
+          const result = CertifiedBadgeImage.fromPartnerKey(null, badgeKey);
 
-      it(`returns temporary badge image for temporary partner key ${badgeKey}`, function () {
-        // when
-        const result = CertifiedBadgeImage.fromPartnerKey(null, badgeKey);
+          // then
+          const { path, levelName } = badges[badgeKey];
 
-        // then
-        const { path, levelName } = badgeInfos[badgeKey];
-
-        expect(result).to.deepEqualInstance(new CertifiedBadgeImage({ path, levelName, isTemporaryBadge: true }));
-      });
-    }
+          expect(result).to.deepEqualInstance(new CertifiedBadgeImage({ path, levelName, isTemporaryBadge: true }));
+        });
+      }
+    });
   });
 });

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -13,48 +13,53 @@ const {
 const badgeInfos = {
   [PIX_DROIT_MAITRE_CERTIF]: {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
-    isTemporaryBadge: false,
   },
   [PIX_DROIT_EXPERT_CERTIF]: {
     path: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
-    isTemporaryBadge: false,
   },
   [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]: {
     path: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
-    isTemporaryBadge: true,
     levelName: 'Initié (entrée dans le métier)',
   },
   [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME]: {
     path: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
-    isTemporaryBadge: true,
     levelName: 'Confirmé',
   },
   [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME]: {
     path: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
-    isTemporaryBadge: true,
     levelName: 'Confirmé',
   },
   [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE]: {
     path: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
-    isTemporaryBadge: true,
     levelName: 'Avancé',
   },
   [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]: {
     path: 'https://images.pix.fr/badges/Pix_plus_Edu-4-Expert-certif.svg',
-    isTemporaryBadge: true,
     levelName: 'Expert',
   },
 };
 
 describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
   describe('#fromPartnerKey', function () {
-    for (const partnerKey in badgeInfos) {
-      it(`returns badge infos for ${partnerKey}`, function () {
+    for (const badgeKey in badgeInfos) {
+      it(`returns not temporary badge image for partner key ${badgeKey}`, function () {
         // when
-        const result = CertifiedBadgeImage.fromPartnerKey(partnerKey);
+        const result = CertifiedBadgeImage.fromPartnerKey(badgeKey);
 
         // then
-        expect(result).to.deepEqualInstance(new CertifiedBadgeImage(badgeInfos[partnerKey]));
+        const { path, levelName } = badgeInfos[badgeKey];
+
+        expect(result).to.deepEqualInstance(new CertifiedBadgeImage({ path, levelName, isTemporaryBadge: false }));
+      });
+
+      it(`returns temporary badge image for temporary partner key ${badgeKey}`, function () {
+        // when
+        const result = CertifiedBadgeImage.fromPartnerKey(null, badgeKey);
+
+        // then
+        const { path, levelName } = badgeInfos[badgeKey];
+
+        expect(result).to.deepEqualInstance(new CertifiedBadgeImage({ path, levelName, isTemporaryBadge: true }));
       });
     }
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du scoring Pix+ Edu en plusieurs volets, on veut afficher un niveau temporaire (volet 1) et un niveau définitif (volet2) sur les certificats de l'utilisateur.

## :robot: Solution

Process
-  lors du scoring auto Pix+ Edu du volet 1, enregistrer automatiquement le niveau obtenu dans le champ `temporaryPartnerKey`
-  dans pix app, afficher le badge temporaire et le message associé (comme il y a une `temporaryPartnerKey` et pas de `partrnerKey`)
-  après le scoring jury Pix+ Edu du volet 2, le niveau est déterminé manuellement en prenant le résultat le plus bas des deux volets (scoring définitif manuel)
-  enregistrer le niveau obtenu dans le champ `partnerKey` (manuellement, `UPDATE` en SQL)
-  dans pix app, afficher le badge du scoring définitif et le message associé (comme il y a un`partrnerKey`)

## :rainbow: Remarques


## :100: Pour tester

### Lorsque la certification (volet 1) a déjà été obtenue
Etapes:
- checkout la version de production
- passer le volet 1
- checkout la branche
- exécuter la mmigration `npm run db:migrate`
- vérifier que le message affiché est celui du volet 1

### Lors du passage de certification

#### Certification obtenue
- Reseeder la base pour pouvoir passer la certification en RA
- Créer une session de certification dans [PixCertif](https://certif-pr4168.review.pix.fr/)
- Passer une certification Edu sur [app](https://app-pr4168.review.pix.fr/) avec `certifedu.continue@example.net`
- Publier la certification
- Vérifier que le message temporaire est affiché sur l'ensemble des certificats liés ( le certificat, le certificat partagé et l'attestation )
- Modifier en base la table partnerCertifications reliée à ce certificationCourse, ajouter une partnerKey
     ```update "partner-certifications" set "partnerKey"='PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE' where "certificationCourseId"=<ID_DU_CERTIF_COURSE>;```
- Constater que le message temporaire a disparu de l'ensemble des certificats liés à ce course

Sans partnerKey
![image](https://user-images.githubusercontent.com/37305474/156774760-9bd36a33-4081-4a21-ad30-f3da04cc605c.png)


Avec partnerKey
![image](https://user-images.githubusercontent.com/37305474/156775863-4ba1a295-0357-4fc2-8fd6-4f7d7ddf0472.png)

#### Certification obtenue volet 2 mais refusée au final

Idem que ci-dessus, mais 
```sql
UPDATE "partner-certifications" 
SET "partnerKey"= null, "acquired" = FALSE
WHERE "certificationCourseId"=<ID_DU_CERTIF_COURSE>;
```

Ca donne
```
 certificationCourseId | partnerKey | acquired |             temporaryPartnerKey             
-----------------------+------------+----------+---------------------------------------------
                 18000 |            | f        | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
```

Vérifier que le badge Pix+Edu est toujours affiché

![image](https://user-images.githubusercontent.com/56302715/157647400-3464d33a-f56d-4072-bbb7-4f090b9cdb19.png)

