### PR TITLE
[FEATURE] Modifier l'ordre d'affichage des signalements sur la page de finalisation de session (PIX-4676)

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -27,12 +27,6 @@
           @toggleOnCategory={{this.toggleOnCategory}}
         />
 
-        <IssueReportModal::InChallengeCertificationIssueReportFields
-          @inChallengeCategory={{this.inChallengeCategory}}
-          @toggleOnCategory={{this.toggleOnCategory}}
-          @maxlength={{@maxlength}}
-        />
-
         <IssueReportModal::NonBlockingTechnicalIssueCertificationIssueReportFields
           @nonBlockingTechnicalIssueCategory={{this.nonBlockingTechnicalIssueCategory}}
           @toggleOnCategory={{this.toggleOnCategory}}
@@ -41,6 +35,12 @@
 
         <IssueReportModal::NonBlockingCandidateIssueCertificationIssueReportFields
           @nonBlockingCandidateIssueCategory={{this.nonBlockingCandidateIssueCategory}}
+          @toggleOnCategory={{this.toggleOnCategory}}
+          @maxlength={{@maxlength}}
+        />
+
+        <IssueReportModal::InChallengeCertificationIssueReportFields
+          @inChallengeCategory={{this.inChallengeCategory}}
           @toggleOnCategory={{this.toggleOnCategory}}
           @maxlength={{@maxlength}}
         />


### PR DESCRIPTION
## :unicorn: Problème
L'ordre des signalements dans la modale n'est pas le bon

## :robot: Solution
L'ordre doit correspondre à celui-ci
- C1-C2

- C3-C4

- C6

- C7

- C8

- E1-E9

- A2


## :100: Pour tester

- Dans pix-certif, finaliser une session en mettant des signalements et constater l'ordre des catégories suivant
![image](https://user-images.githubusercontent.com/37305474/161054853-6f211e02-ba02-40af-8b42-107297c34ef8.png)

