### PR TITLE
[FEATURE] Ne pas pouvoir partager son profil si une participation a été supprimée (PIX-4443).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -57,6 +57,7 @@ module.exports = function buildCampaignParticipation({
     organizationLearnerId,
     createdAt,
     sharedAt,
+    deletedAt,
     participantExternalId,
     validatedSkillsCount,
     masteryRate,

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -14,7 +14,7 @@ module.exports = {
         return campaignParticipationForSerialization;
       },
 
-      attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId', 'campaign', 'assessment'],
+      attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId', 'campaign', 'assessment', 'deletedAt'],
       campaign: {
         ref: 'id',
         attributes: ['code', 'title', 'type'],

--- a/api/tests/acceptance/application/users/get-user-campaign-participation-to-campaign_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-participation-to-campaign_test.js
@@ -45,6 +45,7 @@ describe('Acceptance | Route | GET /users/id/campaigns/id/campaign-participation
             'is-shared': true,
             'participant-external-id': campaignParticipation.participantExternalId,
             'shared-at': campaignParticipation.sharedAt,
+            'deleted-at': campaignParticipation.deletedAt,
             'created-at': campaignParticipation.createdAt,
           },
           relationships: {

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participations_test.js
@@ -103,6 +103,7 @@ describe('Acceptance | Controller | GET /user/id/campaign-participations', funct
                 'is-shared': true,
                 'participant-external-id': campaignParticipation2.participantExternalId,
                 'shared-at': campaignParticipation2.sharedAt,
+                'deleted-at': campaignParticipation2.deletedAt,
                 'created-at': campaignParticipation2.createdAt,
               },
               relationships: {
@@ -123,6 +124,7 @@ describe('Acceptance | Controller | GET /user/id/campaign-participations', funct
                 'is-shared': true,
                 'participant-external-id': campaignParticipation3.participantExternalId,
                 'shared-at': campaignParticipation3.sharedAt,
+                'deleted-at': campaignParticipation3.deletedAt,
                 'created-at': campaignParticipation3.createdAt,
               },
               relationships: {
@@ -138,6 +140,7 @@ describe('Acceptance | Controller | GET /user/id/campaign-participations', funct
                 'is-shared': false,
                 'participant-external-id': campaignParticipation1.participantExternalId,
                 'shared-at': campaignParticipation1.sharedAt,
+                'deleted-at': campaignParticipation1.deletedAt,
                 'created-at': campaignParticipation1.createdAt,
               },
               relationships: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -64,6 +64,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
       status: SHARED,
       participantExternalId: 'mail pro',
       sharedAt: new Date('2018-02-06T14:12:44Z'),
+      deletedAt: new Date('2018-02-06T14:12:44Z'),
       createdAt: new Date('2018-02-05T14:12:44Z'),
       campaign,
       assessments: [{ id: 4, createdAt: new Date('2018-02-06T14:12:44Z') }],
@@ -82,6 +83,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
             'is-shared': true,
             'participant-external-id': 'mail pro',
             'shared-at': new Date('2018-02-06T14:12:44Z'),
+            'deleted-at': new Date('2018-02-06T14:12:44Z'),
             'created-at': new Date('2018-02-05T14:12:44Z'),
           },
           relationships: {

--- a/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
@@ -1,0 +1,52 @@
+<div class="send-profile-header__announcement">
+  {{#if @isDisabled}}
+    <img
+      class="send-profile-header__image"
+      src="{{rootURL}}/images/illustrations/fat-bee.svg"
+      alt={{t "pages.profile-already-shared.first-title"}}
+    />
+    <p class="send-profile-disabled-share__text">
+      {{t "pages.send-profile.disabled-share" htmlSafe=true}}
+    </p>
+    <LinkTo @route="index" class="send-profile-disabled-share__back-to-home link">
+      {{t "pages.send-profile.form.continue"}}
+    </LinkTo>
+  {{else}}
+    <h1 class="send-profile-header__title">
+      {{t "pages.send-profile.first-title"}}
+    </h1>
+    <p class="send-profile-header__instruction">
+      {{t "pages.send-profile.instructions" htmlSafe=true}}
+    </p>
+  {{/if}}
+</div>
+
+{{#unless @isDisabled}}
+  <ProfileSharingForm
+    @sendProfile={{@sendProfile}}
+    @campaignParticipation={{@campaignParticipation}}
+    @campaign={{@campaign}}
+    @errorMessage={{@errorMessage}}
+  />
+{{/unless}}
+
+<div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
+  <HexagonScore @pixScore={{@user.profile.pixScore}} />
+  <div class="send-profile-header__profile__cards">
+    <ProfileScorecards
+      @interactive={{false}}
+      class="send-profile-header__profile__cards"
+      @areasCode={{@user.profile.areasCode}}
+      @scorecards={{@user.profile.scorecards}}
+    />
+  </div>
+</div>
+
+{{#unless @isDisabled}}
+  <ProfileSharingForm
+    @sendProfile={{@sendProfile}}
+    @campaignParticipation={{@campaignParticipation}}
+    @campaign={{@campaign}}
+    @errorMessage={{@errorMessage}}
+  />
+{{/unless}}

--- a/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
@@ -1,5 +1,5 @@
-<div class="send-profile-header__announcement">
-  {{#if @isDisabled}}
+{{#if @isDisabled}}
+  <div class="send-profile-header__announcement">
     <img
       class="send-profile-header__image"
       src="{{rootURL}}/images/illustrations/fat-bee.svg"
@@ -11,42 +11,48 @@
     <LinkTo @route="index" class="send-profile-disabled-share__back-to-home link">
       {{t "pages.send-profile.form.continue"}}
     </LinkTo>
-  {{else}}
+  </div>
+  <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
+    <HexagonScore @pixScore={{@user.profile.pixScore}} />
+    <div class="send-profile-header__profile__cards">
+      <ProfileScorecards
+        @interactive={{false}}
+        class="send-profile-header__profile__cards"
+        @areasCode={{@user.profile.areasCode}}
+        @scorecards={{@user.profile.scorecards}}
+      />
+    </div>
+  </div>
+{{else}}
+  <div class="send-profile-header__announcement">
     <h1 class="send-profile-header__title">
       {{t "pages.send-profile.first-title"}}
     </h1>
     <p class="send-profile-header__instruction">
       {{t "pages.send-profile.instructions" htmlSafe=true}}
     </p>
-  {{/if}}
-</div>
-
-{{#unless @isDisabled}}
-  <ProfileSharingForm
-    @sendProfile={{@sendProfile}}
-    @campaignParticipation={{@campaignParticipation}}
-    @campaign={{@campaign}}
-    @errorMessage={{@errorMessage}}
-  />
-{{/unless}}
-
-<div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
-  <HexagonScore @pixScore={{@user.profile.pixScore}} />
-  <div class="send-profile-header__profile__cards">
-    <ProfileScorecards
-      @interactive={{false}}
-      class="send-profile-header__profile__cards"
-      @areasCode={{@user.profile.areasCode}}
-      @scorecards={{@user.profile.scorecards}}
-    />
   </div>
-</div>
-
-{{#unless @isDisabled}}
   <ProfileSharingForm
     @sendProfile={{@sendProfile}}
     @campaignParticipation={{@campaignParticipation}}
     @campaign={{@campaign}}
     @errorMessage={{@errorMessage}}
   />
-{{/unless}}
+  <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
+    <HexagonScore @pixScore={{@user.profile.pixScore}} />
+    <div class="send-profile-header__profile__cards">
+      <ProfileScorecards
+        @interactive={{false}}
+        class="send-profile-header__profile__cards"
+        @areasCode={{@user.profile.areasCode}}
+        @scorecards={{@user.profile.scorecards}}
+      />
+    </div>
+  </div>
+  <ProfileSharingForm
+    @sendProfile={{@sendProfile}}
+    @campaignParticipation={{@campaignParticipation}}
+    @campaign={{@campaign}}
+    @errorMessage={{@errorMessage}}
+  />
+{{/if}}

--- a/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
@@ -8,6 +8,10 @@ export default class SendProfileController extends Controller {
 
   @tracked errorMessage = null;
 
+  get isDisabled() {
+    return Boolean(this.model.campaignParticipation?.deletedAt) || this.model.campaign.isArchived;
+  }
+
   @action
   async sendProfile() {
     this.errorMessage = null;

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -5,6 +5,7 @@ export default class CampaignParticipation extends Model {
   @attr('boolean') isShared;
   @attr('date') createdAt;
   @attr('date') sharedAt;
+  @attr('date') deletedAt;
 
   // references
   @attr('string') participantExternalId;

--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -72,3 +72,23 @@
     margin-top: 0;
   }
 }
+
+.send-profile-disabled-share {
+
+  &__text {
+    font-size: 1.375rem;
+    max-width: 640px;
+    margin: 30px auto 60px;
+    font-family: $font-open-sans;
+    font-weight: $font-light;
+    color: $grey-35;
+    text-align: center;
+  }
+
+  &__back-to-home {
+    font-size: 1rem;
+    font-weight: $font-bold;
+    font-family: $font-open-sans;
+    text-align: center;
+  }
+}

--- a/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
@@ -4,58 +4,13 @@
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
-
-    <div class="send-profile-header__announcement">
-      {{#if this.isDisabled}}
-        <img
-          class="send-profile-header__image"
-          src="{{rootURL}}/images/illustrations/fat-bee.svg"
-          alt={{t "pages.profile-already-shared.first-title"}}
-        />
-        <p class="send-profile-disabled-share__text">
-          {{t "pages.send-profile.disabled-share" htmlSafe=true}}
-        </p>
-        <LinkTo @route="index" class="send-profile-disabled-share__back-to-home link">
-          {{t "pages.send-profile.form.continue"}}
-        </LinkTo>
-      {{else}}
-        <h1 class="send-profile-header__title">
-          {{t "pages.send-profile.first-title"}}
-        </h1>
-        <p class="send-profile-header__instruction">
-          {{t "pages.send-profile.instructions" htmlSafe=true}}
-        </p>
-      {{/if}}
-    </div>
-
-    {{#unless this.isDisabled}}
-      <ProfileSharingForm
-        @sendProfile={{action "sendProfile"}}
-        @campaignParticipation={{this.model.campaignParticipation}}
-        @campaign={{this.model.campaign}}
-        @errorMessage={{this.errorMessage}}
-      />
-    {{/unless}}
-
-    <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
-      <HexagonScore @pixScore={{this.model.user.profile.pixScore}} />
-      <div class="send-profile-header__profile__cards">
-        <ProfileScorecards
-          @interactive={{false}}
-          class="send-profile-header__profile__cards"
-          @areasCode={{this.model.user.profile.areasCode}}
-          @scorecards={{this.model.user.profile.scorecards}}
-        />
-      </div>
-    </div>
-
-    {{#unless this.isDisabled}}
-      <ProfileSharingForm
-        @sendProfile={{action "sendProfile"}}
-        @campaignParticipation={{this.model.campaignParticipation}}
-        @campaign={{this.model.campaign}}
-        @errorMessage={{this.errorMessage}}
-      />
-    {{/unless}}
+    <Routes::Campaigns::ProfilesCollection::SendProfile
+      @isDisabled={{this.isDisabled}}
+      @user={{this.model.user}}
+      @campaignParticipation={{this.model.campaignParticipation}}
+      @campaign={{this.model.campaign}}
+      @sendProfile={{this.sendProfile}}
+      @errorMessage={{this.errorMessage}}
+    />
   </div>
 </div>

--- a/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
@@ -6,20 +6,36 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
 
     <div class="send-profile-header__announcement">
-      <h1 class="send-profile-header__title">
-        {{t "pages.send-profile.first-title"}}
-      </h1>
-      <p class="send-profile-header__instruction">
-        {{t "pages.send-profile.instructions" htmlSafe=true}}
-      </p>
+      {{#if this.model.campaignParticipation.deletedAt}}
+        <img
+          class="send-profile-header__image"
+          src="{{rootURL}}/images/illustrations/fat-bee.svg"
+          alt={{t "pages.profile-already-shared.first-title"}}
+        />
+        <p class="send-profile-disabled-share__text">
+          {{t "pages.send-profile.disabled-share" htmlSafe=true}}
+        </p>
+        <LinkTo @route="index" class="send-profile-disabled-share__back-to-home link">
+          {{t "pages.send-profile.form.continue"}}
+        </LinkTo>
+      {{else}}
+        <h1 class="send-profile-header__title">
+          {{t "pages.send-profile.first-title"}}
+        </h1>
+        <p class="send-profile-header__instruction">
+          {{t "pages.send-profile.instructions" htmlSafe=true}}
+        </p>
+      {{/if}}
     </div>
 
-    <ProfileSharingForm
-      @sendProfile={{action "sendProfile"}}
-      @campaignParticipation={{this.model.campaignParticipation}}
-      @campaign={{this.model.campaign}}
-      @errorMessage={{this.errorMessage}}
-    />
+    {{#unless this.model.campaignParticipation.deletedAt}}
+      <ProfileSharingForm
+        @sendProfile={{action "sendProfile"}}
+        @campaignParticipation={{this.model.campaignParticipation}}
+        @campaign={{this.model.campaign}}
+        @errorMessage={{this.errorMessage}}
+      />
+    {{/unless}}
 
     <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
       <HexagonScore @pixScore={{this.model.user.profile.pixScore}} />
@@ -33,11 +49,13 @@
       </div>
     </div>
 
-    <ProfileSharingForm
-      @sendProfile={{action "sendProfile"}}
-      @campaignParticipation={{this.model.campaignParticipation}}
-      @campaign={{this.model.campaign}}
-      @errorMessage={{this.errorMessage}}
-    />
+    {{#unless this.model.campaignParticipation.deletedAt}}
+      <ProfileSharingForm
+        @sendProfile={{action "sendProfile"}}
+        @campaignParticipation={{this.model.campaignParticipation}}
+        @campaign={{this.model.campaign}}
+        @errorMessage={{this.errorMessage}}
+      />
+    {{/unless}}
   </div>
 </div>

--- a/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
@@ -6,7 +6,7 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
 
     <div class="send-profile-header__announcement">
-      {{#if this.model.campaignParticipation.deletedAt}}
+      {{#if this.isDisabled}}
         <img
           class="send-profile-header__image"
           src="{{rootURL}}/images/illustrations/fat-bee.svg"
@@ -28,7 +28,7 @@
       {{/if}}
     </div>
 
-    {{#unless this.model.campaignParticipation.deletedAt}}
+    {{#unless this.isDisabled}}
       <ProfileSharingForm
         @sendProfile={{action "sendProfile"}}
         @campaignParticipation={{this.model.campaignParticipation}}
@@ -49,7 +49,7 @@
       </div>
     </div>
 
-    {{#unless this.model.campaignParticipation.deletedAt}}
+    {{#unless this.isDisabled}}
       <ProfileSharingForm
         @sendProfile={{action "sendProfile"}}
         @campaignParticipation={{this.model.campaignParticipation}}

--- a/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
@@ -1,0 +1,45 @@
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import { contains } from '../../../../../helpers/contains';
+import { clickByLabel } from '../../../../../helpers/click-by-label';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | routes/campaigns/profiles_collection/send-profile', function () {
+  setupIntlRenderingTest();
+
+  context('when isDisabled is true', () => {
+    it('should not display the share results button', async function () {
+      // given
+      this.set('isDisabled', true);
+      this.set('campaignParticipation', { isShared: false });
+
+      // when
+      await render(
+        hbs`<Routes::Campaigns::ProfilesCollection::SendProfile @isDisabled={{isDisabled}} @campaignParticipation={{campaignParticipation}} />`
+      );
+
+      expect(contains(this.intl.t('pages.send-profile.form.send'))).to.not.exist;
+    });
+  });
+
+  context('when isDisabled is false', () => {
+    it('should call sendProfile property', async function () {
+      // given
+      const sendProfile = sinon.stub();
+      this.set('isDisabled', false);
+      this.set('sendProfile', sendProfile);
+      this.set('campaignParticipation', { isShared: false });
+
+      // when
+      await render(
+        hbs`<Routes::Campaigns::ProfilesCollection::SendProfile @isDisabled={{isDisabled}} @campaignParticipation={{campaignParticipation}} @sendProfile={{sendProfile}} />`
+      );
+      await clickByLabel(this.intl.t('pages.send-profile.form.send'));
+
+      sinon.assert.called(sendProfile);
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
@@ -13,12 +13,13 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
     set: sinon.stub().resolves(),
   };
 
-  const campaignParticipationShared = { ...campaignParticipation, isShared: true };
+  const campaignParticipationShared = { ...campaignParticipation, isShared: true, deletedAt: null };
 
   const model = {
     campaign: {
       id: 1243,
       code: 'CODECAMPAIGN',
+      isArchived: false,
     },
     campaignParticipation,
   };
@@ -28,6 +29,27 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
     controller = this.owner.lookup('controller:campaigns.profiles-collection.send-profile');
     controller.model = model;
     campaignParticipation.save.resolves(campaignParticipationShared);
+  });
+
+  describe('#isDisabled', function () {
+    it('should return false if campaignParticipation is not deleted and campaign is not archived', function () {
+      // then
+      expect(controller.isDisabled).to.equal(false);
+    });
+    it('should return true if campaignParticipation is deleted', function () {
+      // given
+      controller.model.campaignParticipation.deletedAt = new Date();
+
+      // then
+      expect(controller.isDisabled).to.equal(true);
+    });
+    it('should return true if campaign is archived', function () {
+      // given
+      controller.model.campaign.isArchived = true;
+
+      // then
+      expect(controller.isDisabled).to.equal(true);
+    });
   });
 
   describe('#sendProfile', function () {

--- a/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
@@ -33,12 +33,17 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
 
   describe('#isDisabled', function () {
     it('should return false if campaignParticipation is not deleted and campaign is not archived', function () {
+      // given
+      controller.model.campaignParticipation.deletedAt = null;
+      controller.model.campaign.isArchived = false;
+
       // then
       expect(controller.isDisabled).to.equal(false);
     });
     it('should return true if campaignParticipation is deleted', function () {
       // given
       controller.model.campaignParticipation.deletedAt = new Date();
+      controller.model.campaign.isArchived = false;
 
       // then
       expect(controller.isDisabled).to.equal(true);
@@ -46,6 +51,7 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
     it('should return true if campaign is archived', function () {
       // given
       controller.model.campaign.isArchived = true;
+      controller.model.campaignParticipation.deletedAt = null;
 
       // then
       expect(controller.isDisabled).to.equal(true);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1142,6 +1142,7 @@
       "errors": {
         "archived": "It is no longer possible to submit your profile as the organiser has archived the collection of profiles."
       },
+      "disabled-share": "This customised test has been deactivated by the organiser. It is no longer possible to submit results.",
       "first-title": "Submitting your Pix profile",
       "form": {
         "continue": "Continue my Pix experience",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1142,6 +1142,7 @@
       "errors": {
         "archived": "L’envoi de votre profil n’est plus possible car l’organisateur a archivé la collecte de profils."
       },
+      "disabled-share": "Ce parcours a été désactivé par l'organisateur. L'envoi des résultats n'est plus possible.",
       "first-title": "Envoi de votre profil Pix",
       "form": {
         "continue": "Continuez votre expérience Pix",


### PR DESCRIPTION
## :unicorn: Problème
Dans nos travaux de refonte du prescrit, une fois que nous avions harmoniser la gestion des prescrits dans les orgas PRO/SUP/SCO, import pas import, nous avons compris qu’il était essentiel de pouvoir supprimer une participation (afin de gérer certains cas contraignants de dissociation).

Si la participation d'un utilisateur à une campagne de collecte de profil est "à partager" mais a été supprimé on veut l'empêcher de partager ses résultats.

## :robot: Solution
On cache le bouton pour partager ses résultats lorsque la participation à une collecte de profil a été supprimée.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Mon Pix avec userpix1
- Participer à la campagne PROCOLECT
- Ne pas partager ses résultats 
- Supprimer la participation
- Constater que le bouton pour partager ses résultats n'est plus visible
