### PR TITLE
[TECH] Ne pas logguer les usernames lors de la création d'un compte via la réconciliation (PIX-4630)

### DIFF
--- a/api/lib/domain/models/UserToCreate.js
+++ b/api/lib/domain/models/UserToCreate.js
@@ -1,0 +1,70 @@
+const _ = require('lodash');
+
+class UserToCreate {
+  constructor({
+    firstName = '',
+    lastName = '',
+    email = null,
+    cgu = false,
+    hasSeenAssessmentInstructions = false,
+    username = null,
+    mustValidateTermsOfService = false,
+    lastTermsOfServiceValidatedAt = null,
+    lang = 'fr',
+    hasSeenNewDashboardInfo = false,
+    isAnonymous = false,
+    hasSeenFocusedChallengeTooltip = false,
+    hasSeenOtherChallengesTooltip = false,
+    createdAt,
+    updatedAt,
+  } = {}) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.cgu = cgu;
+    this.hasSeenAssessmentInstructions = hasSeenAssessmentInstructions;
+    this.username = username;
+    this.mustValidateTermsOfService = mustValidateTermsOfService;
+    this.lastTermsOfServiceValidatedAt = lastTermsOfServiceValidatedAt;
+    this.lang = lang;
+    this.hasSeenNewDashboardInfo = hasSeenNewDashboardInfo;
+    this.isAnonymous = isAnonymous;
+    this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;
+    this.hasSeenOtherChallengesTooltip = hasSeenOtherChallengesTooltip;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static create(user) {
+    const now = new Date();
+    return new UserToCreate({
+      ...user,
+      createdAt: now,
+      updatedAt: now,
+      email: user.email ? _(user.email).toLower().trim() : null,
+    });
+  }
+
+  static createFromPoleEmploi(user) {
+    const now = new Date();
+    return new UserToCreate({
+      ...user,
+      cgu: true,
+      lastTermsOfServiceValidatedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  static createAnonymous(user) {
+    const now = new Date();
+    return new UserToCreate({
+      ...user,
+      isAnonymous: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}
+
+module.exports = UserToCreate;

--- a/api/lib/domain/usecases/authenticate-anonymous-user.js
+++ b/api/lib/domain/usecases/authenticate-anonymous-user.js
@@ -1,11 +1,11 @@
-const User = require('../models/User');
 const { UserCantBeCreatedError } = require('../errors');
+const UserToCreate = require('../models/UserToCreate');
 
 module.exports = async function authenticateAnonymousUser({
   campaignCode,
   lang = 'fr',
   campaignToJoinRepository,
-  userRepository,
+  userToCreateRepository,
   tokenService,
 }) {
   const campaign = await campaignToJoinRepository.getByCode(campaignCode);
@@ -13,16 +13,8 @@ module.exports = async function authenticateAnonymousUser({
     throw new UserCantBeCreatedError();
   }
 
-  const newUser = await userRepository.create({
-    user: new User({
-      firstName: '',
-      lastName: '',
-      cgu: false,
-      mustValidateTermsOfService: false,
-      isAnonymous: true,
-      lang,
-    }),
-  });
+  const userToAdd = UserToCreate.createAnonymous({ lang });
+  const newUser = await userToCreateRepository.create({ user: userToAdd });
 
   const accessToken = tokenService.createAccessTokenFromUser(newUser.id, 'pix').accessToken;
   return accessToken;

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
@@ -116,6 +116,7 @@ module.exports = async function createAndReconcileUserToSchoolingRegistration({
   campaignRepository,
   schoolingRegistrationRepository,
   userRepository,
+  userToCreateRepository,
   encryptionService,
   mailService,
   obfuscationService,
@@ -161,7 +162,7 @@ module.exports = async function createAndReconcileUserToSchoolingRegistration({
     user: domainUser,
     authenticationMethodRepository,
     schoolingRegistrationRepository,
-    userRepository,
+    userToCreateRepository,
   });
 
   const createdUser = await userRepository.get(userId);

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
@@ -88,11 +88,11 @@ async function _validateData({ isUsernameMode, password, userAttributes, userRep
   validationErrors.push(_validatePassword(password));
 
   if (isUsernameMode) {
-    try {
-      await userRepository.isUsernameAvailable(userAttributes.username);
-    } catch (err) {
-      validationErrors.push(_manageUsernameAvailabilityError(err));
-    }
+    // try {
+    //   await userRepository.isUsernameAvailable(userAttributes.username);
+    // } catch (err) {
+    //   validationErrors.push(_manageUsernameAvailabilityError(err));
+    // }
   } else {
     try {
       await userRepository.checkIfEmailIsAvailable(userAttributes.email);

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-schooling-registration.js
@@ -88,11 +88,11 @@ async function _validateData({ isUsernameMode, password, userAttributes, userRep
   validationErrors.push(_validatePassword(password));
 
   if (isUsernameMode) {
-    // try {
-    //   await userRepository.isUsernameAvailable(userAttributes.username);
-    // } catch (err) {
-    //   validationErrors.push(_manageUsernameAvailabilityError(err));
-    // }
+    try {
+      await userRepository.isUsernameAvailable(userAttributes.username);
+    } catch (err) {
+      validationErrors.push(_manageUsernameAvailabilityError(err));
+    }
   } else {
     try {
       await userRepository.checkIfEmailIsAvailable(userAttributes.email);

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -14,6 +14,7 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
   authenticationMethodRepository,
   campaignRepository,
   userRepository,
+  userToCreateRepository,
   schoolingRegistrationRepository,
   studentRepository,
 }) {
@@ -71,7 +72,7 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
         samlId: externalUser.samlId,
         authenticationMethodRepository,
         schoolingRegistrationRepository,
-        userRepository,
+        userToCreateRepository,
       });
     }
   } catch (error) {

--- a/api/lib/domain/usecases/create-user.js
+++ b/api/lib/domain/usecases/create-user.js
@@ -63,6 +63,7 @@ module.exports = async function createUser({
   authenticationMethodRepository,
   campaignRepository,
   userRepository,
+  userToCreateRepository,
   encryptionService,
   mailService,
   userService,
@@ -84,7 +85,7 @@ module.exports = async function createUser({
     const savedUser = await userService.createUserWithPassword({
       user,
       hashedPassword,
-      userRepository,
+      userToCreateRepository,
       authenticationMethodRepository,
     });
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -141,6 +141,7 @@ const dependencies = {
   userEmailRepository: require('../../infrastructure/repositories/user-email-repository'),
   userOrgaSettingsRepository: require('../../infrastructure/repositories/user-orga-settings-repository'),
   userReconciliationService: require('../services/user-reconciliation-service'),
+  userToCreateRepository: require('../../infrastructure/repositories/user-to-create-repository'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
   userService: require('../../domain/services/user-service'),
   userTutorialRepository: require('../../infrastructure/repositories/user-tutorial-repository'),

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,4 +1,3 @@
-const omit = require('lodash/omit');
 const moment = require('moment');
 const { knex } = require('../../../db/knex-database-connection');
 
@@ -172,13 +171,6 @@ module.exports = {
       });
     }).fetch({ require: false, withRelated: 'authenticationMethods' });
     return bookshelfUser ? _toDomain(bookshelfUser) : null;
-  },
-
-  create({ user, domainTransaction = DomainTransaction.emptyTransaction() }) {
-    const userToCreate = _adaptModelToDb(user);
-    return new BookshelfUser(userToCreate)
-      .save(null, { transacting: domainTransaction.knexTransaction })
-      .then((bookshelfUser) => _toDomain(bookshelfUser));
   },
 
   updateWithEmailConfirmed({
@@ -567,21 +559,4 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
   if (email) {
     qb.whereRaw('email LIKE ?', `%${email.toLowerCase()}%`);
   }
-}
-
-function _adaptModelToDb(user) {
-  const userToBeSaved = omit(user, [
-    'id',
-    'campaignParticipations',
-    'pixRoles',
-    'memberships',
-    'certificationCenterMemberships',
-    'pixScore',
-    'knowledgeElements',
-    'scorecards',
-    'userOrgaSettings',
-    'authenticationMethods',
-  ]);
-
-  return userToBeSaved;
 }

--- a/api/lib/infrastructure/repositories/user-to-create-repository.js
+++ b/api/lib/infrastructure/repositories/user-to-create-repository.js
@@ -1,0 +1,63 @@
+const { knex } = require('../../../db/knex-database-connection');
+
+const DomainTransaction = require('../DomainTransaction');
+
+const { AlreadyRegisteredUsernameError } = require('../../domain/errors');
+
+const User = require('../../domain/models/User');
+
+module.exports = {
+  async create({ user, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConnection = domainTransaction.knexTransaction || knex;
+
+    if (user.username) {
+      return await _createWithUsername({ knexConnection, user });
+    } else {
+      return await _createWithoutUsername({ knexConnection, user });
+    }
+  },
+};
+
+async function _createWithUsername({ knexConnection, user }) {
+  const result = await knexConnection(
+    knex.raw('?? (??, ??, ??, ??, ??, ??, ??, ??, ??, ??, ??, ??, ??, ??, ??)', ['users', ...Object.keys(user)])
+  )
+    .insert(
+      knex
+        .select(knex.raw('?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?', Object.values(user)))
+        .whereNotExists(knex('users').where({ username: user.username }))
+    )
+    .returning('*');
+
+  if (result.length < 1) {
+    throw new AlreadyRegisteredUsernameError();
+  }
+  return _toUserDomain(result[0]);
+}
+
+async function _createWithoutUsername({ knexConnection, user }) {
+  const result = await knexConnection('users').insert(user).returning('*');
+  return _toUserDomain(result[0]);
+}
+
+function _toUserDomain(userDTO) {
+  return new User({
+    id: userDTO.id,
+    firstName: userDTO.firstName,
+    lastName: userDTO.lastName,
+    email: userDTO.email,
+    emailConfirmedAt: userDTO.emailConfirmedAt,
+    username: userDTO.username,
+    password: userDTO.password,
+    shouldChangePassword: Boolean(userDTO.shouldChangePassword),
+    cgu: Boolean(userDTO.cgu),
+    lang: userDTO.lang,
+    isAnonymous: Boolean(userDTO.isAnonymous),
+    lastTermsOfServiceValidatedAt: userDTO.lastTermsOfServiceValidatedAt,
+    hasSeenNewDashboardInfo: Boolean(userDTO.hasSeenNewDashboardInfo),
+    mustValidateTermsOfService: Boolean(userDTO.mustValidateTermsOfService),
+    pixOrgaTermsOfServiceAccepted: Boolean(userDTO.pixOrgaTermsOfServiceAccepted),
+    pixCertifTermsOfServiceAccepted: Boolean(userDTO.pixCertifTermsOfServiceAccepted),
+    hasSeenAssessmentInstructions: Boolean(userDTO.hasSeenAssessmentInstructions),
+  });
+}

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -149,9 +149,9 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
       });
 
       context('when username is already taken', function () {
-        it.only('should respond with a 422 - Unprocessable entity', async function () {
+        it('should respond with a 422 - Unprocessable entity', async function () {
           // given
-          const username = 'rgpd.please1234';
+          const username = 'angie.go1234';
           databaseBuilder.factory.buildUser({ username });
           await databaseBuilder.commit();
 
@@ -175,7 +175,6 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
           });
 
           // then
-          console.log(response);
           expect(response.statusCode).to.equal(422);
           expect(response.result.errors[0].detail).to.equal(
             'Cet identifiant n’est plus disponible, merci de recharger la page.'

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -27,7 +27,6 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
         nationalStudentId: 'salut',
       });
       campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
-
       await databaseBuilder.commit();
     });
 

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -150,9 +150,9 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
       });
 
       context('when username is already taken', function () {
-        it('should respond with a 422 - Unprocessable entity', async function () {
+        it.only('should respond with a 422 - Unprocessable entity', async function () {
           // given
-          const username = 'angie.go1234';
+          const username = 'rgpd.please1234';
           databaseBuilder.factory.buildUser({ username });
           await databaseBuilder.commit();
 
@@ -176,6 +176,7 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
           });
 
           // then
+          console.log(response);
           expect(response.statusCode).to.equal(422);
           expect(response.result.errors[0].detail).to.equal(
             'Cet identifiant n’est plus disponible, merci de recharger la page.'

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-route_test.js
@@ -16,7 +16,6 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
   describe('POST /api/schooling-registration-dependent-users', function () {
     let organization;
     let campaign;
-    let options;
     let schoolingRegistration;
 
     beforeEach(async function () {
@@ -30,35 +29,28 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
       campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
 
       await databaseBuilder.commit();
-
-      options = {
-        method: 'POST',
-        url: '/api/schooling-registration-dependent-users',
-        payload: {
-          data: {
-            attributes: {
-              'campaign-code': campaign.code,
-              'first-name': schoolingRegistration.firstName,
-              'last-name': schoolingRegistration.lastName,
-              birthdate: schoolingRegistration.birthdate,
-              password: 'P@ssw0rd',
-            },
-          },
-        },
-      };
     });
 
     context('when creation is with email', function () {
-      const email = 'angie@example.net';
-
-      beforeEach(async function () {
-        options.payload.data.attributes.email = email;
-        options.payload.data.attributes['with-username'] = false;
-      });
-
       it('should return an 204 status after having successfully created user and associated user to schoolingRegistration', async function () {
         // when
-        const response = await server.inject(options);
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/schooling-registration-dependent-users',
+          payload: {
+            data: {
+              attributes: {
+                'campaign-code': campaign.code,
+                'first-name': schoolingRegistration.firstName,
+                'last-name': schoolingRegistration.lastName,
+                birthdate: schoolingRegistration.birthdate,
+                password: 'P@ssw0rd',
+                email: 'angie@example.net',
+                'with-username': false,
+              },
+            },
+          },
+        });
 
         // then
         expect(response.statusCode).to.equal(204);
@@ -78,12 +70,24 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
           });
           await databaseBuilder.commit();
 
-          options.payload.data.attributes['first-name'] = schoolingRegistrationAlreadyLinked.firstName;
-          options.payload.data.attributes['last-name'] = schoolingRegistrationAlreadyLinked.lastName;
-          options.payload.data.attributes['birthdate'] = schoolingRegistrationAlreadyLinked.birthdate;
-
           // when
-          const response = await server.inject(options);
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/schooling-registration-dependent-users',
+            payload: {
+              data: {
+                attributes: {
+                  'campaign-code': campaign.code,
+                  'first-name': schoolingRegistrationAlreadyLinked.firstName,
+                  'last-name': schoolingRegistrationAlreadyLinked.lastName,
+                  birthdate: schoolingRegistrationAlreadyLinked.birthdate,
+                  password: 'P@ssw0rd',
+                  email: 'angie@example.net',
+                  'with-username': false,
+                },
+              },
+            },
+          });
 
           // then
           expect(response.statusCode).to.equal(409);
@@ -95,11 +99,24 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
 
       context('when a field is not valid', function () {
         it('should respond with a 422 - Unprocessable Entity', async function () {
-          // given
-          options.payload.data.attributes.email = 'not valid email';
-
           // when
-          const response = await server.inject(options);
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/schooling-registration-dependent-users',
+            payload: {
+              data: {
+                attributes: {
+                  'campaign-code': campaign.code,
+                  'first-name': schoolingRegistration.firstName,
+                  'last-name': schoolingRegistration.lastName,
+                  birthdate: schoolingRegistration.birthdate,
+                  password: 'P@ssw0rd',
+                  email: 'not valid email',
+                  'with-username': false,
+                },
+              },
+            },
+          });
 
           // then
           expect(response.statusCode).to.equal(422);
@@ -108,16 +125,25 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
     });
 
     context('when creation is with username', function () {
-      const username = 'angie.go1234';
-
-      beforeEach(async function () {
-        options.payload.data.attributes.username = username;
-        options.payload.data.attributes['with-username'] = true;
-      });
-
       it('should return a 204 status after having successfully created user and associated user to schoolingRegistration', async function () {
         // when
-        const response = await server.inject(options);
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/schooling-registration-dependent-users',
+          payload: {
+            data: {
+              attributes: {
+                'campaign-code': campaign.code,
+                'first-name': schoolingRegistration.firstName,
+                'last-name': schoolingRegistration.lastName,
+                birthdate: schoolingRegistration.birthdate,
+                password: 'P@ssw0rd',
+                username: 'angie.go1234',
+                'with-username': true,
+              },
+            },
+          },
+        });
 
         // then
         expect(response.statusCode).to.equal(204);
@@ -126,11 +152,28 @@ describe('Acceptance | Route | Schooling-registration-dependent-user', function 
       context('when username is already taken', function () {
         it('should respond with a 422 - Unprocessable entity', async function () {
           // given
+          const username = 'angie.go1234';
           databaseBuilder.factory.buildUser({ username });
           await databaseBuilder.commit();
 
           // when
-          const response = await server.inject(options);
+          const response = await server.inject({
+            method: 'POST',
+            url: '/api/schooling-registration-dependent-users',
+            payload: {
+              data: {
+                attributes: {
+                  'campaign-code': campaign.code,
+                  'first-name': schoolingRegistration.firstName,
+                  'last-name': schoolingRegistration.lastName,
+                  birthdate: schoolingRegistration.birthdate,
+                  password: 'P@ssw0rd',
+                  username,
+                  'with-username': true,
+                },
+              },
+            },
+          });
 
           // then
           expect(response.statusCode).to.equal(422);

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -32,8 +32,8 @@ describe('Integration | Application | Users | Routes', function () {
 
     context('when user create account before joining campaign', function () {
       it('should return HTTP 201', async function () {
-        // given
-        const payload = {
+        // given / when
+        const response = await httpTestServer.request('POST', '/api/users', {
           data: {
             attributes: {
               'first-name': 'marine',
@@ -53,12 +53,7 @@ describe('Integration | Application | Users | Routes', function () {
           meta: {
             'campaign-code': 'TRWYWV411',
           },
-        };
-
-        const url = '/api/users';
-
-        // when
-        const response = await httpTestServer.request('POST', url, payload);
+        });
 
         // then
         expect(response.statusCode).to.equal(201);

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -5,6 +5,7 @@ const { catchErr, domainBuilder, databaseBuilder, expect, knex } = require('../.
 const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
 const schoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/schooling-registration-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const userToCreateRepository = require('../../../../lib/infrastructure/repositories/user-to-create-repository');
 
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const { SchoolingRegistrationNotFound } = require('../../../../lib/domain/errors');
@@ -44,6 +45,7 @@ describe('Integration | Domain | Services | user-service', function () {
         user,
         hashedPassword,
         userRepository,
+        userToCreateRepository,
         authenticationMethodRepository,
       });
 
@@ -165,7 +167,7 @@ describe('Integration | Domain | Services | user-service', function () {
           user,
           authenticationMethodRepository,
           schoolingRegistrationRepository,
-          userRepository,
+          userToCreateRepository,
         });
 
         // then
@@ -192,7 +194,7 @@ describe('Integration | Domain | Services | user-service', function () {
           user,
           authenticationMethodRepository,
           schoolingRegistrationRepository,
-          userRepository,
+          userToCreateRepository,
         });
 
         // then
@@ -217,7 +219,7 @@ describe('Integration | Domain | Services | user-service', function () {
             user,
             authenticationMethodRepository,
             schoolingRegistrationRepository,
-            userRepository,
+            userToCreateRepository,
           });
 
           // then
@@ -249,7 +251,7 @@ describe('Integration | Domain | Services | user-service', function () {
           user,
           authenticationMethodRepository,
           schoolingRegistrationRepository,
-          userRepository,
+          userToCreateRepository,
         });
 
         // then

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-schooling-registration_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-schooling-registration_test.js
@@ -6,6 +6,7 @@ const authenticationMethodRepository = require('../../../../lib/infrastructure/r
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const schoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/schooling-registration-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const userToCreateRepository = require('../../../../lib/infrastructure/repositories/user-to-create-repository');
 
 const encryptionService = require('../../../../lib/domain/services/encryption-service');
 const mailService = require('../../../../lib/domain/services/mail-service');
@@ -251,14 +252,6 @@ describe('Integration | UseCases | create-and-reconcile-user-to-schooling-regist
           const email = 'user@organization.org';
           userAttributes.email = email;
 
-          const expectedUser = {
-            firstName: userAttributes.firstName,
-            lastName: userAttributes.lastName,
-            email,
-            username: null,
-            cgu: false,
-          };
-
           // when
           const result = await createAndReconcileUserToSchoolingRegistration({
             campaignCode,
@@ -269,6 +262,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-schooling-regist
             campaignRepository,
             schoolingRegistrationRepository,
             userRepository,
+            userToCreateRepository,
             encryptionService,
             mailService,
             obfuscationService,
@@ -277,7 +271,13 @@ describe('Integration | UseCases | create-and-reconcile-user-to-schooling-regist
           });
 
           // then
-          expect(pick(result, pickUserAttributes)).to.deep.equal(expectedUser);
+          expect(pick(result, pickUserAttributes)).to.deep.equal({
+            firstName: userAttributes.firstName,
+            lastName: userAttributes.lastName,
+            email,
+            username: null,
+            cgu: false,
+          });
         });
       });
     });
@@ -368,6 +368,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-schooling-regist
             campaignRepository,
             schoolingRegistrationRepository,
             userRepository,
+            userToCreateRepository,
             encryptionService,
             mailService,
             obfuscationService,

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -3,6 +3,7 @@ const { catchErr, databaseBuilder, expect, knex } = require('../../../test-helpe
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const schoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/schooling-registration-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const userToCreateRepository = require('../../../../lib/infrastructure/repositories/user-to-create-repository');
 const studentRepository = require('../../../../lib/infrastructure/repositories/student-repository');
 const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
 
@@ -201,6 +202,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
         schoolingRegistrationRepository,
         studentRepository,
         userRepository,
+        userToCreateRepository,
       });
 
       // then

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -3,7 +3,7 @@ const map = require('lodash/map');
 const times = require('lodash/times');
 const pick = require('lodash/pick');
 
-const { expect, knex, databaseBuilder, domainBuilder, catchErr, sinon } = require('../../../test-helper');
+const { expect, knex, databaseBuilder, catchErr, sinon } = require('../../../test-helper');
 
 const {
   AlreadyExistingEntityError,
@@ -673,51 +673,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         // then
         expect(userDetailsForAdmin.authenticationMethods.length).to.equal(2);
       });
-    });
-  });
-
-  describe('#create', function () {
-    afterEach(async function () {
-      await knex('users').delete();
-    });
-
-    it('should save the user', async function () {
-      // given
-      const email = 'my-email-to-save@example.net';
-      const user = domainBuilder.buildUser({
-        firstName: 'laura',
-        lastName: 'lune',
-        email: email,
-        cgu: true,
-      });
-
-      // when
-      await userRepository.create({ user });
-
-      // then
-      const usersSaved = await knex('users').select();
-      expect(usersSaved).to.have.lengthOf(1);
-    });
-
-    it('should return a Domain User object', async function () {
-      // given
-      const email = 'my-email-to-save@example.net';
-      const user = domainBuilder.buildUser({
-        firstName: 'laura',
-        lastName: 'lune',
-        email: email,
-        cgu: true,
-      });
-
-      // when
-      const userSaved = await userRepository.create({ user });
-
-      // then
-      expect(userSaved).to.be.an.instanceOf(User);
-      expect(userSaved.firstName).to.equal(user.firstName);
-      expect(userSaved.lastName).to.equal(user.lastName);
-      expect(userSaved.email).to.equal(user.email);
-      expect(userSaved.cgu).to.equal(user.cgu);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js
@@ -1,0 +1,76 @@
+const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
+
+const { AlreadyRegisteredUsernameError } = require('../../../../lib/domain/errors');
+
+const User = require('../../../../lib/domain/models/User');
+const UserToCreateRepository = require('../../../../lib/infrastructure/repositories/user-to-create-repository');
+const UserToCreate = require('../../../../lib/domain/models/UserToCreate');
+
+describe('Integration | Infrastructure | Repository | UserToCreateRepository', function () {
+  describe('#create', function () {
+    afterEach(async function () {
+      await knex('users').delete();
+    });
+
+    it('should save the user', async function () {
+      // given
+      const email = 'my-email-to-save@example.net';
+      const user = new UserToCreate({
+        firstName: 'laura',
+        lastName: 'lune',
+        email,
+        cgu: true,
+      });
+
+      // when
+      await UserToCreateRepository.create({ user });
+
+      // then
+      const usersSaved = await knex('users').select();
+      expect(usersSaved).to.have.lengthOf(1);
+    });
+
+    it('should return a Domain User object', async function () {
+      // given
+      const email = 'my-email-to-save@example.net';
+      const user = new UserToCreate({
+        firstName: 'laura',
+        lastName: 'lune',
+        email,
+        cgu: true,
+      });
+
+      // when
+      const userSaved = await UserToCreateRepository.create({ user });
+
+      // then
+      expect(userSaved).to.be.an.instanceOf(User);
+      expect(userSaved.firstName).to.equal(user.firstName);
+      expect(userSaved.lastName).to.equal(user.lastName);
+      expect(userSaved.email).to.equal(user.email);
+      expect(userSaved.cgu).to.equal(user.cgu);
+    });
+
+    it('should throw a custom error when username is already taken', async function () {
+      // given
+      const alreadyExistingUserName = 'thierryDicule1234';
+      databaseBuilder.factory.buildUser({ id: 7, username: alreadyExistingUserName });
+      await databaseBuilder.commit();
+
+      const now = new Date('2022-02-01');
+      const user = new UserToCreate({
+        firstName: 'Thierry',
+        lastName: 'Dicule',
+        username: alreadyExistingUserName,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // when
+      const error = await catchErr(UserToCreateRepository.create)({ user });
+
+      // then
+      expect(error).to.be.instanceOf(AlreadyRegisteredUsernameError);
+    });
+  });
+});

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -2,7 +2,6 @@ const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 
 const User = require('../../../../lib/domain/models/User');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 const encryptionService = require('../../../../lib/domain/services/encryption-service');
 const mailService = require('../../../../lib/domain/services/mail-service');
@@ -37,7 +36,6 @@ describe('Unit | Controller | user-controller', function () {
     beforeEach(function () {
       sinon.stub(userSerializer, 'deserialize').returns(deserializedUser);
       sinon.stub(userSerializer, 'serialize');
-      sinon.stub(userRepository, 'create').resolves(savedUser);
       sinon.stub(validationErrorSerializer, 'serialize');
       sinon.stub(encryptionService, 'hashPassword');
       sinon.stub(mailService, 'sendAccountCreationEmail');
@@ -45,27 +43,28 @@ describe('Unit | Controller | user-controller', function () {
     });
 
     describe('when request is valid', function () {
-      const request = {
-        payload: {
-          data: {
-            attributes: {
-              'first-name': 'John',
-              'last-name': 'DoDoe',
-              email: 'john.dodoe@example.net',
-              cgu: true,
-              password,
-            },
-          },
-        },
-      };
-
       it('should return a serialized user and a 201 status code', async function () {
         // given
         const expectedSerializedUser = { message: 'serialized user' };
         userSerializer.serialize.returns(expectedSerializedUser);
 
         // when
-        const response = await userController.save(request, hFake);
+        const response = await userController.save(
+          {
+            payload: {
+              data: {
+                attributes: {
+                  'first-name': 'John',
+                  'last-name': 'DoDoe',
+                  email: 'john.dodoe@example.net',
+                  cgu: true,
+                  password,
+                },
+              },
+            },
+          },
+          hFake
+        );
 
         // then
         expect(userSerializer.serialize).to.have.been.calledWith(savedUser);
@@ -83,7 +82,22 @@ describe('Unit | Controller | user-controller', function () {
         };
 
         // when
-        await userController.save(request, hFake);
+        await userController.save(
+          {
+            payload: {
+              data: {
+                attributes: {
+                  'first-name': 'John',
+                  'last-name': 'DoDoe',
+                  email: 'john.dodoe@example.net',
+                  cgu: true,
+                  password,
+                },
+              },
+            },
+          },
+          hFake
+        );
 
         // then
         expect(usecases.createUser).to.have.been.calledWith(useCaseParameters);

--- a/api/tests/unit/domain/models/UserToCreate_test.js
+++ b/api/tests/unit/domain/models/UserToCreate_test.js
@@ -1,0 +1,83 @@
+const { expect, sinon } = require('../../../test-helper');
+
+const UserToCreate = require('../../../../lib/domain/models/UserToCreate');
+
+describe('Unit | Domain | Models | UserToCreate', function () {
+  describe('constructor', function () {
+    it('should build a default user', function () {
+      // given / when
+      const user = new UserToCreate();
+
+      // then
+      expect(user).to.deep.equal({
+        firstName: '',
+        lastName: '',
+        email: null,
+        cgu: false,
+        hasSeenAssessmentInstructions: false,
+        username: null,
+        mustValidateTermsOfService: false,
+        lastTermsOfServiceValidatedAt: null,
+        lang: 'fr',
+        hasSeenNewDashboardInfo: false,
+        isAnonymous: false,
+        hasSeenFocusedChallengeTooltip: false,
+        hasSeenOtherChallengesTooltip: false,
+        createdAt: undefined,
+        updatedAt: undefined,
+      });
+    });
+  });
+
+  describe('#create', function () {
+    it('should create a user', function () {
+      // given
+      const now = new Date('2022-04-01');
+      const clock = sinon.useFakeTimers({ now });
+
+      // when
+      const user = UserToCreate.create({ email: '  anneMAIL@example.net ' });
+
+      // then
+      expect(user.email).to.equal('annemail@example.net');
+      expect(user.updatedAt).to.deep.equal(now);
+      expect(user.createdAt).to.deep.equal(now);
+      clock.restore();
+    });
+  });
+
+  describe('#createFromPoleEmploi', function () {
+    it('should create a user from pole emploi', function () {
+      // given
+      const now = new Date('2022-04-01');
+      const clock = sinon.useFakeTimers({ now });
+
+      // when
+      const user = UserToCreate.createFromPoleEmploi({ email: '  anneMAIL@example.net ' });
+
+      // then
+      expect(user.cgu).to.equal(true);
+      expect(user.lastTermsOfServiceValidatedAt).to.deep.equal(now);
+      expect(user.updatedAt).to.deep.equal(now);
+      expect(user.createdAt).to.deep.equal(now);
+      clock.restore();
+    });
+  });
+
+  describe('#createAnonymous', function () {
+    it('should create an anonymous user', function () {
+      // given
+      const now = new Date('2022-04-01');
+      const clock = sinon.useFakeTimers({ now });
+
+      // when
+      const user = UserToCreate.createAnonymous({ email: '  anneMAIL@example.net ' });
+
+      // then
+      expect(user.isAnonymous).to.equal(true);
+      expect(user.updatedAt).to.deep.equal(now);
+      expect(user.createdAt).to.deep.equal(now);
+      clock.restore();
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -21,6 +21,7 @@ describe('Unit | UseCase | create-user', function () {
   let campaignCode;
   let authenticationMethodRepository;
   let userRepository;
+  let userToCreateRepository;
   let campaignRepository;
   let encryptionService;
   let mailService;
@@ -30,6 +31,8 @@ describe('Unit | UseCase | create-user', function () {
     authenticationMethodRepository = {};
     userRepository = {
       checkIfEmailIsAvailable: sinon.stub(),
+    };
+    userToCreateRepository = {
       create: sinon.stub(),
     };
     campaignRepository = {
@@ -50,7 +53,7 @@ describe('Unit | UseCase | create-user', function () {
     sinon.stub(passwordValidator, 'validate');
 
     userRepository.checkIfEmailIsAvailable.resolves();
-    userRepository.create.resolves(savedUser);
+    userToCreateRepository.create.resolves(savedUser);
 
     userValidator.validate.returns();
     passwordValidator.validate.returns();
@@ -76,6 +79,7 @@ describe('Unit | UseCase | create-user', function () {
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userToCreateRepository,
         encryptionService,
         mailService,
         userService,
@@ -95,6 +99,7 @@ describe('Unit | UseCase | create-user', function () {
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userToCreateRepository,
         encryptionService,
         mailService,
         userService,
@@ -114,6 +119,7 @@ describe('Unit | UseCase | create-user', function () {
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userToCreateRepository,
         encryptionService,
         mailService,
         userService,
@@ -147,6 +153,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -185,6 +192,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -225,6 +233,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -253,6 +262,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -280,6 +290,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -327,6 +338,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -349,6 +361,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -368,6 +381,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -377,7 +391,7 @@ describe('Unit | UseCase | create-user', function () {
         expect(userService.createUserWithPassword).to.have.been.calledWith({
           user,
           hashedPassword,
-          userRepository,
+          userToCreateRepository,
           authenticationMethodRepository,
         });
       });
@@ -400,6 +414,7 @@ describe('Unit | UseCase | create-user', function () {
           authenticationMethodRepository,
           campaignRepository,
           userRepository,
+          userToCreateRepository,
           encryptionService,
           mailService,
           userService,
@@ -425,6 +440,7 @@ describe('Unit | UseCase | create-user', function () {
             authenticationMethodRepository,
             campaignRepository,
             userRepository,
+            userToCreateRepository,
             encryptionService,
             mailService,
             userService,
@@ -456,6 +472,7 @@ describe('Unit | UseCase | create-user', function () {
             authenticationMethodRepository,
             campaignRepository,
             userRepository,
+            userToCreateRepository,
             encryptionService,
             mailService,
             userService,
@@ -481,6 +498,7 @@ describe('Unit | UseCase | create-user', function () {
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
+        userToCreateRepository,
         encryptionService,
         mailService,
         userService,


### PR DESCRIPTION
## :unicorn: Problème
Récemment, nous avons eu des remontées d'erreur 500 lors de la réconciliation d'un élève en indiquant que le username devait être unique. Parmi les logs présents sur datadog, certains relevaient le username ce qui n'est pas souhaitable pour des questions RGPD.

On pouvait donc lire : 
```Key (username)=(*****.**********) already exists.```

## :robot: Solution
> En plus de ce message JS, on a PG qui logue le même message donc c’est effectivement compliqué d’empêcher les valeurs d’apparaître si on a une violation de contrainte
https://1024pix.slack.com/archives/C6SGTNVUK/p1648144416669619?thread_ts=1647945740.842549&cid=C6SGTNVUK

Vérifier juste avant de faire l'ajout d'utilisateur que personne ne possède déjà le username.
Etant donné qu'on sépare ça en deux requêtes, cela ne résout pas entièrement le problème mais permet juste d'en limiter les occurrences.

## :rainbow: Remarques
Voir [discussions slack sur les erreurs remontées](https://1024pix.slack.com/archives/C6SGTNVUK/p1647945740842549)

Le pourquoi on sépare la vérification de l'existence du username de l'insertion du nouvel user : https://stackoverflow.com/questions/56998998/knex-issue-wherenotexists

## :100: Pour tester
- Drop les derniers commits pour se placer sur le commit `[API] this commit is just for testing and will be revert`) 
- Lancer le test d'acceptance sur lequel est placé un `.only`
- Constater que vous avez dans vos logs le username du test comme ci-dessous : 
![image](https://user-images.githubusercontent.com/38167520/159742812-86a42b6b-a6c7-467e-947b-f72614dff5e4.png)

- Rétablir les commits jusqu'au commit `[api] use user creation repo`
- Lancer le même test d'acceptance
- Constater qu'il n'y a plus dans les log le username


Faire des tests de non régression sur la création de user : 
- lors d'un parcours simplifié pour tester la création d'un utilisateur anonyme (aller dans pix app sans se connecter sur `/campagnes` et entrez le code campagne SIMPLIFIE). Vérifiez qu'en base votre utilisateur a été créé avec `isAnonymous` à true. 
- lors de la réconciliation d'un élève (aller sur `/campagnes` sans être connecté, entrez le code `SCOBADGE1`, `first, last, 10/10/2010, et Azerty123*` vérifiez en base dans la table `organization-learners` que l'userId est bien mis pour First Last et qu'il correspond à l'utilisateur créé dans la table `users`)
- lors de la création d'un compte classique (`/inscription` puis vérifier en base que les informations sont bonnes) 
- lors de la création d'un utilisateur depuis Pole Emploi (voir https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1949663259/Int+gration+P+le+Emploi+-+Pix) 
