### PR TITLE
[BUGFIX] Ne pas enregistrer des réponses focusedOut sur des épreuves non focused (PIX-4627)

### DIFF
--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -1,3 +1,4 @@
+const logger = require('../../infrastructure/logger');
 const Answer = require('./Answer');
 const AnswerStatus = require('./AnswerStatus');
 
@@ -9,7 +10,7 @@ class Examiner {
     this.validator = validator;
   }
 
-  evaluate({ answer, challengeFormat, isCertificationEvaluation }) {
+  evaluate({ answer, challengeFormat, isFocusedChallenge, isCertificationEvaluation }) {
     const correctedAnswer = new Answer(answer);
 
     if (answer.value === Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
@@ -29,7 +30,14 @@ class Examiner {
       correctedAnswer.result = AnswerStatus.TIMEDOUT;
     }
 
-    if (isCorrectAnswer && answer.isFocusedOut && isCertificationEvaluation) {
+    // Temporary log to find out focusedout answers that should not occur
+    if (!isFocusedChallenge && answer.isFocusedOut) {
+      logger.warn('A non focused challenge received a focused out answer', {
+        answerId: answer.id,
+      });
+    }
+
+    if (isCorrectAnswer && isFocusedChallenge && answer.isFocusedOut && isCertificationEvaluation) {
       correctedAnswer.result = AnswerStatus.FOCUSEDOUT;
     }
 

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -108,6 +108,7 @@ function _evaluateAnswer({ challenge, answer, assessment }) {
   return examiner.evaluate({
     answer,
     challengeFormat: challenge.format,
+    isFocusedChallenge: challenge.focused,
     isCertificationEvaluation: assessment.isCertification(),
   });
 }

--- a/api/tests/unit/domain/models/Examiner_test.js
+++ b/api/tests/unit/domain/models/Examiner_test.js
@@ -81,6 +81,7 @@ describe('Unit | Domain | Models | Examiner', function () {
       let correctedAnswer;
       let examiner;
       let validation;
+      let isFocusedChallenge;
 
       beforeEach(function () {
         // given
@@ -90,48 +91,120 @@ describe('Unit | Domain | Models | Examiner', function () {
         examiner = new Examiner({ validator });
       });
 
-      it('should return an answer with FOCUSED as result when the assessment is a certification, and the correct resultDetails', function () {
-        // given
-        const expectedAnswer = new Answer(uncorrectedAnswer);
-        expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
-        expectedAnswer.resultDetails = validation.resultDetails;
-
-        // when
-        correctedAnswer = examiner.evaluate({
-          answer: uncorrectedAnswer,
-          challengeFormat,
-          isCertificationEvaluation: true,
+      context('and is a focused challenge', function () {
+        beforeEach(function () {
+          // given
+          isFocusedChallenge = true;
         });
 
-        // then
-        expect(correctedAnswer).to.be.an.instanceOf(Answer);
-        expect(correctedAnswer).to.deep.equal(expectedAnswer);
-      });
+        it('should return an answer with FOCUSEDOUT as result when the assessment is a certification, and the correct resultDetails', function () {
+          // given
+          const expectedAnswer = new Answer(uncorrectedAnswer);
+          expectedAnswer.result = AnswerStatus.FOCUSEDOUT;
+          expectedAnswer.resultDetails = validation.resultDetails;
 
-      it('should return an answer with OK as result when the assessment is a certification, and the correct resultDetails', function () {
-        // given
-        const expectedAnswer = new Answer(uncorrectedAnswer);
-        expectedAnswer.result = AnswerStatus.OK;
-        expectedAnswer.resultDetails = validation.resultDetails;
+          // when
+          correctedAnswer = examiner.evaluate({
+            answer: uncorrectedAnswer,
+            challengeFormat,
+            isFocusedChallenge,
+            isCertificationEvaluation: true,
+          });
 
-        // when
-        correctedAnswer = examiner.evaluate({
-          answer: uncorrectedAnswer,
-          challengeFormat,
-          isCertificationEvaluation: false,
+          // then
+          expect(correctedAnswer).to.be.an.instanceOf(Answer);
+          expect(correctedAnswer).to.deep.equal(expectedAnswer);
         });
 
-        // then
-        expect(correctedAnswer).to.be.an.instanceOf(Answer);
-        expect(correctedAnswer).to.deep.equal(expectedAnswer);
+        it('should return an answer with OK as result when the assessment is not a certification, and the correct resultDetails', function () {
+          // given
+          const expectedAnswer = new Answer(uncorrectedAnswer);
+          expectedAnswer.result = AnswerStatus.OK;
+          expectedAnswer.resultDetails = validation.resultDetails;
+
+          // when
+          correctedAnswer = examiner.evaluate({
+            answer: uncorrectedAnswer,
+            challengeFormat,
+            isFocusedChallenge,
+            isCertificationEvaluation: false,
+          });
+
+          // then
+          expect(correctedAnswer).to.be.an.instanceOf(Answer);
+          expect(correctedAnswer).to.deep.equal(expectedAnswer);
+        });
+
+        it('should call validator.assess with answer to assess validity of answer', function () {
+          // when
+          examiner.evaluate({
+            answer: uncorrectedAnswer,
+            challengeFormat,
+            isFocusedChallenge,
+            isCertificationEvaluation: true,
+          });
+
+          // then
+          expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
+        });
       });
 
-      it('should call validator.assess with answer to assess validity of answer', function () {
-        // when
-        examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat, isCertificationEvaluation: true });
+      context('and is not a focused challenge', function () {
+        beforeEach(function () {
+          // given
+          isFocusedChallenge = false;
+        });
 
-        // then
-        expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
+        it('should return an answer with OK as result when the assessment is a certification, and the correct resultDetails', function () {
+          // given
+          const expectedAnswer = new Answer(uncorrectedAnswer);
+          expectedAnswer.result = AnswerStatus.OK;
+          expectedAnswer.resultDetails = validation.resultDetails;
+
+          // when
+          correctedAnswer = examiner.evaluate({
+            answer: uncorrectedAnswer,
+            challengeFormat,
+            isFocusedChallenge,
+            isCertificationEvaluation: true,
+          });
+
+          // then
+          expect(correctedAnswer).to.be.an.instanceOf(Answer);
+          expect(correctedAnswer).to.deep.equal(expectedAnswer);
+        });
+
+        it('should return an answer with OK as result when the assessment is not a certification, and the correct resultDetails', function () {
+          // given
+          const expectedAnswer = new Answer(uncorrectedAnswer);
+          expectedAnswer.result = AnswerStatus.OK;
+          expectedAnswer.resultDetails = validation.resultDetails;
+
+          // when
+          correctedAnswer = examiner.evaluate({
+            answer: uncorrectedAnswer,
+            challengeFormat,
+            isFocusedChallenge,
+            isCertificationEvaluation: false,
+          });
+
+          // then
+          expect(correctedAnswer).to.be.an.instanceOf(Answer);
+          expect(correctedAnswer).to.deep.equal(expectedAnswer);
+        });
+
+        it('should call validator.assess with answer to assess validity of answer', function () {
+          // when
+          examiner.evaluate({
+            answer: uncorrectedAnswer,
+            challengeFormat,
+            isFocusedChallenge,
+            isCertificationEvaluation: true,
+          });
+
+          // then
+          expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
+        });
       });
     });
 

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -26,7 +26,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     pix: 8,
   };
   const answerRepository = {
-    findByChallengeAndAssessment: () => undefined,
     saveWithKnowledgeElements: () => undefined,
   };
   const assessmentRepository = { get: () => undefined };
@@ -49,7 +48,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
   let dependencies;
 
   beforeEach(function () {
-    sinon.stub(answerRepository, 'findByChallengeAndAssessment');
     sinon.stub(answerRepository, 'saveWithKnowledgeElements');
     sinon.stub(assessmentRepository, 'get');
     sinon.stub(challengeRepository, 'get');
@@ -98,9 +96,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       assessment.type = Assessment.types.CERTIFICATION;
       assessment.lastChallengeId = 'anotherChallenge';
       assessmentRepository.get.resolves(assessment);
-      answerRepository.findByChallengeAndAssessment
-        .withArgs({ assessmentId: assessment.id, challengeId: challenge.id })
-        .resolves(true);
     });
 
     it('should fail because Challenge Not Asked', async function () {
@@ -121,9 +116,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       // given
       assessment.state = Assessment.states.ENDED_BY_SUPERVISOR;
       assessmentRepository.get.resolves(assessment);
-      answerRepository.findByChallengeAndAssessment
-        .withArgs({ assessmentId: assessment.id, challengeId: challenge.id })
-        .resolves(true);
 
       // when
       const error = await catchErr(correctAnswerThenUpdateAssessment)({
@@ -800,9 +792,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       });
       assessment.type = Assessment.types.CERTIFICATION;
       assessmentRepository.get.resolves(assessment);
-      answerRepository.findByChallengeAndAssessment
-        .withArgs({ assessmentId: assessment.id, challengeId: challenge.id })
-        .resolves(true);
       answerSaved = domainBuilder.buildAnswer(answer);
       answerSaved.timeSpent = 5;
       answerRepository.saveWithKnowledgeElements.resolves(answerSaved);
@@ -827,9 +816,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         });
         assessment.type = Assessment.types.PREVIEW;
         assessmentRepository.get.resolves(assessment);
-        answerRepository.findByChallengeAndAssessment
-          .withArgs({ assessmentId: assessment.id, challengeId: challenge.id })
-          .resolves(true);
         answerSaved = domainBuilder.buildAnswer(answer);
         answerRepository.saveWithKnowledgeElements.resolves(answerSaved);
 
@@ -863,12 +849,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       assessment = domainBuilder.buildAssessment({
         userId,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
+        type: Assessment.types.CERTIFICATION,
       });
-      assessment.type = Assessment.types.CERTIFICATION;
       assessmentRepository.get.resolves(assessment);
-      answerRepository.findByChallengeAndAssessment
-        .withArgs({ assessmentId: assessment.id, challengeId: nonFocusedChallenge.id })
-        .resolves(true);
       answerSaved = domainBuilder.buildAnswer(focusedOutAnswer);
       answerRepository.saveWithKnowledgeElements.resolves(answerSaved);
     });


### PR DESCRIPTION
## :unicorn: Problème
On remarque des incohérences entre answers et challenges : certaines answers sont marquées avec le `result` `focusedOut` alors que le challenge est en `focused` `false`. 

Autrement dit:
- le front détecte une sortie de fenêtre;
- sur une question qui ne devrait pas être soumise à surveillance (question libre).

Pour le moment on ne connaît pas la cause.

## :robot: Solution
La route appelée en cas de `focusOut` est `PATCH /api/assessments/{id}/last-challenge-state/{state}`

Garder le `result` initial de l'answer si elle est marquée `focusedOut` mais que le challenge n'est pas `focused`.

Logguer ce cas pour pouvoir déterminer la cause

## :rainbow: Remarques
Côté repository, on utilisait des `domainBuilder` pour construire des objets mockés LCMS. On a préféré créé des objets LCMS à passer au `mockLearningContent` et comparer la sortie des méthodes du repository avec des vrais Domain Objects (qui utilisent donc les `domainBuilder`).

## :100: Pour tester
Ce fonctionnement est instable et on n'en connait pas encore la cause mais la reproduction devrait être quelque chose comme ceci :
1. Passer un test de certif avec ```certif1@example.net```
1. Ne pas perdre le focus lors d'une épreuve focus
1. Valider ou passer la question
1. Perdre le focus sur la question non focus suivante
1. Passer la question non focus
1. Constater que le log "A non focused challenge received a focused out answer" est bien remonté
1. Voir que la 2nde épreuve n'est pas `focusOut` mais bien `OK`/`KO`
