### PR TITLE
[FEATURE] Monter la version de Pix-ui pour utiliser les modifications de Pix-pagination (PIX-4721).

### DIFF
--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -113,11 +113,12 @@
     grid-auto-rows: min-content;
     row-gap: 16px;
     width: 100%;
+    margin-bottom: 32px;
 
     @include device-is('desktop') {
       grid-template-columns: 1fr 1fr;
       column-gap: 24px;
-      margin: 0 auto;
+      margin: 0 auto 32px auto;
     }
   }
 

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.191.0",
+      "version": "3.194.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/pix-ui": "^13.3.4",
+        "@1024pix/pix-ui": "^13.4.2",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.0.tgz",
-      "integrity": "sha512-Pv6RDJtJPbrAsTzEbi0a6vvDJWJVYxLVYD7jO8gODYJjqhSRB6wBjpcfCu5inCOnzira/v1Ron2lTSJibpyjEw==",
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.2.tgz",
+      "integrity": "sha512-pk+slG8oPbgzjSfh0WdfkcT3M7FZ4VxZ4xJUFKA7VpumRVfX2P2VjauX4FdMf0CDx+YvA9e8y7NbmFbp1drHog==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -38958,9 +38958,9 @@
   },
   "dependencies": {
     "@1024pix/pix-ui": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.0.tgz",
-      "integrity": "sha512-Pv6RDJtJPbrAsTzEbi0a6vvDJWJVYxLVYD7jO8gODYJjqhSRB6wBjpcfCu5inCOnzira/v1Ron2lTSJibpyjEw==",
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.2.tgz",
+      "integrity": "sha512-pk+slG8oPbgzjSfh0WdfkcT3M7FZ4VxZ4xJUFKA7VpumRVfX2P2VjauX4FdMf0CDx+YvA9e8y7NbmFbp1drHog==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
-    "@1024pix/pix-ui": "^13.3.4",
+    "@1024pix/pix-ui": "^13.4.2",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",


### PR DESCRIPTION
## :unicorn: Problème
Monter la version de pix-ui & ajouter une margin entre les `cards` des tutos et `Pix-Pagination`.

## :robot: Solution

- Update package.json
- Ajouter un margin bottom au container des cards

## :rainbow: Remarques
Pourquoi ne pas avoir défini une margin-top de 32px directement dans le composant `Pix-Pagination` ?

## :100: Pour tester

1. Aller sur pix app
2. Faire un exo pour avoir des tutos
3. Vérifier sur la page tutos que `.user-tutorials-content-v2__cards` possède une margin-bottom de 32px
4. Vérifier que les changements de Pix-Pagination sont à jour.
