### PR TITLE
[FEATURE] Enregistrer le prénom et nom reçu du GAR lors de l'inscription à Pix App (PIX-4518).

### DIFF
--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -39,6 +39,21 @@ class PoleEmploiAuthenticationComplement {
   }
 }
 
+class GARAuthenticationComplement {
+  constructor({ firstName, lastName } = {}) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+
+    validateEntity(
+      Joi.object({
+        firstName: Joi.string().required(),
+        lastName: Joi.string().required(),
+      }),
+      this
+    );
+  }
+}
+
 const validationSchema = Joi.object({
   id: Joi.number().optional(),
   identityProvider: Joi.string()
@@ -97,4 +112,5 @@ class AuthenticationMethod {
 AuthenticationMethod.identityProviders = identityProviders;
 AuthenticationMethod.PixAuthenticationComplement = PixAuthenticationComplement;
 AuthenticationMethod.PoleEmploiAuthenticationComplement = PoleEmploiAuthenticationComplement;
+AuthenticationMethod.GARAuthenticationComplement = GARAuthenticationComplement;
 module.exports = AuthenticationMethod;

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -13,12 +13,15 @@ function _buildPasswordAuthenticationMethod({ userId, hashedPassword }) {
   });
 }
 
-function _buildGARAuthenticationMethod({ externalIdentifier, userId }) {
+function _buildGARAuthenticationMethod({ externalIdentifier, user }) {
   return new AuthenticationMethod({
     externalIdentifier,
     identityProvider: AuthenticationMethod.identityProviders.GAR,
-    userId,
-    authenticationComplement: null,
+    userId: user.id,
+    authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
+      firstName: user.firstName,
+      lastName: user.lastName,
+    }),
   });
 }
 
@@ -79,7 +82,7 @@ async function createAndReconcileUserToSchoolingRegistration({
     if (samlId) {
       authenticationMethod = _buildGARAuthenticationMethod({
         externalIdentifier: samlId,
-        userId: createdUser.id,
+        user: createdUser,
       });
     } else {
       authenticationMethod = _buildPasswordAuthenticationMethod({

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -20,6 +20,8 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   identityProvider = AuthenticationMethod.identityProviders.GAR,
   externalIdentifier = `externalId${id}`,
   userId = 456,
+  userFirstName = 'Margotte',
+  userLastName = 'Saint-James',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-02-01'),
 } = {}) {
@@ -29,7 +31,10 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
     id,
     identityProvider,
     externalIdentifier,
-    authenticationComplement: null,
+    authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
+      firstName: userFirstName,
+      lastName: userLastName,
+    }),
     userId,
     createdAt,
     updatedAt,

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -232,5 +232,55 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
         ).to.throw(ObjectValidationError);
       });
     });
