### PR TITLE
[FEATURE] Empêcher la réconciliation de deux personnes différentes sur un même compte (PIX-1398).

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -334,6 +334,35 @@ function _buildHighSchools({ databaseBuilder }) {
     nationalStudentId: '123456789BB',
     createdAt: new Date('2020-08-14'),
   });
+
+  // siblings using the same computer and in different school
+  const bigSister = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Sister',
+    lastName: 'Big',
+    email: 'sister@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+  databaseBuilder.factory.buildSchoolingRegistration({
+    firstName: 'Sister',
+    lastName: 'Big',
+    birthdate: '2008-02-01',
+    division: '3B',
+    group: null,
+    organizationId: SCO_HIGH_SCHOOL_ID,
+    userId: bigSister.id,
+    nationalStudentId: '987654321EE',
+  });
+  databaseBuilder.factory.buildSchoolingRegistration({
+    firstName: 'Brother',
+    lastName: 'Little',
+    birthdate: '2010-10-10',
+    division: '5A',
+    group: null,
+    organizationId: SCO_MIDDLE_SCHOOL_ID,
+    userId: null,
+    nationalStudentId: '987654321NN',
+  });
+
 }
 
 function _buildAgri({ databaseBuilder }) {

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -407,6 +407,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
 
+  if (error instanceof DomainErrors.UserShouldNotBeReconciledOnAnotherAccountError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+  }
+
   if (error instanceof DomainErrors.CandidateNotAuthorizedToJoinSessionError) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -57,6 +57,7 @@ module.exports = {
         samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         anotherStudentIsAlreadyReconciled: { shortCode: 'R70', code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION' },
       },
+      ACCOUNT_BELONGING_TO_ANOTHER_USER: { shortCode: 'R90', code: 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER' },
     },
     LOGIN_OR_REGISTER: {
       IN_SAME_ORGANIZATION: {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -246,6 +246,14 @@ class UserNotAuthorizedToGenerateUsernamePasswordError extends DomainError {
   }
 }
 
+class UserShouldNotBeReconciledOnAnotherAccountError extends DomainError {
+  constructor({ message = "Cet utilisateur n'est pas autorisé à se réconcilier avec ce compte", code, meta }) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class CertificationCourseUpdateError extends DomainError {
   constructor(message = 'Échec lors la création ou de la mise à jour du test de certification.') {
     super(message);
@@ -1216,6 +1224,7 @@ module.exports = {
   UserNotMemberOfOrganizationError,
   UserOrgaSettingsCreationError,
   UserShouldChangePasswordError,
+  UserShouldNotBeReconciledOnAnotherAccountError,
   WrongDateFormatError,
   YamlParsingError,
 };

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -20,6 +20,7 @@ const {
   CandidateNotAuthorizedToResumeCertificationTestError,
   UncancellableOrganizationInvitationError,
   SchoolingRegistrationCannotBeDissociatedError,
+  UserShouldNotBeReconciledOnAnotherAccountError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -364,6 +365,21 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate UnprocessableEntityError when UserShouldNotBeReconciledOnAnotherAccountError', async function () {
+      // given
+      const code = 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER';
+      const meta = { shortCode: 'R90' };
+      const error = new UserShouldNotBeReconciledOnAnotherAccountError({ code, meta });
+      sinon.stub(HttpErrors, 'UnprocessableEntityError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code, error.meta);
     });
 
     it('should instantiate PreconditionFailedError when SchoolingRegistrationCannotBeDissociatedError', async function () {

--- a/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.js
+++ b/mon-pix/app/components/routes/campaigns/invited/associate-sco-student-form.js
@@ -78,6 +78,9 @@ export default class AssociateScoStudentForm extends Component {
           this.displayInformationModal = true;
           this.session.set('data.expectedUserId', error.meta.userId);
         }
+      } else if (error.status === '422' && error.code === 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER') {
+        this.reconciliationError = error;
+        this.displayInformationModal = true;
       } else if (error.status === '404') {
         this.errorMessage = this.intl.t('pages.join.sco.error-not-found', { htmlSafe: true });
       } else if (error.status === '400') {

--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.hbs
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.hbs
@@ -13,7 +13,28 @@
   </div>
 
   <div class="join-error-modal__body" {{on-key "Escape" @closeModal}}>
-    <div class="join-error-modal-body__message" aria-live="polite">{{this.message}}</div>
+    {{#if this.message}}
+      <div class="join-error-modal-body__message" aria-live="polite">{{this.message}}</div>
+    {{/if}}
+    {{#if this.isAccountBelongingToAnotherUser}}
+      <p>
+        {{t "api-error-messages.join-error.r90.account-belonging-to-another-user"}}
+        <ul class="join-error-modal-body__list">
+          <li>
+            {{t "api-error-messages.join-error.r90.details.if-account-belonging-to-user"}}
+            <a
+              href="{{t "api-error-messages.join-error.r90.details.contact-support.link-url"}}"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{t "api-error-messages.join-error.r90.details.contact-support.link-text"}}
+            </a>
+            {{t "api-error-messages.join-error.r90.details.code"}}
+          </li>
+          <li>{{t "api-error-messages.join-error.r90.details.disconnect-user"}}</li>
+        </ul>
+      </p>
+    {{/if}}
   </div>
 
   <div class="join-error-modal__footer">
@@ -26,7 +47,11 @@
         {{t "pages.join.sco.associate"}}
       </PixButton>
     {{else}}
-      <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.goToHome}}>
+      <PixButton
+        @backgroundColor="{{if this.displayContinueButton "transparent-light" "blue"}}"
+        @isBorderVisible={{true}}
+        @triggerAction={{this.goToHome}}
+      >
         {{t "common.actions.quit"}}
       </PixButton>
       {{#if this.displayContinueButton}}

--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
@@ -15,6 +15,7 @@ export default class JoinScoInformationModal extends Component {
   @service campaignStorage;
 
   @tracked message = null;
+  @tracked isAccountBelongingToAnotherUser = false;
   @tracked displayContinueButton = true;
 
   constructor(owner, args) {
@@ -27,13 +28,19 @@ export default class JoinScoInformationModal extends Component {
       });
     }
     if (this.args.reconciliationError) {
-      this.isInformationMode = false;
       const error = this.args.reconciliationError;
-      this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
-      const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-      this.message =
-        this.intl.t(getJoinErrorsMessageByShortCode(error.meta), { value: error.meta.value, htmlSafe: true }) ||
-        defaultMessage;
+      this.isInformationMode = false;
+
+      if (error.status === '422') {
+        this.displayContinueButton = false;
+        this.isAccountBelongingToAnotherUser = true;
+      } else {
+        this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
+        const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+        this.message =
+          this.intl.t(getJoinErrorsMessageByShortCode(error.meta), { value: error.meta.value, htmlSafe: true }) ||
+          defaultMessage;
+      }
     }
   }
 

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -143,6 +143,7 @@
     padding: 24px 30px 0;
     background-color: $grey-10;
     display: flex;
+    flex-direction: column;
     justify-content: center;
   }
 
@@ -198,5 +199,9 @@
     font-size: 0.875rem;
     font-weight: $font-normal;
     color: $grey-200;
+  }
+
+  &__list li {
+    padding: 5px 0;
   }
 }

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
@@ -227,6 +227,22 @@ describe('Unit | Component | routes/campaigns/invited/associate-sco-student-form
           expect(component.errorMessage.string).to.equal(expectedErrorMessage);
         });
       });
+
+      describe('When user is trying to reconcile on another account', () => {
+        it('should open information modal and set reconciliationError', async function () {
+          // given
+          const error = { status: '422', code: 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER' };
+
+          onSubmitStub.rejects({ errors: [error] });
+
+          // when
+          await component.actions.submit.call(component, attributes);
+
+          // then
+          expect(component.displayInformationModal).to.be.true;
+          expect(component.reconciliationError).to.equal(error);
+        });
+      });
     });
   });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
@@ -10,6 +10,53 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
   setupIntl();
 
   describe('When reconciliation error is provided', function () {
+    describe('When error is a 422 status', function () {
+      it('should set isAccountBelongingToAnotherUser to true', function () {
+        // given
+        const reconciliationError = {
+          status: '422',
+        };
+
+        // when
+        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+          reconciliationError,
+        });
+
+        // then
+        expect(component.isAccountBelongingToAnotherUser).to.be.true;
+      });
+
+      it('should not display continue button', function () {
+        // given
+        const reconciliationError = {
+          status: '422',
+        };
+
+        // when
+        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+          reconciliationError,
+        });
+
+        // then
+        expect(component.displayContinueButton).to.be.false;
+      });
+
+      it('should set is isInformationMode to false', function () {
+        // given
+        const reconciliationError = {
+          status: '422',
+        };
+
+        // when
+        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+          reconciliationError,
+        });
+
+        // then
+        expect(component.isInformationMode).to.be.false;
+      });
+    });
+
     describe('When error is a 409 status', function () {
       const reconciliationError = {
         status: '409',

--- a/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
@@ -10,41 +10,28 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
   setupIntl();
 
   describe('When reconciliation error is provided', function () {
-    const reconciliationError = {
-      status: '409',
-      meta: { shortCode: 'R11', value: 'j***@example.net', userId: 1 },
-    };
+    describe('When error is a 409 status', function () {
+      const reconciliationError = {
+        status: '409',
+        meta: { shortCode: 'R11', value: 'j***@example.net', userId: 1 },
+      };
 
-    it('should set is isInformationMode to false', function () {
-      // when
-      const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-        reconciliationError,
+      it('should set is isInformationMode to false', function () {
+        // when
+        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+          reconciliationError,
+        });
+
+        // then
+        expect(component.isInformationMode).to.be.false;
       });
 
-      // then
-      expect(component.isInformationMode).to.be.false;
-    });
-
-    it('should display error message', function () {
-      // given
-      const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', {
-        value: reconciliationError.meta.value,
-        htmlSafe: true,
-      });
-
-      // when
-      const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-        reconciliationError,
-      });
-
-      // then
-      expect(component.message).to.deep.equal(expectedErrorMessage);
-    });
-
-    describe('When error is not related to samlId', function () {
-      it('should display continue button', function () {
+      it('should display error message', function () {
         // given
-        reconciliationError.meta.shortCode = 'R12';
+        const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', {
+          value: reconciliationError.meta.value,
+          htmlSafe: true,
+        });
 
         // when
         const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
@@ -52,22 +39,37 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
         });
 
         // then
-        expect(component.displayContinueButton).to.be.true;
+        expect(component.message).to.deep.equal(expectedErrorMessage);
       });
-    });
 
