### PR TITLE
[TECH] Tracer la cause de l'erreur si la création d'un candidat échoue (PIX-4663).

### DIFF
--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { normalize } = require('../utils/string-utils');
+const logger = require('../../infrastructure/logger');
 const CertificationCandidateBookshelf = require('../orm-models/CertificationCandidate');
 const bookshelfToDomainConverter = require('../../infrastructure/utils/bookshelf-to-domain-converter');
 const { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } = require('../../../db/pgsql-errors');
@@ -67,6 +68,7 @@ module.exports = {
 
       return new CertificationCandidate(addedCertificationCandidate);
     } catch (error) {
+      logger.error(error);
       throw new CertificationCandidateCreationOrUpdateError(
         'An error occurred while saving the certification candidate in a session'
       );


### PR DESCRIPTION
## :unicorn: Problème
Si la création d'un candidat unitaire échoue (route `POST /api/sessions/{id}/certification-candidates`), on observe une erreur HTTP 400, mais sans autre indication.
Il est difficile de déterminer la cause du problème, et par suite de le corriger.

Il y a  50 erreurs 400 sur la route concernée sur les 15 derniers jours

![image](https://user-images.githubusercontent.com/56302715/162469391-495d253e-7f1e-4ecb-b45e-20fecd40febe.png)


## :robot: Solution
Il est inutile d'afficher le contenu de l'erreur (stacktrace) dans le front.
On choisit de logguer le contenu dans le back.

## :rainbow: Remarques
Il est possible de créer un candidat en doublon (Nom/Prénom/Date de naissance) en simulant un délai aléatoire d'acheminement de la requête en ajoutant dans la route 
``` js
    function delay(ms) {
      return new Promise((resolve) => {
        setTimeout(resolve, ms);
      });
    }

    await delay(1000);
```

Dans ce cas, on peut créer plusieurs fois le même candidat:
- soit en faisant la même demande depuis plusieurs onglets;
- soit en cliquant plusieurs fois sur "Créer le candidat".

![image](https://user-images.githubusercontent.com/56302715/162462637-e3fd1d32-5b93-4962-935f-9912ac02f671.png)

Solutions:
- empêcher l'envoi multiple de création en désactivant le bouton "Envoyer" tant qu'une réponse n'a pas été reçue
- empêcher les doublons en BDD en ajoutant une contrainte d'unicité
```sql
ALTER TABLE "certification-candidates"
ADD CONSTRAINT "certification-candidates_unique" UNIQUE("sessionId", "firstName", "lastName", "birthdate");
ALTER TABLE "complementary-certification-subscriptions"
ADD CONSTRAINT value_unique UNIQUE("complementaryCertificationId", "certificationCandidateId");
```


## :100: Pour tester
Ajouter une contrainte d'unicité

```sql
ALTER TABLE "certification-candidates"
ADD CONSTRAINT "certification-candidates_unique" UNIQUE("sessionId", "firstName", "lastName", "birthdate");
```

Ajouter dans la route un retard d'une seconde
``` js
    function delay(ms) {
      return new Promise((resolve) => {
        setTimeout(resolve, ms);
      });
    }

    await delay(1000);
```

Saisir les informations d'un candidat et cliquer plusieurs fois rapidement sur "Créer le candidat"
Vérifier que 
- un message d'erreur est affiché dans le front
- un message d'erreur est affiché dans le back du type 
```shell
[14:54:56] ERROR: insert into "certification-candidates" ("authorizedToStart", "billingMode", "birthCity", "birthCountry", "birthINSEECode", "birthPostalCode", "birthProvinceCode", "birthdate", "email", "externalId", "extraTimePercentage", "firstName", "lastName", "organizationLearnerId", "prepaymentCode", "resultRecipientEmail", "sessionId", "sex") values (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) returning * - duplicate key value violates unique constraint "certification-candidates_unique"
    err: {
      "type": "DatabaseError",
      "message": "insert into \"certification-candidates\" (\"authorizedToStart\", \"billingMode\", \"birthCity\", \"birthCountry\", \"birthINSEECode\", \"birthPostalCode\", \"birthProvinceCode\", \"birthdate\", \"email\", \"externalId\", \"extraTimePercentage\", \"firstName\", \"lastName\", \"organizationLearnerId\", \"prepaymentCode\", \"resultRecipientEmail\", \"sessionId\", \"sex\") values (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) returning * - duplicate key value violates unique constraint \"certification-candidates_unique\"",

```

![image](https://user-images.githubusercontent.com/56302715/162465608-980837f4-7b03-422f-92f7-47da582cbacf.png)

