### PR TITLE
[FEATURE] Empêcher l'envoi des résultats d'une campagne d'évaluation si la participation est supprimée (PIX-4441).

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -325,7 +325,7 @@ function _buildUsers({ databaseBuilder, users }) {
 }
 
 function _buildParticipationsInDifferentStatus({ databaseBuilder, user }) {
-  participateToAssessmentCampaign({ databaseBuilder, campaignId: 1, user, schoolingRegistrationId: user.id, status: STARTED, deleted: true }); //deleted
+  participateToAssessmentCampaign({ databaseBuilder, campaignId: 22, user, schoolingRegistrationId: user.id, status: STARTED, deleted: true }); //deleted
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 2, user, schoolingRegistrationId: user.id, status: STARTED }); //started
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 12, user, schoolingRegistrationId: user.id, status: TO_SHARE }); //to share
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 13, user, schoolingRegistrationId: user.id, status: SHARED });//archived + shared

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -81,6 +81,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.ArchivedCampaignError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.CampaignParticipationDeletedError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.AlreadyRatedAssessmentError) {
     return new HttpErrors.PreconditionFailedError('Assessment is already rated.');
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1053,6 +1053,12 @@ class MissingBadgeCriterionError extends DomainError {
   }
 }
 
+class CampaignParticipationDeletedError extends DomainError {
+  constructor(message = 'La participation est supprimée.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -1080,6 +1086,7 @@ module.exports = {
   AuthenticationKeyForPoleEmploiTokenExpired,
   UncancellableOrganizationInvitationError,
   CampaignCodeError,
+  CampaignParticipationDeletedError,
   CancelledOrganizationInvitationError,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -4,6 +4,7 @@ const {
   AssessmentNotCompletedError,
   AlreadySharedCampaignParticipationError,
   CantImproveCampaignParticipationError,
+  CampaignParticipationDeletedError,
 } = require('../errors');
 const CampaignParticipationStatuses = require('./CampaignParticipationStatuses');
 
@@ -14,6 +15,7 @@ class CampaignParticipation {
     participantExternalId,
     status,
     sharedAt,
+    deletedAt,
     assessments,
     campaign,
     user,
@@ -27,6 +29,7 @@ class CampaignParticipation {
     this.status = status;
     this.participantExternalId = participantExternalId;
     this.sharedAt = sharedAt;
+    this.deletedAt = deletedAt;
     this.campaign = campaign;
     this.user = user;
     this.assessments = assessments;
@@ -53,6 +56,10 @@ class CampaignParticipation {
 
   get isShared() {
     return this.status === CampaignParticipationStatuses.SHARED;
+  }
+
+  get isDeleted() {
+    return Boolean(this.deletedAt);
   }
 
   get lastAssessment() {
@@ -90,6 +97,9 @@ class CampaignParticipation {
     }
     if (this.campaign.isArchived()) {
       throw new ArchivedCampaignError('Cannot share results on an archived campaign.');
+    }
+    if (this.isDeleted) {
+      throw new CampaignParticipationDeletedError('Cannot share results on a deleted participation.');
     }
     if (this.campaign.isAssessment() && lastAssessmentNotCompleted(this)) {
       throw new AssessmentNotCompletedError();

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -5,7 +5,13 @@ const constants = require('../../constants');
 const moment = require('moment');
 
 class AssessmentResult {
-  constructor(participationResults, targetProfile, isCampaignMultipleSendings, isRegistrationActive) {
+  constructor(
+    participationResults,
+    targetProfile,
+    isCampaignMultipleSendings,
+    isRegistrationActive,
+    isCampaignArchived
+  ) {
     const { knowledgeElements, sharedAt, assessmentCreatedAt } = participationResults;
     const { competences } = targetProfile;
 
@@ -29,6 +35,7 @@ class AssessmentResult {
     }
     this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt);
     this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive);
+    this.isDisabled = this._computeIsDisabled(isCampaignArchived, participationResults.isDeleted);
   }
 
   _computeMasteryRate(masteryRate) {
@@ -60,6 +67,10 @@ class AssessmentResult {
       this.masteryRate < constants.MAX_MASTERY_RATE &&
       isRegistrationActive
     );
+  }
+
+  _computeIsDisabled(isCampaignArchived, isParticipationDeleted) {
+    return isCampaignArchived || isParticipationDeleted;
   }
 
   _timeBeforeRetryingPassed(sharedAt) {

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -18,6 +18,7 @@ module.exports = {
         'stageCount',
         'canRetry',
         'canImprove',
+        'isDisabled',
       ],
       campaignParticipationBadges: {
         ref: 'id',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -197,6 +197,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
             'stage-count': 2,
             'can-retry': false,
             'can-improve': false,
+            'is-disabled': false,
             'participant-external-id': 'participantExternalId',
             'estimated-flash-level': undefined,
           },

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -164,6 +164,13 @@ describe('Integration | API | Controller Error', function () {
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
     });
+
+    it('responds Precondition Failed when a CampaignParticipationDeletedError occurs', async function () {
+      routeHandler.throws(new DomainErrors.CampaignParticipationDeletedError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
+    });
   });
 
   context('404 Not Found', function () {

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -54,6 +54,10 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.ArchivedCampaignError).to.exist;
   });
 
+  it('should export a CampaignParticipationDeletedError', function () {
+    expect(errors.CampaignParticipationDeletedError).to.exist;
+  });
+
   it('should export a UserNotAuthorizedToUpdatePasswordError', function () {
     expect(errors.UserNotAuthorizedToUpdatePasswordError).to.exist;
   });

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -8,6 +8,7 @@ const {
   AssessmentNotCompletedError,
   AlreadySharedCampaignParticipationError,
   CantImproveCampaignParticipationError,
+  CampaignParticipationDeletedError,
 } = require('../../../../lib/domain/errors');
 const { TO_SHARE, SHARED } = CampaignParticipationStatuses;
 
@@ -83,7 +84,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
   });
 
   describe('share', function () {
-    context('when the campaign is not archived', function () {
+    context('when the campaign is not archived nor deleted', function () {
       let clock;
       const now = new Date('2021-09-25');
 
@@ -174,6 +175,18 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
         expect(error).to.be.an.instanceOf(ArchivedCampaignError);
         expect(error.message).to.equals('Cannot share results on an archived campaign.');
+      });
+    });
+
+    context('when the participation is deleted', function () {
+      it('throws a CampaignParticipationDeletedError', async function () {
+        const campaign = domainBuilder.buildCampaign();
+        const campaignParticipation = new CampaignParticipation({ campaign, deletedAt: new Date() });
+
+        const error = await catchErr(campaignParticipation.share, campaignParticipation)();
+
+        expect(error).to.be.an.instanceOf(CampaignParticipationDeletedError);
+        expect(error.message).to.equals('Cannot share results on a deleted participation.');
       });
     });
   });

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -572,4 +572,48 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       }
     );
   });
