### PR TITLE
[BUGFIX] Suppression d'une bannière non nécessaire en mobile sur le dashboard (PIX-4675).

### DIFF
--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -27,6 +27,10 @@
 
   &__main {
     grid-area: main;
+
+    .dashboard-banner {
+      display: none;
+    }
   }
 
   &__certif {


### PR DESCRIPTION
## :unicorn: Problème

En version mobile, si l'utilisateur n'a pas encore cliqué sur la bannière visible sur le dashboard, il verra deux bannières.
<img width="685" alt="Capture d’écran 2022-03-30 à 14 41 41" src="https://user-images.githubusercontent.com/36371437/160836636-a9a86160-e1b3-4493-98e0-a06c6bc87b70.png">

## :robot: Solution

Suppression du DOM d'une des bannières en format mobile

## :rainbow: Remarques
N/A

## :100: Pour tester

Vérifier qu'une seule bannière soit visible quel que soit le format du device utilisé.
