### PR TITLE
[BUGFIX] Permettre l'affichage des classes/groupes d'une campagne même s'il y en a certain(e)s à null (PIX-4618).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -43,11 +43,7 @@ function _buildPaginationQuery(queryBuilder, campaignId, filters) {
     .select('campaign-participations.id')
     .from('campaign-participations')
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .leftJoin('organization-learners', function () {
-      this.on({ 'campaign-participations.userId': 'organization-learners.userId' }).andOn({
-        'campaigns.organizationId': 'organization-learners.organizationId',
-      });
-    })
+    .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.isImproved', '=', false)
     .modify(_filterByDivisions, filters)

--- a/api/lib/infrastructure/repositories/division-repository.js
+++ b/api/lib/infrastructure/repositories/division-repository.js
@@ -2,19 +2,12 @@ const Division = require('../../domain/models/Division');
 const { knex } = require('../bookshelf');
 
 async function findByCampaignId(campaignId) {
-  const divisions = await knex('campaigns')
-    .where({ 'campaigns.id ': campaignId })
+  const divisions = await knex('organization-learners')
+    .where({ campaignId })
     .whereNotNull('division')
     .distinct('division')
     .orderBy('division', 'asc')
-    .join('campaign-participations', 'campaigns.id', 'campaign-participations.campaignId')
-    .innerJoin('organization-learners', function () {
-      this.on('organization-learners.userId', '=', 'campaign-participations.userId').andOn(
-        'organization-learners.organizationId',
-        '=',
-        'campaigns.organizationId'
-      );
-    });
+    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId');
 
   return divisions.map(({ division }) => _toDomain(division));
 }