-    describe('When error is related to samlId', function () {
-      it('should not display continue button', function () {
-        // given
-        reconciliationError.meta.shortCode = 'R13';
+      describe('When error is not related to samlId', function () {
+        it('should display continue button', function () {
+          // given
+          reconciliationError.meta.shortCode = 'R12';
 
-        // when
-        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-          reconciliationError,
+          // when
+          const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+            reconciliationError,
+          });
+
+          // then
+          expect(component.displayContinueButton).to.be.true;
         });
+      });
 
-        // then
-        expect(component.displayContinueButton).to.be.false;
+      describe('When error is related to samlId', function () {
+        it('should not display continue button', function () {
+          // given
+          reconciliationError.meta.shortCode = 'R13';
+
+          // when
+          const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+            reconciliationError,
+          });
+
+          // then
+          expect(component.displayContinueButton).to.be.false;
+        });
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -10,7 +10,19 @@
       "r31": "{ value }",
       "r32": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code R32)",
       "r33": "You already have a Pix account through your virtual learning environment (\"ENT\"). Log in with this account to take your customised test.",
-      "r70": "An error occurred. Please log out and try again."
+      "r70": "An error occurred. Please log out and try again.",
+      "r90": {
+        "account-belonging-to-another-user": "It looks like a pupil is already using this account.",
+        "details": {
+          "if-account-belonging-to-user": "If the account is yours, please contact the",
+          "contact-support": {
+            "link-text": " support team ",
+            "link-url": "https://support.pix.org/en/support/tickets/new"
+          },
+          "code": "(specifying code R90)",
+          "disconnect-user": "Else, logout and access the customised test again from your own account"
+        }
+      }
     },
     "login-unauthorized-error": "There was an error in the email address or username/password entered.",
     "register-error": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -10,7 +10,19 @@
       "r31": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R31)",
       "r32": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R32)",
       "r33": "Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.",
