### PR TITLE
[FEATURE] Faire apparaitre les signalements de focus out sur la page de détails d'une certification sur Pix Admin (PIX-4405).

### DIFF
--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -113,6 +113,7 @@ const subcategoryCodeImpactful = [
   CertificationIssueReportSubcategories.OTHER,
   CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
   CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+  CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
 ];
 
 const deprecatedSubcategories = [

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -420,6 +420,12 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
             subcategory: 'SOFTWARE_NOT_WORKING',
             questionNumber: 42,
           },
+          {
+            certificationCourseId: 42,
+            category: 'IN_CHALLENGE',
+            subcategory: 'UNINTENTIONAL_FOCUS_OUT',
+            questionNumber: 42,
+          },
           { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
         ].forEach((certificationIssueReportDTO) => {
           it(`for ${certificationIssueReportDTO.category} ${


### PR DESCRIPTION
## :unicorn: Problème
Les signalements de [focusOut](https://github.com/1024pix/pix/pull/4242) résolus automatiquement par l'autoJury ne sont pas affichés correctement dans PixAdmin.

## :robot: Solution
Paramétrer le modèle API IssueReport pour obtenir catégorie et sous-catégorie

## :rainbow: Remarques

Ajout  dans les seeds:
- une session prête à finaliser
- avec un seul parcours avec un focusOut utilisateur 
- et le signalement associé

Note: le scoring du parcours est à 0 car les `competencesMarks` n'ont pas été ajoutées

Le commit a été déplacé dans la branche ci-dessous car pas de consensus
https://github.com/1024pix/pix/tree/tech-add-focusable-seed

## :100: Pour tester

Reseeder la RA `npm run db:seed`

Se connecter à [PixAdmin](https://admin-pr4248.review.pix.fr/) avec `pixmaster@example.net`

Vérifier que [la question 3 de la session 13](http://localhost:4202/certifications/106540/details) est "focus échoué"
![image](https://user-images.githubusercontent.com/56302715/160808196-303d6855-8d1e-4b71-a564-c9f81e0b3207.png)

Vérifier [le signalement non résolu](http://localhost:4202/certifications/106540)
![image](https://user-images.githubusercontent.com/56302715/160808430-456cb45c-5b8e-4391-887c-55bc608abb46.png)

Vérifier que le nombre de 
- signalements impactants est 1
- signalements impactants non résolus est 1

Se connecter à [PixCertif](https://certif-pr4248.review.pix.fr/) avec `certifpro@example.net`

Finaliser la session 13. 
Dans l'écran de confirmation, vérifier que le signalement est affiché (la catégorie affichée est E1-E9, mais sera E10 après cette PR)
![image](https://user-images.githubusercontent.com/56302715/160808590-39044032-39b5-4d44-8d44-83d1343b60f5.png)

Une fois finalisée, vérifier dans PïxAdmin que 
- le signalement est résolu
![image](https://user-images.githubusercontent.com/56302715/160808788-1060ae27-f856-4445-8c1b-9edbd84c077e.png)

- le statut de la question 3 est OK

Vérifier que le nombre de 
- signalements impactants est 1
- signalements impactants non résolus est 0


![image](https://user-images.githubusercontent.com/56302715/160808833-53153f2c-a0ba-4c98-9c0f-5e2951bc8d06.png)

![image](https://user-images.githubusercontent.com/56302715/160810709-a8fc68da-481a-4714-a5b5-ce7833107f7b.png)



