### PR TITLE
[FEATURE] Ajouter une sous-catégorie de signalement spécifique aux épreuves focus dans Pix Certif (PIX-4609)

### DIFF
--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -20,6 +20,7 @@ export default class InChallengeCertificationIssueReportFields extends Component
     'WEBSITE_BLOCKED',
     'EXTRA_TIME_EXCEEDED',
     'SOFTWARE_NOT_WORKING',
+    'UNINTENTIONAL_FOCUS_OUT',
   ].map((subcategoryKey) => {
     const subcategory = certificationIssueReportSubcategories[subcategoryKey];
     return {

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -22,6 +22,7 @@ export const certificationIssueReportSubcategories = {
   WEBSITE_BLOCKED: 'WEBSITE_BLOCKED',
   EXTRA_TIME_EXCEEDED: 'EXTRA_TIME_EXCEEDED',
   SOFTWARE_NOT_WORKING: 'SOFTWARE_NOT_WORKING',
+  UNINTENTIONAL_FOCUS_OUT: 'UNINTENTIONAL_FOCUS_OUT',
 };
 
 export const categoryToLabel = {
@@ -51,6 +52,8 @@ export const subcategoryToLabel = {
     "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
   [certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]:
     "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+  [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
+    'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
 };
 
 export const categoryToCode = {
@@ -75,6 +78,7 @@ export const subcategoryToCode = {
   [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
   [certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]: 'E8',
   [certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]: 'E9',
+  [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]: 'E10',
 };
 
 export const subcategoryToTextareaLabel = {

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -60,7 +60,6 @@ export const categoryToCode = {
   [certificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE]: 'C7',
   [certificationIssueReportCategories.NON_BLOCKING_CANDIDATE_ISSUE]: 'C8',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E9',
-  [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
   [certificationIssueReportCategories.OTHER]: 'A2',
 };
 

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -59,7 +59,7 @@ export const categoryToCode = {
   [certificationIssueReportCategories.FRAUD]: 'C6',
   [certificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE]: 'C7',
   [certificationIssueReportCategories.NON_BLOCKING_CANDIDATE_ISSUE]: 'C8',
-  [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E9',
+  [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E10',
   [certificationIssueReportCategories.OTHER]: 'A2',
 };
 

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
@@ -95,5 +95,10 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
         subcategoryToLabel[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]
       }`
     );
+    assert.contains(
+      `${subcategoryToCode[certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]} ${
+        subcategoryToLabel[certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]
+      }`
+    );
   });
 });

--- a/certif/tests/unit/models/certification-issue-report_test.js
+++ b/certif/tests/unit/models/certification-issue-report_test.js
@@ -31,7 +31,8 @@ module('Unit | Model | certification issue report', function (hooks) {
   });
 
   test('it should return the right label for the subcategory', function (assert) {
-    assert.expect(11);
+    const expectedAssertNumber = 12;
+    assert.expect(expectedAssertNumber);
     // given
     const store = this.owner.lookup('service:store');
 
@@ -61,7 +62,8 @@ module('Unit | Model | certification issue report', function (hooks) {
   });
 
   test('it should return the right code for the subcategory', function (assert) {
-    assert.expect(11);
+    const expectedAssertNumber = 12;
+    assert.expect(expectedAssertNumber);
     // given
     const store = this.owner.lookup('service:store');
 


### PR DESCRIPTION
## :unicorn: Problème
Depuis que la nouvelle modalité d'épreuve “en mode focus” a été ajoutée au référentiel, aucune catégorie spécifique de signalement n’a été encore intégrée au PV d’incident, et donc sur la page de finalisation de la session. Il a donc été demandé aux surveillants de remonter tout incident lié à une question focus en utilisant la catégorie “A2 - Autres”. Cette catégorie ne permet pas d’avoir le numéro de la question qui a posé problème, et donc entraîne un traitement manuel de ces signalements par le pôle certif.

## :robot: Solution
Ajouter la sous-catégorie “E10 - Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus” dans la catégorie “Problème technique sur une question” dans la page de finalisation d'une session dans Pix Certif.

## :rainbow: Remarques
Le traitement automatique de ce signalement a été effectué dans une autre PR.

## :100: Pour tester
- Se connecter à Pix Certif, créer une session et y ajouter un candidat.
- Passer une certification avec le compte `certif1@example.net`.
- Répondre juste à une question focus sans focus out.
- Répondre juste à une question focus avec focus out.
- Répondre juste à une question non focus.
- Finaliser la session et effectuer un signalement E10 pour chacune de ces questions.
- Vérifier dans Pix Admin / BDD que le signalement a bien été traité automatiquement.
