### PR TITLE
[TECH] Stocker le clientId du parcours Pôle Emploi uniquement dans l'API (PIX-4682).

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -70,17 +70,10 @@ module.exports = {
 
   async authenticatePoleEmploiUser(request) {
     const authenticatedUserId = get(request.auth, 'credentials.userId');
-    const {
-      code,
-      client_id: clientId,
-      redirect_uri: redirectUri,
-      state_sent: stateSent,
-      state_received: stateReceived,
-    } = request.payload;
+    const { code, redirect_uri: redirectUri, state_sent: stateSent, state_received: stateReceived } = request.payload;
 
     const result = await usecases.authenticatePoleEmploiUser({
       authenticatedUserId,
-      clientId,
       code,
       redirectUri,
       stateReceived,

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -162,7 +162,6 @@ exports.register = async (server) => {
         validate: {
           payload: Joi.object().required().keys({
             code: Joi.string().required(),
-            client_id: Joi.string().required(),
             redirect_uri: Joi.string().required(),
             state_sent: Joi.string().required(),
             state_received: Joi.string().required(),

--- a/api/lib/application/pole-emploi/index.js
+++ b/api/lib/application/pole-emploi/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 const poleEmploiController = require('./pole-emploi-controller');
 const poleEmploiErreurDoc = require('../../infrastructure/open-api-doc/pole-emploi/erreur-doc');
 const poleEmploiEnvoisDoc = require('../../infrastructure/open-api-doc/pole-emploi/envois-doc');
+const PoleEmploiController = require('../pole-emploi/pole-emploi-controller');
 
 exports.register = async function (server) {
   server.route([
@@ -68,6 +69,19 @@ exports.register = async function (server) {
           }).options({ allowUnknown: true }),
         },
         tags: ['api', 'pole-emploi'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/pole-emploi/auth-url',
+      config: {
+        auth: false,
+        handler: PoleEmploiController.getAuthUrl,
+        notes: [
+          "- Cette route permet de récupérer l'url d'authentification de Pole emploi.\n" +
+            '- Elle retournera également les valeurs state et nonce.',
+        ],
+        tags: ['api', 'Pôle emploi'],
       },
     },
   ]);

--- a/api/lib/application/pole-emploi/pole-emploi-controller.js
+++ b/api/lib/application/pole-emploi/pole-emploi-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
 const userRepository = require('../../infrastructure/repositories/user-repository');
+const authenticationService = require('../../../lib/domain/services/authentication-service');
 
 module.exports = {
   async createUser(request, h) {
@@ -23,6 +24,13 @@ module.exports = {
     const filters = _extractFilters(request);
     const { sendings, link } = await usecases.getPoleEmploiSendings({ cursor, filters });
     return h.response(sendings).header('link', link).code(200);
+  },
+
+  async getAuthUrl(request, h) {
+    const result = authenticationService.getPoleEmploiAuthUrl({
+      redirectUri: request.query['redirect_uri'],
+    });
+    return h.response(result).code(200);
   },
 };
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -195,6 +195,7 @@ module.exports = (function () {
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
+      authUrl: process.env.POLE_EMPLOI_AUTHENTICATION_URL,
       temporaryStorage: {
         expirationDelaySeconds:
           parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
@@ -278,10 +279,12 @@ module.exports = (function () {
 
     config.temporaryKey.secret = 'test-jwt-key';
 
+    config.poleEmploi.clientId = 'PIX_POLE_EMPLOI_CLIENT_ID';
     config.poleEmploi.clientSecret = 'PIX_POLE_EMPLOI_CLIENT_SECRET';
     config.poleEmploi.tokenUrl = 'http://tokenUrl.fr';
     config.poleEmploi.sendingUrl = 'http://sendingUrl.fr';
     config.poleEmploi.userInfoUrl = 'http://userInfoUrl.fr';
+    config.poleEmploi.authUrl = 'http://authurl.fr';
 
     config.saml.accessTokenLifespanMs = 1000;
 

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -23,12 +23,12 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
   return foundUser;
 }
 
-async function exchangePoleEmploiCodeForTokens({ code, clientId, redirectUri }) {
+async function exchangePoleEmploiCodeForTokens({ code, redirectUri }) {
   const data = {
     client_secret: settings.poleEmploi.clientSecret,
     grant_type: 'authorization_code',
     code,
-    client_id: clientId,
+    client_id: settings.poleEmploi.clientId,
     redirect_uri: redirectUri,
   };
 

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -23,7 +23,7 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
   return foundUser;
 }
 
-async function generatePoleEmploiTokens({ code, clientId, redirectUri }) {
+async function exchangePoleEmploiCodeForTokens({ code, clientId, redirectUri }) {
   const data = {
     client_secret: settings.poleEmploi.clientSecret,
     grant_type: 'authorization_code',
@@ -78,7 +78,7 @@ function _getErrorMessage(data) {
 }
 
 module.exports = {
-  generatePoleEmploiTokens,
+  exchangePoleEmploiCodeForTokens,
   getPoleEmploiUserInfo,
   getUserByUsernameAndPassword,
 };

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -10,6 +10,7 @@ const PoleEmploiTokens = require('../models/PoleEmploiTokens');
 
 const encryptionService = require('./encryption-service');
 const tokenService = require('./token-service');
+const { v4: uuidv4 } = require('uuid');
 
 async function getUserByUsernameAndPassword({ username, password, userRepository }) {
   const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(username);
@@ -64,6 +65,29 @@ async function getPoleEmploiUserInfo(idToken) {
   };
 }
 
+function getPoleEmploiAuthUrl({ redirectUri }) {
+  const redirectTarget = new URL(`${settings.poleEmploi.authUrl}/connexion/oauth2/authorize`);
+  const state = uuidv4();
+  const nonce = uuidv4();
+  const clientId = settings.poleEmploi.clientId;
+  const params = [
+    { key: 'state', value: state },
+    { key: 'nonce', value: nonce },
+    { key: 'realm', value: '/individu' },
+    { key: 'client_id', value: clientId },
+    { key: 'redirect_uri', value: redirectUri },
+    { key: 'response_type', value: 'code' },
+    {
+      key: 'scope',
+      value: `application_${clientId} api_peconnect-individuv1 openid profile serviceDigitauxExposition api_peconnect-servicesdigitauxv1`,
+    },
+  ];
+
+  params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
+
+  return { redirectTarget: redirectTarget.toString(), state, nonce };
+}
+
 function _getErrorMessage(data) {
   let message;
 
@@ -80,5 +104,6 @@ function _getErrorMessage(data) {
 module.exports = {
   exchangePoleEmploiCodeForTokens,
   getPoleEmploiUserInfo,
+  getPoleEmploiAuthUrl,
   getUserByUsernameAndPassword,
 };

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -22,7 +22,7 @@ module.exports = async function authenticatePoleEmploiUser({
     throw new UnexpectedPoleEmploiStateError();
   }
 
-  const poleEmploiTokens = await authenticationService.generatePoleEmploiTokens({ code, clientId, redirectUri });
+  const poleEmploiTokens = await authenticationService.exchangePoleEmploiCodeForTokens({ code, clientId, redirectUri });
 
   const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
 

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -6,7 +6,6 @@ const logger = require('../../infrastructure/logger');
 
 module.exports = async function authenticatePoleEmploiUser({
   authenticatedUserId,
-  clientId,
   code,
   redirectUri,
   stateReceived,
@@ -22,7 +21,7 @@ module.exports = async function authenticatePoleEmploiUser({
     throw new UnexpectedPoleEmploiStateError();
   }
 
-  const poleEmploiTokens = await authenticationService.exchangePoleEmploiCodeForTokens({ code, clientId, redirectUri });
+  const poleEmploiTokens = await authenticationService.exchangePoleEmploiCodeForTokens({ code, redirectUri });
 
   const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -453,6 +453,13 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_SENDING_URL=
 
+# POLE EMPLOI authentication - Authentication URL
+# Refer to https://pole-emploi.io/data/api/pole-emploi-connect
+#
+# presence: required for POLE EMPLOI authentication, optional otherwise
+# type: URL
+# sample: POLE_EMPLOI_AUTHENTICATION_URL=
+
 
 # ========
 # TEMPORARY STORAGE

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -323,7 +323,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
           },
           payload: querystring.stringify({
             code: 'code',
-            client_id: 'client_id',
             redirect_uri: 'redirect_uri',
             state_sent: 'a_state',
             state_received: 'another_state',
@@ -372,7 +371,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -413,7 +411,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -454,7 +451,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -503,7 +499,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -562,7 +557,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -626,7 +620,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -681,7 +674,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -737,7 +729,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -793,7 +784,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -850,7 +840,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
             },
             payload: querystring.stringify({
               code: 'code',
-              client_id: 'client_id',
               redirect_uri: 'redirect_uri',
               state_sent: 'state',
               state_received: 'state',
@@ -893,7 +882,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
           },
           payload: querystring.stringify({
             code: 'code',
-            client_id: 'client_id',
             redirect_uri: 'redirect_uri',
             state_sent: 'state',
             state_received: 'state',
@@ -938,7 +926,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
           },
           payload: querystring.stringify({
             code: 'code',
-            client_id: 'client_id',
             redirect_uri: 'redirect_uri',
             state_sent: 'state',
             state_received: 'state',
@@ -988,7 +975,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
           },
           payload: querystring.stringify({
             code: 'code',
-            client_id: 'client_id',
             redirect_uri: 'redirect_uri',
             state_sent: 'state',
             state_received: 'state',

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -210,4 +210,40 @@ describe('Acceptance | API | Pole Emploi Controller', function () {
       });
     });
   });
+
+  describe('GET /api/pole-emploi/auth-url', function () {
+    context('When the request returns 200', function () {
+      it('should return the url of authentication', async function () {
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/pole-emploi/auth-url?redirect_uri=${encodeURIComponent(
+            'http://app.pix.fr/connexion-pole-emploi'
+          )}`,
+        });
+
+        // then
+        function _checkIfValidUUID(str) {
+          const regexExp = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+          return regexExp.test(str);
+        }
+
+        expect(response.statusCode).to.equal(200);
+        expect(_checkIfValidUUID(response.result.state)).to.be.true;
+        expect(_checkIfValidUUID(response.result.nonce)).to.be.true;
+
+        const redirectTargetUrl = new URL(response.result.redirectTarget);
+
+        expect(redirectTargetUrl.origin).to.equal('http://authurl.fr');
+        expect(redirectTargetUrl.pathname).to.equal('/connexion/oauth2/authorize');
+        expect(redirectTargetUrl.searchParams.get('redirect_uri')).to.equal('http://app.pix.fr/connexion-pole-emploi');
+        expect(redirectTargetUrl.searchParams.get('client_id')).to.equal('PIX_POLE_EMPLOI_CLIENT_ID');
+        expect(redirectTargetUrl.searchParams.get('response_type')).to.equal('code');
+        expect(redirectTargetUrl.searchParams.get('realm')).to.equal('/individu');
+        expect(redirectTargetUrl.searchParams.get('scope')).to.equal(
+          'application_PIX_POLE_EMPLOI_CLIENT_ID api_peconnect-individuv1 openid profile serviceDigitauxExposition api_peconnect-servicesdigitauxv1'
+        );
+      });
+    });
+  });
 });

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -277,7 +277,6 @@ describe('Integration | Application | Route | AuthenticationRouter', function ()
     const headers = {};
 
     const code = 'ABCD';
-    const client_id = 'CLIENT_ID';
     const redirect_uri = 'http://redirectUri.fr';
     const state_sent = 'state_sent';
     const state_received = 'state_received';
@@ -289,7 +288,6 @@ describe('Integration | Application | Route | AuthenticationRouter', function ()
 
       payload = querystring.stringify({
         code,
-        client_id,
         redirect_uri,
         state_sent,
         state_received,
@@ -329,21 +327,6 @@ describe('Integration | Application | Route | AuthenticationRouter', function ()
     it('should return 400 when code is missing', async function () {
       // given
       payload = querystring.stringify({
-        client_id,
-        redirect_uri,
-      });
-
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return 400 when client_id is missing', async function () {
-      // given
-      payload = querystring.stringify({
-        code,
         redirect_uri,
       });
 
@@ -358,7 +341,6 @@ describe('Integration | Application | Route | AuthenticationRouter', function ()
       // given
       payload = querystring.stringify({
         code,
-        client_id,
       });
 
       // when

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -108,7 +108,6 @@ describe('Unit | Application | Controller | Authentication', function () {
 
   describe('#authenticatePoleEmploiUser', function () {
     const code = 'ABCD';
-    const client_id = 'CLIENT_ID';
     const redirect_uri = 'http://redirectUri.fr';
     const state_sent = 'state';
     const state_received = 'state';
@@ -127,7 +126,6 @@ describe('Unit | Application | Controller | Authentication', function () {
       request = {
         payload: {
           code,
-          client_id,
           redirect_uri,
           state_sent,
           state_received,
@@ -142,7 +140,6 @@ describe('Unit | Application | Controller | Authentication', function () {
       usecases.authenticatePoleEmploiUser.resolves({ pixAccessToken, poleEmploiTokens });
       const expectedParameters = {
         authenticatedUserId: undefined,
-        clientId: client_id,
         code,
         redirectUri: redirect_uri,
         stateReceived: state_received,

--- a/api/tests/unit/domain/services/authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication-service_test.js
@@ -124,7 +124,7 @@ describe('Unit | Domain | Services | authentication-service', function () {
     });
   });
 
-  describe('#generatePoleEmploiTokens', function () {
+  describe('#exchangePoleEmploiCodeForTokens', function () {
     beforeEach(function () {
       sinon.stub(httpAgent, 'post');
     });
@@ -158,7 +158,7 @@ describe('Unit | Domain | Services | authentication-service', function () {
       httpAgent.post.resolves(response);
 
       // when
-      const result = await authenticationService.generatePoleEmploiTokens({ code, clientId, redirectUri });
+      const result = await authenticationService.exchangePoleEmploiCodeForTokens({ code, clientId, redirectUri });
 
       // then
       expect(httpAgent.post).to.have.been.calledWith({
@@ -191,7 +191,7 @@ describe('Unit | Domain | Services | authentication-service', function () {
         httpAgent.post.resolves(response);
 
         // when
-        const error = await catchErr(authenticationService.generatePoleEmploiTokens)({ code, clientId, redirectUri });
+        const error = await catchErr(authenticationService.exchangePoleEmploiCodeForTokens)({ code, clientId, redirectUri });
 
         // then
         expect(error).to.be.an.instanceOf(GeneratePoleEmploiTokensError);

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -90,7 +90,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
   });
 
   context('When user has an account', function () {
-    it('should call authenticate pole emploi user with code, redirectUri and clientId parameters', async function () {
+    it('should call authenticate pole emploi user with code and redirectUri parameters', async function () {
       // given
       _fakePoleEmploiAPI({ authenticationService });
       tokenService.createAccessTokenForPoleEmploi.returns('access-token');
@@ -114,7 +114,6 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       expect(authenticationService.exchangePoleEmploiCodeForTokens).to.have.been.calledWith({
         code: 'code',
         redirectUri: 'redirectUri',
-        clientId: 'clientId',
       });
     });
 

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     clock = sinon.useFakeTimers(Date.now());
 
     authenticationService = {
-      generatePoleEmploiTokens: sinon.stub(),
+      exchangePoleEmploiCodeForTokens: sinon.stub(),
       getPoleEmploiUserInfo: sinon.stub(),
     };
 
@@ -111,7 +111,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       });
 
       // then
-      expect(authenticationService.generatePoleEmploiTokens).to.have.been.calledWith({
+      expect(authenticationService.exchangePoleEmploiCodeForTokens).to.have.been.calledWith({
         code: 'code',
         redirectUri: 'redirectUri',
         clientId: 'clientId',
@@ -465,7 +465,7 @@ function _fakePoleEmploiAPI({ authenticationService }) {
     externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
   };
 
-  authenticationService.generatePoleEmploiTokens.resolves(poleEmploiTokens);
+  authenticationService.exchangePoleEmploiCodeForTokens.resolves(poleEmploiTokens);
   authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
 
   return { poleEmploiTokens };

--- a/mon-pix/app/authenticators/pole-emploi.js
+++ b/mon-pix/app/authenticators/pole-emploi.js
@@ -9,7 +9,7 @@ import { decodeToken } from 'mon-pix/helpers/jwt';
 import ENV from 'mon-pix/config/environment';
 import fetch from 'fetch';
 
-const { host, clientId, afterLogoutUri, endSessionEndpoint } = ENV.poleEmploi;
+const { host, afterLogoutUri, endSessionEndpoint } = ENV.poleEmploi;
 
 export default class PoleEmploiAuthenticator extends BaseAuthenticator {
   @service session;
@@ -31,7 +31,6 @@ export default class PoleEmploiAuthenticator extends BaseAuthenticator {
       serverTokenEndpoint = `${ENV.APP.API_HOST}/api/pole-emploi/token`;
       const bodyObject = {
         code,
-        client_id: clientId,
         redirect_uri: redirectUri,
         state_sent: this.session.data.state,
         state_received: state,

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -45,9 +45,8 @@ module.exports = function (environment) {
     poleEmploi: {
       afterLogoutUri: process.env.POLE_EMPLOI_AFTER_LOGOUT_URI,
       authEndpoint: '/connexion/oauth2/authorize',
-      clientId: process.env.POLE_EMPLOI_CLIENT_ID,
       endSessionEndpoint: '/compte/deconnexion',
-      expiresIn: 60000, // Short expire time (60s) for testing purpose
+      expiresIn: 60000, // Short expire time (60s) for testing purpose,
       host: process.env.POLE_EMPLOI_AUTHENTICATION_URL,
     },
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -86,4 +86,13 @@ export default function () {
   this.get('/certification-candidates/:id/subscriptions', getCertificationCandidatesSubscriptions);
 
   this.get('/certification-courses/:id');
+
+  this.get('/pole-emploi/auth-url', (schema, request) => {
+    const redirectUri = request.queryParams.redirect_uri;
+    return {
+      redirectTarget: `https://pole-emploi/connexion/oauth2/authorize?redirect_uri=${redirectUri}`,
+      state: 'a8a3344f-6d7c-469d-9f84-bdd791e04fdf',
+      nonce: '555c86fe-ed0a-4a80-80f3-45b1f7c2df8c',
+    };
+  });
 }

--- a/mon-pix/tests/acceptance/login-pe_test.js
+++ b/mon-pix/tests/acceptance/login-pe_test.js
@@ -1,0 +1,39 @@
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../helpers/setup-intl';
+import sinon from 'sinon';
+import { visit } from '@ember/test-helpers';
+import { expect } from 'chai';
+
+describe('Acceptance | Route | Login pe', function () {
+  setupApplicationTest();
+  setupMirage();
+  setupIntl();
+
+  it('should redirect to Pole Emploi login page', async function () {
+    // given
+    const route = this.owner.lookup('route:login-pe');
+
+    route.location = { replace: sinon.stub() };
+
+    this.server.get('/pole-emploi/auth-url', (schema, request) => {
+      const redirectUri = request.queryParams.redirect_uri;
+      return {
+        redirectTarget: `https://pole-emploi/connexion/oauth2/authorize?redirect_uri=${redirectUri}`,
+        state: 'a8a3344f-6d7c-469d-9f84-bdd791e04fdf',
+        nonce: '555c86fe-ed0a-4a80-80f3-45b1f7c2df8c',
+      };
+    });
+
+    // when
+    await visit('/connexion-pole-emploi');
+
+    // then
+    sinon.assert.calledWith(
+      route.location.replace,
+      `https://pole-emploi/connexion/oauth2/authorize?redirect_uri=${route.redirectUri}`
+    );
+    expect(route.session.get('data.state')).to.be.equal('a8a3344f-6d7c-469d-9f84-bdd791e04fdf');
+    expect(route.session.get('data.nonce')).to.be.equal('555c86fe-ed0a-4a80-80f3-45b1f7c2df8c');
+  });
+});

--- a/mon-pix/tests/unit/routes/login-pe_test.js
+++ b/mon-pix/tests/unit/routes/login-pe_test.js
@@ -6,30 +6,21 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Route | login-pe', function () {
   setupTest();
 
-  let route;
-  const loginTransition = Symbol('login transition');
-
-  beforeEach(function () {
-    route = this.owner.lookup('route:login-pe');
-    sinon.stub(route, 'replaceWith');
-    route.replaceWith.withArgs('login').returns(loginTransition);
-  });
-
   context('when pole-emploi user disallow PIX to use data', function () {
-    const queryParams = {
-      error: 'access_denied',
-    };
-
     it('should redirect to login route if there is an error in transition.to', function () {
       // given
-      const transition = {
-        to: {
-          queryParams,
-        },
-      };
+      const route = this.owner.lookup('route:login-pe');
+      const loginTransition = Symbol('login transition');
+      sinon.stub(route, 'replaceWith').withArgs('login').returns(loginTransition);
 
       // when
-      const transitionResult = route.beforeModel(transition);
+      const transitionResult = route.beforeModel({
+        to: {
+          queryParams: {
+            error: 'access_denied',
+          },
+        },
+      });
 
       // then
       expect(transitionResult).to.equal(loginTransition);
@@ -37,12 +28,16 @@ describe('Unit | Route | login-pe', function () {
 
     it('should redirect to login route if there is an error in transition', function () {
       // given
-      const transition = {
-        queryParams,
-      };
+      const route = this.owner.lookup('route:login-pe');
+      const loginTransition = Symbol('login transition');
+      sinon.stub(route, 'replaceWith').withArgs('login').returns(loginTransition);
 
       // when
-      const transitionResult = route.beforeModel(transition);
+      const transitionResult = route.beforeModel({
+        queryParams: {
+          error: 'access_denied',
+        },
+      });
 
       // then
       expect(transitionResult).to.equal(loginTransition);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement le paramètre `clientId` que l'on utilise pour communiquer avec Pôle Emploi est stocké coté front (Pix App) et coté API. 
L'appel `api/pole-emploi/token` fait par le front, fournit à l'API le clientId qu'il possède pourtant déjà dans son propre environnement. 
Ce paramètre n'est jamais modifié, c'est systématiquement le même. Il n'y a donc pas de raison qu'il soit à deux endroits à la fois.

## :robot: Solution
Supprimer le clientId de l'environnement front.

## :rainbow: Remarques
Renommage de la méthode `generatePoleEmploiTokens` pour `exchangePoleEmploiCodeForTokens`

## :100: Pour tester
Tester qu'il n'y a pas de régression dans le parcours Pôle Emploi : 
(tester en local) 
- Aller sur Pix App et cliquer sur le bouton Se connecter à Pôle Emploi (préciser le domaine fr pour voir le bouton)
- Entrer l'identifiant et le mot de passe ( seeds disponible ici : https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1961295916/Environnements+P+le+emploi )
- Si première connexion avec cet utilisateur : 
  - valider les cgu et accepter
- Sinon on accède directement à la page d'accueil Pix 
- Se déconnecter

Autre parcours possible : 
- aller sur `/campagnes` 
- Entrer le code campagne PIXEMPLOI
- Entrer les informations de l'utilisateur sur le portail PE
- On accède au début du parcours
- Quitter le parcours, et se déconnecter.

