### PR TITLE
[TECH] Monter de version de Pix-UI dans Pix Admin (Pix-4604).

### DIFF
--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -18,5 +18,9 @@
       text-overflow: ellipsis;
       overflow: hidden;
     }
+
+    .form-actions {
+      padding-bottom: 2px;
+    }
   }
 }

--- a/admin/app/styles/components/organizations/archiving-confirmation-modal.scss
+++ b/admin/app/styles/components/organizations/archiving-confirmation-modal.scss
@@ -7,8 +7,4 @@
   ul.archiving-confirmation-modal__list {
     margin: 0 0 10px 10px;
   }
-
-  &__overlay {
-    z-index: 1000;
-  }
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "pix-admin",
-      "version": "3.183.0",
+      "version": "3.188.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/ember-testing-library": "^0.4.0",
-        "@1024pix/pix-ui": "^13.3.3",
+        "@1024pix/ember-testing-library": "^0.5.0",
+        "@1024pix/pix-ui": "^13.3.4",
         "@ember/jquery": "^1.1.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.2.0",
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@1024pix/ember-testing-library": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.4.0.tgz",
-      "integrity": "sha512-T0Ls/kodHErWPV5NbsrwyntH25CLkna5SkYHAWkf9R1EmbHLOwJLKzmLe0Hd5Xkf14V/zJ7teqM8+76bD2GYPg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.5.0.tgz",
+      "integrity": "sha512-CGlNllnB1TUW+MSjp9B1NT78cI4zha2eUtMWx9TptH4rvNxuP7tplUXHgkNYpqp+M+lhhv7jgr4UkpcOYE2sbg==",
       "dev": true,
       "dependencies": {
         "@testing-library/dom": "^8.9.0",
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "13.3.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.3.tgz",
-      "integrity": "sha512-V1vLopenqM0BWT9wBoHrqBLMCGxqaToX7hiQrbev1zJ5NZl4Us09E4chA1NBL/5cUWwz05V1SK6Aa+7e86Xy6Q==",
+      "version": "13.3.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.4.tgz",
+      "integrity": "sha512-Sj++Y14AUQf9dI9Ql6wA2WfB3pDhNleoGMlAlW1cglASJxyU4c2QPbBkUqpuD8MX9CICaXhke7jCK7WKeoc/fA==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -39653,9 +39653,9 @@
           }
         },
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -39744,9 +39744,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "13.3.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.3.tgz",
-      "integrity": "sha512-V1vLopenqM0BWT9wBoHrqBLMCGxqaToX7hiQrbev1zJ5NZl4Us09E4chA1NBL/5cUWwz05V1SK6Aa+7e86Xy6Q==",
+      "version": "13.3.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.4.tgz",
+      "integrity": "sha512-Sj++Y14AUQf9dI9Ql6wA2WfB3pDhNleoGMlAlW1cglASJxyU4c2QPbBkUqpuD8MX9CICaXhke7jCK7WKeoc/fA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -44541,6 +44541,70 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@jest/types": {
+      "version": "27.2.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
+      "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@miragejs/pretender-node-polyfill": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
@@ -44644,9 +44708,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
-      "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
+      "integrity": "sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -44660,9 +44724,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -44856,6 +44920,30 @@
         "@types/node": "*"
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -44958,6 +45046,21 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -49769,9 +49872,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
-      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
+      "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
       "dev": true
     },
     "dom-serializer": {
@@ -66469,11 +66572,12 @@
       }
     },
     "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "27.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
+      "integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
       "dev": true,
       "requires": {
+        "@jest/types": "^27.2.5",
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"

--- a/admin/package.json
+++ b/admin/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^13.3.3",
+    "@1024pix/pix-ui": "^13.3.4",
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",


### PR DESCRIPTION
## :unicorn: Problème
Il manquait un `z-index` sur le composant PixModal et des éléments de la page dans Pix-Admin se plaçait au dessus. Pour corriger ça, on avait temporairement surchargé la class `pix-modal` pour rajouter le z-index.

## :robot: Solution
Le `z-index` a été rajouté à PixModal dans Pix-UI v.13.3.4. Utiliser cette version dans Pix Admin et nettoyer le css pour enlever la surcharge temporaire

## :rainbow: Remarques
RAS

## :100: Pour tester
- Connecter vous a PixAdmin avec un compte pixmaster
- Cliquer sur une orga non-archivée pour voir ses détails
- Cliquer sur `Archiver l'organisation`
- Vérifier qu'aucun élément de la page ne se place au dessus de la modal
