### PR TITLE
[FEATURE] Afficher les participations supprimées dans la liste des participations d'une campagne Pix Admin (Pix 4576).

### DIFF
--- a/admin/app/components/campaigns/participation-row.hbs
+++ b/admin/app/components/campaigns/participation-row.hbs
@@ -21,6 +21,17 @@
 <td>
   {{if @participation.sharedAt (moment-format @participation.sharedAt "DD/MM/YYYY") "-"}}
 </td>
+{{#if @participation.deletedAt}}
+  <td>
+    {{moment-format @participation.deletedAt "DD/MM/YYYY"}}
+    par
+    <LinkTo @route="authenticated.users.get" @model={{@participation.deletedBy}}>
+      {{@participation.deletedByFullName}}
+    </LinkTo>
+  </td>
+{{else}}
+  <td>-</td>
+{{/if}}
 {{#if @idPixLabel}}
   <td>
     <div class="participation-item-actions">

--- a/admin/app/components/campaigns/participations-section.hbs
+++ b/admin/app/components/campaigns/participations-section.hbs
@@ -15,6 +15,7 @@
             <th>Date de début</th>
             <th>Statut</th>
             <th>Date d'envoi</th>
+            <th>Supprimé le</th>
             {{#if @idPixLabel}}
               <th>Actions</th>
             {{/if}}

--- a/admin/app/models/campaign-participation.js
+++ b/admin/app/models/campaign-participation.js
@@ -13,6 +13,9 @@ export default class CampaignParticipation extends Model {
   @attr('string') status;
   @attr('date') createdAt;
   @attr('date') sharedAt;
+  @attr('date') deletedAt;
+  @attr deletedBy;
+  @attr('string') deletedByFullName;
 
   get displayedStatus() {
     return campaignParticipationStatuses[this.status];

--- a/admin/tests/integration/components/campaigns/participation-row_test.js
+++ b/admin/tests/integration/components/campaigns/participation-row_test.js
@@ -74,6 +74,22 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       // then
       assert.dom(screen.getByText('01/01/2020')).exists();
     });
+
+    test('it should display deletedByFullName and deletedAt if participation is deleted', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        deletedAt: new Date('2022-01-01'),
+        deletedByFullName: 'le coupable',
+      });
+      this.set('participation', participation);
+
+      // when
+      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{participation}}/>`);
+
+      // then
+      assert.dom(screen.getByText('01/01/2022 par')).exists();
+      assert.dom(screen.getByRole('link', { name: 'le coupable' })).exists();
+    });
   }),
     module("when editing participant's external id", function (hooks) {
       hooks.beforeEach(async function () {

--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -57,12 +57,13 @@ module.exports = function buildCampaignParticipation({
     organizationLearnerId,
     createdAt,
     sharedAt,
-    deletedAt,
     participantExternalId,
     validatedSkillsCount,
     masteryRate,
     pixScore,
     status,
     isImproved,
+    deletedAt,
+    deletedBy,
   };
 };

--- a/api/lib/domain/models/ParticipationForCampaignManagement.js
+++ b/api/lib/domain/models/ParticipationForCampaignManagement.js
@@ -1,5 +1,17 @@
 class ParticipationForCampaignManagement {
-  constructor({ id, lastName, firstName, participantExternalId, status, createdAt, sharedAt } = {}) {
+  constructor({
+    id,
+    lastName,
+    firstName,
+    participantExternalId,
+    status,
+    createdAt,
+    sharedAt,
+    deletedAt,
+    deletedBy,
+    deletedByFirstName,
+    deletedByLastName,
+  } = {}) {
     this.id = id;
     this.lastName = lastName;
     this.firstName = firstName;
@@ -7,6 +19,11 @@ class ParticipationForCampaignManagement {
     this.status = status;
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
+    this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
+    if (this.deletedAt) {
+      this.deletedByFullName = deletedByFirstName + ' ' + deletedByLastName;
+    }
   }
 }
 

--- a/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -14,8 +14,13 @@ module.exports = {
         status: 'campaign-participations.status',
         createdAt: 'campaign-participations.createdAt',
         sharedAt: 'campaign-participations.sharedAt',
+        deletedAt: 'campaign-participations.deletedAt',
+        deletedBy: 'users.id',
+        deletedByFirstName: 'users.firstName',
+        deletedByLastName: 'users.lastName',
       })
       .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+      .leftJoin('users', 'users.id', 'campaign-participations.deletedBy')
       .where('campaignId', campaignId)
       .orderBy(['lastName', 'firstName'], ['asc', 'asc']);
 

--- a/api/lib/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js
@@ -3,7 +3,17 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(participationsForCampaignManagement, meta) {
     return new Serializer('campaign-participation', {
-      attributes: ['lastName', 'firstName', 'participantExternalId', 'status', 'createdAt', 'sharedAt'],
+      attributes: [
+        'lastName',
+        'firstName',
+        'participantExternalId',
+        'status',
+        'createdAt',
+        'sharedAt',
+        'deletedAt',
+        'deletedBy',
+        'deletedByFullName',
+      ],
       meta,
     }).serialize(participationsForCampaignManagement);
   },

--- a/api/tests/tooling/domain-builder/factory/build-participation-for-campaign-management.js
+++ b/api/tests/tooling/domain-builder/factory/build-participation-for-campaign-management.js
@@ -9,6 +9,10 @@ module.exports = function buildParticipationForCampaignManagement({
   status = CampaignParticipationStatuses.TO_SHARE,
   createdAt = new Date(),
   sharedAt = null,
+  deletedAt = null,
+  deletedBy = null,
+  deletedByFirstName = null,
+  deletedByLastName = null,
 } = {}) {
   return new ParticipationForCampaignManagement({
     id,
@@ -18,5 +22,9 @@ module.exports = function buildParticipationForCampaignManagement({
     status,
     createdAt,
     sharedAt,
+    deletedAt,
+    deletedBy,
+    deletedByFirstName,
+    deletedByLastName,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer_test.js
@@ -9,6 +9,10 @@ describe('Unit | Serializer | JSONAPI | participation-for-campaign-management-se
         id: 123,
         createdAt: new Date('2020-10-10'),
         sharedAt: new Date('2020-10-11'),
+        deletedAt: new Date('2020-10-12'),
+        deletedBy: 666,
+        deletedByFirstName: 'King',
+        deletedByLastName: 'Cong',
       });
 
       // when
@@ -27,6 +31,9 @@ describe('Unit | Serializer | JSONAPI | participation-for-campaign-management-se
               status: participationForCampaignManagement.status,
               'created-at': participationForCampaignManagement.createdAt,
               'shared-at': participationForCampaignManagement.sharedAt,
+              'deleted-at': participationForCampaignManagement.deletedAt,
+              'deleted-by': participationForCampaignManagement.deletedBy,
+              'deleted-by-full-name': participationForCampaignManagement.deletedByFullName,
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
Dans nos travaux de refonte du prescrit, nous  souhaitons récupérer les informations liée à les participations supprimées comme quand et par qui une participation à été supprimée et par qui dans la page de détail d'une campagne dans pix admin, ce qui n'est pas encore le cas.

## :robot: Solution
Afficher au sein de la liste des participations dans Pix Admin une nouvelle colonne  nommée “Supprimé le”
Si une participation est supprimée alors rajouter dans le champs :  “XX/XX/XXXX par ....”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à pix admin , sélectionner L'organisation "DRAGO & CO" puis la campagne 'Pro - Campagne de collecte de profils - Envois multiple' avec l'id 18
- constater que la colonne "supprimé le" existe mais que elle contient "-" quand il y a pas d'info sur la suppression.
- Dans la bdd en local, run le query suivant :- 
- `UPDATE "campaign-participations" SET "deletedAt" = '10-10-2010', "deletedBy" = 199 WHERE "id" = 108406;`
- constater que dans la colonne "supprimé le" de la participation avec l’identifiaient entreprise **"108023"**, il y a l’information de suppression suivante **10/10/2010 par Pix Master**
