### PR TITLE
[BUGFIX] Ne pas afficher l'attestation des certifications annulées  (PIX-4563).

### DIFF
--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -114,7 +114,6 @@ function _filterMostRecentValidatedAssessmentResult(qb) {
       knex
         .select(1)
         .from({ 'last-assessment-results': 'assessment-results' })
-        .where('last-assessment-results.status', AssessmentResult.status.VALIDATED)
         .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
         .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
     )


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs d'une organisation scolaire ont la possibilité de récupérer, depuis Pix Orga, les attestations de certifications des candidats de leur établissement. Il arrive parfois, qu'après publication, le pôle certification ait à rejeter une certification. Cependant, l'attestation de ce candidat, bien que rejetée, est toujours disponible au téléchargement depuis Pix Orga comme si elle était toujours valide.  

## :robot: Solution
Prendre en compte le dernier résultat de certification et pas le dernier résultat valide.

## :100: Pour tester

### Passer la certification
- Se connecter à [Pix Certif](https://certif-pr4214.review.pix.fr/ avec le compte `certif.sco@example.net`
- Créer une session avec comme candidat Blue Ivy Carter de 3A
- Passer la certification en tant que Blue Ivy Carter 
- Finaliser et publier la session

### Télécharger l'attestation
- Se connecter à [Pix Orga](https://orga-pr4214.review.pix.fr/) avec le compte `sco.admin@example.net`
- Aller dans l'onglet "Certifications", télécharger les attestations de la classe 3A.
- Constater que deux attestations sont générées.

### Annuler la certificatio
- Aller dans Pix Admin à l'adresse https://admin-pr4214.review.pix.fr/sessions/20000/certifications
- Ouvrir l'une des deux certifications.
- Cliquer sur "Modifier" en bas de la page, lui appliquer le statut "Rejetée" et enregistrer.

### Télécharger l'attestation
- Retourner dans PIx Orga, télécharger à nouveau les attestations et constater que l'attestation rejetée n'apparaît plus.