### PR TITLE
[BUGFIX] Les badges de tous les utilisateurs apparaissent sur les certificats (PIX-4548)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -155,8 +155,9 @@ async function _getAcquiredPartnerCertification(certificationCourseId) {
     .select('partnerKey', 'temporaryPartnerKey')
     .from('partner-certifications')
     .where({ certificationCourseId, acquired: true })
-    .whereIn('partnerKey', handledBadgeKeys)
-    .orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+    .where(function () {
+      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+    });
 
   return partnerCertifications;
 }

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -136,8 +136,9 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     .select('partnerKey', 'temporaryPartnerKey')
     .from('partner-certifications')
     .where({ certificationCourseId, acquired: true })
-    .whereIn('partnerKey', handledBadgeKeys)
-    .orWhereIn('temporaryPartnerKey', handledBadgeKeys)
+    .where(function () {
+      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+    })
     .orderBy('partnerKey');
 
   return _.compact(

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -112,10 +112,10 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     .select('partnerKey', 'temporaryPartnerKey')
     .from('partner-certifications')
     .where({ certificationCourseId, acquired: true })
-    .whereIn('partnerKey', handledBadgeKeys)
-    .orWhereIn('temporaryPartnerKey', handledBadgeKeys)
+    .where(function () {
+      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+    })
     .orderBy('partnerKey');
-
   return _.compact(
     _.map(results, ({ partnerKey, temporaryPartnerKey }) =>
       CertifiedBadgeImage.fromPartnerKey(partnerKey, temporaryPartnerKey)

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -409,7 +409,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
         // then
         expect(certificationAttestation.acquiredPartnerCertifications).to.deep.equals([
-          { partnerKey: PIX_DROIT_EXPERT_CERTIF },
+          { partnerKey: PIX_DROIT_EXPERT_CERTIF, temporaryPartnerKey: null },
         ]);
       });
     });

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -400,7 +400,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
-          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
+          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, 'should_be_ignored'],
           notAcquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
         });
 
@@ -497,8 +497,15 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
       const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData,
-        acquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
+        acquiredBadges: [PIX_DROIT_MAITRE_CERTIF, 'should_be_ignored'],
         notAcquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
+      });
+
+      await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
+        privateCertificateData: {},
+        acquiredBadges: [],
+        notAcquiredBadges: [],
+        temporaryAcquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
       });
 
       // when
@@ -546,7 +553,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
       const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData,
-        acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF],
+        acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF, 'should_be_ignored'],
         notAcquiredBadges: [],
       });
 
@@ -596,7 +603,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
       const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData,
         temporaryAcquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
-        acquiredBadges: [],
+        acquiredBadges: ['should_be_ignored'],
         notAcquiredBadges: [],
       });
 
@@ -911,7 +918,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     createdAt: new Date('2021-01-01'),
   });
 
-  [...acquiredBadges, 'should_be_ignored'].forEach((badgeKey) => {
+  acquiredBadges?.forEach((badgeKey) => {
     databaseBuilder.factory.buildBadge({ key: badgeKey });
     databaseBuilder.factory.buildPartnerCertification({
       certificationCourseId: certificateId,

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -15,7 +15,6 @@ const {
   PIX_DROIT_EXPERT_CERTIF,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
 } = require('../../../../lib/domain/models/Badge').keys;
-const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | Shareable Certificate', function () {
   const minimalLearningContent = [
@@ -508,8 +507,8 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           ...shareableCertificateData,
         });
 
-        expect(_.omit(shareableCertificate, ['resultCompetenceTree'])).to.deep.equal(
-          _.omit(expectedShareableCertificate, ['resultCompetenceTree'])
+        expect(shareableCertificate.certifiedBadgeImages).to.deep.equal(
+          expectedShareableCertificate.certifiedBadgeImages
         );
       });
 
@@ -545,6 +544,15 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
           notAcquiredBadges: [],
         });
+
+        const otherCertificateId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildBadge({ key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE });
+        databaseBuilder.factory.buildPartnerCertification({
+          certificationCourseId: otherCertificateId,
+          temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          acquired: true,
+        });
+        await databaseBuilder.commit();
 
         // when
         const shareableCertificate = await shareableCertificateRepository.getByVerificationCode('P-SOMECODE');


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on affiche un certificat (private, shared, pdf), on a plusieurs macarons affichés alors qu'un seul ne correspond à la certification affiché.

Cela est dû à une précédence d'opérateur SQL via knex [OrWhereIn](https://knexjs.org/#Builder-whereIn)

Avant la correction
``` js
    .whereIn('partnerKey', handledBadgeKeys)
    .orWhereIn('temporaryPartnerKey', handledBadgeKeys)
```
génère
```sql
select "partnerKey", "temporaryPartnerKey" from "partner-certifications" 
where "certificationCourseId" = $1 and "acquired" = $2 
and "partnerKey" in ($3, $4, $5, $6, $7, $8, $9) 
or "temporaryPartnerKey" in ($10, $11, $12, $13, $14, $15, $16)
```

Après la correction
```js
    .where(function () {
      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
    })
```
génère
```sql
select "partnerKey", "temporaryPartnerKey" from "partner-certifications" 
where "certificationCourseId" = $1 and "acquired" = $2 and  (
   "partnerKey" in ($3, $4, $5, $6, $7, $8, $9) 
	or "temporaryPartnerKey" in ($10, $11, $12, $13, $14, $15, $16)
)
```

## :robot: Solution
N'afficher que le macaron associé

## :rainbow: Remarques
Problème de parenthèses sur une query

## :100: Pour tester
### Affichage une seule certification hors Pix+Edu
 Passer une certification pix+ droit, par exemple: utilisateur `certifdroit@example.net`
```sql
SELECT
      u.email user_email
     ,pc."partnerKey"
     ,pc."temporaryPartnerKey"
     ,pc.acquired
FROM "certification-courses" cc
    INNER JOIN "partner-certifications" pc ON pc."certificationCourseId" = cc.id
    INNER JOIN users u ON u.id = cc."userId"
    INNER JOIN sessions s on cc."sessionId" = s.id
WHERE u.email = 'certifdroit@example.net';
```

Vérifier que seule la certification Droit est affichée

### Affichage une certification Pix+Edu
Etapes:
- Passer une certification pix+ edu avec `certifedu.initiale@example.net`
- Publier la certification de anne-certif-edu 
- S'assurer que sur les 3 certificats (private, shared, pdf), on a uniquement le macaron pix edu
