### PR TITLE
[FEATURE] Annule toutes les invitations en attente en archivant une organisation (PIX-4281). 

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -86,6 +86,29 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'PUT',
+      path: '/api/admin/organizations/{id}/archived',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRolePixMaster,
+            assign: 'hasRolePixMaster',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationController.archiveOrganization,
+        tags: ['api', 'organizations'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+            "- Elle permet d'archiver une organisation",
+        ],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/organizations/{id}',
       config: {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -308,4 +308,10 @@ module.exports = {
       .header('Content-Type', 'text/csv;charset=utf-8')
       .header('Content-Disposition', `attachment; filename=${request.i18n.__('csv-template.template-name')}.csv`);
   },
+
+  async archiveOrganization(request) {
+    const organizationId = request.params.id;
+    await usecases.archiveOrganization({ organizationId });
+    return null;
+  },
 };

--- a/api/lib/domain/usecases/archive-organization.js
+++ b/api/lib/domain/usecases/archive-organization.js
@@ -1,0 +1,10 @@
+const bluebird = require('bluebird');
+
+module.exports = async function archiveOrganization({ organizationId, organizationInvitationRepository }) {
+  const pendingInvitations = await organizationInvitationRepository.findPendingByOrganizationId({ organizationId });
+
+  await bluebird.mapSeries(pendingInvitations, async (invitation) => {
+    await organizationInvitationRepository.markAsCancelled({ id: invitation.id });
+    await organizationInvitationRepository.updateModificationDate(invitation.id);
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -165,6 +165,7 @@ module.exports = injectDependencies(
     attachOrganizationsFromExistingTargetProfile: require('./attach-organizations-from-existing-target-profile'),
     attachOrganizationsToTargetProfile: require('./attach-organizations-to-target-profile'),
     archiveCampaign: require('./archive-campaign'),
+    archiveOrganization: require('./archive-organization'),
     outdateTargetProfile: require('./outdate-target-profile'),
     assignCertificationOfficerToJurySession: require('./assign-certification-officer-to-jury-session'),
     authenticateAnonymousUser: require('./authenticate-anonymous-user'),

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -104,6 +104,26 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
+  describe('PUT /api/admin/organizations/:id/archived', function () {
+    it('should call the controller to archive the organization', async function () {
+      // given
+      const method = 'PUT';
+      const url = '/api/admin/organizations/1/archived';
+
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(organizationController, 'archiveOrganization').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      expect(organizationController.archiveOrganization).to.have.been.calledOnce;
+    });
+  });
+
   describe('POST /api/organizations/:id/invitations', function () {
     it('should call the organization controller to send invitations', async function () {
       // given

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1037,4 +1037,21 @@ describe('Unit | Application | Organizations | organization-controller', functio
       expect(result).to.be.equal(serializedMembersIdentities);
     });
   });
+
+  describe('#archiveOrganization', function () {
+    it('should call the usecase to cancel all pending invitations', async function () {
+      // given
+      const organizationId = 1234;
+      const request = { params: { id: organizationId } };
+
+      sinon.stub(usecases, 'archiveOrganization').resolves();
+
+      // when
+      await organizationController.archiveOrganization(request, hFake);
+
+      // then
+      expect(usecases.archiveOrganization).to.have.been.calledOnce;
+      expect(usecases.archiveOrganization).to.have.been.calledWith({ organizationId });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/archive-organization_test.js
+++ b/api/tests/unit/domain/usecases/archive-organization_test.js
@@ -1,0 +1,52 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const archiveOrganization = require('../../../../lib/domain/usecases/archive-organization');
+const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
+
+describe('Unit | UseCase | archive-organization', function () {
+  let organizationInvitationRepository;
+
+  beforeEach(function () {
+    organizationInvitationRepository = {
+      findPendingByOrganizationId: sinon.stub(),
+      markAsCancelled: sinon.stub(),
+      updateModificationDate: sinon.stub(),
+    };
+  });
+
+  context('when organization has pending invitations', function () {
+    it('should cancel every invitation and update modification date', async function () {
+      // given
+      const status = OrganizationInvitation.StatusType.PENDING;
+      const organizationId = 1;
+      const organizationInvitations = [
+        domainBuilder.buildOrganizationInvitation({ id: 1, status, organizationId }),
+        domainBuilder.buildOrganizationInvitation({ id: 2, status, organizationId }),
+        domainBuilder.buildOrganizationInvitation({ id: 3, status, organizationId }),
+      ];
+
+      organizationInvitationRepository.findPendingByOrganizationId.resolves(organizationInvitations);
+
+      // when
+      await archiveOrganization({
+        organizationId,
+        organizationInvitationRepository,
+      });
+
+      // then
+      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledThrice;
+      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
+        id: 1,
+      });
+      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
+        id: 2,
+      });
+      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
+        id: 3,
+      });
+      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledThrice;
+      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(1);
+      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(2);
+      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(3);
+    });
+  });
+});


### PR DESCRIPTION
## 🌈  Contexte
Aujourd'hui, il n'existe pas de manière propre d'archiver une organisation. L'archivage est fait avec l'ajout d'un tag (obsolète). Or, les tags n'ont pas été conçus pour ce cas d'usage.

## :unicorn: Problème
Lorsqu'une organisation est archivée, elle peut avoir des invitations encore en attente.

## :robot: Solution
Changer le statut de toutes les invitations en attente a `Cancelled`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Appeler la route `/api/admin/organizations/{id}/archived` en curl pour une organisation qui a des invitations en pending et avec un pixmaster et verifier que toutes les invitations ont le statut `Cancelled`