### PR TITLE
[FEATURE] Augmentation de l'espace entre le score max et l'icone dans l'hexagone de score (PIX-4565).

### DIFF
--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -57,9 +57,9 @@
     width: 70px;
     left: 31px;
     top: 100px;
-    padding-top: 3px;
+    padding: 3px 8px 0;
     display: flex;
-    justify-content: center;
+    justify-content: space-around;
     align-items: center;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Il y a un écart trop faible entre 1024 et l'icone d'aide dans l'hexagone de score sur mon-pix.
![image](https://user-images.githubusercontent.com/36371437/158820416-4ef3150a-bbe3-479c-af70-4df5c290ceae.png)

## :robot: Solution

Ajout de padding latéral et modification du l'alignement flex.

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur la page d'accueil de mon-pix, vérifier que l'écart entre les deux éléments a augmenté.
