### PR TITLE
[FEATURE] Ne pas afficher les participations supprimées dans les résultats de campagnes (PIX-4575).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -45,6 +45,7 @@ function _getParticipations(qb, campaignId, targetProfile, filters) {
     .where('campaign-participations.campaignId', '=', campaignId)
     .where('campaign-participations.status', '=', SHARED)
     .where('campaign-participations.isImproved', '=', false)
+    .where('campaign-participations.deletedAt', 'IS', null)
     .modify(_filterByDivisions, filters)
     .modify(_filterByGroups, filters)
     .modify(_addAcquiredBadgeids, filters)

--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -25,6 +25,7 @@ const CampaignProfilesCollectionParticipationSummaryRepository = {
       .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
       .where('campaign-participations.campaignId', '=', campaignId)
       .where('campaign-participations.isImproved', '=', false)
+      .where('campaign-participations.deletedAt', 'IS', null)
       .whereRaw('"campaign-participations"."sharedAt" IS NOT NULL')
       .orderByRaw('?? ASC, ?? ASC', ['lowerLastName', 'lowerFirstName'])
       .modify(_filterQuery, filters);

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -233,6 +233,47 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
       });
     });
 
+    context('when there is a participation deleted', function () {
+      beforeEach(async function () {
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
+
+        databaseBuilder.factory.buildAssessmentFromParticipation({
+          campaignId: campaign.id,
+          deletedAt: new Date('2022-03-31'),
+          deletedBy: userId,
+        });
+        await databaseBuilder.commit();
+
+        const learningContent = [
+          {
+            id: 'recArea1',
+            competences: [
+              {
+                id: 'recCompetence1',
+                tubes: [
+                  {
+                    id: 'recTube1',
+                    skills: [{ id: 'Skill1', name: '@Acquis1', challenges: [] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+        mockLearningContent(learningContentObjects);
+      });
+
+      it('does not return deleted participations', async function () {
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+        });
+
+        expect(participations).to.be.empty;
+      });
+    });
+
     context('masteryRate', function () {
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -113,6 +113,30 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       expect(names).exactlyContainInOrder(['Jaja', 'Jiji', 'Juju', 'Jojo']);
     });
 
+    describe('when there is a participation deleted', function () {
+      it('does not return deleted participation', async function () {
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        const participationData = {
+          campaignId,
+          isShared: true,
+          sharedAt,
+          participantExternalId: 'JeBu',
+          pixScore: 46,
+          deletedAt: new Date('2020-03-30'),
+          deletedBy: userId,
+        };
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner({}, participationData, false);
+
+        await databaseBuilder.commit();
+
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId
+        );
+
+        expect(results.data).to.be.empty;
+      });
+    });
+
     describe('when a participant has shared the participation to the campaign', function () {
       let campaignParticipation;
 


### PR DESCRIPTION
## :unicorn: Problème
Quand on supprime une participation elle est quand même afficher dans l'onglet résultat d'une campagne.

## :robot: Solution
Ne pas renvoyer les participation supprimées.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur pix orga avec pro.admin@exemple.net.
- Constater qu'il n'y a aucune participation pour toutes les campagnes (J'ai "supprimée" toutes les participations)