### PR TITLE
[TECH] Monter pix-ui en v11 sur mon-pix (PIX-4614)

### DIFF
--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -19,13 +19,17 @@
     <div class="account-recovery__content--form-fields">
       <div class="student-information-form__tooltip">
         <PixTooltip
-          @text={{t "pages.account-recovery.find-sco-record.student-information.form.tooltip" htmlSafe=true}}
           @position="top-left"
           @isLight={{true}}
           @isWide={{true}}
           aria-label={{t "pages.account-recovery.find-sco-record.student-information.form.tooltip" htmlSafe=true}}
         >
-          <FaIcon @icon="question-circle" />
+          <:triggerElement>
+            <FaIcon @icon="question-circle" tabindex="0" />
+          </:triggerElement>
+          <:tooltip>
+            {{t "pages.account-recovery.find-sco-record.student-information.form.tooltip" htmlSafe=true}}
+          </:tooltip>
         </PixTooltip>
       </div>
       <FormTextfield

--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -1,31 +1,29 @@
-<PixTooltip
-  @text="<div class='hexagon-score__information hexagon-score-information__text'>
-          <p class='hexagon-score-information__text--strong'>
-            {{t "pages.profile.total-score-helper.title"}}
-          </p>
-          {{t
-    "pages.profile.total-score-helper.explanation"
-    maxReachablePixCount=this.maxReachablePixCount
-    maxReachableLevel=this.maxReachableLevel
-    htmlSafe=true
-  }}
-         </div>
-        "
-  @isLight={{true}}
-  @isWide={{true}}
-  @position="bottom"
-  @unescapeHtml={{true}}
->
-  <div class="hexagon-score" tabindex="0">
-    <div class="hexagon-score__content">
-      <div class="hexagon-score-content__title">{{t "common.pix"}}</div>
-      <div class="hexagon-score-content__pix-score">{{this.score}}</div>
-      <div class="hexagon-score-content__pix-total">
-        1024
-        <div class="hexagon-score-content-pix-total__icon">
-          <FaIcon @icon="info-circle" />
+<PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
+  <:triggerElement>
+    <div class="hexagon-score" tabindex="0" aria-describedby="hexagon-score-tooltip">
+      <div class="hexagon-score__content">
+        <div class="hexagon-score-content__title">{{t "common.pix"}}</div>
+        <div class="hexagon-score-content__pix-score">{{this.score}}</div>
+        <div class="hexagon-score-content__pix-total">
+          1024
+          <div class="hexagon-score-content-pix-total__icon">
+            <FaIcon @icon="info-circle" />
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </:triggerElement>
+  <:tooltip>
+    <div class="hexagon-score__information hexagon-score-information__text">
+      <p class="hexagon-score-information__text--strong">
+        {{t "pages.profile.total-score-helper.title"}}
+      </p>
+      {{t
+        "pages.profile.total-score-helper.explanation"
+        maxReachablePixCount=this.maxReachablePixCount
+        maxReachableLevel=this.maxReachableLevel
+        htmlSafe=true
+      }}
+    </div>
+  </:tooltip>
 </PixTooltip>

--- a/mon-pix/app/components/user-account/email-with-validation-form.hbs
+++ b/mon-pix/app/components/user-account/email-with-validation-form.hbs
@@ -7,7 +7,7 @@
       @errorMessage={{this.newEmailValidationMessage}}
       @value={{this.newEmail}}
       type="email"
-      {{on "focusout" this.validateNewEmail}}
+      {{on "change" this.validateNewEmail}}
       autocomplete="off"
       required
     />
@@ -19,7 +19,7 @@
     <PixInputPassword
       @id="update-email-with-validation__password"
       @label={{t "pages.user-account.account-update-email-with-validation.fields.password.label"}}
-      @value={{this.password}}
+      {{on "change" this.passwordChanged}}
       autocomplete="off"
       required
     />

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -28,7 +28,8 @@ export default class EmailWithValidationForm extends Component {
   }
 
   @action
