### PR TITLE
[FEATURE] Empêcher l'activation/récupération d'une organisation SCO si celle-ci est archivée sur Pix Orga (PIX-4527).

### DIFF
--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -17,13 +17,13 @@ module.exports = {
   },
 
   async sendScoInvitation(request, h) {
-    const { uai: uai, 'first-name': firstName, 'last-name': lastName } = request.payload.data.attributes;
+    const { uai, 'first-name': firstName, 'last-name': lastName } = request.payload.data.attributes;
 
     const locale = extractLocaleFromRequest(request);
 
-    const organizationSCOInvitation = await usecases.sendScoInvitation({ uai, firstName, lastName, locale });
+    const organizationScoInvitation = await usecases.sendScoInvitation({ uai, firstName, lastName, locale });
 
-    return h.response(scoOrganizationInvitationSerializer.serialize(organizationSCOInvitation)).created();
+    return h.response(scoOrganizationInvitationSerializer.serialize(organizationScoInvitation)).created();
   },
 
   async getOrganizationInvitation(request) {

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -1,8 +1,11 @@
 const _ = require('lodash');
-const { OrganizationNotFoundError, OrganizationWithoutEmailError, ManyOrganizationsFoundError } = require('../errors');
+const {
+  OrganizationNotFoundError,
+  OrganizationWithoutEmailError,
+  ManyOrganizationsFoundError,
+  OrganizationArchivedError,
+} = require('../errors');
 const organizationInvitationService = require('../../domain/services/organization-invitation-service');
-let errorMessage = null;
-let organizationsFound = null;
 
 module.exports = async function sendScoInvitation({
   uai,
@@ -12,49 +15,53 @@ module.exports = async function sendScoInvitation({
   organizationRepository,
   organizationInvitationRepository,
 }) {
-  organizationsFound = await organizationRepository.findScoOrganizationByUai(uai.trim());
+  const organizationsFound = await organizationRepository.findScoOrganizationByUai({ uai: uai.trim() });
 
-  const nbOrganizations = _.get(organizationsFound, 'length', 0);
+  _checkIfManyOrganizationsFoundError(organizationsFound, uai);
 
-  _checkIfManyOrganizationsFoundError(nbOrganizations, uai);
+  _checkIfOrganizationNotFoundError(organizationsFound, uai);
 
-  _checkIfOrganizationNotFoundError(nbOrganizations, uai);
+  _checkIfOrganizationWithoutEmailError(organizationsFound, uai);
 
-  _checkIfOrganizationWithoutEmailError(nbOrganizations, uai);
+  _checkIfOrganizationIsArchivedError(organizationsFound);
 
   const email = organizationsFound[0].email;
   const organizationId = organizationsFound[0].id;
 
-  const scoOrganizationInvitation = await organizationInvitationService.createScoOrganizationInvitation({
-    organizationRepository,
-    organizationInvitationRepository,
+  return await organizationInvitationService.createScoOrganizationInvitation({
     organizationId,
     firstName,
     lastName,
     email,
     locale,
+    organizationRepository,
+    organizationInvitationRepository,
   });
-
-  return scoOrganizationInvitation;
 };
 
-function _checkIfOrganizationNotFoundError(nbOrganizations, uai) {
-  if (nbOrganizations == 0) {
-    errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
+function _checkIfOrganizationNotFoundError(organizationsFound, uai) {
+  if (organizationsFound.length === 0) {
+    const errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
     throw new OrganizationNotFoundError(errorMessage);
   }
 }
 
-function _checkIfManyOrganizationsFoundError(nbOrganizations, uai) {
-  if (nbOrganizations > 1) {
-    errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
+function _checkIfManyOrganizationsFoundError(organizationsFound, uai) {
+  if (organizationsFound.length > 1) {
+    const errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
     throw new ManyOrganizationsFoundError(errorMessage);
   }
 }
 
-function _checkIfOrganizationWithoutEmailError(nbOrganizations, uai) {
-  if (nbOrganizations == 1 && _.isEmpty(organizationsFound[0].email)) {
-    errorMessage = `Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE ${uai}.`;
+function _checkIfOrganizationWithoutEmailError(organizationsFound, uai) {
+  if (organizationsFound.length === 1 && _.isEmpty(organizationsFound[0].email)) {
+    const errorMessage = `Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE ${uai}.`;
     throw new OrganizationWithoutEmailError(errorMessage);
+  }
+}
+
+function _checkIfOrganizationIsArchivedError(organizationsFound) {
+  if (organizationsFound.length === 1 && !!organizationsFound[0].archivedAt) {
+    throw new OrganizationArchivedError();
   }
 }

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -15,15 +15,15 @@ module.exports = async function sendScoInvitation({
   organizationRepository,
   organizationInvitationRepository,
 }) {
-  const organizationsFound = await organizationRepository.findScoOrganizationByUai({ uai: uai.trim() });
+  const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
 
-  _checkIfManyOrganizationsFoundError(organizationsFound, uai);
+  _checkIfManyOrganizationsFound(organizationsFound, uai);
 
-  _checkIfOrganizationNotFoundError(organizationsFound, uai);
+  _checkIfOrganizationNotFound(organizationsFound, uai);
 
-  _checkIfOrganizationWithoutEmailError(organizationsFound, uai);
+  _checkIfOrganizationWithoutEmail(organizationsFound, uai);
 
-  _checkIfOrganizationIsArchivedError(organizationsFound);
+  _checkIfOrganizationIsArchived(organizationsFound);
 
   const email = organizationsFound[0].email;
   const organizationId = organizationsFound[0].id;
@@ -39,28 +39,28 @@ module.exports = async function sendScoInvitation({
   });
 };
 
-function _checkIfOrganizationNotFoundError(organizationsFound, uai) {
+function _checkIfOrganizationNotFound(organizationsFound, uai) {
   if (organizationsFound.length === 0) {
     const errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
     throw new OrganizationNotFoundError(errorMessage);
   }
 }
 
-function _checkIfManyOrganizationsFoundError(organizationsFound, uai) {
+function _checkIfManyOrganizationsFound(organizationsFound, uai) {
   if (organizationsFound.length > 1) {
     const errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
     throw new ManyOrganizationsFoundError(errorMessage);
   }
 }
 
-function _checkIfOrganizationWithoutEmailError(organizationsFound, uai) {
+function _checkIfOrganizationWithoutEmail(organizationsFound, uai) {
   if (organizationsFound.length === 1 && _.isEmpty(organizationsFound[0].email)) {
     const errorMessage = `Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE ${uai}.`;
     throw new OrganizationWithoutEmailError(errorMessage);
   }
 }
 
-function _checkIfOrganizationIsArchivedError(organizationsFound) {
+function _checkIfOrganizationIsArchived(organizationsFound) {
   if (organizationsFound.length === 1 && !!organizationsFound[0].archivedAt) {
     throw new OrganizationArchivedError();
   }

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -156,11 +156,11 @@ module.exports = {
       .then((organizations) => organizations.models.map((model) => _toDomain(model.toJSON())));
   },
 
-  findScoOrganizationByUai(uai) {
+  findScoOrganizationByUai({ uai }) {
     return BookshelfOrganization.query((qb) =>
       qb.where({ type: Organization.types.SCO }).whereRaw('LOWER("externalId") = ? ', `${uai.toLowerCase()}`)
     )
-      .fetchAll({ columns: ['id', 'type', 'externalId', 'email'] })
+      .fetchAll({ columns: ['id', 'type', 'externalId', 'email', 'archivedAt'] })
       .then((organizations) => organizations.models.map((model) => _toDomain(model.toJSON())));
   },
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -156,7 +156,7 @@ module.exports = {
       .then((organizations) => organizations.models.map((model) => _toDomain(model.toJSON())));
   },
 
-  findScoOrganizationByUai({ uai }) {
+  findScoOrganizationsByUai({ uai }) {
     return BookshelfOrganization.query((qb) =>
       qb.where({ type: Organization.types.SCO }).whereRaw('LOWER("externalId") = ? ', `${uai.toLowerCase()}`)
     )

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -11,6 +11,7 @@ const {
   OrganizationWithoutEmailError,
   OrganizationNotFoundError,
   ManyOrganizationsFoundError,
+  OrganizationArchivedError,
 } = require('../../../../lib/domain/errors');
 
 describe('Integration | Application | Organization-invitations | organization-invitation-controller', function () {
@@ -132,7 +133,7 @@ describe('Integration | Application | Organization-invitations | organization-in
         expect(response.statusCode).to.equal(404);
       });
 
-      it('should respond an HTTP response with status code 409 when OrganizationWithoutEmailError', async function () {
+      it('should respond an HTTP response with status code 412 when OrganizationWithoutEmailError', async function () {
         // given
         usecases.sendScoInvitation.rejects(new OrganizationWithoutEmailError());
 
@@ -152,6 +153,17 @@ describe('Integration | Application | Organization-invitations | organization-in
 
         // then
         expect(response.statusCode).to.equal(409);
+      });
+
+      it('should respond an HTTP response with status code 422 when OrganizationArchivedError', async function () {
+        // given
+        usecases.sendScoInvitation.rejects(new OrganizationArchivedError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/sco', payload);
+
+        // then
+        expect(response.statusCode).to.equal(422);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -374,7 +374,7 @@ describe('Integration | Repository | Organization', function () {
     });
   });
 
-  describe('#findScoOrganizationByUai', function () {
+  describe('#findScoOrganizationsByUai', function () {
     let organizations;
 
     beforeEach(async function () {
@@ -389,7 +389,13 @@ describe('Integration | Repository | Organization', function () {
             archivedAt: new Date(),
           },
           { type: 'SUP', name: 'organization 3', externalId: '1234569', email: null },
-          { type: 'SCO', name: 'organization 4', externalId: '0595401A', email: 'sco2.generic.account@example.net' },
+          {
+            type: 'SCO',
+            name: 'organization 4',
+            externalId: '0595401A',
+            email: 'sco2.generic.account@example.net',
+            archivedAt: null,
+          },
           { type: 'SCO', name: 'organization 5', externalId: '0587996a', email: 'sco3.generic.account@example.net' },
           { type: 'SCO', name: 'organization 6', externalId: '058799Aa', email: 'sco4.generic.account@example.net' },
         ],
@@ -407,7 +413,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[1];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+      const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -423,7 +429,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[3];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+      const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -439,7 +445,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[4];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+      const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -455,7 +461,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[5];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+      const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -471,7 +477,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[5];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+      const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -481,16 +487,29 @@ describe('Integration | Repository | Organization', function () {
       expect(foundOrganization[0].email).to.equal(organizationSCO.email);
     });
 
-    it('should return archivedAt attribute', async function () {
+    it('should return archivedAt null value', async function () {
       // given
-      const uai = '1234568';
-      const organizationSCO = organizations[1];
+      const uai = '0595401A';
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+      const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
 
       // then
-      expect(foundOrganization[0].archivedAt).to.deep.equal(organizationSCO.archivedAt);
+      expect(foundOrganization[0].archivedAt).to.deep.equal(null);
+    });
+
+    context('when organization is archived', function () {
+      it('should return archivedAt attribute', async function () {
+        // given
+        const uai = '1234568';
+        const organizationSCO = organizations[1];
+
+        // when
+        const foundOrganization = await organizationRepository.findScoOrganizationsByUai({ uai });
+
+        // then
+        expect(foundOrganization[0].archivedAt).to.deep.equal(organizationSCO.archivedAt);
+      });
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -381,7 +381,13 @@ describe('Integration | Repository | Organization', function () {
       organizations = _.map(
         [
           { type: 'PRO', name: 'organization 1', externalId: '1234567', email: null },
-          { type: 'SCO', name: 'organization 2', externalId: '1234568', email: 'sco.generic.account@example.net' },
+          {
+            type: 'SCO',
+            name: 'organization 2',
+            externalId: '1234568',
+            email: 'sco.generic.account@example.net',
+            archivedAt: new Date(),
+          },
           { type: 'SUP', name: 'organization 3', externalId: '1234569', email: null },
           { type: 'SCO', name: 'organization 4', externalId: '0595401A', email: 'sco2.generic.account@example.net' },
           { type: 'SCO', name: 'organization 5', externalId: '0587996a', email: 'sco3.generic.account@example.net' },
@@ -401,7 +407,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[1];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -417,7 +423,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[3];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -433,7 +439,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[4];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -449,7 +455,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[5];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -465,7 +471,7 @@ describe('Integration | Repository | Organization', function () {
       const organizationSCO = organizations[5];
 
       // when
-      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
 
       // then
       expect(foundOrganization).to.have.lengthOf(1);
@@ -473,6 +479,18 @@ describe('Integration | Repository | Organization', function () {
       expect(foundOrganization[0].externalId).to.equal(organizationSCO.externalId);
       expect(foundOrganization[0].type).to.equal(organizationSCO.type);
       expect(foundOrganization[0].email).to.equal(organizationSCO.email);
+    });
+
+    it('should return archivedAt attribute', async function () {
+      // given
+      const uai = '1234568';
+      const organizationSCO = organizations[1];
+
+      // when
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai({ uai });
+
+      // then
+      expect(foundOrganization[0].archivedAt).to.deep.equal(organizationSCO.archivedAt);
     });
   });
 

--- a/api/tests/unit/domain/usecases/send-sco-invitation_test.js
+++ b/api/tests/unit/domain/usecases/send-sco-invitation_test.js
@@ -1,90 +1,78 @@
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
-const Organization = require('../../../../lib/domain/models/Organization');
 const {
   OrganizationNotFoundError,
   OrganizationWithoutEmailError,
   ManyOrganizationsFoundError,
 } = require('../../../../lib/domain/errors');
 
-describe('Unit | UseCase | find-organizations', function () {
-  const organizationRepository = {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    findScoOrganizationByUai: sinon.stub(),
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    get: sinon.stub(),
-  };
+describe('Unit | UseCase | send-sco-invitation', function () {
+  let organizationRepository;
 
-  it('should throw an NotFoundOrganization when UAI did not match', async function () {
-    // given
-    const uai = '1234567A';
-    const message = "L'UAI/RNE 1234567A de l'établissement n’est pas reconnu.";
-
-    organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([]);
-
-    const requestErr = await catchErr(usecases.sendScoInvitation)({
-      uai,
-      organizationRepository,
-    });
-
-    expect(requestErr).to.be.instanceOf(OrganizationNotFoundError);
-    expect(requestErr.message).to.be.equal(message);
+  beforeEach(function () {
+    organizationRepository = {
+      findScoOrganizationByUai: sinon.stub(),
+    };
   });
 
-  it('should throw an OrganizationWithoutEmailError when email is not present', async function () {
-    // given
-    const uai = '1234567A';
-    const organization = new Organization({
-      id: 2,
-      type: 'SCO',
-      name: 'organization 2',
-      externalId: '1234568',
-      email: null,
-    });
-    const message =
-      "Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE 1234567A.";
-    organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization]);
+  context('when UAI did not match', function () {
+    it('should throw an NotFoundOrganizationError', async function () {
+      // given
+      const uai = '1234567A';
+      domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
 
-    const requestErr = await catchErr(usecases.sendScoInvitation)({
-      uai,
-      organizationRepository,
-    });
+      organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([]);
 
-    expect(requestErr).to.be.instanceOf(OrganizationWithoutEmailError);
-    expect(requestErr.message).to.be.equal(message);
+      const requestErr = await catchErr(usecases.sendScoInvitation)({
+        uai,
+        organizationRepository,
+      });
+
+      expect(requestErr).to.be.instanceOf(OrganizationNotFoundError);
+      expect(requestErr.message).to.be.equal("L'UAI/RNE 1234567A de l'établissement n’est pas reconnu.");
+    });
   });
 
-  it('should throw a ManyOrganizationsFoundError when many organizations found', async function () {
-    // given
-    const uai = '1234567A';
-    const organization1 = new Organization({
-      id: 2,
-      type: 'SCO',
-      name: 'organization 2',
-      externalId: '1234568',
-      email: 'sco.generic.account@example.net',
-    });
-    const organization2 = new Organization({
-      id: 2,
-      type: 'SCO',
-      name: 'organization 2',
-      externalId: '1234568',
-      email: 'sco.generic.account@example.net',
-    });
-    const message = "Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE 1234567A.";
+  context('when email is not present', function () {
+    it('should throw an OrganizationWithoutEmailError', async function () {
+      // given
+      const uai = '1234567A';
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai, email: null });
 
-    organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization1, organization2]);
+      organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization]);
 
-    // when
-    const requestErr = await catchErr(usecases.sendScoInvitation)({
-      uai,
-      organizationRepository,
+      const requestErr = await catchErr(usecases.sendScoInvitation)({
+        uai,
+        organizationRepository,
+      });
+
+      expect(requestErr).to.be.instanceOf(OrganizationWithoutEmailError);
+      expect(requestErr.message).to.be.equal(
+        "Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE 1234567A."
+      );
     });
+  });
 
-    // then
-    expect(requestErr).to.be.instanceOf(ManyOrganizationsFoundError);
-    expect(requestErr.message).to.be.equal(message);
+  context('when many organizations found', function () {
+    it('should throw a ManyOrganizationsFoundError', async function () {
+      // given
+      const uai = '1234567A';
+      const organization1 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
+      const organization2 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
+
+      organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization1, organization2]);
+
+      // when
+      const requestErr = await catchErr(usecases.sendScoInvitation)({
+        uai,
+        organizationRepository,
+      });
+
+      // then
+      expect(requestErr).to.be.instanceOf(ManyOrganizationsFoundError);
+      expect(requestErr.message).to.be.equal(
+        "Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE 1234567A."
+      );
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/send-sco-invitation_test.js
+++ b/api/tests/unit/domain/usecases/send-sco-invitation_test.js
@@ -4,10 +4,12 @@ const {
   OrganizationNotFoundError,
   OrganizationWithoutEmailError,
   ManyOrganizationsFoundError,
+  OrganizationArchivedError,
 } = require('../../../../lib/domain/errors');
+const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
 
 describe('Unit | UseCase | send-sco-invitation', function () {
-  let organizationRepository;
+  let organizationRepository, organizationInvitationRepository;
 
   beforeEach(function () {
     organizationRepository = {
@@ -15,64 +17,125 @@ describe('Unit | UseCase | send-sco-invitation', function () {
     };
   });
 
-  context('when UAI did not match', function () {
-    it('should throw an NotFoundOrganizationError', async function () {
-      // given
-      const uai = '1234567A';
-      domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
+  it('should call createScoOrganizationInvitation service', async function () {
+    // given
+    const firstName = 'Guy';
+    const lastName = 'Tar';
+    const locale = 'fr-fr';
+    const uai = '1234567A';
+    const organization = domainBuilder.buildOrganization({
+      type: 'SCO',
+      externalId: uai,
+      archivedAt: null,
+      email: 'sco.orga@example.net',
+    });
 
-      organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([]);
+    sinon.stub(organizationInvitationService, 'createScoOrganizationInvitation').resolves();
+    organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([organization]);
 
-      const requestErr = await catchErr(usecases.sendScoInvitation)({
-        uai,
-        organizationRepository,
-      });
+    await usecases.sendScoInvitation({
+      firstName,
+      lastName,
+      locale,
+      uai,
+      organizationRepository,
+      organizationInvitationRepository,
+    });
 
-      expect(requestErr).to.be.instanceOf(OrganizationNotFoundError);
-      expect(requestErr.message).to.be.equal("L'UAI/RNE 1234567A de l'établissement n’est pas reconnu.");
+    expect(organizationInvitationService.createScoOrganizationInvitation).to.have.been.calledOnceWithExactly({
+      organizationId: organization.id,
+      firstName,
+      lastName,
+      email: organization.email,
+      locale,
+      organizationRepository,
+      organizationInvitationRepository,
     });
   });
 
-  context('when email is not present', function () {
-    it('should throw an OrganizationWithoutEmailError', async function () {
-      // given
-      const uai = '1234567A';
-      const organization = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai, email: null });
+  context('Error cases', function () {
+    context('when uai did not match', function () {
+      it('should throw an NotFoundOrganizationError', async function () {
+        // given
+        const uai = '1234567A';
+        domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
 
-      organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization]);
+        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([]);
 
-      const requestErr = await catchErr(usecases.sendScoInvitation)({
-        uai,
-        organizationRepository,
+        const requestErr = await catchErr(usecases.sendScoInvitation)({
+          uai,
+          organizationRepository,
+        });
+
+        expect(requestErr).to.be.instanceOf(OrganizationNotFoundError);
+        expect(requestErr.message).to.be.equal("L'UAI/RNE 1234567A de l'établissement n’est pas reconnu.");
       });
-
-      expect(requestErr).to.be.instanceOf(OrganizationWithoutEmailError);
-      expect(requestErr.message).to.be.equal(
-        "Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE 1234567A."
-      );
     });
-  });
 
-  context('when many organizations found', function () {
-    it('should throw a ManyOrganizationsFoundError', async function () {
-      // given
-      const uai = '1234567A';
-      const organization1 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
-      const organization2 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
+    context('when email is not present', function () {
+      it('should throw an OrganizationWithoutEmailError', async function () {
+        // given
+        const uai = '1234567A';
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai, email: null });
 
-      organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization1, organization2]);
+        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([organization]);
 
-      // when
-      const requestErr = await catchErr(usecases.sendScoInvitation)({
-        uai,
-        organizationRepository,
+        const requestErr = await catchErr(usecases.sendScoInvitation)({
+          uai,
+          organizationRepository,
+        });
+
+        expect(requestErr).to.be.instanceOf(OrganizationWithoutEmailError);
+        expect(requestErr.message).to.be.equal(
+          "Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE 1234567A."
+        );
       });
+    });
 
-      // then
-      expect(requestErr).to.be.instanceOf(ManyOrganizationsFoundError);
-      expect(requestErr.message).to.be.equal(
-        "Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE 1234567A."
-      );
+    context('when many organizations found', function () {
+      it('should throw a ManyOrganizationsFoundError', async function () {
+        // given
+        const uai = '1234567A';
+        const organization1 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
+        const organization2 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
+
+        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([organization1, organization2]);
+
+        // when
+        const requestErr = await catchErr(usecases.sendScoInvitation)({
+          uai,
+          organizationRepository,
+        });
+
+        // then
+        expect(requestErr).to.be.instanceOf(ManyOrganizationsFoundError);
+        expect(requestErr.message).to.be.equal(
+          "Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE 1234567A."
+        );
+      });
+    });
+
+    context('when organization is archived', function () {
+      it('should throw a OrganizationArchivedError', async function () {
+        // given
+        const uai = '1234567A';
+        const archivedOrganization = domainBuilder.buildOrganization({
+          type: 'SCO',
+          externalId: uai,
+          archivedAt: '2022-02-02',
+        });
+
+        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([archivedOrganization]);
+
+        // when
+        const requestErr = await catchErr(usecases.sendScoInvitation)({
+          uai,
+          organizationRepository,
+        });
+
+        // then
+        expect(requestErr).to.be.instanceOf(OrganizationArchivedError);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/send-sco-invitation_test.js
+++ b/api/tests/unit/domain/usecases/send-sco-invitation_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
 
   beforeEach(function () {
     organizationRepository = {
-      findScoOrganizationByUai: sinon.stub(),
+      findScoOrganizationsByUai: sinon.stub(),
     };
   });
 
@@ -31,7 +31,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
     });
 
     sinon.stub(organizationInvitationService, 'createScoOrganizationInvitation').resolves();
-    organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([organization]);
+    organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([organization]);
 
     await usecases.sendScoInvitation({
       firstName,
@@ -60,7 +60,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
         const uai = '1234567A';
         domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
 
-        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([]);
+        organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([]);
 
         const requestErr = await catchErr(usecases.sendScoInvitation)({
           uai,
@@ -78,7 +78,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
         const uai = '1234567A';
         const organization = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai, email: null });
 
-        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([organization]);
+        organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([organization]);
 
         const requestErr = await catchErr(usecases.sendScoInvitation)({
           uai,
@@ -99,7 +99,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
         const organization1 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
         const organization2 = domainBuilder.buildOrganization({ type: 'SCO', externalId: uai });
 
-        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([organization1, organization2]);
+        organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([organization1, organization2]);
 
         // when
         const requestErr = await catchErr(usecases.sendScoInvitation)({
@@ -125,7 +125,7 @@ describe('Unit | UseCase | send-sco-invitation', function () {
           archivedAt: '2022-02-02',
         });
 
-        organizationRepository.findScoOrganizationByUai.withArgs({ uai }).resolves([archivedOrganization]);
+        organizationRepository.findScoOrganizationsByUai.withArgs({ uai }).resolves([archivedOrganization]);
 
         // when
         const requestErr = await catchErr(usecases.sendScoInvitation)({

--- a/orga/app/components/auth/join-request-form.hbs
+++ b/orga/app/components/auth/join-request-form.hbs
@@ -4,51 +4,44 @@
     <p class="join-request-form__information">Tous les champs sont obligatoires.</p>
 
     <div class="input-container">
-      <label for="uai" class="label">UAI/RNE de l'établissement</label>
-      {{#if this.validation.uai.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.uai.message}}</div>
-      {{/if}}
-      <Input
-        id="uai"
+      <PixInput
+        @id="uai"
+        @label="UAI/RNE de l'établissement"
         name="uai"
-        @type="text"
-        class="input {{if this.validation.uai.hasError "input--error"}}"
-        @value={{this.uai}}
-        required="true"
+        type="text"
+        {{on "focusout" this.validateUai}}
+        @errorMessage={{this.uaiValidationMessage}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="off"
       />
     </div>
 
     <div class="input-container">
-      <label for="firstName" class="label">Votre prénom</label>
-      {{#if this.validation.firstName.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.firstName.message}}</div>
-      {{/if}}
-      <Input
-        id="firstName"
+      <PixInput
+        @id="firstName"
+        @label="Votre prénom"
         name="firstName"
-        @type="text"
-        class="input {{if this.validation.firstName.hasError "input--error"}}"
-        @value={{this.firstName}}
+        type="firstName"
+        {{on "focusout" this.validateFirstName}}
+        @errorMessage={{this.firstNameValidationMessage}}
+        required={{true}}
+        aria-required={{true}}
         autocomplete="given-name"
-        required="true"
-        {{on "focusout" (fn this.validateInput "firstName" this.firstName)}}
       />
     </div>
 
     <div class="input-container">
-      <label for="lastName" class="label">Votre nom</label>
-      {{#if this.validation.lastName.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.lastName.message}}</div>
-      {{/if}}
-      <Input
-        id="lastName"
+      <PixInput
+        @id="lastName"
+        @label="Votre nom"
         name="lastName"
-        @type="text"
-        class="input {{if this.validation.lastName.hasError "input--error"}}"
-        @value={{this.lastName}}
+        type="lastName"
+        {{on "focusout" this.validateLastName}}
+        @errorMessage={{this.lastNameValidationMessage}}
+        required={{true}}
+        aria-required={{true}}
         autocomplete="family-name"
-        required="true"
-        {{on "focusout" (fn this.validateInput "lastName" this.lastName)}}
       />
     </div>
 

--- a/orga/app/components/auth/join-request-form.js
+++ b/orga/app/components/auth/join-request-form.js
@@ -2,9 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import InputValidator from '../../utils/input-validator';
-
-const isStringValid = (value) => (value ? Boolean(value.trim()) : undefined);
+import isEmpty from 'lodash/isEmpty';
 
 export default class JoinRequestForm extends Component {
   @service session;
@@ -13,17 +11,49 @@ export default class JoinRequestForm extends Component {
   @tracked uai;
   @tracked firstName;
   @tracked lastName;
+  @tracked firstNameValidationMessage = null;
+  @tracked lastNameValidationMessage = null;
+  @tracked uaiValidationMessage = null;
 
   @tracked isLoading = false;
 
   validation = {
-    firstName: new InputValidator(isStringValid, 'Votre prénom n’est pas renseigné.'),
-    lastName: new InputValidator(isStringValid, 'Votre nom n’est pas renseigné.'),
+    firstName: 'Votre prénom n’est pas renseigné.',
+    lastName: 'Votre nom n’est pas renseigné.',
+    uai: "L'UAI/RNE n'est pas renseigné.",
   };
 
   @action
-  validateInput(key, value) {
-    this.validation[key].validate({ value, resetServerMessage: true });
+  validateFirstName(event) {
+    this.firstNameValidationMessage = null;
+    this.firstName = event.target.value?.trim();
+    const isInvalidInput = isEmpty(this.firstName);
+
+    if (isInvalidInput) {
+      this.firstNameValidationMessage = this.validation.firstName;
+    }
+  }
+
+  @action
+  validateLastName(event) {
+    this.lastNameValidationMessage = null;
+    this.lastName = event.target.value?.trim();
+    const isInvalidInput = isEmpty(this.lastName);
+
+    if (isInvalidInput) {
+      this.lastNameValidationMessage = this.validation.lastName;
+    }
+  }
+
+  @action
+  validateUai(event) {
+    this.uaiValidationMessage = null;
+    this.uai = event.target.value?.trim();
+    const isInvalidInput = isEmpty(this.uai);
+
+    if (isInvalidInput) {
+      this.uaiValidationMessage = this.validation.uai;
+    }
   }
 
   @action

--- a/orga/app/controllers/join-request.js
+++ b/orga/app/controllers/join-request.js
@@ -5,13 +5,18 @@ import get from 'lodash/get';
 
 export default class JoinRequestController extends Controller {
   @tracked isSubmit = false;
-  @tracked isOrganizationNotFound = false;
-  @tracked organizationHasNoEmail = false;
-  @tracked hasErrorMessage = false;
+  @tracked errorMessage = null;
+
+  ERROR_MESSAGES = {
+    DEFAULT: 'Une erreur est survenue.',
+    ORGANIZATION_HAS_NO_EMAIL: 'Nous n’avons pas d’adresse e-mail de contact associée à votre établissement.',
+    ORGANIZATION_NOT_FOUND: "L'UAI/RNE de l'établissement n’est pas reconnu.",
+    ORGANIZATION_ARCHIVED: "L'UAI/RNE de l'établissement n’est pas reconnu.",
+  };
 
   @action
   async createScoOrganizationInvitation(scoOrganizationInvitation) {
-    this._resetErrorState();
+    this.errorMessage = null;
     try {
       await this.store.createRecord('sco-organization-invitation', scoOrganizationInvitation).save();
       this.isSubmit = true;
@@ -26,27 +31,24 @@ export default class JoinRequestController extends Controller {
       const firstError = response.errors[0];
       this._showErrorMessages(firstError.status);
     } else {
-      this.hasErrorMessage = true;
+      this.errorMessage = this.ERROR_MESSAGES.DEFAULT;
     }
   }
 
   _showErrorMessages(status) {
     switch (status) {
       case '404':
-        this.isOrganizationNotFound = true;
+        this.errorMessage = this.ERROR_MESSAGES.ORGANIZATION_NOT_FOUND;
         break;
       case '412':
-        this.organizationHasNoEmail = true;
+        this.errorMessage = this.ERROR_MESSAGES.ORGANIZATION_HAS_NO_EMAIL;
+        break;
+      case '422':
+        this.errorMessage = this.ERROR_MESSAGES.ORGANIZATION_ARCHIVED;
         break;
       case '409':
       default:
-        this.hasErrorMessage = true;
+        this.errorMessage = this.ERROR_MESSAGES.DEFAULT;
     }
-  }
-
-  _resetErrorState() {
-    this.isOrganizationNotFound = false;
-    this.organizationHasNoEmail = false;
-    this.hasErrorMessage = false;
   }
 }

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -1,14 +1,14 @@
 .join-request-form {
+  font-family: $roboto;
 
   &__information {
-    font-family: $roboto;
     font-size: 0.875rem;
-    margin: 0 0 24px;
+    margin: 14px 0 24px 0;
+    text-align: center;
   }
 
   &__legal-information {
     color: $blue-zodiac;
-    font-family: $roboto;
     font-size: 0.6875rem;
     max-width: 500px;
   }

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -54,7 +54,7 @@
       width: calc(100vw - 100% - #{$app-sidebar-width} - 32px);
     }
 
-    
+
     &-icon {
       color: $blue;
       margin-right: 8px;
@@ -179,7 +179,7 @@ p.label {
 }
 
 .error-message {
-  color: red;
+  color: $red;
   font-family: $roboto;
   font-size: 0.75rem;
 }

--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -8,7 +8,7 @@
       <p class="join-request__success">
         Un e-mail contenant la démarche à suivre a été envoyé
         <br />
-        à l'adresse email de votre établissement.
+        à l'adresse e-mail de votre établissement.
         <br />
         Si vous ne le recevez pas, vérifiez les courriers indésirables,<br />
         ou
@@ -26,26 +26,12 @@
         devenir administrateur de l'espace Pix Orga.
       </p>
 
-      {{#if this.isOrganizationNotFound}}
-        <div class="join-request__error-message error-message">
-          L'UAI/RNE de l'établissement n’est pas reconnu. Merci de
+      {{#if this.errorMessage}}
+        <p class="join-request__error-message error-message">
+          {{this.errorMessage}}
+          Merci de
           <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.
-        </div>
-      {{/if}}
-
-      {{#if this.organizationHasNoEmail}}
-        <div class="join-request__error-message error-message">
-          Nous n’avons pas d’adresse e-mail de contact associée à votre établissement, merci de
-          <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>
-          pour récupérer votre accès.
-        </div>
-      {{/if}}
-
-      {{#if this.hasErrorMessage}}
-        <div class="join-request__error-message error-message">
-          Une erreur est survenue. Merci de
-          <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.
-        </div>
+        </p>
       {{/if}}
 
       <Auth::JoinRequestForm @onSubmit={{this.createScoOrganizationInvitation}} />


### PR DESCRIPTION
## :unicorn: Problème
Avec la nouvelle fonctionnalité d'archivage d'une organisation, il faut s'assurer que l'on empêche l'accès à une organisation si celle-ci est archivée.
Aujourd'hui l'activation de l'espace d'une organisation SCO sur une organisation archivée est toujours possible.

ℹ️ Que fait l'activation/récupération d'une orga ?
Cette fonctionnalité concerne uniquement les orgas SCO. L'utilisateur va remplir l'UAI (ExternalId) son prénom et son nom, pour recevoir un lien d'activation à l'adresse e-mail de l'orga et devenir administrateur de celle-ci.

Contexte ? 
Le métier créer une organisation SCO sur Pix Admin, sans membres. C'est par cette fonctionnalité que l'utilisateur va créer son membership à l'orga en passant admin directement.

## :robot: Solution
Empêcher l'activation/récupération du compte SCO si l'organisation est archivée sur Pix Orga.

## :rainbow: Remarques
Actuellement le usecase s'appelle `sendScoInvitation` mais il appelle un service qui lui va véritablement envoyer l'invitation ( et qui s'appelle `createScoOrganizationInvitation`). Le nom n'est pas représentatif de ce qu'il fait d'un point de vue métier.
Proposition de renommage du usecase : `scoAccountRecoveryDemand` ? `scoOrganizationRecoveryDemand` ?

--

Changement des inputs de la page pour notre magnifique PixInput.

## :100: Pour tester
- Se connecter sur Pix Orga, aller sur le domaine fr en local (sinon le lien n'apparaît pas)
- Cliquer sur [Activez ou récupérez votre espace Pix Orga](https://orga-pr4212.review.pix.fr/demande-administration-sco)
- Remplir l'UAI d'une organisation archivée (ex: EXABC123), mettre un nom et prénom
- Constater le message d'erreur suivant : L'UAI/RNE de l'établissement n’est pas reconnu. Merci de contacter le support.
- Pour éviter la regression : vérifier que les champs affichent une erreur lorsqu'ils sont vides. (focusout)