### PR TITLE
[FEATURE] Mise à jour du texte de la bannière SCO dans PixCertif (PIX-4690)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -66,9 +66,12 @@
     </div>
 
     {{#if this.showBanner}}
-      <PixBanner @actionLabel="En savoir plus" @actionUrl="https://view.genial.ly/6077017b8b37870d98620200">La
-        certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les
-        collèges. Les sessions passées hors période ne seront pas traitées.</PixBanner>
+      <PixBanner
+        @actionLabel="documentation pour voir les nouveautés."
+        @actionUrl="https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
+      >La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les
+        collèges. Pensez à consulter la
+      </PixBanner>
 
     {{/if}}
 

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -141,11 +141,11 @@ module('Acceptance | authenticated', function (hooks) {
       assert
         .dom(
           screen.getByText(
-            'La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.'
+            'La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Pensez à consulter la'
           )
         )
         .exists();
-      assert.dom(screen.getByRole('link', { name: 'En savoir plus' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'documentation pour voir les nouveautés.' })).exists();
     });
 
     test('it should not display the banner when User is NOT SCO isManagingStudent', async function (assert) {
@@ -158,7 +158,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // then
       const certificationBannerMessage = screen.queryByText(
-        'La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Les sessions passées hors période ne seront pas traitées.'
+        'La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Pensez à consulter la'
       );
       assert.dom(certificationBannerMessage).doesNotExist();
     });


### PR DESCRIPTION
## :unicorn: Problème
Besoin de mettre à jour le texte de la bannière d'information destinée aux centres de certification SCO liées à des organisations `isManagingStudents`

## :robot: Solution
Modification du texte et du lien

## :rainbow: Remarques
Pas indiqué dans le ticket sur comment mettre le lien. Il semble qu'en utilisant la PixBanner je doive choisir un label et un lien qui se mettent en fin de texte. Ainsi j'ai décidé de remplacer "En savoir plus" par "Lien vers la documentation". J'avais d'abord tenté de mettre seulement "Documentation" mais un autre lien dans la page avait déjà ce label (le lien vers la doc de PixCertif).
En gros à check avec la PO avant de merge :
- [ ] Label vers le lien OK
- [ ] L'ancien lien était un genial.ly, faut faire pareil ?

## :100: Pour tester
- Se connecter à PixCertif avec un compte `isManagingStudents` SCO (certifsco@example.net fait l'affaire).
- Constater le changement de texte du bandeau + le lien dirige vers la bonne ressource
