### PR TITLE
[TECH] Créer des ségrégations pour les usages de redis (PIX-4635)

### DIFF
--- a/api/lib/domain/services/refresh-token-service.js
+++ b/api/lib/domain/services/refresh-token-service.js
@@ -2,10 +2,13 @@ const settings = require('../../config');
 const tokenService = require('./token-service');
 const { UnauthorizedError } = require('../../application/http-errors');
 const temporaryStorage = require('../../infrastructure/temporary-storage').withPrefix('refresh-tokens:');
+const { v4: uuidv4 } = require('uuid');
 
 async function createRefreshTokenFromUserId({ userId, source }) {
   const expirationDelaySeconds = settings.authentication.refreshTokenLifespanMs / 1000;
+  const token = uuidv4();
   return await temporaryStorage.save({
+    key: token,
     value: { type: 'refresh_token', userId, source },
     expirationDelaySeconds,
   });

--- a/api/lib/domain/services/refresh-token-service.js
+++ b/api/lib/domain/services/refresh-token-service.js
@@ -1,7 +1,7 @@
 const settings = require('../../config');
-const temporaryStorage = require('../../infrastructure/temporary-storage');
 const tokenService = require('./token-service');
 const { UnauthorizedError } = require('../../application/http-errors');
+const temporaryStorage = require('../../infrastructure/temporary-storage').withPrefix('refresh-tokens:');
 
 async function createRefreshTokenFromUserId({ userId, source }) {
   const expirationDelaySeconds = settings.authentication.refreshTokenLifespanMs / 1000;
@@ -25,4 +25,6 @@ module.exports = {
   createRefreshTokenFromUserId,
   createAccessTokenFromRefreshToken,
   revokeRefreshToken,
+
+  temporaryStorageForTests: temporaryStorage,
 };

--- a/api/lib/infrastructure/caches/DistributedCache.js
+++ b/api/lib/infrastructure/caches/DistributedCache.js
@@ -7,8 +7,8 @@ class DistributedCache extends Cache {
 
     this._underlyingCache = underlyingCache;
 
-    this._redisClientPublisher = new RedisClient(redisUrl, 'distributed-cache-publisher');
-    this._redisClientSubscriber = new RedisClient(redisUrl, 'distributed-cache-subscriber');
+    this._redisClientPublisher = new RedisClient(redisUrl, { name: 'distributed-cache-publisher' });
+    this._redisClientSubscriber = new RedisClient(redisUrl, { name: 'distributed-cache-subscriber' });
     this._channel = channel;
 
     this._redisClientSubscriber.on('ready', () => {

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -14,7 +14,7 @@ class RedisCache extends Cache {
   }
 
   static createClient(redis_url) {
-    return new RedisClient(redis_url, 'redis-cache-query-client');
+    return new RedisClient(redis_url, { name: 'redis-cache-query-client', prefix: 'cache:' });
   }
 
   async get(key, generator) {

--- a/api/lib/infrastructure/repositories/pole-emploi-tokens-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-tokens-repository.js
@@ -1,6 +1,5 @@
 const settings = require('../../config');
-
-const temporaryStorage = require('../temporary-storage');
+const temporaryStorage = require('../temporary-storage').withPrefix('pole-emploi-tokens:');
 
 const EXPIRATION_DELAY_SECONDS = settings.poleEmploi.temporaryStorage.expirationDelaySeconds;
 

--- a/api/lib/infrastructure/repositories/user-email-repository.js
+++ b/api/lib/infrastructure/repositories/user-email-repository.js
@@ -1,11 +1,11 @@
 const settings = require('../../config');
-const temporaryStorage = require('../temporary-storage');
 const EXPIRATION_DELAY_SECONDS = settings.temporaryStorage.expirationDelaySeconds;
 const EmailModificationDemand = require('../../domain/models/EmailModificationDemand');
+const temporaryStorage = require('../temporary-storage').withPrefix('verify-email:');
 
 module.exports = {
   saveEmailModificationDemand({ userId, code, newEmail }) {
-    const key = 'VERIFY-EMAIL-' + userId;
+    const key = userId;
 
     return temporaryStorage.save({
       key,
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   async getEmailModificationDemandByUserId(userId) {
-    const key = 'VERIFY-EMAIL-' + userId;
+    const key = userId;
     const emailModificationDemand = await temporaryStorage.get(key);
 
     if (!emailModificationDemand) return;

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -12,7 +12,7 @@ class RedisTemporaryStorage extends TemporaryStorage {
   }
 
   static createClient(redisUrl) {
-    return new RedisClient(redisUrl, 'temporary-storage');
+    return new RedisClient(redisUrl, { name: 'temporary-storage', prefix: 'temporary-storage:' });
   }
 
   async save({ key, value, expirationDelaySeconds }) {

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -16,6 +16,25 @@ class TemporaryStorage {
   async delete(/* key */) {
     throw new Error('Method #delete(key) must be overridden');
   }
+
+  withPrefix(prefix) {
+    const storage = this;
+    return {
+      async save({ key, ...args }) {
+        key = key ?? TemporaryStorage.generateKey();
+        await storage.save({ key: prefix + key, ...args });
+        return key;
+      },
+
+      get(key) {
+        return storage.get(prefix + key);
+      },
+
+      delete(key) {
+        return storage.delete(prefix + key);
+      },
+    };
+  }
 }
 
 module.exports = TemporaryStorage;

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -26,8 +26,12 @@ class TemporaryStorage {
         return key;
       },
 
-      get(key) {
-        return storage.get(prefix + key);
+      async get(key) {
+        const result = await storage.get(prefix + key);
+        if (result) {
+          return result;
+        }
+        return await storage.get(key);
       },
 
       delete(key) {

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -5,12 +5,16 @@ class TemporaryStorage {
     return uuidv4();
   }
 
-  async save(/* key, value, expirationDelaySeconds */) {
+  async save(/* { key, value, expirationDelaySeconds } */) {
     throw new Error('Method #save({ key, value, expirationDelaySeconds }) must be overridden');
   }
 
   async get(/* key */) {
     throw new Error('Method #get(key) must be overridden');
+  }
+
+  async delete(/* key */) {
+    throw new Error('Method #delete(key) must be overridden');
   }
 }
 

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -26,12 +26,8 @@ class TemporaryStorage {
         return key;
       },
 
-      async get(key) {
-        const result = await storage.get(prefix + key);
-        if (result) {
-          return result;
-        }
-        return await storage.get(key);
+      get(key) {
+        return storage.get(prefix + key);
       },
 
       delete(key) {

--- a/api/lib/infrastructure/temporary-storage/index.js
+++ b/api/lib/infrastructure/temporary-storage/index.js
@@ -12,4 +12,4 @@ function _createTemporaryStorage() {
   }
 }
 
-module.exports = _createTemporaryStorage();
+module.exports = _createTemporaryStorage(); // export an instance of RedisTemporaryStorage or InMemoryTemporaryStorage (not a function)

--- a/api/lib/infrastructure/temporary-storage/index.js
+++ b/api/lib/infrastructure/temporary-storage/index.js
@@ -12,4 +12,4 @@ function _createTemporaryStorage() {
   }
 }
 
-module.exports = _createTemporaryStorage(); // export an instance of RedisTemporaryStorage or InMemoryTemporaryStorage (not a function)
+module.exports = _createTemporaryStorage();

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -24,12 +24,20 @@ module.exports = class RedisClient {
       { retryCount: 0 }
     );
 
-    this.get = promisify(this._wrapWithPrefix(this._client.get)).bind(this._client);
     this.set = promisify(this._wrapWithPrefix(this._client.set)).bind(this._client);
     this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);
     this.ping = promisify(this._client.ping).bind(this._client);
     this.flushall = promisify(this._client.flushall).bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
+  }
+
+  async get(key, ...args) {
+    const promisifiedGet = promisify(this._client.get);
+    let value = await promisifiedGet.call(this._client, this._prefix + key, ...args);
+    if (!value) {
+      value = await promisifiedGet.call(this._client, key, ...args);
+    }
+    return value;
   }
 
   _wrapWithPrefix(fn) {

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -6,8 +6,10 @@ const logger = require('../logger');
 const REDIS_CLIENT_OPTIONS = {};
 
 module.exports = class RedisClient {
-  constructor(redisUrl, clientName) {
-    this._clientName = clientName;
+  constructor(redisUrl, { name, prefix } = {}) {
+    this._clientName = name;
+
+    this._prefix = prefix ?? '';
 
     this._client = redis.createClient(redisUrl, REDIS_CLIENT_OPTIONS);
 
@@ -22,12 +24,19 @@ module.exports = class RedisClient {
       { retryCount: 0 }
     );
 
-    this.get = promisify(this._client.get).bind(this._client);
-    this.set = promisify(this._client.set).bind(this._client);
-    this.del = promisify(this._client.del).bind(this._client);
+    this.get = promisify(this._wrapWithPrefix(this._client.get)).bind(this._client);
+    this.set = promisify(this._wrapWithPrefix(this._client.set)).bind(this._client);
+    this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);
     this.ping = promisify(this._client.ping).bind(this._client);
     this.flushall = promisify(this._client.flushall).bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
+  }
+
+  _wrapWithPrefix(fn) {
+    const prefix = this._prefix;
+    return function (key, ...args) {
+      return fn.call(this, prefix + key, ...args);
+    };
   }
 
   subscribe(channel) {

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -35,7 +35,8 @@ module.exports = class RedisClient {
     const promisifiedGet = promisify(this._client.get);
     let value = await promisifiedGet.call(this._client, this._prefix + key, ...args);
     if (!value) {
-      value = await promisifiedGet.call(this._client, key, ...args);
+      // TODO: this should be useless after 7 days in production
+      value = await promisifiedGet.call(this._client, key.replace(/^.*:/, ''), ...args);
     }
     return value;
   }

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -25,10 +25,15 @@ module.exports = class RedisClient {
     );
 
     this.set = promisify(this._wrapWithPrefix(this._client.set)).bind(this._client);
-    this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);
     this.ping = promisify(this._client.ping).bind(this._client);
     this.flushall = promisify(this._client.flushall).bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
+  }
+
+  async del(key, ...args) {
+    await promisify(this._client.del).call(this._client, this._prefix + key, ...args);
+    // TODO: this should be useless after 7 days in production
+    await promisify(this._client.del).call(this._client, key.replace(/^.*:/, ''), ...args);
   }
 
   async get(key, ...args) {

--- a/api/lib/infrastructure/utils/redis-monitor.js
+++ b/api/lib/infrastructure/utils/redis-monitor.js
@@ -4,7 +4,7 @@ const RedisClient = require('./RedisClient');
 class RedisMonitor {
   constructor() {
     if (settings.caching.redisUrl) {
-      this._client = new RedisClient(settings.caching.redisUrl, 'redis-monitor');
+      this._client = new RedisClient(settings.caching.redisUrl, { name: 'redis-monitor' });
     }
   }
 

--- a/api/tests/integration/infrastructure/repositories/user-email-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-email-repository_test.js
@@ -9,13 +9,12 @@ describe('Integration | Repository | UserEmailRepository', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       const newEmail = 'user@example.net';
       const code = '999999';
-      const expectedKey = 'VERIFY-EMAIL-' + userId;
 
       // when
       const key = await userEmailRepository.saveEmailModificationDemand({ userId, code, newEmail });
 
       // then
-      expect(key).to.equal(expectedKey);
+      expect(key).to.equal(userId);
     });
   });
 

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -1,0 +1,29 @@
+const RedisClient = require('../../../../lib/infrastructure/utils/RedisClient');
+const { expect } = require('../../../test-helper');
+
+describe('Integration | Infrastructure | Utils | RedisClient', function () {
+  it('stores and retrieve a value for a key', async function () {
+    // given
+    const key = new Date().toISOString();
+    const redisClient = new RedisClient(process.env.REDIS_URL);
+
+    // when
+    redisClient.set(key, 'value');
+    const value = await redisClient.get(key);
+
+    // then
+    expect(value).to.equal('value');
+  });
+
+  it('should separate storage for identical keys saved with different prefixes', async function () {
+    // given
+    const redisClient1 = new RedisClient(process.env.REDIS_URL, { prefix: 'test1' });
+    const redisClient2 = new RedisClient(process.env.REDIS_URL, { prefix: 'test2' });
+    redisClient1.set('key', 'value1');
+    redisClient2.set('key', 'value2');
+
+    // when / then
+    expect(await redisClient1.get('key')).to.equal('value1');
+    expect(await redisClient2.get('key')).to.equal('value2');
+  });
+});

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -2,28 +2,42 @@ const RedisClient = require('../../../../lib/infrastructure/utils/RedisClient');
 const { expect } = require('../../../test-helper');
 
 describe('Integration | Infrastructure | Utils | RedisClient', function () {
-  it('stores and retrieve a value for a key', async function () {
-    // given
-    const key = new Date().toISOString();
-    const redisClient = new RedisClient(process.env.REDIS_URL);
+  // this check is used to prevent failure when redis is not setup
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  if (process.env.REDIS_TEST_URL !== undefined) {
+    it('stores and retrieve a value for a key', async function () {
+      // given
+      const key = new Date().toISOString();
+      const redisClient = new RedisClient(process.env.REDIS_TEST_URL);
 
-    // when
-    redisClient.set(key, 'value');
-    const value = await redisClient.get(key);
+      // when
+      redisClient.set(key, 'value');
+      const value = await redisClient.get(key);
 
-    // then
-    expect(value).to.equal('value');
-  });
+      // then
+      expect(value).to.equal('value');
+    });
 
-  it('should separate storage for identical keys saved with different prefixes', async function () {
-    // given
-    const redisClient1 = new RedisClient(process.env.REDIS_URL, { prefix: 'test1' });
-    const redisClient2 = new RedisClient(process.env.REDIS_URL, { prefix: 'test2' });
-    redisClient1.set('key', 'value1');
-    redisClient2.set('key', 'value2');
+    it('should separate storage for identical keys saved with different prefixes', async function () {
+      // given
+      const redisClient1 = new RedisClient(process.env.REDIS_URL, { prefix: 'test1' });
+      const redisClient2 = new RedisClient(process.env.REDIS_URL, { prefix: 'test2' });
+      redisClient1.set('key', 'value1');
+      redisClient2.set('key', 'value2');
 
-    // when / then
-    expect(await redisClient1.get('key')).to.equal('value1');
-    expect(await redisClient2.get('key')).to.equal('value2');
-  });
+      // when / then
+      expect(await redisClient1.get('key')).to.equal('value1');
+      expect(await redisClient2.get('key')).to.equal('value2');
+    });
+
+    it('should allow retrieve without prefix a value with a prefix', async function () {
+      // given
+      const redisClientWithoutPrefix = new RedisClient(process.env.REDIS_URL);
+      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'with-prefix' });
+      redisClientWithoutPrefix.set('key', 'value');
+
+      // when / then
+      expect(await redisClientWithPrefix.get('key')).to.equal('value');
+    });
+  }
 });

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -11,7 +11,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
       const redisClient = new RedisClient(process.env.REDIS_TEST_URL);
 
       // when
-      redisClient.set(key, 'value');
+      await redisClient.set(key, 'value');
       const value = await redisClient.get(key);
 
       // then
@@ -22,8 +22,8 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
       // given
       const redisClient1 = new RedisClient(process.env.REDIS_URL, { prefix: 'test1' });
       const redisClient2 = new RedisClient(process.env.REDIS_URL, { prefix: 'test2' });
-      redisClient1.set('key', 'value1');
-      redisClient2.set('key', 'value2');
+      await redisClient1.set('key', 'value1');
+      await redisClient2.set('key', 'value2');
 
       // when / then
       expect(await redisClient1.get('key')).to.equal('value1');
@@ -32,12 +32,13 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
     it('should allow retrieve without prefix a value with a prefix', async function () {
       // given
+      const value = new Date().toISOString();
       const redisClientWithoutPrefix = new RedisClient(process.env.REDIS_URL);
-      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'with-prefix' });
-      redisClientWithoutPrefix.set('key', 'value');
+      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
+      await redisClientWithoutPrefix.set('key', value);
 
       // when / then
-      expect(await redisClientWithPrefix.get('key')).to.equal('value');
+      expect(await redisClientWithPrefix.get('storage-prefix:key')).to.equal(value);
     });
   }
 });

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -16,6 +16,20 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
       // then
       expect(value).to.equal('value');
+      await redisClient.del(key);
+    });
+
+    it('should delete a value with prefix', async function () {
+      // given
+      const value = new Date().toISOString();
+      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
+      await redisClientWithPrefix.set('AVRIL', value);
+
+      // when
+      await redisClientWithPrefix.del('AVRIL');
+
+      // then
+      expect(await redisClientWithPrefix.get('AVRIL')).to.be.null;
     });
 
     it('should separate storage for identical keys saved with different prefixes', async function () {
@@ -28,6 +42,8 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
       // when / then
       expect(await redisClient1.get('key')).to.equal('value1');
       expect(await redisClient2.get('key')).to.equal('value2');
+      await redisClient1.del('key');
+      await redisClient2.del('key');
     });
 
     it('should allow retrieve without prefix a value with a prefix', async function () {
@@ -39,6 +55,22 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
       // when / then
       expect(await redisClientWithPrefix.get('storage-prefix:key')).to.equal(value);
+      await redisClientWithPrefix.del('storage-prefix:key');
+    });
+
+    it('should allow delete a value without prefix', async function () {
+      // given
+      const value = new Date().toISOString();
+      const redisClientWithoutPrefix = new RedisClient(process.env.REDIS_URL);
+      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
+      await redisClientWithoutPrefix.set('key', value);
+
+      // when
+      await redisClientWithPrefix.del('storage-prefix:key');
+
+      // then
+      expect(await redisClientWithPrefix.get('storage-prefix:key')).to.be.null;
+      await redisClientWithPrefix.del('storage-prefix:key');
     });
   }
 });

