### PR TITLE
[BUGFIX] Les signalements à ne pas résoudre sont affichés en haut de la liste dans Pix Admin (PIX-4495).

### DIFF
--- a/admin/app/components/certifications/list.js
+++ b/admin/app/components/certifications/list.js
@@ -25,8 +25,6 @@ export default class CertificationList extends Component {
         propertyName: 'numberOfCertificationIssueReportsWithRequiredActionLabel',
         title: 'Signalements impactants non résolus',
         className: 'certification-list-page__cell--important',
-        sortPrecedence: 1,
-        sortDirection: 'desc',
       },
       {
         propertyName: 'complementaryCertificationsLabel',

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -19,6 +19,12 @@ export default class ListController extends Controller {
     );
   }
 
+  get sortedCertificationJurySummaries() {
+    return this.model.juryCertificationSummaries
+      .sortBy('numberOfCertificationIssueReportsWithRequiredAction')
+      .reverse();
+  }
+
   @action
   displayCertificationStatusUpdateConfirmationModal() {
     const sessionIsPublished = this.model.isPublished;

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -35,7 +35,7 @@
 
     <div>
       <Certifications::List
-        @certifications={{this.model.juryCertificationSummaries}}
+        @certifications={{this.sortedCertificationJurySummaries}}
         @displayHasSeenEndTestScreenColumn={{this.model.displayHasSeenEndTestScreenColumn}}
       />
     </div>

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-admin",
-      "version": "3.180.0",
+      "version": "3.183.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/admin/tests/integration/components/certifications/list_test.js
+++ b/admin/tests/integration/components/certifications/list_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { findAll, find } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,37 +10,6 @@ module('Integration | Component | certifications/list', function (hooks) {
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
-  });
-
-  test('should display many certifications ordered by the most issues with required action count', async function (assert) {
-    // given
-    this.certifications = [
-      store.createRecord('jury-certification-summary', {
-        id: 1,
-        numberOfCertificationIssueReportsWithRequiredActionLabel: 1,
-      }),
-      store.createRecord('jury-certification-summary', {
-        id: 2,
-        numberOfCertificationIssueReportsWithRequiredActionLabel: 3,
-      }),
-      store.createRecord('jury-certification-summary', {
-        id: 3,
-        numberOfCertificationIssueReportsWithRequiredActionLabel: 2,
-      }),
-    ];
-
-    // when
-    await render(hbs`<Certifications::List @certifications={{certifications}} />`);
-
-    const tableRows = findAll('tbody > tr');
-    assert.strictEqual(tableRows.length, 3);
-    const firstRow = 'tbody > tr:nth-child(1)';
-    const unresolvedImpactfulIssuesColumn = 'td:nth-child(5)';
-    assert.strictEqual(find(firstRow + ' > ' + unresolvedImpactfulIssuesColumn).innerText, '3');
-    const secondRow = 'tbody > tr:nth-child(2)';
-    assert.strictEqual(find(secondRow + ' > ' + unresolvedImpactfulIssuesColumn).innerText, '2');
-    const thirdRow = 'tbody > tr:nth-child(3)';
-    assert.strictEqual(find(thirdRow + ' > ' + unresolvedImpactfulIssuesColumn).innerText, '1');
   });
 
   test('should display number of certification issue reports with required action', async function (assert) {

--- a/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
@@ -164,4 +164,37 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
       });
     });
   });
+
+  module('get sortedCertificationJurySummaries', function () {
+    test('should return jury certification summaries sorted by numberOfCertificationIssueReportsWithRequiredAction in descending order', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const firstJuryCertificationSummary = store.createRecord('jury-certification-summary', {
+        numberOfCertificationIssueReportsWithRequiredAction: 0,
+      });
+      const secondJuryCertificationSummary = store.createRecord('jury-certification-summary', {
+        numberOfCertificationIssueReportsWithRequiredAction: 3,
+      });
+      const thirdJuryCertificationSummary = store.createRecord('jury-certification-summary', {
+        numberOfCertificationIssueReportsWithRequiredAction: 1,
+      });
+      controller.set('model', {
+        juryCertificationSummaries: [
+          firstJuryCertificationSummary,
+          secondJuryCertificationSummary,
+          thirdJuryCertificationSummary,
+        ],
+      });
+
+      // when
+      const sortedCertificationJurySummaries = controller.sortedCertificationJurySummaries;
+
+      // then
+      assert.deepEqual(sortedCertificationJurySummaries, [
+        secondJuryCertificationSummary,
+        thirdJuryCertificationSummary,
+        firstJuryCertificationSummary,
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Une première correction avait été effectuée afin d'afficher en premier les certifications ayant le plus de signalements impactant  non résolus en premier. 

Cependant, la méthode utilisée voyait les certifications n'ayant aucun signalement impactant être placés en haut de la liste puis l'ordre était bon. 

Cela est dû au fait que l'on affiche une chaîne vide (et non 0) lorsqu'une certification n'a pas de signalement impactant et cette chaîne vide se voyait placée en premier par le trI. 

## :robot: Solution
Trier par nombre de signalement impactant non résolus, plutôt que par sa version labellisée.

## :100: Pour tester
Se connecter à Pix Admin, session 6  https://admin-pr4195.review.pix.fr/sessions/6/certifications

Vérifier que les certifications sont bien ordonnées par le plus grand nombre de signalement impactant non résolus

Impactants non résolus
```sql
SELECT
    r.id,
    u."firstName",
    u."lastName",
    r.category,
    r.description
FROM "certification-issue-reports" r
    INNER JOIN "certification-courses" c ON c.id = r."certificationCourseId"
    INNER JOIN "sessions" s ON s.id = c."sessionId"
    INNER JOIN users u ON u.id = c."userId"
WHERE 1=1
  AND r."resolvedAt" IS NULL
  AND ( r.category IN ('TECHNICAL_PROBLEM' ,'OTHER', 'FRAUD') OR r.subcategory IN ('NAME_OR_BIRTHDATE',
  'LEFT_EXAM_ROOM',
  'IMAGE_NOT_DISPLAYING',
  'EMBED_NOT_WORKING',
  'FILE_NOT_OPENING',
  'WEBSITE_UNAVAILABLE',
  'WEBSITE_BLOCKED',
  'LINK_NOT_WORKING',
  'OTHER',
  'EXTRA_TIME_EXCEEDED',
  'SOFTWARE_NOT_WORKING') );
```
