### PR TITLE
[TECH] Nettoyage des erreurs sur les fonctions vides.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -31,3 +31,4 @@ rules:
   mocha/no-pending-tests: error
   mocha/no-skipped-tests: error
   mocha/no-top-level-hooks: error
+  no-empty-function: warn

--- a/api/db/migrations/20180306151846_add_type_to_all_assessments.js
+++ b/api/db/migrations/20180306151846_add_type_to_all_assessments.js
@@ -83,4 +83,6 @@ exports.up = function (knex) {
     });
 };
 
-exports.down = function () {};
+exports.down = function () {
+  return;
+};

--- a/api/db/migrations/20180306164441_remove-score-and-level-for-bugged-assessments.js
+++ b/api/db/migrations/20180306164441_remove-score-and-level-for-bugged-assessments.js
@@ -20,4 +20,6 @@ exports.up = function (knex) {
     });
 };
 
-exports.down = function () {};
+exports.down = function () {
+  return;
+};

--- a/api/db/migrations/20210430154711_trim-certification-candidates-first-name-and-last-name.js
+++ b/api/db/migrations/20210430154711_trim-certification-candidates-first-name-and-last-name.js
@@ -8,4 +8,6 @@ exports.up = function (knex) {
   );
 };
 
-exports.down = function (_) {};
+exports.down = function () {
+  return;
+};

--- a/api/db/migrations/20210506112005_fill-missing-competence-id-values-in-table-competence-marks.js
+++ b/api/db/migrations/20210506112005_fill-missing-competence-id-values-in-table-competence-marks.js
@@ -52,4 +52,6 @@ exports.up = async function (knex) {
   });
 };
 
-exports.down = function (_) {};
+exports.down = function () {
+  return;
+};

--- a/api/db/migrations/20210713145931_set-default-target-profile-image.js
+++ b/api/db/migrations/20210713145931_set-default-target-profile-image.js
@@ -5,7 +5,9 @@ exports.up = async function (knex) {
   await updateWithDefaultImageUrl(knex);
 };
 
