### PR TITLE
[BUG] Corrige un test instable sur le modèle SharedProfileForCampaign.

### DIFF
--- a/api/tests/unit/domain/read-models/SharedProfileForCampaign_test.js
+++ b/api/tests/unit/domain/read-models/SharedProfileForCampaign_test.js
@@ -23,7 +23,10 @@ describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
           },
         });
 
-        expect(sharedProfileForCampaign.scorecards).to.deep.equal([expectedScorecard]);
+        expect(sharedProfileForCampaign.scorecards[0]).to.deep.include({
+          id: expectedScorecard.id,
+          name: expectedScorecard.name,
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Un test récemment ajouté dans le modèle SharedProfileForCampaign s'avère être instable à cause des propriétés calculés dans la fonction buildFrom du modèle Scorecard

cf: https://app.circleci.com/insights/github/1024pix/pix/workflows/build-and-test/tests?branch=dev&reporting-window=last-30-days

## :robot: Solution
On vérifie juste certaines propriétés des scorecards pour rendre le test plus stable.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
La CI ne détecte plus le test comme flaky.
