### PR TITLE
[TECH] Suppression du toggle des certification complémentaires (PIX-4542)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -171,9 +171,6 @@ module.exports = (function () {
 
     featureToggles: {
       isEmailValidationEnabled: isFeatureEnabled(process.env.FT_VALIDATE_EMAIL),
-      isComplementaryCertificationSubscriptionEnabled: isFeatureEnabled(
-        process.env.FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED
-      ),
       isCertificationBillingEnabled: isFeatureEnabled(process.env.FT_CERTIFICATION_BILLING),
       isNewTutorialsPageEnabled: isFeatureEnabled(process.env.FT_NEW_TUTORIALS_PAGE),
     },

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -1,7 +1,6 @@
 const { checkEventTypes } = require('./check-event-types');
 const CertificationScoringCompleted = require('./CertificationScoringCompleted');
 const CertificationRescoringCompleted = require('./CertificationRescoringCompleted');
-const { featureToggles } = require('../../config');
 const { CLEA } = require('../models/ComplementaryCertification');
 
 const eventTypes = [CertificationScoringCompleted, CertificationRescoringCompleted];
@@ -9,91 +8,10 @@ const eventTypes = [CertificationScoringCompleted, CertificationRescoringComplet
 async function handleCleaCertificationScoring({
   event,
   partnerCertificationScoringRepository,
-  badgeRepository,
-  certificationCourseRepository,
-  cleaCertificationResultRepository,
-  certificationCenterRepository,
-  knowledgeElementRepository,
-  targetProfileRepository,
-  badgeCriteriaService,
   complementaryCertificationCourseRepository,
 }) {
   checkEventTypes(event, eventTypes);
   const { certificationCourseId, userId, reproducibilityRate } = event;
-
-  if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-    return _handleScoringAndRescoringWithToggleEnabled(
-      complementaryCertificationCourseRepository,
-      certificationCourseId,
-      partnerCertificationScoringRepository,
-      userId,
-      reproducibilityRate
-    );
-  }
-
-  const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(certificationCourseId);
-  if (!certificationCenter.isHabilitatedClea) {
-    return;
-  }
-
-  if (event instanceof CertificationRescoringCompleted) {
-    return _handleRescoringWithToggleDisabled(
-      event,
-      certificationCenterRepository,
-      cleaCertificationResultRepository,
-      partnerCertificationScoringRepository
-    );
-  }
-
-  await _handleScoringWithToggleDisabled(
-    partnerCertificationScoringRepository,
-    certificationCourseId,
-    userId,
-    reproducibilityRate,
-    certificationCourseRepository,
-    event,
-    badgeRepository,
-    targetProfileRepository,
-    knowledgeElementRepository,
-    badgeCriteriaService
-  );
-}
-
-async function _verifyBadgeValidity(
-  certificationCourseRepository,
-  event,
-  badgeRepository,
-  cleaCertificationScoring,
-  targetProfileRepository,
-  knowledgeElementRepository,
-  badgeCriteriaService
-) {
-  const beginningCertificationDate = await certificationCourseRepository.getCreationDate(event.certificationCourseId);
-
-  const badge = await badgeRepository.getByKey(cleaCertificationScoring.partnerKey);
-  const targetProfile = await targetProfileRepository.get(badge.targetProfileId);
-
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
-    userId: event.userId,
-    limitDate: beginningCertificationDate,
-  });
-
-  cleaCertificationScoring.setBadgeAcquisitionStillValid(
-    badgeCriteriaService.areBadgeCriteriaFulfilled({
-      knowledgeElements,
-      targetProfile,
-      badge,
-    })
-  );
-}
-
-async function _handleScoringAndRescoringWithToggleEnabled(
-  complementaryCertificationCourseRepository,
-  certificationCourseId,
-  partnerCertificationScoringRepository,
-  userId,
-  reproducibilityRate
-) {
   const hasRunCleA = await complementaryCertificationCourseRepository.hasComplementaryCertification({
     certificationCourseId,
     complementaryCertificationName: CLEA,
@@ -109,69 +27,6 @@ async function _handleScoringAndRescoringWithToggleEnabled(
   });
 
   return partnerCertificationScoringRepository.save({ partnerCertificationScoring: cleaCertificationScoring });
-}
-
-async function _handleRescoringWithToggleDisabled(
-  event,
-  certificationCenterRepository,
-  cleaCertificationResultRepository,
-  partnerCertificationScoringRepository
-) {
-  const { certificationCourseId } = event;
-
-  const certificationCenter = await certificationCenterRepository.getByCertificationCourseId(certificationCourseId);
-  if (!certificationCenter.isHabilitatedClea) {
-    return;
-  }
-  const cleaCertificationResult = await cleaCertificationResultRepository.get({ certificationCourseId });
-  if (!cleaCertificationResult.isTaken()) {
-    return;
-  }
-
-  const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
-    certificationCourseId,
-    userId: event.userId,
-    reproducibilityRate: event.reproducibilityRate,
-  });
-
-  await partnerCertificationScoringRepository.save({ partnerCertificationScoring: cleaCertificationScoring });
-
-  return;
-}
-
-async function _handleScoringWithToggleDisabled(
-  partnerCertificationScoringRepository,
-  certificationCourseId,
-  userId,
-  reproducibilityRate,
-  certificationCourseRepository,
-  event,
-  badgeRepository,
-  targetProfileRepository,
-  knowledgeElementRepository,
-  badgeCriteriaService
-) {
-  const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
-    certificationCourseId,
-    userId,
-    reproducibilityRate,
-  });
-
-  if (cleaCertificationScoring.hasAcquiredBadge) {
-    await _verifyBadgeValidity(
-      certificationCourseRepository,
-      event,
-      badgeRepository,
-      cleaCertificationScoring,
-      targetProfileRepository,
-      knowledgeElementRepository,
-      badgeCriteriaService
-    );
-  }
-
-  if (cleaCertificationScoring.isEligible()) {
-    await partnerCertificationScoringRepository.save({ partnerCertificationScoring: cleaCertificationScoring });
-  }
 }
 
 handleCleaCertificationScoring.eventTypes = eventTypes;

--- a/api/lib/domain/events/handle-pix-plus-droit-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-droit-certifications-scoring.js
@@ -6,7 +6,6 @@ const PixPlusDroitCertificationScoring = require('../models/PixPlusDroitCertific
 const { ReproducibilityRate } = require('../models/ReproducibilityRate');
 const AnswerCollectionForScoring = require('../models/AnswerCollectionForScoring');
 const { PIX_PLUS_DROIT } = require('../models/ComplementaryCertification');
-const { featureToggles } = require('../../config');
 const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../models/Badge').keys;
 
 const eventTypes = [CertificationScoringCompleted, CertificationRescoringCompleted];
@@ -20,14 +19,10 @@ async function _isAllowedToBeScored({
     return false;
   }
 
-  if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-    return await complementaryCertificationCourseRepository.hasComplementaryCertification({
-      certificationCourseId,
-      complementaryCertificationName: PIX_PLUS_DROIT,
-    });
-  }
-
-  return true;
+  return await complementaryCertificationCourseRepository.hasComplementaryCertification({
+    certificationCourseId,
+    complementaryCertificationName: PIX_PLUS_DROIT,
+  });
 }
 
 async function _allowedToBeScoredBadgeKeys({

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -9,7 +9,7 @@ const {
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
 } = require('../errors');
-const { features, featureToggles } = require('../../config');
+const { features } = require('../../config');
 
 module.exports = async function retrieveLastOrCreateCertificationCourse({
   domainTransaction,
@@ -138,10 +138,7 @@ async function _startNewCertification({
 
   const complementaryCertifications = await complementaryCertificationRepository.findAll();
 
-  if (
-    certificationCenter.isHabilitatedClea &&
-    (!featureToggles.isComplementaryCertificationSubscriptionEnabled || certificationCandidate.isGrantedCleA())
-  ) {
+  if (certificationCenter.isHabilitatedClea && certificationCandidate.isGrantedCleA()) {
     if (await certificationBadgesService.hasStillValidCleaBadgeAcquisition({ userId })) {
       const cleAComplementaryCertification = complementaryCertifications.find((comp) => comp.name === CLEA);
       if (cleAComplementaryCertification) {
@@ -155,10 +152,7 @@ async function _startNewCertification({
     domainTransaction,
   });
 
-  if (
-    certificationCenter.isHabilitatedPixPlusDroit &&
-    (!featureToggles.isComplementaryCertificationSubscriptionEnabled || certificationCandidate.isGrantedPixPlusDroit())
-  ) {
+  if (certificationCenter.isHabilitatedPixPlusDroit && certificationCandidate.isGrantedPixPlusDroit()) {
     const pixDroitBadgeAcquisition = highestCertifiableBadgeAcquisitions.find((badgeAcquisition) =>
       badgeAcquisition.isPixDroit()
     );

--- a/api/lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js
+++ b/api/lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js
@@ -80,9 +80,7 @@ const _TRANSFORMATION_STRUCT_FOR_PIX_CERTIF_CANDIDATES_IMPORT = [
 function getTransformationStructsForPixCertifCandidatesImport({ complementaryCertifications, isSco }) {
   const transformationStruct = [..._TRANSFORMATION_STRUCT_FOR_PIX_CERTIF_CANDIDATES_IMPORT];
 
-  if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-    _includeComplementaryCertificationColumns(complementaryCertifications, transformationStruct);
-  }
+  _includeComplementaryCertificationColumns(complementaryCertifications, transformationStruct);
 
   if (featureToggles.isCertificationBillingEnabled && !isSco) {
     _includeBillingColumns(transformationStruct);

--- a/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -88,9 +88,7 @@ function _addColumns({ odsBuilder, certificationCenterHabilitations, isScoCertif
         tableFirstRow: CANDIDATE_TABLE_FIRST_ROW,
       });
   }
-  if (featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-    odsBuilder = _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations });
-  }
+  odsBuilder = _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations });
 
   return odsBuilder;
 }

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const { Serializer } = require('jsonapi-serializer');
-const { featureToggles } = require('../../../config');
 
 module.exports = {
   serialize(certificationPointOfContact) {
@@ -40,13 +39,9 @@ module.exports = {
         transformedCertificationPointOfContact.allowedCertificationCenterAccesses = _.map(
           certificationPointOfContact.allowedCertificationCenterAccesses,
           (access) => {
-            let habilitations = access.habilitations;
-            if (!featureToggles.isComplementaryCertificationSubscriptionEnabled) {
-              habilitations = [];
-            }
             return {
               ...access,
-              habilitations,
+              habilitations: access.habilitations,
               isAccessBlockedCollege: access.isAccessBlockedCollege(),
               isAccessBlockedLycee: access.isAccessBlockedLycee(),
               isAccessBlockedAEFE: access.isAccessBlockedAEFE(),

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -29,7 +29,6 @@ const schema = Joi.object({
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   FT_CERTIFICATION_BILLING: Joi.string().optional().valid('true', 'false'),
   FT_VALIDATE_EMAIL: Joi.string().optional().valid('true', 'false'),
-  FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED: Joi.string().optional().valid('true', 'false'),
   FT_NEW_TUTORIALS_PAGE: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -29,13 +29,6 @@
 
 FT_VALIDATE_EMAIL=false
 
-# Prevent candidate from getting a complementary certification without applying
-#
-# presence: optional
-# type: boolean
-# default: false
-FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED=false
-
 # Add info about certification billing
 #
 # presence: optional

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,7 +23,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-certification-billing-enabled': false,
             'is-email-validation-enabled': false,
-            'is-complementary-certification-subscription-enabled': false,
             'is-new-tutorials-page-enabled': false,
           },
           type: 'feature-toggles',

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -181,243 +181,124 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
   });
 
   context('when certification center has habilitations', function () {
-    context('when isComplementaryCertificationSubscriptionEnabled feature toggle is on', function () {
-      it('should return extracted and validated certification candidates with complementary certifications', async function () {
-        // given
-        sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
-        const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-          name: 'CléA Numérique',
-        });
-        const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-          name: 'Pix+ Droit',
-        });
-
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
-        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-          certificationCenterId,
-          complementaryCertificationId: cleaComplementaryCertification.id,
-        });
-        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-          certificationCenterId,
-          complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
-        });
-
-        const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-
-        await databaseBuilder.commit();
-
-        const odsFilePath = `${__dirname}/attendance_sheet_extract_with_complementary_certifications_ok_test.ods`;
-        const odsBuffer = await readFile(odsFilePath);
-        const expectedCertificationCandidates = _.map(
-          [
-            {
-              lastName: 'Gallagher',
-              firstName: 'Jack',
-              birthdate: '1980-08-10',
-              sex: 'M',
-              birthCity: 'Londres',
-              birthCountry: 'ANGLETERRE',
-              birthINSEECode: '99132',
-              birthPostalCode: null,
-              resultRecipientEmail: 'destinataire@gmail.com',
-              email: 'jack@d.it',
-              externalId: null,
-              extraTimePercentage: 0.15,
-              sessionId,
-              complementaryCertifications: [
-                domainBuilder.buildComplementaryCertification(cleaComplementaryCertification),
-                domainBuilder.buildComplementaryCertification(pixPlusDroitComplementaryCertification),
-              ],
-            },
-            {
-              lastName: 'Jackson',
-              firstName: 'Janet',
-              birthdate: '2005-12-05',
-              sex: 'F',
-              birthCity: 'AJACCIO',
-              birthCountry: 'FRANCE',
-              birthINSEECode: '2A004',
-              birthPostalCode: null,
-              resultRecipientEmail: 'destinataire@gmail.com',
-              email: 'jaja@hotmail.fr',
-              externalId: 'DEF456',
-              extraTimePercentage: null,
-              sessionId,
-              complementaryCertifications: [
-                domainBuilder.buildComplementaryCertification(cleaComplementaryCertification),
-              ],
-            },
-            {
-              lastName: 'Jackson',
-              firstName: 'Michael',
-              birthdate: '2004-04-04',
-              sex: 'M',
-              birthCity: 'PARIS 18',
-              birthCountry: 'FRANCE',
-              birthINSEECode: null,
-              birthPostalCode: '75018',
-              resultRecipientEmail: 'destinataire@gmail.com',
-              email: 'jackson@gmail.com',
-              externalId: 'ABC123',
-              extraTimePercentage: 0.6,
-              sessionId,
-              complementaryCertifications: [
-                domainBuilder.buildComplementaryCertification(pixPlusDroitComplementaryCertification),
-              ],
-            },
-            {
-              lastName: 'Mercury',
-              firstName: 'Freddy',
-              birthdate: '1925-06-28',
-              sex: 'M',
-              birthCity: 'SAINT-ANNE',
-              birthCountry: 'FRANCE',
-              birthINSEECode: null,
-              birthPostalCode: '97180',
-              resultRecipientEmail: null,
-              email: null,
-              externalId: 'GHI789',
-              extraTimePercentage: 1.5,
-              sessionId,
-              complementaryCertifications: [],
-            },
-          ],
-          (candidate) => new CertificationCandidate(candidate)
-        );
-
-        // when
-        const actualCertificationCandidates =
-          await certificationCandidatesOdsService.extractCertificationCandidatesFromCandidatesImportSheet({
-            sessionId,
-            odsBuffer,
-            certificationCpfService,
-            certificationCpfCountryRepository,
-            certificationCpfCityRepository,
-            certificationCenterRepository,
-            complementaryCertificationRepository,
-          });
-
-        // then
-        expect(actualCertificationCandidates).to.deep.equal(expectedCertificationCandidates);
+    it('should return extracted and validated certification candidates with complementary certifications', async function () {
+      // given
+      const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        name: 'CléA Numérique',
       });
-    });
-
-    context('when isComplementaryCertificationSubscriptionEnabled feature toggle is off', function () {
-      it('should return extracted and validated certification candidates without complementary certifications', async function () {
-        // given
-        sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
-        const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-          name: 'CléA Numérique',
-        });
-        const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-          name: 'Pix+ Droit',
-        });
-
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
-        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-          certificationCenterId,
-          complementaryCertificationId: cleaComplementaryCertification.id,
-        });
-        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-          certificationCenterId,
-          complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
-        });
-
-        const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-
-        await databaseBuilder.commit();
-
-        const odsFilePath = `${__dirname}/attendance_sheet_extract_ok_test.ods`;
-        const odsBuffer = await readFile(odsFilePath);
-        const expectedCertificationCandidates = _.map(
-          [
-            {
-              lastName: 'Gallagher',
-              firstName: 'Jack',
-              birthdate: '1980-08-10',
-              sex: 'M',
-              birthCity: 'Londres',
-              birthCountry: 'ANGLETERRE',
-              birthINSEECode: '99132',
-              birthPostalCode: null,
-              resultRecipientEmail: 'destinataire@gmail.com',
-              email: 'jack@d.it',
-              externalId: null,
-              extraTimePercentage: 0.15,
-              sessionId,
-              complementaryCertifications: [],
-            },
-            {
-              lastName: 'Jackson',
-              firstName: 'Janet',
-              birthdate: '2005-12-05',
-              sex: 'F',
-              birthCity: 'AJACCIO',
-              birthCountry: 'FRANCE',
-              birthINSEECode: '2A004',
-              birthPostalCode: null,
-              resultRecipientEmail: 'destinataire@gmail.com',
-              email: 'jaja@hotmail.fr',
-              externalId: 'DEF456',
-              extraTimePercentage: null,
-              sessionId,
-              complementaryCertifications: [],
-            },
-            {
-              lastName: 'Jackson',
-              firstName: 'Michael',
-              birthdate: '2004-04-04',
-              sex: 'M',
-              birthCity: 'PARIS 18',
-              birthCountry: 'FRANCE',
-              birthINSEECode: null,
-              birthPostalCode: '75018',
-              resultRecipientEmail: 'destinataire@gmail.com',
-              email: 'jackson@gmail.com',
-              externalId: 'ABC123',
-              extraTimePercentage: 0.6,
-              sessionId,
-              complementaryCertifications: [],
-            },
-            {
-              lastName: 'Mercury',
-              firstName: 'Freddy',
-              birthdate: '1925-06-28',
-              sex: 'M',
-              birthCity: 'SAINT-ANNE',
-              birthCountry: 'FRANCE',
-              birthINSEECode: null,
-              birthPostalCode: '97180',
-              resultRecipientEmail: null,
-              email: null,
-              externalId: 'GHI789',
-              extraTimePercentage: 1.5,
-              sessionId,
-              complementaryCertifications: [],
-            },
-          ],
-          (candidate) => new CertificationCandidate(candidate)
-        );
-
-        // when
-        const actualCertificationCandidates =
-          await certificationCandidatesOdsService.extractCertificationCandidatesFromCandidatesImportSheet({
-            sessionId,
-            odsBuffer,
-            certificationCpfService,
-            certificationCpfCountryRepository,
-            certificationCpfCityRepository,
-            certificationCenterRepository,
-            complementaryCertificationRepository,
-          });
-
-        // then
-        expect(actualCertificationCandidates).to.deep.equal(expectedCertificationCandidates);
+      const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        name: 'Pix+ Droit',
       });
+
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId,
+        complementaryCertificationId: cleaComplementaryCertification.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId,
+        complementaryCertificationId: pixPlusDroitComplementaryCertification.id,
+      });
+
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+
+      await databaseBuilder.commit();
+
+      const odsFilePath = `${__dirname}/attendance_sheet_extract_with_complementary_certifications_ok_test.ods`;
+      const odsBuffer = await readFile(odsFilePath);
+      const expectedCertificationCandidates = _.map(
+        [
+          {
+            lastName: 'Gallagher',
+            firstName: 'Jack',
+            birthdate: '1980-08-10',
+            sex: 'M',
+            birthCity: 'Londres',
+            birthCountry: 'ANGLETERRE',
+            birthINSEECode: '99132',
+            birthPostalCode: null,
+            resultRecipientEmail: 'destinataire@gmail.com',
+            email: 'jack@d.it',
+            externalId: null,
+            extraTimePercentage: 0.15,
+            sessionId,
+            complementaryCertifications: [
+              domainBuilder.buildComplementaryCertification(cleaComplementaryCertification),
+              domainBuilder.buildComplementaryCertification(pixPlusDroitComplementaryCertification),
+            ],
+          },
+          {
+            lastName: 'Jackson',
+            firstName: 'Janet',
+            birthdate: '2005-12-05',
+            sex: 'F',
+            birthCity: 'AJACCIO',
+            birthCountry: 'FRANCE',
+            birthINSEECode: '2A004',
+            birthPostalCode: null,
+            resultRecipientEmail: 'destinataire@gmail.com',
+            email: 'jaja@hotmail.fr',
+            externalId: 'DEF456',
+            extraTimePercentage: null,
+            sessionId,
+            complementaryCertifications: [
+              domainBuilder.buildComplementaryCertification(cleaComplementaryCertification),
+            ],
+          },
+          {
+            lastName: 'Jackson',
+            firstName: 'Michael',
+            birthdate: '2004-04-04',
+            sex: 'M',
+            birthCity: 'PARIS 18',
+            birthCountry: 'FRANCE',
+            birthINSEECode: null,
+            birthPostalCode: '75018',
+            resultRecipientEmail: 'destinataire@gmail.com',
+            email: 'jackson@gmail.com',
+            externalId: 'ABC123',
+            extraTimePercentage: 0.6,
+            sessionId,
+            complementaryCertifications: [
+              domainBuilder.buildComplementaryCertification(pixPlusDroitComplementaryCertification),
+            ],
+          },
+          {
+            lastName: 'Mercury',
+            firstName: 'Freddy',
+            birthdate: '1925-06-28',
+            sex: 'M',
+            birthCity: 'SAINT-ANNE',
+            birthCountry: 'FRANCE',
+            birthINSEECode: null,
+            birthPostalCode: '97180',
+            resultRecipientEmail: null,
+            email: null,
+            externalId: 'GHI789',
+            extraTimePercentage: 1.5,
+            sessionId,
+            complementaryCertifications: [],
+          },
+        ],
+        (candidate) => new CertificationCandidate(candidate)
+      );
+
+      // when
+      const actualCertificationCandidates =
+        await certificationCandidatesOdsService.extractCertificationCandidatesFromCandidatesImportSheet({
+          sessionId,
+          odsBuffer,
+          certificationCpfService,
+          certificationCpfCountryRepository,
+          certificationCpfCityRepository,
+          certificationCenterRepository,
+          complementaryCertificationRepository,
+        });
+
+      // then
+      expect(actualCertificationCandidates).to.deep.equal(expectedCertificationCandidates);
     });
   });
 