-  validateNewEmail() {
+  validateNewEmail(event) {
+    this.newEmail = event.target.value;
     this.newEmail = this.newEmail.trim();
     const isInvalidInput = !isEmailValid(this.newEmail);
 
@@ -64,6 +65,11 @@ export default class EmailWithValidationForm extends Component {
         this.hasRequestedUpdate = false;
       }
     }
+  }
+
+  @action
+  passwordChanged(event) {
+    this.password = event.target.value;
   }
 
   handleSubmitError(response) {

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -50,19 +50,25 @@
           <p class="verification-code__code">{{@certification.verificationCode}}</p>
 
           {{#if (is-clipboard-supported)}}
-            <PixTooltip @text={{this.tooltipText}} @position="bottom" @isInline={{true}}>
-              <CopyButton
-                @clipboardText={{@certification.verificationCode}}
-                @success={{this.clipboardSuccess}}
-                @classNames="icon-button"
-              >
-                <FaIcon
-                  class="verification-code__copy-button"
-                  @icon="copy"
-                  @prefix="far"
-                  alt={{t "pages.certificate.verification-code.alt"}}
-                />
-              </CopyButton>
+            <PixTooltip @position="bottom" @isInline={{true}} @id="verification-code-copy-button-tooltip">
+              <:triggerElement>
+                <CopyButton
+                  @clipboardText={{@certification.verificationCode}}
+                  @success={{this.clipboardSuccess}}
+                  @classNames="icon-button"
+                  aria-describedby="verification-code-copy-button-tooltip"
+                >
+                  <FaIcon
+                    class="verification-code__copy-button"
+                    @icon="copy"
+                    @prefix="far"
+                    alt={{t "pages.certificate.verification-code.alt"}}
+                  />
+                </CopyButton>
+              </:triggerElement>
+              <:tooltip>
+                {{this.tooltipText}}
+              </:tooltip>
             </PixTooltip>
           {{/if}}
         </span>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.185.0",
+      "version": "3.186.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
+        "@1024pix/pix-ui": "^11.2.0",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^1.0.2",
@@ -70,7 +71,7 @@
         "ember-route-action-helper": "^2.0.8",
         "ember-simple-auth": "^3.0.0",
         "ember-sinon": "^5.0.0",
-        "ember-source": "^3.24.5",
+        "ember-source": "^3.25.4",
         "ember-template-lint": "^3.6.0",
         "ember-template-lint-plugin-prettier": "^2.0.1",
         "ember-test-selectors": "^6.0.0",
@@ -90,7 +91,6 @@
         "lodash": "^4.17.21",
         "npm-run-all": "^4.1.5",
         "p-queue": "^6.6.2",
-        "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v10.0.0",
         "prettier": "^2.4.1",
         "sass": "^1.38.0",
         "showdown": "^1.9.1",
@@ -102,6 +102,24 @@
       "engines": {
         "node": "16.14.0",
         "npm": "8.3.1"
+      }
+    },
+    "node_modules/@1024pix/pix-ui": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-11.2.0.tgz",
+      "integrity": "sha512-ouRN7m8W8YT5T/3vW0zubP9iFeRwX39Srq66aeY4zDx0yqpRrd3Y5zpHa/LjALNbCJHM5qC7Kwon4J7ddoi7mQ==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.6.2",
+        "ember-cli-sass": "^10.0.1",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-click-outside": "^2.0.0",
+        "ember-prop-modifier": "^1.0.1",
+        "ember-truth-helpers": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.13.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8692,6 +8710,15 @@
         "@glimmer/util": "^0.42.2"
       }
     },
+    "node_modules/@glimmer/vm-babel-plugins": {
+      "version": "0.77.5",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz",
+      "integrity": "sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-debug-macros": "^0.3.4"
+      }
+    },
     "node_modules/@glimmer/vm/node_modules/@glimmer/interfaces": {
       "version": "0.42.2",
       "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.42.2.tgz",
@@ -12062,9 +12089,9 @@
       }
     },
     "node_modules/babel-plugin-debug-macros": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz",
