### PR TITLE
[FEATURE] Ne pas pouvoir repasser son parcours si la participation a été supprimée (PIX-4442).

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -280,6 +280,7 @@ __Plus d'infos :)__
     customLandingPageText: null,
     idPixLabel: null,
     createdAt: new Date('2020-01-07'),
+    multipleSendings: true,
   });
 
   databaseBuilder.factory.buildCampaign({
@@ -332,7 +333,8 @@ function _buildUsers({ databaseBuilder, users }) {
 }
 
 function _buildParticipationsInDifferentStatus({ databaseBuilder, user }) {
-  participateToAssessmentCampaign({ databaseBuilder, campaignId: 22, user, schoolingRegistrationId: user.id, status: STARTED, deleted: true }); //deleted
+  participateToAssessmentCampaign({ databaseBuilder, campaignId: 22, user, schoolingRegistrationId: user.id, status: STARTED, deleted: true }); //deleted + started
+  participateToAssessmentCampaign({ databaseBuilder, campaignId: 21, user, schoolingRegistrationId: user.id, status: SHARED, deleted: true }); //deleted + shared
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 2, user, schoolingRegistrationId: user.id, status: STARTED }); //started
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 12, user, schoolingRegistrationId: user.id, status: TO_SHARE }); //to share
   participateToAssessmentCampaign({ databaseBuilder, campaignId: 13, user, schoolingRegistrationId: user.id, status: SHARED });//archived + shared

--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -69,7 +69,12 @@ class CampaignParticipant {
         `User ${this.userIdentity.id} has already a campaign participation with campaign ${this.campaignToStartParticipation.id}`
       );
     }
-    if (this.previousCampaignParticipation && this.previousCampaignParticipation.status !== 'SHARED') {
+
+    if (this.previousCampaignParticipation?.isDeleted) {
+      throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
+    }
+
+    if (['STARTED', 'TO_SHARE'].includes(this.previousCampaignParticipation?.status)) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
     }
     if (this._canImproveResults()) {

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -34,8 +34,8 @@ class AssessmentResult {
       this.reachedStage = new ReachedStage(this.masteryRate, targetProfile.stages);
     }
     this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt);
-    this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive);
     this.isDisabled = this._computeIsDisabled(isCampaignArchived, participationResults.isDeleted);
+    this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive);
   }
 
   _computeMasteryRate(masteryRate) {
@@ -65,7 +65,8 @@ class AssessmentResult {
       isCampaignMultipleSendings &&
       this._timeBeforeRetryingPassed(sharedAt) &&
       this.masteryRate < constants.MAX_MASTERY_RATE &&
-      isRegistrationActive
+      isRegistrationActive &&
+      !this.isDisabled
     );
   }
 

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -24,7 +24,12 @@ class AssessmentResult {
     this.totalSkillsCount = competences.flatMap(({ skillIds }) => skillIds).length;
     this.testedSkillsCount = knowledgeElements.length;
     this.validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
-    this.masteryRate = this._computeMasteryRate(participationResults.masteryRate);
+    this.masteryRate = this._computeMasteryRate(
+      participationResults.masteryRate,
+      this.isShared,
+      this.totalSkillsCount,
+      this.validatedSkillsCount
+    );
 
     this.competenceResults = competences.map((competence) => _buildCompetenceResults(competence, knowledgeElements));
     this.badgeResults = targetProfile.badges.map((badge) => new BadgeResult(badge, participationResults));
@@ -33,23 +38,29 @@ class AssessmentResult {
     if (targetProfile.stages.length > 0) {
       this.reachedStage = new ReachedStage(this.masteryRate, targetProfile.stages);
     }
-    this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt);
+    this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt, this.isShared);
     this.isDisabled = this._computeIsDisabled(isCampaignArchived, participationResults.isDeleted);
-    this.canRetry = this._computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive);
+    this.canRetry = this._computeCanRetry(
+      isCampaignMultipleSendings,
+      sharedAt,
+      isRegistrationActive,
+      this.masteryRate,
+      this.isDisabled
+    );
   }
 