@@ -425,7 +306,6 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     it('should return extracted and validated certification candidates with billing information', async function () {
       // given
       const isSco = false;
-      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
       sinon.stub(featureToggles, 'isCertificationBillingEnabled').value(true);
 
       const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
@@ -123,237 +123,233 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
     expect(actualResult).to.deep.equal(expectedResult);
   });
 
-  context('when isComplementaryCertificationSubscriptionEnabled feature toggle is enabled', function () {
-    it('should return a candidate import sheet with session data, certification candidates data prefilled with one complementary certification', async function () {
-      // given
-      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
-      expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification.ods`;
-      actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification.tmp.ods`;
+  it('should return a candidate import sheet with session data, certification candidates data prefilled with one complementary certification', async function () {
+    // given
+    expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification.ods`;
+    actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification.tmp.ods`;
 
-      const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
+    const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
 
-      const certificationCenterName = 'Centre de certification';
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-        name: certificationCenterName,
-      }).id;
+    const certificationCenterName = 'Centre de certification';
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+      name: certificationCenterName,
+    }).id;
 
-      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-        certificationCenterId,
-        complementaryCertificationId: cleaNumerique.id,
-      });
-
-      userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-
-      sessionId = databaseBuilder.factory.buildSession({
-        id: 10,
-        certificationCenter: certificationCenterName,
-        certificationCenterId: certificationCenterId,
-        accessCode: 'ABC123DEF',
-        address: '3 rue des bibiches',
-        room: '28D',
-        examiner: 'Johnny',
-        date: '2020-07-05',
-        time: '14:30',
-        description: 'La super description',
-      }).id;
-
-      const cleaNumeriqueCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'Only',
-        firstName: 'CléA',
-        sex: 'M',
-        birthPostalCode: '97180',
-        birthINSEECode: null,
-        birthCity: 'Sainte-Anne',
-        birthCountry: 'France',
-        email: null,
-        resultRecipientEmail: null,
-        birthdate: '1925-06-28',
-        sessionId,
-        externalId: 'GHI789',
-        extraTimePercentage: 1.5,
-        complementaryCertifications: [cleaNumerique],
-      });
-      databaseBuilder.factory.buildComplementaryCertificationSubscription({
-        certificationCandidateId: cleaNumeriqueCandidate.id,
-        complementaryCertificationId: cleaNumerique.id,
-      });
-
-      databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'No',
-        firstName: 'Complementary certifications',
-        sex: 'M',
-        birthPostalCode: null,
-        birthINSEECode: '99132',
-        birthCity: 'Londres',
-        birthCountry: 'Angleterre',
-        email: 'jack@d.it',
-        resultRecipientEmail: 'destinataire@gmail.com',
-        birthdate: '1980-08-10',
-        sessionId,
-        externalId: null,
-        extraTimePercentage: 0.15,
-        complementaryCertifications: [],
-      });
-
-      await databaseBuilder.commit();
-      // when
-      const { session, certificationCenterHabilitations } = await usecases.getCandidateImportSheetData({
-        sessionId,
-        userId,
-      });
-      const updatedOdsFileBuffer = await fillCandidatesImportSheet({
-        session,
-        certificationCenterHabilitations,
-      });
-      await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
-      const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
-      const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
-
-      // then
-      expect(actualResult).to.deep.equal(expectedResult);
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId,
+      complementaryCertificationId: cleaNumerique.id,
     });
 
