### PR TITLE
[FEATURE] Enregistrer ou mettre à jour le prénom et nom reçu du GAR lors de la connexion (PIX-4656)

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -11,6 +11,8 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
   identityProvider = AuthenticationMethod.identityProviders.GAR,
   externalIdentifier = 'externalId',
   userId,
+  userFirstName = 'Margotte',
+  userLastName = 'Saint-James',
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
 } = {}) {
@@ -20,7 +22,10 @@ buildAuthenticationMethod.withGarAsIdentityProvider = function ({
     id,
     identityProvider,
     externalIdentifier,
-    authenticationComplement: undefined,
+    authenticationComplement: {
+      firstName: userFirstName,
+      lastName: userLastName,
+    },
     userId,
     createdAt,
     updatedAt,

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -18,9 +18,8 @@ module.exports = async function getExternalAuthenticationRedirectionUrl({
     const token = tokenService.createAccessTokenForSaml(user.id);
     await userRepository.updateLastLoggedAt({ userId: user.id });
     return `/?token=${encodeURIComponent(token)}&user-id=${user.id}`;
-  } else {
-    const externalUserToken = tokenService.createIdTokenForUserReconciliation(externalUser);
-
-    return `/campagnes?externalUser=${encodeURIComponent(externalUserToken)}`;
   }
+
+  const externalUserToken = tokenService.createIdTokenForUserReconciliation(externalUser);
+  return `/campagnes?externalUser=${encodeURIComponent(externalUserToken)}`;
 };

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -1,6 +1,9 @@
+const AuthenticationMethod = require('../models/AuthenticationMethod');
+
 module.exports = async function getExternalAuthenticationRedirectionUrl({
   userAttributes,
   userRepository,
+  authenticationMethodRepository,
   tokenService,
   settings,
 }) {
@@ -12,17 +15,61 @@ module.exports = async function getExternalAuthenticationRedirectionUrl({
   };
 
   const user = await userRepository.getBySamlId(externalUser.samlId);
+
   if (user) {
-    return await _getUrlWithAccessToken({ user, tokenService, userRepository });
+    return await _getUrlWithAccessToken({
+      user,
+      externalUser,
+      tokenService,
+      userRepository,
+      authenticationMethodRepository,
+    });
   }
 
   return _getUrlForReconciliationPage({ tokenService, externalUser });
 };
 
-async function _getUrlWithAccessToken({ user, tokenService, userRepository }) {
+async function _getUrlWithAccessToken({
+  user,
+  externalUser,
+  tokenService,
+  userRepository,
+  authenticationMethodRepository,
+}) {
   const token = tokenService.createAccessTokenForSaml(user.id);
   await userRepository.updateLastLoggedAt({ userId: user.id });
+  await _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser });
   return `/?token=${encodeURIComponent(token)}&user-id=${user.id}`;
+}
+
+async function _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser }) {
+  const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+    userId: user.id,
+    identityProvider: AuthenticationMethod.identityProviders.GAR,
+  });
+
+  if (
+    _externalUserFirstAndLastNameMatchesAuthenticationMethodFirstAndLastName({ authenticationMethod, externalUser })
+  ) {
+    return;
+  }
+
+  authenticationMethod.authenticationComplement = new AuthenticationMethod.GARAuthenticationComplement({
+    firstName: externalUser.firstName,
+    lastName: externalUser.lastName,
+  });
+
+  authenticationMethodRepository.update(authenticationMethod);
+}
+
+function _externalUserFirstAndLastNameMatchesAuthenticationMethodFirstAndLastName({
+  authenticationMethod,
+  externalUser,
+}) {
+  return (
+    externalUser.firstName === authenticationMethod.authenticationComplement?.firstName &&
+    externalUser.lastName === authenticationMethod.authenticationComplement?.lastName
+  );
 }
 
 function _getUrlForReconciliationPage({ tokenService, externalUser }) {

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -270,4 +270,8 @@ module.exports = {
       .where({ userId: originUserId, identityProvider })
       .update({ userId: targetUserId, updatedAt: new Date() });
   },
+
+  async update({ id, authenticationComplement }) {
+    await knex(AUTHENTICATION_METHODS_TABLE).where({ id }).update({ authenticationComplement, updatedAt: new Date() });
+  },
 };

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -65,6 +65,8 @@ module.exports = {
           `An authentication method already exists for the user ID ${authenticationMethod.userId} and the externalIdentifier ${authenticationMethod.externalIdentifier}.`
         );
       }
