### PR TITLE
[FEATURE] Recommander des tutoriels de la même langue que celle de l'utilisateur (PIX-4552).

### DIFF
--- a/api/lib/application/user-tutorials/user-tutorials-controller.js
+++ b/api/lib/application/user-tutorials/user-tutorials-controller.js
@@ -3,6 +3,7 @@ const userTutorialSerializer = require('../../infrastructure/serializers/jsonapi
 const tutorialSerializer = require('../../infrastructure/serializers/jsonapi/tutorial-serializer');
 const userTutorialRepository = require('../../infrastructure/repositories/user-tutorial-repository');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
   async add(request, h) {
@@ -37,8 +38,8 @@ module.exports = {
   async findRecommended(request, h) {
     const { userId } = request.auth.credentials;
     const { page } = queryParamsUtils.extractParameters(request.query);
-
-    const userRecommendedTutorials = await usecases.findPaginatedRecommendedTutorials({ userId, page });
+    const locale = extractLocaleFromRequest(request);
+    const userRecommendedTutorials = await usecases.findPaginatedRecommendedTutorials({ userId, page, locale });
 
     return h.response(
       tutorialSerializer.serialize(userRecommendedTutorials.results, userRecommendedTutorials.pagination)

--- a/api/lib/domain/usecases/find-paginated-recommended-tutorials.js
+++ b/api/lib/domain/usecases/find-paginated-recommended-tutorials.js
@@ -1,6 +1,6 @@
 const paginateModule = require('../../infrastructure/utils/paginate');
 
-module.exports = async function findPaginatedRecommendedTutorials({ userId, tutorialRepository, page }) {
-  const tutorials = await tutorialRepository.findRecommendedByUserId(userId);
+module.exports = async function findPaginatedRecommendedTutorials({ userId, tutorialRepository, page, locale }) {
+  const tutorials = await tutorialRepository.findRecommendedByUserId({ userId, locale });
   return paginateModule.paginate(tutorials, page);
 };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -50,12 +50,13 @@ module.exports = {
     return _.map(tutorialData, _toDomain);
   },
 
-  async findRecommendedByUserId(userId) {
+  async findRecommendedByUserId({ userId, locale = FRENCH_FRANCE } = {}) {
     const invalidatedKnowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
-
     const skills = await skillRepository.findOperativeByIds(invalidatedKnowledgeElements.map(({ skillId }) => skillId));
 
-    return this.findByRecordIds(skills.flatMap((skill) => skill.tutorialIds));
+    const tutorialsIds = skills.flatMap((skill) => skill.tutorialIds);
+
+    return _findByRecordIds({ ids: tutorialsIds, locale });
   },
 };
 

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -225,6 +225,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
         url: '/api/users/tutorials/recommended',
         headers: {
           authorization: generateValidRequestAuthorizationHeader(userId),
+          'accept-language': 'fr',
         },
       };
       learningContentObjects = learningContentBuilder.buildLearningContent([
@@ -249,7 +250,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                       tutorials: [
                         {
                           id: 'tuto1',
-                          locale: 'en-us',
+                          locale: 'fr-fr',
                           duration: '00:00:54',
                           format: 'video',
                           link: 'http://www.example.com/this-is-an-example.html',
@@ -258,7 +259,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                         },
                         {
                           id: 'tuto2',
-                          locale: 'en-us',
+                          locale: 'fr-fr',
                           duration: '00:01:51',
                           format: 'video',
                           link: 'http://www.example.com/this-is-an-example2.html',
@@ -293,6 +294,15 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                         {
                           id: 'tuto4',
                           locale: 'fr-fr',
+                          duration: '00:04:38',
+                          format: 'vidéo',
+                          link: 'http://www.example.com/this-is-an-example4.html',
+                          source: 'tuto.com',
+                          title: 'tuto4',
+                        },
+                        {
+                          id: 'tuto5',
+                          locale: 'en-us',
                           duration: '00:04:38',
                           format: 'vidéo',
                           link: 'http://www.example.com/this-is-an-example4.html',

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -391,7 +391,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         });
 
         // when
-        const results = await tutorialRepository.findRecommendedByUserId(userId);
+        const results = await tutorialRepository.findRecommendedByUserId({ userId });
 
         // then
         expect(results).to.deep.equal([]);
@@ -429,7 +429,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         });
 
         // when
-        const results = await tutorialRepository.findRecommendedByUserId(userId);
+        const results = await tutorialRepository.findRecommendedByUserId({ userId });
 
         // then
         expect(results).to.deep.equal([]);
@@ -455,12 +455,15 @@ describe('Integration | Repository | tutorial-repository', function () {
           tutorials: [
             {
               id: 'tuto1',
+              locale: 'fr-fr',
             },
             {
               id: 'tuto2',
+              locale: 'fr-fr',
             },
             {
               id: 'tuto5',
+              locale: 'fr-fr',
             },
           ],
           skills: [
@@ -478,10 +481,61 @@ describe('Integration | Repository | tutorial-repository', function () {
         });
 
         // when
-        const results = await tutorialRepository.findRecommendedByUserId(userId);
+        const results = await tutorialRepository.findRecommendedByUserId({ userId });
 
         // then
         expect(results.map((tutorial) => tutorial.id)).to.exactlyContain(['tuto2', 'tuto1', 'tuto5']);
+      });
+
+      it('should return tutorial related to user locale', async function () {
+        // given
+        const locale = 'en-us';
+        databaseBuilder.factory.buildKnowledgeElement({
+          skillId: 'recSkill1',
+          userId,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({
+          skillId: 'recSkill4',
+          userId,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+        });
+        await databaseBuilder.commit();
+
+        mockLearningContent({
+          tutorials: [
+            {
+              id: 'tuto1',
+              locale: 'en-us',
+            },
+            {
+              id: 'tuto2',
+              locale: 'en-us',
+            },
+            {
+              id: 'tuto5',
+              locale: 'fr-fr',
+            },
+          ],
+          skills: [
+            {
+              id: 'recSkill1',
+              tutorialIds: ['tuto1', 'tuto2'],
+              status: 'actif',
+            },
+            {
+              id: 'recSkill4',
+              tutorialIds: ['tuto5'],
+              status: 'archivé',
+            },
+          ],
+        });
+
+        // when
+        const results = await tutorialRepository.findRecommendedByUserId({ userId, locale });
+
+        // then
+        expect(results.map((tutorial) => tutorial.id)).to.exactlyContain(['tuto2', 'tuto1']);
       });
     });
 
@@ -511,7 +565,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         });
 
         // when
-        const results = await tutorialRepository.findRecommendedByUserId(userId);
+        const results = await tutorialRepository.findRecommendedByUserId({ userId });
 
         // then
         expect(results).to.deep.equal([]);

--- a/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
@@ -85,12 +85,16 @@ describe('Unit | Controller | User-tutorials', function () {
           size: '200',
         },
       };
+      const headers = {
+        'accept-language': 'fr',
+      };
       sinon.stub(usecases, 'findPaginatedRecommendedTutorials').returns([]);
       sinon.stub(queryParamsUtils, 'extractParameters').returns(extractedParams);
       const request = {
         auth: { credentials: { userId } },
         'page[number]': '1',
         'page[size]': '200',
+        headers,
       };
 
       // when
@@ -103,6 +107,7 @@ describe('Unit | Controller | User-tutorials', function () {
         number: '1',
         size: '200',
       });
+      expect(findPaginatedRecommendedTutorialsArgs.locale).to.equal('fr');
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-paginated-recommended-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-recommended-tutorials_test.js
@@ -3,6 +3,32 @@ const paginateModule = require('../../../../lib/infrastructure/utils/paginate');
 const findRecommendedTutorials = require('../../../../lib/domain/usecases/find-paginated-recommended-tutorials');
 
 describe('Unit | UseCase | find-paginated-recommended-tutorials', function () {
+  it('should call tutorial repository with userId and locale', async function () {
+    // given
+    const userId = 1;
+    const page = {
+      number: 1,
+      size: 2,
+    };
+    const tutorialRepository = {
+      findRecommendedByUserId: sinon.stub().resolves([]),
+    };
+    const locale = 'fr-fr';
+
+    sinon.stub(paginateModule, 'paginate').returns({ results: [], pagination: {} });
+
+    // when
+    await findRecommendedTutorials({
+      userId,
+      tutorialRepository,
+      page,
+      locale,
+    });
+
+    // then
+    expect(tutorialRepository.findRecommendedByUserId).to.have.been.calledWith({ userId, locale });
+  });
+
   describe('when there are no recommended tutorials', function () {
     it('should return empty page data', async function () {
       // Given
@@ -41,6 +67,7 @@ describe('Unit | UseCase | find-paginated-recommended-tutorials', function () {
     it('should return a paginated list of tutorials', async function () {
       // Given
       const userId = 1;
+      const locale = 'fr-fr';
       const page = {
         number: 1,
         size: 2,
@@ -75,10 +102,11 @@ describe('Unit | UseCase | find-paginated-recommended-tutorials', function () {
         userId,
         tutorialRepository,
         page,
+        locale,
       });
 
       //Then
-      expect(tutorialRepository.findRecommendedByUserId).to.have.been.calledWith(userId);
+      expect(tutorialRepository.findRecommendedByUserId).to.have.been.calledWith({ userId, locale });
       expect(tutorials.results).to.deep.equal(expectedTutorials.slice(0, 2));
       expect(tutorials.pagination).to.deep.equal(expectedPagination);
       expect(paginateModule.paginate).to.have.been.calledWith(expectedTutorials, page);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, pour les tutoriels recommandés, nous retournons tous les tutoriels associés aux acquis invalidés sans prendre en compte la langue de l'utilisateur. L'utilisateur se retrouve alors avec des tutoriels en anglais alors que tout le reste du contenu proposé par Pix est en français. Afin d'être cohérent, nous souhaitons gérer la locale de l'utilisateur pour les tutoriels recommandés.   

## :robot: Solution
Utiliser la locale fournie dans les headers de la requête pour filtrer les tutoriels recommandés. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ? vous êtes beaux._

## :100: Pour tester
- Se connecter sur App
- Louper des acquis
- Et ensuite vérifier dans la page `/mes-tutos-v2/recommandes` qu'uniquement des tutoriels de la langue courante sont proposés. 