-    it('should return a candidate import sheet with session data, certification candidates data prefilled with two complementary certifications', async function () {
-      // given
-      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
-      expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-two-complementary-certifications.ods`;
-      actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-two-complementary-certifications.tmp.ods`;
+    userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
 
-      const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
-      const pixPlusDroit = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+ Droit' });
+    sessionId = databaseBuilder.factory.buildSession({
+      id: 10,
+      certificationCenter: certificationCenterName,
+      certificationCenterId: certificationCenterId,
+      accessCode: 'ABC123DEF',
+      address: '3 rue des bibiches',
+      room: '28D',
+      examiner: 'Johnny',
+      date: '2020-07-05',
+      time: '14:30',
+      description: 'La super description',
+    }).id;
 
-      const certificationCenterName = 'Centre de certification';
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-        name: certificationCenterName,
-      }).id;
-
-      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-        certificationCenterId,
-        complementaryCertificationId: cleaNumerique.id,
-      });
-      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
-        certificationCenterId,
-        complementaryCertificationId: pixPlusDroit.id,
-      });
-
-      userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-
-      sessionId = databaseBuilder.factory.buildSession({
-        id: 10,
-        certificationCenter: certificationCenterName,
-        certificationCenterId: certificationCenterId,
-        accessCode: 'ABC123DEF',
-        address: '3 rue des bibiches',
-        room: '28D',
-        examiner: 'Johnny',
-        date: '2020-07-05',
-        time: '14:30',
-        description: 'La super description',
-      }).id;
-
-      const allComplementaryCertificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'All',
-        firstName: 'Complementary certifications',
-        sex: 'M',
-        birthPostalCode: '75018',
-        birthINSEECode: null,
-        birthCity: 'Paris',
-        birthCountry: 'France',
-        email: 'jackson@gmail.com',
-        resultRecipientEmail: 'destinataire@gmail.com',
-        birthdate: '2004-04-04',
-        sessionId,
-        externalId: 'ABC123',
-        extraTimePercentage: 0.6,
-        complementaryCertifications: [cleaNumerique, pixPlusDroit],
-      });
-      databaseBuilder.factory.buildComplementaryCertificationSubscription({
-        certificationCandidateId: allComplementaryCertificationCandidate.id,
-        complementaryCertificationId: cleaNumerique.id,
-      });
-      databaseBuilder.factory.buildComplementaryCertificationSubscription({
-        certificationCandidateId: allComplementaryCertificationCandidate.id,
-        complementaryCertificationId: pixPlusDroit.id,
-      });
-
-      const onlyPixPlusDroitCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'Only',
-        firstName: 'Droit',
-        sex: 'F',
-        birthPostalCode: null,
-        birthINSEECode: '2A004',
-        birthCity: 'Ajaccio',
-        birthCountry: 'France',
-        email: 'jaja@hotmail.fr',
-        resultRecipientEmail: 'destinataire@gmail.com',
-        birthdate: '2005-12-05',
-        sessionId,
-        externalId: 'DEF456',
-        extraTimePercentage: null,
-        complementaryCertifications: [pixPlusDroit],
-      });
-      databaseBuilder.factory.buildComplementaryCertificationSubscription({
-        certificationCandidateId: onlyPixPlusDroitCandidate.id,
-        complementaryCertificationId: pixPlusDroit.id,
-      });
-
-      const onlyCleaNumeriqueCandidate = databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'Only',
-        firstName: 'CléA',
-        sex: 'M',
-        birthPostalCode: '97180',
-        birthINSEECode: null,
-        birthCity: 'Sainte-Anne',
-        birthCountry: 'France',
-        email: null,
-        resultRecipientEmail: null,
-        birthdate: '1925-06-28',
-        sessionId,
-        externalId: 'GHI789',
-        extraTimePercentage: 1.5,
-        complementaryCertifications: [cleaNumerique],
-      });
-      databaseBuilder.factory.buildComplementaryCertificationSubscription({
-        certificationCandidateId: onlyCleaNumeriqueCandidate.id,
-        complementaryCertificationId: cleaNumerique.id,
-      });
-
-      databaseBuilder.factory.buildCertificationCandidate({
-        lastName: 'No',
-        firstName: 'Complementary certifications',
-        sex: 'M',
-        birthPostalCode: null,
-        birthINSEECode: '99132',
-        birthCity: 'Londres',
-        birthCountry: 'Angleterre',
-        email: 'jack@d.it',
-        resultRecipientEmail: 'destinataire@gmail.com',
-        birthdate: '1980-08-10',
-        sessionId,
-        externalId: null,
-        extraTimePercentage: 0.15,
-        complementaryCertifications: [],
-      });
-
-      await databaseBuilder.commit();
-      // when
-      const { session, certificationCenterHabilitations } = await usecases.getCandidateImportSheetData({
-        sessionId,
-        userId,
-      });
-      const updatedOdsFileBuffer = await fillCandidatesImportSheet({
-        session,
-        certificationCenterHabilitations,
-      });
-      await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
-      const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
-      const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
-
-      // then
-      expect(actualResult).to.deep.equal(expectedResult);
+    const cleaNumeriqueCandidate = databaseBuilder.factory.buildCertificationCandidate({
+      lastName: 'Only',
+      firstName: 'CléA',
+      sex: 'M',
+      birthPostalCode: '97180',
+      birthINSEECode: null,
+      birthCity: 'Sainte-Anne',
+      birthCountry: 'France',
+      email: null,
+      resultRecipientEmail: null,
+      birthdate: '1925-06-28',
+      sessionId,
+      externalId: 'GHI789',
+      extraTimePercentage: 1.5,
+      complementaryCertifications: [cleaNumerique],
     });
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      certificationCandidateId: cleaNumeriqueCandidate.id,
+      complementaryCertificationId: cleaNumerique.id,
+    });
+
+    databaseBuilder.factory.buildCertificationCandidate({
+      lastName: 'No',
+      firstName: 'Complementary certifications',
+      sex: 'M',
+      birthPostalCode: null,
+      birthINSEECode: '99132',
+      birthCity: 'Londres',
+      birthCountry: 'Angleterre',
+      email: 'jack@d.it',
+      resultRecipientEmail: 'destinataire@gmail.com',
+      birthdate: '1980-08-10',
+      sessionId,
+      externalId: null,
+      extraTimePercentage: 0.15,
+      complementaryCertifications: [],
+    });
+
+    await databaseBuilder.commit();
+    // when
+    const { session, certificationCenterHabilitations } = await usecases.getCandidateImportSheetData({
+      sessionId,
+      userId,
+    });
+    const updatedOdsFileBuffer = await fillCandidatesImportSheet({
+      session,
+      certificationCenterHabilitations,
+    });
+    await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
+    const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
+    const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
+
+    // then
+    expect(actualResult).to.deep.equal(expectedResult);
+  });
+
+  it('should return a candidate import sheet with session data, certification candidates data prefilled with two complementary certifications', async function () {
+    // given
+    expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-two-complementary-certifications.ods`;
+    actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-two-complementary-certifications.tmp.ods`;
+
+    const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
+    const pixPlusDroit = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+ Droit' });
+
+    const certificationCenterName = 'Centre de certification';
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+      name: certificationCenterName,
+    }).id;
+
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId,
+      complementaryCertificationId: cleaNumerique.id,
+    });
+    databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+      certificationCenterId,
+      complementaryCertificationId: pixPlusDroit.id,
+    });
+
+    userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+
+    sessionId = databaseBuilder.factory.buildSession({
+      id: 10,
+      certificationCenter: certificationCenterName,
+      certificationCenterId: certificationCenterId,
+      accessCode: 'ABC123DEF',
+      address: '3 rue des bibiches',
+      room: '28D',
+      examiner: 'Johnny',
+      date: '2020-07-05',
+      time: '14:30',
+      description: 'La super description',
+    }).id;
+
+    const allComplementaryCertificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+      lastName: 'All',
+      firstName: 'Complementary certifications',
+      sex: 'M',
+      birthPostalCode: '75018',
+      birthINSEECode: null,
+      birthCity: 'Paris',
+      birthCountry: 'France',
+      email: 'jackson@gmail.com',
+      resultRecipientEmail: 'destinataire@gmail.com',
+      birthdate: '2004-04-04',
+      sessionId,
+      externalId: 'ABC123',
+      extraTimePercentage: 0.6,
+      complementaryCertifications: [cleaNumerique, pixPlusDroit],
+    });
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      certificationCandidateId: allComplementaryCertificationCandidate.id,
+      complementaryCertificationId: cleaNumerique.id,
+    });
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      certificationCandidateId: allComplementaryCertificationCandidate.id,
+      complementaryCertificationId: pixPlusDroit.id,
+    });
+
+    const onlyPixPlusDroitCandidate = databaseBuilder.factory.buildCertificationCandidate({
+      lastName: 'Only',
+      firstName: 'Droit',
+      sex: 'F',
+      birthPostalCode: null,
+      birthINSEECode: '2A004',
+      birthCity: 'Ajaccio',
+      birthCountry: 'France',
+      email: 'jaja@hotmail.fr',
+      resultRecipientEmail: 'destinataire@gmail.com',
+      birthdate: '2005-12-05',
+      sessionId,
+      externalId: 'DEF456',
+      extraTimePercentage: null,
+      complementaryCertifications: [pixPlusDroit],
+    });
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      certificationCandidateId: onlyPixPlusDroitCandidate.id,
+      complementaryCertificationId: pixPlusDroit.id,
+    });
+
+    const onlyCleaNumeriqueCandidate = databaseBuilder.factory.buildCertificationCandidate({
+      lastName: 'Only',
+      firstName: 'CléA',
+      sex: 'M',
+      birthPostalCode: '97180',
+      birthINSEECode: null,
+      birthCity: 'Sainte-Anne',
+      birthCountry: 'France',
+      email: null,
+      resultRecipientEmail: null,
+      birthdate: '1925-06-28',
+      sessionId,
+      externalId: 'GHI789',
+      extraTimePercentage: 1.5,
+      complementaryCertifications: [cleaNumerique],
+    });
+    databaseBuilder.factory.buildComplementaryCertificationSubscription({
+      certificationCandidateId: onlyCleaNumeriqueCandidate.id,
+      complementaryCertificationId: cleaNumerique.id,
+    });
+
+    databaseBuilder.factory.buildCertificationCandidate({
+      lastName: 'No',
+      firstName: 'Complementary certifications',
+      sex: 'M',
+      birthPostalCode: null,
+      birthINSEECode: '99132',
+      birthCity: 'Londres',
+      birthCountry: 'Angleterre',
+      email: 'jack@d.it',
+      resultRecipientEmail: 'destinataire@gmail.com',
+      birthdate: '1980-08-10',
+      sessionId,
+      externalId: null,
+      extraTimePercentage: 0.15,
+      complementaryCertifications: [],
+    });
+
+    await databaseBuilder.commit();
+    // when
+    const { session, certificationCenterHabilitations } = await usecases.getCandidateImportSheetData({
+      sessionId,
+      userId,
+    });
+    const updatedOdsFileBuffer = await fillCandidatesImportSheet({
+      session,
+      certificationCenterHabilitations,
+    });
+    await writeFile(actualOdsFilePath, updatedOdsFileBuffer);
+    const actualResult = await readOdsUtils.getContentXml({ odsFilePath: actualOdsFilePath });
+    const expectedResult = await readOdsUtils.getContentXml({ odsFilePath: expectedOdsFilePath });
+
+    // then
+    expect(actualResult).to.deep.equal(expectedResult);
   });
 
   context(
@@ -430,7 +426,6 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
       context('when some candidate have complementary certifications', function () {
         it('should return a candidate import sheet with session data, candidates data prefilled', async function () {
           // given
-          sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
           sinon.stub(featureToggles, 'isCertificationBillingEnabled').value(true);
           expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-billing-columns-complementary.ods`;
           actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-billing-columns-complementary.tmp.ods`;

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -3,24 +3,17 @@ const CertificationScoringCompleted = require('../../../../lib/domain/events/Cer
 const CertificationRescoringCompleted = require('../../../../lib/domain/events/CertificationRescoringCompleted');
 const { handleCleaCertificationScoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 const { CLEA } = require('../../../../lib/domain/models/ComplementaryCertification');
-const { featureToggles } = require('../../../../lib/config');
 
 describe('Unit | Domain | Events | handle-clea-certification-scoring', function () {
   let partnerCertificationScoringRepository;
   let certificationCourseRepository;
-  let certificationCenterRepository;
   let badgeRepository;
   let knowledgeElementRepository;
   let targetProfileRepository;
   let badgeCriteriaService;
   let complementaryCertificationCourseRepository;
-  let cleaCertificationResultRepository;
 
   beforeEach(function () {
-    certificationCenterRepository = {
-      getByCertificationCourseId: sinon.stub(),
-    };
-
     partnerCertificationScoringRepository = {
       buildCleaCertificationScoring: sinon.stub(),
       save: sinon.stub(),
@@ -47,183 +40,171 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
     };
 
     complementaryCertificationCourseRepository = { hasComplementaryCertification: sinon.stub() };
-
-    cleaCertificationResultRepository = { get: sinon.stub() };
   });
 
-  context('when feature toggle isComplementaryCertificationSubscriptionEnabled is disabled', function () {
-    beforeEach(function () {
-      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
-    });
-    context('check event', function () {
-      it('fails when event is not an event', async function () {
-        // when / then
-        const event = 'not a good event';
-        const error = await catchErr(handleCleaCertificationScoring)({
-          event,
-          partnerCertificationScoringRepository,
-          badgeRepository,
-          knowledgeElementRepository,
-          certificationCourseRepository,
-          targetProfileRepository,
-          badgeCriteriaService,
-          complementaryCertificationCourseRepository,
-        });
-
-        // then
-        expect(error.message).to.equal(
-          'event must be one of types CertificationScoringCompleted, CertificationRescoringCompleted'
-        );
+  context('check event', function () {
+    it('fails when event is not an event', async function () {
+      // when / then
+      const event = 'not a good event';
+      const error = await catchErr(handleCleaCertificationScoring)({
+        event,
+        partnerCertificationScoringRepository,
+        badgeRepository,
+        knowledgeElementRepository,
+        certificationCourseRepository,
+        targetProfileRepository,
+        badgeCriteriaService,
+        complementaryCertificationCourseRepository,
       });
 
-      it('does not fail if event is of correct type CertificationScoringCompleted', async function () {
-        // when / then
-        const event = new CertificationRescoringCompleted({});
-        const error = await catchErr(handleCleaCertificationScoring)({
-          event,
-          partnerCertificationScoringRepository,
-          badgeRepository,
-          knowledgeElementRepository,
-          certificationCourseRepository,
-          targetProfileRepository,
-          badgeCriteriaService,
-          complementaryCertificationCourseRepository,
-        });
-
-        // then
-        expect(error.message).to.not.equal(
-          'event must be one of types CertificationScoringCompleted, CertificationRescoringCompleted'
-        );
-      });
-
-      it('does not fail if event is of correct type CertificationRescoringCompleted', async function () {
-        // given
-        const event = new CertificationRescoringCompleted({});
-        // when / then
-        const error = await catchErr(handleCleaCertificationScoring)({
-          event,
-          partnerCertificationScoringRepository,
-          badgeRepository,
-          knowledgeElementRepository,
-          certificationCourseRepository,
-          targetProfileRepository,
-          badgeCriteriaService,
-          complementaryCertificationCourseRepository,
-        });
-
-        // then
-        expect(error.message).not.to.equal('event must be one of types CertificationScoringCompleted');
-      });
+      // then
+      expect(error.message).to.equal(
+        'event must be one of types CertificationScoringCompleted, CertificationRescoringCompleted'
+      );
     });
 
-    context('#handleCleaCertificationRescoring', function () {
-      context('when certification center is habilitated', function () {
-        context('when CleA certification was not even taken in the first place', function () {
-          it('should not build or save no partner certification scoring', async function () {
-            // given
-            const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId.withArgs(123).resolves(certificationCenter);
-
-            cleaCertificationResultRepository.get
-              .withArgs({ certificationCourseId: 123 })
-              .resolves(domainBuilder.buildCleaCertificationResult.notTaken());
-
-            // when
-            await handleCleaCertificationScoring({
-              event: certificationRescoringCompletedEvent,
-              partnerCertificationScoringRepository,
-              cleaCertificationResultRepository,
-              certificationCenterRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.buildCleaCertificationScoring).not.to.have.been.called;
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
-          });
-        });
-
-        context('when CleA Certification was taken', function () {
-          it('should save the re-scored cleA certification', async function () {
-            // given
-            const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId.withArgs(123).resolves(certificationCenter);
-
-            cleaCertificationResultRepository.get
-              .withArgs({ certificationCourseId: 123 })
-              .resolves(domainBuilder.buildCleaCertificationResult.acquired());
-            const cleaCertificationRescoring = domainBuilder.buildCleaCertificationScoring();
-            partnerCertificationScoringRepository.buildCleaCertificationScoring.resolves(cleaCertificationRescoring);
-            partnerCertificationScoringRepository.save.resolves();
-
-            // when
-            await handleCleaCertificationScoring({
-              event: certificationRescoringCompletedEvent,
-              partnerCertificationScoringRepository,
-              cleaCertificationResultRepository,
-              certificationCenterRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.buildCleaCertificationScoring).to.have.been.calledWithExactly({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-            expect(partnerCertificationScoringRepository.save).to.have.been.calledWithExactly({
-              partnerCertificationScoring: cleaCertificationRescoring,
-            });
-          });
-        });
+    it('does not fail if event is of correct type CertificationScoringCompleted', async function () {
+      // when / then
+      const event = new CertificationRescoringCompleted({});
+      const error = await catchErr(handleCleaCertificationScoring)({
+        event,
+        partnerCertificationScoringRepository,
+        badgeRepository,
+        knowledgeElementRepository,
+        certificationCourseRepository,
+        targetProfileRepository,
+        badgeCriteriaService,
+        complementaryCertificationCourseRepository,
       });
 
-      context('when certification center is not habilitated', function () {
-        it('should not save the re-scored cleA certification', async function () {
+      // then
+      expect(error.message).not.to.equal(
+        'event must be one of types CertificationScoringCompleted, CertificationRescoringCompleted'
+      );
+    });
+
+    it('does not fail if event is of correct type CertificationRescoringCompleted', async function () {
+      // given
+      const event = new CertificationRescoringCompleted({});
+      // when / then
+      const error = await catchErr(handleCleaCertificationScoring)({
+        event,
+        partnerCertificationScoringRepository,
+        badgeRepository,
+        knowledgeElementRepository,
+        certificationCourseRepository,
+        targetProfileRepository,
+        badgeCriteriaService,
+        complementaryCertificationCourseRepository,
+      });
+
+      // then
+      expect(error.message).not.to.equal('event must be one of types CertificationScoringCompleted');
+    });
+  });
+
+  context('#handleCleaCertificationScoring', function () {
+    context('when scoring', function () {
+      context('when cleA certification has been started', function () {
+        it('should save a certif partner', async function () {
           // given
-          const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-            certificationCourseId: 123,
-            userId: 456,
-            reproducibilityRate: 80,
+          const userId = 1234;
+          const certificationCourseId = 4567;
+          const knowledgeElements = [
+            domainBuilder.buildKnowledgeElement({ userId }),
+            domainBuilder.buildKnowledgeElement({ userId }),
+          ];
+          const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+            reproducibilityRate: 85,
+            hasAcquiredBadge: true,
           });
+          const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
+          const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
+          const event = new CertificationScoringCompleted({
+            certificationCourseId,
+            userId,
+            isCertification: true,
+            reproducibilityRate: 85,
+          });
+          const date = '2021-01-01';
 
-          const complementaryCertification = domainBuilder.buildComplementaryCertification({
-            name: 'Tarte au fromage',
-          });
-          const certificationCenter = domainBuilder.buildCertificationCenter({
-            habilitations: [complementaryCertification],
-          });
+          partnerCertificationScoringRepository.buildCleaCertificationScoring
+            .withArgs({
+              certificationCourseId,
+              userId,
+              reproducibilityRate: 85,
+            })
+            .resolves(cleaCertificationScoring);
 
-          certificationCenterRepository.getByCertificationCourseId.withArgs(123).resolves(certificationCenter);
+          certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
+
+          badgeRepository.getByKey.resolves(badge);
+
+          targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
+
+          knowledgeElementRepository.findUniqByUserId
+            .withArgs({ userId: event.userId, limitDate: date })
+            .resolves(knowledgeElements);
+
+          badgeCriteriaService.areBadgeCriteriaFulfilled
+            .withArgs({ knowledgeElements, targetProfile, badge })
+            .returns(true);
+
+          complementaryCertificationCourseRepository.hasComplementaryCertification
+            .withArgs({
+              certificationCourseId,
+              complementaryCertificationName: CLEA,
+            })
+            .resolves(true);
 
           // when
           await handleCleaCertificationScoring({
-            event: certificationRescoringCompletedEvent,
-            cleaCertificationResultRepository,
+            event,
             partnerCertificationScoringRepository,
-            certificationCenterRepository,
+            badgeRepository,
+            knowledgeElementRepository,
+            certificationCourseRepository,
+            targetProfileRepository,
+            badgeCriteriaService,
+            complementaryCertificationCourseRepository,
+          });
+
+          // then
+          expect(partnerCertificationScoringRepository.save).to.have.been.calledWithMatch({
+            partnerCertificationScoring: cleaCertificationScoring,
+          });
+        });
+      });
+
+      context('when cleA certification has not been started', function () {
+        it('should not save a certif partner', async function () {
+          // given
+          const userId = 1234;
+          const certificationCourseId = 4567;
+          complementaryCertificationCourseRepository.hasComplementaryCertification
+            .withArgs({
+              certificationCourseId,
+              complementaryCertificationName: CLEA,
+            })
+            .resolves(false);
+
+          const event = new CertificationScoringCompleted({
+            certificationCourseId,
+            userId,
+            isCertification: true,
+            reproducibilityRate: 85,
+          });
+
+          // when
+          await handleCleaCertificationScoring({
+            event,
+            partnerCertificationScoringRepository,
+            badgeRepository,
+            knowledgeElementRepository,
+            certificationCourseRepository,
+            targetProfileRepository,
+            badgeCriteriaService,
+            complementaryCertificationCourseRepository,
           });
 
           // then
@@ -232,652 +213,111 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
       });
     });
 
-    context('#handleCleaCertificationScoring', function () {
-      context('when scoring', function () {
-        context('when badge is not acquired', function () {
-          it('should not save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-
-            const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
-              reproducibilityRate: 85,
-              hasAcquiredBadge: false,
-            });
-
-            const event = new CertificationScoringCompleted({
-              certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
-
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId
-              .withArgs(certificationCourseId)
-              .resolves(certificationCenter);
-
-            partnerCertificationScoringRepository.buildCleaCertificationScoring
-              .withArgs({
-                certificationCourseId,
-                userId,
-                reproducibilityRate: 85,
-              })
-              .resolves(cleaCertificationScoring);
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCenterRepository,
-              certificationCourseRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
+    context('when rescoring', function () {
+      context('when cleA certification has been started', function () {
+        it('should save a certif partner', async function () {
+          // given
+          const userId = 1234;
+          const certificationCourseId = 4567;
+          const knowledgeElements = [
+            domainBuilder.buildKnowledgeElement({ userId }),
+            domainBuilder.buildKnowledgeElement({ userId }),
+          ];
+          const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
+            reproducibilityRate: 85,
+            hasAcquiredBadge: true,
           });
-        });
-        context('when certification is eligible', function () {
-          it('should save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-            const knowledgeElements = [
-              domainBuilder.buildKnowledgeElement({ userId }),
-              domainBuilder.buildKnowledgeElement({ userId }),
-            ];
-            const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
-              reproducibilityRate: 85,
-              hasAcquiredBadge: true,
-            });
-            const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
-            const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
-            const event = new CertificationScoringCompleted({
-              certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-            const date = '2021-01-01';
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
-
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId
-              .withArgs(certificationCourseId)
-              .resolves(certificationCenter);
-
-            partnerCertificationScoringRepository.buildCleaCertificationScoring
-              .withArgs({
-                certificationCourseId,
-                userId,
-                reproducibilityRate: 85,
-              })
-              .resolves(cleaCertificationScoring);
-
-            certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
-
-            badgeRepository.getByKey.resolves(badge);
-
-            targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
-
-            knowledgeElementRepository.findUniqByUserId
-              .withArgs({ userId: event.userId, limitDate: date })
-              .resolves(knowledgeElements);
-
-            badgeCriteriaService.areBadgeCriteriaFulfilled
-              .withArgs({ knowledgeElements, targetProfile, badge })
-              .returns(true);
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              certificationCenterRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).to.have.been.calledWithMatch({
-              partnerCertificationScoring: cleaCertificationScoring,
-            });
+          const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
+          const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
+          const event = new CertificationRescoringCompleted({
+            certificationCourseId,
+            userId,
+            isCertification: true,
+            reproducibilityRate: 85,
           });
-        });
+          const date = '2021-01-01';
 
-        context('when certification is not eligible', function () {
-          it('should not save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-            const knowledgeElements = [
-              domainBuilder.buildKnowledgeElement({ userId }),
-              domainBuilder.buildKnowledgeElement({ userId }),
-            ];
-            const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
-              reproducibilityRate: 85,
-              hasAcquiredBadge: true,
-            });
-            const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
-            const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
-            const event = new CertificationScoringCompleted({
+          partnerCertificationScoringRepository.buildCleaCertificationScoring
+            .withArgs({
               certificationCourseId,
               userId,
-              isCertification: true,
               reproducibilityRate: 85,
-            });
-            const date = '2021-01-01';
+            })
+            .resolves(cleaCertificationScoring);
 
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
+          certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
 
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
+          badgeRepository.getByKey.resolves(badge);
 
-            certificationCenterRepository.getByCertificationCourseId
-              .withArgs(certificationCourseId)
-              .resolves(certificationCenter);
+          targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
 
-            partnerCertificationScoringRepository.buildCleaCertificationScoring
-              .withArgs({
-                certificationCourseId,
-                userId,
-                reproducibilityRate: 85,
-              })
-              .resolves(cleaCertificationScoring);
+          knowledgeElementRepository.findUniqByUserId
+            .withArgs({ userId: event.userId, limitDate: date })
+            .resolves(knowledgeElements);
 
-            certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
+          badgeCriteriaService.areBadgeCriteriaFulfilled
+            .withArgs({ knowledgeElements, targetProfile, badge })
+            .returns(true);
 
-            badgeRepository.getByKey.resolves(badge);
+          complementaryCertificationCourseRepository.hasComplementaryCertification
+            .withArgs({
+              certificationCourseId,
+              complementaryCertificationName: CLEA,
+            })
+            .resolves(true);
 
-            targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
-
-            knowledgeElementRepository.findUniqByUserId
-              .withArgs({ userId: event.userId, limitDate: date })
-              .resolves(knowledgeElements);
-
-            badgeCriteriaService.areBadgeCriteriaFulfilled
-              .withArgs({ knowledgeElements, targetProfile, badge })
-              .returns(false);
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              certificationCenterRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
+          // when
+          await handleCleaCertificationScoring({
+            event,
+            partnerCertificationScoringRepository,
+            badgeRepository,
+            knowledgeElementRepository,
+            certificationCourseRepository,
+            targetProfileRepository,
+            badgeCriteriaService,
+            complementaryCertificationCourseRepository,
           });
-        });
 
-        context('when certification center is not habilitated', function () {
-          it('should not save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-
-            const event = new CertificationScoringCompleted({
-              certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'Tarte au fromage',
-            });
-
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId
-              .withArgs(certificationCourseId)
-              .resolves(certificationCenter);
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              certificationCenterRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
+          // then
+          expect(partnerCertificationScoringRepository.save).to.have.been.calledWithMatch({
+            partnerCertificationScoring: cleaCertificationScoring,
           });
         });
       });
 
-      context('when rescoring', function () {
-        context('when CleA certification was not even taken in the first place', function () {
-          it('should not build or save no partner certification scoring', async function () {
-            // given
-            const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId.withArgs(123).resolves(certificationCenter);
-
-            cleaCertificationResultRepository.get
-              .withArgs({ certificationCourseId: 123 })
-              .resolves(domainBuilder.buildCleaCertificationResult.notTaken());
-
-            // when
-            await handleCleaCertificationScoring({
-              event: certificationRescoringCompletedEvent,
-              partnerCertificationScoringRepository,
-              cleaCertificationResultRepository,
-              certificationCenterRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.buildCleaCertificationScoring).not.to.have.been.called;
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
-          });
-        });
-
-        context('when CleA Certification was taken', function () {
-          it('should save the re-scored cleA certification', async function () {
-            // given
-            const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'CléA Numérique',
-            });
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId.withArgs(123).resolves(certificationCenter);
-
-            cleaCertificationResultRepository.get
-              .withArgs({ certificationCourseId: 123 })
-              .resolves(domainBuilder.buildCleaCertificationResult.acquired());
-            const cleaCertificationRescoring = domainBuilder.buildCleaCertificationScoring();
-            partnerCertificationScoringRepository.buildCleaCertificationScoring.resolves(cleaCertificationRescoring);
-            partnerCertificationScoringRepository.save.resolves();
-
-            // when
-            await handleCleaCertificationScoring({
-              event: certificationRescoringCompletedEvent,
-              partnerCertificationScoringRepository,
-              cleaCertificationResultRepository,
-              certificationCenterRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.buildCleaCertificationScoring).to.have.been.calledWithExactly({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-            expect(partnerCertificationScoringRepository.save).to.have.been.calledWithExactly({
-              partnerCertificationScoring: cleaCertificationRescoring,
-            });
-          });
-        });
-
-        context('when certification center is not habilited', function () {
-          it('should not save the re-scored cleA certification', async function () {
-            // given
-            const certificationRescoringCompletedEvent = domainBuilder.buildCertificationRescoringCompletedEvent({
-              certificationCourseId: 123,
-              userId: 456,
-              reproducibilityRate: 80,
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertification({
-              name: 'Tarte au fromage',
-            });
-            const certificationCenter = domainBuilder.buildCertificationCenter({
-              habilitations: [complementaryCertification],
-            });
-
-            certificationCenterRepository.getByCertificationCourseId.withArgs(123).resolves(certificationCenter);
-
-            // when
-            await handleCleaCertificationScoring({
-              event: certificationRescoringCompletedEvent,
-              cleaCertificationResultRepository,
-              partnerCertificationScoringRepository,
-              certificationCenterRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
-          });
-        });
-      });
-    });
-  });
-
-  context('when feature toggle isComplementaryCertificationSubscriptionEnabled is enabled', function () {
-    beforeEach(function () {
-      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
-    });
-    context('check event', function () {
-      it('fails when event is not an event', async function () {
-        // when / then
-        const event = 'not a good event';
-        const error = await catchErr(handleCleaCertificationScoring)({
-          event,
-          partnerCertificationScoringRepository,
-          badgeRepository,
-          knowledgeElementRepository,
-          certificationCourseRepository,
-          targetProfileRepository,
-          badgeCriteriaService,
-          complementaryCertificationCourseRepository,
-        });
-
-        // then
-        expect(error.message).to.equal(
-          'event must be one of types CertificationScoringCompleted, CertificationRescoringCompleted'
-        );
-      });
-
-      it('does not fail if event is of correct type CertificationScoringCompleted', async function () {
-        // when / then
-        const event = new CertificationRescoringCompleted({});
-        const error = await catchErr(handleCleaCertificationScoring)({
-          event,
-          partnerCertificationScoringRepository,
-          badgeRepository,
-          knowledgeElementRepository,
-          certificationCourseRepository,
-          targetProfileRepository,
-          badgeCriteriaService,
-          complementaryCertificationCourseRepository,
-        });
-
-        // then
-        expect(error.message).not.to.equal(
-          'event must be one of types CertificationScoringCompleted, CertificationRescoringCompleted'
-        );
-      });
-
-      it('does not fail if event is of correct type CertificationRescoringCompleted', async function () {
-        // given
-        const event = new CertificationRescoringCompleted({});
-        // when / then
-        const error = await catchErr(handleCleaCertificationScoring)({
-          event,
-          partnerCertificationScoringRepository,
-          badgeRepository,
-          knowledgeElementRepository,
-          certificationCourseRepository,
-          targetProfileRepository,
-          badgeCriteriaService,
-          complementaryCertificationCourseRepository,
-        });
-
-        // then
-        expect(error.message).not.to.equal('event must be one of types CertificationScoringCompleted');
-      });
-    });
-
-    context('#handleCleaCertificationScoring', function () {
-      context('when scoring', function () {
-        context('when cleA certification has been started', function () {
-          it('should save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-            const knowledgeElements = [
-              domainBuilder.buildKnowledgeElement({ userId }),
-              domainBuilder.buildKnowledgeElement({ userId }),
-            ];
-            const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
-              reproducibilityRate: 85,
-              hasAcquiredBadge: true,
-            });
-            const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
-            const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
-            const event = new CertificationScoringCompleted({
+      context('when cleA certification has not been started', function () {
+        it('should not save a certif partner', async function () {
+          // given
+          const userId = 1234;
+          const certificationCourseId = 4567;
+          complementaryCertificationCourseRepository.hasComplementaryCertification
+            .withArgs({
               certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-            const date = '2021-01-01';
+              complementaryCertificationName: CLEA,
+            })
+            .resolves(false);
 
-            partnerCertificationScoringRepository.buildCleaCertificationScoring
-              .withArgs({
-                certificationCourseId,
-                userId,
-                reproducibilityRate: 85,
-              })
-              .resolves(cleaCertificationScoring);
-
-            certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
-
-            badgeRepository.getByKey.resolves(badge);
-
-            targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
-
-            knowledgeElementRepository.findUniqByUserId
-              .withArgs({ userId: event.userId, limitDate: date })
-              .resolves(knowledgeElements);
-
-            badgeCriteriaService.areBadgeCriteriaFulfilled
-              .withArgs({ knowledgeElements, targetProfile, badge })
-              .returns(true);
-
-            complementaryCertificationCourseRepository.hasComplementaryCertification
-              .withArgs({
-                certificationCourseId,
-                complementaryCertificationName: CLEA,
-              })
-              .resolves(true);
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-              complementaryCertificationCourseRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).to.have.been.calledWithMatch({
-              partnerCertificationScoring: cleaCertificationScoring,
-            });
+          const event = new CertificationRescoringCompleted({
+            certificationCourseId,
+            userId,
+            isCertification: true,
+            reproducibilityRate: 85,
           });
-        });
 
-        context('when cleA certification has not been started', function () {
-          it('should not save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-            complementaryCertificationCourseRepository.hasComplementaryCertification
-              .withArgs({
-                certificationCourseId,
-                complementaryCertificationName: CLEA,
-              })
-              .resolves(false);
-
-            const event = new CertificationScoringCompleted({
-              certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-              complementaryCertificationCourseRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
+          // when
+          await handleCleaCertificationScoring({
+            event,
+            partnerCertificationScoringRepository,
+            badgeRepository,
+            knowledgeElementRepository,
+            certificationCourseRepository,
+            targetProfileRepository,
+            badgeCriteriaService,
+            complementaryCertificationCourseRepository,
           });
-        });
-      });
 
-      context('when rescoring', function () {
-        context('when cleA certification has been started', function () {
-          it('should save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-            const knowledgeElements = [
-              domainBuilder.buildKnowledgeElement({ userId }),
-              domainBuilder.buildKnowledgeElement({ userId }),
-            ];
-            const cleaCertificationScoring = domainBuilder.buildCleaCertificationScoring({
-              reproducibilityRate: 85,
-              hasAcquiredBadge: true,
-            });
-            const targetProfile = domainBuilder.buildTargetProfile({ id: 34435 });
-            const badge = domainBuilder.buildBadge({ targetProfileId: 34435 });
-            const event = new CertificationRescoringCompleted({
-              certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-            const date = '2021-01-01';
-
-            partnerCertificationScoringRepository.buildCleaCertificationScoring
-              .withArgs({
-                certificationCourseId,
-                userId,
-                reproducibilityRate: 85,
-              })
-              .resolves(cleaCertificationScoring);
-
-            certificationCourseRepository.getCreationDate.withArgs(certificationCourseId).resolves(date);
-
-            badgeRepository.getByKey.resolves(badge);
-
-            targetProfileRepository.get.withArgs(34435).resolves(targetProfile);
-
-            knowledgeElementRepository.findUniqByUserId
-              .withArgs({ userId: event.userId, limitDate: date })
-              .resolves(knowledgeElements);
-
-            badgeCriteriaService.areBadgeCriteriaFulfilled
-              .withArgs({ knowledgeElements, targetProfile, badge })
-              .returns(true);
-
-            complementaryCertificationCourseRepository.hasComplementaryCertification
-              .withArgs({
-                certificationCourseId,
-                complementaryCertificationName: CLEA,
-              })
-              .resolves(true);
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-              complementaryCertificationCourseRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).to.have.been.calledWithMatch({
-              partnerCertificationScoring: cleaCertificationScoring,
-            });
-          });
-        });
-
-        context('when cleA certification has not been started', function () {
-          it('should not save a certif partner', async function () {
-            // given
-            const userId = 1234;
-            const certificationCourseId = 4567;
-            complementaryCertificationCourseRepository.hasComplementaryCertification
-              .withArgs({
-                certificationCourseId,
-                complementaryCertificationName: CLEA,
-              })
-              .resolves(false);
-
-            const event = new CertificationRescoringCompleted({
-              certificationCourseId,
-              userId,
-              isCertification: true,
-              reproducibilityRate: 85,
-            });
-
-            // when
-            await handleCleaCertificationScoring({
-              event,
-              partnerCertificationScoringRepository,
-              badgeRepository,
-              knowledgeElementRepository,
-              certificationCourseRepository,
-              targetProfileRepository,
-              badgeCriteriaService,
-              complementaryCertificationCourseRepository,
-            });
-
-            // then
-            expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
-          });
+          // then
+          expect(partnerCertificationScoringRepository.save).not.to.have.been.called;
         });
       });
     });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -12,7 +12,6 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 const ComplementaryCertificationCourse = require('../../../../lib/domain/models/ComplementaryCertificationCourse');
 const _ = require('lodash');
-const { featureToggles } = require('../../../../lib/config');
 
 describe('Unit | UseCase | retrieve-last-or-create-certification-course', function () {
   let clock;
@@ -447,943 +446,17 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   });
                 });
 
-                context(
-                  'when the feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is inactive',
-                  function () {
-                    beforeEach(function () {
-                      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
-                    });
-                    context('when certificationCenter has no habilitation', function () {
-                      context('when user is eligible for cleA and Pix+ Droit', function () {
-                        it('should not save complementary certification', async function () {
-                          // given
-                          const domainTransaction = Symbol('someDomainTransaction');
-                          const noComplementaryCertification = [];
-
-                          const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
-                          sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                            .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                            .resolves(null);
-
-                          const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                            userId: 2,
-                            sessionId: 1,
-                            authorizedToStart: true,
-                            complementaryCertifications: noComplementaryCertification,
-                          });
-
-                          const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                            _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                          certificationChallengesService.pickCertificationChallenges
-                            .withArgs(placementProfile)
-                            .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                          certificationCandidateRepository.getBySessionIdAndUserId
-                            .withArgs({ sessionId: 1, userId: 2 })
-                            .resolves(foundCertificationCandidate);
-
-                          const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_DROIT,
-                          });
-                          const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                            name: CLEA,
-                          });
-                          const certificationCenter = domainBuilder.buildCertificationCenter({
-                            habilitations: noComplementaryCertification,
-                          });
-                          certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                          complementaryCertificationRepository.findAll.resolves([
-                            complementaryCertificationPixPlusDroit,
-                            complementaryCertificationCleA,
-                          ]);
-
-                          const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                          const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                          const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-
-                          const pixDroitMaitreBadgeAcquisition =
-                            domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
-                          certificationBadgesService.findStillValidBadgeAcquisitions
-                            .withArgs({ userId: 2, domainTransaction })
-                            .resolves([pixDroitMaitreBadgeAcquisition]);
-
-                          certificationChallengesService.pickCertificationChallengesForPixPlus
-                            .withArgs(pixDroitMaitreBadgeAcquisition.badge, 2)
-                            .resolves([challengePlus1, challengePlus2, challengePlus3]);
-
-                          certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                            .withArgs({ userId: 2 })
-                            .resolves(true);
-
-                          const certificationCourseToSave = CertificationCourse.from({
-                            certificationCandidate: foundCertificationCandidate,
-                            challenges: [challenge1, challenge2],
-                            verificationCode,
-                            maxReachableLevelOnCertificationDate: 5,
-                            complementaryCertificationCourses: [],
-                          });
-
-                          const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                            certificationCourseToSave.toDTO()
-                          );
-
-                          certificationCourseRepository.save
-                            .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                            .resolves(savedCertificationCourse);
-
-                          const assessmentToSave = new Assessment({
-                            userId: 2,
-                            certificationCourseId: savedCertificationCourse.getId(),
-                            state: Assessment.states.STARTED,
-                            type: Assessment.types.CERTIFICATION,
-                            isImproving: false,
-                            method: Assessment.methods.CERTIFICATION_DETERMINED,
-                          });
-                          const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                          assessmentRepository.save
-                            .withArgs({ assessment: assessmentToSave, domainTransaction })
-                            .resolves(savedAssessment);
-
-                          // when
-                          const { certificationCourse: returnedCertificationCourse } =
-                            await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                          // then
-                          expect(certificationCourseRepository.save).to.have.been.calledWithExactly({
-                            certificationCourse: certificationCourseToSave,
-                            domainTransaction,
-                          });
-
-                          expect(returnedCertificationCourse._complementaryCertificationCourses).to.be.empty;
-                        });
-                      });
-                    });
-
-                    context('when certificationCenter has habilitation', function () {
-                      context('when user is eligible for cleA and Pix+ droit', function () {
-                        it('should save complementary certification info for cleA and Pix+ droit', async function () {
-                          // given
-                          const domainTransaction = Symbol('someDomainTransaction');
-                          const noComplementaryCertification = [];
-
-                          const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
-                          sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                            .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                            .resolves(null);
-
-                          const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                            userId: 2,
-                            sessionId: 1,
-                            authorizedToStart: true,
-                            complementaryCertifications: noComplementaryCertification,
-                          });
-
-                          const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                            _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                          certificationChallengesService.pickCertificationChallenges
-                            .withArgs(placementProfile)
-                            .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                          certificationCandidateRepository.getBySessionIdAndUserId
-                            .withArgs({ sessionId: 1, userId: 2 })
-                            .resolves(foundCertificationCandidate);
-
-                          const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_DROIT,
-                          });
-                          const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                            name: CLEA,
-                          });
-                          const certificationCenter = domainBuilder.buildCertificationCenter({
-                            habilitations: [complementaryCertificationCleA, complementaryCertificationPixPlusDroit],
-                          });
-
-                          certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                          complementaryCertificationRepository.findAll.resolves([
-                            complementaryCertificationPixPlusDroit,
-                            complementaryCertificationCleA,
-                          ]);
-
-                          const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                          const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                          const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-
-                          const pixDroitMaitreBadgeAcquisition =
-                            domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
-                          certificationBadgesService.findStillValidBadgeAcquisitions
-                            .withArgs({ userId: 2, domainTransaction })
-                            .resolves([pixDroitMaitreBadgeAcquisition]);
-
-                          certificationChallengesService.pickCertificationChallengesForPixPlus
-                            .withArgs(pixDroitMaitreBadgeAcquisition.badge, 2)
-                            .resolves([challengePlus1, challengePlus2, challengePlus3]);
-
-                          certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                            .withArgs({ userId: 2 })
-                            .resolves(true);
-
-                          const complementaryCertificationCoursePixPlusDroit =
-                            ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                              complementaryCertificationPixPlusDroit.id
-                            );
-                          const complementaryCertificationCourseCleA =
-                            ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                              complementaryCertificationCleA.id
-                            );
-                          const certificationCourseToSave = CertificationCourse.from({
-                            certificationCandidate: foundCertificationCandidate,
-                            challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                            verificationCode,
-                            maxReachableLevelOnCertificationDate: 5,
-                            complementaryCertificationCourses: [
-                              complementaryCertificationCoursePixPlusDroit,
-                              complementaryCertificationCourseCleA,
-                            ],
-                          });
-
-                          const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                            certificationCourseToSave.toDTO()
-                          );
-                          savedCertificationCourse._complementaryCertificationCourses = [
-                            {
-                              ...complementaryCertificationCoursePixPlusDroit,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                            },
-                            {
-                              ...complementaryCertificationCourseCleA,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                            },
-                          ];
-                          certificationCourseRepository.save
-                            .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                            .resolves(savedCertificationCourse);
-
-                          const assessmentToSave = new Assessment({
-                            userId: 2,
-                            certificationCourseId: savedCertificationCourse.getId(),
-                            state: Assessment.states.STARTED,
-                            type: Assessment.types.CERTIFICATION,
-                            isImproving: false,
-                            method: Assessment.methods.CERTIFICATION_DETERMINED,
-                          });
-                          const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                          assessmentRepository.save
-                            .withArgs({ assessment: assessmentToSave, domainTransaction })
-                            .resolves(savedAssessment);
-
-                          // when
-                          const { certificationCourse: returnedCertificationCourse } =
-                            await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                          // then
-                          expect(returnedCertificationCourse._complementaryCertificationCourses).to.deep.equal([
-                            {
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              complementaryCertificationId: complementaryCertificationPixPlusDroit.id,
-                            },
-                            {
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              complementaryCertificationId: complementaryCertificationCleA.id,
-                            },
-                          ]);
-                        });
-                      });
-                    });
-                  }
-                );
-
-                context(
-                  'when the feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is active',
-                  function () {
-                    beforeEach(function () {
-                      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
-                    });
-
-                    context('when certification center has habilitation for Pix+ Droit', function () {
-                      context('when user has certifiable badges with Pix+ Droit', function () {
-                        context('when user is granted for Pix+ Droit complementary certification', function () {
-                          it('should save complementary certification info for Pix+ Droit', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                              complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                            });
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const complementaryCertificationPixPlusDroit =
-                              domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
-                              });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationPixPlusDroit],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([
-                              complementaryCertificationPixPlusDroit,
-                            ]);
-
-                            const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                            const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                            const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-
-                            const pixDroitMaitreBadgeAcquisition =
-                              domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({ userId: 2, domainTransaction })
-                              .resolves([pixDroitMaitreBadgeAcquisition]);
-
-                            certificationChallengesService.pickCertificationChallengesForPixPlus
-                              .withArgs(pixDroitMaitreBadgeAcquisition.badge, 2)
-                              .resolves([challengePlus1, challengePlus2, challengePlus3]);
-
-                            const complementaryCertificationCourse =
-                              ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                                complementaryCertificationPixPlusDroit.id
-                              );
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                              complementaryCertificationCourses: [complementaryCertificationCourse],
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                              certificationCourseToSave.toDTO()
-                            );
-                            savedCertificationCourse._complementaryCertificationCourses = [
-                              {
-                                ...complementaryCertificationCourse,
-                                certificationCourseId: savedCertificationCourse.getId(),
-                              },
-                            ];
-                            certificationCourseRepository.save
-                              .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                              .resolves(savedCertificationCourse);
-
-                            const assessmentToSave = new Assessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                            assessmentRepository.save
-                              .withArgs({ assessment: assessmentToSave, domainTransaction })
-                              .resolves(savedAssessment);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([
-                              {
-                                certificationCourseId: savedCertificationCourse.getId(),
-                                complementaryCertificationId: complementaryCertificationPixPlusDroit.id,
-                              },
-                            ]);
-                          });
-
-                          it('should save all the challenges from pix and Pix+ Droit', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                              complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                            });
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const complementaryCertificationPixPlusDroit =
-                              domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
-                              });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationPixPlusDroit],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([
-                              complementaryCertificationPixPlusDroit,
-                            ]);
-
-                            const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                            const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                            const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-
-                            const pixDroitMaitreBadgeAcquisition =
-                              domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({ userId: 2, domainTransaction })
-                              .resolves([pixDroitMaitreBadgeAcquisition]);
-
-                            certificationChallengesService.pickCertificationChallengesForPixPlus
-                              .withArgs(pixDroitMaitreBadgeAcquisition.badge, 2)
-                              .resolves([challengePlus1, challengePlus2, challengePlus3]);
-
-                            const complementaryCertificationCourse =
-                              ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                                complementaryCertificationPixPlusDroit.id
-                              );
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                              complementaryCertificationCourses: [complementaryCertificationCourse],
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                              certificationCourseToSave.toDTO()
-                            );
-                            savedCertificationCourse._complementaryCertificationCourses = [
-                              {
-                                ...complementaryCertificationCourse,
-                                certificationCourseId: savedCertificationCourse.getId(),
-                              },
-                            ];
-                            certificationCourseRepository.save
-                              .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                              .resolves(savedCertificationCourse);
-
-                            const assessmentToSave = new Assessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                            assessmentRepository.save
-                              .withArgs({ assessment: assessmentToSave, domainTransaction })
-                              .resolves(savedAssessment);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(result.certificationCourse._challenges).to.deep.equal([
-                              challenge1,
-                              challenge2,
-                              challengePlus1,
-                              challengePlus2,
-                              challengePlus3,
-                            ]);
-                          });
-
-                          it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                              complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                            });
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            const complementaryCertificationPixPlusDroit =
-                              domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
-                              });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationPixPlusDroit],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([
-                              complementaryCertificationPixPlusDroit,
-                            ]);
-
-                            const challengesForMaitre = [
-                              domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
-                              domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
-                            ];
-                            const challengesForExpert = [
-                              domainBuilder.buildChallenge({ id: 'challenge-pixexpert1' }),
-                              domainBuilder.buildChallenge({ id: 'challenge-pixexpert2' }),
-                            ];
-                            const maitreBadge = domainBuilder.buildBadge({
-                              key: 'PIX_DROIT_MAITRE_CERTIF',
-                              targetProfileId: 11,
-                            });
-                            const expertBadge = domainBuilder.buildBadge({
-                              key: 'PIX_DROIT_EXPERT_CERTIF',
-                              targetProfileId: 22,
-                            });
-                            domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
-                            const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
-                              badge: expertBadge,
-                            });
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({ userId: 2, domainTransaction })
-                              .resolves([certifiableBadgeAcquisition2]);
-
-                            certificationChallengesService.pickCertificationChallengesForPixPlus
-                              .withArgs(maitreBadge, 2)
-                              .resolves(challengesForMaitre)
-                              .withArgs(expertBadge, 2)
-                              .resolves(challengesForExpert);
-
-                            const complementaryCertificationCourse =
-                              ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                                complementaryCertificationPixPlusDroit.id
-                              );
-
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2, ...challengesForExpert],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                              complementaryCertificationCourses: [complementaryCertificationCourse],
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse({
-                              ...foundCertificationCandidate,
-                              isV2Certification: true,
-                              challenges: [challenge1, challenge2, ...challengesForExpert],
-                            });
-
-                            savedCertificationCourse._complementaryCertificationCourses = [
-                              {
-                                ...complementaryCertificationCourse,
-                                certificationCourseId: savedCertificationCourse.getId(),
-                              },
-                            ];
-
-                            certificationCourseRepository.save
-                              .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                              .resolves(savedCertificationCourse);
-
-                            const savedAssessment = domainBuilder.buildAssessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.id,
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            assessmentRepository.save.resolves(savedAssessment);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(result.certificationCourse._challenges).to.deep.equal([
-                              challenge1,
-                              challenge2,
-                              ...challengesForExpert,
-                            ]);
-                          });
-                        });
-
-                        context('when user is not granted for Pix+ Droit complementary certification', function () {
-                          it('should not save complementary certification info', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              authorizedToStart: true,
-                              sessionId: 1,
-                              complementaryCertifications: [],
-                            });
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            const complementaryCertificationPixPlusDroit =
-                              domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
-                              });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationPixPlusDroit],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([
-                              complementaryCertificationPixPlusDroit,
-                            ]);
-
-                            const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
-                            const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                            const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
-                            const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
-                            const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
-                            const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
-                              badge: certifiableBadge1,
-                            });
-                            const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
-                              badge: certifiableBadge2,
-                            });
-
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({ userId: 2, domainTransaction })
-                              .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
-
-                            certificationChallengesService.pickCertificationChallengesForPixPlus
-                              .withArgs(certifiableBadge1, 2)
-                              .resolves([challengePlus1, challengePlus2])
-                              .withArgs(certifiableBadge2, 2)
-                              .resolves([challengePlus3]);
-
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                              complementaryCertificationCourses: [],
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                              certificationCourseToSave.toDTO()
-                            );
-                            certificationCourseRepository.save
-                              .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                              .resolves(savedCertificationCourse);
-
-                            const assessmentToSave = new Assessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                            assessmentRepository.save
-                              .withArgs({ assessment: assessmentToSave, domainTransaction })
-                              .resolves(savedAssessment);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(result.certificationCourse._complementaryCertificationCourses).to.be.empty;
-                          });
-                        });
-                      });
-
-                      context('when user has no certifiable badges for Pix+ Droit', function () {
-                        context('when user has no certifiable badges for Pix+ Droit', function () {
-                          it('should not save challenges from Pix+ Droit', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                              complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                            });
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            const complementaryCertificationPixPlusDroit =
-                              domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
-                              });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationPixPlusDroit],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([
-                              complementaryCertificationPixPlusDroit,
-                            ]);
-
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({ userId: 2, domainTransaction })
-                              .resolves([]);
-
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                              certificationCourseToSave.toDTO()
-                            );
-                            certificationCourseRepository.save
-                              .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                              .resolves(savedCertificationCourse);
-
-                            const assessmentToSave = new Assessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                            assessmentRepository.save
-                              .withArgs({ assessment: assessmentToSave, domainTransaction })
-                              .resolves(savedAssessment);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(result).to.deep.equal({
-                              created: true,
-                              certificationCourse: new CertificationCourse({
-                                ...savedCertificationCourse.toDTO(),
-                                assessment: savedAssessment,
-                                challenges: [challenge1, challenge2],
-                              }),
-                            });
-                          });
-
-                          it('should not generate challenges for expert badge', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                              complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
-                            });
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            const complementaryCertificationPixPlusDroit =
-                              domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
-                              });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationPixPlusDroit],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([
-                              complementaryCertificationPixPlusDroit,
-                            ]);
-
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({ userId: 2, domainTransaction })
-                              .resolves([]);
-
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse({
-                              ...foundCertificationCandidate,
-                              isV2Certification: true,
-                              challenges: [challenge1, challenge2],
-                            });
-
-                            certificationCourseRepository.save
-                              .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                              .resolves(savedCertificationCourse);
-                            const savedAssessment = domainBuilder.buildAssessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.id,
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            assessmentRepository.save.resolves(savedAssessment);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(result.certificationCourse._challenges).to.deep.equal([challenge1, challenge2]);
-                          });
-                        });
-                      });
-                    });
-
-                    context('when certification center has no habilitation for Pix+ Droit', function () {
-                      it('should save only the challenges from pix', async function () {
+                context('when certification center has habilitation for Pix+ Droit', function () {
+                  context('when user has certifiable badges with Pix+ Droit', function () {
+                    context('when user is granted for Pix+ Droit complementary certification', function () {
+                      it('should save complementary certification info for Pix+ Droit', async function () {
                         // given
                         const domainTransaction = Symbol('someDomainTransaction');
 
-                        const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
                         sessionRepository.get.withArgs(1).resolves(foundSession);
 
                         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
@@ -1394,6 +467,466 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
+                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                        });
+
+                        const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                          _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                        certificationChallengesService.pickCertificationChallenges
+                          .withArgs(placementProfile)
+                          .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                        certificationCandidateRepository.getBySessionIdAndUserId
+                          .withArgs({ sessionId: 1, userId: 2 })
+                          .resolves(foundCertificationCandidate);
+
+                        const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                          name: PIX_PLUS_DROIT,
+                        });
+                        const certificationCenter = domainBuilder.buildCertificationCenter({
+                          habilitations: [complementaryCertificationPixPlusDroit],
+                        });
+                        certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                        const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                        const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                        const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+
+                        const pixDroitMaitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
+                        certificationBadgesService.findStillValidBadgeAcquisitions
+                          .withArgs({ userId: 2, domainTransaction })
+                          .resolves([pixDroitMaitreBadgeAcquisition]);
+
+                        certificationChallengesService.pickCertificationChallengesForPixPlus
+                          .withArgs(pixDroitMaitreBadgeAcquisition.badge, 2)
+                          .resolves([challengePlus1, challengePlus2, challengePlus3]);
+
+                        const complementaryCertificationCourse =
+                          ComplementaryCertificationCourse.fromComplementaryCertificationId(
+                            complementaryCertificationPixPlusDroit.id
+                          );
+                        const certificationCourseToSave = CertificationCourse.from({
+                          certificationCandidate: foundCertificationCandidate,
+                          challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                          verificationCode,
+                          maxReachableLevelOnCertificationDate: 5,
+                          complementaryCertificationCourses: [complementaryCertificationCourse],
+                        });
+
+                        const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                          certificationCourseToSave.toDTO()
+                        );
+                        savedCertificationCourse._complementaryCertificationCourses = [
+                          {
+                            ...complementaryCertificationCourse,
+                            certificationCourseId: savedCertificationCourse.getId(),
+                          },
+                        ];
+                        certificationCourseRepository.save
+                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .resolves(savedCertificationCourse);
+
+                        const assessmentToSave = new Assessment({
+                          userId: 2,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                          state: Assessment.states.STARTED,
+                          type: Assessment.types.CERTIFICATION,
+                          isImproving: false,
+                          method: Assessment.methods.CERTIFICATION_DETERMINED,
+                        });
+                        const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                        assessmentRepository.save
+                          .withArgs({ assessment: assessmentToSave, domainTransaction })
+                          .resolves(savedAssessment);
+
+                        // when
+                        const result = await retrieveLastOrCreateCertificationCourse({
+                          domainTransaction,
+                          sessionId: 1,
+                          accessCode: 'accessCode',
+                          userId: 2,
+                          locale: 'fr',
+                          ...injectables,
+                        });
+
+                        // then
+                        expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([
+                          {
+                            certificationCourseId: savedCertificationCourse.getId(),
+                            complementaryCertificationId: complementaryCertificationPixPlusDroit.id,
+                          },
+                        ]);
+                      });
+
+                      it('should save all the challenges from pix and Pix+ Droit', async function () {
+                        // given
+                        const domainTransaction = Symbol('someDomainTransaction');
+
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
+                        sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .resolves(null);
+
+                        const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                          userId: 2,
+                          sessionId: 1,
+                          authorizedToStart: true,
+                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                        });
+
+                        const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                          _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                        certificationChallengesService.pickCertificationChallenges
+                          .withArgs(placementProfile)
+                          .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                        certificationCandidateRepository.getBySessionIdAndUserId
+                          .withArgs({ sessionId: 1, userId: 2 })
+                          .resolves(foundCertificationCandidate);
+
+                        const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                          name: PIX_PLUS_DROIT,
+                        });
+                        const certificationCenter = domainBuilder.buildCertificationCenter({
+                          habilitations: [complementaryCertificationPixPlusDroit],
+                        });
+                        certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                        const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                        const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                        const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+
+                        const pixDroitMaitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
+                        certificationBadgesService.findStillValidBadgeAcquisitions
+                          .withArgs({ userId: 2, domainTransaction })
+                          .resolves([pixDroitMaitreBadgeAcquisition]);
+
+                        certificationChallengesService.pickCertificationChallengesForPixPlus
+                          .withArgs(pixDroitMaitreBadgeAcquisition.badge, 2)
+                          .resolves([challengePlus1, challengePlus2, challengePlus3]);
+
+                        const complementaryCertificationCourse =
+                          ComplementaryCertificationCourse.fromComplementaryCertificationId(
+                            complementaryCertificationPixPlusDroit.id
+                          );
+                        const certificationCourseToSave = CertificationCourse.from({
+                          certificationCandidate: foundCertificationCandidate,
+                          challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                          verificationCode,
+                          maxReachableLevelOnCertificationDate: 5,
+                          complementaryCertificationCourses: [complementaryCertificationCourse],
+                        });
+
+                        const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                          certificationCourseToSave.toDTO()
+                        );
+                        savedCertificationCourse._complementaryCertificationCourses = [
+                          {
+                            ...complementaryCertificationCourse,
+                            certificationCourseId: savedCertificationCourse.getId(),
+                          },
+                        ];
+                        certificationCourseRepository.save
+                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .resolves(savedCertificationCourse);
+
+                        const assessmentToSave = new Assessment({
+                          userId: 2,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                          state: Assessment.states.STARTED,
+                          type: Assessment.types.CERTIFICATION,
+                          isImproving: false,
+                          method: Assessment.methods.CERTIFICATION_DETERMINED,
+                        });
+                        const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                        assessmentRepository.save
+                          .withArgs({ assessment: assessmentToSave, domainTransaction })
+                          .resolves(savedAssessment);
+
+                        // when
+                        const result = await retrieveLastOrCreateCertificationCourse({
+                          domainTransaction,
+                          sessionId: 1,
+                          accessCode: 'accessCode',
+                          userId: 2,
+                          locale: 'fr',
+                          ...injectables,
+                        });
+
+                        // then
+                        expect(result.certificationCourse._challenges).to.deep.equal([
+                          challenge1,
+                          challenge2,
+                          challengePlus1,
+                          challengePlus2,
+                          challengePlus3,
+                        ]);
+                      });
+
+                      it('should generate challenges for expert badge only if both maitre and expert badges are acquired', async function () {
+                        // given
+                        const domainTransaction = Symbol('someDomainTransaction');
+
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
+                        sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .resolves(null);
+
+                        const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                          userId: 2,
+                          sessionId: 1,
+                          authorizedToStart: true,
+                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                        });
+
+                        certificationCandidateRepository.getBySessionIdAndUserId
+                          .withArgs({ sessionId: 1, userId: 2 })
+                          .resolves(foundCertificationCandidate);
+
+                        const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                          _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                        certificationChallengesService.pickCertificationChallenges
+                          .withArgs(placementProfile)
+                          .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                        const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                          name: PIX_PLUS_DROIT,
+                        });
+                        const certificationCenter = domainBuilder.buildCertificationCenter({
+                          habilitations: [complementaryCertificationPixPlusDroit],
+                        });
+                        certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                        const challengesForMaitre = [
+                          domainBuilder.buildChallenge({ id: 'challenge-pixmaitre1' }),
+                          domainBuilder.buildChallenge({ id: 'challenge-pixmaitre2' }),
+                        ];
+                        const challengesForExpert = [
+                          domainBuilder.buildChallenge({ id: 'challenge-pixexpert1' }),
+                          domainBuilder.buildChallenge({ id: 'challenge-pixexpert2' }),
+                        ];
+                        const maitreBadge = domainBuilder.buildBadge({
+                          key: 'PIX_DROIT_MAITRE_CERTIF',
+                          targetProfileId: 11,
+                        });
+                        const expertBadge = domainBuilder.buildBadge({
+                          key: 'PIX_DROIT_EXPERT_CERTIF',
+                          targetProfileId: 22,
+                        });
+                        domainBuilder.buildBadgeAcquisition({ badge: maitreBadge });
+                        const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
+                          badge: expertBadge,
+                        });
+                        certificationBadgesService.findStillValidBadgeAcquisitions
+                          .withArgs({ userId: 2, domainTransaction })
+                          .resolves([certifiableBadgeAcquisition2]);
+
+                        certificationChallengesService.pickCertificationChallengesForPixPlus
+                          .withArgs(maitreBadge, 2)
+                          .resolves(challengesForMaitre)
+                          .withArgs(expertBadge, 2)
+                          .resolves(challengesForExpert);
+
+                        const complementaryCertificationCourse =
+                          ComplementaryCertificationCourse.fromComplementaryCertificationId(
+                            complementaryCertificationPixPlusDroit.id
+                          );
+
+                        const certificationCourseToSave = CertificationCourse.from({
+                          certificationCandidate: foundCertificationCandidate,
+                          challenges: [challenge1, challenge2, ...challengesForExpert],
+                          verificationCode,
+                          maxReachableLevelOnCertificationDate: 5,
+                          complementaryCertificationCourses: [complementaryCertificationCourse],
+                        });
+
+                        const savedCertificationCourse = domainBuilder.buildCertificationCourse({
+                          ...foundCertificationCandidate,
+                          isV2Certification: true,
+                          challenges: [challenge1, challenge2, ...challengesForExpert],
+                        });
+
+                        savedCertificationCourse._complementaryCertificationCourses = [
+                          {
+                            ...complementaryCertificationCourse,
+                            certificationCourseId: savedCertificationCourse.getId(),
+                          },
+                        ];
+
+                        certificationCourseRepository.save
+                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .resolves(savedCertificationCourse);
+
+                        const savedAssessment = domainBuilder.buildAssessment({
+                          userId: 2,
+                          certificationCourseId: savedCertificationCourse.id,
+                          state: Assessment.states.STARTED,
+                          type: Assessment.types.CERTIFICATION,
+                          isImproving: false,
+                          method: Assessment.methods.CERTIFICATION_DETERMINED,
+                        });
+                        assessmentRepository.save.resolves(savedAssessment);
+
+                        // when
+                        const result = await retrieveLastOrCreateCertificationCourse({
+                          domainTransaction,
+                          sessionId: 1,
+                          accessCode: 'accessCode',
+                          userId: 2,
+                          locale: 'fr',
+                          ...injectables,
+                        });
+
+                        // then
+                        expect(result.certificationCourse._challenges).to.deep.equal([
+                          challenge1,
+                          challenge2,
+                          ...challengesForExpert,
+                        ]);
+                      });
+                    });
+
+                    context('when user is not granted for Pix+ Droit complementary certification', function () {
+                      it('should not save complementary certification info', async function () {
+                        // given
+                        const domainTransaction = Symbol('someDomainTransaction');
+
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
+                        sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .resolves(null);
+
+                        const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                          userId: 2,
+                          authorizedToStart: true,
+                          sessionId: 1,
+                          complementaryCertifications: [],
+                        });
+
+                        certificationCandidateRepository.getBySessionIdAndUserId
+                          .withArgs({ sessionId: 1, userId: 2 })
+                          .resolves(foundCertificationCandidate);
+
+                        const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                          _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                        certificationChallengesService.pickCertificationChallenges
+                          .withArgs(placementProfile)
+                          .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                        const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                          name: PIX_PLUS_DROIT,
+                        });
+                        const certificationCenter = domainBuilder.buildCertificationCenter({
+                          habilitations: [complementaryCertificationPixPlusDroit],
+                        });
+                        certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                        const challengePlus1 = domainBuilder.buildChallenge({ id: 'challenge-pixplus1' });
+                        const challengePlus2 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                        const challengePlus3 = domainBuilder.buildChallenge({ id: 'challenge-pixplus2' });
+                        const certifiableBadge1 = domainBuilder.buildBadge({ key: 'COUCOU', targetProfileId: 11 });
+                        const certifiableBadge2 = domainBuilder.buildBadge({ key: 'SALUT', targetProfileId: 22 });
+                        const certifiableBadgeAcquisition1 = domainBuilder.buildBadgeAcquisition({
+                          badge: certifiableBadge1,
+                        });
+                        const certifiableBadgeAcquisition2 = domainBuilder.buildBadgeAcquisition({
+                          badge: certifiableBadge2,
+                        });
+
+                        certificationBadgesService.findStillValidBadgeAcquisitions
+                          .withArgs({ userId: 2, domainTransaction })
+                          .resolves([certifiableBadgeAcquisition1, certifiableBadgeAcquisition2]);
+
+                        certificationChallengesService.pickCertificationChallengesForPixPlus
+                          .withArgs(certifiableBadge1, 2)
+                          .resolves([challengePlus1, challengePlus2])
+                          .withArgs(certifiableBadge2, 2)
+                          .resolves([challengePlus3]);
+
+                        const certificationCourseToSave = CertificationCourse.from({
+                          certificationCandidate: foundCertificationCandidate,
+                          challenges: [challenge1, challenge2],
+                          verificationCode,
+                          maxReachableLevelOnCertificationDate: 5,
+                          complementaryCertificationCourses: [],
+                        });
+
+                        const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                          certificationCourseToSave.toDTO()
+                        );
+                        certificationCourseRepository.save
+                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .resolves(savedCertificationCourse);
+
+                        const assessmentToSave = new Assessment({
+                          userId: 2,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                          state: Assessment.states.STARTED,
+                          type: Assessment.types.CERTIFICATION,
+                          isImproving: false,
+                          method: Assessment.methods.CERTIFICATION_DETERMINED,
+                        });
+                        const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                        assessmentRepository.save
+                          .withArgs({ assessment: assessmentToSave, domainTransaction })
+                          .resolves(savedAssessment);
+
+                        // when
+                        const result = await retrieveLastOrCreateCertificationCourse({
+                          domainTransaction,
+                          sessionId: 1,
+                          accessCode: 'accessCode',
+                          userId: 2,
+                          locale: 'fr',
+                          ...injectables,
+                        });
+
+                        // then
+                        expect(result.certificationCourse._complementaryCertificationCourses).to.be.empty;
+                      });
+                    });
+                  });
+
+                  context('when user has no certifiable badges for Pix+ Droit', function () {
+                    context('when user has no certifiable badges for Pix+ Droit', function () {
+                      it('should not save challenges from Pix+ Droit', async function () {
+                        // given
+                        const domainTransaction = Symbol('someDomainTransaction');
+
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
+                        sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .resolves(null);
+
+                        const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                          userId: 2,
+                          sessionId: 1,
+                          authorizedToStart: true,
+                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
                         });
 
                         certificationCandidateRepository.getBySessionIdAndUserId
@@ -1457,426 +990,24 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         });
 
                         // then
-                        expect(result.certificationCourse._challenges).to.deep.equal([challenge1, challenge2]);
-                        expect(
-                          certificationChallengesService.pickCertificationChallengesForPixPlus
-                        ).not.to.have.been.called;
-                      });
-                    });
-
-                    context('when certification center has habilitation for CleA', function () {
-                      context('when user has no certifiable badges with CleA', function () {
-                        context('when user is granted for CleA certification', function () {
-                          it('should not save complementary certification info', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                              complementaryCertifications: [{ name: CLEA }],
-                            });
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                              name: CLEA,
-                            });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationCleA],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
-
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                              complementaryCertificationCourses: [],
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                              certificationCourseToSave.toDTO()
-                            );
-                            certificationCourseRepository.save.resolves(savedCertificationCourse);
-
-                            const assessmentToSave = new Assessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                            assessmentRepository.save
-                              .withArgs({ assessment: assessmentToSave, domainTransaction })
-                              .resolves(savedAssessment);
-
-                            certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                              .withArgs({ userId: 2 })
-                              .resolves(false);
-
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({
-                                userId: 2,
-                                domainTransaction,
-                              })
-                              .resolves([]);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(certificationCourseRepository.save).to.have.been.calledWith({
-                              certificationCourse: certificationCourseToSave,
-                              domainTransaction,
-                            });
-
-                            expect(result.certificationCourse._complementaryCertificationCourses).to.be.empty;
-                          });
-                        });
-                      });
-
-                      context('when user has certifiable badges with CleA', function () {
-                        it('should save complementary certification info', async function () {
-                          // given
-                          const domainTransaction = Symbol('someDomainTransaction');
-
-                          const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
-                          sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                            .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                            .resolves(null);
-
-                          const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                            userId: 2,
-                            sessionId: 1,
-                            authorizedToStart: true,
-                            complementaryCertifications: [{ name: CLEA }],
-                          });
-
-                          certificationCandidateRepository.getBySessionIdAndUserId
-                            .withArgs({ sessionId: 1, userId: 2 })
-                            .resolves(foundCertificationCandidate);
-
-                          const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                            _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                          certificationChallengesService.pickCertificationChallenges
-                            .withArgs(placementProfile)
-                            .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                          const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                            name: CLEA,
-                          });
-                          const certificationCenter = domainBuilder.buildCertificationCenter({
-                            habilitations: [complementaryCertificationCleA],
-                          });
-                          certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                          complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
-
-                          certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                            .withArgs({ userId: 2 })
-                            .resolves(true);
-
-                          certificationBadgesService.findStillValidBadgeAcquisitions
-                            .withArgs({ userId: 2, domainTransaction })
-                            .resolves([]);
-
-                          certificationChallengesService.pickCertificationChallengesForPixPlus.resolves([]);
-
-                          const complementaryCertificationCourse =
-                            ComplementaryCertificationCourse.fromComplementaryCertificationId(
-                              complementaryCertificationCleA.id
-                            );
-                          const certificationCourseToSave = CertificationCourse.from({
-                            certificationCandidate: foundCertificationCandidate,
+                        expect(result).to.deep.equal({
+                          created: true,
+                          certificationCourse: new CertificationCourse({
+                            ...savedCertificationCourse.toDTO(),
+                            assessment: savedAssessment,
                             challenges: [challenge1, challenge2],
-                            verificationCode,
-                            maxReachableLevelOnCertificationDate: 5,
-                            complementaryCertificationCourses: [complementaryCertificationCourse],
-                          });
-
-                          const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                            certificationCourseToSave.toDTO()
-                          );
-
-                          savedCertificationCourse._complementaryCertificationCourses = [
-                            {
-                              ...complementaryCertificationCourse,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                            },
-                          ];
-                          certificationCourseRepository.save.resolves(savedCertificationCourse);
-
-                          const assessmentToSave = new Assessment({
-                            userId: 2,
-                            certificationCourseId: savedCertificationCourse.getId(),
-                            state: Assessment.states.STARTED,
-                            type: Assessment.types.CERTIFICATION,
-                            isImproving: false,
-                            method: Assessment.methods.CERTIFICATION_DETERMINED,
-                          });
-                          const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                          assessmentRepository.save
-                            .withArgs({ assessment: assessmentToSave, domainTransaction })
-                            .resolves(savedAssessment);
-
-                          certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                            .withArgs({ userId: 2 })
-                            .resolves(true);
-
-                          // when
-                          const result = await retrieveLastOrCreateCertificationCourse({
-                            domainTransaction,
-                            sessionId: 1,
-                            accessCode: 'accessCode',
-                            userId: 2,
-                            locale: 'fr',
-                            ...injectables,
-                          });
-
-                          // then
-                          expect(certificationCourseRepository.save).to.have.been.calledWith({
-                            certificationCourse: certificationCourseToSave,
-                            domainTransaction,
-                          });
-
-                          expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([
-                            {
-                              certificationCourseId: result.certificationCourse.getId(),
-                              complementaryCertificationId: complementaryCertificationCleA.id,
-                            },
-                          ]);
-                        });
-
-                        context('when user is not granted for CleA certification', function () {
-                          it('should not save complementary certification info', async function () {
-                            // given
-                            const domainTransaction = Symbol('someDomainTransaction');
-
-                            const foundSession = domainBuilder.buildSession.created({
-                              id: 1,
-                              accessCode: 'accessCode',
-                            });
-                            sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                              .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                              .resolves(null);
-
-                            const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                              userId: 2,
-                              sessionId: 1,
-                              authorizedToStart: true,
-                            });
-
-                            certificationCandidateRepository.getBySessionIdAndUserId
-                              .withArgs({ sessionId: 1, userId: 2 })
-                              .resolves(foundCertificationCandidate);
-
-                            const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                              _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                            certificationChallengesService.pickCertificationChallenges
-                              .withArgs(placementProfile)
-                              .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                            const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                              name: CLEA,
-                            });
-                            const certificationCenter = domainBuilder.buildCertificationCenter({
-                              habilitations: [complementaryCertificationCleA],
-                            });
-                            certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                            complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
-
-                            const certificationCourseToSave = CertificationCourse.from({
-                              certificationCandidate: foundCertificationCandidate,
-                              challenges: [challenge1, challenge2],
-                              verificationCode,
-                              maxReachableLevelOnCertificationDate: 5,
-                              complementaryCertificationCourses: [],
-                            });
-
-                            const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                              certificationCourseToSave.toDTO()
-                            );
-                            certificationCourseRepository.save.resolves(savedCertificationCourse);
-
-                            const assessmentToSave = new Assessment({
-                              userId: 2,
-                              certificationCourseId: savedCertificationCourse.getId(),
-                              state: Assessment.states.STARTED,
-                              type: Assessment.types.CERTIFICATION,
-                              isImproving: false,
-                              method: Assessment.methods.CERTIFICATION_DETERMINED,
-                            });
-                            const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                            assessmentRepository.save
-                              .withArgs({ assessment: assessmentToSave, domainTransaction })
-                              .resolves(savedAssessment);
-
-                            certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                              .withArgs({ userId: 2 })
-                              .resolves(true);
-
-                            certificationBadgesService.findStillValidBadgeAcquisitions
-                              .withArgs({
-                                userId: 2,
-                                domainTransaction,
-                              })
-                              .resolves([]);
-
-                            // when
-                            const result = await retrieveLastOrCreateCertificationCourse({
-                              domainTransaction,
-                              sessionId: 1,
-                              accessCode: 'accessCode',
-                              userId: 2,
-                              locale: 'fr',
-                              ...injectables,
-                            });
-
-                            // then
-                            expect(certificationCourseRepository.save).to.have.been.calledWith({
-                              certificationCourse: certificationCourseToSave,
-                              domainTransaction,
-                            });
-
-                            expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([]);
-                          });
+                          }),
                         });
                       });
