### PR TITLE
[TECH] Mettre fin aux connexions existantes lors de la suppression du schéma de BDD (PIX-4714)

### DIFF
--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -34,6 +34,7 @@ const schema = Joi.object({
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),
   POLE_EMPLOI_SENDING_URL: Joi.string().uri().optional(),
   CONTAINER_VERSION: Joi.string().optional(),
+  FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/sample.env
+++ b/api/sample.env
@@ -119,6 +119,13 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # sample: KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=1000000
 # KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE=
 
+# Force dropping database (in case a connection is open)
+#
+# type: boolean
+# default: none
+# sample: FORCE_DROP_DATABASE=true
+# FORCE_DROP_DATABASE=
+
 # ========
 # EMAILING
 # ========

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -26,7 +26,8 @@ url.pathname = '/postgres';
 
 PgClient.getClient(url.href).then(async (client) => {
   try {
-    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME} WITH (FORCE);`);
+    const WITH_FORCE = _withForceOption();
+    await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME}${WITH_FORCE};`);
     logger.info('Database dropped');
     await client.end();
     process.exit(0);
@@ -38,3 +39,7 @@ PgClient.getClient(url.href).then(async (client) => {
     }
   }
 });
+
+function _withForceOption() {
+  return process.env.FORCE_DROP_DATABASE === 'true' ? ' WITH (FORCE)' : '';
+}


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la BDD à une connexion ouverte, il n'est pas possible de lancer un `db:delete` (et donc un `db:reset`). Il faut donc clore la connexion existante (en général arreter l'API) ce qui fait perdre du temps

## :robot: Solution
Permettre de forcer le drop via FORCE_DROP_DATABASE qui active `WITH FORCE`

## :rainbow: Remarques
Le `WITH FORCE` est deja présent, on rajoute la varenv pour ne pas dropper sans le vouloir
Sur scalingo cela n'a pas d'impact, le script ne se lance pas sur les environnements scalingo.

## :100: Pour tester
Lancer l'api, puis un `npm run db:delete`
constater qu'il ne se passe rien
Lancer l'api puis `FORCE_DROP_DATABASE=true npm run db:delete`
constater que la BDD est supprimée
