### PR TITLE
[TECH] Ajouter un index manquant sur la table knowledge-elements concernant la colonne "assessmentid".

### DIFF
--- a/api/db/migrations/20220406083222_add_index_for_table_knowledge_elements_on_column_assessmentId.js
+++ b/api/db/migrations/20220406083222_add_index_for_table_knowledge_elements_on_column_assessmentId.js
@@ -1,0 +1,9 @@
+exports.up = (knex) => {
+  return knex.raw(
+    'CREATE INDEX IF NOT EXISTS "knowledge_elements_assessmentid_index" on "knowledge-elements" ("assessmentId")'
+  );
+};
+
+exports.down = function (knex) {
+  return knex.raw('DROP INDEX "knowledge_elements_assessmentid_index"');
+};


### PR DESCRIPTION
## :unicorn: Problème
En production, un index a été créé sans passer par une migration Knex. 
https://1024pix.slack.com/archives/C02C3JH7MLY/p1649173650348689
Cet index est donc manquant pour les environnements hors production et datawarehouse.

## :robot: Solution
Créer une migration pour rajouter cet index si ce dernier n'existe pas.

## :rainbow: Remarques
L'index en production se nomme knowledge-elements_assessmentId_idx. Comme il sera recrée suite au chantier Bigint et dump dans l'environnement datawarehouse. Le nom a été changé pour garder la convention de Knex.
Découvert suite au chantier bigint.
Merci à @laura-bergoens pour son aide.

## :100: Pour tester
Scénario 1 : Cas d'un environnement hors production ou l'index n'existe pas.
- Lancer un reset de la base de donnée.
`npm run db:reset`
- Vérifier l'existance de l'index
```sql
SELECT
           a.attname,
           am.amname index_type,
           cls.relname
        FROM pg_index idx
            INNER JOIN pg_class cls ON cls.oid=idx.indexrelid
            INNER JOIN pg_class tab ON tab.oid=idx.indrelid
            INNER JOIN pg_am am     ON am.oid=cls.relam
            INNER JOIN pg_attribute a ON a.attrelid = cls.oid
        WHERE tab.relname = 'knowledge-elements'
        and cls.relname = 'knowledge_elements_assessmentid_index'
        ORDER BY a.attname
```

Scénario 2 : Cas d'un environnement production ou datawarehouse ou l'index existe déjà.
- Vérifier que la migration ne rajoute pas d'index.
- Done en local, en créant deux migrations pour simuler l'index déjà créé.
- Vérifier que le reset de la base de donnée se fait correctement.
