### PR TITLE
[TECH] Ajout d'un Redis pour les tests dans la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:5.0.7-alpine
     resource_class: small
     working_directory: ~/pix/api
     steps:
@@ -115,6 +116,7 @@ jobs:
             npm run test:ci
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
+            TEST_REDIS_URL: redis://localhost:6379
             MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
             MOCHA_REPORTER: mocha-junit-reporter
           when: always

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -341,7 +341,7 @@ module.exports = (function () {
     config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };
     config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
-    config.logging.enabled = isBooleanFeatureEnabledElseDefault(process.env.LOG_ENABLED, false);
+    config.logging.enabled = isBooleanFeatureEnabledElseDefault(process.env.TEST_LOG_ENABLED, false);
     config.logging.enableLogKnexQueries = false;
     config.logging.enableLogStartingEventDispatch = false;
     config.logging.enableLogEndingEventDispatch = false;

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -300,6 +300,9 @@ module.exports = (function () {
     config.poleEmploi.sendingUrl = 'http://sendingUrl.fr';
     config.poleEmploi.userInfoUrl = 'http://userInfoUrl.fr';
     config.poleEmploi.authUrl = 'http://authurl.fr';
+    config.poleEmploi.temporaryStorage.redisUrl = null;
+
+    config.temporaryStorage.redisUrl = null;
 
     config.cnav.clientId = 'PIX_CNAV_CLIENT_ID';
     config.cnav.authUrl = 'http://idp.cnav/auth';
@@ -348,6 +351,11 @@ module.exports = (function () {
     config.caching.redisCacheLockedWaitBeforeRetry = 0;
 
     config.sentry.enabled = false;
+
+    config.redis = {
+      url: process.env.TEST_REDIS_URL,
+      database: 1,
+    };
   }
 
   return config;

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -38,6 +38,7 @@ const schema = Joi.object({
   CNAV_TOKEN_URL: Joi.string().uri().optional(),
   CONTAINER_VERSION: Joi.string().optional(),
   FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
+  TEST_REDIS_URL: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -38,6 +38,7 @@ const schema = Joi.object({
   CNAV_TOKEN_URL: Joi.string().uri().optional(),
   CONTAINER_VERSION: Joi.string().optional(),
   FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
+  TEST_LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   TEST_REDIS_URL: Joi.string().optional(),
 }).options({ allowUnknown: true });
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -599,3 +599,17 @@ POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN=7d
 # type: string
 # default: 7d
 CNAV_ACCESS_TOKEN_LIFESPAN=7d
+
+
+# ========
+# TESTS
+# ========
+
+# URL of the Redis database used for API testing.
+#
+# If not present, the tests will fail.
+#
+# presence: required
+# type: Url
+# default: none
+TEST_REDIS_URL=redis://localhost:6379

--- a/api/sample.env
+++ b/api/sample.env
@@ -605,6 +605,13 @@ CNAV_ACCESS_TOKEN_LIFESPAN=7d
 # TESTS
 # ========
 
+# Enable or disable the logging of the API testing.
+#
+# presence: optional
+# type: Boolean
+# default: `false`
+TEST_LOG_ENABLED=false
+
 # URL of the Redis database used for API testing.
 #
 # If not present, the tests will fail.

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -1,99 +1,96 @@
 const RedisClient = require('../../../../lib/infrastructure/utils/RedisClient');
+const config = require('../../../../lib/config');
 const { expect } = require('../../../test-helper');
 
 describe('Integration | Infrastructure | Utils | RedisClient', function () {
-  // this check is used to prevent failure when redis is not setup
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  if (process.env.REDIS_TEST_URL !== undefined) {
-    it('stores and retrieve a value for a key', async function () {
-      // given
-      const key = new Date().toISOString();
-      const redisClient = new RedisClient(process.env.REDIS_TEST_URL);
+  it('stores and retrieve a value for a key', async function () {
+    // given
+    const key = new Date().toISOString();
+    const redisClient = new RedisClient(config.redis.url);
 
-      // when
-      await redisClient.set(key, 'value');
-      const value = await redisClient.get(key);
+    // when
+    await redisClient.set(key, 'value');
+    const value = await redisClient.get(key);
 
-      // then
-      expect(value).to.equal('value');
-      await redisClient.del(key);
-    });
+    // then
+    expect(value).to.equal('value');
+    await redisClient.del(key);
+  });
 
-    it('should delete a value with prefix', async function () {
+  it('should delete a value with prefix', async function () {
+    // given
+    const value = new Date().toISOString();
+    const redisClientWithPrefix = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
+    await redisClientWithPrefix.set('AVRIL', value);
+
+    // when
+    await redisClientWithPrefix.del('AVRIL');
+
+    // then
+    expect(await redisClientWithPrefix.get('AVRIL')).to.be.null;
+  });
+
+  it('should separate storage for identical keys saved with different prefixes', async function () {
+    // given
+    const redisClient1 = new RedisClient(config.redis.url, { prefix: 'test1' });
+    const redisClient2 = new RedisClient(config.redis.url, { prefix: 'test2' });
+    await redisClient1.set('key', 'value1');
+    await redisClient2.set('key', 'value2');
+
+    // when / then
+    expect(await redisClient1.get('key')).to.equal('value1');
+    expect(await redisClient2.get('key')).to.equal('value2');
+    await redisClient1.del('key');
+    await redisClient2.del('key');
+  });
+
+  describe('#deleteByPrefix', function () {
+    it('should delete keys with given matching prefix', async function () {
       // given
       const value = new Date().toISOString();
-      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
-      await redisClientWithPrefix.set('AVRIL', value);
+      const redisClient = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
+      await redisClient.set('123:AVRIL', value);
+      await redisClient.set('123:abcde', value);
+      await redisClient.set('456:abcde', value);
 
       // when
-      await redisClientWithPrefix.del('AVRIL');
+      await redisClient.deleteByPrefix('123:');
 
       // then
-      expect(await redisClientWithPrefix.get('AVRIL')).to.be.null;
+      expect(await redisClient.get('123:AVRIL')).to.not.exist;
+      expect(await redisClient.get('123:abcde')).to.not.exist;
+      expect(await redisClient.get('456:abcde')).to.exist;
     });
 
-    it('should separate storage for identical keys saved with different prefixes', async function () {
+    it('should escape special characters', async function () {
       // given
-      const redisClient1 = new RedisClient(process.env.REDIS_URL, { prefix: 'test1' });
-      const redisClient2 = new RedisClient(process.env.REDIS_URL, { prefix: 'test2' });
-      await redisClient1.set('key', 'value1');
-      await redisClient2.set('key', 'value2');
+      const value = new Date().toISOString();
+      const redisClient = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
+      await redisClient.set('123:AVRIL', value);
+      await redisClient.set('123:abcde', value);
+      await redisClient.set('456:abcde', value);
+      await redisClient.set('*:abcde', value);
+      await redisClient.set('**:abcde', value);
 
-      // when / then
-      expect(await redisClient1.get('key')).to.equal('value1');
-      expect(await redisClient2.get('key')).to.equal('value2');
-      await redisClient1.del('key');
-      await redisClient2.del('key');
+      // when
+      await redisClient.deleteByPrefix('**');
+
+      // then
+      expect(await redisClient.get('**:abcde')).to.not.exist;
+      expect(await redisClient.get('*:abcde')).to.exist;
     });
 
-    describe('#deleteByPrefix', function () {
-      it('should delete keys with given matching prefix', async function () {
-        // given
-        const value = new Date().toISOString();
-        const redisClient = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
-        await redisClient.set('123:AVRIL', value);
-        await redisClient.set('123:abcde', value);
-        await redisClient.set('456:abcde', value);
+    it('should do nothing if there is no matching prefix', async function () {
+      // given
+      const value = new Date().toISOString();
+      const redisClient = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
+      await redisClient.set('789:abcde', value);
 
-        // when
-        await redisClient.deleteByPrefix('123:');
+      // when
+      await redisClient.deleteByPrefix('333:');
 
-        // then
-        expect(await redisClient.get('123:AVRIL')).to.not.exist;
-        expect(await redisClient.get('123:abcde')).to.not.exist;
-        expect(await redisClient.get('456:abcde')).to.exist;
-      });
-
-      it('should escape special characters', async function () {
-        // given
-        const value = new Date().toISOString();
-        const redisClient = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
-        await redisClient.set('123:AVRIL', value);
-        await redisClient.set('123:abcde', value);
-        await redisClient.set('456:abcde', value);
-        await redisClient.set('*:abcde', value);
-        await redisClient.set('**:abcde', value);
-
-        // when
-        await redisClient.deleteByPrefix('**');
-
-        // then
-        expect(await redisClient.get('**:abcde')).to.not.exist;
-        expect(await redisClient.get('*:abcde')).to.exist;
-      });
-
-      it('should do nothing if there is no matching prefix', async function () {
-        // given
-        const value = new Date().toISOString();
-        const redisClient = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
-        await redisClient.set('789:abcde', value);
-
-        // when
-        await redisClient.deleteByPrefix('333:');
-
-        // then
-        expect(await redisClient.get('789:abcde')).to.exist;
-      });
+      // then
+      expect(await redisClient.get('789:abcde')).to.exist;
     });
-  }
+  });
 });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: `${__dirname}/../.env` });
 const _ = require('lodash');
 const chai = require('chai');
 const expect = chai.expect;

--- a/docs/adr/0033-tester-en-utilisant-redis.md
+++ b/docs/adr/0033-tester-en-utilisant-redis.md
@@ -1,0 +1,59 @@
+# 33. Tester en utilisant Redis 
+
+Date : 2022-03-16
+
+## État
+Adopté
+
+## Contexte 
+
+Notre architecture de cache repose essentiellement sur Redis. 
+Afin d'assurer la connexion à ce dernier, nous utilisons la librairie [node-redis](https://github.com/redis/node-redis) 
+qui est enveloppée dans une classe dédiée : `RedisClient`.
+Actuellement, cette classe est testée uniquement en local. 
+
+### Difficulté rencontrée
+
+La version 4 de cette librairie introduit [des breaking changes](https://github.com/redis/node-redis/blob/master/CHANGELOG.md#v400---24-nov-2021)
+qui auront comme conséquence de complexifier la classe `RedisClient`.
+
+Afin d'assurer le bon fonctionnement de cette partie du code, nous souhaitons mettre en place plus de tests automatisés.   
+Au départ, ces derniers n'avaient pas été mis en place pour éviter d'avoir un stockage Redis qui tourne en local. 
+Cependant, il est devenu obligatoire au fil du temps. 
+L'ajout de ces tests n'impactera donc pas l'expérience des développeurs.
+
+La classe évolue très peu, nous pouvons donc questionner la pertinence du lancement de ces tests à chaque fois dans la CI. 
+
+### Solution n°1 : Ne pas faire évoluer l'existant : tester avec un stockage Redis uniquement en local lorsqu'on le souhaite
+
+#### Avantages
+
+- Gain de temps lors du lancement des tests
+- Gain de temps sur la CI 
+- Évite de lancer un stockage Redis dans la CI
+
+#### Inconvénients
+
+- Les tests peuvent être oubliés
+- Pas de tests de bout en bout avec l'implémentation de production
+
+
+### Solution n°2 : Tester avec un stockage Redis en local et dans la CI.
+
+#### Avantages
+
+- Pas de risque d'oubli
+- La CI lance les mêmes tests qu'en local
+- Les tests de bout en bout peuvent utiliser l'implémentation de production
+
+#### Inconvénients
+
+- Les tests peuvent être un peu plus longs
+
+## Décision
+
+La solution n°2 est adoptée, étant la solution apportant le plus de bénéfices.
+
+## Conséquences
+
+Des tests sur la classe `RedisClient` ont été ajoutés. 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la classe `RedisClient` n'est pas testé dans la CI. Cela nous empêche de faire la montée de version de `node-redis` en toute sérénité.

## :robot: Solution
- Ajouter d'un redis dans la CI
- Ajouter des variables d'environnement
- 

## :rainbow: Remarques
- L'ajout de ces tests engendre l'obligation d'avoir un redis en fonctionnement. 
- Ajout d'un ADR pour expliquer le choix de la mise en place de ces tests. 

Par ailleurs, l'ajout du redis en local, permettra à l'avenir de tester le LearningContentCache avec le redis comme en production, ou bien encore l'anti-rejeu #4416. 

## :100: Pour tester
- Voir que la CI passe 
