### PR TITLE
[TECH] Supprimer les styles customs sur les boutons "Recommandés"&"Enregistrés" (Pix-4653)

### DIFF
--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -6,21 +6,11 @@
     </p>
 
     <div class="user-tutorials-banner-v2__filters">
-      <PixButtonLink
-        @route="user-tutorials-v2.recommended"
-        @shape="rounded"
-        class="user-tutorials-banner-v2-filters__button"
-        @backgroundColor="grey"
-      >
+      <PixButtonLink @route="user-tutorials-v2.recommended" @shape="rounded" @backgroundColor={{this.isRecommended}}>
         {{t "pages.user-tutorials-v2.recommended"}}
       </PixButtonLink>
 
-      <PixButtonLink
-        @route="user-tutorials-v2.saved"
-        @shape="rounded"
-        class="user-tutorials-banner-v2-filters__button"
-        @backgroundColor="grey"
-      >
+      <PixButtonLink @route="user-tutorials-v2.saved" @shape="rounded" @backgroundColor={{this.isSaved}}>
         {{t "pages.user-tutorials-v2.saved"}}
       </PixButtonLink>
     </div>

--- a/mon-pix/app/components/tutorials/header.js
+++ b/mon-pix/app/components/tutorials/header.js
@@ -5,12 +5,12 @@ export default class Header extends Component {
   @service router;
 
   get isRecommended() {
-    return this.isActive('user-tutorials-v2.recommended');
+    return this._isActive('user-tutorials-v2.recommended');
   }
   get isSaved() {
-    return this.isActive('user-tutorials-v2.saved');
+    return this._isActive('user-tutorials-v2.saved');
   }
-  isActive(route) {
+  _isActive(route) {
     return route === this.router.currentRouteName ? 'grey' : 'transparent-light';
   }
 }

--- a/mon-pix/app/components/tutorials/header.js
+++ b/mon-pix/app/components/tutorials/header.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class Header extends Component {
+  @service router;
+
+  get isRecommended() {
+    return this.isActive('user-tutorials-v2.recommended');
+  }
+  get isSaved() {
+    return this.isActive('user-tutorials-v2.saved');
+  }
+  isActive(route) {
+    return route === this.router.currentRouteName ? 'grey' : 'transparent-light';
+  }
+}

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -87,35 +87,6 @@
     display: flex;
     gap: 16px;
     flex-wrap: wrap;
-
-    a.active {
-      background-color: $grey-20;
-    }
-  }
-}
-
-.user-tutorials-banner-v2-filters__button {
-  height: 36px;
-  background-color: white;
-  border: 2px solid transparent;
-  outline: none;
-  color: $grey-60;
-
-  &:hover {
-    background-color: $grey-30 !important;
-    box-shadow: none !important;
-    border: 2px solid transparent;
-  }
-
-  &:focus,
-  &:focus-visible {
-    border: 2px solid white;
-    color: white;
-    outline: none;
-  }
-
-  @include device-is('desktop') {
-    height: 44px;
   }
 }
 

--- a/mon-pix/tests/integration/components/tutorials/content_test.js
+++ b/mon-pix/tests/integration/components/tutorials/content_test.js
@@ -1,11 +1,19 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { find, findAll, render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import Service from '@ember/service';
 
 describe('Integration | Component | Tutorials | Header', function () {
   setupIntlRenderingTest();
+
+  beforeEach(function () {
+    class RouterStub extends Service {
+      currentRouteName = 'user-tutorials-v2.recommended';
+    }
+    this.owner.register('service:router', RouterStub);
+  });
 
   it('renders the header', async function () {
     // when
@@ -15,6 +23,11 @@ describe('Integration | Component | Tutorials | Header', function () {
     expect(find('.user-tutorials-banner-v2__title')).to.exist;
     expect(find('.user-tutorials-banner-v2__description')).to.exist;
     expect(find('.user-tutorials-banner-v2__filters')).to.exist;
-    expect(findAll('.user-tutorials-banner-v2-filters__button')).to.have.lengthOf(2);
+    expect(find('a.pix-button--background-grey')).to.exist;
+    expect(find('a.pix-button--background-grey')).to.have.property('textContent').that.contains('Recommandés');
+    expect(find('a.pix-button--background-transparent-light')).to.exist;
+    expect(find('a.pix-button--background-transparent-light'))
+      .to.have.property('textContent')
+      .that.contains('Enregistrés');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour le style des boutons "Recommandés" & "Enregistrés",  le CSS override le style du composant `Pix-Button-Link`.

## :robot: Solution

- Suppression du css qui override le style du composant  `Pix-Button-Link`.
- Changer la valeur de `@backgroundColor` en fonction de la route où on se trouve.

## :rainbow: Remarques
 - Peut-on gérer cela directement dans pix-ui ?

## :100: Pour tester

- Aller sur la page des tutos
- Vérifier qu'en arrivant sur cette page, le bouton 'Recommandés' possède la classe : `pix-button--background-grey`
- Vérifier que le bouton 'Enregistrés' possède la classe :`pix-button--background-transparent-light'
- Après avoir cliquer sur le bouton Enregistrés, vérifier que le bouton 'Enregistrés' possède la classe :`pix-button--background-grey`
- Vérifier que le bouton 'Recommandés' possède la classe :`pix-button--background-transparent-light'