-  _computeMasteryRate(masteryRate) {
-    if (this.isShared) {
+  _computeMasteryRate(masteryRate, isShared, totalSkillsCount, validatedSkillsCount) {
+    if (isShared) {
       return masteryRate;
-    } else if (this.totalSkillsCount > 0) {
-      const rate = (this.validatedSkillsCount / this.totalSkillsCount).toPrecision(2);
+    } else if (totalSkillsCount > 0) {
+      const rate = (validatedSkillsCount / totalSkillsCount).toPrecision(2);
       return parseFloat(rate);
     } else {
       return 0;
     }
   }
 
-  _computeCanImprove(knowledgeElements, assessmentCreatedAt) {
+  _computeCanImprove(knowledgeElements, assessmentCreatedAt, isShared) {
     const isImprovementPossible =
       knowledgeElements.filter((knowledgeElement) => {
         const isOldEnoughToBeImproved =
@@ -57,16 +68,16 @@ class AssessmentResult {
           constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
         return knowledgeElement.isInvalidated && isOldEnoughToBeImproved;
       }).length > 0;
-    return isImprovementPossible && !this.isShared;
+    return isImprovementPossible && !isShared;
   }
 
-  _computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive) {
+  _computeCanRetry(isCampaignMultipleSendings, sharedAt, isRegistrationActive, masteryRate, isDisabled) {
     return (
       isCampaignMultipleSendings &&
       this._timeBeforeRetryingPassed(sharedAt) &&
-      this.masteryRate < constants.MAX_MASTERY_RATE &&
+      masteryRate < constants.MAX_MASTERY_RATE &&
       isRegistrationActive &&
-      !this.isDisabled
+      !isDisabled
     );
   }
 
@@ -75,7 +86,8 @@ class AssessmentResult {
   }
 
   _timeBeforeRetryingPassed(sharedAt) {
-    if (!this.isShared) return false;
+    const isShared = Boolean(sharedAt);
+    if (!isShared) return false;
     return sharedAt && moment().diff(sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -481,9 +481,14 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           participantExternalId: 'something',
           validatedSkillsCount: 1,
           status: 'SHARED',
+          isDeleted: true,
         };
         databaseBuilder.factory.buildCampaignParticipation({
-          ...expectedAttributes,
+          id: 10,
+          participantExternalId: 'something',
+          validatedSkillsCount: 1,
+          status: 'SHARED',
+          deletedAt: new Date(),
           userId,
           campaignId: campaignToStartParticipation.id,
         });
@@ -499,6 +504,28 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         });
 
         expect(campaignParticipant.previousCampaignParticipation).to.deep.equal(expectedAttributes);
+      });
+    });
+
+    context('when there is no previous campaign participation', function () {
+      it('return null', async function () {
+        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({
+          organizationId,
+          idPixLabel: 'externalId',
+        });
+        const { id: userId } = databaseBuilder.factory.buildUser();
+
+        await databaseBuilder.commit();
+
+        const campaignParticipant = await DomainTransaction.execute(async (domainTransaction) => {
+          return campaignParticipantRepository.get({
+            userId,
+            campaignId: campaignToStartParticipation.id,
+            domainTransaction,
+          });
+        });
+
+        expect(campaignParticipant.previousCampaignParticipation).to.be.null;
       });
     });
 

--- a/api/tests/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipant_test.js
@@ -376,6 +376,27 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           `User ${userIdentity.id} has already a campaign participation with campaign ${campaignToStartParticipation.id}`
         );
       });