-                    });
 
-                    context('when certification center has no habilitation for CleA', function () {
-                      context('when user has certifiable badges with CleA', function () {
-                        it('should not save complementary certification info', async function () {
-                          // given
-                          const domainTransaction = Symbol('someDomainTransaction');
-
-                          const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
-                          sessionRepository.get.withArgs(1).resolves(foundSession);
-
-                          certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-                            .withArgs({ userId: 2, sessionId: 1, domainTransaction })
-                            .resolves(null);
-
-                          const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
-                            userId: 2,
-                            sessionId: 1,
-                            authorizedToStart: true,
-                          });
-
-                          certificationCandidateRepository.getBySessionIdAndUserId
-                            .withArgs({ sessionId: 1, userId: 2 })
-                            .resolves(foundCertificationCandidate);
-
-                          const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
-                            _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
-                          certificationChallengesService.pickCertificationChallenges
-                            .withArgs(placementProfile)
-                            .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
-
-                          const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                            name: CLEA,
-                          });
-                          const certificationCenter = domainBuilder.buildCertificationCenter();
-                          certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                          complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
-
-                          const certificationCourseToSave = CertificationCourse.from({
-                            certificationCandidate: foundCertificationCandidate,
-                            challenges: [challenge1, challenge2],
-                            verificationCode,
-                            maxReachableLevelOnCertificationDate: 5,
-                            complementaryCertificationCourses: [],
-                          });
-
-                          const savedCertificationCourse = domainBuilder.buildCertificationCourse(
-                            certificationCourseToSave.toDTO()
-                          );
-                          certificationCourseRepository.save.resolves(savedCertificationCourse);
-
-                          const assessmentToSave = new Assessment({
-                            userId: 2,
-                            certificationCourseId: savedCertificationCourse.getId(),
-                            state: Assessment.states.STARTED,
-                            type: Assessment.types.CERTIFICATION,
-                            isImproving: false,
-                            method: Assessment.methods.CERTIFICATION_DETERMINED,
-                          });
-                          const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
-                          assessmentRepository.save
-                            .withArgs({ assessment: assessmentToSave, domainTransaction })
-                            .resolves(savedAssessment);
-
-                          certificationBadgesService.hasStillValidCleaBadgeAcquisition
-                            .withArgs({ userId: 2 })
-                            .resolves(true);
-
-                          certificationBadgesService.findStillValidBadgeAcquisitions
-                            .withArgs({
-                              userId: 2,
-                              domainTransaction,
-                            })
-                            .resolves([]);
-
-                          // when
-                          const result = await retrieveLastOrCreateCertificationCourse({
-                            domainTransaction,
-                            sessionId: 1,
-                            accessCode: 'accessCode',
-                            userId: 2,
-                            locale: 'fr',
-                            ...injectables,
-                          });
-
-                          // then
-                          expect(certificationCourseRepository.save).to.have.been.calledWith({
-                            certificationCourse: certificationCourseToSave,
-                            domainTransaction,
-                          });
-
-                          expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([]);
-                        });
-                      });
-                    });
-
-                    context('when user has certifiable badge for Pix+ Édu', function () {
-                      it('should save all the challenges from pix and Pix+ Édu', async function () {
+                      it('should not generate challenges for expert badge', async function () {
                         // given
                         const domainTransaction = Symbol('someDomainTransaction');
 
-                        const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
                         sessionRepository.get.withArgs(1).resolves(foundSession);
 
                         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
@@ -1887,7 +1018,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [],
+                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
                         });
 
                         certificationCandidateRepository.getBySessionIdAndUserId
@@ -1900,28 +1031,194 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           .withArgs(placementProfile)
                           .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
+                        const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                          name: PIX_PLUS_DROIT,
+                        });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
-                          habilitations: [],
+                          habilitations: [complementaryCertificationPixPlusDroit],
                         });
                         certificationCenterRepository.getBySessionId.resolves(certificationCenter);
