### PR TITLE
[FEATURE] Cacher le bandeau d'envoi de profil si la campagne est archivée (PIX-4596).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -25,6 +25,7 @@ module.exports = {
       .join('campaigns', 'campaigns.id', 'campaignId')
       .where({ userId })
       .whereNull('deletedAt')
+      .whereNull('archivedAt')
       .andWhere({ status: TO_SHARE })
       .andWhere({ 'campaigns.type': Campaign.types.PROFILES_COLLECTION })
       .orderBy('campaign-participations.createdAt', 'desc')

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -92,7 +92,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.SHARED,
         userId,
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when
@@ -112,7 +112,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         status: CampaignParticipationStatuses.TO_SHARE,
         deletedAt: new Date(),
         userId,
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when
@@ -130,7 +130,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.TO_SHARE,
         userId,
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when
@@ -149,7 +149,27 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.TO_SHARE,
         userId: otherUser.id,
-      }).id;
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const code = await campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(
+        userId
+      );
+
+      // then
+      expect(code).to.equal(null);
+    });
+
+    it('should return null if campaign is archived', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', archivedAt: new Date() });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: CampaignParticipationStatuses.TO_SHARE,
+        userId,
+        createdAt: new Date(),
+      });
       await databaseBuilder.commit();
 
       // when
@@ -170,13 +190,13 @@ describe('Integration | Repository | Campaign Participation', function () {
         status: CampaignParticipationStatuses.TO_SHARE,
         createdAt: new Date(Date.parse('11/11/2011')),
         userId,
-      }).id;
+      });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.TO_SHARE,
         userId,
         createdAt: new Date(Date.parse('12/11/2011')),
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when
@@ -188,6 +208,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       expect(code).to.equal(expectedCode);
     });
   });
+
   describe('#get', function () {
     let campaignId;
     let campaignParticipationId, campaignParticipationNotSharedId;


### PR DESCRIPTION
## :unicorn: Problème
Le bandeau de reprise permet de reprendre des collectes de profils qui ont été archivées. L’utilisateur lorsqu’il clique sur le bandeau arrive sur une page ou il ne peut rien faire car la campagne est archivée.

## :robot: Solution
Ne plus afficher ce bandeau si la campagne est archivée.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à Pix App avec userpix1@example.net, participer à PROCOLECT mais ne pas envoyer son profil.
- Revenir sur la page d'accueil et vérifier que le bandeau s'affiche.
- Se connecter à Pix Orga avec pro.admin@example.net, archiver la campagne PROCOLECT.
- Revenir sur Pix App, et vérifier que le bandeau ne s'affiche plus.
