### PR TITLE
[FEATURE] Ne pas pouvoir repasser une collecte de profil à envoi multiple supprimé (PIX-4444)

### DIFF
--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -20,7 +20,12 @@ class SharedProfileForCampaign {
     this.sharedAt = campaignParticipation.sharedAt;
     this.pixScore = campaignParticipation.pixScore || 0;
     this.scorecards = this._buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId);
-    this.canRetry = this._computeCanRetry(campaignAllowsRetry, this.sharedAt, isRegistrationActive);
+    this.canRetry = this._computeCanRetry(
+      campaignAllowsRetry,
+      this.sharedAt,
+      isRegistrationActive,
+      campaignParticipation.deletedAt
+    );
   }
 
   _buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId) {
@@ -37,8 +42,8 @@ class SharedProfileForCampaign {
     });
   }
 
-  _computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive) {
-    return campaignAllowsRetry && Boolean(sharedAt) && isRegistrationActive;
+  _computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive, deletedAt) {
+    return campaignAllowsRetry && Boolean(sharedAt) && isRegistrationActive && !deletedAt;
   }
 }
 

--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -4,14 +4,7 @@ const Scorecard = require('./Scorecard');
 const { NoCampaignParticipationForUserAndCampaign } = require('../errors');
 
 class SharedProfileForCampaign {
-  constructor({
-    campaignParticipation,
-    campaignAllowsRetry,
-    isRegistrationActive,
-    userId,
-    competencesWithArea,
-    knowledgeElementsGroupedByCompetenceId,
-  }) {
+  constructor({ campaignParticipation }) {
     if (!campaignParticipation) {
       throw new NoCampaignParticipationForUserAndCampaign();
     }
@@ -19,13 +12,18 @@ class SharedProfileForCampaign {
     this.id = campaignParticipation.id;
     this.sharedAt = campaignParticipation.sharedAt;
     this.pixScore = campaignParticipation.pixScore || 0;
+  }
+
+  build({
+    campaignAllowsRetry,
+    isRegistrationActive,
+    competencesWithArea,
+    knowledgeElementsGroupedByCompetenceId,
+    userId,
+    deletedAt,
+  }) {
     this.scorecards = this._buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId);
-    this.canRetry = this._computeCanRetry(
-      campaignAllowsRetry,
-      this.sharedAt,
-      isRegistrationActive,
-      campaignParticipation.deletedAt
-    );
+    this.canRetry = this._computeCanRetry(campaignAllowsRetry, this.sharedAt, isRegistrationActive, deletedAt);
   }
 
   _buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId) {

--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -1,10 +1,40 @@
+const map = require('lodash/map');
+const isEmpty = require('lodash/isEmpty');
+const Scorecard = require('./Scorecard');
+const { NoCampaignParticipationForUserAndCampaign } = require('../errors');
+
 class SharedProfileForCampaign {
-  constructor({ id, sharedAt, pixScore, campaignAllowsRetry, isRegistrationActive, scorecards = [] }) {
-    this.id = id;
-    this.sharedAt = sharedAt;
-    this.scorecards = scorecards;
-    this.pixScore = pixScore || 0;
-    this.canRetry = this._computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive);
+  constructor({
+    campaignParticipation,
+    campaignAllowsRetry,
+    isRegistrationActive,
+    userId,
+    competencesWithArea,
+    knowledgeElementsGroupedByCompetenceId,
+  }) {
+    if (!campaignParticipation) {
+      throw new NoCampaignParticipationForUserAndCampaign();
+    }
+
+    this.id = campaignParticipation.id;
+    this.sharedAt = campaignParticipation.sharedAt;
+    this.pixScore = campaignParticipation.pixScore || 0;
+    this.scorecards = this._buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId);
+    this.canRetry = this._computeCanRetry(campaignAllowsRetry, this.sharedAt, isRegistrationActive);
+  }
+
+  _buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId) {
+    if (isEmpty(knowledgeElementsGroupedByCompetenceId)) return [];
+    return map(competencesWithArea, (competence) => {
+      const competenceId = competence.id;
+      const knowledgeElements = knowledgeElementsGroupedByCompetenceId[competenceId];
+
+      return Scorecard.buildFrom({
+        userId,
+        knowledgeElements,
+        competence,
+      });
+    });
   }
 
   _computeCanRetry(campaignAllowsRetry, sharedAt, isRegistrationActive) {

--- a/api/lib/domain/models/SharedProfileForCampaign.js
+++ b/api/lib/domain/models/SharedProfileForCampaign.js
@@ -1,29 +1,26 @@
 const map = require('lodash/map');
 const isEmpty = require('lodash/isEmpty');
 const Scorecard = require('./Scorecard');
-const { NoCampaignParticipationForUserAndCampaign } = require('../errors');
 
 class SharedProfileForCampaign {
-  constructor({ campaignParticipation }) {
-    if (!campaignParticipation) {
-      throw new NoCampaignParticipationForUserAndCampaign();
-    }
-
-    this.id = campaignParticipation.id;
-    this.sharedAt = campaignParticipation.sharedAt;
-    this.pixScore = campaignParticipation.pixScore || 0;
-  }
-
-  build({
+  constructor({
+    campaignParticipation,
     campaignAllowsRetry,
     isRegistrationActive,
     competencesWithArea,
     knowledgeElementsGroupedByCompetenceId,
     userId,
-    deletedAt,
   }) {
+    this.id = campaignParticipation?.id;
+    this.sharedAt = campaignParticipation?.sharedAt;
+    this.pixScore = campaignParticipation?.pixScore || 0;
     this.scorecards = this._buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId);
-    this.canRetry = this._computeCanRetry(campaignAllowsRetry, this.sharedAt, isRegistrationActive, deletedAt);
+    this.canRetry = this._computeCanRetry(
+      campaignAllowsRetry,
+      this.sharedAt,
+      isRegistrationActive,
+      campaignParticipation?.deletedAt
+    );
   }
 
   _buildScorecards(userId, competencesWithArea, knowledgeElementsGroupedByCompetenceId) {

--- a/api/lib/domain/read-models/SharedProfileForCampaign.js
+++ b/api/lib/domain/read-models/SharedProfileForCampaign.js
@@ -1,6 +1,6 @@
 const map = require('lodash/map');
 const isEmpty = require('lodash/isEmpty');
-const Scorecard = require('./Scorecard');
+const Scorecard = require('../models/Scorecard');
 
 class SharedProfileForCampaign {
   constructor({

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -1,4 +1,4 @@
-const SharedProfileForCampaign = require('../models/SharedProfileForCampaign');
+const SharedProfileForCampaign = require('../read-models/SharedProfileForCampaign');
 const { NoCampaignParticipationForUserAndCampaign } = require('../errors');
 
 module.exports = async function getUserProfileSharedForCampaign({

--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -1,4 +1,5 @@
 const SharedProfileForCampaign = require('../models/SharedProfileForCampaign');
+const { NoCampaignParticipationForUserAndCampaign } = require('../errors');
 
 module.exports = async function getUserProfileSharedForCampaign({
   userId,
@@ -15,9 +16,9 @@ module.exports = async function getUserProfileSharedForCampaign({
     userId,
   });
 
-  const sharedProfileForCampaign = new SharedProfileForCampaign({
-    campaignParticipation,
-  });
+  if (!campaignParticipation) {
+    throw new NoCampaignParticipationForUserAndCampaign();
+  }
 
   const [
     { multipleSendings: campaignAllowsRetry },
@@ -34,14 +35,12 @@ module.exports = async function getUserProfileSharedForCampaign({
     }),
   ]);
 
-  sharedProfileForCampaign.build({
+  return new SharedProfileForCampaign({
+    campaignParticipation,
     campaignAllowsRetry,
     isRegistrationActive,
     competencesWithArea,
     knowledgeElementsGroupedByCompetenceId,
     userId,
-    deletedAt: campaignParticipation.deletedAt,
   });
-
-  return sharedProfileForCampaign;
 };

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -10,9 +10,6 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
           campaignParticipation: {
             sharedAt: new Date('2020-01-01'),
           },
-        });
-
-        sharedProfileForCampaign.build({
           campaignAllowsRetry: true,
           isRegistrationActive: false,
         });
@@ -27,9 +24,6 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
           campaignParticipation: {
             sharedAt: new Date('2020-01-01'),
           },
-        });
-
-        sharedProfileForCampaign.build({
           campaignAllowsRetry: false,
           isRegistrationActive: true,
         });
@@ -41,13 +35,10 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
           campaignParticipation: {
             sharedAt: new Date('2020-01-01'),
+            deletedAt: new Date('2020-01-01'),
           },
-        });
-
-        sharedProfileForCampaign.build({
           campaignAllowsRetry: true,
           isRegistrationActive: true,
-          deletedAt: new Date('2020-01-01'),
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -61,9 +52,6 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
             campaignParticipation: {
               sharedAt: null,
             },
-          });
-
-          sharedProfileForCampaign.build({
             campaignAllowsRetry: true,
             isRegistrationActive: true,
           });
@@ -78,9 +66,6 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
             campaignParticipation: {
               sharedAt: new Date('2020-01-01'),
             },
-          });
-
-          sharedProfileForCampaign.build({
             campaignAllowsRetry: true,
             isRegistrationActive: true,
           });

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -1,8 +1,50 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 
 const SharedProfileForCampaign = require('../../../../lib/domain/models/SharedProfileForCampaign');
+const Scorecard = require('../../../../lib/domain/models/Scorecard');
 
 describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
+  describe('#scorecards', function () {
+    context('when participant has knowledge elements', function () {
+      it('return scorecards', function () {
+        const userId = 1;
+        const competence = { id: 1, name: 'Useful competence' };
+        const knowledgeElements = [domainBuilder.buildKnowledgeElement({ competenceId: competence.id })];
+        const expectedScorecard = Scorecard.buildFrom({ userId, competence, knowledgeElements });
+
+        const sharedProfileForCampaign = new SharedProfileForCampaign({
+          userId,
+          campaignParticipation: {
+            sharedAt: new Date('2020-01-01'),
+          },
+          competencesWithArea: [competence],
+          knowledgeElementsGroupedByCompetenceId: {
+            [competence.id]: knowledgeElements,
+          },
+        });
+
+        expect(sharedProfileForCampaign.scorecards).to.deep.equal([expectedScorecard]);
+      });
+    });
+
+    context('when participant does not have knowledge elements', function () {
+      it('return empty array', function () {
+        const userId = 1;
+        const competence = { id: 1, name: 'Useful competence' };
+
+        const sharedProfileForCampaign = new SharedProfileForCampaign({
+          userId,
+          campaignParticipation: {
+            sharedAt: new Date('2020-01-01'),
+          },
+          competencesWithArea: [competence],
+        });
+
+        expect(sharedProfileForCampaign.scorecards).to.deep.equal([]);
+      });
+    });
+  });
+
   describe('#canRetry', function () {
     context('when participant is disabled', function () {
       it('cannot retry', function () {

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -7,11 +7,14 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
     context('when participant is disabled', function () {
       it('cannot retry', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
-          campaignAllowsRetry: true,
-          isRegistrationActive: false,
           campaignParticipation: {
             sharedAt: new Date('2020-01-01'),
           },
+        });
+
+        sharedProfileForCampaign.build({
+          campaignAllowsRetry: true,
+          isRegistrationActive: false,
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -21,11 +24,14 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
     context('when the campaign does not allow retry', function () {
       it('return false', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
-          campaignAllowsRetry: false,
-          isRegistrationActive: true,
           campaignParticipation: {
             sharedAt: new Date('2020-01-01'),
           },
+        });
+
+        sharedProfileForCampaign.build({
+          campaignAllowsRetry: false,
+          isRegistrationActive: true,
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -33,12 +39,15 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
 
       it('returns false if campaign participation is deleted', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
-          campaignAllowsRetry: true,
-          isRegistrationActive: true,
           campaignParticipation: {
             sharedAt: new Date('2020-01-01'),
-            deletedAt: new Date('2020-01-01'),
           },
+        });
+
+        sharedProfileForCampaign.build({
+          campaignAllowsRetry: true,
+          isRegistrationActive: true,
+          deletedAt: new Date('2020-01-01'),
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -49,11 +58,14 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
       context('when participation is not shared', function () {
         it('return false', function () {
           const sharedProfileForCampaign = new SharedProfileForCampaign({
-            campaignAllowsRetry: true,
-            isRegistrationActive: true,
             campaignParticipation: {
               sharedAt: null,
             },
+          });
+
+          sharedProfileForCampaign.build({
+            campaignAllowsRetry: true,
+            isRegistrationActive: true,
           });
 
           expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -63,12 +75,14 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
       context('when the profile has been shared', function () {
         it('return true', function () {
           const sharedProfileForCampaign = new SharedProfileForCampaign({
-            campaignAllowsRetry: true,
-            isRegistrationActive: true,
-            sharedAt: new Date('2020-01-01'),
             campaignParticipation: {
               sharedAt: new Date('2020-01-01'),
             },
+          });
+
+          sharedProfileForCampaign.build({
+            campaignAllowsRetry: true,
+            isRegistrationActive: true,
           });
 
           expect(sharedProfileForCampaign.canRetry).to.equal(true);

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -9,8 +9,9 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
           campaignAllowsRetry: true,
           isRegistrationActive: false,
-          scorecards: [],
-          sharedAt: new Date('2020-01-01'),
+          campaignParticipation: {
+            sharedAt: new Date('2020-01-01'),
+          },
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -22,8 +23,9 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
         const sharedProfileForCampaign = new SharedProfileForCampaign({
           campaignAllowsRetry: false,
           isRegistrationActive: true,
-          scorecards: [],
-          sharedAt: new Date('2020-01-01'),
+          campaignParticipation: {
+            sharedAt: new Date('2020-01-01'),
+          },
         });
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -36,8 +38,9 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
           const sharedProfileForCampaign = new SharedProfileForCampaign({
             campaignAllowsRetry: true,
             isRegistrationActive: true,
-            scorecards: [],
-            sharedAt: null,
+            campaignParticipation: {
+              sharedAt: null,
+            },
           });
 
           expect(sharedProfileForCampaign.canRetry).to.equal(false);
@@ -49,8 +52,10 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
           const sharedProfileForCampaign = new SharedProfileForCampaign({
             campaignAllowsRetry: true,
             isRegistrationActive: true,
-            scorecards: [],
             sharedAt: new Date('2020-01-01'),
+            campaignParticipation: {
+              sharedAt: new Date('2020-01-01'),
+            },
           });
 
           expect(sharedProfileForCampaign.canRetry).to.equal(true);

--- a/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/models/SharedProfileForCampaign_test.js
@@ -30,6 +30,19 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
 
         expect(sharedProfileForCampaign.canRetry).to.equal(false);
       });
+
+      it('returns false if campaign participation is deleted', function () {
+        const sharedProfileForCampaign = new SharedProfileForCampaign({
+          campaignAllowsRetry: true,
+          isRegistrationActive: true,
+          campaignParticipation: {
+            sharedAt: new Date('2020-01-01'),
+            deletedAt: new Date('2020-01-01'),
+          },
+        });
+
+        expect(sharedProfileForCampaign.canRetry).to.equal(false);
+      });
     });
 
     context('when participant is  active', function () {

--- a/api/tests/unit/domain/read-models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/read-models/SharedProfileForCampaign_test.js
@@ -1,6 +1,6 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 
-const SharedProfileForCampaign = require('../../../../lib/domain/models/SharedProfileForCampaign');
+const SharedProfileForCampaign = require('../../../../lib/domain/read-models/SharedProfileForCampaign');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
 
 describe('Unit | Domain | Models | SharedProfileForCampaign', function () {

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -5,12 +5,6 @@ const { NoCampaignParticipationForUserAndCampaign } = require('../../../../lib/d
 
 describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
   const sharedAt = new Date('2020-02-01');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const userId = Symbol('user id');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const campaignId = Symbol('campaign id');
   const expectedCampaignParticipation = { id: '1', sharedAt, pixScore: 15 };
   const locale = 'fr';
 
@@ -19,9 +13,13 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
   let competenceRepository;
   let campaignRepository;
   let schoolingRegistrationRepository;
+  let userId;
+  let campaignId;
 
   context('When user has shared its profile for the campaign', function () {
     beforeEach(function () {
+      userId = Symbol('user id');
+      campaignId = Symbol('campaign id');
       campaignParticipationRepository = { findOneByCampaignIdAndUserId: sinon.stub() };
       knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
       competenceRepository = { listPixCompetencesOnly: sinon.stub() };
@@ -94,6 +92,7 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
         knowledgeElementRepository,
         competenceRepository,
         campaignRepository,
+        schoolingRegistrationRepository,
       });
 
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -13,198 +13,141 @@ describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer',
     clock = sinon.useFakeTimers(now);
   });
 
+  let profileSharedForCampaign;
   describe('#serialize()', function () {
-    const area1 = {
-      id: '1',
-      code: '1',
-      title: '1',
-      color: '1',
-    };
-    const area2 = {
-      id: '2',
-      code: '2',
-      title: '2',
-      color: '2',
-    };
-    const expectedScorecards = [
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      domainBuilder.buildUserScorecard({ id: 'rec1', area: area1 }),
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      domainBuilder.buildUserScorecard({ id: 'rec2', area: area2 }),
-    ];
+    beforeEach(function () {
+      const area1 = {
+        id: '1',
+        code: '1',
+        title: '1',
+        color: '1',
+      };
+      const area2 = {
+        id: '2',
+        code: '2',
+        title: '2',
+        color: '2',
+      };
 
-    const profileSharedForCampaign = new SharedProfileForCampaign({
-      id: '1',
-      sharedAt: new Date('2020-01-01'),
-      campaignAllowsRetry: true,
-      isRegistrationActive: true,
-      scorecards: expectedScorecards,
+      const competencesWithArea = [
+        domainBuilder.buildCompetence({ id: 'rec1', area: area1 }),
+        domainBuilder.buildCompetence({ id: 'rec2', area: area2 }),
+      ];
+      const knowledgeElementsGroupedByCompetenceId = {
+        rec1: [domainBuilder.buildKnowledgeElement()],
+        rec2: [domainBuilder.buildKnowledgeElement()],
+      };
+
+      const campaignParticipation = domainBuilder.buildCampaignParticipation({
+        id: '1',
+        sharedAt: new Date('2020-01-01'),
+      });
+
+      profileSharedForCampaign = new SharedProfileForCampaign({
+        campaignParticipation,
+        campaignAllowsRetry: true,
+        isRegistrationActive: true,
+        competencesWithArea,
+        knowledgeElementsGroupedByCompetenceId,
+      });
     });
 
-    const expectedSerializedScorecard = {
-      data: {
-        type: 'SharedProfileForCampaigns',
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        id: profileSharedForCampaign.id,
-        attributes: {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          'pix-score': profileSharedForCampaign.pixScore,
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          'shared-at': profileSharedForCampaign.sharedAt,
-          'can-retry': true,
-        },
-        relationships: {
-          scorecards: {
-            data: [
-              {
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                id: expectedScorecards[0].id,
-                type: 'scorecards',
-              },
-              {
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                id: expectedScorecards[1].id,
-                type: 'scorecards',
-              },
-            ],
-          },
-        },
-      },
-      included: [
-        {
-          attributes: {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            code: expectedScorecards[0].area.code,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            title: expectedScorecards[0].area.title,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            color: expectedScorecards[0].area.color,
-          },
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          id: expectedScorecards[0].area.id,
-          type: 'areas',
-        },
-        {
-          attributes: {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            name: expectedScorecards[0].name,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            description: expectedScorecards[0].description,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            index: expectedScorecards[0].index,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            'competence-id': expectedScorecards[0].competenceId,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            'earned-pix': expectedScorecards[0].earnedPix,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            level: expectedScorecards[0].level,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            'pix-score-ahead-of-next-level': expectedScorecards[0].pixScoreAheadOfNextLevel,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            status: expectedScorecards[0].status,
-          },
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          id: expectedScorecards[0].id,
-          type: 'scorecards',
-          relationships: {
-            area: {
-              data: {
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                id: expectedScorecards[0].area.id,
-                type: 'areas',
-              },
-            },
-          },
-        },
-        {
-          attributes: {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            code: expectedScorecards[1].area.code,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            title: expectedScorecards[1].area.title,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            color: expectedScorecards[1].area.color,
-          },
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          id: expectedScorecards[1].area.id,
-          type: 'areas',
-        },
-        {
-          attributes: {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            name: expectedScorecards[1].name,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            description: expectedScorecards[1].description,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            index: expectedScorecards[1].index,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            'competence-id': expectedScorecards[1].competenceId,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            'earned-pix': expectedScorecards[1].earnedPix,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            level: expectedScorecards[1].level,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            'pix-score-ahead-of-next-level': expectedScorecards[1].pixScoreAheadOfNextLevel,
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            status: expectedScorecards[1].status,
-          },
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line mocha/no-setup-in-describe
-          id: expectedScorecards[1].id,
-          type: 'scorecards',
-          relationships: {
-            area: {
-              data: {
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                id: expectedScorecards[1].area.id,
-                type: 'areas',
-              },
-            },
-          },
-        },
-      ],
-    };
-
     it('should convert a scorecard object into JSON API data', function () {
+      const expectedSharedProfileForCampaign = {
+        data: {
+          type: 'SharedProfileForCampaigns',
+          id: profileSharedForCampaign.id,
+          attributes: {
+            'pix-score': profileSharedForCampaign.pixScore,
+            'shared-at': profileSharedForCampaign.sharedAt,
+            'can-retry': true,
+          },
+          relationships: {
+            scorecards: {
+              data: [
+                {
+                  id: profileSharedForCampaign.scorecards[0].id,
+                  type: 'scorecards',
+                },
+                {
+                  id: profileSharedForCampaign.scorecards[1].id,
+                  type: 'scorecards',
+                },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            attributes: {
+              code: profileSharedForCampaign.scorecards[0].area.code,
+              title: profileSharedForCampaign.scorecards[0].area.title,
+              color: profileSharedForCampaign.scorecards[0].area.color,
+            },
+            id: profileSharedForCampaign.scorecards[0].area.id,
+            type: 'areas',
+          },
+          {
+            attributes: {
+              name: profileSharedForCampaign.scorecards[0].name,
+              description: profileSharedForCampaign.scorecards[0].description,
+              index: profileSharedForCampaign.scorecards[0].index,
+              'competence-id': profileSharedForCampaign.scorecards[0].competenceId,
+              'earned-pix': profileSharedForCampaign.scorecards[0].earnedPix,
+              level: profileSharedForCampaign.scorecards[0].level,
+              'pix-score-ahead-of-next-level': profileSharedForCampaign.scorecards[0].pixScoreAheadOfNextLevel,
+              status: profileSharedForCampaign.scorecards[0].status,
+            },
+            id: profileSharedForCampaign.scorecards[0].id,
+            type: 'scorecards',
+            relationships: {
+              area: {
+                data: {
+                  id: profileSharedForCampaign.scorecards[0].area.id,
+                  type: 'areas',
+                },
+              },
+            },
+          },
+          {
+            attributes: {
+              code: profileSharedForCampaign.scorecards[1].area.code,
+              title: profileSharedForCampaign.scorecards[1].area.title,
+              color: profileSharedForCampaign.scorecards[1].area.color,
+            },
+            id: profileSharedForCampaign.scorecards[1].area.id,
+            type: 'areas',
+          },
+          {
+            attributes: {
+              name: profileSharedForCampaign.scorecards[1].name,
+              description: profileSharedForCampaign.scorecards[1].description,
+              index: profileSharedForCampaign.scorecards[1].index,
+              'competence-id': profileSharedForCampaign.scorecards[1].competenceId,
+              'earned-pix': profileSharedForCampaign.scorecards[1].earnedPix,
+              level: profileSharedForCampaign.scorecards[1].level,
+              'pix-score-ahead-of-next-level': profileSharedForCampaign.scorecards[1].pixScoreAheadOfNextLevel,
+              status: profileSharedForCampaign.scorecards[1].status,
+            },
+            id: profileSharedForCampaign.scorecards[1].id,
+            type: 'scorecards',
+            relationships: {
+              area: {
+                data: {
+                  id: profileSharedForCampaign.scorecards[1].area.id,
+                  type: 'areas',
+                },
+              },
+            },
+          },
+        ],
+      };
+
       // when
       const json = serializer.serialize(profileSharedForCampaign);
 
       // then
-      expect(json).to.deep.equal(expectedSerializedScorecard);
+      expect(json).to.deep.equal(expectedSharedProfileForCampaign);
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -1,5 +1,5 @@
 const { expect, domainBuilder, sinon } = require('../../../../test-helper');
-const SharedProfileForCampaign = require('../../../../../lib/domain/models/SharedProfileForCampaign');
+const SharedProfileForCampaign = require('../../../../../lib/domain/read-models/SharedProfileForCampaign');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer');
 
 describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer', function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans nos travaux de refonte du prescrit, une fois que nous avions harmoniser la gestion des prescrits dans les orgas PRO/SUP/SCO, import pas import, nous avons compris qu’il était essentiel de pouvoir supprimer une participation (afin de gérer certains cas contraignants de dissociation). 

Si la participation d'un utilisateur à une campagne de collecte de profil à envoi multiple on veut l'empêcher de re-participer.

## :robot: Solution
Dans le détail des résultats d’un parcours (CAMPAGNE de COLLECTE), si le parcours a été supprimé par le prescripteur, on n'affiche plus le bouton “repasser mon parcours” dans le cadre d’une campagne à envoi multiple.

## :rainbow: Remarques
J'ai profité de cette PR pour refactorer le usecase getUserProfileSharedForCampaign. J'ai extrait la logique métier dans le model SharedProfileForCampaign.

## :100: Pour tester
- Se connecter à Pix App avec userpix1
- Participer une première fois à la campagne PROCOLMUL
- Valoriser le champ deletedAt en BDD pour la participation
- Tenter de re-participer à la campagne PROCOLMUL
- Constater que l'abeille est présente et que le bouton "repasser mon parcours" n'est pas présent