-                        complementaryCertificationRepository.findAll.resolves([]);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
 
-                        const challengeEdu1 = domainBuilder.buildChallenge({ id: 'challenge-pix-edu1' });
-                        const challengeEdu2 = domainBuilder.buildChallenge({ id: 'challenge-pix-edu2' });
-
-                        const pixEduFormationContinueFormateurBadgeAcquisition =
-                          domainBuilder.buildBadgeAcquisition.forPixEduFormationContinue2ndDegreFormateur();
                         certificationBadgesService.findStillValidBadgeAcquisitions
                           .withArgs({ userId: 2, domainTransaction })
-                          .resolves([pixEduFormationContinueFormateurBadgeAcquisition]);
-
-                        certificationChallengesService.pickCertificationChallengesForPixPlus
-                          .withArgs(pixEduFormationContinueFormateurBadgeAcquisition.badge, 2)
-                          .resolves([challengeEdu1, challengeEdu2]);
+                          .resolves([]);
 
                         const certificationCourseToSave = CertificationCourse.from({
                           certificationCandidate: foundCertificationCandidate,
-                          challenges: [challenge1, challenge2, challengeEdu1, challengeEdu2],
+                          challenges: [challenge1, challenge2],
+                          verificationCode,
+                          maxReachableLevelOnCertificationDate: 5,
+                        });
+
+                        const savedCertificationCourse = domainBuilder.buildCertificationCourse({
+                          ...foundCertificationCandidate,
+                          isV2Certification: true,
+                          challenges: [challenge1, challenge2],
+                        });
+
+                        certificationCourseRepository.save
+                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                          .resolves(savedCertificationCourse);
+                        const savedAssessment = domainBuilder.buildAssessment({
+                          userId: 2,
+                          certificationCourseId: savedCertificationCourse.id,
+                          state: Assessment.states.STARTED,
+                          type: Assessment.types.CERTIFICATION,
+                          isImproving: false,
+                          method: Assessment.methods.CERTIFICATION_DETERMINED,
+                        });
+                        assessmentRepository.save.resolves(savedAssessment);
+
+                        // when
+                        const result = await retrieveLastOrCreateCertificationCourse({
+                          domainTransaction,
+                          sessionId: 1,
+                          accessCode: 'accessCode',
+                          userId: 2,
+                          locale: 'fr',
+                          ...injectables,
+                        });
+
+                        // then
+                        expect(result.certificationCourse._challenges).to.deep.equal([challenge1, challenge2]);
+                      });
+                    });
+                  });
+                });
+
+                context('when certification center has no habilitation for Pix+ Droit', function () {
+                  it('should save only the challenges from pix', async function () {
+                    // given
+                    const domainTransaction = Symbol('someDomainTransaction');
+
+                    const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
+                    sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                      .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                      .resolves(null);
+
+                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                      userId: 2,
+                      sessionId: 1,
+                      authorizedToStart: true,
+                    });
+
+                    certificationCandidateRepository.getBySessionIdAndUserId
+                      .withArgs({ sessionId: 1, userId: 2 })
+                      .resolves(foundCertificationCandidate);
+
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                    certificationChallengesService.pickCertificationChallenges
+                      .withArgs(placementProfile)
+                      .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                    const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
+                      name: PIX_PLUS_DROIT,
+                    });
+                    const certificationCenter = domainBuilder.buildCertificationCenter({
+                      habilitations: [complementaryCertificationPixPlusDroit],
+                    });
+                    certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                    complementaryCertificationRepository.findAll.resolves([complementaryCertificationPixPlusDroit]);
+
+                    certificationBadgesService.findStillValidBadgeAcquisitions
+                      .withArgs({ userId: 2, domainTransaction })
+                      .resolves([]);
+
+                    const certificationCourseToSave = CertificationCourse.from({
+                      certificationCandidate: foundCertificationCandidate,
+                      challenges: [challenge1, challenge2],
+                      verificationCode,
+                      maxReachableLevelOnCertificationDate: 5,
+                    });
+
+                    const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                      certificationCourseToSave.toDTO()
+                    );
+                    certificationCourseRepository.save
+                      .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                      .resolves(savedCertificationCourse);
+
+                    const assessmentToSave = new Assessment({
+                      userId: 2,
+                      certificationCourseId: savedCertificationCourse.getId(),
+                      state: Assessment.states.STARTED,
+                      type: Assessment.types.CERTIFICATION,
+                      isImproving: false,
+                      method: Assessment.methods.CERTIFICATION_DETERMINED,
+                    });
+                    const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                    assessmentRepository.save
+                      .withArgs({ assessment: assessmentToSave, domainTransaction })
+                      .resolves(savedAssessment);
+
+                    // when
+                    const result = await retrieveLastOrCreateCertificationCourse({
+                      domainTransaction,
+                      sessionId: 1,
+                      accessCode: 'accessCode',
+                      userId: 2,
+                      locale: 'fr',
+                      ...injectables,
+                    });
+
+                    // then
+                    expect(result.certificationCourse._challenges).to.deep.equal([challenge1, challenge2]);
+                    expect(
+                      certificationChallengesService.pickCertificationChallengesForPixPlus
+                    ).not.to.have.been.called;
+                  });
+                });
+
+                context('when certification center has habilitation for CleA', function () {
+                  context('when user has no certifiable badges with CleA', function () {
+                    context('when user is granted for CleA certification', function () {
+                      it('should not save complementary certification info', async function () {
+                        // given
+                        const domainTransaction = Symbol('someDomainTransaction');
+
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
+                        sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .resolves(null);
+
+                        const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                          userId: 2,
+                          sessionId: 1,
+                          authorizedToStart: true,
+                          complementaryCertifications: [{ name: CLEA }],
+                        });
+
+                        certificationCandidateRepository.getBySessionIdAndUserId
+                          .withArgs({ sessionId: 1, userId: 2 })
+                          .resolves(foundCertificationCandidate);
+
+                        const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                          _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                        certificationChallengesService.pickCertificationChallenges
+                          .withArgs(placementProfile)
+                          .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                        const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
+                          name: CLEA,
+                        });
+                        const certificationCenter = domainBuilder.buildCertificationCenter({
+                          habilitations: [complementaryCertificationCleA],
+                        });
+                        certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
+
+                        const certificationCourseToSave = CertificationCourse.from({
+                          certificationCandidate: foundCertificationCandidate,
+                          challenges: [challenge1, challenge2],
                           verificationCode,
                           maxReachableLevelOnCertificationDate: 5,
                           complementaryCertificationCourses: [],
@@ -1930,9 +1227,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         const savedCertificationCourse = domainBuilder.buildCertificationCourse(
                           certificationCourseToSave.toDTO()
                         );
-                        certificationCourseRepository.save
-                          .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
-                          .resolves(savedCertificationCourse);
+                        certificationCourseRepository.save.resolves(savedCertificationCourse);
 
                         const assessmentToSave = new Assessment({
                           userId: 2,
@@ -1947,6 +1242,17 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           .withArgs({ assessment: assessmentToSave, domainTransaction })
                           .resolves(savedAssessment);
 
+                        certificationBadgesService.hasStillValidCleaBadgeAcquisition
+                          .withArgs({ userId: 2 })
+                          .resolves(false);
+
+                        certificationBadgesService.findStillValidBadgeAcquisitions
+                          .withArgs({
+                            userId: 2,
+                            domainTransaction,
+                          })
+                          .resolves([]);
+
                         // when
                         const result = await retrieveLastOrCreateCertificationCourse({
                           domainTransaction,
@@ -1958,16 +1264,417 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         });
 
                         // then
-                        expect(result.certificationCourse._challenges).to.deep.equal([
-                          challenge1,
-                          challenge2,
-                          challengeEdu1,
-                          challengeEdu2,
-                        ]);
+                        expect(certificationCourseRepository.save).to.have.been.calledWith({
+                          certificationCourse: certificationCourseToSave,
+                          domainTransaction,
+                        });
+
+                        expect(result.certificationCourse._complementaryCertificationCourses).to.be.empty;
                       });
                     });
-                  }
-                );
+                  });
+
+                  context('when user has certifiable badges with CleA', function () {
+                    it('should save complementary certification info', async function () {
+                      // given
+                      const domainTransaction = Symbol('someDomainTransaction');
+
+                      const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
+                      sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                      certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                        .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                        .resolves(null);
+
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId: 2,
+                        sessionId: 1,
+                        authorizedToStart: true,
+                        complementaryCertifications: [{ name: CLEA }],
+                      });
+
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId: 1, userId: 2 })
+                        .resolves(foundCertificationCandidate);
+
+                      const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                        _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                      certificationChallengesService.pickCertificationChallenges
+                        .withArgs(placementProfile)
+                        .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                      const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
+                        name: CLEA,
+                      });
+                      const certificationCenter = domainBuilder.buildCertificationCenter({
+                        habilitations: [complementaryCertificationCleA],
+                      });
+                      certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                      complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
+
+                      certificationBadgesService.hasStillValidCleaBadgeAcquisition
+                        .withArgs({ userId: 2 })
+                        .resolves(true);
+
+                      certificationBadgesService.findStillValidBadgeAcquisitions
+                        .withArgs({ userId: 2, domainTransaction })
+                        .resolves([]);
+
+                      certificationChallengesService.pickCertificationChallengesForPixPlus.resolves([]);
+
+                      const complementaryCertificationCourse =
+                        ComplementaryCertificationCourse.fromComplementaryCertificationId(
+                          complementaryCertificationCleA.id
+                        );
+                      const certificationCourseToSave = CertificationCourse.from({
+                        certificationCandidate: foundCertificationCandidate,
+                        challenges: [challenge1, challenge2],
+                        verificationCode,
+                        maxReachableLevelOnCertificationDate: 5,
+                        complementaryCertificationCourses: [complementaryCertificationCourse],
+                      });
+
+                      const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                        certificationCourseToSave.toDTO()
+                      );
+
+                      savedCertificationCourse._complementaryCertificationCourses = [
+                        {
+                          ...complementaryCertificationCourse,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                        },
+                      ];
+                      certificationCourseRepository.save.resolves(savedCertificationCourse);
+
+                      const assessmentToSave = new Assessment({
+                        userId: 2,
+                        certificationCourseId: savedCertificationCourse.getId(),
+                        state: Assessment.states.STARTED,
+                        type: Assessment.types.CERTIFICATION,
+                        isImproving: false,
+                        method: Assessment.methods.CERTIFICATION_DETERMINED,
+                      });
+                      const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                      assessmentRepository.save
+                        .withArgs({ assessment: assessmentToSave, domainTransaction })
+                        .resolves(savedAssessment);
+
+                      certificationBadgesService.hasStillValidCleaBadgeAcquisition
+                        .withArgs({ userId: 2 })
+                        .resolves(true);
+
+                      // when
+                      const result = await retrieveLastOrCreateCertificationCourse({
+                        domainTransaction,
+                        sessionId: 1,
+                        accessCode: 'accessCode',
+                        userId: 2,
+                        locale: 'fr',
+                        ...injectables,
+                      });
+
+                      // then
+                      expect(certificationCourseRepository.save).to.have.been.calledWith({
+                        certificationCourse: certificationCourseToSave,
+                        domainTransaction,
+                      });
+
+                      expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([
+                        {
+                          certificationCourseId: result.certificationCourse.getId(),
+                          complementaryCertificationId: complementaryCertificationCleA.id,
+                        },
+                      ]);
+                    });
+
+                    context('when user is not granted for CleA certification', function () {
+                      it('should not save complementary certification info', async function () {
+                        // given
+                        const domainTransaction = Symbol('someDomainTransaction');
+
+                        const foundSession = domainBuilder.buildSession.created({
+                          id: 1,
+                          accessCode: 'accessCode',
+                        });
+                        sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                          .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                          .resolves(null);
+
+                        const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                          userId: 2,
+                          sessionId: 1,
+                          authorizedToStart: true,
+                        });
+
+                        certificationCandidateRepository.getBySessionIdAndUserId
+                          .withArgs({ sessionId: 1, userId: 2 })
+                          .resolves(foundCertificationCandidate);
+
+                        const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                          _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                        certificationChallengesService.pickCertificationChallenges
+                          .withArgs(placementProfile)
+                          .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                        const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
+                          name: CLEA,
+                        });
+                        const certificationCenter = domainBuilder.buildCertificationCenter({
+                          habilitations: [complementaryCertificationCleA],
+                        });
+                        certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                        complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
+
+                        const certificationCourseToSave = CertificationCourse.from({
+                          certificationCandidate: foundCertificationCandidate,
+                          challenges: [challenge1, challenge2],
+                          verificationCode,
+                          maxReachableLevelOnCertificationDate: 5,
+                          complementaryCertificationCourses: [],
+                        });
+
+                        const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                          certificationCourseToSave.toDTO()
+                        );
+                        certificationCourseRepository.save.resolves(savedCertificationCourse);
+
+                        const assessmentToSave = new Assessment({
+                          userId: 2,
+                          certificationCourseId: savedCertificationCourse.getId(),
+                          state: Assessment.states.STARTED,
+                          type: Assessment.types.CERTIFICATION,
+                          isImproving: false,
+                          method: Assessment.methods.CERTIFICATION_DETERMINED,
+                        });
+                        const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                        assessmentRepository.save
+                          .withArgs({ assessment: assessmentToSave, domainTransaction })
+                          .resolves(savedAssessment);
+
+                        certificationBadgesService.hasStillValidCleaBadgeAcquisition
+                          .withArgs({ userId: 2 })
+                          .resolves(true);
+
+                        certificationBadgesService.findStillValidBadgeAcquisitions
+                          .withArgs({
+                            userId: 2,
+                            domainTransaction,
+                          })
+                          .resolves([]);
+
+                        // when
+                        const result = await retrieveLastOrCreateCertificationCourse({
+                          domainTransaction,
+                          sessionId: 1,
+                          accessCode: 'accessCode',
+                          userId: 2,
+                          locale: 'fr',
+                          ...injectables,
+                        });
+
+                        // then
+                        expect(certificationCourseRepository.save).to.have.been.calledWith({
+                          certificationCourse: certificationCourseToSave,
+                          domainTransaction,
+                        });
+
+                        expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([]);
+                      });
+                    });
+                  });
+                });
+
+                context('when certification center has no habilitation for CleA', function () {
+                  context('when user has certifiable badges with CleA', function () {
+                    it('should not save complementary certification info', async function () {
+                      // given
+                      const domainTransaction = Symbol('someDomainTransaction');
+
+                      const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
+                      sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                      certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                        .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                        .resolves(null);
+
+                      const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                        userId: 2,
+                        sessionId: 1,
+                        authorizedToStart: true,
+                      });
+
+                      certificationCandidateRepository.getBySessionIdAndUserId
+                        .withArgs({ sessionId: 1, userId: 2 })
+                        .resolves(foundCertificationCandidate);
+
+                      const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                        _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                      certificationChallengesService.pickCertificationChallenges
+                        .withArgs(placementProfile)
+                        .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                      const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
+                        name: CLEA,
+                      });
+                      const certificationCenter = domainBuilder.buildCertificationCenter();
+                      certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                      complementaryCertificationRepository.findAll.resolves([complementaryCertificationCleA]);
+
+                      const certificationCourseToSave = CertificationCourse.from({
+                        certificationCandidate: foundCertificationCandidate,
+                        challenges: [challenge1, challenge2],
+                        verificationCode,
+                        maxReachableLevelOnCertificationDate: 5,
+                        complementaryCertificationCourses: [],
+                      });
+
+                      const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                        certificationCourseToSave.toDTO()
+                      );
+                      certificationCourseRepository.save.resolves(savedCertificationCourse);
+
+                      const assessmentToSave = new Assessment({
+                        userId: 2,
+                        certificationCourseId: savedCertificationCourse.getId(),
+                        state: Assessment.states.STARTED,
+                        type: Assessment.types.CERTIFICATION,
+                        isImproving: false,
+                        method: Assessment.methods.CERTIFICATION_DETERMINED,
+                      });
+                      const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                      assessmentRepository.save
+                        .withArgs({ assessment: assessmentToSave, domainTransaction })
+                        .resolves(savedAssessment);
+
+                      certificationBadgesService.hasStillValidCleaBadgeAcquisition
+                        .withArgs({ userId: 2 })
+                        .resolves(true);
+
+                      certificationBadgesService.findStillValidBadgeAcquisitions
+                        .withArgs({
+                          userId: 2,
+                          domainTransaction,
+                        })
+                        .resolves([]);
+
+                      // when
+                      const result = await retrieveLastOrCreateCertificationCourse({
+                        domainTransaction,
+                        sessionId: 1,
+                        accessCode: 'accessCode',
+                        userId: 2,
+                        locale: 'fr',
+                        ...injectables,
+                      });
+
+                      // then
+                      expect(certificationCourseRepository.save).to.have.been.calledWith({
+                        certificationCourse: certificationCourseToSave,
+                        domainTransaction,
+                      });
+
+                      expect(result.certificationCourse._complementaryCertificationCourses).to.deep.equal([]);
+                    });
+                  });
+                });
+
+                context('when user has certifiable badge for Pix+ Édu', function () {
+                  it('should save all the challenges from pix and Pix+ Édu', async function () {
+                    // given
+                    const domainTransaction = Symbol('someDomainTransaction');
+
+                    const foundSession = domainBuilder.buildSession.created({ id: 1, accessCode: 'accessCode' });
+                    sessionRepository.get.withArgs(1).resolves(foundSession);
+
+                    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+                      .withArgs({ userId: 2, sessionId: 1, domainTransaction })
+                      .resolves(null);
+
+                    const foundCertificationCandidate = domainBuilder.buildCertificationCandidate({
+                      userId: 2,
+                      sessionId: 1,
+                      authorizedToStart: true,
+                      complementaryCertifications: [],
+                    });
+
+                    certificationCandidateRepository.getBySessionIdAndUserId
+                      .withArgs({ sessionId: 1, userId: 2 })
+                      .resolves(foundCertificationCandidate);
+
+                    const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
+                      _buildPlacementProfileWithTwoChallenges(placementProfileService, 2, now);
+                    certificationChallengesService.pickCertificationChallenges
+                      .withArgs(placementProfile)
+                      .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
+
+                    const certificationCenter = domainBuilder.buildCertificationCenter({
+                      habilitations: [],
+                    });
+                    certificationCenterRepository.getBySessionId.resolves(certificationCenter);
+                    complementaryCertificationRepository.findAll.resolves([]);
+
+                    const challengeEdu1 = domainBuilder.buildChallenge({ id: 'challenge-pix-edu1' });
+                    const challengeEdu2 = domainBuilder.buildChallenge({ id: 'challenge-pix-edu2' });
+
+                    const pixEduFormationContinueFormateurBadgeAcquisition =
+                      domainBuilder.buildBadgeAcquisition.forPixEduFormationContinue2ndDegreFormateur();
+                    certificationBadgesService.findStillValidBadgeAcquisitions
+                      .withArgs({ userId: 2, domainTransaction })
+                      .resolves([pixEduFormationContinueFormateurBadgeAcquisition]);
+
+                    certificationChallengesService.pickCertificationChallengesForPixPlus
+                      .withArgs(pixEduFormationContinueFormateurBadgeAcquisition.badge, 2)
+                      .resolves([challengeEdu1, challengeEdu2]);
+
+                    const certificationCourseToSave = CertificationCourse.from({
+                      certificationCandidate: foundCertificationCandidate,
+                      challenges: [challenge1, challenge2, challengeEdu1, challengeEdu2],
+                      verificationCode,
+                      maxReachableLevelOnCertificationDate: 5,
+                      complementaryCertificationCourses: [],
+                    });
+
+                    const savedCertificationCourse = domainBuilder.buildCertificationCourse(
+                      certificationCourseToSave.toDTO()
+                    );
+                    certificationCourseRepository.save
+                      .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
+                      .resolves(savedCertificationCourse);
+
+                    const assessmentToSave = new Assessment({
+                      userId: 2,
+                      certificationCourseId: savedCertificationCourse.getId(),
+                      state: Assessment.states.STARTED,
+                      type: Assessment.types.CERTIFICATION,
+                      isImproving: false,
+                      method: Assessment.methods.CERTIFICATION_DETERMINED,
+                    });
+                    const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
+                    assessmentRepository.save
+                      .withArgs({ assessment: assessmentToSave, domainTransaction })
+                      .resolves(savedAssessment);
+
+                    // when
+                    const result = await retrieveLastOrCreateCertificationCourse({
+                      domainTransaction,
+                      sessionId: 1,
+                      accessCode: 'accessCode',
+                      userId: 2,
+                      locale: 'fr',
+                      ...injectables,
+                    });
+
+                    // then
+                    expect(result.certificationCourse._challenges).to.deep.equal([
+                      challenge1,
+                      challenge2,
+                      challengeEdu1,
+                      challengeEdu2,
+                    ]);
+                  });
+                });
               });
             });
           });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -1,13 +1,10 @@
 const { expect, domainBuilder, sinon } = require('../../../../test-helper');
 const certificationPointOfContactSerializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer');