+
+    context('GARAuthenticationComplement', function () {
+      it('should successfully instantiate object when passing all valid arguments', function () {
+        expect(
+          () =>
+            new AuthenticationMethod.GARAuthenticationComplement({
+              firstName: 'Margaret',
+              lastName: 'Remington',
+            })
+        ).not.to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when firstName is not a string', function () {
+        expect(
+          () =>
+            new AuthenticationMethod.GARAuthenticationComplement({
+              lastName: 'Remington',
+              firstName: 1234,
+            })
+        ).to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when firstName is missing', function () {
+        expect(
+          () =>
+            new AuthenticationMethod.GARAuthenticationComplement({
+              lastName: 'Remington',
+            })
+        ).to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when lastName is not a string', function () {
+        expect(
+          () =>
+            new AuthenticationMethod.GARAuthenticationComplement({
+              firstName: 'Margaret',
+              lastName: 4567,
+            })
+        ).to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when lastName is missing', function () {
+        expect(
+          () =>
+            new AuthenticationMethod.GARAuthenticationComplement({
+              firstName: 'Margaret',
+            })
+        ).to.throw(ObjectValidationError);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -112,21 +112,16 @@ describe('Unit | Service | user-service', function () {
   });
 
   describe('#createAndReconcileUserToSchoolingRegistration', function () {
-    const samlId = 'ABCD';
-
-    beforeEach(async function () {
-      user = domainBuilder.buildUser();
-      authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+    it('should call user and authenticationMethod create and function, and schoolingRegistration update function', async function () {
+      // given
+      const samlId = 'ABCD';
+      const user = domainBuilder.buildUser();
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: samlId,
         userId: user.id,
       });
-    });
-
-    it('should call user and authenticationMethod create and function, and schoolingRegistration update function', async function () {
-      // given
       const schoolingRegistrationId = 1;
       userRepository.create.resolves(user);
-
       const expectedAuthenticationMethod = omit(authenticationMethod, ['id', 'createdAt', 'updatedAt']);
 
       // when

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -114,8 +114,10 @@ describe('Unit | Service | user-service', function () {
   describe('#createAndReconcileUserToSchoolingRegistration', function () {
     it('should call user and authenticationMethod create and function, and schoolingRegistration update function', async function () {
       // given
-      const samlId = 'ABCD';
-      const user = domainBuilder.buildUser();
+      const user = domainBuilder.buildUser({
+        firstName: 'Mnémosyne',
+        lastName: 'Pachidermata',
+      });
       const schoolingRegistrationId = 1;
       userRepository.create.resolves(user);
 
@@ -131,10 +133,6 @@ describe('Unit | Service | user-service', function () {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
-        externalIdentifier: samlId,
-        userId: user.id,
-      });
       expect(userRepository.create).to.have.been.calledWithMatch({
         user,
       });

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -7,9 +7,7 @@ const DomainTransaction = require('../../../../lib/infrastructure/DomainTransact
 const userService = require('../../../../lib/domain/services/user-service');
 
 describe('Unit | Service | user-service', function () {
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const domainTransaction = Symbol('domain transaction');
+  let domainTransaction;
   const hashedPassword = 'ABCD1234';
 
   let user;
@@ -21,6 +19,8 @@ describe('Unit | Service | user-service', function () {
   let userRepository;
 
   beforeEach(function () {
+    domainTransaction = Symbol('domain transaction');
+
     userRepository = {
       create: sinon.stub(),
       updateUsername: sinon.stub(),

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -116,17 +116,12 @@ describe('Unit | Service | user-service', function () {
       // given
       const samlId = 'ABCD';
       const user = domainBuilder.buildUser();
-      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
-        externalIdentifier: samlId,
-        userId: user.id,
-      });
       const schoolingRegistrationId = 1;
       userRepository.create.resolves(user);
-      const expectedAuthenticationMethod = omit(authenticationMethod, ['id', 'createdAt', 'updatedAt']);
 
       // when
       await userService.createAndReconcileUserToSchoolingRegistration({
-        samlId,
+        samlId: 'SAML_ID',
         schoolingRegistrationId,
         user,
         authenticationMethodRepository,
@@ -136,11 +131,22 @@ describe('Unit | Service | user-service', function () {
       await transactionToBeExecuted(domainTransaction);
 
       // then
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+        externalIdentifier: samlId,
+        userId: user.id,
+      });
       expect(userRepository.create).to.have.been.calledWithMatch({
         user,
       });
       expect(authenticationMethodRepository.create).to.have.been.calledWithMatch({
-        authenticationMethod: expectedAuthenticationMethod,
+        authenticationMethod: {
+          externalIdentifier: 'SAML_ID',
+          userId: user.id,
+          authenticationComplement: {
+            firstName: 'Mnémosyne',
+            lastName: 'Pachidermata',
+          },
+        },
       });
       expect(schoolingRegistrationRepository.updateUserIdWhereNull).to.have.been.calledWithMatch({
         schoolingRegistrationId,


### PR DESCRIPTION
## :unicorn: Problème

On a parfois besoin de savoir à qui appartient une connexion GAR dans le cas d'utilisateur qui ont de multiples élèves réconciliés. On ne sait pas si on peut/doit supprimer la connexion GAR de l'utilisateur pour éviter qu'un autre utilisateur s'y connecte.

## :robot: Solution

Quand un utilisateur se connecte à Pix via le GAR, on aimerait stocker le prénom et nom reçu du GAR dans la table authentication-methods.authenticationComplement.

## :rainbow: Remarques

Cette PR gère le cas où l'utilisateur se connecte pour la première fois (ajout d'une nouvelle ligne à la table `authentication-methods`). Dans une autre PR, on gèrera le cas où l'utilisateur se connecte à nouveau (mise à jour de la ligne).

## :100: Pour tester

Inscription
1. Accéder à Pix [depuis le GAR simulé](https://test-idp.integration.pix.fr/) avec utilisateur non réconcilié (First Last 10 10 2010 et code SCOBADGE1)
2. Vérifier que le champ `authenticationComplement` de la table `authentication-methods` a été remplie avec le prénom et le nom de l'utilisateur *

\* Par exemple avec : 
```sql
SELECT * FROM "authentication-methods" WHERE "identityProvider" = 'GAR' ORDER BY "id" DESC;
```