### PR TITLE
[BUGFIX] Considérer les réponses comme "focusedout" si il y a eu un évènement "focusedout" (PIX-4723)

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -145,6 +145,10 @@ class Assessment {
     return challenges[Math.abs(hashInt(this.id)) % challenges.length];
   }
 
+  get hasLastQuestionBeenFocusedOut() {
+    return this.lastQuestionState === Assessment.statesOfLastQuestion.FOCUSEDOUT;
+  }
+
   static computeMethodFromType(type) {
     switch (type) {
       case Assessment.types.CERTIFICATION:

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -10,7 +10,7 @@ class Examiner {
     this.validator = validator;
   }
 
-  evaluate({ answer, challengeFormat, isFocusedChallenge, isCertificationEvaluation }) {
+  evaluate({ answer, challengeFormat, isFocusedChallenge, isCertificationEvaluation, hasLastQuestionBeenFocusedOut }) {
     const correctedAnswer = new Answer(answer);
 
     if (answer.value === Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
@@ -28,6 +28,25 @@ class Examiner {
 
     if (isCorrectAnswer && answer.hasTimedOut) {
       correctedAnswer.result = AnswerStatus.TIMEDOUT;
+    }
+
+    // Temporary log to find out synchronization problems
+    // between PATCH /focusedout and POST /answers
+    if (
+      (answer.isFocusedOut && !hasLastQuestionBeenFocusedOut) ||
+      (!answer.isFocusedOut && hasLastQuestionBeenFocusedOut)
+    ) {
+      logger.warn(
+        {
+          subject: 'focusOut',
+          challengeFormat,
+          challengeId: answer.challengeId,
+          assessmentId: answer.assessmentId,
+        },
+        `Received an answer whose isFocusedOut is %s whereas a %s focusedout event has already been received`,
+        answer.isFocusedOut,
+        hasLastQuestionBeenFocusedOut ? 'a' : 'no'
+      );
     }
 
     // Temporary log to find out focusedout answers that should not occur

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -49,6 +49,11 @@ class Examiner {
       );
     }
 
+    // Consider user has focused out if at least one of the following is true :
+    //   - assessment has recorded a focusedout event
+    //   - answer.isFocusedOut is true
+    answer.isFocusedOut = answer.isFocusedOut || hasLastQuestionBeenFocusedOut;
+
     // Temporary log to find out focusedout answers that should not occur
     if (!isFocusedChallenge && answer.isFocusedOut) {
       logger.warn(
@@ -64,6 +69,7 @@ class Examiner {
 
     if (isCorrectAnswer && isFocusedChallenge && answer.isFocusedOut && isCertificationEvaluation) {
       correctedAnswer.result = AnswerStatus.FOCUSEDOUT;
+      correctedAnswer.isFocusedOut = true;
     }
 
     return correctedAnswer;

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -109,6 +109,7 @@ function _evaluateAnswer({ challenge, answer, assessment }) {
     answer,
     challengeFormat: challenge.format,
     isFocusedChallenge: challenge.focused,
+    hasLastQuestionBeenFocusedOut: assessment.hasLastQuestionBeenFocusedOut,
     isCertificationEvaluation: assessment.isCertification(),
   });
 }


### PR DESCRIPTION
## :unicorn: Problème

Le front peut envoyer une réponse avec `isFocusedOut=false` alors qu'il y a eu un évènement "focusedout", et donc que l'assessment à un `lastQuestionState="focusedout"`.

Ça permet potentiellement la triche en certification :

![Screenshot from 2022-04-06 11-38-46](https://user-images.githubusercontent.com/19571875/161970402-0c937860-e839-4b19-8810-d635d132334d.png)

## :robot: Solution

Considérer que la réponse est `focusedOut` si un événement "focusedout" a été enregistré, c'est à dire
- il y a eu un appel sur `PATCH /api/assessments/{id}/last-challenge-state/{state}` avec `state=focusedOut`
- il y a en BDD un `assessments.lastQuestionState=focusedOut`


## :rainbow: Remarques

On ajoute aussi un warning si il y a incohérence entre `answer.isFocusedOut` et `assessment.lastQuestionState`.

## :100: Pour tester

Possible de tester avec Postman comme montré dans la capture d'écran.
