### PR TITLE
[FEATURE] Bloquer le rattachement de membres et l'invitation de nouveaux membres (Pix-4282).

### DIFF
--- a/admin/app/routes/authenticated/organizations/get.js
+++ b/admin/app/routes/authenticated/organizations/get.js
@@ -4,6 +4,6 @@ export default class GetRoute extends Route {
   @service store;
 
   model(params) {
-    return this.store.findRecord('organization', params.organization_id);
+    return this.store.findRecord('organization', params.organization_id, { reload: true });
   }
 }

--- a/admin/app/routes/authenticated/organizations/get/invitations.js
+++ b/admin/app/routes/authenticated/organizations/get/invitations.js
@@ -3,6 +3,14 @@ import { inject as service } from '@ember/service';
 
 export default class InvitationsRoute extends Route {
   @service store;
+  @service router;
+
+  beforeModel() {
+    const organization = this.modelFor('authenticated.organizations.get');
+    if (organization.get('archivistFullName')) {
+      return this.router.replaceWith('authenticated.organizations.get.target-profiles');
+    }
+  }
 
   async model() {
     this.store.unloadAll('organization-invitation');

--- a/admin/app/routes/authenticated/organizations/get/team.js
+++ b/admin/app/routes/authenticated/organizations/get/team.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OrganizationTeamRoute extends Route {
+  @service router;
+
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
@@ -9,6 +12,13 @@ export default class OrganizationTeamRoute extends Route {
     email: { refreshModel: true },
     organizationRole: { refreshModel: true },
   };
+
+  beforeModel() {
+    const organization = this.modelFor('authenticated.organizations.get');
+    if (organization.get('archivistFullName')) {
+      return this.router.replaceWith('authenticated.organizations.get.target-profiles');
+    }
+  }
 
   async model(params) {
     const organization = this.modelFor('authenticated.organizations.get');

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -15,13 +15,16 @@
   />
 
   <nav class="navbar">
-    <LinkTo @route="authenticated.organizations.get.team" @model={{@model}} class="navbar-item">
-      Équipe
-    </LinkTo>
 
-    <LinkTo @route="authenticated.organizations.get.invitations" @model={{@model}} class="navbar-item">
-      Invitations
-    </LinkTo>
+    {{#unless @model.archivistFullName}}
+      <LinkTo @route="authenticated.organizations.get.team" @model={{@model}} class="navbar-item">
+        Équipe
+      </LinkTo>
+
+      <LinkTo @route="authenticated.organizations.get.invitations" @model={{@model}} class="navbar-item">
+        Invitations
+      </LinkTo>
+    {{/unless}}
 
     <LinkTo @route="authenticated.organizations.get.target-profiles" @model={{@model}} class="navbar-item">
       Profils cibles

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -28,6 +28,50 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       // then
       assert.contains('newOrganizationName');
+    });
+  });
+
+  module('when organization is archived', function () {
+    test('should redirect to organization target profiles page', async function (assert) {
+      // given
+      const organization = this.server.create('organization', {
+        name: 'oldOrganizationName',
+        archivistFullName: 'Clément Tine',
+      });
+
+      // when
+      await visit(`/organizations/${organization.id}`);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
+    });
+
+    test('should not allow user to access team page', async function (assert) {
+      // given
+      const organization = this.server.create('organization', {
+        name: 'oldOrganizationName',
+        archivistFullName: 'Clément Tine',
+      });
+
+      // when
+      await visit(`/organizations/${organization.id}/team`);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
+    });
+
+    test('should not allow user to access invitation page', async function (assert) {
+      // given
+      const organization = this.server.create('organization', {
+        name: 'oldOrganizationName',
+        archivistFullName: 'Clément Tine',
+      });
+
+      // when
+      await visit(`/organizations/${organization.id}/invitations`);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/organizations/team_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/team_test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/organizations/get/invitations', function (hooks) {
+module('Unit | Route | authenticated/organizations/get/team', function (hooks) {
   setupTest(hooks);
 
   test('it exists', function (assert) {
-    const route = this.owner.lookup('route:authenticated/organizations/get/invitations');
+    const route = this.owner.lookup('route:authenticated/organizations/get/team');
     assert.ok(route);
   });
 
@@ -15,7 +15,7 @@ module('Unit | Route | authenticated/organizations/get/invitations', function (h
     test('it should transition to target-profiles route when organization is archived', async function (assert) {
       // given
       const organization = EmberObject.create({ archivistFullName: 'Clément Tine' });
-      const route = this.owner.lookup('route:authenticated/organizations/get/invitations');
+      const route = this.owner.lookup('route:authenticated/organizations/get/team');
       sinon.stub(route.router, 'replaceWith');
       sinon.stub(route, 'modelFor').returns(organization);
 

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -63,6 +63,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AccountRecoveryDemandExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.OrganizationArchivedError) {
+    return new HttpErrors.UnprocessableEntityError(error.message);
+  }
   if (error instanceof DomainErrors.AuthenticationKeyForPoleEmploiTokenExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -682,6 +682,12 @@ class ObjectValidationError extends DomainError {
   }
 }
 
+class OrganizationArchivedError extends DomainError {
+  constructor(message = "L'organisation est archivée.") {
+    super(message);
+  }
+}
+
 class UserCouldNotBeReconciledError extends DomainError {
   constructor(message = "Cet utilisateur n'a pas pu être rattaché à une organisation.") {
     super(message);
@@ -1156,6 +1162,7 @@ module.exports = {
   NotFoundError,
   NotImplementedError,
   ObjectValidationError,
+  OrganizationArchivedError,
   OrganizationTagNotFound,
   OrganizationAlreadyExistError,
   OrganizationNotFoundError,

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -30,6 +30,7 @@ class Organization {
     showNPS,
     formNPSUrl,
     showSkills,
+    archivedAt,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -49,6 +50,7 @@ class Organization {
     this.showNPS = showNPS;
     this.formNPSUrl = formNPSUrl;
     this.showSkills = showSkills;
+    this.archivedAt = archivedAt;
   }
 
   get isSup() {

--- a/api/lib/domain/usecases/create-membership.js
+++ b/api/lib/domain/usecases/create-membership.js
@@ -1,6 +1,18 @@
 const { roles } = require('../models/Membership');
+const { OrganizationArchivedError } = require('../errors');
 
-module.exports = async function createMembership({ membershipRepository, userId, organizationId }) {
+module.exports = async function createMembership({
+  userId,
+  organizationId,
+  membershipRepository,
+  organizationRepository,
+}) {
+  const organization = await organizationRepository.get(organizationId);
+
+  if (organization.archivedAt) {
+    throw new OrganizationArchivedError();
+  }
+
   const memberships = await membershipRepository.findByOrganizationId({ organizationId });
   const organizationRole = memberships.length ? roles.MEMBER : roles.ADMIN;
 

--- a/api/lib/domain/usecases/create-organization-invitation-by-admin.js
+++ b/api/lib/domain/usecases/create-organization-invitation-by-admin.js
@@ -1,4 +1,5 @@
 const organizationInvitationService = require('../services/organization-invitation-service');
+const { OrganizationArchivedError } = require('../errors');
 
 module.exports = async function createOrganizationInvitationByAdmin({
   organizationId,
@@ -8,6 +9,12 @@ module.exports = async function createOrganizationInvitationByAdmin({
   organizationRepository,
   organizationInvitationRepository,
 }) {
+  const organization = await organizationRepository.get(organizationId);
+
+  if (organization.archivedAt) {
+    throw new OrganizationArchivedError();
+  }
+
   return organizationInvitationService.createOrganizationInvitation({
     organizationId,
     email,

--- a/api/lib/domain/usecases/create-organization-invitations.js
+++ b/api/lib/domain/usecases/create-organization-invitations.js
@@ -1,6 +1,7 @@
 const bluebird = require('bluebird');
 
 const organizationInvitationService = require('../../domain/services/organization-invitation-service');
+const { OrganizationArchivedError } = require('../errors');
 
 module.exports = async function createOrganizationInvitations({
   organizationId,
@@ -9,6 +10,12 @@ module.exports = async function createOrganizationInvitations({
   organizationRepository,
   organizationInvitationRepository,
 }) {
+  const organization = await organizationRepository.get(organizationId);
+
+  if (organization.archivedAt) {
+    throw new OrganizationArchivedError();
+  }
+
   const trimmedEmails = emails.map((email) => email.trim());
   const uniqueEmails = [...new Set(trimmedEmails)];
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -26,6 +26,7 @@ function _toDomain(rawOrganization) {
     showNPS: rawOrganization.showNPS,
     formNPSUrl: rawOrganization.formNPSUrl,
     showSkills: rawOrganization.showSkills,
+    archivedAt: rawOrganization.archivedAt,
   });
 
   organization.targetProfileShares = rawOrganization.targetProfileShares || [];

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -769,6 +769,14 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
       expect(responseDetail(response)).to.equal('Authentication method already exists.');
     });
+
+    it('responds UnprocessableEntityError when an OrganizationArchived error occurs', async function () {
+      routeHandler.throws(new DomainErrors.OrganizationArchivedError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
+      expect(responseDetail(response)).to.equal("L'organisation est archivée.");
+    });
   });
 
   context('should respond 401 Unauthorized', function () {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -178,6 +178,7 @@ describe('Integration | Repository | Organization', function () {
           showNPS: true,
           formNPSUrl: 'https://pix.fr/',
           showSkills: false,
+          archivedAt: null,
         };
 
         await databaseBuilder.commit();

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -23,7 +23,6 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', fun
         'tags',
         'createdBy',
         'archivedBy',
-        'archivedAt',
       ]);
 
       await databaseBuilder.commit();

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -29,6 +29,7 @@ function buildOrganization({
   showNPS = false,
   formNPSUrl = 'https://pix.fr',
   showSkills = false,
+  archivedAt = null,
 } = {}) {
   return new Organization({
     id,
@@ -48,6 +49,7 @@ function buildOrganization({
     showNPS,
     formNPSUrl,
     showSkills,
+    archivedAt,
   });
 }
 

--- a/api/tests/unit/domain/usecases/create-membership_test.js
+++ b/api/tests/unit/domain/usecases/create-membership_test.js
@@ -1,39 +1,73 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const createMembership = require('../../../../lib/domain/usecases/create-membership');
 const Membership = require('../../../../lib/domain/models/Membership');
+const { OrganizationArchivedError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-membership', function () {
   it('should insert a new membership with role ADMIN', async function () {
     // given
+    const organization = domainBuilder.buildOrganization();
     const membershipRepository = {
       create: sinon.stub(),
       findByOrganizationId: sinon.stub().resolves([]),
     };
+    const organizationRepository = {
+      get: sinon.stub().resolves(organization),
+    };
     const userId = 1;
-    const organizationId = 2;
     const role = Membership.roles.ADMIN;
 
     // when
-    await createMembership({ membershipRepository, userId, organizationId });
+    await createMembership({ userId, organizationId: organization.id, membershipRepository, organizationRepository });
 
     // then
-    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organizationId, role);
+    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organization.id, role);
   });
 
   it('should insert a new membership with role MEMBER', async function () {
     // given
+    const organization = domainBuilder.buildOrganization();
     const membershipRepository = {
       create: sinon.stub(),
       findByOrganizationId: sinon.stub().resolves([{}]),
     };
+    const organizationRepository = {
+      get: sinon.stub().resolves(organization),
+    };
     const userId = 1;
-    const organizationId = 2;
     const role = Membership.roles.MEMBER;
 
     // when
-    await createMembership({ membershipRepository, userId, organizationId });
+    await createMembership({ userId, organizationId: organization.id, membershipRepository, organizationRepository });
 
     // then
-    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organizationId, role);
+    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organization.id, role);
+  });
+
+  describe('when organization is archived', function () {
+    it('should throw an organization archived error', async function () {
+      // given
+      const userId = domainBuilder.buildUser().id;
+      const archivedOrganization = domainBuilder.buildOrganization({ archivedAt: '2022-02-02' });
+      const membershipRepository = {
+        create: sinon.stub(),
+      };
+      const organizationRepository = {
+        get: sinon.stub().resolves(archivedOrganization),
+      };
+
+      // when
+      const error = await catchErr(createMembership)({
+        userId,
+        organizationId: archivedOrganization.id,
+        membershipRepository,
+        organizationRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(OrganizationArchivedError);
+      expect(error.message).to.be.equal("L'organisation est archivée.");
+      expect(membershipRepository.create).to.not.have.been.called;
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
@@ -1,26 +1,27 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 
 const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
 const Membership = require('../../../../lib/domain/models/Membership');
 
 const createOrganizationInvitationByAdmin = require('../../../../lib/domain/usecases/create-organization-invitation-by-admin');
+const { OrganizationArchivedError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-organization-invitation-by-admin', function () {
   describe('#createOrganizationInvitationByAdmin', function () {
     it('should create one organization-invitation with organizationId, role and email', async function () {
       // given
-      const organizationId = 1;
+      const organization = domainBuilder.buildOrganization();
       const email = 'member@organization.org';
       const locale = 'fr-fr';
       const role = Membership.roles.MEMBER;
 
       const organizationInvitationRepository = sinon.stub();
-      const organizationRepository = sinon.stub();
+      const organizationRepository = { get: sinon.stub().resolves(organization) };
       sinon.stub(organizationInvitationService, 'createOrganizationInvitation').resolves();
 
       // when
       await createOrganizationInvitationByAdmin({
-        organizationId,
+        organizationId: organization.id,
         email,
         locale,
         role,
@@ -31,13 +32,42 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
       // then
       expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledOnce;
       expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledWith({
-        organizationId,
+        organizationId: organization.id,
         email,
         locale,
         role,
         organizationRepository,
         organizationInvitationRepository,
       });
+    });
+
+    it('should throw an organization archived error when it is archived', async function () {
+      // given
+      const archivedOrganization = domainBuilder.buildOrganization({ archivedAt: '2022-02-02' });
+      const emails = ['member01@organization.org'];
+      const locale = 'fr-fr';
+      const role = Membership.roles.MEMBER;
+
+      const organizationInvitationRepository = sinon.stub();
+      const organizationRepository = {
+        get: sinon.stub().resolves(archivedOrganization),
+      };
+      sinon.stub(organizationInvitationService, 'createOrganizationInvitation').resolves();
+
+      // when
+      const error = await catchErr(createOrganizationInvitationByAdmin)({
+        organizationId: archivedOrganization.id,
+        emails,
+        locale,
+        role,
+        organizationRepository,
+        organizationInvitationRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(OrganizationArchivedError);
+      expect(error.message).to.be.equal("L'organisation est archivée.");
+      expect(organizationInvitationService.createOrganizationInvitation).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
## 🌈  Contexte
Aujourd'hui, il n'existe pas de manière propre d'archiver une organisation. L'archivage est fait avec l'ajout d'un tag (obsolète). Or, les tags n'ont pas été conçus pour ce cas d'usage.

## :unicorn: Problème
Lorsqu'une organisation est archivée, on peut encore rattacher des membres ou en inviter de nouveaux.

## :robot: Solution
Soulever une erreur `OrganizationArchivedError` si l'orga est archivée quand on essaie de rattacher un membre ou en inviter un nouveau.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter sur une orga archivée [PixAdmin](https://admin-pr4178.review.pix.fr/organizations/15/team) avec un compte `pixmaster`
- Verifier qu'il n'est plus possible de rattacher un membre ou d'inviter un nouveau.

Pour tester l'API
Appeler la route `/api/admin/organizations/15/invitations` en curl pour inviter un membre a une orga archivée.

exemple de curl : `curl 'https://app-pr4178.review.pix.fr/api/admin/organizations/15/invitations' -X 'POST' -H 'authorization: Bearer {a-remplir}' -H 'content-type: application/vnd.api+json' -H 'accept: application/vnd.api+json' data-raw '{"data":{"attributes":{"email":"example@example.net","lang":"fr-fr","role":null}}}'`