### PR TITLE
[FEATURE] Ne prend plus en compte les parcours supprimés dans le bandeau de reprise (PIX-4439).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -41,6 +41,7 @@ module.exports = {
       .select('campaigns.code')
       .join('campaigns', 'campaigns.id', 'campaignId')
       .where({ userId })
+      .whereNull('deletedAt')
       .andWhere({ status: TO_SHARE })
       .andWhere({ 'campaigns.type': Campaign.types.PROFILES_COLLECTION })
       .orderBy('campaign-participations.createdAt', 'desc')

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -104,6 +104,26 @@ describe('Integration | Repository | Campaign Participation', function () {
       expect(code).to.equal(null);
     });
 
+    it('should return null if participations are deleted', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION' });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.TO_SHARE,
+        deletedAt: new Date(),
+        userId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const code = await campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(
+        userId
+      );
+
+      // then
+      expect(code).to.equal(null);
+    });
+
     it('should return null if there is no campaigns of type profiles collection', async function () {
       const campaign = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' });
       databaseBuilder.factory.buildCampaignParticipation({


### PR DESCRIPTION
## :unicorn: Problème
Avec l'ajout de la suppression des participations à une campagne certaines fonctionnalités doivent être améliorer pour prendre en compte cette suppression logique. Le bandeau de reprise de participations à des campagnes de collecte de profils s'affichent aussi pour les participations supprimées.

## :robot: Solution
Ajouter un filtre sur les colonnes deletedAt et deletedBy dans la requête qui récupère le code de la campagne à reprendre.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix App avec le compte userpix1
- Lancer la participation à la campagne PROCOLMUL sans partager ses résultats
- Aller sur le tableau de bord et constater la présence du bandeau de reprise
- Aller en base de donnée et valoriser les champs deletedAt et deletedBy pour la dernière participation
- Aller sur le tableau de bord et constater que le bandeau de reprise n'est plus présent
