### PR TITLE
[TECH] Refacto du usecase send-sco-invitation (PIX-4632).

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -80,6 +80,10 @@ class Organization {
   get isScoAndHasExternalId() {
     return this.isSco && Boolean(this.externalId);
   }
+
+  get isArchived() {
+    return this.archivedAt !== null;
+  }
 }
 
 Organization.types = types;

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -15,8 +15,8 @@ module.exports = async function sendScoInvitation({
   organizationRepository,
   organizationInvitationRepository,
 }) {
-  const organizationWithGivenUAI = await _getOrganizationWithGivenUAI(organizationRepository, uai);
-  _ensureOrganizationHasAnEmail(organizationWithGivenUAI, uai);
+  const organizationWithGivenUAI = await _getOrganizationWithGivenUAI({ uai, organizationRepository });
+  _ensureOrganizationHasAnEmail({ email: organizationWithGivenUAI.email, uai });
   _ensureOrganizationIsNotArchived(organizationWithGivenUAI);
 
   return await organizationInvitationService.createScoOrganizationInvitation({
@@ -30,29 +30,29 @@ module.exports = async function sendScoInvitation({
   });
 };
 
-async function _getOrganizationWithGivenUAI(organizationRepository, uai) {
+async function _getOrganizationWithGivenUAI({ uai, organizationRepository }) {
   const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
-  _ensureThereIsNoMoreThanOneOrganization(organizationsFound.length, uai);
-  _ensureThereIsAtLeastOneOrganization(organizationsFound.length, uai);
+  _ensureThereIsNoMoreThanOneOrganization({ organizationCount: organizationsFound.length, uai });
+  _ensureThereIsAtLeastOneOrganization({ organizationCount: organizationsFound.length, uai });
   return organizationsFound[0];
 }
 
-function _ensureThereIsAtLeastOneOrganization(organizationCount, uai) {
+function _ensureThereIsAtLeastOneOrganization({ organizationCount, uai }) {
   if (organizationCount === 0) {
     const errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
     throw new OrganizationNotFoundError(errorMessage);
   }
 }
 
-function _ensureThereIsNoMoreThanOneOrganization(organizationCount, uai) {
+function _ensureThereIsNoMoreThanOneOrganization({ organizationCount, uai }) {
   if (organizationCount > 1) {
     const errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
     throw new ManyOrganizationsFoundError(errorMessage);
   }
 }
 
-function _ensureOrganizationHasAnEmail(organization, uai) {
-  if (_.isEmpty(organization.email)) {
+function _ensureOrganizationHasAnEmail({ email, uai }) {
+  if (_.isEmpty(email)) {
     const errorMessage = `Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE ${uai}.`;
     throw new OrganizationWithoutEmailError(errorMessage);
   }

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -15,11 +15,7 @@ module.exports = async function sendScoInvitation({
   organizationRepository,
   organizationInvitationRepository,
 }) {
-  const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
-  _ensureThereIsNoMoreThanOneOrganization(organizationsFound, uai);
-  _ensureThereIsAtLeastOneOrganization(organizationsFound, uai);
-
-  const organizationForUAI = organizationsFound[0];
+  const organizationForUAI = await _getOrganizationForUAI(organizationRepository, uai);
   _ensureOrganizationHasAnEmail(organizationForUAI, uai);
   _ensureOrganizationIsNotArchived(organizationForUAI);
 
@@ -33,6 +29,13 @@ module.exports = async function sendScoInvitation({
     organizationInvitationRepository,
   });
 };
+
+async function _getOrganizationForUAI(organizationRepository, uai) {
+  const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
+  _ensureThereIsNoMoreThanOneOrganization(organizationsFound, uai);
+  _ensureThereIsAtLeastOneOrganization(organizationsFound, uai);
+  return organizationsFound[0];
+}
 
 function _ensureThereIsAtLeastOneOrganization(organizationsFound, uai) {
   if (organizationsFound.length === 0) {

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -59,7 +59,7 @@ function _ensureOrganizationHasAnEmail(organization, uai) {
 }
 
 function _ensureOrganizationIsNotArchived(organization) {
-  if (organization.archivedAt) {
+  if (organization.isArchived) {
     throw new OrganizationArchivedError();
   }
 }

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -17,13 +17,13 @@ module.exports = async function sendScoInvitation({
 }) {
   const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
 
-  _checkIfManyOrganizationsFound(organizationsFound, uai);
+  _ensureThereIsNoMoreThanOneOrganization(organizationsFound, uai);
 
-  _checkIfOrganizationNotFound(organizationsFound, uai);
+  _ensureThereIsAtLeastOneOrganization(organizationsFound, uai);
 
-  _checkIfOrganizationWithoutEmail(organizationsFound, uai);
+  _ensureOrganizationHasAnEmail(organizationsFound, uai);
 
-  _checkIfOrganizationIsArchived(organizationsFound);
+  _ensureOrganizationIsNotArchived(organizationsFound);
 
   const email = organizationsFound[0].email;
   const organizationId = organizationsFound[0].id;
@@ -39,28 +39,28 @@ module.exports = async function sendScoInvitation({
   });
 };
 
-function _checkIfOrganizationNotFound(organizationsFound, uai) {
+function _ensureThereIsAtLeastOneOrganization(organizationsFound, uai) {
   if (organizationsFound.length === 0) {
     const errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
     throw new OrganizationNotFoundError(errorMessage);
   }
 }
 
-function _checkIfManyOrganizationsFound(organizationsFound, uai) {
+function _ensureThereIsNoMoreThanOneOrganization(organizationsFound, uai) {
   if (organizationsFound.length > 1) {
     const errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
     throw new ManyOrganizationsFoundError(errorMessage);
   }
 }
 
-function _checkIfOrganizationWithoutEmail(organizationsFound, uai) {
+function _ensureOrganizationHasAnEmail(organizationsFound, uai) {
   if (organizationsFound.length === 1 && _.isEmpty(organizationsFound[0].email)) {
     const errorMessage = `Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE ${uai}.`;
     throw new OrganizationWithoutEmailError(errorMessage);
   }
 }
 
-function _checkIfOrganizationIsArchived(organizationsFound) {
+function _ensureOrganizationIsNotArchived(organizationsFound) {
   if (organizationsFound.length === 1 && !!organizationsFound[0].archivedAt) {
     throw new OrganizationArchivedError();
   }

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -15,13 +15,13 @@ module.exports = async function sendScoInvitation({
   organizationRepository,
   organizationInvitationRepository,
 }) {
-  const organizationForUAI = await _getOrganizationForUAI(organizationRepository, uai);
-  _ensureOrganizationHasAnEmail(organizationForUAI, uai);
-  _ensureOrganizationIsNotArchived(organizationForUAI);
+  const organizationWithGivenUAI = await _getOrganizationWithGivenUAI(organizationRepository, uai);
+  _ensureOrganizationHasAnEmail(organizationWithGivenUAI, uai);
+  _ensureOrganizationIsNotArchived(organizationWithGivenUAI);
 
   return await organizationInvitationService.createScoOrganizationInvitation({
-    organizationId: organizationForUAI.id,
-    email: organizationForUAI.email,
+    organizationId: organizationWithGivenUAI.id,
+    email: organizationWithGivenUAI.email,
     firstName,
     lastName,
     locale,
@@ -30,7 +30,7 @@ module.exports = async function sendScoInvitation({
   });
 };
 
-async function _getOrganizationForUAI(organizationRepository, uai) {
+async function _getOrganizationWithGivenUAI(organizationRepository, uai) {
   const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
   _ensureThereIsNoMoreThanOneOrganization(organizationsFound.length, uai);
   _ensureThereIsAtLeastOneOrganization(organizationsFound.length, uai);

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -32,20 +32,20 @@ module.exports = async function sendScoInvitation({
 
 async function _getOrganizationForUAI(organizationRepository, uai) {
   const organizationsFound = await organizationRepository.findScoOrganizationsByUai({ uai: uai.trim() });
-  _ensureThereIsNoMoreThanOneOrganization(organizationsFound, uai);
-  _ensureThereIsAtLeastOneOrganization(organizationsFound, uai);
+  _ensureThereIsNoMoreThanOneOrganization(organizationsFound.length, uai);
+  _ensureThereIsAtLeastOneOrganization(organizationsFound.length, uai);
   return organizationsFound[0];
 }
 
-function _ensureThereIsAtLeastOneOrganization(organizationsFound, uai) {
-  if (organizationsFound.length === 0) {
+function _ensureThereIsAtLeastOneOrganization(organizationCount, uai) {
+  if (organizationCount === 0) {
     const errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
     throw new OrganizationNotFoundError(errorMessage);
   }
 }
 
-function _ensureThereIsNoMoreThanOneOrganization(organizationsFound, uai) {
-  if (organizationsFound.length > 1) {
+function _ensureThereIsNoMoreThanOneOrganization(organizationCount, uai) {
+  if (organizationCount > 1) {
     const errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
     throw new ManyOrganizationsFoundError(errorMessage);
   }

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -220,4 +220,22 @@ describe('Unit | Domain | Models | Organization', function () {
       expect(organization.isScoAndHasExternalId).is.false;
     });
   });
+
+  describe('get#isArchived', function () {
+    it('should return true when organization has an archive date', function () {
+      // given
+      const organization = domainBuilder.buildOrganization({ archivedAt: new Date('2013-05-22T23:42:00Z') });
+
+      // when / then
+      expect(organization.isArchived).is.true;
+    });
+
+    it('should return false when organization does not have an archive date', function () {
+      // given
+      const organization = domainBuilder.buildOrganization({ archivedAt: null });
+
+      // when / then
+      expect(organization.isArchived).is.false;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

En faisant la revue de code de la PR , on a constaté que le code du use-case send-sco-invitation était améliorable, mais on a décidé de garder ce ticket pour plus tard.

## :robot: Solution

Refactorer le code pour améliorer sa lisibilité et éviter les redites.

## :rainbow: Remarques

IMHO le refacto fait apparaître que les méthodes privées ne sont pas très utiles et qu'on pourrait les supprimer, mais je me suis arrêté là pour l'instant.

## :100: Pour tester

Tester l'activation d'un espace Pix Orga et constater le bon affichage des messages d'erreurs pour les cas suivants :
- avec un UAI ne correspondant à aucune orga
- avec un UAI correspondant à plusieurs orga
- avec un UAI correspondant à une orga sans e-mail
- avec un UAI correspondant à une orga archivée

Tester le cas passant.
