### PR TITLE
[FEATURE] Modifier l'id externe d'une participation depuis Pix Admin(Pix-4430)

### DIFF
--- a/admin/app/components/campaigns/participation-row.hbs
+++ b/admin/app/components/campaigns/participation-row.hbs
@@ -1,0 +1,58 @@
+<td>{{@participation.lastName}}</td>
+<td>{{@participation.firstName}}</td>
+{{#if @idPixLabel}}
+  <td>
+    {{#if this.isEditionMode}}
+      <PixInput
+        id="participantExternalId"
+        type="text"
+        aria-label="Modifier"
+        value={{@participation.participantExternalId}}
+        onchange={{this.handleChange}}
+        class="table-admin-input form-control"
+      />
+    {{else}}
+      {{@participation.participantExternalId}}
+    {{/if}}
+  </td>
+{{/if}}
+<td>{{moment-format @participation.createdAt "DD/MM/YYYY"}}</td>
+<td>{{@participation.displayedStatus}}</td>
+<td>
+  {{if @participation.sharedAt (moment-format @participation.sharedAt "DD/MM/YYYY") "-"}}
+</td>
+{{#if @idPixLabel}}
+  <td>
+    <div class="participation-item-actions">
+      {{#if this.isEditionMode}}
+        <div class="participation-item-actions__modify">
+          <PixButton
+            @size="small"
+            @triggerAction={{this.updateParticipantExternalId}}
+            class="participation-item-actions__button participation-item-actions__button--save"
+          >
+            Enregistrer
+          </PixButton>
+          <PixButton
+            @size="small"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @triggerAction={{this.cancelUpdateParticipantExternalId}}
+            aria-label="Annuler"
+            class="participation-item-actions__button--icon"
+          >
+            <FaIcon @icon="times" />
+          </PixButton>
+        </div>
+      {{else}}
+        <PixButton
+          @triggerAction={{this.editParticipantExternalId}}
+          @size="small"
+          class="participation-item-actions__button"
+        >
+          <FaIcon @icon="edit" />Modifier
+        </PixButton>
+      {{/if}}
+    </div>
+  </td>
+{{/if}}

--- a/admin/app/components/campaigns/participation-row.js
+++ b/admin/app/components/campaigns/participation-row.js
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+export default class ParticipationRow extends Component {
+  @service notifications;
+
+  @tracked isEditionMode = false;
+  @tracked newParticipantExternalId;
+
+  constructor() {
+    super(...arguments);
+  }
+
+  _checkIfParticipantExternalIdIsNull(newParticipantExternalId) {
+    const trimedNewParticipantExternalId = newParticipantExternalId.trim();
+    return trimedNewParticipantExternalId || null;
+  }
+
+  @action
+  updateParticipantExternalId() {
+    this.isEditionMode = false;
+    this.args.participation.participantExternalId = this._checkIfParticipantExternalIdIsNull(
+      this.newParticipantExternalId
+    );
+    return this.args.updateParticipantExternalId(this.args.participation);
+  }
+
+  @action
+  cancelUpdateParticipantExternalId() {
+    this.isEditionMode = false;
+    this.newParticipantExternalId = null;
+  }
+
+  @action
+  editParticipantExternalId() {
+    this.isEditionMode = true;
+    this.newParticipantExternalId = null;
+  }
+
+  @action
+  handleChange(e) {
+    this.newParticipantExternalId = e.target.value;
+  }
+}

--- a/admin/app/components/campaigns/participations-section.hbs
+++ b/admin/app/components/campaigns/participations-section.hbs
@@ -15,6 +15,9 @@
             <th>Date de début</th>
             <th>Statut</th>
             <th>Date d'envoi</th>
+            {{#if @idPixLabel}}
+              <th>Actions</th>
+            {{/if}}
           </tr>
         </thead>
 
@@ -22,20 +25,11 @@
           <tbody>
             {{#each @participations as |participation|}}
               <tr aria-label="participation">
-                <td>{{participation.lastName}}</td>
-                <td>{{participation.firstName}}</td>
-                {{#if @idPixLabel}}
-                  <td>{{participation.participantExternalId}}</td>
-                {{/if}}
-                <td>{{moment-format participation.createdAt "DD/MM/YYYY"}}</td>
-                <td>{{participation.displayedStatus}}</td>
-                <td>
-                  {{#if participation.sharedAt}}
-                    {{moment-format participation.sharedAt "DD/MM/YYYY"}}
-                  {{else}}
-                    -
-                  {{/if}}
-                </td>
+                <Campaigns::ParticipationRow
+                  @participation={{participation}}
+                  @idPixLabel={{@idPixLabel}}
+                  @updateParticipantExternalId={{@updateParticipantExternalId}}
+                />
               </tr>
             {{/each}}
           </tbody>

--- a/admin/app/controllers/authenticated/campaigns/campaign/participations.js
+++ b/admin/app/controllers/authenticated/campaigns/campaign/participations.js
@@ -1,5 +1,7 @@
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
@@ -8,4 +10,16 @@ export default class CampaignParticipationsController extends Controller {
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
+
+  @service notifications;
+
+  @action
+  async updateParticipantExternalId(campaignParticipation) {
+    try {
+      await campaignParticipation.save();
+      this.notifications.success("L'id externe du participant été mis à jour avec succès.");
+    } catch (e) {
+      this.notifications.error("Une erreur est survenue lors de la mise à jour de l'id externe du participant.");
+    }
+  }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -55,6 +55,7 @@
 @import 'components/organization-team-section';
 @import 'components/organization-invitations';
 @import 'components/pagination-control';
+@import 'components/participation-row';
 @import 'components/publish-session-button';
 @import 'components/sessions/jury-comment';
 @import 'components/sessions/list-items.scss';

--- a/admin/app/styles/components/participation-row.scss
+++ b/admin/app/styles/components/participation-row.scss
@@ -1,0 +1,25 @@
+.participation-item-actions {
+  display: flex;
+  flex-direction: column;
+
+  &__modify {
+    display: flex;
+  }
+
+  &__button {
+    max-height: 30px;
+
+    svg {
+      margin-right: 6px;
+    }
+
+    &--save {
+      margin-right: 12px;
+    }
+
+    &--icon {
+      height: 30px;
+      width: 30px;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/campaigns/campaign/participations.hbs
+++ b/admin/app/templates/authenticated/campaigns/campaign/participations.hbs
@@ -1,2 +1,6 @@
 {{page-title "Campagne " @model.campaignId " | Participations"}}
-<Campaigns::ParticipationsSection @participations={{@model.participations}} @idPixLabel={{@model.idPixLabel}} />
+<Campaigns::ParticipationsSection
+  @participations={{@model.participations}}
+  @idPixLabel={{@model.idPixLabel}}
+  @updateParticipantExternalId={{this.updateParticipantExternalId}}
+/>

--- a/admin/tests/integration/components/campaigns/participation-row_test.js
+++ b/admin/tests/integration/components/campaigns/participation-row_test.js
@@ -1,0 +1,145 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+
+module('Integration | Component | Campaigns | participation-row', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('Display information', function () {
+    test('it should display firstName, lastName and createdAt', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        firstName: 'Jean',
+        lastName: 'Claude',
+        createdAt: new Date('2020-01-01'),
+      });
+      this.set('participation', participation);
+
+      // when
+      await render(hbs`<Campaigns::ParticipationRow @participation={{participation}}/>`);
+
+      // then
+      assert.contains('Jean');
+      assert.contains('Claude');
+      assert.contains('01/01/2020');
+    });
+
+    test('it should not display participantExternalId if idPixLabel is null', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        participationExternalId: '123',
+      });
+
+      this.set('participation', participation);
+      this.set('idPixLabel', null);
+
+      // when
+      await render(hbs`<Campaigns::ParticipationRow @participation={{participation}} @idPixLabel={{idPixLabel}}/>`);
+
+      // then
+      assert.notContains('123');
+    });
+
+    test('it should display participantExternalId if idPixLabel is set', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        participantExternalId: '123',
+      });
+      this.set('participation', participation);
+      this.set('idPixLabel', 'identifiant');
+
+      // when
+      await render(hbs`<Campaigns::ParticipationRow @participation={{participation}} @idPixLabel={{idPixLabel}}/>`);
+
+      // then
+      assert.contains('123');
+    });
+
+    test('it should display shared date if participation is shared', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        sharedAt: new Date('2020-01-01'),
+      });
+      this.set('participation', participation);
+
+      // when
+      await render(hbs`<Campaigns::ParticipationRow @participation={{participation}}/>`);
+
+      // then
+      assert.contains('01/01/2020');
+    });
+  }),
+    module("when editing participant's external id", function (hooks) {
+      hooks.beforeEach(async function () {
+        // given
+        const participation = EmberObject.create({
+          participantExternalId: '123',
+        });
+        this.participation = participation;
+        this.idPixLabel = 'identifiant';
+        this.updateParticipantExternalId = sinon.spy();
+
+        // when
+        await render(
+          hbs`<Campaigns::ParticipationRow @participation={{this.participation}} @idPixLabel={{this.idPixLabel}} @updateParticipantExternalId={{this.updateParticipantExternalId}} />`
+        );
+        await clickByLabel('Modifier');
+      });
+
+      test('it should display save and cancel button', async function (assert) {
+        // then
+        assert.contains('Enregistrer');
+        assert.dom('button[aria-label="Annuler"]').exists();
+      });
+
+      test('it should update participantExternalId on save', async function (assert) {
+        // when
+
+        await fillIn('#participantExternalId', '4567890');
+        await clickByLabel('Enregistrer');
+
+        // then
+        assert.notContains('Enregistrer');
+        assert.strictEqual(this.participation.participantExternalId, '4567890');
+        assert.ok(this.updateParticipantExternalId.called);
+      });
+
+      test('it should update participantExternalId with null if participantExternalId only  has blank space', async function (assert) {
+        // when
+
+        await fillIn('#participantExternalId', '    ');
+        await clickByLabel('Enregistrer');
+
+        // then
+        assert.notContains('Enregistrer');
+        assert.strictEqual(this.participation.participantExternalId, null);
+        assert.ok(this.updateParticipantExternalId.called);
+      });
+
+      test('it should update participantExternalId with null if participantExternalId is empty', async function (assert) {
+        await fillIn('#participantExternalId', '');
+        await clickByLabel('Enregistrer');
+
+        // then
+        assert.notContains('Enregistrer');
+        assert.strictEqual(this.participation.participantExternalId, null);
+        assert.ok(this.updateParticipantExternalId.called);
+      });
+
+      test('it should not update participantExternalId on cancel', async function (assert) {
+        // when
+
+        await fillIn('#participantExternalId', '4567890');
+        await clickByLabel('Annuler');
+
+        // then
+        assert.notContains('Enregistrer');
+        assert.strictEqual(this.participation.participantExternalId, '123');
+        assert.notOk(this.updateParticipantExternalId.called);
+      });
+    });
+});

--- a/admin/tests/integration/components/campaigns/participations-section_test.js
+++ b/admin/tests/integration/components/campaigns/participations-section_test.js
@@ -28,46 +28,7 @@ module('Integration | Component | Campaigns | participations-section', function 
     assert.dom('[aria-label="participation"]').exists({ count: 2 });
   });
 
-  test('it should display firstName, lastName and createdAt', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      firstName: 'Jean',
-      lastName: 'Claude',
-      createdAt: new Date('2020-01-01'),
-    });
-    const participations = [participation];
-    this.set('participations', participations);
-    participations.meta = { rowCount: 1 };
-
-    // when
-    await render(hbs`<Campaigns::ParticipationsSection @participations={{participations}}/>`);
-
-    // then
-    assert.contains('Jean');
-    assert.contains('Claude');
-    assert.contains('01/01/2020');
-  });
-
-  test('it should not display participantExternalId if idPixLabel is null', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      participantExternalId: '123',
-    });
-    const participations = [participation];
-    this.set('participations', participations);
-    this.set('idPixLabel', null);
-    participations.meta = { rowCount: 1 };
-
-    // when
-    await render(
-      hbs`<Campaigns::ParticipationsSection @participations={{participations}} @idPixLabel={{idPixLabel}}/>`
-    );
-
-    // then
-    assert.notContains('123');
-  });
-
-  test('it should display participantExternalId if idPixLabel is set', async function (assert) {
+  test('it should display participantExternalId column if idPixLabel is set', async function (assert) {
     // given
     const participation = EmberObject.create({
       participantExternalId: '123',
@@ -75,7 +36,7 @@ module('Integration | Component | Campaigns | participations-section', function 
     const participations = [participation];
     this.set('participations', participations);
     this.set('idPixLabel', 'identifiant');
-    participations.meta = { rowCount: 1 };
+    participations.meta = { rowCount: 2 };
 
     // when
     await render(
@@ -84,23 +45,6 @@ module('Integration | Component | Campaigns | participations-section', function 
 
     // then
     assert.contains('identifiant');
-    assert.contains('123');
-  });
-
-  test('it should display shared date if participation is shared', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      sharedAt: new Date('2020-01-01'),
-    });
-    const participations = [participation];
-    this.set('participations', participations);
-    participations.meta = { rowCount: 1 };
-
-    // when
-    await render(hbs`<Campaigns::ParticipationsSection @participations={{participations}}/>`);
-
-    // then
-    assert.contains('01/01/2020');
   });
 
   test('it should an empty table when no participations', async function (assert) {

--- a/admin/tests/integration/components/member-item_test.js
+++ b/admin/tests/integration/components/member-item_test.js
@@ -42,7 +42,7 @@ module('Integration | Component | member-item', function (hooks) {
     test('it should display save and cancel button', async function (assert) {
       // then
       assert.contains('Enregistrer');
-      assert.dom('button[aria-label="Annuler"]');
+      assert.dom('button[aria-label="Annuler"]').exists();
     });
 
     test('it should display the options when select is open', async function (assert) {

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -135,4 +135,12 @@ module.exports = {
     });
     return campaignAssessmentResultMinimalSerializer.serialize(paginatedParticipations);
   },
+
+  async updateParticipantExternalId(request, h) {
+    const campaignParticipationId = request.params.id;
+    const participantExternalId = request.payload.data.attributes['participant-external-id'];
+
+    await usecases.updateParticipantExternalId({ campaignParticipationId, participantExternalId });
+    return h.response({}).code(204);
+  },
 };

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -1,5 +1,6 @@
 const Joi = require('joi');
 const campaignParticipationController = require('./campaign-participation-controller');
+const securityPreHandlers = require('../security-pre-handlers');
 const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function (server) {
@@ -162,6 +163,24 @@ exports.register = async function (server) {
             "- Récupération des résultats d'une campagne d'évaluation",
         ],
         tags: ['api', 'campaign-assessment-participation-result-minimal'],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/admin/campaign-participations/{id}',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasRolePixMaster }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignParticipationId,
+          }),
+        },
+        handler: campaignParticipationController.updateParticipantExternalId,
+        tags: ['api', 'campaign', 'participations', 'admin'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+            "- Elle permet de mettre à jour l'identifaint externe d'une participation ",
+        ],
       },
     },
   ]);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -375,6 +375,7 @@ module.exports = injectDependencies(
     updateExpiredPassword: require('./update-expired-password'),
     updateMembership: require('./update-membership'),
     updateOrganizationInformation: require('./update-organization-information'),
+    updateParticipantExternalId: require('./update-participant-external-id'),
     uncancelCertificationCourse: require('./uncancel-certification-course'),
     updateSchoolingRegistrationDependentUserPassword: require('./update-schooling-registration-dependent-user-password'),
     updateSession: require('./update-session'),

--- a/api/lib/domain/usecases/update-participant-external-id.js
+++ b/api/lib/domain/usecases/update-participant-external-id.js
@@ -1,0 +1,10 @@
+module.exports = async function updateParticipantExternalId({
+  campaignParticipationId,
+  participantExternalId,
+  participationsForCampaignManagementRepository,
+}) {
+  await participationsForCampaignManagementRepository.updateParticipantExternalId({
+    campaignParticipationId,
+    participantExternalId,
+  });
+};

--- a/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -1,6 +1,7 @@
 const { knex } = require('../bookshelf');
 const ParticipationForCampaignManagement = require('../../domain/models/ParticipationForCampaignManagement');
 const { fetchPage } = require('../utils/knex-utils');
+const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
   async findPaginatedParticipationsForCampaignManagement({ campaignId, page }) {
@@ -24,5 +25,13 @@ module.exports = {
       (attributes) => new ParticipationForCampaignManagement(attributes)
     );
     return { models: participationsForCampaignManagement, meta: { ...pagination } };
+  },
+
+  async updateParticipantExternalId({ campaignParticipationId, participantExternalId }) {
+    try {
+      await knex('campaign-participations').where('id', campaignParticipationId).update({ participantExternalId });
+    } catch (error) {
+      throw new NotFoundError(`La participation avec l'id ${campaignParticipationId} n'existe pas.`);
+    }
   },
 };

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -356,4 +356,36 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       expect(response).to.equal(expectedResults);
     });
   });
