### PR TITLE
[TECH] Résoudre les tests flakys sur Pix Admin.

### DIFF
--- a/admin/tests/acceptance/organization-invitations-management_test.js
+++ b/admin/tests/acceptance/organization-invitations-management_test.js
@@ -4,10 +4,21 @@ import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import moment from 'moment';
+import sinon from 'sinon';
 
 module('Acceptance | organization invitations management', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  const now = new Date('2019-01-01T05:06:07Z');
+
+  hooks.beforeEach(function () {
+    sinon.stub(Date, 'now').returns(now);
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
 
   test('should display invitations tab', async function (assert) {
     // given
@@ -28,7 +39,6 @@ module('Acceptance | organization invitations management', function (hooks) {
       const user = server.create('user');
       const organization = this.server.create('organization');
       await createAuthenticateSession({ userId: user.id });
-      const now = new Date();
 
       // when
       const screen = await visit(`/organizations/${organization.id}/invitations`);
@@ -48,7 +58,6 @@ module('Acceptance | organization invitations management', function (hooks) {
       const user = server.create('user');
       const organization = this.server.create('organization');
       await createAuthenticateSession({ userId: user.id });
-      const now = new Date();
 
       this.server.post(
         '/admin/organizations/:id/invitations',


### PR DESCRIPTION
## :unicorn: Problème
Certains tests sur Pix Admin sont flakys (cf: https://app.circleci.com/pipelines/github/1024pix/pix/37681/workflows/d41f84bf-2c5f-4590-9fe4-594c42e7a23c/jobs/304737) 

## :robot: Solution
- Stuber `Date.now` pour fixer la date

## :rainbow: Remarques
- Utiliser sinon.useFakeTimers ne fonctionne pas car cela casse le comportement de QUnit.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
