### PR TITLE
[TECH] Monter pix-ui en v13 sur mon-pix (PIX-4615)

### DIFF
--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/pix-ui": "^11.2.0",
+        "@1024pix/pix-ui": "^12.0.0",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^1.0.2",
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-11.2.0.tgz",
-      "integrity": "sha512-ouRN7m8W8YT5T/3vW0zubP9iFeRwX39Srq66aeY4zDx0yqpRrd3Y5zpHa/LjALNbCJHM5qC7Kwon4J7ddoi7mQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-12.0.0.tgz",
+      "integrity": "sha512-2WU+bX8xDCExBCVOmS6TsQOGtOy7wT0s1MgOq7xAnfSdHpNmdlrB37zaM8hx+1oNMLFk07F2XzaDSD3Pz4e+Yg==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -41785,9 +41785,9 @@
   },
   "dependencies": {
     "@1024pix/pix-ui": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-11.2.0.tgz",
-      "integrity": "sha512-ouRN7m8W8YT5T/3vW0zubP9iFeRwX39Srq66aeY4zDx0yqpRrd3Y5zpHa/LjALNbCJHM5qC7Kwon4J7ddoi7mQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-12.0.0.tgz",
+      "integrity": "sha512-2WU+bX8xDCExBCVOmS6TsQOGtOy7wT0s1MgOq7xAnfSdHpNmdlrB37zaM8hx+1oNMLFk07F2XzaDSD3Pz4e+Yg==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.186.0",
+      "version": "3.190.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.4.tgz",
-      "integrity": "sha512-Sj++Y14AUQf9dI9Ql6wA2WfB3pDhNleoGMlAlW1cglASJxyU4c2QPbBkUqpuD8MX9CICaXhke7jCK7WKeoc/fA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.0.tgz",
+      "integrity": "sha512-Pv6RDJtJPbrAsTzEbi0a6vvDJWJVYxLVYD7jO8gODYJjqhSRB6wBjpcfCu5inCOnzira/v1Ron2lTSJibpyjEw==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -41785,9 +41785,9 @@
   },
   "dependencies": {
     "@1024pix/pix-ui": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.4.tgz",
-      "integrity": "sha512-Sj++Y14AUQf9dI9Ql6wA2WfB3pDhNleoGMlAlW1cglASJxyU4c2QPbBkUqpuD8MX9CICaXhke7jCK7WKeoc/fA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.0.tgz",
+      "integrity": "sha512-Pv6RDJtJPbrAsTzEbi0a6vvDJWJVYxLVYD7jO8gODYJjqhSRB6wBjpcfCu5inCOnzira/v1Ron2lTSJibpyjEw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/pix-ui": "^12.0.0",
+        "@1024pix/pix-ui": "^13.3.4",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^1.0.2",
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-12.0.0.tgz",
-      "integrity": "sha512-2WU+bX8xDCExBCVOmS6TsQOGtOy7wT0s1MgOq7xAnfSdHpNmdlrB37zaM8hx+1oNMLFk07F2XzaDSD3Pz4e+Yg==",
+      "version": "13.3.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.4.tgz",
+      "integrity": "sha512-Sj++Y14AUQf9dI9Ql6wA2WfB3pDhNleoGMlAlW1cglASJxyU4c2QPbBkUqpuD8MX9CICaXhke7jCK7WKeoc/fA==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -41785,9 +41785,9 @@
   },
   "dependencies": {
     "@1024pix/pix-ui": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-12.0.0.tgz",
-      "integrity": "sha512-2WU+bX8xDCExBCVOmS6TsQOGtOy7wT0s1MgOq7xAnfSdHpNmdlrB37zaM8hx+1oNMLFk07F2XzaDSD3Pz4e+Yg==",
+      "version": "13.3.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.3.4.tgz",
+      "integrity": "sha512-Sj++Y14AUQf9dI9Ql6wA2WfB3pDhNleoGMlAlW1cglASJxyU4c2QPbBkUqpuD8MX9CICaXhke7jCK7WKeoc/fA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
-    "@1024pix/pix-ui": "^12.0.0",
+    "@1024pix/pix-ui": "^13.3.4",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^1.0.2",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
-    "@1024pix/pix-ui": "^11.2.0",
+    "@1024pix/pix-ui": "^12.0.0",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^1.0.2",


### PR DESCRIPTION
## :unicorn: Problème

mon-pix a deux versions de retard sur pix-ui.

## :robot: Solution

Upgrade pix-ui en v13.4.

## :rainbow: Remarques

Les breakings changes pour la v12 et la v13 :

 - 1024pix/pix-ui#186
   - **Pas d'impact car `PixSelect` n'est jamais utilisé avec `isSearchable={{true}}` dans mon-pix**
 - 1024pix/pix-ui#188
   - **Impact déjà pris en compte dans #4220**

Voir https://github.com/1024pix/pix-ui/blob/dev/CHANGELOG.md pour le reste des changements.

En attente de #4220 

## :100: Pour tester

Vérifier que la RA fonctionne correctement.
