### PR TITLE
[TECH] Unifier la création des read-models `TutorialForUser`.

### DIFF
--- a/api/lib/domain/usecases/find-paginated-recommended-tutorials.js
+++ b/api/lib/domain/usecases/find-paginated-recommended-tutorials.js
@@ -1,6 +1,3 @@
-const paginateModule = require('../../infrastructure/utils/paginate');
-
 module.exports = async function findPaginatedRecommendedTutorials({ userId, tutorialRepository, page, locale }) {
-  const tutorials = await tutorialRepository.findRecommendedByUserId({ userId, locale });
-  return paginateModule.paginate(tutorials, page);
+  return tutorialRepository.findPaginatedRecommendedByUserId({ userId, page, locale });
 };

--- a/api/lib/domain/usecases/find-paginated-saved-tutorials.js
+++ b/api/lib/domain/usecases/find-paginated-saved-tutorials.js
@@ -1,30 +1,10 @@
-module.exports = async function findPaginatedSavedTutorials({
-  tutorialEvaluationRepository,
-  tutorialRepository,
-  userId,
-  page,
-} = {}) {
-  const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
-  const { models: tutorials, meta } = await tutorialRepository.findPaginatedForCurrentUser({
+module.exports = async function findPaginatedSavedTutorials({ tutorialRepository, userId, page } = {}) {
+  const { models: results, meta } = await tutorialRepository.findPaginatedForCurrentUser({
     userId,
     page,
   });
-  const savedTutorials = tutorials.map(_setTutorialEvaluation(tutorialEvaluations));
   return {
-    results: savedTutorials,
+    results,
     meta,
   };
 };
-
-function _setTutorialEvaluation(tutorialEvaluations) {
-  return (tutorial) => {
-    const tutorialEvaluation = tutorialEvaluations.find(
-      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorial.id
-    );
-    if (!tutorialEvaluation) return tutorial;
-    return {
-      ...tutorial,
-      tutorialEvaluation,
-    };
-  };
-}

--- a/api/lib/domain/usecases/find-paginated-saved-tutorials.js
+++ b/api/lib/domain/usecases/find-paginated-saved-tutorials.js
@@ -5,12 +5,11 @@ module.exports = async function findPaginatedSavedTutorials({
   page,
 } = {}) {
   const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
-  const { models: tutorialWithUserSavedTutorial, meta } =
-    await tutorialRepository.findPaginatedWithUserTutorialForCurrentUser({
-      userId,
-      page,
-    });
-  const savedTutorials = tutorialWithUserSavedTutorial.map(_setTutorialEvaluation(tutorialEvaluations));
+  const { models: tutorials, meta } = await tutorialRepository.findPaginatedForCurrentUser({
+    userId,
+    page,
+  });
+  const savedTutorials = tutorials.map(_setTutorialEvaluation(tutorialEvaluations));
   return {
     results: savedTutorials,
     meta,
@@ -18,13 +17,13 @@ module.exports = async function findPaginatedSavedTutorials({
 };
 
 function _setTutorialEvaluation(tutorialEvaluations) {
-  return (tutorialWithUserSavedTutorial) => {
+  return (tutorial) => {
     const tutorialEvaluation = tutorialEvaluations.find(
-      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorialWithUserSavedTutorial.id
+      (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorial.id
     );
-    if (!tutorialEvaluation) return tutorialWithUserSavedTutorial;
+    if (!tutorialEvaluation) return tutorial;
     return {
-      ...tutorialWithUserSavedTutorial,
+      ...tutorial,
       tutorialEvaluation,
     };
   };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -29,12 +29,7 @@ module.exports = {
       tutorialEvaluationRepository.find({ userId }),
     ]);
 
-    const tutorialsForUser = tutorials.map((tutorial) => {
-      const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
-      const tutorialEvaluation = tutorialEvaluations.find(({ tutorialId }) => tutorialId === tutorial.id);
-
-      return new TutorialForUser({ ...tutorial, userTutorial, tutorialEvaluation });
-    });
+    const tutorialsForUser = _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
 
     return { models: tutorialsForUser, meta };
   },
@@ -67,11 +62,7 @@ module.exports = {
       tutorialEvaluationRepository.find({ userId }),
     ]);
 
-    return tutorials.map((tutorial) => {
-      const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
-      const tutorialEvaluation = tutorialEvaluations.find(({ tutorialId }) => tutorialId === tutorial.id);
-      return new TutorialForUser({ ...tutorial, userTutorial, tutorialEvaluation });
-    });
+    return _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
   },
 };
 
@@ -83,6 +74,14 @@ function _toDomain(tutorialData) {
     link: tutorialData.link,
     source: tutorialData.source,
     title: tutorialData.title,
+  });
+}
+
+function _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials }) {
+  return tutorials.map((tutorial) => {
+    const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
+    const tutorialEvaluation = tutorialEvaluations.find(({ tutorialId }) => tutorialId === tutorial.id);
+    return new TutorialForUser({ ...tutorial, userTutorial, tutorialEvaluation });
   });
 }
 

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -24,8 +24,10 @@ module.exports = {
 
   async findPaginatedForCurrentUser({ userId, page }) {
     const { models: userTutorials, meta } = await userTutorialRepository.findPaginated({ userId, page });
-    const tutorials = await tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId));
-    const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
+    const [tutorials, tutorialEvaluations] = await Promise.all([
+      tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId)),
+      tutorialEvaluationRepository.find({ userId }),
+    ]);
 
     const tutorialsForUser = tutorials.map((tutorial) => {
       const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -22,7 +22,7 @@ module.exports = {
     return _findByRecordIds({ ids });
   },
 
-  async findPaginatedWithUserTutorialForCurrentUser({ userId, page }) {
+  async findPaginatedForCurrentUser({ userId, page }) {
     const { models: userTutorials, meta } = await userTutorialRepository.findPaginated({ userId, page });
     const tutorials = await tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId));
     const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -8,6 +8,7 @@ const TutorialForUser = require('../../domain/read-models/TutorialForUser');
 const { FRENCH_FRANCE } = require('../../domain/constants').LOCALE;
 const knowledgeElementRepository = require('./knowledge-element-repository');
 const skillRepository = require('./skill-repository');
+const paginateModule = require('../utils/paginate');
 
 module.exports = {
   async findByRecordIdsForCurrentUser({ ids, userId, locale }) {
@@ -50,7 +51,7 @@ module.exports = {
     return _.map(tutorialData, _toDomain);
   },
 
-  async findRecommendedByUserId({ userId, locale = FRENCH_FRANCE } = {}) {
+  async findPaginatedRecommendedByUserId({ userId, page, locale = FRENCH_FRANCE } = {}) {
     const invalidatedKnowledgeElements = await knowledgeElementRepository.findInvalidatedAndDirectByUserId(userId);
     const skills = await skillRepository.findOperativeByIds(invalidatedKnowledgeElements.map(({ skillId }) => skillId));
 
@@ -62,7 +63,8 @@ module.exports = {
       tutorialEvaluationRepository.find({ userId }),
     ]);
 
-    return _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
+    const tutorialsForUser = _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
+    return paginateModule.paginate(tutorialsForUser, page);
   },
 };
 

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -25,13 +25,16 @@ module.exports = {
   async findPaginatedWithUserTutorialForCurrentUser({ userId, page }) {
     const { models: userTutorials, meta } = await userTutorialRepository.findPaginated({ userId, page });
     const tutorials = await tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId));
+    const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
 
-    const tutorialsWithUserSavedTutorial = tutorials.map((tutorial) => {
+    const tutorialsForUser = tutorials.map((tutorial) => {
       const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
-      return new TutorialForUser({ ...tutorial, userTutorial });
+      const tutorialEvaluation = tutorialEvaluations.find(({ tutorialId }) => tutorialId === tutorial.id);
+
+      return new TutorialForUser({ ...tutorial, userTutorial, tutorialEvaluation });
     });
 
-    return { models: tutorialsWithUserSavedTutorial, meta };
+    return { models: tutorialsForUser, meta };
   },
 
   async get(id) {

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -131,11 +131,13 @@ describe('Integration | Repository | tutorial-repository', function () {
     });
   });
 
-  describe('#findPaginatedWithUserTutorialForCurrentUser', function () {
+  describe('#findPaginatedForCurrentUser', function () {
     let userId;
+
     beforeEach(function () {
       userId = databaseBuilder.factory.buildUser().id;
     });
+
     context('when user has saved tutorials', function () {
       it('should return tutorial with user tutorial belonging to given user', async function () {
         // given
@@ -150,7 +152,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         await databaseBuilder.commit();
 
         // when
-        const { models: tutorialsForUser } = await tutorialRepository.findPaginatedWithUserTutorialForCurrentUser({
+        const { models: tutorialsForUser } = await tutorialRepository.findPaginatedForCurrentUser({
           userId,
         });
 
@@ -176,7 +178,7 @@ describe('Integration | Repository | tutorial-repository', function () {
           await databaseBuilder.commit();
 
           // when
-          const { models: tutorialsForUser } = await tutorialRepository.findPaginatedWithUserTutorialForCurrentUser({
+          const { models: tutorialsForUser } = await tutorialRepository.findPaginatedForCurrentUser({
             userId,
           });
 
@@ -190,7 +192,7 @@ describe('Integration | Repository | tutorial-repository', function () {
       it('should return an empty list', async function () {
         mockLearningContent({ tutorials: [] });
 
-        const { models: tutorialsForUser } = await tutorialRepository.findPaginatedWithUserTutorialForCurrentUser({
+        const { models: tutorialsForUser } = await tutorialRepository.findPaginatedForCurrentUser({
           userId,
         });
 
@@ -205,7 +207,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         databaseBuilder.factory.buildUserSavedTutorial({ tutorialId: 'recTutorial', userId });
         await databaseBuilder.commit();
 
-        const { models: tutorialsForUser } = await tutorialRepository.findPaginatedWithUserTutorialForCurrentUser({
+        const { models: tutorialsForUser } = await tutorialRepository.findPaginatedForCurrentUser({
           userId,
         });
 
@@ -232,8 +234,10 @@ describe('Integration | Repository | tutorial-repository', function () {
         await databaseBuilder.commit();
 
         // when
-        const { models: foundTutorials, meta: pagination } =
-          await tutorialRepository.findPaginatedWithUserTutorialForCurrentUser({ userId, page });
+        const { models: foundTutorials, meta: pagination } = await tutorialRepository.findPaginatedForCurrentUser({
+          userId,
+          page,
+        });
 
         // then
         expect(foundTutorials).to.have.lengthOf(2);

--- a/api/tests/unit/domain/usecases/find-paginated-recommended-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-recommended-tutorials_test.js
@@ -1,9 +1,8 @@
-const { sinon, expect, domainBuilder } = require('../../../test-helper');
-const paginateModule = require('../../../../lib/infrastructure/utils/paginate');
+const { sinon, expect } = require('../../../test-helper');
 const findRecommendedTutorials = require('../../../../lib/domain/usecases/find-paginated-recommended-tutorials');
 
 describe('Unit | UseCase | find-paginated-recommended-tutorials', function () {
-  it('should call tutorial repository with userId and locale', async function () {
+  it('should call tutorial repository with userId, page and locale', async function () {
     // given
     const userId = 1;
     const page = {
@@ -11,11 +10,9 @@ describe('Unit | UseCase | find-paginated-recommended-tutorials', function () {
       size: 2,
     };
     const tutorialRepository = {
-      findRecommendedByUserId: sinon.stub().resolves([]),
+      findPaginatedRecommendedByUserId: sinon.stub().resolves([]),
     };
     const locale = 'fr-fr';
-
-    sinon.stub(paginateModule, 'paginate').returns({ results: [], pagination: {} });
 
     // when
     await findRecommendedTutorials({
@@ -26,90 +23,6 @@ describe('Unit | UseCase | find-paginated-recommended-tutorials', function () {
     });
 
     // then
-    expect(tutorialRepository.findRecommendedByUserId).to.have.been.calledWith({ userId, locale });
-  });
-
-  describe('when there are no recommended tutorials', function () {
-    it('should return empty page data', async function () {
-      // Given
-      const userId = 1;
-      const page = {
-        number: 1,
-        size: 2,
-      };
-      const tutorialRepository = {
-        findRecommendedByUserId: sinon.stub().resolves([]),
-      };
-
-      const expectedPagination = {
-        page: 1,
-        pageSize: 2,
-        rowCount: 0,
-        pageCount: 0,
-      };
-
-      sinon.stub(paginateModule, 'paginate').returns({ results: [], pagination: expectedPagination });
-
-      // When
-      const tutorials = await findRecommendedTutorials({
-        userId,
-        tutorialRepository,
-        page,
-      });
-
-      // Then
-      expect(tutorials.results).to.have.lengthOf(0);
-      expect(tutorials.pagination).to.deep.equal(expectedPagination);
-    });
-  });
-
-  describe('when there are recommended tutorials for user', function () {
-    it('should return a paginated list of tutorials', async function () {
-      // Given
-      const userId = 1;
-      const locale = 'fr-fr';
-      const page = {
-        number: 1,
-        size: 2,
-      };
-
-      const expectedTutorials = [
-        domainBuilder.buildTutorial({ id: 'tuto1' }),
-        domainBuilder.buildTutorial({ id: 'tuto2' }),
-        domainBuilder.buildTutorial({ id: 'tuto3' }),
-        domainBuilder.buildTutorial({ id: 'tuto4' }),
-      ];
-
-      const expectedPagination = {
-        page: 1,
-        pageSize: 2,
-        rowCount: 4,
-        pageCount: 2,
-      };
-
-      sinon
-        .stub(paginateModule, 'paginate')
-        .returns({ results: expectedTutorials.slice(0, 2), pagination: expectedPagination });
-
-      const tutorialRepository = {
-        findRecommendedByUserId: sinon.stub(),
-      };
-
-      tutorialRepository.findRecommendedByUserId.resolves(expectedTutorials);
-
-      // When
-      const tutorials = await findRecommendedTutorials({
-        userId,
-        tutorialRepository,
-        page,
-        locale,
-      });
-
-      //Then
-      expect(tutorialRepository.findRecommendedByUserId).to.have.been.calledWith({ userId, locale });
-      expect(tutorials.results).to.deep.equal(expectedTutorials.slice(0, 2));
-      expect(tutorials.pagination).to.deep.equal(expectedPagination);
-      expect(paginateModule.paginate).to.have.been.calledWith(expectedTutorials, page);
-    });
+    expect(tutorialRepository.findPaginatedRecommendedByUserId).to.have.been.calledWith({ userId, page, locale });
   });
 });

--- a/api/tests/unit/domain/usecases/find-paginated-saved-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-saved-tutorials_test.js
@@ -2,13 +2,11 @@ const { sinon, expect, domainBuilder } = require('../../../test-helper');
 const findPaginatedSavedTutorials = require('../../../../lib/domain/usecases/find-paginated-saved-tutorials');
 
 describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
-  let tutorialEvaluationRepository;
   let tutorialRepository;
   const userId = 'userId';
 
   context('when there is no tutorial saved by current user', function () {
     beforeEach(function () {
-      tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
       tutorialRepository = {
         findPaginatedForCurrentUser: sinon.spy(async () => ({
           models: [],
@@ -30,7 +28,7 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
       };
 
       // When
-      await findPaginatedSavedTutorials({ tutorialEvaluationRepository, tutorialRepository, userId, page });
+      await findPaginatedSavedTutorials({ tutorialRepository, userId, page });
 
       // Then
       expect(tutorialRepository.findPaginatedForCurrentUser).to.have.been.calledWith({ userId, page });
@@ -52,7 +50,6 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
 
       // When
       const paginatedSavedTutorials = await findPaginatedSavedTutorials({
-        tutorialEvaluationRepository,
         tutorialRepository,
         userId,
         page,
@@ -67,7 +64,6 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
     it('should return paginated tutorial with user-tutorials', async function () {
       // Given
       const tutorialWithUserSavedTutorial = domainBuilder.buildTutorialForUser();
-      tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
       tutorialRepository = {
         findPaginatedForCurrentUser: sinon.spy(async () => ({
           models: [tutorialWithUserSavedTutorial],
@@ -94,7 +90,6 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
 
       // When
       const paginatedSavedTutorials = await findPaginatedSavedTutorials({
-        tutorialEvaluationRepository,
         tutorialRepository,
         userId,
         page,
@@ -104,60 +99,6 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
       expect(paginatedSavedTutorials).to.deep.equal({
         results: [tutorialWithUserSavedTutorial],
         meta: expectedPagination,
-      });
-    });
-
-    context('when user has evaluated a tutorial', function () {
-      it('should return tutorial with user-tutorials', async function () {
-        // Given
-        const tutorialWithUserSavedTutorial = domainBuilder.buildTutorialForUser();
-        const tutorialEvaluation = {
-          id: 123,
-          userId: tutorialWithUserSavedTutorial.userTutorial.userId,
-          tutorialId: tutorialWithUserSavedTutorial.id,
-        };
-        tutorialEvaluationRepository = { find: sinon.spy(async () => [tutorialEvaluation]) };
-        tutorialRepository = {
-          findPaginatedForCurrentUser: sinon.spy(async () => ({
-            models: [tutorialWithUserSavedTutorial],
-            meta: {
-              page: 1,
-              pageSize: 2,
-              rowCount: 1,
-              pageCount: 1,
-            },
-          })),
-        };
-
-        const page = {
-          number: 1,
-          size: 2,
-        };
-
-        const expectedPagination = {
-          page: 1,
-          pageSize: 2,
-          rowCount: 1,
-          pageCount: 1,
-        };
-
-        const expectedSavedTutorialWithUserTutorial = {
-          ...tutorialWithUserSavedTutorial,
-          tutorialEvaluation,
-        };
-        // When
-        const paginatedSavedTutorials = await findPaginatedSavedTutorials({
-          tutorialEvaluationRepository,
-          tutorialRepository,
-          userId,
-          page,
-        });
-
-        // Then
-        expect(paginatedSavedTutorials).to.deep.equal({
-          results: [expectedSavedTutorialWithUserTutorial],
-          meta: expectedPagination,
-        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/find-paginated-saved-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-saved-tutorials_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
     beforeEach(function () {
       tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
       tutorialRepository = {
-        findPaginatedWithUserTutorialForCurrentUser: sinon.spy(async () => ({
+        findPaginatedForCurrentUser: sinon.spy(async () => ({
           models: [],
           meta: {
             page: 1,
@@ -33,7 +33,7 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
       await findPaginatedSavedTutorials({ tutorialEvaluationRepository, tutorialRepository, userId, page });
 
       // Then
-      expect(tutorialRepository.findPaginatedWithUserTutorialForCurrentUser).to.have.been.calledWith({ userId, page });
+      expect(tutorialRepository.findPaginatedForCurrentUser).to.have.been.calledWith({ userId, page });
     });
 
     it('should return an empty array', async function () {
@@ -69,7 +69,7 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
       const tutorialWithUserSavedTutorial = domainBuilder.buildTutorialForUser();
       tutorialEvaluationRepository = { find: sinon.spy(async () => []) };
       tutorialRepository = {
-        findPaginatedWithUserTutorialForCurrentUser: sinon.spy(async () => ({
+        findPaginatedForCurrentUser: sinon.spy(async () => ({
           models: [tutorialWithUserSavedTutorial],
           meta: {
             page: 1,
@@ -118,7 +118,7 @@ describe('Unit | UseCase | find-paginated-saved-tutorials', function () {
         };
         tutorialEvaluationRepository = { find: sinon.spy(async () => [tutorialEvaluation]) };
         tutorialRepository = {
-          findPaginatedWithUserTutorialForCurrentUser: sinon.spy(async () => ({
+          findPaginatedForCurrentUser: sinon.spy(async () => ({
             models: [tutorialWithUserSavedTutorial],
             meta: {
               page: 1,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les méthodes du repository tutorials créées des instances de `TutorialForUser` de la même façon, nous avons donc une duplication du code. 

De plus, nous avons vu que les use-cases `find-paginated-recommend-tutorials` et `find-paginated-saved-tutorials` ne faisaient pas la pagination au même endroit. 

## :robot: Solution
- Unifier la création des `TutorialForUser`
- Descendre la pagination dans le cas des tutoriels recommandés dans le repository. Grâce à ça, le use-case devient un passe-plat. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier le bon fonctionnement des 2 onglets des tutos v2