--- a/api/tests/unit/domain/services/refresh-token-service_test.js
+++ b/api/tests/unit/domain/services/refresh-token-service_test.js
@@ -1,9 +1,9 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const settings = require('../../../../lib/config');
-const temporaryStorage = require('../../../../lib/infrastructure/temporary-storage');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const refreshTokenService = require('../../../../lib/domain/services/refresh-token-service');
 const { UnauthorizedError } = require('../../../../lib/application/http-errors');
+const temporaryStorage = refreshTokenService.temporaryStorageForTests;
 
 describe('Unit | Domain | Service | Refresh Token Service', function () {
   describe('#createRefreshTokenFromUserId', function () {

--- a/api/tests/unit/domain/services/refresh-token-service_test.js
+++ b/api/tests/unit/domain/services/refresh-token-service_test.js
@@ -19,7 +19,10 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
       };
       const expirationDelaySeconds = settings.authentication.refreshTokenLifespanMs / 1000;
 
-      sinon.stub(temporaryStorage, 'save').withArgs({ value, expirationDelaySeconds }).resolves(validRefreshToken);
+      sinon
+        .stub(temporaryStorage, 'save')
+        .withArgs(sinon.match({ key: sinon.match(/^[-0-9a-f]+$/), value, expirationDelaySeconds }))
+        .resolves(validRefreshToken);
 
       // when
       const result = await refreshTokenService.createRefreshTokenFromUserId({ userId, source });

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -50,4 +50,36 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
       expect(result).to.be.ok;
     });
   });