+
+      throw err;
     }
   },
 

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -31,6 +31,15 @@ function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationCo
     return new AuthenticationMethod.PoleEmploiAuthenticationComplement(bookshelfAuthenticationComplement);
   }
 
+  if (identityProvider === AuthenticationMethod.identityProviders.GAR) {
+    const methodWasCreatedWithoutUserFirstAndLastName = bookshelfAuthenticationComplement === null;
+    if (methodWasCreatedWithoutUserFirstAndLastName) {
+      return undefined;
+    }
+
+    return new AuthenticationMethod.GARAuthenticationComplement(bookshelfAuthenticationComplement);
+  }
+
   return undefined;
 }
 

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -33,7 +33,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           userId,
         });
         delete authenticationMethod.id;
-        authenticationMethod.authenticationComplement = undefined;
 
         // when
         const savedAuthenticationMethod = await authenticationMethodRepository.create({ authenticationMethod });
@@ -282,7 +281,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         id: 123,
         userId,
       });
-      garAuthenticationMethod.authenticationComplement = undefined;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(garAuthenticationMethod);
       await databaseBuilder.commit();
 
@@ -369,6 +367,33 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         );
       });
     });
+
+    describe('when GAR is the authentication provider', function () {
+      it('brings along a GAR authentication complement', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+          userId: user.id,
+          userFirstName: 'Katie',
+          userLastName: 'McGuffin',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const garAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+        });
+
+        // then
+        expect(garAuthenticationMethod.authenticationComplement).to.deep.equal(
+          new AuthenticationMethod.GARAuthenticationComplement({
+            firstName: 'Katie',
+            lastName: 'McGuffin',
+          })
+        );
+      });
+    });
   });
 
   describe('#findOneByExternalIdentifierAndIdentityProvider', function () {
@@ -381,7 +406,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         externalIdentifier,
         userId,
       });
-      authenticationMethod.authenticationComplement = undefined;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethod);
       databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
         externalIdentifier: 'another_sub',
@@ -421,7 +445,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           externalIdentifier: 'old_value',
           userId,
         });
-        authenticationMethod.authenticationComplement = undefined;
         databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethod);
         await databaseBuilder.commit();
 
@@ -446,7 +469,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           externalIdentifier: 'old_value',
           userId,
         });
-        authenticationMethod.authenticationComplement = undefined;
         databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(authenticationMethod);
         await databaseBuilder.commit();
 
@@ -923,7 +945,6 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         externalIdentifier: 'externalIdentifier',
         userId,
       });
-      secondAuthenticationMethod.authenticationComplement = undefined;
       databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider(secondAuthenticationMethod);
       const firstAuthenticationMethod =
         domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -313,6 +313,62 @@ describe('Integration | Repository | AuthenticationMethod', function () {
       // then
       expect(authenticationMethodsByUserIdAndIdentityProvider).to.be.null;
     });
