### PR TITLE
[FEATURE] Ajout de la possibilité de basculer une campagne en envoi multiple dans PixAdmin (PIX-4421).

### DIFF
--- a/admin/app/components/campaigns/details.hbs
+++ b/admin/app/components/campaigns/details.hbs
@@ -56,6 +56,7 @@
     {{#if @campaign.customResultPageButtonUrl}}
       <li>URL du bouton de la page de fin de parcours : {{@campaign.customResultPageButtonUrl}}</li>
     {{/if}}
+    <li>Envoi multiple : {{if @campaign.multipleSendings "Oui" "Non"}}</li>
   </ul>
 
   <br />

--- a/admin/app/components/campaigns/update.hbs
+++ b/admin/app/components/campaigns/update.hbs
@@ -108,6 +108,19 @@
         {{/if}}
         <p class="form__instructions">Si une URL pour le bouton est saisie, le texte est également requis.</p>
       {{/if}}
+
+      {{#unless @campaign.totalParticipationsCount}}
+        <div class="form-field campaign-edit-form__checkbox">
+          <label for="multipleSendings" class="form-field__label">Envoi multiple</label>
+          <Input
+            id="multipleSendings"
+            @type="checkbox"
+            class={{if (v-get this.form "multipleSendings" "isInvalid") "form-control is-invalid" "form-control"}}
+            @checked={{this.form.multipleSendings}}
+          />
+        </div>
+      {{/unless}}
+
     </div>
 
     <div class="form-actions">

--- a/admin/app/components/campaigns/update.js
+++ b/admin/app/components/campaigns/update.js
@@ -71,6 +71,7 @@ class Form extends Object.extend(Validations) {
   @tracked customResultPageText;
   @tracked customResultPageButtonText;
   @tracked customResultPageButtonUrl;
+  @tracked multipleSendings;
 }
 
 export default class Update extends Component {
@@ -85,6 +86,7 @@ export default class Update extends Component {
     this.form.customResultPageText = this.args.campaign.customResultPageText;
     this.form.customResultPageButtonText = this.args.campaign.customResultPageButtonText;
     this.form.customResultPageButtonUrl = this.args.campaign.customResultPageButtonUrl;
+    this.form.multipleSendings = this.args.campaign.multipleSendings;
   }
 
   async _checkFormValidation() {
@@ -106,6 +108,7 @@ export default class Update extends Component {
     campaign.customResultPageText = customResultPageTextTrim || null;
     campaign.customResultPageButtonText = customResultPageButtonTextTrim || null;
     campaign.customResultPageButtonUrl = customResultPageButtonUrlTrim || null;
+    campaign.multipleSendings = this.form.multipleSendings;
 
     try {
       await campaign.save();

--- a/admin/app/models/campaign.js
+++ b/admin/app/models/campaign.js
@@ -23,4 +23,5 @@ export default class Campaign extends Model {
   @attr('number') totalParticipationsCount;
   @attr('boolean') isTypeProfilesCollection;
   @attr('boolean') isTypeAssessment;
+  @attr('boolean') multipleSendings;
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -73,3 +73,4 @@
 @import 'components/target-profiles/stages';
 @import 'components/target-profiles/stage-form';
 @import 'components/badges/badge';
+@import 'components/campaigns/update';

--- a/admin/app/styles/components/campaigns/update.scss
+++ b/admin/app/styles/components/campaigns/update.scss
@@ -1,0 +1,10 @@
+.campaign-edit-form__checkbox {
+  display: flex;
+  align-items: center;
+
+  & > input[type=checkbox] {
+    margin: 0 8px;
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/admin/tests/integration/components/campaigns/details_test.js
+++ b/admin/tests/integration/components/campaigns/details_test.js
@@ -110,4 +110,30 @@ module('Integration | Component | Campaigns | details', function (hooks) {
     // then
     assert.contains('10 participants');
   });
+
+  module('when campaign is multiple sendings', function () {
+    test("should display 'Oui' when 'multipleSendings' is true", async function (assert) {
+      // given
+      this.campaign = {
+        multipleSendings: true,
+      };
+
+      // when
+      await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // then
+      assert.contains('Envoi multiple : Oui');
+    });
+
+    test("should display 'Non' when 'multipleSendings' is false", async function (assert) {
+      // given
+      this.campaign = {
+        multipleSendings: false,
+      };
+
+      // when
+      await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
+      // then
+      assert.contains('Envoi multiple : Non');
+    });
+  });
 });

--- a/admin/tests/integration/components/campaigns/update_test.js
+++ b/admin/tests/integration/components/campaigns/update_test.js
@@ -166,4 +166,26 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
     // then
     assert.ok(this.onExit.called);
   });
+
+  module('Multiple sendings checkbox', function () {
+    test('it should display multiple sendings checkbox when campaign has no participations', async function (assert) {
+      //given
+      this.campaign.totalParticipationsCount = 0;
+
+      // when
+      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
+      // then
+      assert.contains('Envoi multiple');
+    });
+
+    test('it should not display multiple sendings checkbox when campaign has participations', async function (assert) {
+      //given
+      this.campaign.totalParticipationsCount = 1;
+
+      // when
+      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
+      // then
+      assert.dom('label[for="multipleSendings"]').doesNotExist();
+    });
+  });
 });

--- a/api/lib/application/campaigns/campaign-management-controller.js
+++ b/api/lib/application/campaigns/campaign-management-controller.js
@@ -2,6 +2,7 @@ const usecases = require('../../domain/usecases');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const campaignDetailsManagementSerializer = require('../../infrastructure/serializers/jsonapi/campaign-details-management-serializer');
 const participationForCampaignManagementSerializer = require('../../infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer');
+const commonDeserializer = require('../../infrastructure/serializers/jsonapi/deserializer');
 
 module.exports = {
   async getCampaignDetails(request) {
@@ -24,22 +25,11 @@ module.exports = {
 
   async updateCampaignDetailsManagement(request, h) {
     const campaignId = request.params.id;
-    const {
-      name,
-      title,
-      'custom-landing-page-text': customLandingPageText,
-      'custom-result-page-button-text': customResultPageButtonText,
-      'custom-result-page-button-url': customResultPageButtonUrl,
-      'custom-result-page-text': customResultPageText,
-    } = request.payload.data.attributes;
+
+    const campaignDetailsManagement = await commonDeserializer.deserialize(request.payload);
     await usecases.updateCampaignDetailsManagement({
       campaignId,
-      name,
-      title,
-      customLandingPageText,
-      customResultPageText,
-      customResultPageButtonText,
-      customResultPageButtonUrl,
+      ...campaignDetailsManagement,
     });
     return h.response({}).code(204);
   },

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -106,6 +106,7 @@ exports.register = async function (server) {
                 'custom-result-page-text': Joi.string().required().allow(null),
                 'custom-result-page-button-text': Joi.string().required().allow(null),
                 'custom-result-page-button-url': Joi.string().required().allow(null),
+                'multiple-sendings': Joi.boolean().required(),
               },
             },
           }),

--- a/api/lib/domain/read-models/CampaignManagement.js
+++ b/api/lib/domain/read-models/CampaignManagement.js
@@ -25,6 +25,7 @@ class CampaignManagement {
     shared,
     started,
     completed,
+    multipleSendings,
   } = {}) {
     this.id = id;
     this.code = code;
@@ -50,6 +51,7 @@ class CampaignManagement {
     this.ownerId = ownerId;
     this.sharedParticipationsCount = shared;
     this.totalParticipationsCount = this.sharedParticipationsCount + (started || 0) + completed;
+    this.multipleSendings = multipleSendings;
   }
 
   get isTypeProfilesCollection() {

--- a/api/lib/domain/validators/campaign-validator.js
+++ b/api/lib/domain/validators/campaign-validator.js
@@ -110,6 +110,11 @@ const campaignValidationJoiSchema = Joi.object({
     'string.empty': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
     'any.required': 'CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED',
   }),
+
+  multipleSendings: Joi.boolean().required().messages({
+    'any.required': 'MULTIPLE_SENDINGS_CHOICE_IS_REQUIRED',
+    'boolean.base': 'MULTIPLE_SENDINGS_CHOICE_IS_REQUIRED',
+  }),
 });
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-management-repository.js
@@ -34,6 +34,7 @@ module.exports = {
         customResultPageText: 'campaigns.customResultPageText',
         customResultPageButtonText: 'campaigns.customResultPageButtonText',
         customResultPageButtonUrl: 'campaigns.customResultPageButtonUrl',
+        multipleSendings: 'campaigns.multipleSendings',
       })
       .join('users', 'users.id', 'campaigns.creatorId')
       .join('users AS ownerUser', 'ownerUser.id', 'campaigns.ownerId')
@@ -84,6 +85,7 @@ module.exports = {
       'customResultPageText',
       'customResultPageButtonText',
       'customResultPageButtonUrl',
+      'multipleSendings',
     ]);
     return knex('campaigns').where({ id: campaignId }).update(editableAttributes);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-details-management-serializer.js
@@ -26,6 +26,7 @@ module.exports = {
         'totalParticipationsCount',
         'isTypeProfilesCollection',
         'isTypeAssessment',
+        'multipleSendings',
       ],
       meta,
     }).serialize(campaignManagement);

