### PR TITLE
[BUGFIX] Erreur 500 lorsqu'on retente une compétence (PIX-4526)

### DIFF
--- a/api/lib/application/competence-evaluations/index.js
+++ b/api/lib/application/competence-evaluations/index.js
@@ -16,7 +16,7 @@ exports.register = async function (server) {
       },
     },
     {
-      method: 'POST',
+      method: 'PUT',
       path: '/api/competence-evaluations/improve',
       config: {
         handler: competenceEvaluationController.improve,

--- a/api/lib/domain/usecases/improve-competence-evaluation.js
+++ b/api/lib/domain/usecases/improve-competence-evaluation.js
@@ -14,6 +14,7 @@ module.exports = async function improveCompetenceEvaluation({
     competenceId,
     userId,
     domainTransaction,
+    forUpdate: true,
   });
 
   if (competenceEvaluation.assessment.isStarted() && competenceEvaluation.assessment.isImproving) {

--- a/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
@@ -12,7 +12,7 @@ describe('Acceptance | API | Improve Competence Evaluation', function () {
     server = await createServer();
   });
 
-  describe('POST /api/competence-evaluations/improve', function () {
+  describe('PUT /api/competence-evaluations/improve', function () {
     const competenceId = 'recABCD123';
 
     context('When user is authenticated', function () {
@@ -35,7 +35,7 @@ describe('Acceptance | API | Improve Competence Evaluation', function () {
           beforeEach(async function () {
             // given
             const options = {
-              method: 'POST',
+              method: 'PUT',
               url: '/api/competence-evaluations/improve',
               headers: {
                 authorization: generateValidRequestAuthorizationHeader(userId),
@@ -76,7 +76,7 @@ describe('Acceptance | API | Improve Competence Evaluation', function () {
             await databaseBuilder.commit();
 
             const options = {
-              method: 'POST',
+              method: 'PUT',
               url: '/api/competence-evaluations/improve',
               headers: {
                 authorization: generateValidRequestAuthorizationHeader(userId),
@@ -97,7 +97,7 @@ describe('Acceptance | API | Improve Competence Evaluation', function () {
         it('should return 404 error', async function () {
           // given
           const options = {
-            method: 'POST',
+            method: 'PUT',
             url: '/api/competence-evaluations/improve',
             headers: {
               authorization: generateValidRequestAuthorizationHeader(userId),
@@ -118,7 +118,7 @@ describe('Acceptance | API | Improve Competence Evaluation', function () {
       it('should return 401 error', async function () {
         // given
         const options = {
-          method: 'POST',
+          method: 'PUT',
           url: '/api/competence-evaluations/improve',
           headers: {
             authorization: null,

--- a/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
@@ -4,6 +4,8 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 const { MAX_REACHABLE_LEVEL } = require('../../../../lib/domain/constants');
 const { ImproveCompetenceEvaluationForbiddenError } = require('../../../../lib/domain/errors');
 
+const domainTransaction = Symbol('DomainTransaction');
+
 describe('Unit | UseCase | Improve Competence Evaluation', function () {
   let competenceEvaluation, userId, competenceEvaluationRepository, assessmentRepository;
   let getCompetenceLevel;
@@ -11,9 +13,6 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
   let expectedAssessment;
   let createdAssessment;
   const assessmentId = 'created-assessment-id';
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const domainTransaction = Symbol('DomainTransaction');
 
   beforeEach(function () {
     const currentAssessment = new Assessment({
@@ -63,6 +62,7 @@ describe('Unit | UseCase | Improve Competence Evaluation', function () {
       competenceId,
       userId,
       domainTransaction,
+      forUpdate: true,
     });
   });
 

--- a/mon-pix/app/adapters/competence-evaluation.js
+++ b/mon-pix/app/adapters/competence-evaluation.js
@@ -35,7 +35,7 @@ export default class CompetenceEvaluation extends ApplicationAdapter {
     if (query.improve) {
       const url = this.buildURL(type.modelName, null, null, 'queryRecord', query);
 
-      return this.ajax(url, 'POST', { data: { userId: query.userId, competenceId: query.competenceId } });
+      return this.ajax(url, 'PUT', { data: { userId: query.userId, competenceId: query.competenceId } });
     }
 
     return super.queryRecord(...arguments);


### PR DESCRIPTION
## :unicorn: Problème

Des appels en double sont faits sur la ressource `/api/competence-evaluations/improve` lorsqu'un utilisateur retente une compétence , et parfois l'un des 2 appels renvoie une erreur 500.

L'appel en double est effectué avec un referer différent, l'un depuis `/competences`, l'autre depuis `/competences/xxxx/details`, on arrive pas à reproduire ce comportement pour le moment.

La ressource est sensée être idempotent, car elle utilise bien une transaction et effectue une vérification préalable avant de faire l'update de la `CompetenceEvaluation` : https://github.com/1024pix/pix/blob/b23d82e7b43c5cdd726135d48323640a789aabbd/api/lib/domain/usecases/improve-competence-evaluation.js#L19

Cependant il manque la clause `FOR UPDATE` sur le `SELECT` pour récupérer l'entité `CompetenceEvaluation`, il peut donc y avoir une race condition dans certains cas.

## :robot: Solution

En attendant de corriger le problème côté front, rendre la ressource réellement idempotent en utilisant `FOR UPDATE`.

## :rainbow: Remarques

L'ajoute du `lock: 'forUpdate'` dans le fetch Bookshelf ne permet pas d'utiliser en même temps le `withRelated` pour précharger l'`Assessment` (Bookshelf produit une requête invalide), c'est pourquoi le chargement est effectué après coup.

## :100: Pour tester

Retenter une compétence pour vérifier qu'il n'y a pas eu de réression.