+
+  describe('#withPrefix', function () {
+    it('should return a wrapper that adds a prefix to all methods', async function () {
+      // given
+      const store = {};
+      class TestStorage extends TemporaryStorage {
+        async save({ key, value }) {
+          store[key] = value;
+        }
+        async get(key) {
+          return store[key];
+        }
+        async delete(key) {
+          delete store[key];
+        }
+      }
+      const storage = new TestStorage().withPrefix('a-prefix:');
+
+      // when & then
+      expect(await storage.save({ key: 'a-key', value: 'a-value' })).to.equal('a-key');
+      expect(store).to.deep.equal({ 'a-prefix:a-key': 'a-value' });
+
+      expect(await storage.get('a-key')).to.equal('a-value');
+      await storage.delete('a-key');
+      expect(await storage.get('a-key')).to.be.undefined;
+
+      const randomKey = await storage.save({ value: 'random-key-value' });
+      expect(randomKey).to.exist;
+      expect(store['a-prefix:' + randomKey]).to.exist;
+      expect(await storage.get(randomKey)).to.equal('random-key-value');
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -28,6 +28,19 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
     });
   });
 
+  describe('#delete', function () {
+    it('should reject an error (because this class actually mocks an interface)', function () {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.delete('key');
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
   describe('#generateKey', function () {
     it('should return a key from static method', function () {
       // when

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -81,20 +81,5 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
       expect(store['a-prefix:' + randomKey]).to.exist;
       expect(await storage.get(randomKey)).to.equal('random-key-value');
     });
-
-    it('should allow retrieve without prefix a value with a prefix', async function () {
-      // given
-      const store = {};
-      class TestStorage extends TemporaryStorage {
-        async get(key) {
-          return store[key];
-        }
-      }
-      const storage = new TestStorage().withPrefix('a-prefix:');
-      store['a-key'] = 'a-value';
-
-      // when & then
-      expect(await storage.get('a-key')).to.equal('a-value');
-    });
   });
 });

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -81,5 +81,20 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
       expect(store['a-prefix:' + randomKey]).to.exist;
       expect(await storage.get(randomKey)).to.equal('random-key-value');
     });
