### PR TITLE
[BUGFIX] Permettre la réconciliation si l'INE est vide (PIX-4685).

### DIFF
--- a/api/lib/domain/usecases/reconcile-schooling-registration.js
+++ b/api/lib/domain/usecases/reconcile-schooling-registration.js
@@ -81,24 +81,31 @@ async function _checkIfUserIsConnectedOnAnotherAccount({
   authenticatedUserId,
   schoolingRegistrationRepository,
 }) {
-  const loggedAccountSchoolingRegistrationReconciled = await schoolingRegistrationRepository.findByUserId({
+  const loggedAccountReconciledSchoolingRegistrations = await schoolingRegistrationRepository.findByUserId({
     userId: authenticatedUserId,
   });
 
-  if (isEmpty(loggedAccountSchoolingRegistrationReconciled)) {
+  const loggedAccountReconciledSchoolingRegistrationsWithoutNullNationalStudentIds =
+    loggedAccountReconciledSchoolingRegistrations.filter(
+      (schoolingRegistration) => !!schoolingRegistration.nationalStudentId
+    );
+
+  if (isEmpty(loggedAccountReconciledSchoolingRegistrationsWithoutNullNationalStudentIds)) {
     return;
   }
 
-  const isUserNationalStudentIdDifferentFromLoggedAccount = loggedAccountSchoolingRegistrationReconciled.every(
-    (schoolingRegistration) =>
-      schoolingRegistration.nationalStudentId !== schoolingRegistrationOfUserAccessingCampaign.nationalStudentId
-  );
+  const isUserNationalStudentIdDifferentFromLoggedAccount =
+    loggedAccountReconciledSchoolingRegistrationsWithoutNullNationalStudentIds.every(
+      (schoolingRegistration) =>
+        schoolingRegistration.nationalStudentId !== schoolingRegistrationOfUserAccessingCampaign.nationalStudentId
+    );
 
   if (isUserNationalStudentIdDifferentFromLoggedAccount) {
-    const isUserBirthdayDifferentFromLoggedAccount = loggedAccountSchoolingRegistrationReconciled.every(
-      (schoolingRegistration) =>
-        schoolingRegistration.birthdate !== schoolingRegistrationOfUserAccessingCampaign.birthdate
-    );
+    const isUserBirthdayDifferentFromLoggedAccount =
+      loggedAccountReconciledSchoolingRegistrationsWithoutNullNationalStudentIds.every(
+        (schoolingRegistration) =>
+          schoolingRegistration.birthdate !== schoolingRegistrationOfUserAccessingCampaign.birthdate
+      );
 
     if (isUserBirthdayDifferentFromLoggedAccount) {
       const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.ACCOUNT_BELONGING_TO_ANOTHER_USER;


### PR DESCRIPTION
## :unicorn: Problème
Dans le parcours de réconciliation sur Pix App, si l'INE de l'utilisateur est vide, la réconciliation échoue. Or une INE peut être vide dans le cas d'un élève qui était précédemment dans une AEFE.

## :robot: Solution
Permettre la réconciliation si l'INE est vide et qu'aucune autre réconciliation n'existe. 

## :rainbow: Remarques
RAS

## :100: Pour tester
Il faudra manipuler les données en bdd
- Copier le record de `Sister Big`
- Changer son id a un non existant
- Changer l'organization id a `9`
- Effacer la DDN et le nationatlStudentId

De nouveau en bdd
- Copier le record de `Sister Big`
- Changer son id a un non existant
- Changer l'organization id a `3`
- Changer le nationalStudentId a `987654321MM`
- Effacer le userId (donc un organization learner non reconcilie)

Dans l'application
- Lancer Pix App
- Se connecter avec `sister@example.net` et `pix123`

Sister Big veut joindre une campagne sur sa nouvelle organisation (3) avec un different INE sans se déconnecter
- Cliquer sur "J'ai un code"
- Coller le `SCOBADGE1`
- Cliquer sur "Je commence"
- Remplissez le formulaire (Sister Big 01/02/2008)
- Verifier que la pop-up apparait pour etre reconcilie avec le user deja existant `Sister Big`
- Cliquer sur `Associer`
- Verifier en bdd que le dernier record de Sister Big qui n'avait pas de user id en a un maintenant, et le meme que les 2 autres records

Scalingo :

Supprimer l'add-on PostgreSQL
Ajouter l'add-on PostgreSQL (SANDBOX)
Relancer la migration et les seeds : `scalingo -a pix-api-review-pr4275 --region osc-fr1 run "npm run db:migrate && npm run db:seed"`

Local :

Reset la db : `npm run db:reset`

