### PR TITLE
[FEATURE] Permettre d'archiver toutes les campagnes en archivant une organisation sur Pix Admin (PIX-4280).

### DIFF
--- a/api/lib/domain/models/OrganizationToArchive.js
+++ b/api/lib/domain/models/OrganizationToArchive.js
@@ -1,0 +1,15 @@
+const OrganizationInvitation = require('./OrganizationInvitation');
+
+class OrganizationToArchive {
+  constructor({ id } = {}) {
+    this.id = id;
+  }
+
+  archive({ archiveDate = new Date() } = {}) {
+    this.previousInvitationStatus = OrganizationInvitation.StatusType.PENDING;
+    this.newInvitationStatus = OrganizationInvitation.StatusType.CANCELLED;
+    this.archiveDate = archiveDate;
+  }
+}
+
+module.exports = OrganizationToArchive;

--- a/api/lib/domain/usecases/archive-organization.js
+++ b/api/lib/domain/usecases/archive-organization.js
@@ -1,9 +1,7 @@
-const bluebird = require('bluebird');
+const OrganizationToArchive = require('../models/OrganizationToArchive');
 
-module.exports = async function archiveOrganization({ organizationId, organizationInvitationRepository }) {
-  const pendingInvitations = await organizationInvitationRepository.findPendingByOrganizationId({ organizationId });
-
-  await bluebird.mapSeries(pendingInvitations, async (invitation) => {
-    await organizationInvitationRepository.markAsCancelled({ id: invitation.id });
-  });
+module.exports = async function archiveOrganization({ organizationId, organizationToArchiveRepository }) {
+  const organizationToArchive = new OrganizationToArchive({ id: organizationId });
+  organizationToArchive.archive();
+  await organizationToArchiveRepository.save(organizationToArchive);
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -90,6 +90,7 @@ const dependencies = {
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
   organizationInvitedUserRepository: require('../../infrastructure/repositories/organization-invited-user-repository'),
   organizationTagRepository: require('../../infrastructure/repositories/organization-tag-repository'),
+  organizationToArchiveRepository: require('../../infrastructure/repositories/organization-to-archive-repository'),
   organizationsToAttachToTargetProfileRepository: require('../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository'),
   participantResultRepository: require('../../infrastructure/repositories/participant-result-repository'),
   participationsForCampaignManagementRepository: require('../../infrastructure/repositories/participations-for-campaign-management-repository'),

--- a/api/lib/infrastructure/repositories/organization-to-archive-repository.js
+++ b/api/lib/infrastructure/repositories/organization-to-archive-repository.js
@@ -1,0 +1,17 @@
+const { knex } = require('../../../db/knex-database-connection');
+
+module.exports = {
+  async save(organizationToArchive) {
+    if (organizationToArchive.newInvitationStatus) {
+      await knex('organization-invitations')
+        .where({ organizationId: organizationToArchive.id, status: organizationToArchive.previousInvitationStatus })
+        .update({ status: organizationToArchive.newInvitationStatus });
+    }
+
+    if (organizationToArchive.archiveDate) {
+      await knex('campaigns')
+        .where({ organizationId: organizationToArchive.id, archivedAt: null })
+        .update({ archivedAt: organizationToArchive.archiveDate });
+    }
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/organization-to-archive-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-to-archive-repository_test.js
@@ -1,0 +1,85 @@
+const { expect, knex, databaseBuilder } = require('../../../test-helper');
+const OrganizationToArchive = require('../../../../lib/domain/models/OrganizationToArchive');
+const organizationToArchiveRepository = require('../../../../lib/infrastructure/repositories/organization-to-archive-repository');
+
+describe('Integration | Repository | OrganizationToArchive', function () {
+  describe('#save', function () {
+    it('should update invitation status for given organization', async function () {
+      // given
+      const organizationId = 1;
+      const pendingStatus = 'PENDING';
+      const cancelledStatus = 'CANCELLED';
+      const acceptedStatus = 'ACCEPTED';
+      databaseBuilder.factory.buildOrganization({ id: organizationId });
+
+      databaseBuilder.factory.buildOrganizationInvitation({ id: 1, organizationId, status: pendingStatus });
+      databaseBuilder.factory.buildOrganizationInvitation({ id: 2, organizationId, status: pendingStatus });
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId,
+        status: acceptedStatus,
+      });
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId,
+        status: cancelledStatus,
+      });
+
+      await databaseBuilder.commit();
+
+      const organizationToArchive = new OrganizationToArchive({ id: organizationId });
+      organizationToArchive.previousInvitationStatus = pendingStatus;
+      organizationToArchive.newInvitationStatus = cancelledStatus;
+
+      // when
+      await organizationToArchiveRepository.save(organizationToArchive);
+
+      // then
+      const pendingInvitations = await knex('organization-invitations').where({
+        organizationId,
+        status: pendingStatus,
+      });
+      const cancelledInvitations = await knex('organization-invitations').where({
+        organizationId,
+        status: cancelledStatus,
+      });
+      const acceptedInvitations = await knex('organization-invitations').where({
+        organizationId,
+        status: acceptedStatus,
+      });
+      expect(pendingInvitations).to.have.lengthOf(0);
+      expect(acceptedInvitations).to.have.lengthOf(1);
+      expect(cancelledInvitations).to.have.lengthOf(3);
+    });
+
+    it('should update active campaigns', async function () {
+      // given
+      const now = new Date('2022-02-02');
+      const previousDate = new Date('2021-01-01');
+      const organizationId = 1;
+      databaseBuilder.factory.buildOrganization({ id: organizationId });
+
+      databaseBuilder.factory.buildCampaign({ id: 1, organizationId });
+      databaseBuilder.factory.buildCampaign({ id: 2, organizationId });
+      databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: previousDate });
+
+      await databaseBuilder.commit();
+
+      const organizationToArchive = new OrganizationToArchive({ id: organizationId });
+      organizationToArchive.archiveDate = now;
+
+      // when
+      await organizationToArchiveRepository.save(organizationToArchive);
+
+      // then
+      const activeCampaigns = await knex('campaigns').where({
+        archivedAt: null,
+      });
+      expect(activeCampaigns).to.have.lengthOf(0);
+
+      const newlyArchivedCampaigns = await knex('campaigns').where({ archivedAt: now });
+      expect(newlyArchivedCampaigns).to.have.lengthOf(2);
+
+      const previousArchivedCampaigns = await knex('campaigns').where({ archivedAt: previousDate });
+      expect(previousArchivedCampaigns).to.have.lengthOf(1);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/OrganizationToArchive_test.js
+++ b/api/tests/unit/domain/models/OrganizationToArchive_test.js
@@ -1,0 +1,21 @@
+const { expect } = require('../../../test-helper');
+const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
+const OrganizationToArchive = require('../../../../lib/domain/models/OrganizationToArchive');
+
+describe('Unit | Domain | Models | OrganizationToArchive', function () {
+  describe('#archive', function () {
+    it('should set the invitation status and the archive date', function () {
+      // given
+      const now = new Date('2022-02-22');
+      const organizationToArchive = new OrganizationToArchive({ id: 1 });
+
+      // when
+      organizationToArchive.archive({ archiveDate: now });
+
+      // then
+      expect(organizationToArchive.previousInvitationStatus).to.equal(OrganizationInvitation.StatusType.PENDING);
+      expect(organizationToArchive.newInvitationStatus).to.equal(OrganizationInvitation.StatusType.CANCELLED);
+      expect(organizationToArchive.archiveDate).to.equal(now);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/archive-organization_test.js
+++ b/api/tests/unit/domain/usecases/archive-organization_test.js
@@ -1,47 +1,36 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const archiveOrganization = require('../../../../lib/domain/usecases/archive-organization');
-const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
+const OrganizationToArchive = require('../../../../lib/domain/models/OrganizationToArchive');
 
 describe('Unit | UseCase | archive-organization', function () {
-  let organizationInvitationRepository;
+  let organizationToArchiveRepository;
 
   beforeEach(function () {
-    organizationInvitationRepository = {
-      findPendingByOrganizationId: sinon.stub(),
-      markAsCancelled: sinon.stub(),
+    organizationToArchiveRepository = {
+      save: sinon.stub(),
     };
   });
 
-  context('when organization has pending invitations', function () {
-    it('should cancel every invitation and update modification date', async function () {
-      // given
-      const status = OrganizationInvitation.StatusType.PENDING;
-      const organizationId = 1;
-      const organizationInvitations = [
-        domainBuilder.buildOrganizationInvitation({ id: 1, status, organizationId }),
-        domainBuilder.buildOrganizationInvitation({ id: 2, status, organizationId }),
-        domainBuilder.buildOrganizationInvitation({ id: 3, status, organizationId }),
-      ];
+  it('should archive the organization', async function () {
+    // given
+    const now = new Date('2022-02-22');
+    const clock = sinon.useFakeTimers(now);
+    const organizationId = 1;
 
-      organizationInvitationRepository.findPendingByOrganizationId.resolves(organizationInvitations);
+    organizationToArchiveRepository.save.resolves();
 
-      // when
-      await archiveOrganization({
-        organizationId,
-        organizationInvitationRepository,
-      });
-
-      // then
-      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledThrice;
-      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
-        id: 1,
-      });
-      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
-        id: 2,
-      });
-      expect(organizationInvitationRepository.markAsCancelled).to.have.been.calledWith({
-        id: 3,
-      });
+    // when
+    await archiveOrganization({
+      organizationId,
+      organizationToArchiveRepository,
     });
+
+    // then
+    const expectedOrganizationToArchive = new OrganizationToArchive({ id: organizationId });
+    expectedOrganizationToArchive.archive();
+
+    expect(organizationToArchiveRepository.save).to.have.been.calledWith(expectedOrganizationToArchive);
+
+    clock.restore();
   });
 });


### PR DESCRIPTION
## 🌈  Contexte
Aujourd'hui, il n'existe pas de manière propre d'archiver une organisation. L'archivage est fait avec l'ajout d'un tag (obsolète). Or, les tags n'ont pas été conçus pour ce cas d'usage.

## :unicorn: Problème
Lorsqu'une organisation est archivée, elle peut avoir des campagnes actives.

## :robot: Solution
Archiver toutes les campagnes actives.

## :rainbow: Remarques
RAS

## :100: Pour tester
Appeler la route `/api/admin/organizations/{id}/archived` en curl pour une organisation qui a des campagnes actives avec un pixmaster et verifier qu'elles ont toutes été archivées

ℹ️ C'est cette même route qui marque les invitations comme annulés, tester fonctionnellement qu'il n'y a pas de régression > constater qu'elles n'apparaîssent plus également.

exemple de curl : `curl 'https://app-pr4173.review.pix.fr/api/admin/organizations/{id}/archived' -X 'PUT' -H 'authorization: Bearer {a-remplir}' -H 'content-type: application/vnd.api+json' -H 'accept: application/vnd.api+json' `