+
+  describe('#isDisabled', function () {
+    context('when participation is deleted', function () {
+      it('returns true', function () {
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          isDeleted: true,
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false, false);
+
+        expect(assessmentResult.isDisabled).to.be.true;
+      });
+    });
+
+    context('when campaign is archived', function () {
+      it('returns true', function () {
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          isDeleted: false,
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false, true);
+
+        expect(assessmentResult.isDisabled).to.be.true;
+      });
+    });
+
+    context('when campaign is not archived and participation is not deleted', function () {
+      it('returns false', function () {
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          isDeleted: false,
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false, false);
+
+        expect(assessmentResult.isDisabled).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -10,6 +10,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
     beforeEach(function () {
       const isCampaignMultipleSendings = true;
       const isRegistrationActive = true;
+      const isCampaignArchived = false;
       const knowledgeElements = [
         domainBuilder.buildKnowledgeElement({
           skillId: 'skill1',
@@ -32,6 +33,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         participantExternalId: 'greg@lafleche.fr',
         masteryRate: 0.5,
         estimatedFlashLevel: -2.4672347856,
+        isDeleted: false,
       };
 
       const competences = [
@@ -68,7 +70,8 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         participationResults,
         targetProfile,
         isCampaignMultipleSendings,
-        isRegistrationActive
+        isRegistrationActive,
+        isCampaignArchived
       );
     });
 
@@ -85,6 +88,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'stage-count': 3,
             'can-retry': true,
             'can-improve': false,
+            'is-disabled': false,
             'participant-external-id': 'greg@lafleche.fr',
             'estimated-flash-level': -2.4672347856,
           },

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -2,17 +2,17 @@
   <AssessmentBanner @title={{@model.campaign.title}} @displayHomeLink={{false}} />
 </div>
 
-{{#if @model.campaign.isArchived}}
+{{#if @model.campaignParticipationResult.isDisabled}}
   <PixBlock class="skill-review__result-abstract-container">
-    <div class="skill-review__campaign-archived">
+    <div class="skill-review__disabled-share">
       <img
-        class="skill-review__campaign-archived-image"
+        class="skill-review-disabled-share__image"
         src="{{this.rootURL}}/images/illustrations/fat-bee.svg"
         alt=""
         role="none"
       />
-      <p class="skill-review__campaign-archived-text">
-        {{t "pages.skill-review.archived" htmlSafe=true}}
+      <p class="skill-review-disabled-share__text">
+        {{t "pages.skill-review.disabled-share" htmlSafe=true}}
       </p>
       <LinkTo @route="index" class="skill-review-share__back-to-home link">
         {{t "pages.skill-review.actions.continue"}}

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -9,6 +9,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('number') stageCount;
   @attr('boolean') canRetry;
   @attr('boolean') canImprove;
+  @attr('boolean') isDisabled;
   @attr('boolean') isShared;
   @attr('string') participantExternalId;
   @attr('number') estimatedFlashLevel;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -427,24 +427,27 @@
   }
 }
 
-.skill-review__campaign-archived {
+.skill-review__disabled-share {
   position: relative;
   text-align: center;
   margin-bottom: 10px;
 }
 
-.skill-review__campaign-archived-image {
-  margin-top: -50px;
-}
+.skill-review-disabled-share {
 
-.skill-review__campaign-archived-text {
-  font-size: 1.375rem;
-  line-height: 30px;
-  max-width: 640px;
-  margin: 30px auto 60px;
-  font-family: $font-open-sans;
-  font-weight: $font-light;
-  color: $grey-35;
+  &__image {
+    margin-top: -50px;
+  }
+
+  &__text {
+    font-size: 1.375rem;
+    line-height: 30px;
+    max-width: 640px;
+    margin: 30px auto 60px;
+    font-family: $font-open-sans;
+    font-weight: $font-light;
+    color: $grey-35;
+  }
 }
 
 .stage-congrats {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -19,7 +19,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
   context('When user want to share his/her results', function () {
     it('should see the button to share', async function () {
       // Given
-      const campaignParticipationResult = { isShared: false, campaignParticipationBadges: [] };
+      const campaignParticipationResult = { isShared: false, campaignParticipationBadges: [], isDisabled: false };
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
@@ -32,10 +32,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     context('when a skill has been reset after campaign completion and before sending results', function () {
       it('displays an error message and a resume button on share', async function () {
         // Given
-        const campaignParticipationResult = {
-          isShared: false,
-          campaignParticipationBadges: [],
-        };
+        const campaignParticipationResult = { isShared: false, campaignParticipationBadges: [], isDisabled: false };
         this.set('model', { campaign, campaignParticipationResult });
 
         const store = this.owner.lookup('service:store');
@@ -56,10 +53,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     context('when an error occurred during share', function () {
       it('displays an error message and a go home button', async function () {
         // Given
-        const campaignParticipationResult = {
-          isShared: false,
-          campaignParticipationBadges: [],
-        };
+        const campaignParticipationResult = { isShared: false, campaignParticipationBadges: [], isDisabled: false };
         this.set('model', { campaign, campaignParticipationResult });
 
         const store = this.owner.lookup('service:store');
@@ -106,7 +100,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     beforeEach(async function () {
       // Given
       campaign = { isFlash: true };
-      const campaignParticipationResult = { estimatedFlashLevel };
+      const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false };
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
@@ -513,6 +507,44 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
       it('should not display NPS Block', function () {
         expect(contains(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.not.exist;
+      });
+    });
+  });
+
+  describe('The disabled block', function () {
+    context('when participation is disabled', function () {
+      beforeEach(async function () {
+        const campaignParticipationResult = {
+          campaignParticipationBadges: [],
+          isDisabled: true,
+        };
+        this.set('model', { campaign, campaignParticipationResult });
+
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      });
+
+      it('should display disabled block', function () {
+        // Then
+        expect(contains("Ce parcours a été désactivé par l'organisateur.")).to.exist;
+      });
+    });
+
+    context('when participation is not disabled', function () {
+      beforeEach(async function () {
+        const campaignParticipationResult = {
+          campaignParticipationBadges: [],
+          isDisabled: false,
+        };
+        this.set('model', { campaign, campaignParticipationResult });
+
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      });
+
+      it('should not display disabled block', function () {
+        // Then
+        expect(contains("Ce parcours a été désactivé par l'organisateur.")).to.not.exist;
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1218,7 +1218,6 @@
         "send": "Submit my results"
       },
       "already-shared": "Thank you, your results have been submitted!",
-      "archived": "This customised test has been archived by the organiser.'<br>' It is no longer possible to submit results.",
       "badge-card": {
         "acquired": "Awarded",
         "not-acquired": "Not awarded"
@@ -1232,6 +1231,7 @@
         "result-by-skill": "Your results for the competence",
         "percentage": "{rate, number, ::percent}"
       },
+      "disabled-share": "This customised test has been disabled by the organiser.'<br>' It is no longer possible to submit results.",
       "error": "Oops, an error occurred!",
       "improve": {
         "title": "Want to improve your results?",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1218,7 +1218,6 @@
         "send": "J'envoie mes résultats"
       },
       "already-shared": "Merci, vos résultats ont bien été envoyés !",
-      "archived": "Ce parcours a été archivé par l'organisateur.'<br>' L'envoi des résultats n'est plus possible.",
       "badge-card": {
         "acquired": "Obtenu",
         "not-acquired": "Non obtenu"
@@ -1232,6 +1231,7 @@
         "result-by-skill": "Votre résultat pour la compétence",
         "percentage": "{rate, number, ::percent}"
       },
+      "disabled-share": "Ce parcours a été désactivé par l'organisateur.'<br>' L'envoi des résultats n'est plus possible.",
       "error": "Oups, une erreur est survenue !",
       "improve": {
         "title": "Envie d'améliorer vos résultats ?",


### PR DESCRIPTION
## :unicorn: Problème
Nous sommes en train de mettre en place un mécanisme de suppression de la participation à la main du prescripteur. Avant de permettre cette suppression véritablement, il est nécéssaire de gérer tous les impacts.

## :robot: Solution
Pour une campagne d'évaluation, empêcher l'envoi des résultats en fin de parcours.

## :rainbow: Remarques
RAS

## :100: Pour tester
- se connecter à Pix App avec jaune.attend@example.net
- taper le code PROBADGE1
- terminer son parcours
- vérifier que l'on ne peut pas envoyer ses résultats
