### PR TITLE
[FEATURE] Ne plus afficher les participations supprimées dans l'onglet activités dans PixOrga (PIX-4573).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -33,6 +33,7 @@ function _buildCampaignParticipationByParticipant(qb, campaignId, filters) {
     .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
+    .whereNull('campaign-participations.deletedAt')
     .modify(_filterByDivisions, filters)
     .modify(_filterByStatus, filters)
     .modify(_filterByGroup, filters);
@@ -46,6 +47,7 @@ function _buildPaginationQuery(queryBuilder, campaignId, filters) {
     .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
+    .whereNull('campaign-participations.deletedAt')
     .modify(_filterByDivisions, filters)
     .modify(_filterByStatus, filters)
     .modify(_filterByGroup, filters);

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -149,14 +149,11 @@ module.exports = {
   async countParticipationsByStatus(campaignId, campaignType) {
     const row = await knex('campaign-participations')
       .select([
-        // eslint-disable-next-line knex/avoid-injections
-        knex.raw(`sum(case when status = '${SHARED}' then 1 else 0 end) as shared`),
-        // eslint-disable-next-line knex/avoid-injections
-        knex.raw(`sum(case when status = '${TO_SHARE}' then 1 else 0 end) as completed`),
-        // eslint-disable-next-line knex/avoid-injections
-        knex.raw(`sum(case when status = '${STARTED}' then 1 else 0 end) as started`),
+        knex.raw(`sum(case when status = ? then 1 else 0 end) as shared`, SHARED),
+        knex.raw(`sum(case when status = ? then 1 else 0 end) as completed`, TO_SHARE),
+        knex.raw(`sum(case when status = ? then 1 else 0 end) as started`, STARTED),
       ])
-      .where({ campaignId, isImproved: false })
+      .where({ campaignId, isImproved: false, deletedAt: null })
       .groupBy('campaignId')
       .first();
 

--- a/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -28,7 +28,7 @@ async function _getCumulativeParticipationCountsByDay(campaignId, column) {
     `
     SELECT CAST(:column: AS DATE) AS "day", SUM(COUNT(*)) OVER (ORDER BY CAST(:column: AS DATE)) AS "count"
     FROM "campaign-participations"
-    WHERE "campaignId" = :campaignId AND :column: IS NOT NULL AND "isImproved" = false
+    WHERE "campaignId" = :campaignId AND :column: IS NOT NULL AND "isImproved" = false AND "deletedAt" is null
     GROUP BY "day"`,
     { column, campaignId }
   );

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -56,10 +56,10 @@ module.exports = {
         knex.raw('ARRAY_AGG("badges"."id")  AS "badgeIds"'),
         knex.raw('ARRAY_AGG("stages"."id")  AS "stageIds"'),
         knex.raw(
-          '(SELECT COUNT(*) from "campaign-participations" WHERE "campaign-participations"."campaignId" = "campaigns"."id" AND "campaign-participations"."isImproved" IS FALSE) AS "participationsCount"'
+          '(SELECT COUNT(*) from "campaign-participations" WHERE "campaign-participations"."campaignId" = "campaigns"."id" AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) AS "participationsCount"'
         ),
         knex.raw(
-          '(SELECT COUNT(*) from "campaign-participations" WHERE "campaign-participations"."campaignId" = "campaigns"."id" AND "campaign-participations"."status" = \'SHARED\' AND "campaign-participations"."isImproved" IS FALSE) AS "sharedParticipationsCount"'
+          '(SELECT COUNT(*) from "campaign-participations" WHERE "campaign-participations"."campaignId" = "campaigns"."id" AND "campaign-participations"."status" = \'SHARED\' AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) AS "sharedParticipationsCount"'
         )
       )
       .join('users', 'users.id', 'campaigns.ownerId')

--- a/api/lib/infrastructure/repositories/division-repository.js
+++ b/api/lib/infrastructure/repositories/division-repository.js
@@ -5,6 +5,7 @@ async function findByCampaignId(campaignId) {
   const divisions = await knex('organization-learners')
     .where({ campaignId })
     .whereNotNull('division')
+    .where({ 'campaign-participations.deletedAt': null })
     .distinct('division')
     .orderBy('division', 'asc')
     .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId');

--- a/api/lib/infrastructure/repositories/group-repository.js
+++ b/api/lib/infrastructure/repositories/group-repository.js
@@ -4,6 +4,7 @@ const { knex } = require('../bookshelf');
 async function findByCampaignId(campaignId) {
   const groups = await knex('organization-learners')
     .where({ campaignId })
+    .where({ 'campaign-participations.deletedAt': null })
     .distinct('group')
     .whereNotNull('group')
     .orderBy('group', 'asc')

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -260,6 +260,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         const participation = { campaignId: campaign.id };
         databaseBuilder.factory.buildCampaignParticipation(participation);
         databaseBuilder.factory.buildCampaignParticipation(participation);
+        databaseBuilder.factory.buildCampaignParticipation({ ...participation, deletedAt: new Date() });
 
         await databaseBuilder.commit();
       });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -950,10 +950,20 @@ describe('Integration | Repository | Campaign Participation', function () {
         expect(result).to.deep.equal({ started: 0, completed: 0, shared: 0 });
       });
 
+      it("should not count any participation regardless of it's status when participation is deleted ", async function () {
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: SHARED, deletedAt: '2022-03-17' });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: TO_SHARE, deletedAt: '2022-03-17' });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: STARTED, deletedAt: '2022-03-17' });
+        await databaseBuilder.commit();
+
+        const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
+
+        expect(result).to.deep.equal({ started: 0, completed: 0, shared: 0 });
+      });
+
       describe('Count shared Participation', function () {
         it('counts participations shared', async function () {
-          databaseBuilder.factory.buildCampaignParticipation();
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: SHARED });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
@@ -1060,10 +1070,19 @@ describe('Integration | Repository | Campaign Participation', function () {
         expect(result).to.deep.equal({ completed: 0, shared: 0 });
       });
 
+      it("should not count any participation regardless of it's status when participation is deleted ", async function () {
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: SHARED, deletedAt: '2022-03-17' });
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: TO_SHARE, deletedAt: '2022-03-17' });
+        await databaseBuilder.commit();
+
+        const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);
+
+        expect(result).to.deep.equal({ completed: 0, shared: 0 });
+      });
+
       describe('Count shared Participation', function () {
         it('counts participations shared', async function () {
-          databaseBuilder.factory.buildCampaignParticipation();
-          databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+          databaseBuilder.factory.buildCampaignParticipation({ campaignId, status: SHARED });
           await databaseBuilder.commit();
 
           const result = await campaignParticipationRepository.countParticipationsByStatus(campaignId, campaignType);

--- a/api/tests/integration/infrastructure/repositories/division-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/division-repository_test.js
@@ -60,6 +60,24 @@ describe('Integration | Repository | Division', function () {
         expect(divisions).to.deep.equal([]);
       });
     });
+
+    context('when participation is deleted', function () {
+      it('should not return the division of the deleted campaignParticipation', async function () {
+        const division = '5eme1';
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, division: division },
+          { campaignId: campaign.id, deletedAt: '2020-01-22' }
+        );
+
+        await databaseBuilder.commit();
+
+        const divisions = await divisionRepository.findByCampaignId(campaign.id);
+
+        expect(divisions).to.deep.equal([]);
+      });
+    });
   });
 
   describe('#findByOrganizationIdForCurrentSchoolYear', function () {

--- a/api/tests/integration/infrastructure/repositories/group-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/group-repository_test.js
@@ -60,6 +60,24 @@ describe('Integration | Repository | Group', function () {
         expect(groups).to.deep.equal([]);
       });
     });
+
+    context('when participation is deleted', function () {
+      it('should not return group', async function () {
+        const group = 'AB5';
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, group: group },
+          { campaignId: campaign.id, deletedAt: new Date() }
+        );
+
+        await databaseBuilder.commit();
+
+        const groups = await groupRepository.findByCampaignId(campaign.id);
+
+        expect(groups).to.deep.equal([]);
+      });
+    });
   });
 
   describe('#findByOrganizationId', function () {


### PR DESCRIPTION
## :unicorn: Problème
l'affichage des participations supprimées n'est plus nécessaire, actuellement ils sont toujours récupérés de la BDD et afficher dans plusieurs endroit dans pix Orga, danse cette PR, nous voulons gérer l'affichage dans l'onglet activités dans pix orga.

## :robot: Solution
Ne plus récupérer et afficher les participations supprimées (cad ayant une date de suppression non nulle)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Créer une participation pour une campagne donnée 
- vérifier que la participation est afficher dans l’onglet activité de pix orga, dans la liste des participants ainsi que les statistiques de campagne 
- supprimer cette participation 
- constater que la participation n'est plus affichée ni dans la list des participations , ni dans les statistiques de cette campagne 