### PR TITLE
[FEATURE] Ne pas compter les participations supprimées dans les chiffres d'une campagne dans PixAdmin (PIX-4595).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-management-repository.js
@@ -99,6 +99,7 @@ async function _countParticipationsByStatus(campaignId, campaignType) {
       knex.raw(`sum(case when status = ? then 1 else 0 end) as started`, STARTED),
     ])
     .where({ campaignId, isImproved: false })
+    .whereNull('campaign-participations.deletedAt')
     .groupBy('campaignId')
     .first();
 

--- a/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -159,56 +159,55 @@ describe('Integration | Repository | Campaign-Management', function () {
           expect(result.totalParticipationsCount).to.equal(0);
           expect(result.sharedParticipationsCount).to.equal(0);
         });
-
-        context('when campaign type is PROFILES_COLLECTION', function () {
-          it('should return total and shared participations count', async function () {
-            //given
-            const userId = databaseBuilder.factory.buildUser().id;
-            const organization = databaseBuilder.factory.buildOrganization({});
-            const campaign = databaseBuilder.factory.buildCampaign({
-              creatorId: userId,
-              organizationId: organization.id,
-              type: Campaign.types.PROFILES_COLLECTION,
-            });
-
-            databaseBuilder.factory.buildCampaignParticipation({
-              campaignId: campaign.id,
-              status: SHARED,
-            });
-
-            await databaseBuilder.commit();
-
-            // when
-            const result = await campaignManagementRepository.get(campaign.id);
-
-            expect(result.totalParticipationsCount).to.equal(1);
-            expect(result.sharedParticipationsCount).to.equal(1);
+      });
+      context('when campaign type is PROFILES_COLLECTION', function () {
+        it('should return total and shared participations count', async function () {
+          //given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organization = databaseBuilder.factory.buildOrganization({});
+          const campaign = databaseBuilder.factory.buildCampaign({
+            creatorId: userId,
+            organizationId: organization.id,
+            type: Campaign.types.PROFILES_COLLECTION,
           });
 
-          it('should not count neither total nor shared participations for deleted participations', async function () {
-            //given
-            const userId = databaseBuilder.factory.buildUser().id;
-            const organization = databaseBuilder.factory.buildOrganization({});
-            const campaign = databaseBuilder.factory.buildCampaign({
-              creatorId: userId,
-              organizationId: organization.id,
-              type: Campaign.types.PROFILES_COLLECTION,
-            });
-
-            databaseBuilder.factory.buildCampaignParticipation({
-              campaignId: campaign.id,
-              status: SHARED,
-              deletedAt: new Date(),
-            });
-
-            await databaseBuilder.commit();
-
-            // when
-            const result = await campaignManagementRepository.get(campaign.id);
-
-            expect(result.totalParticipationsCount).to.equal(0);
-            expect(result.sharedParticipationsCount).to.equal(0);
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            status: SHARED,
           });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await campaignManagementRepository.get(campaign.id);
+
+          expect(result.totalParticipationsCount).to.equal(1);
+          expect(result.sharedParticipationsCount).to.equal(1);
+        });
+
+        it('should not count neither total nor shared participations for deleted participations', async function () {
+          //given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organization = databaseBuilder.factory.buildOrganization({});
+          const campaign = databaseBuilder.factory.buildCampaign({
+            creatorId: userId,
+            organizationId: organization.id,
+            type: Campaign.types.PROFILES_COLLECTION,
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            status: SHARED,
+            deletedAt: new Date(),
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await campaignManagementRepository.get(campaign.id);
+
+          expect(result.totalParticipationsCount).to.equal(0);
+          expect(result.sharedParticipationsCount).to.equal(0);
         });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -101,7 +101,7 @@ describe('Integration | Repository | Campaign-Management', function () {
       });
     });
 
-    describe('When there are participation', function () {
+    describe('When there are participations', function () {
       context('when campaign type is ASSESSMENT', function () {
         it('should return total and shared participations count', async function () {
           //given
@@ -130,6 +130,36 @@ describe('Integration | Repository | Campaign-Management', function () {
           expect(result.sharedParticipationsCount).to.equal(1);
         });
 
+        it('should not count neither total nor shared participations for deleted participations', async function () {
+          //given
+          const campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            status: STARTED,
+            deletedAt: new Date(),
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            status: TO_SHARE,
+            deletedAt: new Date(),
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaign.id,
+            status: SHARED,
+            deletedAt: new Date(),
+          });
+
+          await databaseBuilder.commit();
+          // when
+          const result = await campaignManagementRepository.get(campaign.id);
+
+          expect(result.totalParticipationsCount).to.equal(0);
+          expect(result.sharedParticipationsCount).to.equal(0);
+        });
+
         context('when campaign type is PROFILES_COLLECTION', function () {
           it('should return total and shared participations count', async function () {
             //given
@@ -153,6 +183,31 @@ describe('Integration | Repository | Campaign-Management', function () {
 
             expect(result.totalParticipationsCount).to.equal(1);
             expect(result.sharedParticipationsCount).to.equal(1);
+          });
+
+          it('should not count neither total nor shared participations for deleted participations', async function () {
+            //given
+            const userId = databaseBuilder.factory.buildUser().id;
+            const organization = databaseBuilder.factory.buildOrganization({});
+            const campaign = databaseBuilder.factory.buildCampaign({
+              creatorId: userId,
+              organizationId: organization.id,
+              type: Campaign.types.PROFILES_COLLECTION,
+            });
+
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaign.id,
+              status: SHARED,
+              deletedAt: new Date(),
+            });
+
+            await databaseBuilder.commit();
+
+            // when
+            const result = await campaignManagementRepository.get(campaign.id);
+
+            expect(result.totalParticipationsCount).to.equal(0);
+            expect(result.sharedParticipationsCount).to.equal(0);
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
A l’heure actuelle , nous prenons en compte toute les participations d'une campagne même celles qui ont été supprimés , Cependant , Dans nos travaux de refonte du prescrit, nous ne souhaitons plus récupérer les participations supprimées, ce qui n'est pas encore le cas pour les compteurs des participations partagées et total d'une campagne dans Pix Admin.

## :robot: Solution
Se baser uniquement sur les participations ayant `deletedAt = null` dans la table `campaign-participations` pour calculer les `shared` et `total` participations count et non les participation ayant une date de délétion.

## :rainbow: Remarques
RAS
## :100: Pour tester
- Se connecter à pix admin , sélectionner L'organisation "DRAGO & CO" puis la campagne 'Pro - Campagne de collecte de profils - Envois multiple' avec l'id 18
- Aller dans la page de détail d'une campagne pour voir les 2 compteurs des `shared et total` participations
- Dans la bdd, modifier l'une des participations de cette campagne sélectionnée, modifiée sa `deletedAt` pour lui donner une date ou lieu de `null`
`UPDATE "campaign-participations" SET "deletedAt" = '10-10-2010' WHERE "id" = 108407 AND "campaignId" = 18 AND "isImproved" = false AND "status" = 'SHARED';`
- Constater que le total  et shared participations compteurs ont baissé par 1 car on ne récupère plus la participation supprimée.