-const { featureToggles } = require('../../../../../lib/config');
 
 describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serializer', function () {
   describe('#serialize()', function () {
     it('should convert a CertificationPointOfContact model into JSON API data', function () {
       // given
-      sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(true);
-
       const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 123,
         name: 'Sunnydale Center',
@@ -107,110 +104,6 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
             },
           },
         ],
-      });
-    });
-
-    context('when isComplementaryCertificationSubscriptionEnabled is false', function () {
-      it('should not serialize the certification center habilitations', function () {
-        // given
-        sinon.stub(featureToggles, 'isComplementaryCertificationSubscriptionEnabled').value(false);
-
-        const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
-          id: 123,
-          name: 'Sunnydale Center',
-          externalId: 'BUFFY_SLAYER',
-          type: 'PRO',
-          isRelatedToManagingStudentsOrganization: false,
-          relatedOrganizationTags: [],
-          habilitations: [
-            { id: 1, name: 'Certif comp 1' },
-            { id: 2, name: 'Certif comp 2' },
-          ],
-        });
-        const allowedCertificationCenterAccess2 = domainBuilder.buildAllowedCertificationCenterAccess({
-          id: 456,
-          name: 'Hellmouth',
-          externalId: 'SPIKE',
-          type: 'SCO',
-          isRelatedToManagingStudentsOrganization: true,
-          relatedOrganizationTags: ['tag1'],
-          habilitations: [],
-        });
-        const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
-          id: 789,
-          firstName: 'Buffy',
-          lastName: 'Summers',
-          email: 'buffy.summers@example.net',
-          pixCertifTermsOfServiceAccepted: true,
-          allowedCertificationCenterAccesses: [allowedCertificationCenterAccess1, allowedCertificationCenterAccess2],
-        });
-
-        // when
-        const jsonApi = certificationPointOfContactSerializer.serialize(certificationPointOfContact);
-
-        // then
-        expect(jsonApi).to.deep.equal({
-          data: {
-            id: '789',
-            type: 'certification-point-of-contact',
-            attributes: {
-              'first-name': 'Buffy',
-              'last-name': 'Summers',
-              email: 'buffy.summers@example.net',
-              'pix-certif-terms-of-service-accepted': true,
-            },
-            relationships: {
-              'allowed-certification-center-accesses': {
-                data: [
-                  {
-                    id: '123',
-                    type: 'allowed-certification-center-access',
-                  },
-                  {
-                    id: '456',
-                    type: 'allowed-certification-center-access',
-                  },
-                ],
-              },
-            },
-          },
-          included: [
-            {
-              id: '123',
-              type: 'allowed-certification-center-access',
-              attributes: {
-                name: 'Sunnydale Center',
-                'external-id': 'BUFFY_SLAYER',
-                type: 'PRO',
-                'is-related-to-managing-students-organization': false,
-                'is-access-blocked-college': false,
-                'is-access-blocked-lycee': false,
-                'is-access-blocked-aefe': false,
-                'is-access-blocked-agri': false,
-                'related-organization-tags': [],
-                habilitations: [],
-                'is-end-test-screen-removal-enabled': false,
-              },
-            },
-            {
-              id: '456',
-              type: 'allowed-certification-center-access',
-              attributes: {
-                name: 'Hellmouth',
-                'external-id': 'SPIKE',
-                type: 'SCO',
-                'is-related-to-managing-students-organization': true,
-                'is-access-blocked-college': false,
-                'is-access-blocked-lycee': false,
-                'is-access-blocked-aefe': false,
-                'is-access-blocked-agri': false,
-                'related-organization-tags': ['tag1'],
-                habilitations: [],
-                'is-end-test-screen-removal-enabled': false,
-              },
-            },
-          ],
-        });
       });
     });
   });

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -43,10 +43,7 @@ export default class CertificationCandidatesController extends Controller {
   }
 
   get shouldDisplayComplementaryCertifications() {
-    return (
-      this.featureToggles.featureToggles.isComplementaryCertificationSubscriptionEnabled &&
-      this.currentUser.currentAllowedCertificationCenterAccess.hasHabilitations
-    );
+    return this.currentUser.currentAllowedCertificationCenterAccess.hasHabilitations;
   }
 
   get shouldDisplayPaymentOptions() {

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,6 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isComplementaryCertificationSubscriptionEnabled;
   @attr('boolean') isCertificationBillingEnabled;
 }

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -39,6 +39,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         isAccessBlockedLycee: false,
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
+        habilitations: [],
       });
       certificationPointOfContact = server.create('certification-point-of-contact', {
         firstName: 'Buffy',

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -9,33 +9,80 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 module('Integration | Component | certification-candidate-details-modal', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is enabled', function () {
-    test('it shows candidate details with complementary certification', async function (assert) {
+  test('it shows candidate details with complementary certification', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const candidate = store.createRecord('certification-candidate', {
+      firstName: 'Jean-Paul',
+      lastName: 'Candidat',
+      birthCity: 'Eu',
+      birthCountry: 'France',
+      email: 'jeanpauldeu@pix.fr',
+      resultRecipientEmail: 'suric@animal.fr',
+      externalId: '12345',
+      birthdate: '2000-12-25',
+      extraTimePercentage: 0.1,
+      birthInseeCode: 76255,
+      birthPostalCode: 76260,
+      sex: 'F',
+      complementaryCertifications: [
+        {
+          id: 1,
+          name: 'Pix+Edu',
+        },
+        {
+          id: 2,
+          name: 'Pix+Droit',
+        },
+      ],
+    });
+
+    const closeModalStub = sinon.stub();
+    this.set('closeModal', closeModalStub);
+    this.set('candidate', candidate);
+    this.set('displayComplementaryCertification', true);
+
+    // when
+    const screen = await renderScreen(hbs`
+      <CertificationCandidateDetailsModal
+        @closeModal={{this.closeModal}}
+        @candidate={{this.candidate}}
+        @displayComplementaryCertification={{this.displayComplementaryCertification}}
+      />
+    `);
+
+    // then
+    assert.dom(screen.getByText('Détail du candidat')).exists();
+    assert.dom(screen.getByText('Jean-Paul')).exists();
+    assert.dom(screen.getByText('Candidat')).exists();
+    assert.dom(screen.getByText('Eu')).exists();
+    assert.dom(screen.getByText('76260')).exists();
+    assert.dom(screen.getByText('76255')).exists();
+    assert.dom(screen.getByText('Femme')).exists();
+    assert.dom(screen.getByText('France')).exists();
+    assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
+    assert.dom(screen.getByText('suric@animal.fr')).exists();
+    assert.dom(screen.getByText('12345')).exists();
+    assert.dom(screen.getByText('25/12/2000')).exists();
+    assert.dom(screen.getByText('10 %')).exists();
+    assert.dom(screen.getByText('Pix+Edu, Pix+Droit')).exists();
+  });
+
+  module('when candidate has missing data', () => {
+    test('it displays a dash', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const candidate = store.createRecord('certification-candidate', {
-        firstName: 'Jean-Paul',
-        lastName: 'Candidat',
-        birthCity: 'Eu',
-        birthCountry: 'France',
-        email: 'jeanpauldeu@pix.fr',
-        resultRecipientEmail: 'suric@animal.fr',
-        externalId: '12345',
-        birthdate: '2000-12-25',
-        extraTimePercentage: 0.1,
-        birthInseeCode: 76255,
-        birthPostalCode: 76260,
-        sex: 'F',
-        complementaryCertifications: [
-          {
-            id: 1,
-            name: 'Pix+Edu',
-          },
-          {
-            id: 2,
-            name: 'Pix+Droit',
-          },
-        ],
+        firstName: undefined,
+        lastName: undefined,
+        birthCountry: undefined,
+        birthdate: undefined,
+        sex: undefined,
+        email: undefined,
+        resultRecipientEmail: undefined,
+        externalId: undefined,
+        extraTimePercentage: undefined,
+        complementaryCertifications: [],
       });
 
       const closeModalStub = sinon.stub();
@@ -45,54 +92,6 @@ module('Integration | Component | certification-candidate-details-modal', functi
 
       // when
       const screen = await renderScreen(hbs`
-      <CertificationCandidateDetailsModal
-        @closeModal={{this.closeModal}}
-        @candidate={{this.candidate}}
-        @displayComplementaryCertification={{this.displayComplementaryCertification}}
-      />
-    `);
-
-      // then
-      assert.dom(screen.getByText('Détail du candidat')).exists();
-      assert.dom(screen.getByText('Jean-Paul')).exists();
-      assert.dom(screen.getByText('Candidat')).exists();
-      assert.dom(screen.getByText('Eu')).exists();
-      assert.dom(screen.getByText('76260')).exists();
-      assert.dom(screen.getByText('76255')).exists();
-      assert.dom(screen.getByText('Femme')).exists();
-      assert.dom(screen.getByText('France')).exists();
-      assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
-      assert.dom(screen.getByText('suric@animal.fr')).exists();
-      assert.dom(screen.getByText('12345')).exists();
-      assert.dom(screen.getByText('25/12/2000')).exists();
-      assert.dom(screen.getByText('10 %')).exists();
-      assert.dom(screen.getByText('Pix+Edu, Pix+Droit')).exists();
-    });
-
-    module('when candidate has missing data', () => {
-      test('it displays a dash', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const candidate = store.createRecord('certification-candidate', {
-          firstName: undefined,
-          lastName: undefined,
-          birthCountry: undefined,
-          birthdate: undefined,
-          sex: undefined,
-          email: undefined,
-          resultRecipientEmail: undefined,
-          externalId: undefined,
-          extraTimePercentage: undefined,
-          complementaryCertifications: [],
-        });
-
-        const closeModalStub = sinon.stub();
-        this.set('closeModal', closeModalStub);
-        this.set('candidate', candidate);
-        this.set('displayComplementaryCertification', true);
-
-        // when
-        const screen = await renderScreen(hbs`
         <CertificationCandidateDetailsModal
           @closeModal={{this.closeModal}}
           @candidate={{this.candidate}}
@@ -100,70 +99,8 @@ module('Integration | Component | certification-candidate-details-modal', functi
         />
       `);
 
-        // then
-        assert.strictEqual(screen.getAllByText('-').length, 13);
-      });
-    });
-  });
-
-  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is disabled', function () {
-    test('it shows candidate details without complementary certifications', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const candidate = store.createRecord('certification-candidate', {
-        firstName: 'Jean-Paul',
-        lastName: 'Candidat',
-        birthCity: 'Eu',
-        birthCountry: 'France',
-        email: 'jeanpauldeu@pix.fr',
-        resultRecipientEmail: 'suric@animal.fr',
-        externalId: '12345',
-        birthdate: '2000-12-25',
-        extraTimePercentage: 0.1,
-        birthInseeCode: 76255,
-        birthPostalCode: 76260,
-        sex: 'F',
-        complementaryCertifications: [
-          {
-            id: 1,
-            name: 'Pix+Edu',
-          },
-          {
-            id: 2,
-            name: 'Pix+Droit',
-          },
-        ],
-      });
-
-      const closeModalStub = sinon.stub();
-      this.set('closeModal', closeModalStub);
-      this.set('candidate', candidate);
-      this.set('displayComplementaryCertification', false);
-
-      // when
-      const screen = await renderScreen(hbs`
-      <CertificationCandidateDetailsModal
-        @closeModal={{this.closeModal}}
-        @candidate={{this.candidate}}
-        @displayComplementaryCertification={{this.displayComplementaryCertification}}
-      />
-    `);
-
       // then
-      assert.dom(screen.getByText('Détail du candidat')).exists();
-      assert.dom(screen.getByText('Jean-Paul')).exists();
-      assert.dom(screen.getByText('Candidat')).exists();
-      assert.dom(screen.getByText('Eu')).exists();
-      assert.dom(screen.getByText('76260')).exists();
-      assert.dom(screen.getByText('76255')).exists();
-      assert.dom(screen.getByText('Femme')).exists();
-      assert.dom(screen.getByText('France')).exists();
-      assert.dom(screen.getByText('jeanpauldeu@pix.fr')).exists();
-      assert.dom(screen.getByText('suric@animal.fr')).exists();
-      assert.dom(screen.getByText('12345')).exists();
-      assert.dom(screen.getByText('25/12/2000')).exists();
-      assert.dom(screen.getByText('10 %')).exists();
-      assert.dom(screen.queryByText('Pix+Edu, Pix+Droit')).doesNotExist();
+      assert.strictEqual(screen.getAllByText('-').length, 13);
     });
   });
 

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -15,20 +15,19 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is enabled', () => {
-    test('it displays candidate information', async function (assert) {
-      // given
-      this.set('displayComplementaryCertification', true);
-      const candidate = _buildCertificationCandidate({
-        birthdate: new Date('2019-04-28'),
-      });
+  test('it displays candidate information', async function (assert) {
+    // given
+    this.set('displayComplementaryCertification', true);
+    const candidate = _buildCertificationCandidate({
+      birthdate: new Date('2019-04-28'),
+    });
 
-      const certificationCandidate = store.createRecord('certification-candidate', candidate);
+    const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-      this.set('certificationCandidates', [certificationCandidate]);
+    this.set('certificationCandidates', [certificationCandidate]);
 
-      // when
-      const screen = await renderScreen(hbs`
+    // when
+    const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
@@ -37,60 +36,32 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         </EnrolledCandidates>
       `);
 
-      // then
-      assert.dom(screen.getByRole('cell', { name: certificationCandidate.externalId })).exists();
-      assert.dom(screen.getByRole('cell', { name: certificationCandidate.lastName })).exists();
-      assert.dom(screen.getByRole('cell', { name: certificationCandidate.firstName })).exists();
-      assert.dom(screen.getByRole('cell', { name: certificationCandidate.resultRecipientEmail })).exists();
-      assert.dom(screen.getByRole('cell', { name: '3000 %' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Pix+Edu, Pix+Droit' })).exists();
-      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCity })).doesNotExist();
-      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthProvinceCode })).doesNotExist();
-      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCountry })).doesNotExist();
-      assert.dom(screen.queryByRole('cell', { name: certificationCandidate.email })).doesNotExist();
-    });
-
-    test('it displays a dash where there is no certification', async function (assert) {
-      // given
-      this.set('displayComplementaryCertification', true);
-      const candidate = _buildCertificationCandidate({
-        complementaryCertifications: null,
-      });
-
-      const certificationCandidate = store.createRecord('certification-candidate', candidate);
-
-      this.set('certificationCandidates', [certificationCandidate]);
-
-      // when
-      const screen = await renderScreen(hbs`
-        <EnrolledCandidates
-          @sessionId="1"
-          @certificationCandidates={{certificationCandidates}}
-          @displayComplementaryCertification={{displayComplementaryCertification}}
-          >
-        </EnrolledCandidates>
-      `);
-
-      // then
-      assert.dom(screen.getByRole('cell', { name: '-' })).exists();
-    });
+    // then
+    assert.dom(screen.getByRole('cell', { name: certificationCandidate.externalId })).exists();
+    assert.dom(screen.getByRole('cell', { name: certificationCandidate.lastName })).exists();
+    assert.dom(screen.getByRole('cell', { name: certificationCandidate.firstName })).exists();
+    assert.dom(screen.getByRole('cell', { name: certificationCandidate.resultRecipientEmail })).exists();
+    assert.dom(screen.getByRole('cell', { name: '3000 %' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Pix+Edu, Pix+Droit' })).exists();
+    assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCity })).doesNotExist();
+    assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthProvinceCode })).doesNotExist();
+    assert.dom(screen.queryByRole('cell', { name: certificationCandidate.birthCountry })).doesNotExist();
+    assert.dom(screen.queryByRole('cell', { name: certificationCandidate.email })).doesNotExist();
   });
 
