### PR TITLE
[API] Supprimer les `userId` des schooling-registrations crééent automatiquement  (PIX-4503)

### DIFF
--- a/api/scripts/prod/dissociate-user-from-created-schooling-registrations-for-organizations-with-import.js
+++ b/api/scripts/prod/dissociate-user-from-created-schooling-registrations-for-organizations-with-import.js
@@ -1,0 +1,30 @@
+const { knex } = require('../../db/knex-database-connection');
+const bluebird = require('bluebird');
+const chunk = require('lodash/chunk');
+
+async function dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport(chunkSize = 10) {
+  const allOrganizationIds = await knex('organizations').where({ isManagingStudents: true }).pluck('id');
+  const organizationIdsChunks = chunk(allOrganizationIds, chunkSize);
+
+  await bluebird.mapSeries(organizationIdsChunks, async (organizationIds) => {
+    await knex('schooling-registrations')
+      .update({ userId: null })
+      .whereIn('organizationId', organizationIds)
+      .where({ birthdate: null })
+      .whereNotNull('userId');
+  });
+}
+
+module.exports = {
+  dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport,
+};
+
+if (require.main === module) {
+  const chunkSize = process.argv[2];
+  dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport(chunkSize)
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/api/tests/integration/scripts/prod/dissociate-user-from-created-schooling-registrations-for-organizations-with-import_test.js
+++ b/api/tests/integration/scripts/prod/dissociate-user-from-created-schooling-registrations-for-organizations-with-import_test.js
@@ -1,0 +1,46 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const {
+  dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport,
+} = require('../../../../scripts/prod/dissociate-user-from-created-schooling-registrations-for-organizations-with-import');
+
+describe('dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport', function () {
+  describe('when the organizations manages students and the registration has no birthdate', function () {
+    it('dissociate the the user from the schooling registration', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true }).id;
+
+      const userId1 = databaseBuilder.factory.buildUser().id;
+      const userId2 = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.buildSchoolingRegistration({ birthdate: '2000-01-01', userId: userId1, organizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({ birthdate: null, userId: userId2, organizationId });
+
+      await databaseBuilder.commit();
+
+      await dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport();
+
+      const result = await knex('schooling-registrations').select('userId').whereNotNull('userId').pluck('userId');
+
+      expect(result).deep.equal([userId1]);
+    });
+  });
+
+  describe('when the organizations does not manage students and the registration has no birthdate', function () {
+    it('does not dissociate the the user from the schooling registration', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: false }).id;
+
+      const userId1 = databaseBuilder.factory.buildUser().id;
+      const userId2 = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.buildSchoolingRegistration({ birthdate: '2000-01-01', userId: userId1, organizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({ birthdate: null, userId: userId2, organizationId });
+
+      await databaseBuilder.commit();
+
+      await dissociateUserFromCreatedSchoolingRegistrationsForOrganizationsWithImport();
+
+      const result = await knex('schooling-registrations').select('userId').where({ organizationId }).pluck('userId');
+
+      expect(result).deep.equal([userId1, userId2]);
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
+++ b/api/tests/integration/scripts/prod/select-category-for-target-profiles_test.js
@@ -31,7 +31,7 @@ describe('Integration | Scripts | select-category-for-target-profiles.js', funct
         .select('category')
         .whereIn('id', targetProfilesId)
         .distinct('category');
-      expect(targetProfilesCategories).deep.equal([{ category: categories.COMPETENCES }]);
+      expect(targetProfilesCategories).to.deep.equal([{ category: categories.COMPETENCES }]);
     });
 
     it('should not set category on other target profiles', async function () {
@@ -97,7 +97,7 @@ ${secondTargetProfileId},COMPETENCES`;
       await setCategoriesToTargetProfiles(csvData);
 
       const targetProfiles = await knex('target-profiles').select(['id', 'category']).whereNotNull('category');
-      expect(targetProfiles).deep.equal([
+      expect(targetProfiles).to.deep.have.members([
         { id: firstTargetProfileId, category: categories.DISCIPLINE },
         { id: secondTargetProfileId, category: categories.COMPETENCES },
       ]);


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas pensé à dissocier les user, lors de la création des prescrit automatique dans le cadre de la refonte de la gestion des prescrit.
Nous nous retrouvons avec des utilisateurs qui ne peuvent plus s'associer avec leur compte

## :robot: Solution
Supprimer les userId des entrées de la table schooling-registrations lorsque celle-ci a été généré automatiquement.

## :rainbow: Remarques
RAS

## :100: Pour tester
🤔 