+
+    describe('when Pix is the authentication provider', function () {
+      it('brings along a Pix authentication complement', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+          userId: user.id,
+          hashedPassword: 'H4SHED',
+          shouldChangePassword: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const pixAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.PIX,
+        });
+
+        // then
+        expect(pixAuthenticationMethod.authenticationComplement).to.deep.equal(
+          new AuthenticationMethod.PixAuthenticationComplement({
+            password: 'H4SHED',
+            shouldChangePassword: false,
+          })
+        );
+      });
+    });
+
+    describe('when Pole Emploi is the authentication provider', function () {
+      it('brings along a Pole Emploi authentication complement', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+          userId: user.id,
+          accessToken: 'AGENCENATIONALEPOURLEMPLOI',
+          refreshToken: 'FRANCETRAVAIL',
+          expiredDate: new Date('2021-01-01'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const pixAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
+        });
+
+        // then
+        expect(pixAuthenticationMethod.authenticationComplement).to.deep.equal(
+          new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+            accessToken: 'AGENCENATIONALEPOURLEMPLOI',
+            refreshToken: 'FRANCETRAVAIL',
+            expiredDate: '2021-01-01T00:00:00.000Z',
+          })
+        );
+      });
+    });
   });
 
   describe('#findOneByExternalIdentifierAndIdentityProvider', function () {

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -1,9 +1,11 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const User = require('../../../../lib/domain/models/User');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const getExternalAuthenticationRedirectionUrl = require('../../../../lib/domain/usecases/get-external-authentication-redirection-url');
 
 describe('Unit | UseCase | get-external-authentication-redirection-url', function () {
   let userRepository;
+  let authenticationMethodRepository;
   let tokenService;
   let samlSettings;
 
@@ -11,6 +13,11 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
     userRepository = {
       getBySamlId: sinon.stub(),
       updateLastLoggedAt: sinon.stub(),
+    };
+
+    authenticationMethodRepository = {
+      findOneByUserIdAndIdentityProvider: sinon.stub(),
+      update: sinon.stub(),
     };
 
     tokenService = {
@@ -55,6 +62,17 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   });
 
   context('when user already exists in database', function () {
+    let clock;
+    const now = new Date('2022-03-13');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now);
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
     it('should return access token url', async function () {
       // given
       const userAttributes = {
@@ -70,12 +88,16 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       });
 
       userRepository.getBySamlId.withArgs('saml-id-for-adele').resolves(expectedUser);
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
+        domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider()
+      );
       tokenService.createAccessTokenForSaml.returns('access-token');
 
       // when
       const result = await getExternalAuthenticationRedirectionUrl({
         userAttributes,
         userRepository,
+        authenticationMethodRepository,
         tokenService,
         settings: samlSettings,
       });
@@ -95,12 +117,16 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       const user = domainBuilder.buildUser({ id: 777 });
 
       userRepository.getBySamlId.resolves(user);
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
+        domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider()
+      );
       tokenService.createIdTokenForUserReconciliation.returns('external-user-token');
 
       // when
       await getExternalAuthenticationRedirectionUrl({
         userAttributes,
         userRepository,
+        authenticationMethodRepository,
         tokenService,
         settings: samlSettings,
       });
@@ -108,5 +134,153 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       // then
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });
     });