+
+    it('should allow retrieve without prefix a value with a prefix', async function () {
+      // given
+      const store = {};
+      class TestStorage extends TemporaryStorage {
+        async get(key) {
+          return store[key];
+        }
+      }
+      const storage = new TestStorage().withPrefix('a-prefix:');
+      store['a-key'] = 'a-value';
+
+      // when & then
+      expect(await storage.get('a-key')).to.equal('a-value');
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui quand on demande la révocation d'un refresh-token (`/api/revoke`)  le token fourni est utilisé directement pour supprimer une clé du même nom dans Redis, ce qui pourrait poser des problèmes (mineurs) si le token passé correspond à une clé Redis utilisée pour autre chose.

## :robot: Solution
Créer un "compartiment" dans redis pour ranger les refresh token (et donc les manipuler de manière plus sécurisée).

On introduit **deux niveaux de compartimentation** dans les données stockées dans Redis. Au premier niveau :
- les clés utilisées par `RedisCache` (en pratique il n'y a que `LearningContent`) sont préfixées par `cache:` ;
- les clés utilisées par `RedisTemporaryStorage` sont préfixées par `temporary-storage:`.

Ensuite pour séparer les utilisations de `TemporaryStorage` on a un deuxième niveau de préfixes :
- `refresh-tokens:` pour les refresh tokens
- `pole-emploi-tokens:` pour les tokens liés à pole emploi
- `verify-email:` pour la fonctionnalité de validation d'email

Ainsi, le refresh token `aaaa-bbbb-cccc-dddd` sera stocké dans Redis sous la clé `temporary-storage:refresh-tokens: aaaa-bbbb-cccc-dddd`.

## :rainbow: Remarques

Lors de la mise en production, tous les refresh tokens seront immédiatement invalidés puisque le chemin des clés aura changé. De même pour les éventuelles modifications d'adresse email en cours, ou créations d'utilisateurs depuis Pole Emploi Connect. 

Par ailleurs, le cache du référentiel pédagogique sera également invalidé, ce qui ne devrait pas poser de problème particulier car il sera automatiquement rechargé au prochain démarrage de conteneur.

Pour éviter ces inconvénients, nous avons décidé de permettre à Redis d'effectuer de nouvelles tentatives de recherche de clef lorsqu'il ne trouvait pas de résultat suite à un get. C'est à dire : 
- on tente de chercher une clef avec les prefixes 
- si on ne trouve pas on tente sans le prefix `temporary-storage:`
- si on ne trouve pas on tente sans le prefix `refresh-tokens:`
- si on ne trouve pas on tente sans les 2 prefix `temporary-storage:refresh-tokens:`

Exemple de log que redis pourra faire s'il n'arrive pas à trouver la clé avec les prefixes : 
```
1648568646.480937 [0 172.18.0.1:58696] "get" "temporary-storage:refresh-tokens:549c785f-7dab-48d2-98a3-490bace23ac6"
1648568646.483249 [0 172.18.0.1:58696] "get" "refresh-tokens:549c785f-7dab-48d2-98a3-490bace23ac6"
1648568646.485905 [0 172.18.0.1:58696] "get" "temporary-storage:549c785f-7dab-48d2-98a3-490bace23ac6"
1648568646.487849 [0 172.18.0.1:58696] "get" "549c785f-7dab-48d2-98a3-490bace23ac6"
```

C'est un peu "overkill" mais comme nous comptons enlever le support des anciennes clefs (sans prefixes) dans 7 jours , il ne nous semble pas nécessaire d'optimiser ça. 

## :100: Pour tester

On peut vérifier ce qui se passe dans Redis avec la commande [MONITOR](https://redis.io/commands/monitor/).

Confirmer que l'ouverture de session Pix se passe bien et vérifier qu'elle crée des refresh tokens au bon endroit dans Redis. De même pour la connexion via Pole Emploi et le changement d'adresse email.