### PR TITLE
[TECH] Ajouter le support d'Internet Explorer dans Pix App, Pix Orga, Pix Certif et Pix Admin (PIX-4719)

### DIFF
--- a/admin/config/targets.js
+++ b/admin/config/targets.js
@@ -2,6 +2,13 @@
 
 const browsers = ['> 1%'];
 
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
   browsers,
 };

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -2,6 +2,13 @@
 
 const browsers = ['> 1%'];
 
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
   browsers,
 };

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-certif",
-      "version": "3.191.0",
+      "version": "3.188.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
@@ -9794,20 +9794,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001322",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -42743,9 +42737,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001322",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
       "dev": true
     },
     "capture-exit": {

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -2,6 +2,13 @@
 
 const browsers = ['> 1%'];
 
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
   browsers,
 };

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.191.0",
+      "version": "3.190.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
@@ -15506,20 +15506,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001322",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -54784,9 +54778,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001322",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
       "dev": true
     },
     "capture-exit": {

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -2,6 +2,13 @@
 
 const browsers = ['> 1%'];
 
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
## :unicorn: Contexte

La PR #4260 retirait le support d'Internet Explorer qui n'est plus officiellement supporté par Pix. À la place, nous supportons désormais uniquement [les navigateurs représentant plus de 1 % de part de marché](https://browserslist.dev/?q=PiAxJQ%3D%3D). Cela signifie que nous avons aussi retiré le support de tous les navigateurs sorti depuis IE 11 et qui sont aujourd'hui 

## :unicorn: Problème

Certains centres de certifications utilisent de vieux navigateurs, comme Firefox 68, qui ne sont plus supportés. Il faut définir une stratégie plus précise de support des navigateurs en fonction de nos utilisateurs, et communiquer ce pré-requis au centres de certification.

## :robot: Solution

Ajouter IE 11 dans les cibles de compilation dans la configuration Ember.

## :rainbow: Remarques

Les utilisateurs avec Firefox 68 représentent 0,28 % des utilisateurs Pix.

## :100: Pour tester

Vérifier que Pix App fonctionne avec Firefox 68.
