### PR TITLE
[FEATURE] Ajout d'un script permettant de remplir la colonne skillId dans la table `user-saved-tutorials` (PIX-4383).

### DIFF
--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -1,6 +1,7 @@
 const { knex } = require('../tests/test-helper');
 const UserSavedTutorial = require('../lib/domain/models/UserSavedTutorial');
 const tutorialDatasource = require('../lib/infrastructure/datasources/learning-content/tutorial-datasource');
+const skillDatasource = require('../lib/infrastructure/datasources/learning-content/skill-datasource');
 const UserSavedTutorialWithTutorial = require('../lib/domain/models/UserSavedTutorialWithTutorial');
 
 if (require.main === module) {
@@ -31,6 +32,10 @@ async function getAllTutorials() {
   return tutorialDatasource.list();
 }
 
+async function getAllSkills() {
+  return skillDatasource.list();
+}
+
 function associateTutorialToUserSavedTutorial(userSavedTutorial, tutorials) {
   const tutorial = tutorials.find((tutorial) => tutorial.id === userSavedTutorial.tutorialId);
   return new UserSavedTutorialWithTutorial({ ...userSavedTutorial, tutorial });
@@ -39,5 +44,6 @@ function associateTutorialToUserSavedTutorial(userSavedTutorial, tutorials) {
 module.exports = {
   getAllUserSavedTutorialsWithoutSkillId,
   getAllTutorials,
+  getAllSkills,
   associateTutorialToUserSavedTutorial,
 };

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -36,6 +36,20 @@ async function getAllSkills() {
   return skillDatasource.list();
 }
 
+function _skillHasTutorialId(skill, tutorialId) {
+  return skill.tutorialIds.includes(tutorialId);
+}
+
+function associateSkillsToTutorial(skills, tutorials) {
+  return tutorials.map((tutorial) => {
+    const skillIds = skills.filter((skill) => _skillHasTutorialId(skill, tutorial.id)).map((skill) => skill.id);
+    return {
+      ...tutorial,
+      skillIds,
+    };
+  });
+}
+
 function associateTutorialToUserSavedTutorial(userSavedTutorial, tutorials) {
   const tutorial = tutorials.find((tutorial) => tutorial.id === userSavedTutorial.tutorialId);
   return new UserSavedTutorialWithTutorial({ ...userSavedTutorial, tutorial });
@@ -46,4 +60,5 @@ module.exports = {
   getAllTutorials,
   getAllSkills,
   associateTutorialToUserSavedTutorial,
+  associateSkillsToTutorial,
 };

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -1,0 +1,30 @@
+const { knex } = require('../tests/test-helper');
+const UserSavedTutorial = require('../lib/domain/models/UserSavedTutorial');
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+async function getAllUserSavedTutorialsWithoutSkillId() {
+  const userSavedTutorials = await knex('user-saved-tutorials').whereNull('skillId');
+  return userSavedTutorials.map(_toDomain);
+}
+
+function _toDomain(userSavedTutorial) {
+  return new UserSavedTutorial({
+    id: userSavedTutorial.id,
+    tutorialId: userSavedTutorial.tutorialId,
+    userId: userSavedTutorial.userId,
+    skillId: userSavedTutorial.skillId,
+  });
+}
+
+module.exports = {
+  getAllUserSavedTutorialsWithoutSkillId,
+};

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -1,5 +1,6 @@
 const { knex } = require('../tests/test-helper');
 const UserSavedTutorial = require('../lib/domain/models/UserSavedTutorial');
+const tutorialDatasource = require('../lib/infrastructure/datasources/learning-content/tutorial-datasource');
 
 if (require.main === module) {
   main().then(
@@ -25,6 +26,11 @@ function _toDomain(userSavedTutorial) {
   });
 }
 
+async function getAllTutorials() {
+  return tutorialDatasource.list();
+}
+
 module.exports = {
   getAllUserSavedTutorialsWithoutSkillId,
+  getAllTutorials,
 };

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -1,6 +1,7 @@
 const { knex } = require('../tests/test-helper');
 const UserSavedTutorial = require('../lib/domain/models/UserSavedTutorial');
 const tutorialDatasource = require('../lib/infrastructure/datasources/learning-content/tutorial-datasource');
+const UserSavedTutorialWithTutorial = require('../lib/domain/models/UserSavedTutorialWithTutorial');
 
 if (require.main === module) {
   main().then(
@@ -30,7 +31,13 @@ async function getAllTutorials() {
   return tutorialDatasource.list();
 }
 
+function associateTutorialToUserSavedTutorial(userSavedTutorial, tutorials) {
+  const tutorial = tutorials.find((tutorial) => tutorial.id === userSavedTutorial.tutorialId);
+  return new UserSavedTutorialWithTutorial({ ...userSavedTutorial, tutorial });
+}
+
 module.exports = {
   getAllUserSavedTutorialsWithoutSkillId,
   getAllTutorials,
+  associateTutorialToUserSavedTutorial,
 };

--- a/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
+++ b/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
@@ -1,9 +1,17 @@
-const { expect, databaseBuilder, learningContentBuilder, mockLearningContent } = require('../../test-helper');
+const {
+  expect,
+  databaseBuilder,
+  learningContentBuilder,
+  mockLearningContent,
+  domainBuilder,
+} = require('../../test-helper');
 const {
   getAllUserSavedTutorialsWithoutSkillId,
   getAllTutorials,
+  associateTutorialToUserSavedTutorial,
 } = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
 const UserSavedTutorial = require('../../../lib/domain/models/UserSavedTutorial');
+const UserSavedTutorialWithTutorial = require('../../../lib/domain/models/UserSavedTutorialWithTutorial');
 
 describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', function () {
   describe('#getAllUserSavedTutorialsWithoutSkillId', function () {
@@ -126,6 +134,21 @@ describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', functio
 
       // then
       expect(tutorials).to.be.lengthOf(5);
+    });
+  });
+
+  describe('#associateTutorialToUserSagedTutorial', function () {
+    it('should retrieve one UserSavedTutorialWithTutorial', async function () {
+      // given
+      const tutorials = [domainBuilder.buildTutorial({ id: 'tuto1' }), domainBuilder.buildTutorial({ id: 'tuto2' })];
+      const userSavedTutorial = domainBuilder.buildUserSavedTutorial({ tutorialId: 'tuto1' });
+
+      // when
+      const userSavedTutorialWithTutorial = associateTutorialToUserSavedTutorial(userSavedTutorial, tutorials);
+
+      // then
+      expect(userSavedTutorialWithTutorial).to.be.instanceOf(UserSavedTutorialWithTutorial);
+      expect(userSavedTutorialWithTutorial.tutorial.id).to.equal(userSavedTutorial.tutorialId);
     });
   });
 });

--- a/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
+++ b/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
@@ -1,5 +1,8 @@
-const { expect, databaseBuilder } = require('../../test-helper');
-const { getAllUserSavedTutorialsWithoutSkillId } = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
+const { expect, databaseBuilder, learningContentBuilder, mockLearningContent } = require('../../test-helper');
+const {
+  getAllUserSavedTutorialsWithoutSkillId,
+  getAllTutorials,
+} = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
 const UserSavedTutorial = require('../../../lib/domain/models/UserSavedTutorial');
 
 describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', function () {
@@ -20,6 +23,109 @@ describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', functio
       expect(userSavedTutorials[0].tutorialId).to.equal('tuto1');
       expect(userSavedTutorials[1].tutorialId).to.equal('tuto3');
       expect(userSavedTutorials.every((userSavedTutorials) => userSavedTutorials.skillId === null)).to.be.true;
+    });
+  });
+
+  describe('#getAllTutorials', function () {
+    it('should retrieve all tutorials', async function () {
+      // given
+      const learningContentObjects = learningContentBuilder.buildLearningContent([
+        {
+          id: 'recArea1',
+          titleFrFr: 'area1_Title',
+          color: 'specialColor',
+          competences: [
+            {
+              id: 'recCompetence1',
+              name: 'Fabriquer un meuble',
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube1',
+                  skills: [
+                    {
+                      id: 'recSkill1',
+                      nom: '@web1',
+                      challenges: [],
+                      tutorialIds: ['tuto1', 'tuto2'],
+                      tutorials: [
+                        {
+                          id: 'tuto1',
+                          locale: 'fr-fr',
+                          duration: '00:00:54',
+                          format: 'video',
+                          link: 'http://www.example.com/this-is-an-example.html',
+                          source: 'tuto.com',
+                          title: 'tuto1',
+                        },
+                        {
+                          id: 'tuto2',
+                          locale: 'fr-fr',
+                          duration: '00:01:51',
+                          format: 'video',
+                          link: 'http://www.example.com/this-is-an-example2.html',
+                          source: 'tuto.com',
+                          title: 'tuto2',
+                        },
+                      ],
+                    },
+                    {
+                      id: 'recSkill2',
+                      nom: '@web2',
+                      challenges: [],
+                      tutorialIds: ['tuto1'],
+                      tutorials: [
+                        {
+                          id: 'tuto1',
+                          locale: 'fr-fr',
+                          duration: '00:00:54',
+                          format: 'video',
+                          link: 'http://www.example.com/this-is-an-example.html',
+                          source: 'tuto.com',
+                          title: 'tuto1',
+                        },
+                      ],
+                    },
+                    {
+                      id: 'recSkill3',
+                      nom: '@web3',
+                      challenges: [],
+                      tutorialIds: ['tuto4'],
+                      tutorials: [
+                        {
+                          id: 'tuto4',
+                          locale: 'fr-fr',
+                          duration: '00:04:38',
+                          format: 'vidéo',
+                          link: 'http://www.example.com/this-is-an-example4.html',
+                          source: 'tuto.com',
+                          title: 'tuto4',
+                        },
+                        {
+                          id: 'tuto5',
+                          locale: 'en-us',
+                          duration: '00:04:38',
+                          format: 'vidéo',
+                          link: 'http://www.example.com/this-is-an-example4.html',
+                          source: 'tuto.com',
+                          title: 'tuto4',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+      mockLearningContent(learningContentObjects);
+
+      // when
+      const tutorials = await getAllTutorials();
+
+      // then
+      expect(tutorials).to.be.lengthOf(5);
     });
   });
 });

--- a/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
+++ b/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
@@ -4,6 +4,8 @@ const {
   learningContentBuilder,
   mockLearningContent,
   domainBuilder,
+  knex,
+  sinon,
 } = require('../../test-helper');
 const {
   getAllUserSavedTutorialsWithoutSkillId,
@@ -12,12 +14,197 @@ const {
   associateTutorialToUserSavedTutorial,
   associateSkillsToTutorial,
   getMostRelevantSkillId,
+  main,
 } = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
 const UserSavedTutorial = require('../../../lib/domain/models/UserSavedTutorial');
 const UserSavedTutorialWithTutorial = require('../../../lib/domain/models/UserSavedTutorialWithTutorial');
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
 
 describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', function () {
+  describe('#main', function () {
+    describe('happy path', function () {
+      let learningContentObjects;
+
+      beforeEach(function () {
+        sinon.stub(console, 'log');
+        learningContentObjects = learningContentBuilder.buildLearningContent([
+          {
+            id: 'recArea1',
+            titleFrFr: 'area1_Title',
+            color: 'specialColor',
+            competences: [
+              {
+                id: 'recCompetence1',
+                name: 'Fabriquer un meuble',
+                index: '1.1',
+                tubes: [
+                  {
+                    id: 'recTube1',
+                    skills: [
+                      {
+                        id: 'recSkill1',
+                        nom: '@web1',
+                        challenges: [],
+                        tutorialIds: ['tuto1', 'tuto2'],
+                        tutorials: [
+                          {
+                            id: 'tuto1',
+                            locale: 'fr-fr',
+                            duration: '00:00:54',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example.html',
+                            source: 'tuto.com',
+                            title: 'tuto1',
+                          },
+                          {
+                            id: 'tuto2',
+                            locale: 'fr-fr',
+                            duration: '00:01:51',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example2.html',
+                            source: 'tuto.com',
+                            title: 'tuto2',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recSkill2',
+                        nom: '@web2',
+                        challenges: [],
+                        tutorialIds: ['tuto1'],
+                        tutorials: [
+                          {
+                            id: 'tuto1',
+                            locale: 'fr-fr',
+                            duration: '00:00:54',
+                            format: 'video',
+                            link: 'http://www.example.com/this-is-an-example.html',
+                            source: 'tuto.com',
+                            title: 'tuto1',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recSkill3',
+                        nom: '@web3',
+                        challenges: [],
+                        tutorialIds: ['tuto4', 'tuto5'],
+                        tutorials: [
+                          {
+                            id: 'tuto4',
+                            locale: 'fr-fr',
+                            duration: '00:04:38',
+                            format: 'vidéo',
+                            link: 'http://www.example.com/this-is-an-example4.html',
+                            source: 'tuto.com',
+                            title: 'tuto4',
+                          },
+                          {
+                            id: 'tuto5',
+                            locale: 'en-us',
+                            duration: '00:04:38',
+                            format: 'vidéo',
+                            link: 'http://www.example.com/this-is-an-example5.html',
+                            source: 'tuto.com',
+                            title: 'tuto5',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+        mockLearningContent(learningContentObjects);
+      });
+
+      it('should update the user-saved-tutorials with the skillId of the most recent invalidated KE', async function () {
+        // given
+        const mostRecentDirectInvalidatedSkillId = 'recSkill1';
+        const oldestDirectInvalidatedSkillId = 'recSkill2';
+        const directInvalidatedSkillId = 'recSkill3';
+
+        const userId = databaseBuilder.factory.buildUser().id;
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          source: KnowledgeElement.SourceType.DIRECT,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          skillId: mostRecentDirectInvalidatedSkillId,
+          createdAt: new Date('2022-03-18'),
+        });
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          source: KnowledgeElement.SourceType.DIRECT,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          skillId: oldestDirectInvalidatedSkillId,
+          createdAt: new Date('2022-03-16'),
+        });
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          source: KnowledgeElement.SourceType.DIRECT,
+          status: KnowledgeElement.StatusType.INVALIDATED,
+          skillId: directInvalidatedSkillId,
+          createdAt: new Date('2022-03-16'),
+        });
+
+        const { id: userSavedTutorialId1 } = databaseBuilder.factory.buildUserSavedTutorial({
+          userId,
+          tutorialId: 'tuto1',
+          skillId: null,
+        });
+        const { id: userSavedTutorialId2 } = databaseBuilder.factory.buildUserSavedTutorial({
+          userId,
+          tutorialId: 'tuto2',
+          skillId: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await main();
+
+        // then
+
+        const [updatedUserSavedTutorial1] = await knex('user-saved-tutorials').where({ id: userSavedTutorialId1 });
+
+        const [updatedUserSavedTutorial2] = await knex('user-saved-tutorials').where({ id: userSavedTutorialId2 });
+
+        expect(updatedUserSavedTutorial1.skillId).to.equal(mostRecentDirectInvalidatedSkillId);
+        expect(updatedUserSavedTutorial2.skillId).to.equal(mostRecentDirectInvalidatedSkillId);
+      });
+
+      describe('when the saved tutorial is not available anymore', function () {
+        it('should not modify user-saved-tutorials', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+
+          const { id: userSavedTutorialId1 } = databaseBuilder.factory.buildUserSavedTutorial({
+            userId,
+            tutorialId: 'notAvailable',
+            skillId: null,
+          });
+          databaseBuilder.factory.buildUserSavedTutorial({
+            userId: 123,
+            tutorialId: 'tuto1',
+            skillId: null,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          await main();
+
+          // then
+
+          const [results] = await knex('user-saved-tutorials').where({ id: userSavedTutorialId1 });
+          expect(results.skillId).to.equal(null);
+        });
+      });
+    });
+  });
+
   describe('#getAllUserSavedTutorialsWithoutSkillId', function () {
     it('should retrieve all user saved tutorials without skillId', async function () {
       // given
@@ -205,7 +392,7 @@ describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', functio
                       id: 'recSkill3',
                       nom: '@web3',
                       challenges: [],
-                      tutorialIds: ['tuto4'],
+                      tutorialIds: ['tuto4', 'tuto5'],
                       tutorials: [
                         {
                           id: 'tuto4',
@@ -221,9 +408,9 @@ describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', functio
                           locale: 'en-us',
                           duration: '00:04:38',
                           format: 'vidéo',
-                          link: 'http://www.example.com/this-is-an-example4.html',
+                          link: 'http://www.example.com/this-is-an-example5.html',
                           source: 'tuto.com',
-                          title: 'tuto4',
+                          title: 'tuto5',
                         },
                       ],
                     },

--- a/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
+++ b/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
@@ -8,6 +8,7 @@ const {
 const {
   getAllUserSavedTutorialsWithoutSkillId,
   getAllTutorials,
+  getAllSkills,
   associateTutorialToUserSavedTutorial,
 } = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
 const UserSavedTutorial = require('../../../lib/domain/models/UserSavedTutorial');
@@ -134,6 +135,109 @@ describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', functio
 
       // then
       expect(tutorials).to.be.lengthOf(5);
+    });
+  });
+
+  describe('#getAllSkills', function () {
+    it('should retrieve all skills', async function () {
+      // given
+      const learningContentObjects = learningContentBuilder.buildLearningContent([
+        {
+          id: 'recArea1',
+          titleFrFr: 'area1_Title',
+          color: 'specialColor',
+          competences: [
+            {
+              id: 'recCompetence1',
+              name: 'Fabriquer un meuble',
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube1',
+                  skills: [
+                    {
+                      id: 'recSkill1',
+                      nom: '@web1',
+                      challenges: [],
+                      tutorialIds: ['tuto1', 'tuto2'],
+                      tutorials: [
+                        {
+                          id: 'tuto1',
+                          locale: 'fr-fr',
+                          duration: '00:00:54',
+                          format: 'video',
+                          link: 'http://www.example.com/this-is-an-example.html',
+                          source: 'tuto.com',
+                          title: 'tuto1',
+                        },
+                        {
+                          id: 'tuto2',
+                          locale: 'fr-fr',
+                          duration: '00:01:51',
+                          format: 'video',
+                          link: 'http://www.example.com/this-is-an-example2.html',
+                          source: 'tuto.com',
+                          title: 'tuto2',
+                        },
+                      ],
+                    },
+                    {
+                      id: 'recSkill2',
+                      nom: '@web2',
+                      challenges: [],
+                      tutorialIds: ['tuto1'],
+                      tutorials: [
+                        {
+                          id: 'tuto1',
+                          locale: 'fr-fr',
+                          duration: '00:00:54',
+                          format: 'video',
+                          link: 'http://www.example.com/this-is-an-example.html',
+                          source: 'tuto.com',
+                          title: 'tuto1',
+                        },
+                      ],
+                    },
+                    {
+                      id: 'recSkill3',
+                      nom: '@web3',
+                      challenges: [],
+                      tutorialIds: ['tuto4'],
+                      tutorials: [
+                        {
+                          id: 'tuto4',
+                          locale: 'fr-fr',
+                          duration: '00:04:38',
+                          format: 'vidéo',
+                          link: 'http://www.example.com/this-is-an-example4.html',
+                          source: 'tuto.com',
+                          title: 'tuto4',
+                        },
+                        {
+                          id: 'tuto5',
+                          locale: 'en-us',
+                          duration: '00:04:38',
+                          format: 'vidéo',
+                          link: 'http://www.example.com/this-is-an-example4.html',
+                          source: 'tuto.com',
+                          title: 'tuto4',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+      mockLearningContent(learningContentObjects);
+
+      // when
+      const skills = await getAllSkills();
+
+      // then
+      expect(skills).to.be.lengthOf(3);
     });
   });
 

--- a/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
+++ b/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
@@ -10,6 +10,7 @@ const {
   getAllTutorials,
   getAllSkills,
   associateTutorialToUserSavedTutorial,
+  associateSkillsToTutorial,
 } = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
 const UserSavedTutorial = require('../../../lib/domain/models/UserSavedTutorial');
 const UserSavedTutorialWithTutorial = require('../../../lib/domain/models/UserSavedTutorialWithTutorial');
@@ -238,6 +239,29 @@ describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', functio
 
       // then
       expect(skills).to.be.lengthOf(3);
+    });
+  });
+
+  describe('#associateSkillsToTutorial', function () {
+    it('should associate skillIds to related tutorial', async function () {
+      // given
+      const tutorials = [
+        domainBuilder.buildTutorial({ id: 'tutorial1_skill1_and_skill2' }),
+        domainBuilder.buildTutorial({ id: 'tutorial2_skill1' }),
+        domainBuilder.buildTutorial({ id: 'tutorial3_skill2' }),
+      ];
+      const skills = [
+        domainBuilder.buildSkill({ id: 'skill1', tutorialIds: ['tutorial1_skill1_and_skill2', 'tutorial2_skill1'] }),
+        domainBuilder.buildSkill({ id: 'skill2', tutorialIds: ['tutorial1_skill1_and_skill2', 'tutorial3_skill2'] }),
+      ];
+
+      // when
+      const tutorialsWithSkillIds = associateSkillsToTutorial(skills, tutorials);
+
+      // then
+      expect(tutorialsWithSkillIds[0].skillIds).to.deep.equal(['skill1', 'skill2']);
+      expect(tutorialsWithSkillIds[1].skillIds).to.deep.equal(['skill1']);
+      expect(tutorialsWithSkillIds[2].skillIds).to.deep.equal(['skill2']);
     });
   });
 

--- a/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
+++ b/api/tests/integration/scripts/fill-skill-id-in-user-saved-tutorials_test.js
@@ -1,0 +1,25 @@
+const { expect, databaseBuilder } = require('../../test-helper');
+const { getAllUserSavedTutorialsWithoutSkillId } = require('../../../scripts/fill-skill-id-in-user-saved-tutorials');
+const UserSavedTutorial = require('../../../lib/domain/models/UserSavedTutorial');
+
+describe('Integration | Scripts | fill-skillId-in-user-saved-tutorials', function () {
+  describe('#getAllUserSavedTutorialsWithoutSkillId', function () {
+    it('should retrieve all user saved tutorials without skillId', async function () {
+      // given
+      databaseBuilder.factory.buildUserSavedTutorial({ tutorialId: 'tuto1', skillId: null });
+      databaseBuilder.factory.buildUserSavedTutorial({ tutorialId: 'tuto2', skillId: 'skill1' });
+      databaseBuilder.factory.buildUserSavedTutorial({ tutorialId: 'tuto3', skillId: null });
+      await databaseBuilder.commit();
+
+      // when
+      const userSavedTutorials = await getAllUserSavedTutorialsWithoutSkillId();
+
+      // then
+      expect(userSavedTutorials).to.be.lengthOf(2);
+      expect(userSavedTutorials[0]).to.be.instanceOf(UserSavedTutorial);
+      expect(userSavedTutorials[0].tutorialId).to.equal('tuto1');
+      expect(userSavedTutorials[1].tutorialId).to.equal('tuto3');
+      expect(userSavedTutorials.every((userSavedTutorials) => userSavedTutorials.skillId === null)).to.be.true;
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -119,6 +119,7 @@ module.exports = {
   buildUserDetailsForAdmin: require('./build-user-details-for-admin'),
   buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserScorecard: require('./build-user-scorecard'),
+  buildUserSavedTutorial: require('./build-user-saved-tutorial'),
   buildUserSavedTutorialWithTutorial: require('./build-user-saved-tutorial-with-tutorial'),
   buildUserWithSchoolingRegistration: require('./build-user-with-schooling-registration'),
   buildValidation: require('./build-validation'),


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment ajouté la colonne `skillId` dans la table `user-saved-tutorials`, mais celle-ci n'est pas encore remplie avec des données consistantes. 

## :robot: Solution
Reprendre les données existantes pour remplir cette nouvelle colonne à l'aide d'un script de migration.

## :rainbow: Remarques
- Dans le cas où le tutoriel est associé à plusieurs acquis : nous choisissons l'acquis le plus récemment invalidé.
- Le script nettoie également les enregistrement de la table `user-saved-tutorials` qui comprennent un tutoriel qui n'existe plus. 

## :100: Pour tester
- Créer un container one-off sur la RA 
- Lancer le script de migration : 
```bash
scalingo -a pix-api-review-pr4218 run node ./scripts/fill-skill-id-in-user-saved-tutorials.js
```
- Vérifier dans la base de données que la colonne `skillId` est remplie pour tous les enregistrements.
- Remettre à l'état initial pour les copains qui testent après vous ! : 
```bash
scalingo -a pix-api-review-pr4217 pgsql-console
```
```sql
UPDATE "user-saved-tutorials" SET skillId = null;
```