### PR TITLE
[FEATURE] Création de prescrits pour les anciennes participations des utilisateurs dissociés(PIX-4484)

### DIFF
--- a/api/scripts/prod/create-old-organization-learners-for-dissociated-users.js
+++ b/api/scripts/prod/create-old-organization-learners-for-dissociated-users.js
@@ -36,6 +36,7 @@ async function _createOldOrganizationLearnersForDissociatedUsers(participation) 
       lastName: participation.lastName,
       userId: participation.userId,
       organizationId: participation.organizationId,
+      isDisabled: true,
     })
     .returning('id');
   await _updateCampaignParticipationWithOrganizationLearnerId(participation, organizationLearnerId);

--- a/api/scripts/prod/create-old-organization-learners-for-dissociated-users.js
+++ b/api/scripts/prod/create-old-organization-learners-for-dissociated-users.js
@@ -30,12 +30,19 @@ async function createOldOrganizationLearnersForDissociatedUsers(concurrency = 1,
 }
 
 async function _createOldOrganizationLearnersForDissociatedUsers(participation) {
-  await knex('organization-learners').insert({
-    firstName: participation.firstName,
-    lastName: participation.lastName,
-    userId: participation.userId,
-    organizationId: participation.organizationId,
-  });
+  const [organizationLearnerId] = await knex('organization-learners')
+    .insert({
+      firstName: participation.firstName,
+      lastName: participation.lastName,
+      userId: participation.userId,
+      organizationId: participation.organizationId,
+    })
+    .returning('id');
+  await _updateCampaignParticipationWithOrganizationLearnerId(participation, organizationLearnerId);
+}
+
+function _updateCampaignParticipationWithOrganizationLearnerId(participation, organizationLearnerId) {
+  return knex('campaign-participations').update({ organizationLearnerId }).where('id', participation.id);
 }
 
 module.exports = createOldOrganizationLearnersForDissociatedUsers;

--- a/api/scripts/prod/create-old-organization-learners-for-dissociated-users.js
+++ b/api/scripts/prod/create-old-organization-learners-for-dissociated-users.js
@@ -32,16 +32,7 @@ async function createOldOrganizationLearnersForDissociatedUsers(concurrency = 1,
 
 async function _createOldOrganizationLearnerForDissociatedUser(participation) {
   await DomainTransaction.execute(async (domainTransaction) => {
-    const [organizationLearnerId] = await domainTransaction
-      .knexTransaction('organization-learners')
-      .insert({
-        firstName: participation.firstName,
-        lastName: participation.lastName,
-        userId: participation.userId,
-        organizationId: participation.organizationId,
-        isDisabled: true,
-      })
-      .returning('id');
+    const organizationLearnerId = await _insertOldOrganizationLearner(domainTransaction, participation);
     await _updateCampaignParticipationWithOrganizationLearnerId(
       participation,
       organizationLearnerId,
@@ -51,6 +42,20 @@ async function _createOldOrganizationLearnerForDissociatedUser(participation) {
 
   count++;
   _log(`${count} / ${total}`);
+}
+
+async function _insertOldOrganizationLearner(domainTransaction, participation) {
+  const [organizationLearnerId] = await domainTransaction
+    .knexTransaction('organization-learners')
+    .insert({
+      firstName: participation.firstName,
+      lastName: participation.lastName,
+      userId: participation.userId,
+      organizationId: participation.organizationId,
+      isDisabled: true,
+    })
+    .returning('id');
+  return organizationLearnerId;
 }
 
 function _updateCampaignParticipationWithOrganizationLearnerId(

--- a/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
+++ b/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
@@ -4,7 +4,7 @@ const pick = require('lodash/pick');
 
 describe('Integration | Scripts | create-old-organization-learners-for-dissociated-users', function () {
   describe('#createOldOrganizationLearnersForDissociatedUsers', function () {
-    it('should create a new organizationLearner', async function () {
+    it('should create a new organizationLearner with disabled status', async function () {
       const user = databaseBuilder.factory.buildUser({ firstName: 'Henri', lastName: 'Golo' });
       const campaign = databaseBuilder.factory.buildCampaign();
       const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
@@ -29,7 +29,7 @@ describe('Integration | Scripts | create-old-organization-learners-for-dissociat
       //then
       expect(organizationLearners.length).to.equal(2);
       const organizationLearnersToCheck = organizationLearners.map((organizationLearner) =>
-        pick(organizationLearner, ['userId', 'firstName', 'lastName', 'organizationId'])
+        pick(organizationLearner, ['userId', 'firstName', 'lastName', 'organizationId', 'isDisabled'])
       );
       expect(organizationLearnersToCheck).to.deep.include.members([
         {
@@ -37,6 +37,7 @@ describe('Integration | Scripts | create-old-organization-learners-for-dissociat
           firstName: user.firstName,
           lastName: user.lastName,
           organizationId: campaign.organizationId,
+          isDisabled: true,
         },
       ]);
     });

--- a/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
+++ b/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
@@ -143,5 +143,167 @@ describe('Integration | Scripts | create-old-organization-learners-for-dissociat
       //then
       expect(campaignParticipation.organizationLearnerId).to.equal(recentCampaignParticipation.schoolingRegistrationId);
     });
+
+    it('should not create organizationLearner if old participation is improved', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+        isImproved: true,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(1);
+    });
+
+    it('should not create organizationLearner if new participation is improved', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+        isImproved: true,
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(1);
+    });
+
+    it('should not create organizationLearner if old participation is deleted', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+        deletedAt: new Date(),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(1);
+    });
+
+    it('should not create organizationLearner if new participation is deleted', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+        deletedAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(1);
+    });
+
+    it('should not create organizationLearner if both participations have already their own', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId1 = databaseBuilder.factory.buildSchoolingRegistration().id;
+      const organizationLearnerId2 = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId1,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId2,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(2);
+    });
+
+    it('should not create organizationLearner if participations are in different campaigns', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaignId1 = databaseBuilder.factory.buildCampaign().id;
+      const campaignId2 = databaseBuilder.factory.buildCampaign().id;
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaignId1,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaignId2,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(1);
+    });
   });
 });

--- a/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
+++ b/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
@@ -40,5 +40,62 @@ describe('Integration | Scripts | create-old-organization-learners-for-dissociat
         },
       ]);
     });