+
+    context("when user's authentication method does not contain first and last name", function () {
+      it('should save first and last name as the authentication complement and the authentication method modification date', async function () {
+        // given
+        const user = domainBuilder.buildUser();
+        const authenticationMethodWithoutFirstAndLastName = new AuthenticationMethod({
+          id: 1234,
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          authenticationComplement: null,
+          externalIdentifier: 'saml-id',
+          createdAt: new Date('2020-01-01'),
+          updatedAt: new Date('2020-02-01'),
+        });
+        userRepository.getBySamlId.withArgs('saml-id').resolves(user);
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .resolves(authenticationMethodWithoutFirstAndLastName);
+
+        // when
+        await getExternalAuthenticationRedirectionUrl({
+          userAttributes: { IDO: 'saml-id', NOM: 'Lisitsa', PRE: 'Vassili' },
+          userRepository,
+          authenticationMethodRepository,
+          tokenService,
+          settings: samlSettings,
+        });
+
+        // then
+        const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+          id: authenticationMethodWithoutFirstAndLastName.id,
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          userFirstName: 'Vassili',
+          userLastName: 'Lisitsa',
+          externalIdentifier: 'saml-id',
+        });
+        expect(authenticationMethodRepository.update).to.have.been.calledWith(expectedAuthenticationMethod);
+      });
+    });
+
+    context("when user's authentication method contains a different first name", function () {
+      it('should update first and last name in the authentication complement and the authentication method modification date', async function () {
+        // given
+        const { user, authenticationMethod } = _buildUserWithAuthenticationMethod({
+          firstName: 'Vassili',
+          lastName: 'Lisitsa',
+          externalIdentifier: 'saml-id',
+        });
+        userRepository.getBySamlId.withArgs('saml-id').resolves(user);
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .resolves(authenticationMethod);
+
+        // when
+        await getExternalAuthenticationRedirectionUrl({
+          userAttributes: { IDO: 'saml-id', NOM: 'Lisitsa', PRE: 'Valentina' },
+          userRepository,
+          authenticationMethodRepository,
+          tokenService,
+          settings: samlSettings,
+        });
+
+        // then
+        const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+          id: authenticationMethod.id,
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          userFirstName: 'Valentina',
+          userLastName: 'Lisitsa',
+          externalIdentifier: 'saml-id',
+        });
+        expect(authenticationMethodRepository.update).to.have.been.calledWith(expectedAuthenticationMethod);
+      });
+    });
+
+    context("when user's authentication method contains a different last name", function () {
+      it('should update first and last name in the authentication complement and the authentication method modification date', async function () {
+        // given
+        const { user, authenticationMethod } = _buildUserWithAuthenticationMethod({
+          firstName: 'Valentina',
+          lastName: 'Lisitsa',
+          externalIdentifier: 'saml-id',
+        });
+        userRepository.getBySamlId.withArgs('saml-id').resolves(user);
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .resolves(authenticationMethod);
+
+        // when
+        await getExternalAuthenticationRedirectionUrl({
+          userAttributes: { IDO: 'saml-id', NOM: 'Volk', PRE: 'Valentina' },
+          userRepository,
+          authenticationMethodRepository,
+          tokenService,
+          settings: samlSettings,
+        });
+
+        // then
+        const expectedAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+          id: authenticationMethod.id,
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          userFirstName: 'Valentina',
+          userLastName: 'Volk',
+          externalIdentifier: 'saml-id',
+        });
+        expect(authenticationMethodRepository.update).to.have.been.calledWith(expectedAuthenticationMethod);
+      });
+    });
+
+    context("when user's authentication method contains the same first and last name", function () {
+      it('should not update first and last name in the authentication complement', async function () {
+        // given
+        const { user, authenticationMethod } = _buildUserWithAuthenticationMethod({
+          firstName: 'Valentina',
+          lastName: 'Volk',
+          externalIdentifier: 'saml-id',
+        });
+        userRepository.getBySamlId.withArgs('saml-id').resolves(user);
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.GAR })
+          .resolves(authenticationMethod);
+
+        // when
+        await getExternalAuthenticationRedirectionUrl({
+          userAttributes: { IDO: 'saml-id', NOM: 'Volk', PRE: 'Valentina' },
+          userRepository,
+          authenticationMethodRepository,
+          tokenService,
+          settings: samlSettings,
+        });
+
+        // then
+        expect(authenticationMethodRepository.update).to.not.have.been.called;
+      });
+    });
   });
 });
+
+function _buildUserWithAuthenticationMethod({ firstName, lastName, externalIdentifier }) {
+  const user = domainBuilder.buildUser();
+  const authenticationMethod = domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({
+    userId: user.id,
+    userFirstName: firstName,
+    userLastName: lastName,
+    externalIdentifier: externalIdentifier,
+  });
+  return { user, authenticationMethod };
+}

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -5,6 +5,7 @@ const getExternalAuthenticationRedirectionUrl = require('../../../../lib/domain/
 describe('Unit | UseCase | get-external-authentication-redirection-url', function () {
   let userRepository;
   let tokenService;
+  let samlSettings;
 
   beforeEach(function () {
     userRepository = {
@@ -16,6 +17,16 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       createIdTokenForUserReconciliation: sinon.stub(),
       createAccessTokenForSaml: sinon.stub(),
     };
+
+    samlSettings = {
+      saml: {
+        attributeMapping: {
+          samlId: 'IDO',
+          firstName: 'PRE',
+          lastName: 'NOM',
+        },
+      },
+    };
   });
 
   context('when user does not exist in database yet', function () {
@@ -26,15 +37,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         NOM: 'Lopez',
         PRE: 'Adèle',
       };
-      const settings = {
-        saml: {
-          attributeMapping: {
-            samlId: 'IDO',
-            firstName: 'PRE',
-            lastName: 'NOM',
-          },
-        },
-      };
 
       tokenService.createIdTokenForUserReconciliation.returns('external-user-token');
       userRepository.getBySamlId.resolves(null);
@@ -44,7 +46,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userAttributes,
         userRepository,
         tokenService,
-        settings,
+        settings: samlSettings,
       });
 
       // then
@@ -59,15 +61,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         IDO: 'saml-id-for-adele',
         NOM: 'Lopez',
         PRE: 'Adèle',
-      };
-      const settings = {
-        saml: {
-          attributeMapping: {
-            samlId: 'IDO',
-            firstName: 'PRE',
-            lastName: 'NOM',
-          },
-        },
       };
       const expectedUser = new User({
         id: 1,
@@ -84,7 +77,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userAttributes,
         userRepository,
         tokenService,
-        settings,
+        settings: samlSettings,
       });
 
       // then
@@ -99,22 +92,18 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         NOM: 'Lopez',
         PRE: 'Adèle',
       };
