### PR TITLE
[BUGFIX] Suppression d'un glitch au survol d'une carte de compétence (PIX-4550).

### DIFF
--- a/mon-pix/app/styles/components/_competence-card-default.scss
+++ b/mon-pix/app/styles/components/_competence-card-default.scss
@@ -118,7 +118,6 @@
   }
 
   .competence-card:hover {
-    top: -8px;
     box-shadow: $box-shadow-competence-cards-hover;
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on pointe la souris au bord inférieur d'une carte de compétence, un glitch fait que le bouton qui apparait ne fait que "sauter"

## :robot: Solution

Modification du style de la carte.

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur le tableau de bord ou sur la page compétences, vérifier que le glitch en question n'est plus une fois que l'on pointe la souris sur une carte en passant par le côté inférieur.