--- a/api/lib/infrastructure/repositories/division-repository.js
+++ b/api/lib/infrastructure/repositories/division-repository.js
@@ -4,8 +4,9 @@ const { knex } = require('../bookshelf');
 async function findByCampaignId(campaignId) {
   const divisions = await knex('campaigns')
     .where({ 'campaigns.id ': campaignId })
-    .select('division')
-    .groupBy('division')
+    .whereNotNull('division')
+    .distinct('division')
+    .orderBy('division', 'asc')
     .join('campaign-participations', 'campaigns.id', 'campaign-participations.campaignId')
     .innerJoin('organization-learners', function () {
       this.on('organization-learners.userId', '=', 'campaign-participations.userId').andOn(

--- a/api/lib/infrastructure/repositories/group-repository.js
+++ b/api/lib/infrastructure/repositories/group-repository.js
@@ -2,19 +2,12 @@ const Group = require('../../domain/models/Group');
 const { knex } = require('../bookshelf');
 
 async function findByCampaignId(campaignId) {
-  const groups = await knex('campaigns')
-    .where({ 'campaigns.id': campaignId })
+  const groups = await knex('organization-learners')
+    .where({ campaignId })
     .distinct('group')
     .whereNotNull('group')
     .orderBy('group', 'asc')
-    .join('campaign-participations', 'campaigns.id', 'campaign-participations.campaignId')
-    .join('organization-learners', function () {
-      this.on('organization-learners.userId', '=', 'campaign-participations.userId').andOn(
-        'organization-learners.organizationId',
-        '=',
-        'campaigns.organizationId'
-      );
-    });
+    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId');
 
   return groups.map(({ group }) => _toDomain(group));
 }

--- a/api/lib/infrastructure/repositories/group-repository.js
+++ b/api/lib/infrastructure/repositories/group-repository.js
@@ -4,8 +4,9 @@ const { knex } = require('../bookshelf');
 async function findByCampaignId(campaignId) {
   const groups = await knex('campaigns')
     .where({ 'campaigns.id': campaignId })
-    .select('group')
-    .groupBy('group')
+    .distinct('group')
+    .whereNotNull('group')
+    .orderBy('group', 'asc')
     .join('campaign-participations', 'campaigns.id', 'campaign-participations.campaignId')
     .join('organization-learners', function () {
       this.on('organization-learners.userId', '=', 'campaign-participations.userId').andOn(

--- a/api/tests/integration/infrastructure/repositories/division-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/division-repository_test.js
@@ -23,54 +23,6 @@ describe('Integration | Repository | Division', function () {
       expect(divisions).to.deep.equal([{ name: '3emeA' }, { name: '6emeB' }]);
     });
 
-    context('when there are schooling registrations for another campaign of the same organization', function () {
-      it('returns the division from schooling registration associated to the given campaign', async function () {
-        const division1 = '6emeB';
-        const division2 = '3emeA';
-        const campaign = databaseBuilder.factory.buildCampaign();
-
-        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
-          { organizationId: campaign.organizationId, division: division1 },
-          { campaignId: campaign.id }
-        );
-        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration({
-          organizationId: campaign.organizationId,
-          division: division2,
-        });
-        await databaseBuilder.commit();
-
-        const divisions = await divisionRepository.findByCampaignId(campaign.id);
-
-        expect(divisions).to.deep.equal([{ name: '6emeB' }]);
-      });
-    });
-
-    context('when a participant has schooling registrations for another organization', function () {
-      it('returns the division from schooling registration associated to organization of the given campaign', async function () {
-        const division1 = '4emeG';
-        const division2 = '3emeC';
-        const user = { id: 100001 };
-        const campaign = databaseBuilder.factory.buildCampaign();
-        const otherCampaign = databaseBuilder.factory.buildCampaign();
-
-        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
-          { organizationId: campaign.organizationId, division: division1, user },
-          { campaignId: campaign.id }
-        );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: otherCampaign.organizationId,
-          division: division2,
-          userId: user.id,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId: otherCampaign.id, userId: user.id });
-        await databaseBuilder.commit();
-
-        const divisions = await divisionRepository.findByCampaignId(campaign.id);
-
-        expect(divisions).to.deep.equal([{ name: '4emeG' }]);
-      });
-    });
-
     context('when several participants have the same division', function () {
       it('returns each division one time', async function () {
         const division = '5eme1';

--- a/api/tests/integration/infrastructure/repositories/division-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/division-repository_test.js
@@ -91,6 +91,23 @@ describe('Integration | Repository | Division', function () {
         expect(divisions).to.deep.equal([{ name: '5eme1' }]);
       });
     });
+
+    context('when participants has no division', function () {
+      it('returns empty array', async function () {
+        const division = null;
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, division: division },
+          { campaignId: campaign.id }
+        );
+        await databaseBuilder.commit();
+
+        const divisions = await divisionRepository.findByCampaignId(campaign.id);
+
+        expect(divisions).to.deep.equal([]);
+      });
+    });
   });
 
   describe('#findByOrganizationIdForCurrentSchoolYear', function () {

--- a/api/tests/integration/infrastructure/repositories/group-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/group-repository_test.js
@@ -93,6 +93,23 @@ describe('Integration | Repository | Group', function () {
         expect(groups).to.deep.equal([{ name: 'AB5' }]);
       });
     });
+
+    context('when participants has no group', function () {
+      it('returns empty array', async function () {
+        const group = null;
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
+          { organizationId: campaign.organizationId, group: group },
+          { campaignId: campaign.id }
+        );
+        await databaseBuilder.commit();
+
+        const groups = await groupRepository.findByCampaignId(campaign.id);
+
+        expect(groups).to.deep.equal([]);
+      });
+    });
   });
 
   describe('#findByOrganizationId', function () {

--- a/api/tests/integration/infrastructure/repositories/group-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/group-repository_test.js
@@ -23,56 +23,6 @@ describe('Integration | Repository | Group', function () {
       expect(groups).to.deep.equal([{ name: 'L1' }, { name: 'L2' }]);
     });
 
-    context('when there are schooling registrations for another campaign of the same organization', function () {
-      it('returns the group from schooling registration associated to the given campaign', async function () {
-        const group1 = 'LB1';
-        const group2 = 'LB2';
-        const firstCampaign = databaseBuilder.factory.buildCampaign();
-        const secondCampaign = databaseBuilder.factory.buildCampaign();
-
-        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
-          { organizationId: firstCampaign.organizationId, group: group1 },
-          { campaignId: firstCampaign.id }
-        );
-        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
-          { organizationId: secondCampaign.organizationId, group: group2 },
-          { campaignId: secondCampaign.id }
-        );
-
-        await databaseBuilder.commit();
-
-        const groups = await groupRepository.findByCampaignId(firstCampaign.id);
-
-        expect(groups).to.deep.equal([{ name: 'LB1' }]);
-      });
-    });
-
-    context('when a participant has schooling registrations for another organization', function () {
-      it('returns the group from schooling registration associated to organization of the given campaign', async function () {
-        const group1 = 'AB1';
-        const group2 = 'AB2';
-        const user = { id: 100001 };
-        const campaign = databaseBuilder.factory.buildCampaign();
-        const otherCampaign = databaseBuilder.factory.buildCampaign();
-
-        databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration(
-          { organizationId: campaign.organizationId, group: group1, user },
-          { campaignId: campaign.id }
-        );
-        databaseBuilder.factory.buildSchoolingRegistration({
-          organizationId: otherCampaign.organizationId,
-          group: group2,
-          user,
-        });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId: otherCampaign.id, userId: user.id });
-        await databaseBuilder.commit();
-
-        const groups = await groupRepository.findByCampaignId(campaign.id);
-
-        expect(groups).to.deep.equal([{ name: 'AB1' }]);
-      });
-    });
-
     context('when several participants have the same group', function () {
       it('returns each group one time', async function () {
         const group = 'AB5';


### PR DESCRIPTION
## :unicorn: Problème
Parfois, des participants à des campagnes n'ont pas de classe/groupe. Or on les remontent quand même à Pix Orga. Ember n'est pas content car incapable de lire un id `null` (setté à la valeur du name). Visuellement on a un chargement infini.
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/23451175/159756202-3daf4425-010e-46ce-8535-fab168638ae9.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/23451175/159756333-0d16290a-f87f-40bc-8d50-87e8a6d1fbf1.png">

## :robot: Solution
filtrer les classes et groupes `null`. (Ce qui est déjà fait dans le filtre pour toutes les classes et tous les groupes d'une organisation)

## :rainbow: Remarques
La requête passait encore par une ancienne jointure, on utilise désormais `organizationLearnerId` dans la table `campaign-participations`.

## :100: Pour tester
TODO
