### PR TITLE
[FEATURE] Mettre à jour le wording en cas de défocus en certif (PIX-4558)

### DIFF
--- a/mon-pix/tests/integration/components/challenge-actions_test.js
+++ b/mon-pix/tests/integration/components/challenge-actions_test.js
@@ -33,4 +33,56 @@ describe('Integration | Component | challenge actions', function () {
       expect(find('.challenge-actions__action-continue')).to.exist;
     });
   });
+
+  describe('when user has focused out', function () {
+    context('when assessent is of type certification', function () {
+      it("should show certification focus out's error message", async function () {
+        // given
+        this.set('isValidateButtonEnabled', true);
+        this.set('isCertification', true);
+        this.set('hasFocusedOutOfWindow', true);
+        this.set('hasChallengeTimedOut', false);
+        this.set('isSkipButtonEnabled', true);
+        this.set('validateActionStub', () => {});
+
+        // when
+        await render(hbs`<ChallengeActions
+                            @isCertification={{this.isCertification}}
+                            @validateAnswer={{this.validateActionStub}}
+                            @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+                            @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
+                            @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                            @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>`);
+
+        // then
+        expect(find('[data-test="certification-focused-out-error-message"]')).to.exist;
+        expect(find('[data-test="default-focused-out-error-message"]')).not.to.exist;
+      });
+    });
+
+    context('when assessent is not of type certification', function () {
+      it("should show default focus out's error message", async function () {
+        // given
+        this.set('isValidateButtonEnabled', true);
+        this.set('isCertification', false);
+        this.set('hasFocusedOutOfWindow', true);
+        this.set('hasChallengeTimedOut', false);
+        this.set('isSkipButtonEnabled', true);
+        this.set('validateActionStub', () => {});
+
+        // when
+        await render(hbs`<ChallengeActions
+                            @isCertification={{this.isCertification}}
+                            @validateAnswer={{this.validateActionStub}}
+                            @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+                            @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
+                            @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                            @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>`);
+
+        // then
+        expect(find('[data-test="certification-focused-out-error-message"]')).not.to.exist;
+        expect(find('[data-test="default-focused-out-error-message"]')).to.exist;
+      });
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -487,7 +487,7 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "We have detected a page switch.'<br>'Your answer will not be validated.",
+        "certification": "We have detected a page switch. Your answer will not be validated.'<br>'If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
         "default": "We have detected a page switch.'<br>'During a certification test, your answer would not be validated."
       },
       "parts": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -487,7 +487,7 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Nous avons détecté un changement de page.'<br>'Votre réponse sera comptée comme fausse.",
+        "certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.",
         "default": "Nous avons détecté un changement de page.'<br>'En certification, votre réponse ne serait pas validée."
       },
       "parts": {


### PR DESCRIPTION
## :unicorn: Problème
Le traitement des épreuves focus en certif va être automatisé, notamment si un signalement indique qu’un candidat a été contraint de perdre le focus (car utilisait un lecteur d'écran par exemple), et que la réponse à la question est OK, alors le statut de la question passera de “focusedOut” à “OK”

Cela implique qu’un candidat ayant perdu le focus par erreur réponde tout de même à la question. Or, le message affiché actuellement en cas de défocus n’incite pas à répondre malgré tout

## :robot: Solution
Modifier le wording de ce message : 

Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question.

## :rainbow: Remarques
- [x] Traduction en attente...

## :100: Pour tester
- Passer une certification avec [certif1@exemple.net](mailto:certif1@exemple.net)
- Constater après avoir focus out, l'affichage de l'avertissement :

![image](https://user-images.githubusercontent.com/37305474/159018949-41e2364a-883c-4935-9752-9da5726015b5.png)
