### PR TITLE
[FEATURE] Ajoute une tooltip d'info tarification pour la modal d'ajout de candidat (PIX-4605)

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -258,11 +258,28 @@
             required
           />
         </div>
-
         <div
-          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
+          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double new-certification-candidate-modal__form__field__tooltip"
         >
-          <label for="prepayment-code" class="label">Code de prépaiement</label>
+          <label for="prepayment-code" class="label">
+            Code de prépaiement
+          </label>
+          <PixTooltip @id="tooltip-prepayment-code" @position="left" @isWide={{true}} class="label">
+            <:triggerElement>
+              <FaIcon
+                @icon="info-circle"
+                tabindex="0"
+                aria-describedby="tooltip-prepayment-code"
+                aria-label="Information du code de prépaiement"
+              />
+            </:triggerElement>
+            <:tooltip>
+              (Requis notamment dans le cas d'un achat de crédits combinés)<br />
+              Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br
+              />
+              Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.
+            </:tooltip>
+          </PixTooltip>
           <Input
             id="prepayment-code"
             @type="text"

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -55,7 +55,7 @@
         width: 248px;
       }
 
-      input[type="radio"] {
+      input[type='radio'] {
         height: 20px;
         width: 20px;
       }
@@ -67,6 +67,20 @@
 
       &-double {
         width: 248px;
+      }
+
+      &__tooltip {
+        display: flex;
+        flex-wrap: wrap;
+
+        .pix-tooltip {
+          padding-left: 5px;
+          cursor: help;
+        }
+
+        .pix-tooltip__content--wide {
+          width: 600px;
+        }
       }
 
       .complementary-certifications-checkbox-list {

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -138,6 +138,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
       assert.dom(screen.getByLabelText('* Tarification part Pix')).exists();
       assert.dom(screen.getByLabelText('Code de prépaiement')).exists();
+      assert.dom(screen.getByLabelText('Information du code de prépaiement')).exists();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Il manque des informations pour la tarification

## :robot: Solution
Ajouter le texte

> (Requis notamment dans le cas d'un achat de crédits combinés)
> Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.
> Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.

<img width="746" alt="image" src="https://user-images.githubusercontent.com/3769147/159531199-de8c2583-7f0f-4b05-a10d-bf5f50fb349c.png">

## :100: Pour tester
Se connecter en certif avec certifpro@example.net
Ajouter un candidat. Verifier que le tooltip s'affiche bien
