### PR TITLE
[FEATURE] Désactiver tous les membres actifs lors de l'archivage d'une organisation  (PIX-3818).

### DIFF
--- a/api/lib/infrastructure/repositories/organization-to-archive-repository.js
+++ b/api/lib/infrastructure/repositories/organization-to-archive-repository.js
@@ -12,6 +12,10 @@ module.exports = {
       await knex('campaigns')
         .where({ organizationId: organizationToArchive.id, archivedAt: null })
         .update({ archivedAt: organizationToArchive.archiveDate });
+
+      await knex('memberships')
+        .where({ organizationId: organizationToArchive.id, disabledAt: null })
+        .update({ disabledAt: organizationToArchive.archiveDate });
     }
   },
 };


### PR DESCRIPTION
## 🌈  Contexte
Aujourd'hui, il n'existe pas de manière propre d'archiver une organisation. L'archivage est fait avec l'ajout d'un tag (obsolète). Or, les tags n'ont pas été conçus pour ce cas d'usage.

## :unicorn: Problème
Lorsqu'une organisation est archivée, elle peut avoir des membres actifs.

## :robot: Solution
Désactiver tous les membres actifs.

## :rainbow: Remarques
RAS

## :100: Pour tester
Appeler la route `/api/admin/organizations/{id}/archived` en curl pour une organisation qui a des membres actifs avec un pixmaster et verifier qu'ils ont tous été désactivés.

ℹ️ C'est cette même route qui :
- annule les invitations
- archive les campagnes

Donc tester fonctionnellement qu'il n'y a pas de régression.

exemple de curl : `curl 'https://app-pr4177.review.pix.fr/api/admin/organizations/{id}/archived' -X 'PUT' -H 'authorization: Bearer {a-remplir}' -H 'content-type: application/vnd.api+json' -H 'accept: application/vnd.api+json' `