-      const settings = {
-        saml: {
-          attributeMapping: {
-            samlId: 'IDO',
-            firstName: 'PRE',
-            lastName: 'NOM',
-          },
-        },
-      };
       const user = domainBuilder.buildUser({ id: 777 });
 
       userRepository.getBySamlId.resolves(user);
       tokenService.createIdTokenForUserReconciliation.returns('external-user-token');
 
       // when
-      await getExternalAuthenticationRedirectionUrl({ userAttributes, userRepository, tokenService, settings });
+      await getExternalAuthenticationRedirectionUrl({
+        userAttributes,
+        userRepository,
+        tokenService,
+        settings: samlSettings,
+      });
 
       // then
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 777 });


### PR DESCRIPTION
## :unicorn: Problème

On a parfois besoin de savoir à qui appartient une connexion GAR dans le cas d'utilisateur qui ont de multiples élèves réconciliés. On ne sait pas si on peut/doit supprimer la connexion GAR de l'utilisateur pour éviter qu'un autre utilisateur s'y connecte.

## :robot: Solution

A chaque connexion d’un élève via le GAR, regarder si les infos du prénom et nom (stockés dans “authentication-methods”.”authenticationComplement”) ont été remplies.
- si les infos sont vides, alors les remplir, et mettre à jour le 'updatedAt'
- si les infos sont remplis, vérifier si des infos ont changé. Si oui les mettre à jour et mettre à jour le ‘updatedAt’. Si non, ne rien faire.

TODO

- [x] Mettre à jour le champ `updatedAt` de `authentication-methods`

## :rainbow: Remarques

- Dans la méthode `create` du `authenticate-methods-repository` on ignorait toutes les erreurs sauf `UniqConstraintViolated` du coup la création d'une méthode pouvait échouer sans qu'on s'en rende compte. Le premier commit corrige ça.
- Il manquait des cas de tests pour vérifier qu'on récupérait bien les `authenticationComplement` (et de fait on ne le faisait pas pour le GAR), le deuxième commit les ajoute.

## :100: Pour tester

1. Se connecter à Pix App depuis le GAR simulé
2. Trouver la ligne correspondante de `authentications-method` et mettre le champ `authenticationComplement` à `null`.
3. Se connecter à nouveau à Pix App depuis le GAR simulé
4. Vérifier que le champ `authenticationComplement` a bien été rempli et `updatedAt` mis à jour
5. Se connecter à Pix App depuis le GAR simulé, avec un prénom différent
6. Vérifier que le prénom du champ `authenticationComplement` et `updatedAt` ont été mis à jour
7. Se connecter à Pix App depuis le GAR simulé, avec un nom différent
8. Vérifier que le nom du champ `authenticationComplement` et `updatedAt` ont été mis à jour
9. Se connecter à Pix App depuis le GAR simulé, avec le même nom et prénom que précédemment
10. Vérifier que le champ `updatedAt` n'a pas été mis à jour

