### PR TITLE
[FEATURE] Ajouter le nom du user sur la landing page(PIX-4431)

### DIFF
--- a/mon-pix/app/components/campaign-start-block.hbs
+++ b/mon-pix/app/components/campaign-start-block.hbs
@@ -15,18 +15,27 @@
     {{/if}}
   </div>
 
-  <form {{action @startCampaignParticipation on="submit"}}>
+  <form {{on "submit" this.start}}>
     <div class="campaign-landing-page__start__text">
-      <h1 class="campaign-landing-page__start__text__title">{{@titleText}}</h1>
-      <h2 class="campaign-landing-page__start__text__announcement">{{{@announcementText}}}</h2>
+      <h1 class="campaign-landing-page__start__text__title">{{this.titleText}}</h1>
+      <h2 class="campaign-landing-page__start__text__announcement">{{{this.announcementText}}}</h2>
       <PixButton
         @type="submit"
         class="campaign-landing-page__start-button"
         @loading-color="white"
-      >{{@buttonText}}</PixButton>
-      <p class="campaign-landing-page__start__text__legal">{{@legalText}}</p>
+      >{{this.buttonText}}</PixButton>
+      <p class="campaign-landing-page__start__text__legal">{{this.legalText}}</p>
     </div>
   </form>
+
+  {{#if this.showWarningMessage}}
+    <div class="campaign-landing-page__start__warning">
+      <span>{{this.warningMessage}}</span>
+      <a href="#" class="link" {{on "click" this.disconnect}}>
+        {{t "pages.campaign-landing.warning-message-logout"}}
+      </a>
+    </div>
+  {{/if}}
 
   {{#if @campaign.customLandingPageText}}
     <div class="campaign-landing-page__start__custom-text">

--- a/mon-pix/app/components/campaign-start-block.js
+++ b/mon-pix/app/components/campaign-start-block.js
@@ -1,0 +1,60 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class CampaignStartBlock extends Component {
+  @service currentUser;
+  @service session;
+  @service intl;
+
+  get showWarningMessage() {
+    return this.session.isAuthenticated && !this.currentUser.user.isAnonymous;
+  }
+
+  get campaignType() {
+    return this.args.campaign.isAssessment ? 'assessment' : 'profiles-collection';
+  }
+
+  get titleText() {
+    if (this.showWarningMessage) {
+      return this.intl.t(`pages.campaign-landing.${this.campaignType}.title-with-username`, {
+        userFirstName: this.currentUser.user.firstName,
+        htmlSafe: true,
+      });
+    } else {
+      return this.intl.t(`pages.campaign-landing.${this.campaignType}.title`, {
+        htmlSafe: true,
+      });
+    }
+  }
+
+  get buttonText() {
+    return this.intl.t(`pages.campaign-landing.${this.campaignType}.action`);
+  }
+
+  get announcementText() {
+    return this.intl.t(`pages.campaign-landing.${this.campaignType}.announcement`);
+  }
+
+  get legalText() {
+    return this.intl.t(`pages.campaign-landing.${this.campaignType}.legal`);
+  }
+
+  get warningMessage() {
+    return this.intl.t('pages.campaign-landing.warning-message', {
+      firstName: this.currentUser.user.firstName,
+      lastName: this.currentUser.user.lastName,
+    });
+  }
+
+  @action
+  disconnect() {
+    this.session.invalidate();
+  }
+
+  @action
+  start(event) {
+    event.preventDefault();
+    this.args.startCampaignParticipation();
+  }
+}

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -3,11 +3,10 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 
 export default class CampaignLandingPageController extends Controller {
-  @service campaignStorage;
   @service router;
 
   @action
   startCampaignParticipation() {
-    return this.router.transitionTo('campaigns.access', this.model.code);
+    this.router.transitionTo('campaigns.access', this.model.code);
   }
 }

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -51,6 +51,10 @@
     @include device-is('tablet') {
       font-size: 3rem;
     }
+
+    span {
+      font-weight: $font-semi-bold;
+    }
   }
 
   &__announcement {
@@ -98,6 +102,13 @@
   @include device-is('tablet') {
     margin: 30px;
   }
+}
+
+.campaign-landing-page__start__warning {
+  color: $grey-90;
+  font-size: 0.875rem;
+  text-align: center;
+  margin-top: 40px;
 }
 
 /* ------------------------ DETAILS ------------------------ */

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -3,26 +3,7 @@
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="campaign-landing-page__container rounded-panel--over-background-banner">
-
-    {{#if @model.isAssessment}}
-      <CampaignStartBlock
-        @campaign={{@model}}
-        @startCampaignParticipation={{this.startCampaignParticipation}}
-        @titleText={{t "pages.campaign-landing.assessment.title"}}
-        @announcementText={{t "pages.campaign-landing.assessment.announcement" htmlSafe=true}}
-        @buttonText={{t "pages.campaign-landing.assessment.action"}}
-        @legalText={{t "pages.campaign-landing.assessment.legal"}}
-      />
-    {{else}}
-      <CampaignStartBlock
-        @campaign={{@model}}
-        @startCampaignParticipation={{this.startCampaignParticipation}}
-        @titleText={{t "pages.campaign-landing.profiles-collection.title"}}
-        @announcementText={{t "pages.campaign-landing.profiles-collection.announcement" htmlSafe=true}}
-        @buttonText={{t "pages.campaign-landing.profiles-collection.action"}}
-        @legalText={{t "pages.campaign-landing.profiles-collection.legal"}}
-      />
-    {{/if}}
+    <CampaignStartBlock @campaign={{@model}} @startCampaignParticipation={{this.startCampaignParticipation}} />
 
     {{#if @model.isAssessment}}
       <div class="rounded-panel campaign-landing-page__container__details">

--- a/mon-pix/tests/integration/components/campaign-start-block_test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block_test.js
@@ -1,70 +1,292 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import Service from '@ember/service';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
+import { contains } from '../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
+import { clickByLabel } from '../../helpers/click-by-label';
+import sinon from 'sinon';
 
-describe('Integration | Component | campaign-start-block template', function () {
+describe('Integration | Component | campaign-start-block', function () {
   setupIntlRenderingTest();
 
-  it('should display all text arguments correctly', async function () {
-    // given
-    this.set('campaign', {});
-    this.set('startCampaignParticipation', () => {});
-    this.set('titleText', 'title');
-    this.set('announcementText', 'announcement');
-    this.set('buttonText', 'button');
-    this.set('legalText', 'legal');
+  context('When the organization has a logo and landing page text', function () {
+    it('should display organization logo and landing page text', async function () {
+      // given
+      this.set('campaign', {
+        organizationName: 'My organisation',
+        organizationLogoUrl: 'http://orga.com/logo.png',
+        customLandingPageText: 'My campaign text',
+      });
+      this.set('startCampaignParticipation', sinon.stub());
 
-    // when
-    await render(hbs`
-      <CampaignStartBlock
-        @campaign={{this.campaign}}
-        @startCampaignParticipation={{this.startCampaignParticipation}}
-        @titleText={{this.titleText}}
-        @announcementText={{this.announcementText}}
-        @buttonText={{this.buttonText}}
-        @legalText={{this.legalText}}
-      />`);
+      // when
+      await render(hbs`
+        <CampaignStartBlock
+          @campaign={{this.campaign}}
+          @startCampaignParticipation={{this.startCampaignParticipation}}
+        />`);
 
-    // then
-    expect(find('.campaign-landing-page__start__text__title').textContent.trim()).to.equal('title');
-    expect(find('.campaign-landing-page__start__text__announcement').textContent.trim()).to.equal('announcement');
-    expect(find('.campaign-landing-page__start-button').textContent.trim()).to.equal('button');
-    expect(find('.campaign-landing-page__start__text__legal').textContent.trim()).to.equal('legal');
+      // then
+      expect(find('[src="http://orga.com/logo.png"][alt="My organisation"]')).to.exist;
+      expect(contains('My campaign text')).to.exist;
+    });
   });
 
-  it('should display display organization logo and landing page text', async function () {
-    // given
-    this.set('campaign', {
-      organizationName: 'My organisation',
-      organizationLogoUrl: 'http://orga.com/logo.png',
-      customLandingPageText: 'My campaign text',
+  describe('When the user is authenticated', function () {
+    let session;
+
+    beforeEach(function () {
+      class currentUser extends Service {
+        user = {
+          firstName: 'Izuku',
+          lastName: 'Midorya',
+          isAnonymous: false,
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+      class SessionStub extends Service {
+        isAuthenticated = true;
+        invalidate = sinon.stub();
+      }
+
+      this.owner.register('service:session', SessionStub);
+      session = this.owner.lookup('service:session', SessionStub);
+      this.set('campaign', {});
+      this.set('startCampaignParticipation', sinon.stub());
     });
-    this.set('startCampaignParticipation', () => {});
-    this.set('titleText', 'title');
-    this.set('announcementText', 'announcement');
-    this.set('buttonText', 'button');
-    this.set('legalText', 'legal');
 
-    // when
-    await render(hbs`
-      <CampaignStartBlock
-        @campaign={{this.campaign}}
-        @startCampaignParticipation={{this.startCampaignParticipation}}
-        @titleText={{this.titleText}}
-        @announcementText={{this.announcementText}}
-        @buttonText={{this.buttonText}}
-        @legalText={{this.legalText}}
-      />`);
+    it('should display the link to disconnect', async function () {
+      // when
+      await render(hbs`
+        <CampaignStartBlock
+          @campaign={{this.campaign}}
+          @startCampaignParticipation={{this.startCampaignParticipation}}
+        />`);
 
-    // then
-    expect(
-      find('div[data-test-id="campaign-landing-page__logo"] .campaign-landing-page__image').getAttribute('src')
-    ).to.equal('http://orga.com/logo.png');
-    expect(
-      find('div[data-test-id="campaign-landing-page__logo"] .campaign-landing-page__image').getAttribute('alt')
-    ).to.equal('My organisation');
-    expect(find('.campaign-landing-page__start__custom-text').textContent).to.contain('My campaign text');
+      // then
+      expect(
+        contains(this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' }))
+      ).to.exist;
+      expect(contains(this.intl.t('pages.campaign-landing.warning-message-logout'))).to.exist;
+    });
+
+    it('should call session.invalidate to shut down the session when user click on disconnect', async function () {
+      // when
+      await render(hbs`
+        <CampaignStartBlock
+          @campaign={{this.campaign}}
+          @startCampaignParticipation={{this.startCampaignParticipation}}
+        />`);
+
+      await clickByLabel(this.intl.t('pages.campaign-landing.warning-message-logout'));
+
+      // then
+      sinon.assert.calledOnce(session.invalidate);
+    });
+
+    context('when the campaign is a PROFILES_COLLECTION type', function () {
+      this.beforeEach(function () {
+        this.set('campaign', { type: 'PROFILES_COLLECTION' });
+      });
+
+      it('should display all text arguments correctly', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+        // then
+        expect(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement'))).to.exist;
+        expect(contains(this.intl.t('pages.campaign-landing.profiles-collection.action'))).to.exist;
+        expect(contains(this.intl.t('pages.campaign-landing.profiles-collection.legal'))).to.exist;
+      });
+
+      it('should display the userName', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+
+        // then
+        expect(contains('Izuku')).to.exist;
+        expect(contains('envoyez votre profil')).to.exist;
+      });
+    });
+
+    context('when the campaign is a ASSESSMENT type', function () {
+      this.beforeEach(function () {
+        this.set('campaign', { isAssessment: true });
+      });
+      it('should display all text arguments correctly', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+        // then
+        expect(contains("Démarrez votre parcours d'évaluation personnalisé.")).to.exist;
+        expect(contains(this.intl.t('pages.campaign-landing.assessment.action'))).to.exist;
+        expect(contains(this.intl.t('pages.campaign-landing.assessment.legal'))).to.exist;
+      });
+
+      it('should display the userName', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+
+        // then
+        expect(contains('Izuku')).to.exist;
+        expect(contains('commencez votre parcours')).to.exist;
+      });
+    });
+  });
+
+  describe('When the user is not authenticated', function () {
+    beforeEach(function () {
+      class currentUser extends Service {
+        user = {
+          firstName: 'Izuku',
+          lastName: 'Midorya',
+          isAnonymous: false,
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+      class SessionStub extends Service {
+        isAuthenticated = false;
+        invalidate = sinon.stub();
+      }
+
+      this.owner.register('service:session', SessionStub);
+      this.set('campaign', {});
+      this.set('startCampaignParticipation', sinon.stub());
+    });
+
+    it('should not display the link to disconnect', async function () {
+      // when
+      await render(hbs`
+        <CampaignStartBlock
+          @campaign={{this.campaign}}
+          @startCampaignParticipation={{this.startCampaignParticipation}}
+        />`);
+
+      // then
+      expect(
+        contains(this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' }))
+      ).to.not.exist;
+      expect(contains(this.intl.t('pages.campaign-landing.warning-message-logout'))).to.not.exist;
+    });
+
+    context('when the campaign is a PROFILES_COLLECTION type', function () {
+      this.beforeEach(function () {
+        this.set('campaign', { type: 'PROFILES_COLLECTION' });
+      });
+
+      it('should not display the userName', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+        // then
+        expect(contains(this.intl.t('pages.campaign-landing.profiles-collection.title'))).to.exist;
+      });
+    });
+
+    context('when the campaign is a ASSESSMENT type', function () {
+      this.beforeEach(function () {
+        this.set('campaign', { isAssessment: true });
+      });
+
+      it('should not display the userName', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+        // then
+        expect(contains(this.intl.t('pages.campaign-landing.assessment.title'))).to.exist;
+      });
+    });
+  });
+
+  describe('When the user has isAnonymous', function () {
+    beforeEach(function () {
+      class currentUser extends Service {
+        user = {
+          firstName: 'Izuku',
+          lastName: 'Midorya',
+          isAnonymous: true,
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+      class SessionStub extends Service {
+        isAuthenticated = true;
+        invalidate = sinon.stub();
+      }
+
+      this.owner.register('service:session', SessionStub);
+      this.set('campaign', {});
+      this.set('startCampaignParticipation', sinon.stub());
+    });
+
+    it('should not display the link to disconnect', async function () {
+      // when
+      await render(hbs`
+        <CampaignStartBlock
+          @campaign={{this.campaign}}
+          @startCampaignParticipation={{this.startCampaignParticipation}}
+        />`);
+
+      // then
+      expect(
+        contains(this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' }))
+      ).to.not.exist;
+      expect(contains(this.intl.t('pages.campaign-landing.warning-message-logout'))).to.not.exist;
+    });
+
+    context('when the campaign is a PROFILES_COLLECTION type', function () {
+      this.beforeEach(function () {
+        this.set('campaign', { type: 'PROFILES_COLLECTION' });
+      });
+
+      it('should not display the userName', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+        // then
+        expect(contains(this.intl.t('pages.campaign-landing.profiles-collection.title'))).to.exist;
+      });
+    });
+
+    context('when the campaign is a ASSESSMENT type', function () {
+      this.beforeEach(function () {
+        this.set('campaign', { isAssessment: true });
+      });
+
+      it('should not display the userName', async function () {
+        // when
+        await render(hbs`
+          <CampaignStartBlock
+            @campaign={{this.campaign}}
+            @startCampaignParticipation={{this.startCampaignParticipation}}
+          />`);
+        // then
+        expect(contains(this.intl.t('pages.campaign-landing.assessment.title'))).to.exist;
+      });
+    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -127,6 +127,7 @@
     "campaign-landing": {
       "title": "Presentation",
       "assessment": {
+        "title-with-username": "<span>{userFirstName}</span>,<br> begin your customised test",
         "title": "Begin your customised test",
         "action": "Begin",
         "announcement": "Start your customised test.'<br>' Sign up or log in to the Pix platform and start your test.",
@@ -151,11 +152,14 @@
         "legal": "By clicking on “Begin“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your customised test, your results will be shared with your organisation when clicking on “Submit my results“."
       },
       "profiles-collection": {
+        "title-with-username": "<span>{userFirstName}</span>,<br> submit your profile",
         "title": "Submit your profile",
         "action": "Let’s go!",
         "announcement": "Sign up or log in to the Pix platform and send your profile to the recipient organisation.",
         "legal": "Information about your progress will be sent to the organiser so they can help you if necessary. It will only be sent with your permission."
-      }
+      },
+      "warning-message": "If you are not { firstName } { lastName },",
+      "warning-message-logout": "please log out"
     },
     "campaign-participation": {
       "title": "Customised test"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -127,6 +127,7 @@
     "campaign-landing": {
       "title": "Présentation",
       "assessment": {
+        "title-with-username": "<span>{userFirstName}</span>,<br> commencez votre parcours",
         "title": "Commencez votre parcours",
         "action": "Je commence",
         "announcement": "Démarrez votre parcours d'évaluation personnalisé.'<br>' Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",
@@ -151,11 +152,14 @@
         "legal": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. A la fin du parcours, en cliquant sur le bouton “J’envoie mes résultats” vos résultats seront transmis à l’organisateur."
       },
       "profiles-collection": {
+        "title-with-username": "<span>{userFirstName}</span>,<br> envoyez votre profil",
         "title": "Envoyez votre profil",
         "action": "C'est parti !",
         "announcement": "Inscrivez-vous ou connectez-vous sur la plateforme Pix et envoyez votre profil à l'organisation destinataire.",
         "legal": "Les informations relatives à votre profil PIX seront transmises à l'organisateur pour lui permettre de vous accompagner. Elle ne seront transmises qu'avec votre consentement."
-      }
+      },
+      "warning-message": "Vous n'êtes pas { firstName } { lastName } ?",
+      "warning-message-logout": "Se déconnecter"
     },
     "campaign-participation": {
       "title": "Parcours"


### PR DESCRIPTION
## :unicorn: Problème
Une fois que le user avait mis le code campagne, on arrivait sur la landing page mais rien ne nous permettait de connaitre qui était le user connecté. Or parfois quand il a partage du poste, une personne fait une campagne mais avec le mauvais user.

## :robot: Solution
Ajouter le nom du user connecté juste avant de commencer la campagne plus la possibilité de se déconnecter si c'est pas le bon user.

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à Pix
- entrer un code d'une nouvelle campagne à laquelle le user n'a pas participé
- Constater le nom du user sur la landing page.
- Tester la déconnection.