+
+      it('throws a ForbiddenAccess exception when the previous participation is deleted', async function () {
+        const userIdentity = { id: 1 };
+        const campaignToStartParticipation = domainBuilder.buildCampaignToStartParticipation({
+          multipleSendings: true,
+          idPixLabel: null,
+        });
+
+        const campaignParticipant = new CampaignParticipant({
+          campaignToStartParticipation,
+          userIdentity,
+          previousCampaignParticipation: {
+            status: 'SHARED',
+            isDeleted: true,
+          },
+        });
+        const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
+
+        expect(error).to.be.an.instanceof(ForbiddenAccess);
+        expect(error.message).to.equal('Vous ne pouvez pas repasser la campagne');
+      });
     });
 
     it('throws a ForbiddenAccess exception when the campaign is archived', async function () {

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -289,18 +289,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       it('returns false', function () {
         const isCampaignMultipleSendings = false;
         const isRegistrationActive = true;
+        const isCampaignArchived = false;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
           masteryRate: '0.34',
           sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
         const assessmentResult = new AssessmentResult(
           participationResults,
           targetProfile,
           isCampaignMultipleSendings,
-          isRegistrationActive
+          isRegistrationActive,
+          isCampaignArchived
         );
 
         expect(assessmentResult.canRetry).to.be.false;
@@ -311,18 +314,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       it('returns false', function () {
         const isCampaignMultipleSendings = true;
         const isRegistrationActive = false;
+        const isCampaignArchived = false;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
           masteryRate: '0.34',
           sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
         const assessmentResult = new AssessmentResult(
           participationResults,
           targetProfile,
           isCampaignMultipleSendings,
-          isRegistrationActive
+          isRegistrationActive,
+          isCampaignArchived
         );
 
         expect(assessmentResult.canRetry).to.be.false;
@@ -333,18 +339,71 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       it('returns false', function () {
         const isCampaignMultipleSendings = true;
         const isRegistrationActive = true;
+        const isCampaignArchived = false;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
           masteryRate: '0.34',
           sharedAt: null,
+          isDeleted: false,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
         const assessmentResult = new AssessmentResult(
           participationResults,
           targetProfile,
           isCampaignMultipleSendings,
-          isRegistrationActive
+          isRegistrationActive,
+          isCampaignArchived
+        );
+
+        expect(assessmentResult.canRetry).to.be.false;
+      });
+    });
+
+    context('when the participation is deleted', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isRegistrationActive = true;
+        const isCampaignArchived = false;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: true,
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(
+          participationResults,
+          targetProfile,
+          isCampaignMultipleSendings,
+          isRegistrationActive,
+          isCampaignArchived
+        );
+
+        expect(assessmentResult.canRetry).to.be.false;
+      });
+    });
+
+    context('when campaign is archived', function () {
+      it('returns false', function () {
+        const isCampaignMultipleSendings = true;
+        const isRegistrationActive = true;
+        const isCampaignArchived = true;
+        const participationResults = {
+          knowledgeElements: [],
+          acquiredBadgeIds: [],
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
+        };
+        const targetProfile = { competences: [], stages: [], badges: [] };
+        const assessmentResult = new AssessmentResult(
+          participationResults,
+          targetProfile,
+          isCampaignMultipleSendings,
+          isRegistrationActive,
+          isCampaignArchived
         );
 
         expect(assessmentResult.canRetry).to.be.false;
@@ -357,18 +416,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         it('returns false', function () {
           const isCampaignMultipleSendings = true;
           const isRegistrationActive = true;
+          const isCampaignArchived = false;
           const participationResults = {
             knowledgeElements: [],
             acquiredBadgeIds: [],
             masteryRate: '0.34',
             sharedAt: new Date('2020-01-03T05:06:07Z'),
+            isDeleted: false,
           };
           const targetProfile = { competences: [], stages: [], badges: [] };
           const assessmentResult = new AssessmentResult(
             participationResults,
             targetProfile,
             isCampaignMultipleSendings,
-            isRegistrationActive
+            isRegistrationActive,
+            isCampaignArchived
           );
 
           expect(assessmentResult.canRetry).to.be.false;
@@ -380,11 +442,13 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       it('returns false', function () {
         const isCampaignMultipleSendings = true;
         const isRegistrationActive = true;
+        const isCampaignArchived = false;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
           masteryRate: '1',
           sharedAt: new Date('2020-01-01T05:06:07Z'),
+          isDeleted: false,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
 
@@ -392,7 +456,8 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           participationResults,
           targetProfile,
           isCampaignMultipleSendings,
-          isRegistrationActive
+          isRegistrationActive,
+          isCampaignArchived
         );
 
         expect(assessmentResult.canRetry).to.be.false;
@@ -405,18 +470,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         it('returns true', function () {
           const isCampaignMultipleSendings = true;
           const isRegistrationActive = true;
+          const isCampaignArchived = false;
           const participationResults = {
             knowledgeElements: [],
             acquiredBadgeIds: [],
             masteryRate: '0.45',
             sharedAt: new Date('2019-12-12'),
+            isDeleted: false,
           };
           const targetProfile = { competences: [], stages: [], badges: [] };
           const assessmentResult = new AssessmentResult(
             participationResults,
             targetProfile,
             isCampaignMultipleSendings,
-            isRegistrationActive
+            isRegistrationActive,
+            isCampaignArchived
           );
 
           expect(assessmentResult.canRetry).to.be.true;
@@ -430,18 +498,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         it('returns true', function () {
           const isCampaignMultipleSendings = true;
           const isRegistrationActive = true;
+          const isCampaignArchived = false;
           const participationResults = {
             knowledgeElements: [],
             acquiredBadgeIds: [],
             masteryRate: '0.34',
             sharedAt: new Date('2020-01-01T05:06:07Z'),
+            isDeleted: false,
           };
           const targetProfile = { competences: [], stages: [], badges: [] };
           const assessmentResult = new AssessmentResult(
             participationResults,
             targetProfile,
             isCampaignMultipleSendings,
-            isRegistrationActive
+            isRegistrationActive,
+            isCampaignArchived
           );
 
           expect(assessmentResult.canRetry).to.be.true;

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -271,13 +271,11 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
   });
 
   describe('#canRetry', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
-    const now = new Date('2020-01-05T05:06:07Z');
-    let clock;
+    let clock, originalConstantValue, now;
 
     beforeEach(function () {
+      originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+      now = new Date('2020-01-05T05:06:07Z');
       clock = sinon.useFakeTimers(now);
       constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = 4;
     });
@@ -289,14 +287,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
     context('when the campaign does not allow multiple sendings', function () {
       it('returns false', function () {
+        const isCampaignMultipleSendings = false;
+        const isRegistrationActive = true;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
-          sharedAt: new Date('2020-01-04'),
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
-
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+        const assessmentResult = new AssessmentResult(
+          participationResults,
+          targetProfile,
+          isCampaignMultipleSendings,
+          isRegistrationActive
+        );
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -305,18 +310,19 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     context('when participant is disabled', function () {
       it('returns false', function () {
         const isCampaignMultipleSendings = true;
+        const isRegistrationActive = false;
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
-          sharedAt: new Date('2020-01-04'),
+          masteryRate: '0.34',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
-
         const assessmentResult = new AssessmentResult(
           participationResults,
           targetProfile,
           isCampaignMultipleSendings,
-          false
+          isRegistrationActive
         );
 
         expect(assessmentResult.canRetry).to.be.false;
@@ -330,10 +336,10 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         const participationResults = {
           knowledgeElements: [],
           acquiredBadgeIds: [],
+          masteryRate: '0.34',
           sharedAt: null,
         };
         const targetProfile = { competences: [], stages: [], badges: [] };
-
         const assessmentResult = new AssessmentResult(
           participationResults,
           targetProfile,
@@ -350,18 +356,19 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       function () {
         it('returns false', function () {
           const isCampaignMultipleSendings = true;
+          const isRegistrationActive = true;
           const participationResults = {
             knowledgeElements: [],
             acquiredBadgeIds: [],
-            sharedAt: new Date('2020-01-01T04:06:07Z'),
+            masteryRate: '0.34',
+            sharedAt: new Date('2020-01-03T05:06:07Z'),
           };
           const targetProfile = { competences: [], stages: [], badges: [] };
-
           const assessmentResult = new AssessmentResult(
             participationResults,
             targetProfile,
             isCampaignMultipleSendings,
-            false
+            isRegistrationActive
           );
 
           expect(assessmentResult.canRetry).to.be.false;
@@ -372,24 +379,20 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     context('when the mastery rate equals to 1', function () {
       it('returns false', function () {
         const isCampaignMultipleSendings = true;
-        const competences = [
-          { id: 'rec1', name: 'C1', index: '1.1', areaName: 'Domaine1', areaColor: 'Couleur1', skillIds: ['skill1'] },
-        ];
-        const knowledgeElements = [
-          domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.VALIDATED }),
-        ];
+        const isRegistrationActive = true;
         const participationResults = {
-          knowledgeElements,
+          knowledgeElements: [],
           acquiredBadgeIds: [],
-          sharedAt: new Date('2020-01-01'),
+          masteryRate: '1',
+          sharedAt: new Date('2020-01-01T05:06:07Z'),
         };
-        const targetProfile = { competences, stages: [], badges: [] };
+        const targetProfile = { competences: [], stages: [], badges: [] };
 
         const assessmentResult = new AssessmentResult(
           participationResults,
           targetProfile,
           isCampaignMultipleSendings,
-          false
+          isRegistrationActive
         );
 
         expect(assessmentResult.canRetry).to.be.false;
@@ -402,23 +405,13 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         it('returns true', function () {
           const isCampaignMultipleSendings = true;
           const isRegistrationActive = true;
-          const competences = [
-            {
-              id: 'rec1',
-              name: 'C1',
-              index: '1.1',
-              areaName: 'Domaine1',
-              areaColor: 'Couleur1',
-              skillIds: ['skill1', 'skill2', 'skill3'],
-            },
-          ];
           const participationResults = {
             knowledgeElements: [],
             acquiredBadgeIds: [],
             masteryRate: '0.45',
             sharedAt: new Date('2019-12-12'),
           };
-          const targetProfile = { competences, stages: [], badges: [] };
+          const targetProfile = { competences: [], stages: [], badges: [] };
           const assessmentResult = new AssessmentResult(
             participationResults,
             targetProfile,
@@ -437,23 +430,13 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         it('returns true', function () {
           const isCampaignMultipleSendings = true;
           const isRegistrationActive = true;
-          const competences = [
-            {
-              id: 'rec1',
-              name: 'C1',
-              index: '1.1',
-              areaName: 'Domaine1',
-              areaColor: 'Couleur1',
-              skillIds: ['skill1', 'skill2', 'skill3'],
-            },
-          ];
           const participationResults = {
             knowledgeElements: [],
             acquiredBadgeIds: [],
             masteryRate: '0.34',
             sharedAt: new Date('2020-01-01T05:06:07Z'),
           };
-          const targetProfile = { competences, stages: [], badges: [] };
+          const targetProfile = { competences: [], stages: [], badges: [] };
           const assessmentResult = new AssessmentResult(
             participationResults,
             targetProfile,

--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -32,7 +32,7 @@
         {{/if}}
       {{else}}
         <p class="campaign-participation-overview-card-content--archived">
-          {{t "pages.campaign-participation-overview.card.text-archived" htmlSafe=true}}
+          {{t "pages.campaign-participation-overview.card.text-disabled" htmlSafe=true}}
         </p>
       {{/if}}
     </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -2,7 +2,7 @@
   <AssessmentBanner @title={{@model.campaign.title}} @displayHomeLink={{false}} />
 </div>
 
-{{#if @model.campaignParticipationResult.isDisabled}}
+{{#if this.showDisabledBlock}}
   <PixBlock class="skill-review__result-abstract-container">
     <div class="skill-review__disabled-share">
       <img

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -31,6 +31,10 @@ export default class SkillReview extends Component {
     return this._isCleaBadgeAcquired && this.acquiredBadges.length === 1;
   }
 
+  get showDisabledBlock() {
+    return this.args.model.campaignParticipationResult.isDisabled && !this.isShared;
+  }
+
   get showBadges() {
     return this.orderedBadges.length > 0;
   }

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -512,11 +512,12 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
   });
 
   describe('The disabled block', function () {
-    context('when participation is disabled', function () {
+    context('when participation is disabled and not shared', function () {
       beforeEach(async function () {
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           isDisabled: true,
+          isShared: false,
         };
         this.set('model', { campaign, campaignParticipationResult });
 
@@ -530,11 +531,12 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       });
     });
 
-    context('when participation is not disabled', function () {
+    context('when participation is disabled but already shared', function () {
       beforeEach(async function () {
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
-          isDisabled: false,
+          isDisabled: true,
+          isShared: true,
         };
         this.set('model', { campaign, campaignParticipationResult });
 
@@ -544,7 +546,26 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
       it('should not display disabled block', function () {
         // Then
-        expect(contains("Ce parcours a été désactivé par l'organisateur.")).to.not.exist;
+        expect(contains('Merci, vos résultats ont bien été envoyés !')).to.exist;
+      });
+    });
+
+    context('when participation is not disabled', function () {
+      beforeEach(async function () {
+        const campaignParticipationResult = {
+          campaignParticipationBadges: [],
+          isDisabled: false,
+          isShared: false,
+        };
+        this.set('model', { campaign, campaignParticipationResult });
+
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      });
+
+      it('should not display disabled block', function () {
+        // Then
+        expect(contains("J'envoie mes résultats")).to.exist;
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -160,12 +160,12 @@
         "stages": "{count} { count, plural, =0 {star} =1 {star} other {stars} } out of {total}",
         "started-at": "Started the {date}",
         "tag": {
-          "disabled": "Disabled",
+          "disabled": "Inactive",
           "completed": "To be submitted",
           "finished": "Finished",
           "started": "In progress"
         },
-        "text-archived": "Your customised test has been disabled by your organisation.'<br>'Your results could not be submitted."
+        "text-disabled": "This customised test has been deactivated by your organisation.'<br>'It is no longer possible to submit your results."
       }
     },
     "certificate": {
@@ -1231,7 +1231,7 @@
         "result-by-skill": "Your results for the competence",
         "percentage": "{rate, number, ::percent}"
       },
-      "disabled-share": "This customised test has been disabled by the organiser.'<br>' It is no longer possible to submit results.",
+      "disabled-share": "This customised test has been deactivated by the organiser.'<br>'It is no longer possible to submit results.",
       "error": "Oops, an error occurred!",
       "improve": {
         "title": "Want to improve your results?",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -165,7 +165,7 @@
           "finished": "Terminé",
           "started": "En cours"
         },
-        "text-archived": "Parcours désactivé par votre organisation.'<br>'Vous ne pouvez plus envoyer vos résultats."
+        "text-disabled": "Parcours désactivé par votre organisation.'<br>'Vous ne pouvez plus envoyer vos résultats."
       }
     },
     "certificate": {
@@ -1231,7 +1231,7 @@
         "result-by-skill": "Votre résultat pour la compétence",
         "percentage": "{rate, number, ::percent}"
       },
-      "disabled-share": "Ce parcours a été désactivé par l'organisateur.'<br>' L'envoi des résultats n'est plus possible.",
+      "disabled-share": "Ce parcours a été désactivé par l'organisateur.'<br>'L'envoi des résultats n'est plus possible.",
       "error": "Oups, une erreur est survenue !",
       "improve": {
         "title": "Envie d'améliorer vos résultats ?",


### PR DESCRIPTION
## :unicorn: Problème
Nous sommes en train de mettre en place un mécanisme de suppression de la participation à la main du prescripteur. Avant de permettre cette suppression véritablement, il est nécéssaire de gérer tous les impacts.

## :robot: Solution
Pour une campagne d'évaluation, supprimer la possibilité de repasser son parcours.

## :rainbow: Remarques
- Certains tests ont été améliorés, ils ne testaient pas les bonnes choses ;
- les méthodes de AssessmentResults n'étaient pas pures, et selon l'ordre d'exécution, cela pouvait fonctionner ou non. En les rendant pures, on met en évidence ce dont chaque méthode a besoin et donc on peut établir un ordre correct d'exécution.

## :100: Pour tester
- Se connecter à Pix App en tant que jaune.attend@example.net
- taper le code campagne PRODROIT1
- vérifier qu'on ne peut pas repasser le parcours