-      "integrity": "sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
+      "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
       "dev": true,
       "dependencies": {
         "semver": "^5.3.0"
@@ -18509,21 +18536,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/ember-cli-babel/node_modules/babel-plugin-debug-macros": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
-      "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/ember-cli-babel/node_modules/babel-plugin-ember-modules-api-polyfill": {
@@ -26725,6 +26737,19 @@
         "node": "10.* || >= 12"
       }
     },
+    "node_modules/ember-prop-modifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-prop-modifier/-/ember-prop-modifier-1.0.1.tgz",
+      "integrity": "sha512-IbWHOY1MtEFwA5oMC+54CiTh0TuhMDIE6Z+QyX9pYvIOpr+BJsDphujPw9697Dt/0EK3PE41ZWllI8G4Butd/w==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier": "^2.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
     "node_modules/ember-require-module": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
@@ -27371,15 +27396,16 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.24.5.tgz",
-      "integrity": "sha512-j39L7C+q9o9qkwrwNtRN1AVGzE8TlxHm0c6xMzFZFaWMyQt3E7ov72fz3oIn17h8H7zZ1i7dl471Rbqx1GZsLw==",
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.4.tgz",
+      "integrity": "sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-transform-block-scoping": "^7.8.3",
         "@babel/plugin-transform-object-assign": "^7.8.3",
         "@ember/edition-utils": "^1.2.0",
+        "@glimmer/vm-babel-plugins": "0.77.5",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
         "broccoli-concat": "^4.2.4",
@@ -36105,24 +36131,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pix-ui": {
-      "version": "10.0.0",
-      "resolved": "https://github.com/1024pix/pix-ui/tarball/v10.0.0",
-      "integrity": "sha512-bR/XHTY5/0SwujvhF4yop2at1NVAM/qKhefzKEtKqyKYCVhPHwSwQssIcFQ1VDiLOKWJFwkCVV3cWo4FmtOXZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
-        "ember-truth-helpers": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.16.0"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -41776,6 +41784,21 @@
     }
   },
   "dependencies": {
+    "@1024pix/pix-ui": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-11.2.0.tgz",
+      "integrity": "sha512-ouRN7m8W8YT5T/3vW0zubP9iFeRwX39Srq66aeY4zDx0yqpRrd3Y5zpHa/LjALNbCJHM5qC7Kwon4J7ddoi7mQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.6.2",
+        "ember-cli-sass": "^10.0.1",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-click-outside": "^2.0.0",
+        "ember-prop-modifier": "^1.0.1",
+        "ember-truth-helpers": "^3.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -48895,6 +48918,15 @@
         }
       }
     },
+    "@glimmer/vm-babel-plugins": {
+      "version": "0.77.5",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz",
+      "integrity": "sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-debug-macros": "^0.3.4"
+      }
+    },
     "@glimmer/wire-format": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.27.0.tgz",
@@ -51673,9 +51705,9 @@
       }
     },
     "babel-plugin-debug-macros": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz",
-      "integrity": "sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
+      "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -58092,15 +58124,6 @@
             "to-fast-properties": "^2.0.0"
           }
         },
-        "babel-plugin-debug-macros": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
-          "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.5.0.tgz",
@@ -63716,6 +63739,16 @@
         "ember-cli-babel": "^7.23.1"
       }
     },
+    "ember-prop-modifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-prop-modifier/-/ember-prop-modifier-1.0.1.tgz",
+      "integrity": "sha512-IbWHOY1MtEFwA5oMC+54CiTh0TuhMDIE6Z+QyX9pYvIOpr+BJsDphujPw9697Dt/0EK3PE41ZWllI8G4Butd/w==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier": "^2.1.1"
+      }
+    },
     "ember-require-module": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
