### PR TITLE
[FEATURE] N'afficher que les certifications complementaires passées par le candidat (PIX-4510)

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -9,7 +9,6 @@ export const NOT_TAKEN = 'not_taken';
 export const partnerCertificationStatusToDisplayName = {
   [ACQUIRED]: 'Validée',
   [REJECTED]: 'Rejetée',
-  [NOT_TAKEN]: 'Non passée',
 };
 export const STARTED = 'started';
 export const ERROR = 'error';

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -57,48 +57,62 @@
               @edition={{false}}
               @label="Publiée :"
             />
-            <Certifications::InfoField
-              @value={{this.certification.cleaCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification CléA numérique :"
-              @class="certification-informations__complementary-certification--{{this.certification.cleaCertificationStatus}}"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.pixPlusDroitMaitreCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification Pix+ Droit Maître :"
-              @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitMaitreCertificationStatus}}"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.pixPlusDroitExpertCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification Pix+ Droit Expert :"
-              @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitExpertCertificationStatus}}"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.pixPlusEduInitieCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification Pix+ Édu Initié (entrée dans le métier) :"
-              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduInitieCertificationStatus}}"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.pixPlusEduConfirmeCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification Pix+ Édu Confirmé :"
-              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduConfirmeCertificationStatus}}"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.pixPlusEduAvanceCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification Pix+ Édu Avancé :"
-              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduAvanceCertificationStatus}}"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.pixPlusEduExpertCertificationStatusLabel}}
-              @edition={{false}}
-              @label="Certification Pix+ Édu Expert :"
-              @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduExpertCertificationStatus}}"
-            />
+            {{#if this.certification.cleaCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.cleaCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification CléA numérique :"
+                @class="certification-informations__complementary-certification--{{this.certification.cleaCertificationStatus}}"
+              />
+            {{/if}}
+            {{#if this.certification.pixPlusDroitMaitreCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.pixPlusDroitMaitreCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification Pix+ Droit Maître :"
+                @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitMaitreCertificationStatus}}"
+              />
+            {{/if}}
+            {{#if this.certification.pixPlusDroitExpertCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.pixPlusDroitExpertCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification Pix+ Droit Expert :"
+                @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitExpertCertificationStatus}}"
+              />
+            {{/if}}
+            {{#if this.certification.pixPlusEduInitieCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.pixPlusEduInitieCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification Pix+ Édu Initié (entrée dans le métier) :"
+                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduInitieCertificationStatus}}"
+              />
+            {{/if}}
+            {{#if this.certification.pixPlusEduConfirmeCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.pixPlusEduConfirmeCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification Pix+ Édu Confirmé :"
+                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduConfirmeCertificationStatus}}"
+              />
+            {{/if}}
+            {{#if this.certification.pixPlusEduAvanceCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.pixPlusEduAvanceCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification Pix+ Édu Avancé :"
+                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduAvanceCertificationStatus}}"
+              />
+            {{/if}}
+            {{#if this.certification.pixPlusEduExpertCertificationStatusLabel}}
+              <Certifications::InfoField
+                @value={{this.certification.pixPlusEduExpertCertificationStatusLabel}}
+                @edition={{false}}
+                @label="Certification Pix+ Édu Expert :"
+                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduExpertCertificationStatus}}"
+              />
+            {{/if}}
           </div>
         </div>
       </div>

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -63,6 +63,24 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
     assert.dom(screen.getByText('Code postal de naissance :')).exists();
     assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
+  });
+
+  test('it displays validated partner certifications', async function (assert) {
+    //given
+    certification.update({
+      cleaCertificationStatus: 'acquired',
+      pixPlusDroitMaitreCertificationStatus: 'acquired',
+      pixPlusDroitExpertCertificationStatus: 'acquired',
+      pixPlusEduInitieCertificationStatus: 'acquired',
+      pixPlusEduConfirmeCertificationStatus: 'acquired',
+      pixPlusEduAvanceCertificationStatus: 'acquired',
+      pixPlusEduExpertCertificationStatus: 'acquired',
+    });
+
+    // when
+    const screen = await visitScreen(`/certifications/${certification.id}`);
+
+    // then
     assert.dom(screen.getByText('Certification CléA numérique :')).exists();
     assert.dom(screen.getByText('Certification Pix+ Droit Maître :')).exists();
     assert.dom(screen.getByText('Certification Pix+ Droit Expert :')).exists();
@@ -70,7 +88,58 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     assert.dom(screen.getByText('Certification Pix+ Édu Confirmé :')).exists();
     assert.dom(screen.getByText('Certification Pix+ Édu Avancé :')).exists();
     assert.dom(screen.getByText('Certification Pix+ Édu Expert :')).exists();
-    assert.strictEqual(screen.getAllByText('Non passée').length, 7);
+    assert.strictEqual(screen.getAllByText('Validée').length, 7);
+  });
+
+  test('it displays rejected partner certifications', async function (assert) {
+    // given
+    certification.update({
+      cleaCertificationStatus: 'rejected',
+      pixPlusDroitMaitreCertificationStatus: 'rejected',
+      pixPlusDroitExpertCertificationStatus: 'rejected',
+      pixPlusEduInitieCertificationStatus: 'rejected',
+      pixPlusEduConfirmeCertificationStatus: 'rejected',
+      pixPlusEduAvanceCertificationStatus: 'rejected',
+      pixPlusEduExpertCertificationStatus: 'rejected',
+    });
+
+    // when
+    const screen = await visitScreen(`/certifications/${certification.id}`);
+
+    // then
+    assert.dom(screen.getByText('Certification CléA numérique :')).exists();
+    assert.dom(screen.getByText('Certification Pix+ Droit Maître :')).exists();
+    assert.dom(screen.getByText('Certification Pix+ Droit Expert :')).exists();
+    assert.dom(screen.getByText('Certification Pix+ Édu Initié (entrée dans le métier) :')).exists();
+    assert.dom(screen.getByText('Certification Pix+ Édu Confirmé :')).exists();
+    assert.dom(screen.getByText('Certification Pix+ Édu Avancé :')).exists();
+    assert.dom(screen.getByText('Certification Pix+ Édu Expert :')).exists();
+    assert.strictEqual(screen.getAllByText('Rejetée').length, 7);
+  });
+
+  test('it does not display not passed partner certifications', async function (assert) {
+    // given
+    certification.update({
+      cleaCertificationStatus: 'not_taken',
+      pixPlusDroitMaitreCertificationStatus: 'not_taken',
+      pixPlusDroitExpertCertificationStatus: 'not_taken',
+      pixPlusEduInitieCertificationStatus: 'not_taken',
+      pixPlusEduConfirmeCertificationStatus: 'not_taken',
+      pixPlusEduAvanceCertificationStatus: 'not_taken',
+      pixPlusEduExpertCertificationStatus: 'not_taken',
+    });
+
+    // when
+    const screen = await visitScreen(`/certifications/${certification.id}`);
+
+    // then
+    assert.dom(screen.queryByLabelText('Certification CléA numérique :')).doesNotExist();
+    assert.dom(screen.queryByLabelText('Certification Pix+ Droit Maître :')).doesNotExist();
+    assert.dom(screen.queryByLabelText('Certification Pix+ Droit Expert :')).doesNotExist();
+    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Initié (entrée dans le métier) :')).doesNotExist();
+    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Confirmé :')).doesNotExist();
+    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Avancé :')).doesNotExist();
+    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Expert :')).doesNotExist();
   });
 
   module('Candidate information edition', function () {

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -14,32 +14,47 @@ module('Unit | Model | certification', function (hooks) {
   const certificationStatusesAndExpectedLabel = new Map([
     [ACQUIRED, 'Validée'],
     [REJECTED, 'Rejetée'],
-    [NOT_TAKEN, 'Non passée'],
   ]);
 
   [
-    { name: 'cleaCertificationStatus', labelField: 'cleaCertificationStatusLabel' },
-    { name: 'pixPlusDroitMaitreCertificationStatus', labelField: 'pixPlusDroitMaitreCertificationStatusLabel' },
-    { name: 'pixPlusDroitExpertCertificationStatus', labelField: 'pixPlusDroitExpertCertificationStatusLabel' },
-    { name: 'pixPlusEduInitieCertificationStatus', labelField: 'pixPlusEduInitieCertificationStatusLabel' },
-    { name: 'pixPlusEduAvanceCertificationStatus', labelField: 'pixPlusEduAvanceCertificationStatusLabel' },
-    { name: 'pixPlusEduExpertCertificationStatus', labelField: 'pixPlusEduExpertCertificationStatusLabel' },
-    { name: 'pixPlusEduConfirmeCertificationStatus', labelField: 'pixPlusEduConfirmeCertificationStatusLabel' },
-  ].forEach(function ({ name, labelField }) {
-    module(`#${name}`, function () {
+    { domainName: 'cleaCertificationStatus', displayName: 'cleaCertificationStatusLabel' },
+    { domainName: 'pixPlusDroitMaitreCertificationStatus', displayName: 'pixPlusDroitMaitreCertificationStatusLabel' },
+    { domainName: 'pixPlusDroitExpertCertificationStatus', displayName: 'pixPlusDroitExpertCertificationStatusLabel' },
+    { domainName: 'pixPlusEduInitieCertificationStatus', displayName: 'pixPlusEduInitieCertificationStatusLabel' },
+    { domainName: 'pixPlusEduAvanceCertificationStatus', displayName: 'pixPlusEduAvanceCertificationStatusLabel' },
+    { domainName: 'pixPlusEduExpertCertificationStatus', displayName: 'pixPlusEduExpertCertificationStatusLabel' },
+    { domainName: 'pixPlusEduConfirmeCertificationStatus', displayName: 'pixPlusEduConfirmeCertificationStatusLabel' },
+  ].forEach(function ({ domainName, displayName }) {
+    module(`#${domainName}`, function () {
       certificationStatusesAndExpectedLabel.forEach((expectedLabel, status) => {
-        module(`when ${labelField} is ${status}`, function () {
-          test(`${name} should be ${expectedLabel}`, function (assert) {
+        module(`when ${displayName} is ${status}`, function () {
+          test(`${domainName} should be ${expectedLabel}`, function (assert) {
             // given
             const certification = store.createRecord('certification', {
-              [name]: status,
+              [domainName]: status,
             });
 
             // when
-            const label = certification[labelField];
+            const label = certification[displayName];
 
+            // then
             assert.strictEqual(label, expectedLabel);
           });
+        });
+      });
+
+      module(`when ${domainName} is not passed`, function () {
+        test(`${domainName} should be hidden`, function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            [domainName]: NOT_TAKEN,
+          });
+
+          // when
+          const label = certification[displayName];
+
+          // then
+          assert.false(Boolean(label));
         });
       });
     });

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -11,171 +11,35 @@ module('Unit | Model | certification', function (hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('#cleaCertificationStatusLabel', function () {
-    const cleaStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    cleaStatusesAndExpectedLabel.forEach((expectedLabel, cleaStatus) => {
-      module(`when cleaCertificationStatus is ${cleaStatus}`, function () {
-        test(`cleaCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            cleaCertificationStatus: cleaStatus,
-          });
+  const certificationStatusesAndExpectedLabel = new Map([
+    [ACQUIRED, 'Validée'],
+    [REJECTED, 'Rejetée'],
+    [NOT_TAKEN, 'Non passée'],
+  ]);
 
-          // when
-          const label = certification.cleaCertificationStatusLabel;
-
-          assert.strictEqual(label, expectedLabel);
-        });
-      });
-    });
-  });
-
-  module('#pixPlusDroitMaitreCertificationStatusLabel', function () {
-    const pixPlusDroitMaitreStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    pixPlusDroitMaitreStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusDroitMaitreCertificationStatus) => {
-      module(`when pixPlusDroitMaitreCertificationStatus is ${pixPlusDroitMaitreCertificationStatus}`, function () {
-        test(`pixPlusDroitMaitreCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            pixPlusDroitMaitreCertificationStatus: pixPlusDroitMaitreCertificationStatus,
-          });
-
-          // when
-          const label = certification.pixPlusDroitMaitreCertificationStatusLabel;
-
-          // then
-          assert.strictEqual(label, expectedLabel);
-        });
-      });
-    });
-  });
-
-  module('#pixPlusDroitExpertCertificationStatusLabel', function () {
-    const pixPlusDroitExpertStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    pixPlusDroitExpertStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusDroitExpertCertificationStatus) => {
-      module(`when pixPlusDroitExpertCertificationStatus is ${pixPlusDroitExpertCertificationStatus}`, function () {
-        test(`pixPlusDroitMaitreCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            pixPlusDroitExpertCertificationStatus: pixPlusDroitExpertCertificationStatus,
-          });
-
-          // when
-          const label = certification.pixPlusDroitExpertCertificationStatusLabel;
-
-          // then
-          assert.strictEqual(label, expectedLabel);
-        });
-      });
-    });
-  });
-
-  module('#pixPlusEduInitieCertificationStatusLabel', function () {
-    const pixPlusEduInitieStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    pixPlusEduInitieStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduInitieCertificationStatus) => {
-      module(`when pixPlusEduInitieCertificationStatusLabel is ${pixPlusEduInitieCertificationStatus}`, function () {
-        test(`pixPlusEduInitieCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            pixPlusEduInitieCertificationStatus,
-          });
-
-          // when
-          const label = certification.pixPlusEduInitieCertificationStatusLabel;
-
-          // then
-          assert.strictEqual(label, expectedLabel);
-        });
-      });
-    });
-  });
-
-  module('#pixPlusEduConfirmeCertificationStatusLabel', function () {
-    const pixPlusEduConfirmeStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    pixPlusEduConfirmeStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduConfirmeCertificationStatus) => {
-      module(
-        `when pixPlusEduConfirmeCertificationStatusLabel is ${pixPlusEduConfirmeCertificationStatus}`,
-        function () {
-          test(`pixPlusEduConfirmeCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
+  [
+    { name: 'cleaCertificationStatus', labelField: 'cleaCertificationStatusLabel' },
+    { name: 'pixPlusDroitMaitreCertificationStatus', labelField: 'pixPlusDroitMaitreCertificationStatusLabel' },
+    { name: 'pixPlusDroitExpertCertificationStatus', labelField: 'pixPlusDroitExpertCertificationStatusLabel' },
+    { name: 'pixPlusEduInitieCertificationStatus', labelField: 'pixPlusEduInitieCertificationStatusLabel' },
+    { name: 'pixPlusEduAvanceCertificationStatus', labelField: 'pixPlusEduAvanceCertificationStatusLabel' },
+    { name: 'pixPlusEduExpertCertificationStatus', labelField: 'pixPlusEduExpertCertificationStatusLabel' },
+    { name: 'pixPlusEduConfirmeCertificationStatus', labelField: 'pixPlusEduConfirmeCertificationStatusLabel' },
+  ].forEach(function ({ name, labelField }) {
+    module(`#${name}`, function () {
+      certificationStatusesAndExpectedLabel.forEach((expectedLabel, status) => {
+        module(`when ${labelField} is ${status}`, function () {
+          test(`${name} should be ${expectedLabel}`, function (assert) {
             // given
             const certification = store.createRecord('certification', {
-              pixPlusEduConfirmeCertificationStatus,
+              [name]: status,
             });
 
             // when
-            const label = certification.pixPlusEduConfirmeCertificationStatusLabel;
+            const label = certification[labelField];
 
-            // then
             assert.strictEqual(label, expectedLabel);
           });
-        }
-      );
-    });
-  });
-
-  module('#pixPlusEduAvanceCertificationStatusLabel', function () {
-    const pixPlusEduAvanceStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    pixPlusEduAvanceStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduAvanceCertificationStatus) => {
-      module(`when pixPlusEduAvanceCertificationStatusLabel is ${pixPlusEduAvanceCertificationStatus}`, function () {
-        test(`pixPlusEduAvanceCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            pixPlusEduAvanceCertificationStatus,
-          });
-
-          // when
-          const label = certification.pixPlusEduAvanceCertificationStatusLabel;
-
-          // then
-          assert.strictEqual(label, expectedLabel);
-        });
-      });
-    });
-  });
-
-  module('#pixPlusEduExpertCertificationStatusLabel', function () {
-    const pixPlusEduExpertStatusesAndExpectedLabel = new Map([
-      [ACQUIRED, 'Validée'],
-      [REJECTED, 'Rejetée'],
-      [NOT_TAKEN, 'Non passée'],
-    ]);
-    pixPlusEduExpertStatusesAndExpectedLabel.forEach((expectedLabel, pixPlusEduExpertCertificationStatus) => {
-      module(`when pixPlusEduExpertCertificationStatusLabel is ${pixPlusEduExpertCertificationStatus}`, function () {
-        test(`pixPlusEduExpertCertificationStatusLabel should be ${expectedLabel}`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            pixPlusEduExpertCertificationStatus,
-          });
-
-          // when
-          const label = certification.pixPlusEduExpertCertificationStatusLabel;
-
-          // then
-          assert.strictEqual(label, expectedLabel);
         });
       });
     });

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -28,10 +28,7 @@ module('Unit | Model | certification', function (hooks) {
           // when
           const label = certification.cleaCertificationStatusLabel;
 
-          // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(label, expectedLabel);
+          assert.strictEqual(label, expectedLabel);
         });
       });
     });
@@ -55,9 +52,7 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusDroitMaitreCertificationStatusLabel;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(label, expectedLabel);
+          assert.strictEqual(label, expectedLabel);
         });
       });
     });
@@ -81,9 +76,7 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusDroitExpertCertificationStatusLabel;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(label, expectedLabel);
+          assert.strictEqual(label, expectedLabel);
         });
       });
     });
@@ -107,9 +100,7 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusEduInitieCertificationStatusLabel;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(label, expectedLabel);
+          assert.strictEqual(label, expectedLabel);
         });
       });
     });
@@ -135,9 +126,7 @@ module('Unit | Model | certification', function (hooks) {
             const label = certification.pixPlusEduConfirmeCertificationStatusLabel;
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(label, expectedLabel);
+            assert.strictEqual(label, expectedLabel);
           });
         }
       );
@@ -162,9 +151,7 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusEduAvanceCertificationStatusLabel;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(label, expectedLabel);
+          assert.strictEqual(label, expectedLabel);
         });
       });
     });
@@ -188,9 +175,7 @@ module('Unit | Model | certification', function (hooks) {
           const label = certification.pixPlusEduExpertCertificationStatusLabel;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(label, expectedLabel);
+          assert.strictEqual(label, expectedLabel);
         });
       });
     });
@@ -207,9 +192,7 @@ module('Unit | Model | certification', function (hooks) {
       const isPublishedLabel = certification.publishedText;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(isPublishedLabel, 'Oui');
+      assert.strictEqual(isPublishedLabel, 'Oui');
     });
 
     test('it should return "non" when isPublished is false', function (assert) {
@@ -222,9 +205,7 @@ module('Unit | Model | certification', function (hooks) {
       const isPublishedLabel = certification.publishedText;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(isPublishedLabel, 'Non');
+      assert.strictEqual(isPublishedLabel, 'Non');
     });
   });
 
@@ -375,9 +356,7 @@ module('Unit | Model | certification', function (hooks) {
       const juryCertificationSummary = store.createRecord('certification', { completedAt: null });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(juryCertificationSummary.completionDate, null);
+      assert.strictEqual(juryCertificationSummary.completionDate, null);
     });
 
     test('it should a formatted date when completedAt is defined', function (assert) {
@@ -385,9 +364,7 @@ module('Unit | Model | certification', function (hooks) {
       const juryCertificationSummary = store.createRecord('certification', { completedAt: '2021-06-30 15:10:45' });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
+      assert.strictEqual(juryCertificationSummary.completionDate, '30/06/2021, 15:10:45');
     });
   });
 

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -26,7 +26,7 @@ url.pathname = '/postgres';
 
 PgClient.getClient(url.href).then(async (client) => {
   try {
-    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`);
+    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME} WITH (FORCE);`);
     logger.info('Database dropped');
     await client.end();
     process.exit(0);


### PR DESCRIPTION
## :unicorn: Problème
Sur la page admin d'une certification, on affiche la resultat de toutes les certifications complémentairse. 
Il y en a de plus en plus.
Pour autant, il est rare qu'un candidat en passe plus d'une à la fois.

## :robot: Solution
N'afficher que les certifications suivies 
<img width="475" alt="Screenshot 2022-03-22 at 08 55 06" src="https://user-images.githubusercontent.com/3769147/159433702-5bc5fe38-1980-46a5-81d1-1ffc9f3be777.png">


## :rainbow: Remarques
Refacto sur les tests

## :100: Pour tester

Se connecter sur [Pix admin](https://admin-pr4224.review.pix.fr/) et consulter la certification 200.

### Candidat avec une partie des certifications
S'assurer qu'on a 
> Certification CléA numérique : Validée
> Certification Pix+ Droit Maître : Validée

S'assurer que les autres certifications ne sont pas affichés.

### Candidat avec toutes les certifications

Les insérer en base
```sql
INSERT INTO 
	"public"."partner-certifications" ("certificationCourseId", "partnerKey", "acquired", "temporaryPartnerKey") 
VALUES
	  (200, 'PIX_DROIT_MAITRE_CERTIF', 't', NULL),
	  (200, 'PIX_DROIT_EXPERT_CERTIF', 'f', NULL),
	  (200, 'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT', 't', NULL),
	  (200, 'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE', 'f', NULL),
	  (200, 'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME', 't', NULL),
	  (200, 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME', 't', NULL),
	  (200, 'PIX_EMPLOI_CLEA', 't', NULL),
	  (200, 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE', 'f', NULL);
```

Vérifier qu'elles sont toutes affichées
