### PR TITLE
[TECH] Eviter le crash de container lorsqu'on récupère les profiles cibles.

### DIFF
--- a/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
@@ -11,6 +11,10 @@ async function availableForOrganization(organizationId) {
 }
 
 function _fetchTargetProfiles(organizationId) {
+  const selectTargetProfileSharesIdsBelongToOrganization = knex
+    .select('targetProfileId')
+    .from('target-profile-shares')
+    .where({ organizationId });
   return knex('target-profiles')
     .select([
       'target-profiles.id',
@@ -24,12 +28,11 @@ function _fetchTargetProfiles(organizationId) {
     .leftJoin('target-profiles_skills', 'target-profiles_skills.targetProfileId', 'target-profiles.id')
     .leftJoin('badges', 'badges.targetProfileId', 'target-profiles.id')
     .leftJoin('stages', 'stages.targetProfileId', 'target-profiles.id')
-    .leftJoin('target-profile-shares', 'target-profile-shares.targetProfileId', 'target-profiles.id')
     .where({ outdated: false })
     .where((qb) => {
       qb.orWhere({ isPublic: true });
       qb.orWhere({ ownerOrganizationId: organizationId });
-      qb.orWhere({ organizationId });
+      qb.orWhereIn('target-profiles.id', selectTargetProfileSharesIdsBelongToOrganization);
     })
     .groupBy('target-profiles.id');
 }


### PR DESCRIPTION
## :unicorn: Problème
Deux crashs de conteneurs APIs ont eu lieu suite à l'appel de l'API de récupération de profiles cibles.

<img width="1505" alt="Capture d’écran 2022-03-16 à 16 28 03" src="https://user-images.githubusercontent.com/10045497/158626942-31008292-800a-426d-98fa-5abca7483eb5.png">


<img width="1497" alt="Capture d’écran 2022-03-16 à 16 19 34" src="https://user-images.githubusercontent.com/10045497/158625024-1aea59ab-a94a-444d-b903-a28c301974e2.png">

La requête SQL responsable du crash est la suivante:

`select "target-profiles"."id", "target-profiles"."name", "target-profiles"."description", "target-profiles"."category", ARRAY_AGG("skillId") AS "skillIds", ARRAY_AGG("badges"."id")  AS "badgeIds", ARRAY_AGG("stages"."id")  AS "stageIds" from "target-profiles" left join "target-profiles_skills" on "target-profiles_skills"."targetProfileId" = "target-profiles"."id" left join "badges" on "badges"."targetProfileId" = "target-profiles"."id" left join "stages" on "stages"."targetProfileId" = "target-profiles"."id" left join "target-profile-shares" on "target-profile-shares"."targetProfileId" = "target-profiles"."id" where "outdated" = false and (("isPublic" = true) or ("ownerOrganizationId" = 266) or ("organizationId" = 266)) group by "target-profiles"."id";`

Lancer cette requête sur metabase a fait crash toute l'instance. Voir discussion ci-dessous
https://1024pix.slack.com/archives/C658LDBAQ/p1643888564818659

Avec @jonathanperret, on a reproduit facilement le crash dans un conteneur scalingo en one-off.

## :robot: Solution
Remplacer la jointure avec la table "target-profile-shares" par un IN avec une sub query.
"target-profiles".id in (select "targetProfileId" from "target-profile-shares" where "organizationId" = 266)

Plan d'exécution avec la requête avec Jointure:

<img width="925" alt="Capture d’écran 2022-03-16 à 16 38 02" src="https://user-images.githubusercontent.com/10045497/158631344-4f345262-d7ce-4f10-81aa-71113e4a48cc.png">


Plan d'exécution avec la  requête avec une sous query:

<img width="1010" alt="Capture d’écran 2022-03-16 à 16 38 26" src="https://user-images.githubusercontent.com/10045497/158631304-3b3854b9-7acf-407a-8fcf-d0fdcd3b780a.png">

## :rainbow: Remarques
Au passage, on a vu que les remontées de skillIds, badges et stages étaient largement inutiles puisqu’on ne s’en sert que pour quelques comptages en JS. On peut optimiser cette remontée dans un second temps.

## :100: Pour tester
Les tests de CI passent.
Faire une non régression.
