### PR TITLE
[FEATURE] Permettre d'archiver une organisation sur Pix Admin (PIX-3817).

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -21,4 +21,13 @@ export default class OrganizationAdapter extends ApplicationAdapter {
 
     return this.ajax(url, 'GET');
   }
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot?.adapterOptions?.archiveOrganization) {
+      const url = `${this.host}/${this.namespace}/admin/organizations/${snapshot.id}/archive`;
+      return this.ajax(url, 'POST');
+    }
+
+    return super.updateRecord(...arguments);
+  }
 }

--- a/admin/app/components/organizations/archiving-confirmation-modal.hbs
+++ b/admin/app/components/organizations/archiving-confirmation-modal.hbs
@@ -1,0 +1,35 @@
+<PixModal
+  @title="Archiver l'organisation {{@organizationName}}"
+  @onCloseButtonClick={{@toggleArchivingConfirmationModal}}
+>
+  <:content>
+    <p>
+      Êtes-vous sûr de vouloir archiver cette organisation ?
+    </p>
+    <ul class="archiving-confirmation-modal__list">
+      <li class="archiving-confirmation-modal__information">Les membres actifs vont être désactivés</li>
+      <li class="archiving-confirmation-modal__information">Les invitations en attente vont être annulées</li>
+      <li class="archiving-confirmation-modal__information">Les campagnes actives vont être archivées</li>
+      <li class="archiving-confirmation-modal__information">
+        Le rattachement et l'invitation de nouvelles personnes seront bloqués
+      </li>
+    </ul>
+    <p>
+      <strong>
+        Cette action est irréversible.
+      </strong>
+    </p>
+  </:content>
+
+  <:footer>
+    <PixButton
+      @size="small"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @triggerAction={{@toggleArchivingConfirmationModal}}
+    >Annuler</PixButton>
+    <PixButton @type="submit" @size="small" {{on "click" @archiveOrganization}}>
+      Confirmer
+    </PixButton>
+  </:footer>
+</PixModal>

--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -166,7 +166,7 @@
           </ul>
         {{/if}}
 