-      "r70": "Une erreur est survenue. Déconnectez-vous et recommencez."
+      "r70": "Une erreur est survenue. Déconnectez-vous et recommencez.",
+      "r90": {
+        "account-belonging-to-another-user": "Il semblerait qu'un élève utilise déjà ce compte.",
+        "details": {
+          "if-account-belonging-to-user": "Si le compte vous appartient bien,",
+          "contact-support": {
+            "link-text": " contactez le support ",
+            "link-url": "https://support.pix.org/fr/support/tickets/new"
+          },
+          "code": "(en spécifiant le code R90)",
+          "disconnect-user": "Sinon déconnectez-vous et rejoignez la campagne depuis votre compte"
+        }
+      }
     },
     "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
     "register-error": {


### PR DESCRIPTION
## 🤯 Scénario
La grande soeur, Emmy Barbier (né le 01/02/2008), est au Lycée Nigth Watch (1234567B) possède déjà un compte Pix et a participé un parcours que son prof lui a fait faire. Elle est donc bien rattaché à son établissement (le Lycée).

Son petit frère, Nicolas Barbier (né le 01/02/2010), est au Collège Night Watch (1234567A), ne possède pas encore de compte Pix. Son prof lui a filé un code pour faire un parcours. Il va sur l'ordi de la maison et lance l'url `/campagnes/SCOBADGE1` pour faire son parcours. 
Après avoir remplis ses infos pour rejoindre son établissement, il tombe sur la pop-up suivante : 
<img width="790" alt="image" src="https://user-images.githubusercontent.com/38167520/159037121-563d618b-2ea4-4654-a25d-65cc96ec32b6.png">
Comme Nicolas est étourdis ou qu'il se fiche de lire la pop-up, clique sur "Associer". Il ne comprend pas qu'il est en train de lier son parcours / son identité d'élève au compte de sa soeur.

Côté Pix Admin, on retrouve donc le compte (initialement de la grande soeur) à être associé avec les informations d'étudiant de son frère : 
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/38167520/159037661-beda3bfe-40fa-4502-8068-2ff35a6f1715.png">


## :unicorn: Problème
Deux élèves (différents) dans des établissements différents peuvent se relier au même compte.

Scénario qui va plus loin : 
Sachant qu'un élève peut demander à son prof de lui réinitialiser son mot de passe, il y a des cas où pour utiliser le même compte, un frère et une soeur demandent systématiquement à leur prof de réinitialiser leur mot de passe ou alors ils se partagent entre eux le mot de passe.

## :robot: Solution
Lors du rattachement du compte d'un élève à nouvel établissement, vérifier si l'élève qui essaie de s'y rattacher semble être la même personne que la personne possédant le compte.

Pour déterminer si cette personne est la même on se propose de :
- comparer les INE. Si INE de l'utilisateur != INE enregistré dans le compte => on jette une erreur. Sinon on passe à la comparaison des dates de naissance.
- comparer les date de naissance. Si date de naissance de l'utilisateur != date de naissance enregistré dans le compte => on jette une erreur. Sinon on réconcilie.

Autrement dit, on souhaite bloquer le rattachement d'un schooling registration à un compte possédant déjà un schooling registration et dont l'INE ou la date de naissance est différente.

## :rainbow: Remarques
Les données du scénario décrit plus haut ont été rajouté dans les seeds.

## :100: Pour tester
PART 1 - La grande soeur utilise Pix et laisse sa session ouverte
- Lancer Pix App
- Se connecter avec `emmy.barbier@example.net` et `pix123`

PART 2 - Le petit frère prend le relais sur l'ordi sans déconnecter le compte de sa soeur
- Cliquer sur "J'ai un code"
- Coller le `SCOBADGE1` (qui est une campagne du Collège Night Watch dont fait partis Nicolas - mais pas Emmy)
(ou coller directement l'url `/campagnes/SCOBADGE1`) 
- Cliquer sur "Je commence"
- Remplissez les informations (Nicolas Barbier 01/02/2010)
- Constater qu'une pop-up avec le nouveau message apparaît.
<img width="799" alt="Capture d’écran 2022-03-25 à 09 51 59" src="https://user-images.githubusercontent.com/58915422/160087773-f6735916-fa48-49e9-b363-95c980aeefb1.png">



Relancer les seeds : `scalingo -a pix-api-review-pr4219 --region osc-fr1 run "npm run db:seed"`