### PR TITLE
[TECH] Ajoute des détails dans les logs des focusOut (PIX-4722)

### DIFF
--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -32,9 +32,15 @@ class Examiner {
 
     // Temporary log to find out focusedout answers that should not occur
     if (!isFocusedChallenge && answer.isFocusedOut) {
-      logger.warn('A non focused challenge received a focused out answer', {
-        answerId: answer.id,
-      });
+      logger.warn(
+        {
+          subject: 'focusOut',
+          challengeFormat,
+          challengeId: answer.challengeId,
+          assessmentId: answer.assessmentId,
+        },
+        'A non focused challenge received a focused out answer'
+      );
     }
 
     if (isCorrectAnswer && isFocusedChallenge && answer.isFocusedOut && isCertificationEvaluation) {

--- a/api/lib/domain/usecases/update-last-question-state.js
+++ b/api/lib/domain/usecases/update-last-question-state.js
@@ -12,20 +12,28 @@ module.exports = async function updateLastQuestionState({
   if (lastQuestionState === Assessment.statesOfLastQuestion.FOCUSEDOUT && challengeId !== undefined) {
     const challenge = await challengeRepository.get(challengeId, domainTransaction);
     if (!challenge.focused) {
-      logger.warn('Trying to focusOut a non focused challenge', {
-        challengeId,
-        assessmentId,
-      });
+      logger.warn(
+        {
+          subject: 'focusOut',
+          challengeId: challengeId,
+          assessmentId: assessmentId,
+        },
+        'Trying to focusOut a non focused challenge'
+      );
 
       return;
     }
 
     const assessment = await assessmentRepository.get(assessmentId, domainTransaction);
     if (challengeId !== assessment.lastChallengeId) {
-      logger.warn('An event has been received on a answer that has already been answered', {
-        challengeId,
-        assessmentId,
-      });
+      logger.warn(
+        {
+          subject: 'focusOut',
+          challengeId: challengeId,
+          assessmentId: assessmentId,
+        },
+        'An event has been received on a answer that has already been answered'
+      );
 
       return;
     }


### PR DESCRIPTION
## :unicorn: Problème
Les infos complémentaires des logs sur les évenements focusOut incohérents ne remontent pas. Cela complique le debug Datadog.

## :robot: Solution
Ajouter les infos suivantes à nos logs : 
- `subject: 'focusOut'`
- `challengeId`
- `assessmentId`

Ça devrait nous permettre de faire des stats sur des dashboard Datadog voir si ces évenements arrivent souvent.

## :rainbow: Remarques
On a vérifié, les infos supplémentaires remontent bien.

## :100: Pour tester
Sortir un des logs pour vérifier que les infos supplémentaires s'affichent dans le log.
