### PR TITLE
[TECH] Supprimer des indexs non utilisés en production.

### DIFF
--- a/api/db/migrations/20220406140150_drop-unused-index-on-userid-table-user-orga-settings.js
+++ b/api/db/migrations/20220406140150_drop-unused-index-on-userid-table-user-orga-settings.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'user-orga-settings';
+const USERID_COLUMN = 'userId';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropIndex(USERID_COLUMN);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.index(USERID_COLUMN);
+  });
+};

--- a/api/db/migrations/20220406140553_drop-unused-index-on-owner-organization-id-table-target-profiles.js
+++ b/api/db/migrations/20220406140553_drop-unused-index-on-owner-organization-id-table-target-profiles.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'target-profiles';
+const USERID_COLUMN = 'ownerOrganizationId';
+const INDEX_NAME = 'target_profiles_organizationid_index';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(USERID_COLUMN, INDEX_NAME);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.index(USERID_COLUMN);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Il existe des indexes non utilisés en production.
Ils prennent de l'espace disque et ralentisent les insertions.

![image](https://user-images.githubusercontent.com/10045497/161998194-01e16bc7-06ff-4d24-a817-d9dbe3f90583.png)

<img width="1385" alt="Capture d’écran 2022-04-06 à 16 46 22" src="https://user-images.githubusercontent.com/10045497/162004839-f6213f5d-3f13-4096-b70f-c9e095925dff.png">

## :robot: Solution
Supprimer ces indexes.

## :100: Pour tester
Lancer un reset de la base de donnée:
`npm run db:reset`

Vérifier que ces indexes ne sont pas présents.
```sql
SELECT
    t.schemaname,
    t.tablename,
    c.reltuples::bigint                            AS num_rows,
    pg_size_pretty(pg_relation_size(c.oid))        AS table_size,
    psai.indexrelname                              AS index_name,
    pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
    CASE WHEN i.indisunique THEN 'Y' ELSE 'N' END  AS "unique",
    psai.idx_scan                                  AS number_of_scans,
    psai.idx_tup_read                              AS tuples_read,
    psai.idx_tup_fetch                             AS tuples_fetched
FROM
    pg_tables t
    LEFT JOIN pg_class c ON t.tablename = c.relname
    LEFT JOIN pg_index i ON c.oid = i.indrelid
    LEFT JOIN pg_stat_all_indexes psai ON i.indexrelid = psai.indexrelid
WHERE
    t.schemaname NOT IN ('pg_catalog', 'information_schema')
    AND
    psai.indexrelname IN ('target_profiles_organizationid_index','user_orga_settings_userid_index')
ORDER BY 1, 2;
```