--- a/api/lib/infrastructure/serializers/jsonapi/deserializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/deserializer.js
@@ -1,0 +1,7 @@
+const { Deserializer } = require('jsonapi-serializer');
+
+const deserializer = new Deserializer({
+  keyForAttribute: 'camelCase',
+});
+
+module.exports = deserializer;

--- a/api/scripts/prod/create-assessment-campaigns-for-sco.js
+++ b/api/scripts/prod/create-assessment-campaigns-for-sco.js
@@ -42,6 +42,7 @@ async function prepareCampaigns(campaignsData) {
       name: campaignData.name,
       title: campaignData.title,
       customLandingPageText: campaignData.customLandingPageText,
+      multipleSendings: campaignData.multipleSendings,
     };
 
     campaignValidator.validate(campaign);

--- a/api/scripts/prod/create-profiles-collection-campaigns.js
+++ b/api/scripts/prod/create-profiles-collection-campaigns.js
@@ -37,6 +37,7 @@ async function prepareCampaigns(campaignsData) {
         type: Campaign.types.PROFILES_COLLECTION,
         name: campaignData.name,
         customLandingPageText: campaignData.customLandingPageText,
+        multipleSendings: campaignData.multipleSendings,
       };
 
       campaignValidator.validate(campaign);

--- a/api/tests/acceptance/application/campaign-management-controller_test.js
+++ b/api/tests/acceptance/application/campaign-management-controller_test.js
@@ -52,7 +52,7 @@ describe('Acceptance | API | Campaign Management Controller', function () {
   describe('PATCH /api/admin/campaigns/{id}', function () {
     it('should return the updated campaign', async function () {
       // given
-      const campaign = databaseBuilder.factory.buildCampaign({ name: 'odlName' });
+      const campaign = databaseBuilder.factory.buildCampaign({ name: 'odlName', multipleSendings: false });
       const user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
       await databaseBuilder.commit();
 
@@ -70,6 +70,7 @@ describe('Acceptance | API | Campaign Management Controller', function () {
               'custom-result-page-button-text': null,
               'custom-result-page-button-url': null,
               'custom-result-page-text': null,
+              'multiple-sendings': true,
             },
           },
         },
@@ -78,6 +79,7 @@ describe('Acceptance | API | Campaign Management Controller', function () {
       // then
       expect(response.statusCode).to.equal(204);
       expect(updatedCampaign.name).to.equal('newName');
+      expect(updatedCampaign.multipleSendings).to.be.true;
     });
   });
 });

--- a/api/tests/integration/domain/usecases/update-campaign-details-management_test.js
+++ b/api/tests/integration/domain/usecases/update-campaign-details-management_test.js
@@ -1,7 +1,11 @@
-const { expect, databaseBuilder, mockLearningContent, knex } = require('../../../test-helper');
+const { expect, databaseBuilder, mockLearningContent, knex, catchErr } = require('../../../test-helper');
 
 const campaignManagementRepository = require('../../../../lib/infrastructure/repositories/campaign-management-repository');
 const updateCampaignDetailsManagement = require('../../../../lib/domain/usecases/update-campaign-details-management');
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+const { SHARED } = CampaignParticipationStatuses;
 
 describe('Integration | UseCases | update-campaign-details-management', function () {
   let userId;
@@ -14,7 +18,12 @@ describe('Integration | UseCases | update-campaign-details-management', function
     userId = databaseBuilder.factory.buildUser().id;
     targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
     databaseBuilder.factory.buildMembership({ organizationId, userId });
-    campaign = databaseBuilder.factory.buildCampaign({ targetProfileId, creatorId: userId, organizationId });
+    campaign = databaseBuilder.factory.buildCampaign({
+      targetProfileId,
+      creatorId: userId,
+      organizationId,
+      multipleSendings: false,
+    });
     campaignId = campaign.id;
     await databaseBuilder.commit();
 
@@ -33,6 +42,7 @@ describe('Integration | UseCases | update-campaign-details-management', function
       customResultPageText: 'new result text',
       customResultPageButtonText: 'new result button text',
       customResultPageButtonUrl: 'http://some.url.com',
+      multipleSendings: true,
     };
     const expectedCampaign = { ...campaign, ...campaignAttributes };
 
@@ -40,5 +50,103 @@ describe('Integration | UseCases | update-campaign-details-management', function
 
     const actualCampaign = await knex.select('*').from('campaigns').first();
     expect(actualCampaign).to.deep.equal(expectedCampaign);
+  });
+
+  it('should not update multipleSendings attribute when campaign has participations', async function () {
+    //given
+    const campaignId = databaseBuilder.factory.buildCampaign({
+      multipleSendings: false,
+    }).id;
+
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      status: SHARED,
+    });
+
+    await databaseBuilder.commit();
+
+    //when
+    const campaignAttributes = {
+      name: 'new Name',
+      title: 'new title',
+      customLandingPageText: 'new landing text',
+      customResultPageText: 'new result text',
+      customResultPageButtonText: 'new result button text',
+      customResultPageButtonUrl: 'http://some.url.com',
+      multipleSendings: true,
+    };
+
+    const error = await catchErr(updateCampaignDetailsManagement)({
+      campaignId,
+      ...campaignAttributes,
+      campaignManagementRepository,
+    });
+
+    //then
+    const { multipleSendings: actualMultipleSendings } = await knex
+      .select('multipleSendings')
+      .from('campaigns')
+      .where({ id: campaignId })
+      .first();
+
+    expect(error).to.be.an.instanceOf(EntityValidationError);
+    expect(actualMultipleSendings).to.be.false;
+  });
+
+  it('should update other attribut when campaign has participations', async function () {
+    //given
+    const campaignId = databaseBuilder.factory.buildCampaign({
+      name: 'mapetitelicorne',
+      multipleSendings: false,
+    }).id;
+
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      status: SHARED,
+    });
+
+    await databaseBuilder.commit();
+
+    //when
+    const campaignAttributes = {
+      name: 'Daddy cool',
+      title: 'new title',
+      customLandingPageText: 'new landing text',
+      customResultPageText: 'new result text',
+      customResultPageButtonText: 'new result button text',
+      customResultPageButtonUrl: 'http://some.url.com',
+      multipleSendings: false,
+    };
+
+    await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });
+
+    //then
+    const { name: actualName } = await knex.select('name').from('campaigns').where({ id: campaignId }).first();
+
+    expect(actualName).to.equal('Daddy cool');
+  });
+
+  it('should update multipleSendings attribute when campaign has no participations', async function () {
+    //given
+    const campaignAttributes = {
+      name: 'new Name',
+      title: 'new title',
+      customLandingPageText: 'new landing text',
+      customResultPageText: 'new result text',
+      customResultPageButtonText: 'new result button text',
+      customResultPageButtonUrl: 'http://some.url.com',
+      multipleSendings: true,
+    };
+    const expectedCampaign = { ...campaign, ...campaignAttributes };
+
+    //when
+    await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });
+
+    //then
+    const { multipleSendings: actualMultipleSendings } = await knex
+      .select('multipleSendings')
+      .from('campaigns')
+      .first();
+    expect(actualMultipleSendings).to.equal(expectedCampaign.multipleSendings);
   });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -52,6 +52,7 @@ describe('Integration | Repository | Campaign-Management', function () {
         customResultPageButtonUrl: null,
         sharedParticipationsCount: 0,
         totalParticipationsCount: 0,
+        multipleSendings: false,
       });
     });
 
