### PR TITLE
[FEATURE] Enregistrement de tuto sur les cards V2 (PIX-4598)

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -22,8 +22,13 @@
       {{moment-duration @tutorial.duration}}
     </p>
     <div class="tutorial-card-v2-content__actions">
-      <button class="tutorial-card-v2-content-actions__save" type="button">
-        <FaIcon @prefix="fas" @icon="bookmark" />
+      <button
+        class="tutorial-card-v2-content-actions__save"
+        type="button"
+        {{on "click" this.toggleSaveTutorial}}
+        disabled={{this.isSaveButtonDisabled}}
+      >
+        <FaIcon @prefix={{if this.isSaved "fas" "far"}} @icon="bookmark" />
         {{this.buttonLabel}}
       </button>
       <button

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -38,13 +38,13 @@ export default class Card extends Component {
   @action
   async toggleSaveTutorial() {
     if (this.isSaved) {
-      await this.removeTutorial();
+      await this._removeTutorial();
     } else {
-      await this.saveTutorial();
+      await this._saveTutorial();
     }
   }
 
-  async saveTutorial() {
+  async _saveTutorial() {
     this.savingStatus = buttonStatusTypes.pending;
     try {
       const userTutorial = this.store.createRecord('userTutorial', { tutorial: this.args.tutorial });
@@ -55,10 +55,11 @@ export default class Card extends Component {
     }
   }
 
-  async removeTutorial() {
+  async _removeTutorial() {
     this.savingStatus = buttonStatusTypes.pending;
     try {
       await this.args.tutorial.userTutorial.destroyRecord({ adapterOptions: { tutorialId: this.args.tutorial.id } });
+      await this.args.tutorial.unloadRecord();
       this.savingStatus = buttonStatusTypes.unrecorded;
     } catch (e) {
       this.savingStatus = buttonStatusTypes.recorded;

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -23,6 +23,7 @@ import loadSchoolingRegistrationDependentUserRoutes from './routes/schooling-reg
 import loadAccountRecoveryRoutes from './routes/account-recovery/index';
 import loadUserRoutes from './routes/users/index';
 import putSaveTutorial from './routes/put-save-tutorial';
+import deleteUserTutorial from './routes/delete-user-tutorial';
 import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import postPoleEmploiUser from './routes/post-pole-emploi-user';
 import postSharedCertifications from './routes/post-shared-certifications';
@@ -73,6 +74,7 @@ export default function () {
   this.post('/expired-password-updates', postExpiredPasswordUpdates);
 
   this.put('/users/tutorials/:tutorialId', putSaveTutorial);
+  this.del('/users/tutorials/:tutorialId', deleteUserTutorial);
   this.put('/users/tutorials/:tutorialId/evaluate', putTutorialEvaluation);
 
   this.post('/pole-emploi/users', postPoleEmploiUser);

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -22,6 +22,7 @@ import loadSchoolingRegistrationUserAssociationRoutes from './routes/schooling-r
 import loadSchoolingRegistrationDependentUserRoutes from './routes/schooling-registration-dependent-users/index';
 import loadAccountRecoveryRoutes from './routes/account-recovery/index';
 import loadUserRoutes from './routes/users/index';
+import putSaveTutorial from './routes/put-save-tutorial';
 import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import postPoleEmploiUser from './routes/post-pole-emploi-user';
 import postSharedCertifications from './routes/post-shared-certifications';
@@ -71,6 +72,7 @@ export default function () {
 
   this.post('/expired-password-updates', postExpiredPasswordUpdates);
 
+  this.put('/users/tutorials/:tutorialId', putSaveTutorial);
   this.put('/users/tutorials/:tutorialId/evaluate', putTutorialEvaluation);
 
   this.post('/pole-emploi/users', postPoleEmploiUser);

--- a/mon-pix/mirage/factories/tutorial.js
+++ b/mon-pix/mirage/factories/tutorial.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'faker';
 
 export default Factory.extend({
@@ -17,4 +17,10 @@ export default Factory.extend({
   title() {
     return faker.random.word();
   },
+
+  withUserTutorial: trait({
+    afterCreate(tutorial, server) {
+      server.schema.create('user-tutorial', { tutorial });
+    },
+  }),
 });

--- a/mon-pix/mirage/routes/delete-user-tutorial.js
+++ b/mon-pix/mirage/routes/delete-user-tutorial.js
@@ -1,0 +1,6 @@
+export default function (schema, request) {
+  request.params.tutorialId;
+  const tutorialId = request.params.tutorialId;
+  const tutorial = schema.tutorials.find(tutorialId);
+  return tutorial.userTutorial.destroy();
+}

--- a/mon-pix/mirage/routes/put-save-tutorial.js
+++ b/mon-pix/mirage/routes/put-save-tutorial.js
@@ -1,0 +1,18 @@
+import { Response } from 'ember-cli-mirage';
+
+export default function (schema, request) {
+  const userId = 1;
+  const tutorialId = request.params.tutorialId;
+  const tutorial = schema.tutorials.find(tutorialId);
+  const user = schema.users.find(userId);
+
+  if (!user) {
+    return new Response(401);
+  }
+
+  if (!tutorial) {
+    return new Response(404);
+  }
+
+  return schema.userTutorials.create({ id: 1 });
+}

--- a/mon-pix/mirage/serializers/tutorial.js
+++ b/mon-pix/mirage/serializers/tutorial.js
@@ -1,3 +1,5 @@
 import ApplicationSerializer from './application';
 
-export default ApplicationSerializer.extend({});
+export default ApplicationSerializer.extend({
+  include: ['userTutorial'],
+});

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -10,47 +10,47 @@ describe('Acceptance | Tutorial | Actions', function () {
   setupMirage();
   let user;
   let firstScorecard;
-  let competenceNumber;
   let competenceId;
 
   beforeEach(async function () {
-    user = server.create('user', 'withEmail');
-    await authenticateByEmail(user);
-
     //given
+    user = server.create('user', 'withEmail');
     firstScorecard = user.scorecards.models[0];
     competenceId = firstScorecard.competenceId;
-    const splitIndex = firstScorecard.index.split('.');
-    competenceNumber = splitIndex[splitIndex.length - 1];
     const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+    server.create('feature-toggle', { id: 0, isNewTutorialsPageEnabled: true });
     server.create('challenge', 'forCompetenceEvaluation', 'QCM');
     server.create('competence-evaluation', { user, competenceId, assessment });
+
+    // when
+    await authenticateByEmail(user);
+    await visit('/mes-tutos');
   });
 
   describe('Authenticated cases as simple user', function () {
     it('should display tutorial item in competence page with actions', async function () {
-      // when
-      await visit('/competences');
-      await click(
-        `.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__title`
-      );
-
       // then
-      expect(find('.tutorial__content')).to.exist;
-      expect(find('.tutorial-content-actions__save')).to.exist;
-      expect(find('.tutorial-content-actions__evaluate')).to.exist;
+      expect(find('.tutorial-card-v2')).to.exist;
+      expect(find('.tutorial-card-v2-content-actions__save')).to.exist;
+      expect(find('.tutorial-card-v2-content-actions__evaluate')).to.exist;
     });
 
     it('should disable evaluate action on click', async function () {
       // when
-      await visit('/competences');
-      await click(
-        `.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__title`
-      );
-      await click('.tutorial-content-actions__evaluate');
+      await click('.tutorial-card-v2-content-actions__evaluate');
 
       // then
-      expect(find('.tutorial-content-actions__evaluate').disabled).to.be.true;
+      expect(find('.tutorial-card-v2-content-actions__evaluate').disabled).to.be.true;
+    });
+
+    describe('when save action is clicked', function () {
+      it('should display remove action button', async function () {
+        // when
+        await click('.tutorial-card-v2-content-actions__save');
+
+        // then
+        expect(find('.tutorial-card-v2-content-actions__save').textContent).to.include('Retirer');
+      });
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { visit, find, findAll } from '@ember/test-helpers';
+import { visit, click, find, findAll } from '@ember/test-helpers';
 import { authenticateByEmail } from '../../helpers/authentication';
 
 describe('Acceptance | User-tutorials-v2 | Saved', function () {
@@ -16,15 +16,31 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
     server.create('feature-toggle', { id: 0, isNewTutorialsPageEnabled: true });
     await authenticateByEmail(user);
     await server.db.tutorials.remove();
-    server.createList('tutorial', numberOfTutorials);
+    server.createList('tutorial', numberOfTutorials, 'withUserTutorial');
   });
 
-  describe('When there are tutorials saved', () => {
+  describe('When there are tutorials saved', function () {
     it('should display paginated tutorial cards', async function () {
       await visit('/mes-tutos-v2/enregistres');
       expect(findAll('.tutorial-card-v2')).to.exist;
       expect(findAll('.tutorial-card-v2')).to.be.lengthOf(10);
       expect(find('.pix-pagination__navigation').textContent).to.contain('Page 1 / 10');
+    });
+
+    describe('when user clicking save again', function () {
+      it('should remove tutorial ', async function () {
+        // given
+        const numberOfTutorials = 10;
+        await server.db.tutorials.remove();
+        server.createList('tutorial', numberOfTutorials, 'withUserTutorial');
+        await visit('/mes-tutos-v2/enregistres');
+
+        // when
+        await click('.tutorial-card-v2-content-actions__save');
+
+        // then
+        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(9);
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -54,4 +54,124 @@ describe('Unit | Component | Tutorial | card item', function () {
       expect(result).to.equal(true);
     });
   });
+
+  describe('#isSaved', function () {
+    it('should return false when the tutorial has not already been saved', function () {
+      // when
+      const result = component.isSaved;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return true when the tutorial has been saved', function () {
+      // given
+      component.savingStatus = 'recorded';
+
+      // when
+      const result = component.isSaved;
+
+      // then
+      expect(result).to.equal(true);
+    });
+  });
+
+  describe('#isSaveButtonDisabled', function () {
+    it('should return false when the tutorial has not already been saved', function () {
+      // when
+      const result = component.isSaveButtonDisabled;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return false when the tutorial has already been saved', function () {
+      // given
+      component.savingStatus = 'recorded';
+
+      // when
+      const result = component.isSaveButtonDisabled;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return true when the save/unsave operation is in progress', function () {
+      // given
+      component.savingStatus = 'pending';
+
+      // when
+      const result = component.isSaveButtonDisabled;
+
+      // then
+      expect(result).to.equal(true);
+    });
+  });
+
+  describe('#toggleSaveTutorial', function () {
+    describe('when user has not saved a tutorial', function () {
+      let store;
+      let userTutorial;
+
+      beforeEach(() => {
+        userTutorial = { save: sinon.stub().resolves(null) };
+        store = { createRecord: sinon.stub().returns(userTutorial) };
+        component.store = store;
+      });
+
+      it('should create user tutorial in store', async function () {
+        // when
+        await component.toggleSaveTutorial();
+
+        // then
+        sinon.assert.calledWith(store.createRecord, 'userTutorial', { tutorial });
+      });
+
+      it('should save user tutorial', async function () {
+        // when
+        await component.toggleSaveTutorial();
+
+        // then
+        sinon.assert.calledWith(userTutorial.save, { adapterOptions: { tutorialId: tutorial.id } });
+      });
+
+      it('should set status to recorded', async function () {
+        // when
+        await component.toggleSaveTutorial();
+
+        // then
+        expect(component.savingStatus).to.equal('recorded');
+      });
+    });
+
+    describe('when user has already saved a tutorial', function () {
+      let store;
+      let userTutorial;
+
+      beforeEach(() => {
+        userTutorial = { id: 'userTutorialId', destroyRecord: sinon.stub().resolves(null) };
+        tutorial.userTutorial = userTutorial;
+        tutorial.unloadRecord = sinon.stub().resolves();
+        component.store = store;
+        component.savingStatus = 'recorded';
+        component.currentUser = { user: { id: 'userId' } };
+      });
+
+      it('should destroy user tutorial record', async function () {
+        // when
+        await component.toggleSaveTutorial();
+
+        // then
+        sinon.assert.calledWith(userTutorial.destroyRecord, { adapterOptions: { tutorialId: tutorial.id } });
+      });
+
+      it('should set status to unrecorded', async function () {
+        // when
+        await component.toggleSaveTutorial();
+
+        // then
+        expect(component.savingStatus).to.equal('unrecorded');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

L'enregistrement sur les cards tuto V2 ne fonctionnent pas.

## :robot: Solution

Réimplémenter la solution existante sur les cards V1 (Enregistrement et suppression).

## :rainbow: Remarques

 - Les tests d'acceptances qui avaient été écrits pour l'évaluation s'exécutait sur les cards V1, ça a été corrigé

## :100: Pour tester

Aller sur la page Mes tutos recommandés, et essayer d'enregistrer/retirer un ou plusieurs tutos.
