### PR TITLE
[TECH] Conditionner l'execution des jobs JIRA à la présence de la variable JIRA_URL

### DIFF
--- a/.github/workflows/jira-transition-to-dev-in-progress.yaml
+++ b/.github/workflows/jira-transition-to-dev-in-progress.yaml
@@ -7,15 +7,17 @@ jobs:
   transition-issue:
     name: Transition Issue
     runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     steps:
       - name: Login
+        if: env.JIRA_BASE_URL != ''
         uses: atlassian/gajira-login@master
-        env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Find Issue Key
+        if: env.JIRA_BASE_URL != ''
         id: find
         uses: atlassian/gajira-find-issue-key@master
         continue-on-error: true
@@ -24,7 +26,7 @@ jobs:
 
       - name: Transition issue
         uses: atlassian/gajira-transition@master
-        if: ${{ steps.find.outputs.issue }}
+        if: env.JIRA_BASE_URL != '' && steps.find.outputs.issue
         continue-on-error: true
         with:
           issue: ${{ steps.find.outputs.issue }}

--- a/.github/workflows/jira-transition-to-review.yaml
+++ b/.github/workflows/jira-transition-to-review.yaml
@@ -7,17 +7,19 @@ jobs:
   transition-issue:
     name: Transition Issue
     runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     if: >
       contains(github.event.pull_request.labels.*.name, ':eyes: Tech Review Needed')
     steps:
       - name: Login
+        if: env.JIRA_BASE_URL != ''
         uses: atlassian/gajira-login@master
-        env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Find Issue Key
+        if: env.JIRA_BASE_URL != ''
         id: find
         uses: atlassian/gajira-find-issue-key@master
         continue-on-error: true
@@ -26,7 +28,7 @@ jobs:
 
       - name: Transition issue
         uses: atlassian/gajira-transition@master
-        if: ${{ steps.find.outputs.issue }}
+        if: env.JIRA_BASE_URL != '' && steps.find.outputs.issue
         continue-on-error: true
         with:
           issue: ${{ steps.find.outputs.issue }}

--- a/.github/workflows/on-dev-merge.yaml
+++ b/.github/workflows/on-dev-merge.yaml
@@ -7,15 +7,17 @@ jobs:
   transition-issue:
     name: Transition Issue
     runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     steps:
       - name: Login
+        if: env.JIRA_BASE_URL != ''
         uses: atlassian/gajira-login@master
-        env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Find Issue Key
+        if: env.JIRA_BASE_URL != ''
         id: find
         uses: atlassian/gajira-find-issue-key@master
         continue-on-error: true
@@ -24,12 +26,16 @@ jobs:
 
       - name: Transition issue
         uses: atlassian/gajira-transition@master
-        if: ${{ steps.find.outputs.issue }}
+        if: env.JIRA_BASE_URL != '' && steps.find.outputs.issue
         continue-on-error: true
         with:
           issue: ${{ steps.find.outputs.issue }}
           transition: "Move to 'Deployed in Integration'"
 
+  notify-team:
+    name: Notify team on config file changed
+    runs-on: ubuntu-latest
+    steps:
       - name: Notify team on config file change
         uses: 1024pix/notify-team-on-config-file-change@v1.0.2
         with:


### PR DESCRIPTION
## :unicorn: Problème
Les jobs JIRA des GitHub actions s'exécutent notamment sur les forks, sans vérifier que la configuration est bonne au préalable. 
Les vérifications échouent donc à chaque fois pour les contributeurs externes

## :robot: Solution
Désactiver l'execution des jobs qui concernent JIRA si la variable JIRA_URL n'est pas définie

## :rainbow: Remarques
Les différents niveaux de contextes de variables de Github nous contraignent à répéter la condition pour chaque étape : https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
Nous avons également tenté de mutualiser les jobs via les actions composite de GitHub, mais le `continue-on-error` n'est pas encore disponible, ce qui fait que toute PR qui n'est pas liée à un ticket Jira voit ses checks échouer.

## :100: Pour tester

- Au préalable: Merger cette PR / la cherry pick
- Non reg: Créer une PR liée à un ticket JIRA, la merger et vérifier que le comportement est identique
- Feat: Créer une PR depuis un fork et vérifier que les jobs JIRA ne s'exécutent pas 