@@ -168,6 +169,7 @@ describe('Integration | Repository | Campaign-Management', function () {
         customResultPageText: null,
         customResultPageButtonText: null,
         customResultPageButtonUrl: null,
+        multipleSendings: false,
       });
       await databaseBuilder.commit();
 
@@ -178,6 +180,7 @@ describe('Integration | Repository | Campaign-Management', function () {
         customResultPageText: 'Congrats you finished !',
         customResultPageButtonText: 'Continue here',
         customResultPageButtonUrl: 'www.next-step.net',
+        multipleSendings: true,
       };
       const expectedCampaign = databaseBuilder.factory.buildCampaign({ ...campaign, ...campaignAttributes });
       // when
@@ -193,14 +196,20 @@ describe('Integration | Repository | Campaign-Management', function () {
       const campaign = databaseBuilder.factory.buildCampaign({
         code: 'SOMECODE',
         name: 'some name',
+        multipleSendings: false,
       });
       await databaseBuilder.commit();
 
       const campaignAttributes = {
         code: 'NEWCODE',
         name: 'new name',
+        multipleSendings: true,
       };
-      const expectedCampaign = databaseBuilder.factory.buildCampaign({ ...campaign, name: 'new name' });
+      const expectedCampaign = databaseBuilder.factory.buildCampaign({
+        ...campaign,
+        name: 'new name',
+        multipleSendings: true,
+      });
 
       // when
       await campaignManagementRepository.update({ campaignId: campaign.id, campaignAttributes });

--- a/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
+++ b/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
@@ -24,6 +24,7 @@ describe('Integration | Scripts | create-assessment-campaigns', function () {
         name: 'CampaignName',
         externalId,
         creatorId,
+        multipleSendings: false,
       };
 
       // when
@@ -47,6 +48,7 @@ describe('Integration | Scripts | create-assessment-campaigns', function () {
         title: 'title1',
         customLandingPageText: 'customLandingPageText1',
         creatorId,
+        multipleSendings: false,
       };
       const campaignData2 = {
         targetProfileId: targetProfileId2,
@@ -55,6 +57,7 @@ describe('Integration | Scripts | create-assessment-campaigns', function () {
         title: 'title2',
         customLandingPageText: 'customLandingPageText2',
         creatorId,
+        multipleSendings: false,
       };
 
       // when
@@ -80,6 +83,7 @@ describe('Integration | Scripts | create-assessment-campaigns', function () {
       const campaignData = {
         targetProfileId: 'foireux',
         externalId,
+        multipleSendings: false,
       };
 
       // when

--- a/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
@@ -23,6 +23,7 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
         name: 'CampaignName',
         organizationId: organizationId1,
         creatorId: '789',
+        multipleSendings: false,
       };
 
       // when
@@ -40,6 +41,7 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
         name: 'CampaignName',
         organizationId: organizationId1,
         creatorId: '789',
+        multipleSendings: false,
       };
 
       // when
@@ -58,12 +60,14 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
         organizationId: organizationId1,
         customLandingPageText: 'customLandingPageText1',
         creatorId,
+        multipleSendings: false,
       };
       const campaignData2 = {
         name: 'Name2',
         organizationId: organizationId2,
         customLandingPageText: undefined,
         creatorId,
+        multipleSendings: false,
       };
 
       // when
@@ -88,6 +92,7 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
       const campaignData = {
         name: '',
         organizationId: organizationId1,
+        multipleSendings: false,
       };
 
       // when

--- a/api/tests/tooling/domain-builder/factory/build-campaign.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign.js
@@ -23,6 +23,7 @@ function buildCampaign({
   customResultPageButtonText = null,
   customResultPageButtonUrl = null,
   customResultPageText = null,
+  multipleSendings = false,
 } = {}) {
   return new Campaign({
     id,
@@ -44,6 +45,7 @@ function buildCampaign({
     customResultPageButtonText,
     customResultPageButtonUrl,
     customResultPageText,
+    multipleSendings,
   });
 }
 
@@ -67,6 +69,7 @@ buildCampaign.ofTypeAssessment = function ({
   customResultPageButtonText = null,
   customResultPageButtonUrl = null,
   customResultPageText = null,
+  multipleSendings = false,
 } = {}) {
   return new Campaign({
     id,
@@ -88,6 +91,7 @@ buildCampaign.ofTypeAssessment = function ({
     customResultPageButtonText,
     customResultPageButtonUrl,
     customResultPageText,
+    multipleSendings,
   });
 };
 
@@ -109,6 +113,7 @@ buildCampaign.ofTypeProfilesCollection = function ({
   customResultPageButtonText = null,
   customResultPageButtonUrl = null,
   customResultPageText = null,
+  multipleSendings = false,
 } = {}) {
   return new Campaign({
     id,
@@ -130,6 +135,7 @@ buildCampaign.ofTypeProfilesCollection = function ({
     customResultPageButtonText,
     customResultPageButtonUrl,
     customResultPageText,
+    multipleSendings,
   });
 };
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -169,6 +169,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
             'custom-result-page-text': null,
             'custom-result-page-button-text': null,
             'custom-result-page-button-url': null,
+            'multiple-sendings': false,
           },
         },
       };
@@ -270,6 +271,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
             'custom-result-page-text': null,
             'custom-result-page-button-text': null,
             'custom-result-page-button-url': null,
+            'multiple-sendings': false,
           },
         },
       };

--- a/api/tests/unit/domain/usecases/update-campaign-details-management_test.js
+++ b/api/tests/unit/domain/usecases/update-campaign-details-management_test.js
@@ -28,6 +28,7 @@ describe('Unit | UseCase | update-campaign-details-management', function () {
       customResultPageText: 'new result text',
       customResultPageButtonText: 'new result button text',
       customResultPageButtonUrl: 'new result button url',
+      multipleSendings: false,
     };
 
     await updateCampaignDetailsManagement({ campaignId, ...campaignAttributes, campaignManagementRepository });

--- a/api/tests/unit/domain/validators/campaign-validator_test.js
+++ b/api/tests/unit/domain/validators/campaign-validator_test.js
@@ -5,6 +5,7 @@ const Campaign = require('../../../../lib/domain/models/Campaign');
 const MISSING_VALUE = null;
 const EMPTY_VALUE = '';
 const UNDEFINED_VALUE = undefined;
+const NOT_BOOLEAN_VALUE = 'NOT_BOOLEAN_VALUE';
 
 function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError) {
   expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(1);
@@ -22,6 +23,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
     idPixLabel: 'Mail Pro',
     customResultPageButtonText: null,
     customResultPageButtonUrl: null,
+    multipleSendings: false,
   };
 
   const campaignOfTypeAssessment = {
@@ -36,6 +38,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
     targetProfileId: 44,
     customResultPageButtonText: null,
     customResultPageButtonUrl: null,
+    multipleSendings: false,
   };
 
   describe('#validate', function () {
@@ -288,6 +291,42 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
             });
           });
 
+          context('on multipleSendigs attribute', function () {
+            // given
+            const expectedRequiredError = {
+              attribute: 'multipleSendings',
+              message: 'MULTIPLE_SENDINGS_CHOICE_IS_REQUIRED',
+            };
+
+            it('should reject with error when multipleSendings not a boolean', function () {
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  multipleSendings: NOT_BOOLEAN_VALUE,
+                });
+                expect.fail('should have thrown an error');
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedRequiredError);
+              }
+            });
+
+            it('should reject with error when multipleSendings is undefined', function () {
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  multipleSendings: UNDEFINED_VALUE,
+                });
+                expect.fail('should have thrown an error');
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedRequiredError);
+              }
+            });
+          });
+
           it('should reject with errors on all fields (but only once by field) when all fields are missing', function () {
             try {
               // when
@@ -296,11 +335,12 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
                 name: MISSING_VALUE,
                 creatorId: MISSING_VALUE,
                 organizationId: MISSING_VALUE,
+                multipleSendings: MISSING_VALUE,
               });
               expect.fail('should have thrown an error');
             } catch (entityValidationErrors) {
               // then
-              expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(3);
+              expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(4);
             }
           });
 