+
+  describe('#updateParticipantExternalId', function () {
+    beforeEach(function () {
+      sinon.stub(usecases, 'updateParticipantExternalId');
+    });
+
+    it('should call usecase and serializer with expected parameters', async function () {
+      //given
+      const request = {
+        params: {
+          id: 123,
+        },
+        payload: {
+          data: {
+            attributes: {
+              'participant-external-id': 'Pixer123',
+            },
+          },
+        },
+      };
+      // when
+      const response = await campaignParticipationController.updateParticipantExternalId(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      expect(usecases.updateParticipantExternalId).to.have.been.calledOnce;
+      expect(usecases.updateParticipantExternalId).to.have.been.calledWithMatch({
+        campaignParticipationId: 123,
+        participantExternalId: 'Pixer123',
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/campaignParticipations/index_test.js
+++ b/api/tests/unit/application/campaignParticipations/index_test.js
@@ -1,4 +1,5 @@
 const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 
 const moduleUnderTest = require('../../../../lib/application/campaign-participations');
 const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
@@ -45,6 +46,34 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
 
       // then
       expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  describe('PATCH /api/admin/update-participant-external-id', function () {
+    it('should exist', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(campaignParticipationController, 'updateParticipantExternalId')
+        .callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'PATCH';
+      const payload = {
+        data: {
+          attributes: {
+            'participant-external-id': 'new ext id',
+          },
+        },
+      };
+      const url = '/api/admin/campaign-participations/123';
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -457,7 +457,7 @@ describe('Integration | Application | Target Profiles | Routes', function () {
     });
   });
 
-  describe('PATCH /api/target-profiles', function () {
+  describe('PATCH /api/admin/target-profiles', function () {
     it('should exist', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));

--- a/api/tests/unit/domain/usecases/update-participant-external-id_test.js
+++ b/api/tests/unit/domain/usecases/update-participant-external-id_test.js
@@ -1,0 +1,26 @@
+const { expect, sinon } = require('../../../test-helper');
+const { updateParticipantExternalId } = require('../../../../lib/domain/usecases');
+
+describe('Unit | UseCase | update-participation-external-id', function () {
+  it('should call repository method to update the external id for a participation', async function () {
+    //given
+    const participationsForCampaignManagementRepository = {
+      updateParticipantExternalId: sinon.stub(),
+    };
+
+    //when
+    await updateParticipantExternalId({
+      campaignParticipationId: 34,
+      participantExternalId: 'new1234567',
+      participationsForCampaignManagementRepository,
+    });
+
+    //then
+    expect(
+      participationsForCampaignManagementRepository.updateParticipantExternalId
+    ).to.have.been.calledOnceWithExactly({
+      campaignParticipationId: 34,
+      participantExternalId: 'new1234567',
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On souhaite pouvoir mettre à jour l'id externe d'une participation depuis Pix Admin

## :robot: Solution
Ajouter la fonctionnalité qui le permet dans pix admin

## :rainbow: Remarques
Si l'orga ne demande pas d'identifiant externe, on n'affiche pas la colonne `Actions`

## :100: Pour tester
Aller sur pix admin > organisation id:1 > campagne id:1> participants > mettre à jour un id externe