-        {{#if @organization.archivistFullName}}
+        {{#if @organization.isArchived}}
           <PixMessage class="organization-information-section__archived-message" @type="warning">
             Archivée le
             {{@organization.archivedFormattedDate}}
@@ -227,12 +227,25 @@
                 Non spécifié
               {{/if}}
             </p>
-            <PixButton
-              @backgroundColor="transparent-light"
-              @isBorderVisible={{true}}
-              @size="small"
-              @triggerAction={{this.toggleEditMode}}
-            >Editer</PixButton>
+            <div class="form-actions">
+              <PixButton
+                @backgroundColor="transparent-light"
+                @isBorderVisible={{true}}
+                @size="small"
+                @triggerAction={{this.toggleEditMode}}
+              >
+                Éditer
+              </PixButton>
+              {{#unless @organization.isArchived}}
+                <PixButton
+                  @backgroundColor="red"
+                  @size="small"
+                  @triggerAction={{this.toggleArchivingConfirmationModal}}
+                >
+                  Archiver l'organisation
+                </PixButton>
+              {{/unless}}
+            </div>
           </div>
           <div>
             <PixButtonLink
@@ -247,6 +260,14 @@
           </div>
         </div>
       </div>
+    {{/if}}
+
+    {{#if this.showArchivingConfirmationModal}}
+      <Organizations::ArchivingConfirmationModal
+        @organizationName={{@organization.name}}
+        @toggleArchivingConfirmationModal={{this.toggleArchivingConfirmationModal}}
+        @archiveOrganization={{this.archiveOrganization}}
+      />
     {{/if}}
   </div>
 </section>

--- a/admin/app/components/organizations/information-section.js
+++ b/admin/app/components/organizations/information-section.js
@@ -98,6 +98,7 @@ class Form extends Object.extend(Validations) {
 
 export default class OrganizationInformationSection extends Component {
   @tracked isEditMode = false;
+  @tracked showArchivingConfirmationModal = false;
 
   constructor() {
     super(...arguments);
@@ -121,6 +122,11 @@ export default class OrganizationInformationSection extends Component {
   toggleEditMode() {
     this.isEditMode = !this.isEditMode;
     this._initForm();
+  }
+
+  @action
+  toggleArchivingConfirmationModal() {
+    this.showArchivingConfirmationModal = !this.showArchivingConfirmationModal;
   }
 
   @action
@@ -149,6 +155,12 @@ export default class OrganizationInformationSection extends Component {
 
     this.isEditMode = false;
     return this.args.onSubmit();
+  }
+
+  @action
+  archiveOrganization() {
+    this.toggleArchivingConfirmationModal();
+    this.args.archiveOrganization();
   }
 
   _initForm() {

--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -1,9 +1,11 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
+import get from 'lodash/get';
 
 export default class GetController extends Controller {
   @service notifications;
+  @service router;
 
   @action
   updateOrganizationInformation() {
@@ -16,5 +18,21 @@ export default class GetController extends Controller {
         this.model.rollbackAttributes();
         this.notifications.error('Une erreur est survenue.');
       });
+  }
+
+  @action
+  async archiveOrganization() {
+    try {
+      await this.model.save({ adapterOptions: { archiveOrganization: true } });
+
+      this.notifications.success('Cette organisation a bien été archivée.');
+      this.router.transitionTo('authenticated.organizations.get');
+    } catch (responseError) {
+      const status = get(responseError, 'errors[0].status');
+      if (status === '422') {
+        return this.notifications.error("L'organisation n'a pas pu être archivée.");
+      }
+      this.notifications.error('Une erreur est survenue.');
+    }
   }
 }

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -37,6 +37,10 @@ export default class Organization extends Model {
     return dayjs(this.archivedAt).format('DD/MM/YYYY');
   }
 
+  get isArchived() {
+    return !!this.archivistFullName;
+  }
+
   attachTargetProfiles = memberAction({
     path: 'target-profiles',
     type: 'post',

--- a/admin/app/routes/authenticated/organizations/get/invitations.js
+++ b/admin/app/routes/authenticated/organizations/get/invitations.js
@@ -7,7 +7,7 @@ export default class InvitationsRoute extends Route {
 
   beforeModel() {
     const organization = this.modelFor('authenticated.organizations.get');
-    if (organization.get('archivistFullName')) {
+    if (organization.isArchived) {
       return this.router.replaceWith('authenticated.organizations.get.target-profiles');
     }
   }

--- a/admin/app/routes/authenticated/organizations/get/team.js
+++ b/admin/app/routes/authenticated/organizations/get/team.js
@@ -15,7 +15,7 @@ export default class OrganizationTeamRoute extends Route {
 
   beforeModel() {
     const organization = this.modelFor('authenticated.organizations.get');
-    if (organization.get('archivistFullName')) {
+    if (organization.isArchived) {
       return this.router.replaceWith('authenticated.organizations.get.target-profiles');
     }
   }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -51,6 +51,7 @@
 @import 'components/menu-bar';
 @import 'components/modal';
 @import 'components/organization-form';
+@import 'components/organizations/archiving-confirmation-modal';
 @import 'components/organization-information-section';
 @import 'components/organization-team-section';
 @import 'components/organization-invitations';

--- a/admin/app/styles/components/organizations/archiving-confirmation-modal.scss
+++ b/admin/app/styles/components/organizations/archiving-confirmation-modal.scss
@@ -1,0 +1,14 @@
+.pix-modal {
+
+  li.archiving-confirmation-modal__information {
+    list-style: disc;
+  }
+
+  ul.archiving-confirmation-modal__list {
+    margin: 0 0 10px 10px;
+  }
+
+  &__overlay {
+    z-index: 1000;
+  }
+}

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -12,11 +12,12 @@
     @organization={{@model}}
     @onLogoUpdated={{this.updateOrganizationInformation}}
     @onSubmit={{this.updateOrganizationInformation}}
+    @archiveOrganization={{this.archiveOrganization}}
   />
 
   <nav class="navbar">
 
-    {{#unless @model.archivistFullName}}
+    {{#unless @model.isArchived}}
       <LinkTo @route="authenticated.organizations.get.team" @model={{@model}} class="navbar-item">
         Équipe
       </LinkTo>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -18,7 +18,11 @@ import { createMembership } from './handlers/memberships';
 import { getBadge } from './handlers/badges';
 import { createStage } from './handlers/stages';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
-import { findPaginatedOrganizationMemberships, getOrganizationInvitations } from './handlers/organizations';
+import {
+  archiveOrganization,
+  findPaginatedOrganizationMemberships,
+  getOrganizationInvitations,
+} from './handlers/organizations';
 import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 
 export default function () {
@@ -346,4 +350,6 @@ export default function () {
   });
 
   this.put('/admin/target-profiles/:id/simplified-access', markTargetProfileAsSimplifiedAccess);
+
+  this.post('/admin/organizations/:id/archive', archiveOrganization);
 }

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -25,6 +25,13 @@ function findPaginatedOrganizationMemberships(schema, request) {
   return json;
 }
 
+function archiveOrganization(schema, request) {
+  const id = request.params.id;
+
+  const organization = schema.organizations.find(id);
+  return organization.update({ archivistFullName: 'Clément Tine', archivedAt: new Date('2022-02-02') });
+}
+
 function _getPaginationFromQueryParams(queryParams) {
   return {
     pageSize: parseInt(get(queryParams, 'page[size]', 10)),
@@ -39,4 +46,4 @@ function _applyPagination(memberships, { page, pageSize }) {
   return slice(memberships, start, end);
 }
 
-export { getOrganizationInvitations, findPaginatedOrganizationMemberships };
+export { archiveOrganization, getOrganizationInvitations, findPaginatedOrganizationMemberships };

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -143,7 +143,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // then
-      assert.contains('Editer');
+      assert.contains('Éditer');
     });
 
     test('it should toggle edition mode on click to edit button', async function (assert) {
@@ -151,7 +151,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
 
       // then
       assert.dom('.organization__edit-form').exists();
@@ -162,7 +162,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
 
       // then
       assert.dom('input#name').hasValue(organization.name);
@@ -180,7 +180,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#name', '');
 
       // then
@@ -192,7 +192,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#name', 'a'.repeat(256));
 
       // then
@@ -204,7 +204,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#externalId', 'a'.repeat(256));
 
       // then
@@ -216,7 +216,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#provinceCode', 'a'.repeat(256));
 
       // then
@@ -228,7 +228,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#email', 'a'.repeat(256));
 
       // then
@@ -240,7 +240,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#email', 'not-valid-email-format');
 
       // then
@@ -252,7 +252,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#credit', 'credit');
 
       // then
@@ -262,7 +262,7 @@ module('Integration | Component | organizations/information-section', function (
     test('it should toggle display mode on click to cancel button', async function (assert) {
       // given
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
 
       // when
       await clickByLabel('Annuler');
@@ -276,7 +276,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('#documentationUrl', 'not-valid-url-format');
 
       // then
@@ -287,7 +287,7 @@ module('Integration | Component | organizations/information-section', function (
       // given
       await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', 'new provinceCode');
@@ -313,7 +313,7 @@ module('Integration | Component | organizations/information-section', function (
       await render(
         hbs`<Organizations::InformationSection @organization={{this.organization}} @onSubmit={{this.onSubmit}} />`
       );
-      await clickByLabel('Editer');
+      await clickByLabel('Éditer');
 
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');

--- a/admin/tests/unit/controllers/authenticated/organizations/get_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get_test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/organizations/get', function (hooks) {
+  setupTest(hooks);
+
+  module('#archiveOrganization', function () {
+    test('it should update organization and redirect to get route', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated.organizations.get');
+      controller.router = { transitionTo: sinon.stub() };
+      controller.model = {
+        id: 3,
+        save: sinon.stub(),
+      };
+      controller.notifications = {
+        success: sinon.stub(),
+      };
+      controller.model.save.resolves();
+
+      // when
+      await controller.archiveOrganization();
+
+      // then
+      assert.ok(controller.model.save.called);
+      assert.true(controller.router.transitionTo.calledWith('authenticated.organizations.get'));
+    });
+  });
+});

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -5,15 +5,31 @@ import { run } from '@ember/runloop';
 module('Unit | Model | organization', function (hooks) {
   setupTest(hooks);
 
-  test('it formats the archived date', function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('organization', { archivedAt: new Date('2022-02-22') }));
+  module('#archivedFormattedDate', function () {
+    test('it formats the archived date', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = run(() => store.createRecord('organization', { archivedAt: new Date('2022-02-22') }));
 
-    // when
-    const archivedFormattedDate = model.archivedFormattedDate;
+      // when
+      const archivedFormattedDate = model.archivedFormattedDate;
 
-    // then
-    assert.strictEqual(archivedFormattedDate, '22/02/2022');
+      // then
+      assert.strictEqual(archivedFormattedDate, '22/02/2022');
+    });
+  });
+
+  module('#isArchived', function () {
+    test('it return whether organization is archived', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = run(() => store.createRecord('organization', { archivistFullName: 'Anne Héantie' }));
+
+      // when
+      const isOrganizationArchived = model.isArchived;
+
+      // then
+      assert.true(isOrganizationArchived);
+    });
   });
 });

--- a/admin/tests/unit/routes/authenticated/organizations/invitations_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/invitations_test.js
@@ -14,7 +14,7 @@ module('Unit | Route | authenticated/organizations/get/invitations', function (h
   module('#beforeModel', function () {
     test('it should transition to target-profiles route when organization is archived', async function (assert) {
       // given
-      const organization = EmberObject.create({ archivistFullName: 'Clément Tine' });
+      const organization = EmberObject.create({ isArchived: true });
       const route = this.owner.lookup('route:authenticated/organizations/get/invitations');
       sinon.stub(route.router, 'replaceWith');
       sinon.stub(route, 'modelFor').returns(organization);

--- a/admin/tests/unit/routes/authenticated/organizations/team_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/team_test.js
@@ -14,7 +14,7 @@ module('Unit | Route | authenticated/organizations/get/team', function (hooks) {
   module('#beforeModel', function () {
     test('it should transition to target-profiles route when organization is archived', async function (assert) {
       // given
-      const organization = EmberObject.create({ archivistFullName: 'Clément Tine' });
+      const organization = EmberObject.create({ isArchived: true });
       const route = this.owner.lookup('route:authenticated/organizations/get/team');
       sinon.stub(route.router, 'replaceWith');
       sinon.stub(route, 'modelFor').returns(organization);

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -66,6 +66,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.OrganizationArchivedError) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
+  if (error instanceof DomainErrors.MissingAttributesError) {
+    return new HttpErrors.UnprocessableEntityError(error.message);
+  }
   if (error instanceof DomainErrors.AuthenticationKeyForPoleEmploiTokenExpired) {
     return new HttpErrors.UnauthorizedError(error.message);
   }

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -86,8 +86,8 @@ exports.register = async (server) => {
       },
     },
     {
-      method: 'PUT',
-      path: '/api/admin/organizations/{id}/archived',
+      method: 'POST',
+      path: '/api/admin/organizations/{id}/archive',
       config: {
         pre: [
           {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -311,7 +311,8 @@ module.exports = {
 
   async archiveOrganization(request) {
     const organizationId = request.params.id;
-    await usecases.archiveOrganization({ organizationId });
-    return null;
+    const userId = extractUserIdFromRequest(request);
+    const archivedOrganization = await usecases.archiveOrganization({ organizationId, userId });
+    return organizationForAdminSerializer.serialize(archivedOrganization);
   },
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -646,6 +646,12 @@ class MissingOrInvalidCredentialsError extends DomainError {
   }
 }
 
+class MissingAttributesError extends DomainError {
+  constructor(message = 'Attributs manquants.') {
+    super(message);
+  }
+}
+
 class MissingAssessmentId extends DomainError {
   constructor(message = 'AssessmentId manquant ou incorrect') {
     super(message);
@@ -1150,6 +1156,7 @@ module.exports = {
   MembershipCreationError,
   MembershipUpdateError,
   MissingAssessmentId,
+  MissingAttributesError,
   MissingBadgeCriterionError,
   MissingOrInvalidCredentialsError,
   MultipleSchoolingRegistrationsWithDifferentNationalStudentIdError,

--- a/api/lib/domain/models/OrganizationToArchive.js
+++ b/api/lib/domain/models/OrganizationToArchive.js
@@ -5,10 +5,11 @@ class OrganizationToArchive {
     this.id = id;
   }
 
-  archive({ archiveDate = new Date() } = {}) {
+  archive({ archiveDate = new Date(), archivedBy } = {}) {
     this.previousInvitationStatus = OrganizationInvitation.StatusType.PENDING;
     this.newInvitationStatus = OrganizationInvitation.StatusType.CANCELLED;
     this.archiveDate = archiveDate;
+    this.archivedBy = archivedBy;
   }
 }
 

--- a/api/lib/domain/usecases/archive-organization.js
+++ b/api/lib/domain/usecases/archive-organization.js
@@ -1,7 +1,14 @@
 const OrganizationToArchive = require('../models/OrganizationToArchive');
 
-module.exports = async function archiveOrganization({ organizationId, organizationToArchiveRepository }) {
+module.exports = async function archiveOrganization({
+  organizationId,
+  userId,
+  organizationToArchiveRepository,
+  organizationForAdminRepository,
+}) {
   const organizationToArchive = new OrganizationToArchive({ id: organizationId });
-  organizationToArchive.archive();
+  organizationToArchive.archive({ archivedBy: userId });
   await organizationToArchiveRepository.save(organizationToArchive);
+
+  return await organizationForAdminRepository.get(organizationId);
 };

--- a/api/lib/infrastructure/repositories/organization-to-archive-repository.js
+++ b/api/lib/infrastructure/repositories/organization-to-archive-repository.js
@@ -1,21 +1,28 @@
 const { knex } = require('../../../db/knex-database-connection');
+const { MissingAttributesError } = require('../../domain/errors');
 
 module.exports = {
   async save(organizationToArchive) {
+    if (!organizationToArchive.archiveDate || !organizationToArchive.archivedBy) {
+      throw new MissingAttributesError();
+    }
+
     if (organizationToArchive.newInvitationStatus) {
       await knex('organization-invitations')
         .where({ organizationId: organizationToArchive.id, status: organizationToArchive.previousInvitationStatus })
         .update({ status: organizationToArchive.newInvitationStatus });
     }
 
-    if (organizationToArchive.archiveDate) {
-      await knex('campaigns')
-        .where({ organizationId: organizationToArchive.id, archivedAt: null })
-        .update({ archivedAt: organizationToArchive.archiveDate });
+    await knex('campaigns')
+      .where({ organizationId: organizationToArchive.id, archivedAt: null })
+      .update({ archivedAt: organizationToArchive.archiveDate });
 
-      await knex('memberships')
-        .where({ organizationId: organizationToArchive.id, disabledAt: null })
-        .update({ disabledAt: organizationToArchive.archiveDate });
-    }
+    await knex('memberships')
+      .where({ organizationId: organizationToArchive.id, disabledAt: null })
+      .update({ disabledAt: organizationToArchive.archiveDate });
+
+    await knex('organizations')
+      .where({ id: organizationToArchive.id, archivedBy: null })
+      .update({ archivedBy: organizationToArchive.archivedBy, archivedAt: organizationToArchive.archiveDate });
   },
 };

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1253,7 +1253,7 @@ describe('Acceptance | Application | organization-controller', function () {
     });
   });
 
-  describe('PUT /api/admin/organizations/{id}/archived', function () {
+  describe('POST /api/admin/organizations/{id}/archive', function () {
     it('should return the archived organization', async function () {
       // given
       const adminUser = databaseBuilder.factory.buildUser.withPixRolePixMaster();
@@ -1284,8 +1284,8 @@ describe('Acceptance | Application | organization-controller', function () {
 
       // when
       const response = await server.inject({
-        method: 'PUT',
-        url: `/api/admin/organizations/${organizationId}/archived`,
+        method: 'POST',
+        url: `/api/admin/organizations/${organizationId}/archive`,
         headers: { authorization: generateValidRequestAuthorizationHeader(adminUser.id) },
       });
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -777,6 +777,14 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
       expect(responseDetail(response)).to.equal("L'organisation est archivée.");
     });
+
+    it('responds UnprocessableEntityError when an MissingAttributes error occurs', async function () {
+      routeHandler.throws(new DomainErrors.MissingAttributesError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(UNPROCESSABLE_ENTITY_ERROR);
+      expect(responseDetail(response)).to.equal('Attributs manquants.');
+    });
   });
 
   context('should respond 401 Unauthorized', function () {

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -104,11 +104,11 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
-  describe('PUT /api/admin/organizations/:id/archived', function () {
+  describe('POST /api/admin/organizations/:id/archive', function () {
     it('should call the controller to archive the organization', async function () {
       // given
-      const method = 'PUT';
-      const url = '/api/admin/organizations/1/archived';
+      const method = 'POST';
+      const url = '/api/admin/organizations/1/archive';
 
       sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(organizationController, 'archiveOrganization').callsFake((request, h) => h.response('ok').code(204));

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1039,19 +1039,31 @@ describe('Unit | Application | Organizations | organization-controller', functio
   });
 
   describe('#archiveOrganization', function () {
-    it('should call the usecase to cancel all pending invitations', async function () {
+    it('should call the usecase to archive the organization with the user id', async function () {
       // given
       const organizationId = 1234;
-      const request = { params: { id: organizationId } };
+      const userId = 10;
+      const request = {
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+        params: { id: organizationId },
+      };
 
-      sinon.stub(usecases, 'archiveOrganization').resolves();
+      const archivedOrganization = Symbol('archivedOrganization');
+      const archivedOrganizationSerialized = Symbol('archivedOrganizationSerialized');
+      sinon.stub(usecases, 'archiveOrganization').resolves(archivedOrganization);
+      sinon
+        .stub(organizationForAdminSerializer, 'serialize')
+        .withArgs(archivedOrganization)
+        .returns(archivedOrganizationSerialized);
 
       // when
-      await organizationController.archiveOrganization(request, hFake);
+      const response = await organizationController.archiveOrganization(request, hFake);
 
       // then
-      expect(usecases.archiveOrganization).to.have.been.calledOnce;
-      expect(usecases.archiveOrganization).to.have.been.calledWith({ organizationId });
+      expect(usecases.archiveOrganization).to.have.been.calledOnceWithExactly({ organizationId, userId });
+      expect(response).to.deep.equal(archivedOrganizationSerialized);
     });
   });
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -503,6 +503,10 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.AlreadyAcceptedOrCancelledOrganizationInvitationError).to.exist;
   });
 
+  it('should export an MissingAttributesError', function () {
+    expect(errors.MissingAttributesError).to.exist;
+  });
+
   describe('CertificationCandidateAddError', function () {
     context('#fromInvalidCertificationCandidateError', function () {
       it('should return a CertificationCandidateAddError', function () {

--- a/api/tests/unit/domain/models/OrganizationToArchive_test.js
+++ b/api/tests/unit/domain/models/OrganizationToArchive_test.js
@@ -4,18 +4,19 @@ const OrganizationToArchive = require('../../../../lib/domain/models/Organizatio
 
 describe('Unit | Domain | Models | OrganizationToArchive', function () {
   describe('#archive', function () {
-    it('should set the invitation status and the archive date', function () {
+    it('should set the invitation status, the archive date and the user id', function () {
       // given
       const now = new Date('2022-02-22');
       const organizationToArchive = new OrganizationToArchive({ id: 1 });
 
       // when
-      organizationToArchive.archive({ archiveDate: now });
+      organizationToArchive.archive({ archiveDate: now, archivedBy: 2 });
 
       // then
       expect(organizationToArchive.previousInvitationStatus).to.equal(OrganizationInvitation.StatusType.PENDING);
       expect(organizationToArchive.newInvitationStatus).to.equal(OrganizationInvitation.StatusType.CANCELLED);
       expect(organizationToArchive.archiveDate).to.equal(now);
+      expect(organizationToArchive.archivedBy).to.equal(2);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/archive-organization_test.js
+++ b/api/tests/unit/domain/usecases/archive-organization_test.js
@@ -1,36 +1,44 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const archiveOrganization = require('../../../../lib/domain/usecases/archive-organization');
 const OrganizationToArchive = require('../../../../lib/domain/models/OrganizationToArchive');
 
 describe('Unit | UseCase | archive-organization', function () {
-  let organizationToArchiveRepository;
-
-  beforeEach(function () {
-    organizationToArchiveRepository = {
-      save: sinon.stub(),
-    };
-  });
-
   it('should archive the organization', async function () {
     // given
+    const organizationToArchiveRepository = {
+      save: sinon.stub(),
+    };
+    const organizationForAdminRepository = {
+      get: sinon.stub(),
+    };
     const now = new Date('2022-02-22');
     const clock = sinon.useFakeTimers(now);
     const organizationId = 1;
+    const pixMasterUser = domainBuilder.buildUser({
+      id: 123,
+    });
+    const expectOrganizationForAdmin = domainBuilder.buildOrganizationForAdmin({
+      archivedAt: now,
+    });
 
     organizationToArchiveRepository.save.resolves();
+    organizationForAdminRepository.get.resolves(expectOrganizationForAdmin);
 
     // when
-    await archiveOrganization({
+    const archivedOrganizationForAdmin = await archiveOrganization({
       organizationId,
+      userId: pixMasterUser.id,
       organizationToArchiveRepository,
+      organizationForAdminRepository,
     });
 
     // then
     const expectedOrganizationToArchive = new OrganizationToArchive({ id: organizationId });
-    expectedOrganizationToArchive.archive();
+    expectedOrganizationToArchive.archive({ archivedBy: pixMasterUser.id });
 
     expect(organizationToArchiveRepository.save).to.have.been.calledWith(expectedOrganizationToArchive);
-
+    expect(organizationForAdminRepository.get).to.have.been.calledWith(organizationId);
+    expect(archivedOrganizationForAdmin).to.deep.equal(expectOrganizationForAdmin);
     clock.restore();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Aujourd'hui, il n'existe pas de manière propre d'archiver une organisation. 
L'archivage est fait avec l'ajout d'un tag "obsolète". Or, les tags n'ont pas été conçus pour ce cas d'usage.
Les membres, les campagnes, les invitations sont parfois oubliés dans le process et restent actifs.

## :robot: Solution
Permettre de pouvoir archiver une organisation sur Pix Admin.

Dans ce ticket, on marque l'organisation comme archivée et on retourne les informations à Pix Admin. 
Les autres actions de cette archivage ont été fait dans des précédents tickets (voir remarque).

## :rainbow: Remarques

Cette fonctionnalité permet donc : 
- d'annuler les invitations à rejoindre une orga qui sont en attente
- de désactiver les membres de l'organisation
- d'archiver les campagnes de l'organisation
- de marquer l'organisation comme archivé
- de renseigner l'id de l'utilisateur qui à fait l'action

## :100: Pour tester
- Se connecter sur Pix Admin : 
- Aller dans la liste des organisations
- Cliquer sur une organisation au hasard,  qui n'est pas encore archivée
-  Dans la page de détails de cette organisation, cliquer sur le bouton "Archiver l'organisation"
- Cliquer sur confirmer à l'affichage de la pop-up
- Constater qu'une notification s'affiche confirmant l'action
- Constater le bandeau jaune en haut de la page, indiquant la date et l'utilisateur qui à fait l'action d'archivage.
- Constater que l'on a plus accès aux onglets "Equipe" et "Invitations" sur la page.
- Constater que les membres n'existent plus ( en bdd, vu qu'on à plus accès à la page sur Admin) et que les invitations sont cancelled
- Constater que les campagnes sont archivées.