### PR TITLE
[FEATURE] Utiliser la nouvelle card des tutoriels pour le détails des compétences (PIX-4600).

### DIFF
--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -140,7 +140,11 @@
               <h4 class="tube__title">{{tube.practicalTitle}}</h4>
               <div class="tube__content">
                 {{#each tube.tutorials as |tutorial|}}
-                  <TutorialItem @tutorial={{tutorial}} />
+                  {{#if this.areNewTutorialsEnabled}}
+                    <Tutorials::Card @tutorial={{tutorial}} />
+                  {{else}}
+                    <TutorialItem @tutorial={{tutorial}} />
+                  {{/if}}
                 {{/each}}
               </div>
             </div>

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -9,8 +9,13 @@ export default class ScorecardDetails extends Component {
   @service store;
   @service router;
   @service competenceEvaluation;
+  @service featureToggles;
 
   @tracked showResetModal = false;
+
+  get areNewTutorialsEnabled() {
+    return this.featureToggles.featureToggles.isNewTutorialsPageEnabled;
+  }
 
   get level() {
     return this.args.scorecard.isNotStarted ? null : this.args.scorecard.level;

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -34,6 +34,13 @@
     color: $grey-90;
     margin-bottom: 24px;
   }
+
+  &__content {
+
+    > .tutorial-card-v2 {
+      margin-bottom: 16px;
+    }
+  }
 }
 
 .scorecard-details {

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -5,6 +5,7 @@ import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import Service from '@ember/service';
 
 describe('Integration | Component | scorecard-details', function () {
   setupIntlRenderingTest();
@@ -261,6 +262,12 @@ describe('Integration | Component | scorecard-details', function () {
       context('and the user has some tutorials', async function () {
         it('should display the tutorial section and the related tutorials', async function () {
           // given
+          class FeatureTogglesService extends Service {
+            featureToggles = {
+              isNewTutorialsPageEnabled: false,
+            };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesService);
           const tuto1 = EmberObject.create({
             title: 'Tuto 1.1',
             tubeName: '@first_tube',
@@ -297,6 +304,54 @@ describe('Integration | Component | scorecard-details', function () {
           expect(find('.tutorials')).to.exist;
           expect(findAll('.tube')).to.have.lengthOf(2);
           expect(findAll('.tutorial-item')).to.have.lengthOf(3);
+        });
+
+        context('when newTutorials FT is enabled', function () {
+          it('should display the tutorial section and related tutorials', async function () {
+            // given
+            class FeatureTogglesService extends Service {
+              featureToggles = {
+                isNewTutorialsPageEnabled: true,
+              };
+            }
+            this.owner.register('service:featureToggles', FeatureTogglesService);
+            const tuto1 = EmberObject.create({
+              title: 'Tuto 1.1',
+              tubeName: '@first_tube',
+              tubePracticalTitle: 'Practical Title',
+              duration: '00:15:10',
+            });
+            const tuto2 = EmberObject.create({
+              title: 'Tuto 2.1',
+              tubeName: '@second_tube',
+              tubePracticalTitle: 'Practical Title',
+              duration: '00:04:00',
+            });
+            const tuto3 = EmberObject.create({
+              title: 'Tuto 2.2',
+              tubeName: '@second_tube',
+              tubePracticalTitle: 'Practical Title',
+              duration: '00:04:00',
+            });
+
+            const tutorials = A([tuto1, tuto2, tuto3]);
+
+            const scorecard = EmberObject.create({
+              competenceId: 1,
+              isStarted: true,
+              tutorials,
+            });
+
+            this.set('scorecard', scorecard);
+
+            // when
+            await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
+            // then
+            expect(find('.tutorials')).to.exist;
+            expect(findAll('.tube')).to.have.lengthOf(2);
+            expect(findAll('.tutorial-card-v2')).to.have.lengthOf(3);
+          });
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les nouvelles cartes des tutoriels sont utilisées que dans la page des tutoriels. Il reste donc des endroits où nous affichons encore les anciennes cartes.

## :robot: Solution
Afficher les nouvelles cartes de tutoriels dans le détail des compétences lorsque le FT : `FT_NEW_TUTORIALS_PAGE` est activé.  

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
 - Se connecter sur Pix App 
 - Regarder le détail d'une compétence et constater qu'il s'agit des nouvelles cartes des tutos 
