### PR TITLE
[FEATURE] Ne plus prendre en compte les participations supprimées dans le rapport d'analyse d'une campagne (PIX-4577)

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-analysis-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-analysis-repository.js
@@ -59,7 +59,7 @@ module.exports = {
 async function _getSharedParticipationsWithUserIdsAndDates(campaignId) {
   const results = await knex('campaign-participations')
     .select('userId', 'sharedAt')
-    .where({ campaignId, status: SHARED, isImproved: false });
+    .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
 
   const userIdsAndDates = [];
   for (const result of results) {

--- a/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
@@ -38,7 +38,7 @@ module.exports = {
 async function _getChunksSharedParticipationsWithUserIdsAndDates(campaignId) {
   const results = await knex('campaign-participations')
     .select('userId', 'sharedAt')
-    .where({ campaignId, status: SHARED, isImproved: false });
+    .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null });
 
   const userIdsAndDates = [];
   for (const result of results) {

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -107,10 +107,10 @@ module.exports = {
         'users.firstName AS ownerFirstName',
         'users.lastName AS ownerLastName',
         knex.raw(
-          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE) OVER (partition by "campaigns"."id") AS "participationsCount"'
+          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'
         ),
         knex.raw(
-          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."status" = \'SHARED\' AND "campaign-participations"."isImproved" IS FALSE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'
+          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."status" = \'SHARED\' AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'
         )
       )
       .join('users', 'users.id', 'campaigns.ownerId')

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -18,6 +18,18 @@ function _createUserWithSharedCampaignParticipation(userName, campaignId, shared
   return { userId, campaignParticipation };
 }
 
+function _createUserWithSharedCampaignParticipationDeleted(userName, campaignId, sharedAt, deletedAt) {
+  const userId = databaseBuilder.factory.buildUser({ firstName: userName }).id;
+  const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+    campaignId,
+    userId,
+    sharedAt,
+    deletedAt,
+  });
+
+  return { userId, campaignParticipation };
+}
+
 function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
   const userId = databaseBuilder.factory.buildUser({ firstName: userName }).id;
   const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
@@ -159,19 +171,10 @@ describe('Integration | Repository | Campaign collective result repository', fun
           );
 
           // then
-          const pickedAttributes = [
-            'areaCode',
-            'competenceId',
-            'id',
-            'competenceName',
-            'areaColor',
-            'targetedSkillsCount',
-            'averageValidatedSkills',
-          ];
           expect(result).to.be.an.instanceof(CampaignCollectiveResult);
           expect(result.id).to.equal(campaignId);
           const competenceACollectiveResult = result.campaignCompetenceCollectiveResults[0];
-          expect(_.pick(competenceACollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceACollectiveResult).to.deep.include({
             areaCode: '1',
             areaColor: 'jaffa',
             competenceId: 'recCompetenceA',
@@ -181,7 +184,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceBCollectiveResult = result.campaignCompetenceCollectiveResults[1];
-          expect(_.pick(competenceBCollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceBCollectiveResult).to.deep.include({
             areaCode: '1',
             areaColor: 'jaffa',
             competenceId: 'recCompetenceB',
@@ -191,7 +194,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceCCollectiveResult = result.campaignCompetenceCollectiveResults[2];
-          expect(_.pick(competenceCCollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceCCollectiveResult).to.deep.include({
             areaCode: '1',
             areaColor: 'jaffa',
             competenceId: 'recCompetenceC',
@@ -201,7 +204,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceECollectiveResult = result.campaignCompetenceCollectiveResults[3];
-          expect(_.pick(competenceECollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceECollectiveResult).to.deep.include({
             areaCode: '2',
             areaColor: 'emerald',
             competenceId: 'recCompetenceE',
@@ -211,7 +214,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceFCollectiveResult = result.campaignCompetenceCollectiveResults[4];
-          expect(_.pick(competenceFCollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceFCollectiveResult).to.deep.include({
             areaCode: '2',
             areaColor: 'emerald',
             competenceId: 'recCompetenceF',
@@ -254,19 +257,10 @@ describe('Integration | Repository | Campaign collective result repository', fun
           );
 
           // then
-          const pickedAttributes = [
-            'areaCode',
-            'competenceId',
-            'id',
-            'competenceName',
-            'areaColor',
-            'targetedSkillsCount',
-            'averageValidatedSkills',
-          ];
           expect(result).to.be.an.instanceof(CampaignCollectiveResult);
           expect(result.id).to.equal(campaignId);
           const competenceACollectiveResult = result.campaignCompetenceCollectiveResults[0];
-          expect(_.pick(competenceACollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceACollectiveResult).to.deep.include({
             areaCode: '1',
             areaColor: 'jaffa',
             competenceId: 'recCompetenceA',
@@ -276,7 +270,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceBCollectiveResult = result.campaignCompetenceCollectiveResults[1];
-          expect(_.pick(competenceBCollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceBCollectiveResult).to.deep.include({
             areaCode: '1',
             areaColor: 'jaffa',
             competenceId: 'recCompetenceB',
@@ -286,7 +280,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceCCollectiveResult = result.campaignCompetenceCollectiveResults[2];
-          expect(_.pick(competenceCCollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceCCollectiveResult).to.deep.include({
             areaCode: '1',
             areaColor: 'jaffa',
             competenceId: 'recCompetenceC',
@@ -296,7 +290,7 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceECollectiveResult = result.campaignCompetenceCollectiveResults[3];
-          expect(_.pick(competenceECollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceECollectiveResult).to.deep.include({
             areaCode: '2',
             areaColor: 'emerald',
             competenceId: 'recCompetenceE',
@@ -306,7 +300,91 @@ describe('Integration | Repository | Campaign collective result repository', fun
             averageValidatedSkills: 0,
           });
           const competenceFCollectiveResult = result.campaignCompetenceCollectiveResults[4];
-          expect(_.pick(competenceFCollectiveResult, pickedAttributes)).to.deep.equal({
+          expect(competenceFCollectiveResult).to.deep.include({
+            areaCode: '2',
+            areaColor: 'emerald',
+            competenceId: 'recCompetenceF',
+            id: `${campaignId}_recCompetenceF`,
+            competenceName: 'Competence F',
+            targetedSkillsCount: 1,
+            averageValidatedSkills: 0,
+          });
+        });
+      });
+
+      context('when there a deleted participations', function () {
+        beforeEach(function () {
+          const goliath = _createUserWithSharedCampaignParticipationDeleted(
+            'Fred',
+            campaignId,
+            new Date('2019-02-10'),
+            new Date('2022-01-01')
+          );
+
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId: goliath.userId,
+            competenceId: 'recCompetenceA',
+            skillId: 'recUrl1',
+            status: 'validated',
+            campaignId,
+            createdAt: new Date('2019-02-01'),
+          });
+
+          return databaseBuilder.commit();
+        });
+
+        it('should resolves a collective result synthesis with default values for all competences', async function () {
+          // when
+          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(
+            campaignId,
+            targetProfile
+          );
+
+          // then
+          expect(result).to.be.an.instanceof(CampaignCollectiveResult);
+          expect(result.id).to.equal(campaignId);
+          const competenceACollectiveResult = result.campaignCompetenceCollectiveResults[0];
+          expect(competenceACollectiveResult).to.deep.include({
+            areaCode: '1',
+            areaColor: 'jaffa',
+            competenceId: 'recCompetenceA',
+            id: `${campaignId}_recCompetenceA`,
+            competenceName: 'Competence A',
+            targetedSkillsCount: 5,
+            averageValidatedSkills: 0,
+          });
+          const competenceBCollectiveResult = result.campaignCompetenceCollectiveResults[1];
+          expect(competenceBCollectiveResult).to.deep.include({
+            areaCode: '1',
+            areaColor: 'jaffa',
+            competenceId: 'recCompetenceB',
+            id: `${campaignId}_recCompetenceB`,
+            competenceName: 'Competence B',
+            targetedSkillsCount: 4,
+            averageValidatedSkills: 0,
+          });
+          const competenceCCollectiveResult = result.campaignCompetenceCollectiveResults[2];
+          expect(competenceCCollectiveResult).to.deep.include({
+            areaCode: '1',
+            areaColor: 'jaffa',
+            competenceId: 'recCompetenceC',
+            id: `${campaignId}_recCompetenceC`,
+            competenceName: 'Competence C',
+            targetedSkillsCount: 1,
+            averageValidatedSkills: 0,
+          });
+          const competenceECollectiveResult = result.campaignCompetenceCollectiveResults[3];
+          expect(competenceECollectiveResult).to.deep.include({
+            areaCode: '2',
+            areaColor: 'emerald',
+            competenceId: 'recCompetenceE',
+            id: `${campaignId}_recCompetenceE`,
+            competenceName: 'Competence E',
+            targetedSkillsCount: 1,
+            averageValidatedSkills: 0,
+          });
+          const competenceFCollectiveResult = result.campaignCompetenceCollectiveResults[4];
+          expect(competenceFCollectiveResult).to.deep.include({
             areaCode: '2',
             areaColor: 'emerald',
             competenceId: 'recCompetenceF',


### PR DESCRIPTION
## :unicorn: Problème
Dans nos travaux de refonte du prescrit, une fois que nous avions harmoniser la gestion des prescrits dans les orgas PRO/SUP/SCO, import pas import, nous avons compris qu’il était essentiel de pouvoir supprimer une participation (entre autre afin de gérer certains cas contraignants de dissociation). 
C’est pourquoi nous allons dans cette épix mettre en place ce nouvel mécanisme de suppression.

## :robot: Solution
Ajouter la condition du deletedAt à null afin de ne pas prendre en compte les campaign-participations supprimé

## :rainbow: Remarques
RAS

## :100: Pour tester
Participer à une campagne. Vérifier dans l'onglet analyse de la campagne que la participation est prise en compte. Suprrimer sa participation. Vérifier qu'elle n'est plus prise en compte dans l'onglet analyse