### PR TITLE
[TECH] Refacto mettre à jour la date de modification dès qu'on annule une invitation

### DIFF
--- a/api/lib/domain/usecases/archive-organization.js
+++ b/api/lib/domain/usecases/archive-organization.js
@@ -5,6 +5,5 @@ module.exports = async function archiveOrganization({ organizationId, organizati
 
   await bluebird.mapSeries(pendingInvitations, async (invitation) => {
     await organizationInvitationRepository.markAsCancelled({ id: invitation.id });
-    await organizationInvitationRepository.updateModificationDate(invitation.id);
   });
 };

--- a/api/lib/domain/usecases/cancel-organization-invitation.js
+++ b/api/lib/domain/usecases/cancel-organization-invitation.js
@@ -10,6 +10,5 @@ module.exports = async function cancelOrganizationInvitation({
     throw new UncancellableOrganizationInvitationError();
   }
 
-  await organizationInvitationRepository.markAsCancelled({ id: organizationInvitationId });
-  return await organizationInvitationRepository.updateModificationDate(organizationInvitationId);
+  return await organizationInvitationRepository.markAsCancelled({ id: organizationInvitationId });
 };

--- a/api/lib/infrastructure/repositories/organization-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-invitation-repository.js
@@ -61,6 +61,7 @@ module.exports = {
       .where({ id })
       .update({
         status: OrganizationInvitation.StatusType.CANCELLED,
+        updatedAt: new Date(),
       })
       .returning('*');
 

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -159,9 +159,12 @@ describe('Integration | Repository | OrganizationInvitationRepository', function
   });
 
   describe('#markAsCancelled', function () {
-    it('should return an Organization-invitation domain object', async function () {
+    it('should return the cancelled organization invitation', async function () {
       // given
+      const now = new Date('2021-01-02');
+      const clock = sinon.useFakeTimers(now);
       const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+        updatedAt: new Date('2020-01-01T00:00:00Z'),
         status: OrganizationInvitation.StatusType.PENDING,
       });
       await databaseBuilder.commit();
@@ -178,6 +181,8 @@ describe('Integration | Repository | OrganizationInvitationRepository', function
       expect(organizationInvitationSaved.email).to.equal(organizationInvitation.email);
       expect(organizationInvitationSaved.status).to.equal(OrganizationInvitation.StatusType.CANCELLED);
       expect(organizationInvitationSaved.code).to.equal(organizationInvitation.code);
+      expect(organizationInvitationSaved.updatedAt).to.be.deep.equal(now);
+      clock.restore();
     });
 
     it('should throw a not found error', async function () {

--- a/api/tests/unit/domain/usecases/archive-organization_test.js
+++ b/api/tests/unit/domain/usecases/archive-organization_test.js
@@ -9,7 +9,6 @@ describe('Unit | UseCase | archive-organization', function () {
     organizationInvitationRepository = {
       findPendingByOrganizationId: sinon.stub(),
       markAsCancelled: sinon.stub(),
-      updateModificationDate: sinon.stub(),
     };
   });
 
@@ -43,10 +42,6 @@ describe('Unit | UseCase | archive-organization', function () {
       expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
         id: 3,
       });
-      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledThrice;
-      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(1);
-      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(2);
-      expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(3);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/cancel-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/cancel-organization-invitation_test.js
@@ -10,7 +10,6 @@ describe('Unit | UseCase | cancel-organization-invitation', function () {
     organizationInvitationRepository = {
       get: sinon.stub(),
       markAsCancelled: sinon.stub(),
-      updateModificationDate: sinon.stub(),
     };
   });
 
@@ -49,27 +48,28 @@ describe('Unit | UseCase | cancel-organization-invitation', function () {
     });
 
     context('when invitation is pending', function () {
-      it('should cancel organization invitation and update modification date', async function () {
+      it('should return the cancelled organization invitation', async function () {
         // given
         const status = OrganizationInvitation.StatusType.PENDING;
         const organizationInvitation = domainBuilder.buildOrganizationInvitation({ status });
         const organizationInvitationId = organizationInvitation.id;
+        const cancelledOrganizationInvitation = Symbol('the cancelled invitation');
 
         organizationInvitationRepository.get.resolves(organizationInvitation);
+        organizationInvitationRepository.markAsCancelled
+          .withArgs({
+            id: organizationInvitationId,
+          })
+          .resolves(cancelledOrganizationInvitation);
 
         // when
-        await cancelOrganizationInvitation({
+        const result = await cancelOrganizationInvitation({
           organizationInvitationId,
           organizationInvitationRepository,
         });
 
         // then
-        expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
-          id: organizationInvitationId,
-        });
-        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(
-          organizationInvitationId
-        );
+        expect(result).to.be.equal(cancelledOrganizationInvitation);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On fait deux appels de répo qui pourraient être fait en un seul appel. Et il n'y a pas d'intérêt à afficher dans le usecase les deux actions de manière séparées.

## :robot: Solution
Faire en sorte que markAsCancelled mette à jour la date de modification d'une invitation et supprimer les appels repo devenus obsolètes.

## :rainbow: Remarques
Il reste des appels à la méthode `updateModificationDate` dans `api/lib/domain/services/organization-invitation-service.js`. 
Cependant c'est un cas un peu particulier. 

## :100: Pour tester
- Vérifier si l'archivage d'une orga fonctionne toujours
- Vérifier si l'annulation d'une invitation fonctionne toujours
