### PR TITLE
[FEATURE] Amélioration du design des cartes de tutos (PIX-4337).

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,9 +1,5 @@
 <article class="tutorial-card-v2">
   <div class="tutorial-card-v2__content">
-    {{! template-lint-disable no-bare-strings }}
-    <p class="tutorial-card-v2-content__skill">
-      Mener une recherche et une veille d'information
-    </p>
     <a
       target="_blank"
       rel="noopener noreferrer"

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,5 +1,4 @@
 <article class="tutorial-card-v2">
-  <div class="tutorial-card-v2__domain-border"></div>
   <div class="tutorial-card-v2__content">
     {{! template-lint-disable no-bare-strings }}
     <p class="tutorial-card-v2-content__skill">

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -7,12 +7,6 @@
   padding: 16px;
   gap: 12px;
 
-  &__domain-border {
-    width: 3px;
-    background: $yellow;
-    border-radius: 2px;
-  }
-
   &__content {
     flex: 1;
     display: flex;

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -20,7 +20,7 @@
     display: -webkit-box;
     margin-bottom: 4px;
     color: $grey-90;
-    font-size: 1rem;
+    font-size: 1.25rem;
     font-family: $font-open-sans;
     font-weight: $font-semi-bold;
     overflow: hidden;
@@ -28,10 +28,6 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     width: 100%;
-
-    @include device-is('tablet') {
-      font-size: 1.125rem;
-    }
 
     &:hover,
     &:focus {

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -16,18 +16,6 @@
 
 .tutorial-card-v2-content {
 
-  &__skill {
-    margin: 0 0 16px 0;
-    width: 100%;
-    color: $grey-50;
-    font-family: $font-roboto;
-    font-size: 0.813rem;
-    font-weight: normal;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
   &__link {
     display: -webkit-box;
     margin-bottom: 4px;

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -24,7 +24,6 @@ describe('Integration | Component | Tutorials | Card', function () {
 
     // then
     expect(find('.tutorial-card-v2')).to.exist;
-    expect(find('.tutorial-card-v2__domain-border')).to.exist;
     expect(find('.tutorial-card-v2__content')).to.exist;
     expect(find('.tutorial-card-v2-content__skill'))
       .to.have.property('textContent')

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -25,9 +25,6 @@ describe('Integration | Component | Tutorials | Card', function () {
     // then
     expect(find('.tutorial-card-v2')).to.exist;
     expect(find('.tutorial-card-v2__content')).to.exist;
-    expect(find('.tutorial-card-v2-content__skill'))
-      .to.have.property('textContent')
-      .that.contains("Mener une recherche et une veille d'information");
     expect(find('.tutorial-card-v2-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
     expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
     expect(find('.tutorial-card-v2-content__details'))


### PR DESCRIPTION
## :unicorn: Problème

Le style des cartes des nouvelles pages de tutos n'est pas conforme aux [maquettes](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?node-id=2%3A10). 

## :robot: Solution

Pour ce premier ticket dédié au style des cartes des pages de tutos, nous : 
- ~~ajoutons une animation au hover de la carte~~
- ~~ajoutons le clic sur l'entièreté de la carte~~
- modifions la taille de la police du titre
- supprimons le liseret de couleur correspondant à la compétence

## :rainbow: Remarques

Ne pas prendre en compte la taille des cartes différentes sur les maquettes et dans la RA.

## :100: Pour tester

Sur la page de tutos, vérifier les différents points listés ci-dessus.