@@ -313,6 +353,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
                 type: MISSING_VALUE,
                 title: MISSING_VALUE,
                 idPixLabel: MISSING_VALUE,
+                multipleSendings: MISSING_VALUE,
                 organizationId: 1,
               };
 
@@ -322,7 +363,7 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
                 expect.fail('should have thrown an error');
               } catch (entityValidationErrors) {
                 // then
-                expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(3);
+                expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(4);
               }
             });
           });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-details-management-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-details-management-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | campaign-details-management-serializer',
         totalParticipationsCount: 10,
         isTypeProfilesCollection: false,
         isTypeAssessment: true,
+        multipleSendings: false,
       };
 
       // when
@@ -60,6 +61,7 @@ describe('Unit | Serializer | JSONAPI | campaign-details-management-serializer',
             'total-participations-count': campaignManagement.totalParticipationsCount,
             'is-type-profiles-collection': false,
             'is-type-assessment': true,
+            'multiple-sendings': campaignManagement.multipleSendings,
           },
         },
       });


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’ouverture  La campagne à envoie multiple  ’envoi multiple  Les organisations ne peuvent pas 

## :robot: Solution
permettre dans pix admin de basculer une campagne (collecte & évaluation) en envoi multiple SI ET SEULEMENT SI elle ne comporte pas de participation.

Lorsqu’un utilisateur édite une campagne dans pix admin (et si elle n’a pas de participation) on ajoute une case à cocher permettant d’activer l' “Envoi multiple”.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur pixAdmin , sélectionner une orga puis une campagne qui n'a pas de participations, constater que son statut d’envoi multiple est 'non'.
- Modifier cette campagne en le basculant en envoi multiple grâce à la checkbox dans la page d’édition d'une campagne.
- commencer une participation pour la même campagne puis essayer de modifier le status d’envoi multiple pour cette campagne, constater que la checkbox 'Envoie Multiple' n’existe plus car la campagne maintenant a des participations.