-exports.down = function () {};
+exports.down = function () {
+  return;
+};
 
 async function updateWithDefaultImageUrl(knex) {
   await knex(TABLE_NAME).whereNull('imageUrl').update({

--- a/api/db/migrations/20210916120235_update-badges-imageUrl-to-url-with-pix-domain.js
+++ b/api/db/migrations/20210916120235_update-badges-imageUrl-to-url-with-pix-domain.js
@@ -10,4 +10,6 @@ exports.up = function (knex) {
   );
 };
 
-exports.down = function () {};
+exports.down = function () {
+  return;
+};

--- a/api/db/migrations/20211123133135_resole-existing-certification-issue-reports.js
+++ b/api/db/migrations/20211123133135_resole-existing-certification-issue-reports.js
@@ -12,4 +12,6 @@ exports.up = async function (knex) {
                   )`);
 };
 
-exports.down = function () {};
+exports.down = function () {
+  return;
+};

--- a/api/lib/infrastructure/caches/InMemoryCache.js
+++ b/api/lib/infrastructure/caches/InMemoryCache.js
@@ -41,7 +41,9 @@ class InMemoryCache extends Cache {
 
   async _chainPromise(fn) {
     const queuedPromise = this._queue.then(fn);
-    this._queue = queuedPromise.catch(() => {});
+    this._queue = queuedPromise.catch(() => {
+      return;
+    });
     return queuedPromise;
   }
 

--- a/api/tests/integration/domain/usecases/abort-certification-course_test.js
+++ b/api/tests/integration/domain/usecases/abort-certification-course_test.js
@@ -3,8 +3,6 @@ const abortCertificationCourse = require('../../../../lib/domain/usecases/abort-
 const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 
 describe('Integration | UseCase | abort-certification-course', function () {
-  beforeEach(function () {});
-
   context('when abort reason is valid', function () {
     it('should update the certificationCourse with a reason', async function () {
       // given

--- a/api/tests/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
+++ b/api/tests/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
@@ -25,7 +25,9 @@ describe('SiecleFileStreamer', function () {
             streamer.perform,
             streamer
           )((saxStream, resolve) => {
-            saxStream.on('data', () => {});
+            saxStream.on('data', () => {
+              return;
+            });
             saxStream.on('end', resolve);
           });
 
@@ -55,7 +57,9 @@ describe('SiecleFileStreamer', function () {
             streamer.perform,
             streamer
           )((saxStream, resolve) => {
-            saxStream.on('data', () => {});
+            saxStream.on('data', () => {
+              return;
+            });
             saxStream.on('end', resolve);
           });
 
@@ -138,7 +142,9 @@ describe('SiecleFileStreamer', function () {
             streamer.perform,
             streamer
           )((saxStream, resolve) => {
-            saxStream.on('data', () => {});
+            saxStream.on('data', () => {
+              return;
+            });
             saxStream.on('end', resolve);
           });
 

--- a/api/tests/unit/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/unit/application/certification-candidates/certification-candidates-controller_test.js
@@ -66,8 +66,6 @@ describe('Unit | Controller | certifications-candidate-controller', function () 
 describe('#endAssessmentBySupervisor', function () {
   const certificationCandidateId = 2;
 
-  beforeEach(function () {});
-
   it('should call the endAssessmentBySupervisor use case', async function () {
     // given
     sinon.stub(usecases, 'endAssessmentBySupervisor');

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -224,7 +224,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -497,7 +499,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -555,7 +559,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const challengeWithoutEmbed = domainBuilder.buildChallenge({ embedUrl: null });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutEmbed),
@@ -777,7 +783,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -835,7 +843,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const challengeWithoutAttachment = domainBuilder.buildChallenge({ attachments: [] });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutAttachment),
@@ -1058,7 +1068,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -1116,7 +1128,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const notTimedChallenge = domainBuilder.buildChallenge({});
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const challengeRepository = {
           get: sinon.stub().resolves(notTimedChallenge),

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1439,7 +1439,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -1498,7 +1500,9 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const notFocusedChallenge = domainBuilder.buildChallenge({ focused: false });
         const certificationIssueReportRepository = {
-          save: () => {},
+          save: () => {
+            return;
+          },
         };
         const challengeRepository = {
           get: sinon.stub().resolves(notFocusedChallenge),

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -245,7 +245,9 @@ describe('Unit | Domain | Service | Token Service', function () {
       );
 
       // when
-      setTimeout(async () => {}, 100);
+      setTimeout(async () => {
+        return;
+      }, 100);
       const error = await catchErr(tokenService.extractSessionId)(invalidIdToken);
 
       // then
@@ -304,7 +306,9 @@ describe('Unit | Domain | Service | Token Service', function () {
       );
 
       // when
-      setTimeout(async () => {}, 100);
+      setTimeout(async () => {
+        return;
+      }, 100);
       const error = await catchErr(tokenService.extractResultRecipientEmailAndSessionId)(invalidIdToken);
 
       // then

--- a/api/tests/unit/domain/usecases/get-campaign-by-code_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-by-code_test.js
@@ -3,7 +3,11 @@ const usecases = require('../../../../lib/domain/usecases');
 
 describe('Unit | UseCase | get-campaign-by-code', function () {
   const code = 'QWERTY123';
-  const campaignToJoinRepository = { getByCode: () => {} };
+  const campaignToJoinRepository = {
+    getByCode: () => {
+      return;
+    },
+  };
 
   beforeEach(function () {
     sinon.stub(campaignToJoinRepository, 'getByCode');

--- a/api/tests/unit/infrastructure/caches/Cache_test.js
+++ b/api/tests/unit/infrastructure/caches/Cache_test.js
@@ -7,7 +7,9 @@ describe('Unit | Infrastructure | Caches | Cache', function () {
   describe('#get', function () {
     it('should reject an error (because this class actually mocks an interface)', function () {
       // when
-      const result = cacheInstance.get('some-key', () => {});
+      const result = cacheInstance.get('some-key', () => {
+        return;
+      });
 
       // then
       expect(result).to.be.rejected;

--- a/api/tests/unit/infrastructure/caches/RedisCache_test.js
+++ b/api/tests/unit/infrastructure/caches/RedisCache_test.js
@@ -13,7 +13,9 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
 
   beforeEach(function () {
     stubbedClient = {
-      lockDisposer: sinon.stub().resolves(() => {}),
+      lockDisposer: sinon.stub().resolves(() => {
+        return;
+      }),
     };
     sinon.stub(RedisCache, 'createClient').withArgs(REDIS_URL).returns(stubbedClient);
     redisCache = new RedisCache(REDIS_URL);
@@ -103,7 +105,9 @@ describe('Unit | Infrastructure | Cache | redis-cache', function () {
         it('should wait and retry to get the value from the cache', function () {
           // given
           stubbedClient.lockDisposer.rejects(new Redlock.LockError());
-          const handler = () => {};
+          const handler = () => {
+            return;
+          };
 
           // when
           const promise = redisCache.get(CACHE_KEY, handler);


### PR DESCRIPTION
## :unicorn: Problème
Remontée critique SonarQube : [Unexpected Empty Function](https://rules.sonarsource.com/javascript/RSPEC-1186)

## :robot: Solution
- Retirer des `beforeEach` inutile
- Ajouter des `return ;` dans les fonctions vides
- SR : renommage d'un fichier test qui n'avait pas le `_test` dans son nom

## :rainbow: Remarques
Ajout d'une règle ESlint pour éviter d'en remettre.

## :100: Pour tester
Le serveur se lance et l'application fonctionne