### PR TITLE
[FEATURE] Clarifier la formulation lors de la finalisation de session (PIX-4546).

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "3.180.0",
+      "version": "3.188.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -59,6 +59,7 @@
         "samlify": "^2.8.3",
         "sax": "^1.2.4",
         "saxpath": "^0.6.5",
+        "scalingo": "^0.4.0",
         "sharp": "^0.30.2",
         "sib-api-v3-sdk": "^8.2.1",
         "uuid": "^8.3.2",
@@ -96,8 +97,8 @@
         "stream-to-promise": "^3.0.0"
       },
       "engines": {
-        "node": "14.17.0",
-        "npm": "6.14.13"
+        "node": "16.14.0",
+        "npm": "8.3.1"
       }
     },
     "node_modules/@authenio/xml-encryption": {
@@ -5433,6 +5434,14 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -8557,6 +8566,24 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/scalingo": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.4.0.tgz",
+      "integrity": "sha512-ydENwwZPvTCkLjq4fKc8VtKSrit8FUOiIIMlQEErLckpTB+HT5g9T0qXBVz8xHc9aFDi/ZietEYdCyTvmhqkag==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "isomorphic-ws": "4.x",
+        "ws": "^7.4.3"
+      }
+    },
+    "node_modules/scalingo/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
@@ -10128,7 +10155,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -14548,7 +14574,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -18189,7 +18216,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
       "requires": {}
     },
     "xdg-basedir": {

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -14,7 +14,7 @@
 
   <SessionFinalizationStepContainer
     @number="1"
-    @title="Renseigner les informations de vos candidats"
+    @title="Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
     @icon="/icons/session-finalization-user.svg"
     @iconAlt=""
   >
@@ -85,6 +85,8 @@
               candidat(s)</p>
           {{/if}}
           <p>Attention : il ne vous sera plus possible de modifier ces informations par la suite.</p>
+          <p>Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de
+            traitement pouvant varier d'une session à l'autre).</p>
         </div>
       </div>
 

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-certif",
-      "version": "3.180.0",
+      "version": "3.188.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -106,9 +106,9 @@ When(`je clique sur le bouton pour finaliser la session`, () => {
 When('je vois une modale qui me signale {int} oubli(s) de case Écran de fin test', (endTestForgottenCount) => {
   cy.get('.pix-modal__container').should('exist');
   if(endTestForgottenCount === 0) {
-    cy.get('div.app-modal-body__warning p').should('have.length', 1);
-  } else {
     cy.get('div.app-modal-body__warning p').should('have.length', 2);
+  } else {
+    cy.get('div.app-modal-body__warning p').should('have.length', 3);
     cy.get('.app-modal-body__contextual').contains(`La case "Écran de fin du test vu" n'est pas cochée pour ${endTestForgottenCount} candidat(s)`);
   }
 });


### PR DESCRIPTION
## :unicorn: Problème
Le pôle certif a identifié récemment problématiques liées à la gestion des sessions de certification, notamment mis en avant par la massification de la certification : 

il arrive régulièrement que les utilisateurs Pix certif reportent les signalements liés à un candidat/1 question en particulier dans la section “commentaire global” et non dans la section “Signalement” avec la catégorie “Problème technique sur une question”, ce qui bloque le traitement automatique de ces signalements et entraîne un traitement manuel

certains centre de certification s'étonnent de ne pas recevoir dans les mêmes délais les résultats de certification d’une session à l’autre

## :robot: Solution
Rendre plus clairs certains wording sur la page de finalisation de session pour simplifier la compréhension des 2 problématiques ci-dessus pour nos utilisateurs : 

Section Etape 1 : mettre à jour le wording comme suit 

Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident

Sur la pop-up de confirmation de finalisation de session : ajouter en dessous du “Attention…”, après un saut de ligne, le texte suivant : 

Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement pouvant varier d'une session à l'autre).

## :100: Pour tester
- Lancer Pix Certif
- Se rendre sur [une session de certification finalisable](https://certif-pr4227.review.pix.fr/sessions/4)
- Aller sur la page de finalisation de session et vérifier la présence du texte `Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident`
- Cliquer sur le bouton de finalisation qui fera apparaitre une pop-in de confirmation, vérifier la présence du texte 
`Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement pouvant varier d'une session à l'autre).`