### PR TITLE
[BUGFIX] Un membre d’espace Pix Certif ne voit pas la liste de ses candidats en prescription de certification SCO (PIX-4316)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -75,7 +75,12 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
       ),
     })
     .from('certification-centers')
-    .leftJoin('organizations', 'organizations.externalId', 'certification-centers.externalId')
+    .leftJoin('organizations', function () {
+      this.on('organizations.externalId', 'certification-centers.externalId').andOn(
+        'organizations.type',
+        'certification-centers.type'
+      );
+    })
     .leftJoin('organization-tags', 'organization-tags.organizationId', 'organizations.id')
     .leftJoin('tags', 'tags.id', 'organization-tags.tagId')
     .leftJoin(

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -132,7 +132,12 @@ module.exports = {
     const organizationIds = await knex
       .pluck('organizations.id')
       .from('organizations')
-      .join('certification-centers', 'certification-centers.externalId', 'organizations.externalId')
+      .innerJoin('certification-centers', function () {
+        this.on('certification-centers.externalId', 'organizations.externalId').andOn(
+          'certification-centers.type',
+          'organizations.type'
+        );
+      })
       .where('certification-centers.id', certificationCenterId);
 
     if (organizationIds.length !== 1)

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -129,14 +129,15 @@ module.exports = {
   },
 
   async getIdByCertificationCenterId(certificationCenterId) {
-    const bookshelfOrganization = await BookshelfOrganization.query((qb) => {
-      qb.join('certification-centers', 'certification-centers.externalId', 'organizations.externalId');
-      qb.where('certification-centers.id', '=', certificationCenterId);
-    }).fetch({ require: false, columns: ['organizations.id'] });
+    const organizationIds = await knex
+      .pluck('organizations.id')
+      .from('organizations')
+      .join('certification-centers', 'certification-centers.externalId', 'organizations.externalId')
+      .where('certification-centers.id', certificationCenterId);
 
-    const id = _.get(bookshelfOrganization, 'attributes.id');
-    if (id) return id;
-    throw new NotFoundError(`Not found organization for certification center id ${certificationCenterId}`);
+    if (organizationIds.length !== 1)
+      throw new NotFoundError(`Not found organization for certification center id ${certificationCenterId}`);
+    return organizationIds[0];
   },
 
   async getScoOrganizationByExternalId(externalId) {

--- a/api/lib/infrastructure/repositories/sessions/session-for-attendance-sheet-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-attendance-sheet-repository.js
@@ -31,7 +31,12 @@ module.exports = {
       })
       .from('sessions')
       .join('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
-      .leftJoin('organizations', 'organizations.externalId', 'certification-centers.externalId')
+      .leftJoin('organizations', function () {
+        this.on('organizations.externalId', 'certification-centers.externalId').andOn(
+          'organizations.type',
+          'certification-centers.type'
+        );
+      })
       .leftJoin('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
       .leftJoin('organization-learners', 'organization-learners.id', 'certification-candidates.organizationLearnerId')
       .groupBy('sessions.id', 'certification-centers.id', 'organizations.id')

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -321,7 +321,7 @@ describe('Acceptance | API | Certification Center', function () {
       // given
       const externalId = 'anExternalId';
       const { certificationCenter, user } = _buildUserWithCertificationCenterMemberShip(externalId);
-      const organization = databaseBuilder.factory.buildOrganization({ externalId });
+      const organization = databaseBuilder.factory.buildOrganization({ externalId, type: 'SCO' });
 
       _buildSchoolingRegistrations(
         organization,
@@ -397,7 +397,7 @@ describe('Acceptance | API | Certification Center', function () {
       it('should return the schooling registrations asked', async function () {
         // given
         const { certificationCenter, user } = _buildUserWithCertificationCenterMemberShip(externalId);
-        const organization = databaseBuilder.factory.buildOrganization({ externalId });
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId });
         const session = databaseBuilder.factory.buildSession({ certificationCenterId: certificationCenter.id });
         _buildSchoolingRegistrations(
           organization,
@@ -720,6 +720,7 @@ describe('Acceptance | API | Certification Center', function () {
     const user = databaseBuilder.factory.buildUser({});
     const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
       externalId: certificationCenterExternalId,
+      type: 'SCO',
     });
     databaseBuilder.factory.buildCertificationCenterMembership({
       certificationCenterId: certificationCenter.id,

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -79,7 +79,9 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       });
 
       beforeEach(async function () {
-        const { id: certificationCenterId, externalId } = databaseBuilder.factory.buildCertificationCenter();
+        const { id: certificationCenterId, externalId } = databaseBuilder.factory.buildCertificationCenter({
+          type: 'SCO',
+        });
 
         sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
         const { id: organizationId } = databaseBuilder.factory.buildOrganization({

--- a/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
+++ b/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
@@ -138,7 +138,7 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
 
       beforeEach(async function () {
         const certificationCenterName = 'Centre de certification';
-        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
+        databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId: 'EXT1234', isManagingStudents: true });
         certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
           name: certificationCenterName,
           type: 'SCO',
@@ -195,7 +195,7 @@ describe('Integration | UseCases | getAttendanceSheet', function () {
 
       beforeEach(async function () {
         const certificationCenterName = 'Centre de certification';
-        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
+        databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId: 'EXT1234', isManagingStudents: true });
         certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
           name: certificationCenterName,
           type: 'SCO',

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -235,29 +235,30 @@ describe('Integration | Repository | Organization', function () {
   });
 
   describe('#getIdByCertificationCenterId', function () {
-    let organizations;
-
     beforeEach(function () {
-      organizations = _.map(
+      _.map(
         [
           { id: 1, type: 'SCO', name: 'organization 1', externalId: '1234567' },
           { id: 2, type: 'SCO', name: 'organization 2', externalId: '1234568' },
-          { id: 3, type: 'SCO', name: 'organization 3', externalId: '1234569' },
+          { id: 3, type: 'SUP', name: 'organization 3', externalId: '1234568' },
+          { id: 4, type: 'SCO', name: 'organization 4', externalId: '1234569' },
+          { id: 5, type: 'SCO', name: 'organization 5', externalId: '1234569' },
         ],
         (organization) => {
-          return databaseBuilder.factory.buildOrganization(organization);
+          databaseBuilder.factory.buildOrganization(organization);
         }
       );
 
       databaseBuilder.factory.buildCertificationCenter({
         id: 10,
         externalId: '1234568',
+        type: 'SCO',
       });
 
       return databaseBuilder.commit();
     });
 
-    it('should return the id of the organization given the certification center id', async function () {
+    it('should return the id of the organization given the certification center id matching the same type', async function () {
       // when
       const organisationId = await organizationRepository.getIdByCertificationCenterId(10);
 
@@ -265,7 +266,7 @@ describe('Integration | Repository | Organization', function () {
       expect(organisationId).to.equal(2);
     });
 
-    it('should throw an error if the id does not match an certification center with organization ', async function () {
+    it('should throw an error if the id does not match a certification center with organization', async function () {
       // when
       const error = await catchErr(organizationRepository.getIdByCertificationCenterId)(123456);
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -236,10 +236,8 @@ describe('Integration | Repository | Organization', function () {
 
   describe('#getIdByCertificationCenterId', function () {
     let organizations;
-    let organization;
-    let certificationCenterId;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       organizations = _.map(
         [
           { id: 1, type: 'SCO', name: 'organization 1', externalId: '1234567' },
@@ -251,33 +249,29 @@ describe('Integration | Repository | Organization', function () {
         }
       );
 
-      organization = organizations[1];
+      databaseBuilder.factory.buildCertificationCenter({
+        id: 10,
+        externalId: '1234568',
+      });
 
-      certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-        externalId: organization.externalId,
-      }).id;
-
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
     it('should return the id of the organization given the certification center id', async function () {
       // when
-      const organisationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
+      const organisationId = await organizationRepository.getIdByCertificationCenterId(10);
 
       // then
-      expect(organisationId).to.equal(organization.id);
+      expect(organisationId).to.equal(2);
     });
 
     it('should throw an error if the id does not match an certification center with organization ', async function () {
-      // given
-      const wrongCertificationCenterId = '666';
-
       // when
-      const error = await catchErr(organizationRepository.getIdByCertificationCenterId)(wrongCertificationCenterId);
+      const error = await catchErr(organizationRepository.getIdByCertificationCenterId)(123456);
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal('Not found organization for certification center id 666');
+      expect(error.message).to.equal('Not found organization for certification center id 123456');
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-attendance-sheet-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-attendance-sheet-repository_test.js
@@ -9,7 +9,8 @@ describe('Integration | Repository | Session-for-attendance-sheet', function () 
     context('when there are no schooling registrations', function () {
       it('should return session information with ordered candidates and no division', async function () {
         // given
-        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: false });
+        databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId: 'EXT1234', isManagingStudents: true });
+        databaseBuilder.factory.buildOrganization({ type: 'SUP', externalId: 'EXT1234', isManagingStudents: false });
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
           name: 'Tour Gamma',
           type: 'SUP',
@@ -73,7 +74,7 @@ describe('Integration | Repository | Session-for-attendance-sheet', function () 
     context('when there are schooling registrations', function () {
       it('should return session information with with ordered candidates and division', async function () {
         // given
-        databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234', isManagingStudents: true });
+        databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId: 'EXT1234', isManagingStudents: true });
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
           name: 'Tour Gamma',
           type: 'SCO',


### PR DESCRIPTION
## :unicorn: Problème
Un membre d’espace Pix Certif SCO isManagingStudent nous a remonté un problème dans son espace lors de l’inscription de candidats en session. En effet, il ne voyait pas la liste des candidats de son établissement, pourtant bien importés dans Pix Orga. Lors des investigations pour comprendre le souci, nous avons remarqué qu’il y avait en fait 2 orgas, une orga SUP et une orga SCO isManagingStudent avec le même UAI. Ce qui a fait beugué le process de prescription de certif SCO pour le centre de certification avec ce même UAI.

## :robot: Solution
Si plusieurs centres de certification ont le même externalId, et que l'un d'eux est de type SCO, lors de l'inscription des candidats à une session de certification, n'afficher que les élèves de cette organisation.

Pour cela il faudrait, lors de la récupération des étudiants d’une organization, rajouter l'égalité du type de centre de certification et de celui de l’organisation en plus de l'égalité des UAI (externalId). 

## :rainbow: Remarques

### Données

#### Existante
```sql

-- organization
SELECT
    o."externalId",
    o.type,
    COUNT(1)
FROM
     organizations o
WHERE 1=1
    AND o."externalId" IS NOT NULL
    AND o."archivedAt" IS NULL
GROUP BY
    o."externalId", o.type
HAVING COUNT(1) > 1
;

```

#### Création
Les centres de certification sont créés manuellement dans PixAdmin, et il n'y a pas de vérification s'il existe :
- un centre de certification;
- avec une externalId identique;
- sur une orga d'un type différent (ou similaire) du centre de certif.

![image](https://user-images.githubusercontent.com/56302715/161764066-5b87340b-85b8-41ed-ac0e-949fc324fc95.png)

### tech
J'en profite pour un poil de refacto de rien du tout.
Méthodologie, j'ai d'abord ajouté de la data dans les tests pour les casser, puis j'ai modifié la jointure pour passer les tests au vert.

## :100: Pour tester
Pour reproduire le problème sur dev, il faut modifier des valeurs en base de sorte à avoir, pour un centre de certification SCO isManagingStudents deux organisations correspondants, une du même type et l'autre non. Idéalement, on choisira une orga de mauvais type avec un ID inférieur à la "bonne orga" (favorise le bug).
On constate qu'on ne peut pas inscrire de candidats via la prescription de certif SCO.

Faire la même démarche sur cette branche et constater que c'est réparé