-  module('when feature toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED is disabled', () => {
-    test('it display candidate information without complementary certification', async function (assert) {
-      // given
-      this.set('displayComplementaryCertification', false);
+  test('it displays a dash where there is no certification', async function (assert) {
+    // given
+    this.set('displayComplementaryCertification', true);
+    const candidate = _buildCertificationCandidate({
+      complementaryCertifications: null,
+    });
 
-      const candidate = _buildCertificationCandidate({
-        birthdate: new Date('2019-04-28'),
-      });
+    const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
-      const certificationCandidate = store.createRecord('certification-candidate', candidate);
+    this.set('certificationCandidates', [certificationCandidate]);
 
-      this.set('certificationCandidates', [certificationCandidate]);
-
-      // when
-      const screen = await renderScreen(hbs`
+    // when
+    const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{certificationCandidates}}
@@ -99,12 +70,8 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
         </EnrolledCandidates>
       `);
 
-      // then
-      assert.dom(screen.queryByRole('columnheader', { name: 'Certifications complémentaires' })).doesNotExist();
-      assert
-        .dom(screen.queryByRole('cell', { name: certificationCandidate.complementaryCertificationsList }))
-        .doesNotExist();
-    });
+    // then
+    assert.dom(screen.getByRole('cell', { name: '-' })).exists();
   });
 
   test('it should display details button', async function (assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates_test.js
@@ -39,22 +39,8 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
   });
 
   module('#get shouldDisplayComplementaryCertifications', function () {
-    test('should return false if feature toggle is false and center has complementary certifications', function (assert) {
+    test('should return false if center has no complementary certifications', function (assert) {
       // given
-      _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', false);
-      _stubCurrentCenter(this, store, { habilitations: ['Pix+Droit'] });
-      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
-
-      // when
-      const shouldDisplayComplementaryCertifications = controller.shouldDisplayComplementaryCertifications;
-
-      // then
-      assert.false(shouldDisplayComplementaryCertifications);
-    });
-
-    test('should return false if feature toggle is true and center has no complementary certifications', function (assert) {
-      // given
-      _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', true);
       _stubCurrentCenter(this, store, { habilitations: [] });
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 
@@ -65,9 +51,8 @@ module('Unit | Controller | authenticated/sessions/details/certification-candida
       assert.false(shouldDisplayComplementaryCertifications);
     });
 
-    test('should return true if feature toggle is true and center has complementary certifications', function (assert) {
+    test('should return true and center has complementary certifications', function (assert) {
       // given
-      _stubFeatureToggle(this, 'isComplementaryCertificationSubscriptionEnabled', true);
       _stubCurrentCenter(this, store, { habilitations: ['Pix+Edu'] });
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
 


### PR DESCRIPTION
## :unicorn: Problème
Le toggle FT_IS_COMPLEMENTARY_CERTIFICATION_SUBSCRIPTION_ENABLED est activé en production

## :robot: Solution
Supprimer le toggle et les parties ou il est desactivé

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer des certifs clea + pix+ + pix edu, s'assurer que tout est ok
Faire un rescoring et s'assurer que tout est ok (en neutralisant des answers)