@@ -64255,15 +64288,16 @@
       }
     },
     "ember-source": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.24.5.tgz",
-      "integrity": "sha512-j39L7C+q9o9qkwrwNtRN1AVGzE8TlxHm0c6xMzFZFaWMyQt3E7ov72fz3oIn17h8H7zZ1i7dl471Rbqx1GZsLw==",
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.4.tgz",
+      "integrity": "sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-transform-block-scoping": "^7.8.3",
         "@babel/plugin-transform-object-assign": "^7.8.3",
         "@ember/edition-utils": "^1.2.0",
+        "@glimmer/vm-babel-plugins": "0.77.5",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
         "broccoli-concat": "^4.2.4",
@@ -71200,19 +71234,6 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "pix-ui": {
-      "version": "https://github.com/1024pix/pix-ui/tarball/v10.0.0",
-      "integrity": "sha512-bR/XHTY5/0SwujvhF4yop2at1NVAM/qKhefzKEtKqyKYCVhPHwSwQssIcFQ1VDiLOKWJFwkCVV3cWo4FmtOXZA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
-        "ember-truth-helpers": "^3.0.0"
       }
     },
     "pkg-dir": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,6 +39,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
+    "@1024pix/pix-ui": "^11.2.0",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^1.0.2",
@@ -99,7 +100,7 @@
     "ember-route-action-helper": "^2.0.8",
     "ember-simple-auth": "^3.0.0",
     "ember-sinon": "^5.0.0",
-    "ember-source": "^3.24.5",
+    "ember-source": "^3.25.4",
     "ember-template-lint": "^3.6.0",
     "ember-template-lint-plugin-prettier": "^2.0.1",
     "ember-test-selectors": "^6.0.0",
@@ -119,7 +120,6 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "https://github.com/1024pix/pix-ui/tarball/v10.0.0",
     "prettier": "^2.4.1",
     "sass": "^1.38.0",
     "showdown": "^1.9.1",
@@ -127,6 +127,5 @@
     "stylelint-config-standard": "^22.0.0",
     "uuid": "^8.3.2",
     "xss": "^1.0.9"
-  },
-  "dependencies": {}
+  }
 }

--- a/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
@@ -12,10 +12,9 @@ describe('Unit | Component | user-account | email-with-validation-form', functio
       // given
       const emailWithSpaces = '   lea@example.net   ';
       const component = createGlimmerComponent('component:user-account/email-with-validation-form');
-      component.newEmail = emailWithSpaces;
 
       // when
-      component.validateNewEmail();
+      component.validateNewEmail({ target: { value: emailWithSpaces } });
 
       // then
       expect(component.newEmail).to.equal(emailWithSpaces.trim());


### PR DESCRIPTION
## :unicorn: Problème

mon-pix a trois versions de retard sur pix-ui.

## :robot: Solution

Upgrade pix-ui en v11.

S'accompagne également d'une montée de version ember-source en v3.25.4

## :rainbow: Remarques

Les breakings changes pour la v11 :
 - Refactoring du composant Tooltip
 - Changement de la gestion des events sur PixInput

## :100: Pour tester

 - Vérifier que le nombre de pix et sa tooltip s'affichent toujours correctement sur le dashboard
 - Aller sur https://app-pr4220.review.pix.fr/recuperer-mon-compte et vérifier que la tooltip du petit point d'interrogation fonctionne correctement
 - Se connecter avec `certif-success@example.net`, aller dans "Mes certifications" puis sur "Voir les résultats" de la certification obtenue, vérifier que la tooltip du bouton de Copier/Coller du code fonctionne correctement
 - Dans Mon compte > Mes méthodes de connexion, vérifier que le formulaire de changement d'email (avec vérification, variable d'env `FT_VALIDATE_EMAIL` passée à `true` sur la RA) fonctionne correctement, au niveau des inputs mail et passwords puis validation du formulaire.
