### PR TITLE
[TECH] Retirer le support d'Internet Explorer dans Pix App, Pix Orga, Pix Certif et Pix Admin (PIX-4678)

### DIFF
--- a/admin/config/targets.js
+++ b/admin/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['> 1%'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['> 1%'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-certif",
-      "version": "3.188.0",
+      "version": "3.191.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
@@ -9794,14 +9794,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001255",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
+      "version": "1.0.30001322",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -42737,9 +42743,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001255",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
+      "version": "1.0.30001322",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
       "dev": true
     },
     "capture-exit": {

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['> 1%'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.190.0",
+      "version": "3.191.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
@@ -15506,14 +15506,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001255",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
+      "version": "1.0.30001322",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -54778,9 +54784,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001255",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
+      "version": "1.0.30001322",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
       "dev": true
     },
     "capture-exit": {

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['> 1%'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
## :unicorn: Problème

Nous ne supportons officiellement plus Internet Explorer depuis plusieurs mois, mais nos apps sont toujours compilées avec des polyfills et des transpilations qui permettent de supporter ce navigateur obsolète. Cela rallonge le temps de compilation et le poids des fichiers JS.

## :robot: Solution

Supprimer IE 11 des cibles de compilation dans la configuration Ember.

## :rainbow: Remarques

En mars 2022, seulement 0,2% des visites ont été effectuées avec Internet Explorer.

Quelques chiffres avant/après : 

<table>
<tr>
	<th>
	<th>Avec le support IE 11
	<th>Sans le support IE 11
    <th>Gain
<tr>
	<td>Temps de compilation Pix App
	<td>2:44
	<td>1:49
    <td>33 %
<tr>
	<td>Temps de compilation Pix Admin
	<td>1:54
	<td>1:12
    <td>36 %
<tr>
	<td>Bundles JS Pix App (gzippés)
	<td>784 Ko
	<td>718 Ko
    <td>8 %
<tr>
	<td>Bundles JS Pix Admin (gzippés)
	<td>1106 Ko
	<td>1028 Mo
    <td>7 %
<tr>
	<td>CO2 émis par Pix App en 1 an*
	<td>779 Tonnes**
	<td>746 Tonnes***
    <td>4 %
</table>

\* pour 100.000.000 pages vues par mois
\*\* https://www.websitecarbon.com/website/app-pix-fr/
\*\*\* https://www.websitecarbon.com/website/app-pr4260-review-pix-fr/

## :100: Pour tester

Passe fonctionnelle sur les quatre applications.