+
+    it('should create a new organizationLearner for old campaign participation only', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      const oldCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const [organizationLearner] = await knex('organization-learners').whereNot({ id: organizationLearnerId });
+      const [updatedCampaignParticipation] = await knex('campaign-participations').where({
+        id: oldCampaignParticipation.id,
+      });
+
+      //then
+      expect(updatedCampaignParticipation.organizationLearnerId).to.equal(organizationLearner.id);
+    });
+
+    it('should not update with new organizationLearnerId all participations', async function () {
+      const user = databaseBuilder.factory.buildUser();
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+      });
+      const recentCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const [campaignParticipation] = await knex('campaign-participations').where({
+        id: recentCampaignParticipation.id,
+      });
+
+      //then
+      expect(campaignParticipation.organizationLearnerId).to.equal(recentCampaignParticipation.schoolingRegistrationId);
+    });
   });
 });

--- a/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
+++ b/api/tests/integration/scripts/prod/create-old-organization-learners-for-dissociated-users_test.js
@@ -1,0 +1,44 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const createOldOrganizationLearnersForDissociatedUsers = require('../../../../scripts/prod/create-old-organization-learners-for-dissociated-users.js');
+const pick = require('lodash/pick');
+
+describe('Integration | Scripts | create-old-organization-learners-for-dissociated-users', function () {
+  describe('#createOldOrganizationLearnersForDissociatedUsers', function () {
+    it('should create a new organizationLearner', async function () {
+      const user = databaseBuilder.factory.buildUser({ firstName: 'Henri', lastName: 'Golo' });
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const organizationLearnerId = databaseBuilder.factory.buildSchoolingRegistration().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date('2020-01-01'),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        schoolingRegistrationId: organizationLearnerId,
+        createdAt: new Date(),
+      });
+
+      await databaseBuilder.commit();
+
+      //when
+      await createOldOrganizationLearnersForDissociatedUsers(1, false);
+      const organizationLearners = await knex('organization-learners');
+
+      //then
+      expect(organizationLearners.length).to.equal(2);
+      const organizationLearnersToCheck = organizationLearners.map((organizationLearner) =>
+        pick(organizationLearner, ['userId', 'firstName', 'lastName', 'organizationId'])
+      );
+      expect(organizationLearnersToCheck).to.deep.include.members([
+        {
+          userId: user.id,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          organizationId: campaign.organizationId,
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dû à la dissociation, certains prescrits ont 2 participations pour une même campagne. Or il n'est possible d'en avoir qu'une par campagne.
Pour empêcher que cela se reproduise, on souhaite modifier une contrainte en BDD. Mais avant cela, on doit créer des prescrits désactivés dédiés à ces participations.

## :robot: Solution
Création d'un script permettant de créer des prescrits

## :rainbow: Remarques


## :100: Pour tester
Lancer le script sur la RA.
