### PR TITLE
[BUGFIX] Alignement des containers de pix-app (PIX-4679).

### DIFF
--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -3,12 +3,12 @@
 }
 
 .footer {
-  padding: 18px 16px;
+  padding: 20px 0;
 
   &__container {
     display: flex;
     flex-direction: column;
-    padding-top: 24px;
+    padding: 24px 20px 0;
     max-width: 1280px;
     width: 100%;
     margin: auto;

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -2,7 +2,7 @@
 
   &__container {
     margin: 0 auto;
-    max-width: 1320px;
+    max-width: 1280px;
     display: flex;
     flex-direction: row;
     padding: 20px;

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -58,7 +58,7 @@
   padding-bottom: 16px;
 
   @include device-is('desktop') {
-    max-width: 1320px;
+    max-width: 1280px;
     padding: 0 20px 16px 20px;
     margin: 0 auto;
   }
@@ -103,7 +103,7 @@
     padding: 0 20px;
 
     @include device-is('desktop') {
-      max-width: 1320px;
+      max-width: 1280px;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Les différents containers de pix-app (navbar, contenu principal) ne sont pas alignés dans les pages où la largeur des containers est supposée être de 1280px.

<img width="523" alt="Capture d’écran 2022-03-30 à 15 33 58" src="https://user-images.githubusercontent.com/36371437/160846933-1d5a19da-5e35-48e0-bf15-330d2ba13a38.png">

## :robot: Solution

Modification des largeurs des éléments posant problème

## :rainbow: Remarques
N/A

## :100: Pour tester

Vérifier que les éléments sont bien alignés sur l'ensemble des pages et des formats possibles.
