### PR TITLE
[FEATURE] Amélioration du style des boutons des nouvelles cartes tutos (PIX-4724).

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -18,15 +18,6 @@
     </p>
     <div class="tutorial-card-v2-content__actions">
       <button
-        class="tutorial-card-v2-content-actions__save"
-        type="button"
-        {{on "click" this.toggleSaveTutorial}}
-        disabled={{this.isSaveButtonDisabled}}
-      >
-        <FaIcon @prefix={{if this.isSaved "fas" "far"}} @icon="bookmark" />
-        {{this.buttonLabel}}
-      </button>
-      <button
         class="tutorial-card-v2-content-actions__evaluate"
         type="button"
         {{on "click" this.evaluateTutorial}}
@@ -34,6 +25,10 @@
       >
         <FaIcon @prefix="fas" @icon="thumbs-up" />
         {{t "pages.user-tutorials.list.tutorial.actions.evaluate.label"}}
+      </button>
+      <button class="tutorial-card-v2-content-actions__save" type="button">
+        <FaIcon @prefix="fas" @icon="bookmark" />
+        {{this.buttonLabel}}
       </button>
     </div>
   </div>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -18,20 +18,21 @@
     </p>
     <div class="tutorial-card-v2-content__actions">
       <button
-        class="tutorial-card-v2-content-actions__evaluate"
+        class="pix-action-chip {{if this.isTutorialEvaluated "pix-action-chip--selected"}}"
+        aria-label={{this.evaluateLabel}}
         type="button"
         {{on "click" this.evaluateTutorial}}
         disabled={{this.isTutorialEvaluated}}
       >
-        <FaIcon @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
+        <FaIcon class="pix-action-chip__icon" @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
       </button>
       <button
-        class="tutorial-card-v2-content-actions__save"
-        aria-label={{this.buttonLabel}}
+        class="pix-action-chip {{if this.isTutorialSaved "pix-action-chip--selected"}}"
+        aria-label={{this.saveLabel}}
         type="button"
         {{on "click" this.toggleSaveTutorial}}
       >
-        <FaIcon @prefix={{if this.isTutorialSaved "fas" "far"}} @icon="bookmark" />
+        <FaIcon class="pix-action-chip__icon" @prefix={{if this.isTutorialSaved "fas" "far"}} @icon="bookmark" />
       </button>
     </div>
   </div>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -25,8 +25,8 @@
       >
         <FaIcon @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
       </button>
-      <button class="tutorial-card-v2-content-actions__save" type="button">
-        <FaIcon @prefix="fas" @icon="bookmark" />
+      <button class="tutorial-card-v2-content-actions__save" type="button" {{on "click" this.toggleSaveTutorial}}>
+        <FaIcon @prefix={{if this.isTutorialSaved "fas" "far"}} @icon="bookmark" />
       </button>
     </div>
   </div>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -21,9 +21,9 @@
         class="tutorial-card-v2-content-actions__evaluate"
         type="button"
         {{on "click" this.evaluateTutorial}}
-        disabled={{this.isEvaluateButtonDisabled}}
+        disabled={{this.isTutorialEvaluated}}
       >
-        <FaIcon @prefix="fas" @icon="thumbs-up" />
+        <FaIcon @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
       </button>
       <button class="tutorial-card-v2-content-actions__save" type="button">
         <FaIcon @prefix="fas" @icon="bookmark" />

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -24,11 +24,9 @@
         disabled={{this.isEvaluateButtonDisabled}}
       >
         <FaIcon @prefix="fas" @icon="thumbs-up" />
-        {{t "pages.user-tutorials.list.tutorial.actions.evaluate.label"}}
       </button>
       <button class="tutorial-card-v2-content-actions__save" type="button">
         <FaIcon @prefix="fas" @icon="bookmark" />
-        {{this.buttonLabel}}
       </button>
     </div>
   </div>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -25,7 +25,12 @@
       >
         <FaIcon @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
       </button>
-      <button class="tutorial-card-v2-content-actions__save" type="button" {{on "click" this.toggleSaveTutorial}}>
+      <button
+        class="tutorial-card-v2-content-actions__save"
+        aria-label={{this.buttonLabel}}
+        type="button"
+        {{on "click" this.toggleSaveTutorial}}
+      >
         <FaIcon @prefix={{if this.isTutorialSaved "fas" "far"}} @icon="bookmark" />
       </button>
     </div>

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -17,10 +17,16 @@ export default class Card extends Component {
     this.evaluationStatus = args.tutorial.isEvaluated ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
   }
 
-  get buttonLabel() {
+  get saveLabel() {
     return this.savingStatus === buttonStatusTypes.recorded
       ? this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.label')
       : this.intl.t('pages.user-tutorials.list.tutorial.actions.save.label');
+  }
+
+  get evaluateLabel() {
+    return this.evaluationStatus === buttonStatusTypes.recorded
+      ? this.intl.t('pages.user-tutorials.list.tutorial.actions.evaluate.label')
+      : this.intl.t('pages.user-tutorials.list.tutorial.actions.evaluate.extra-information');
   }
 
   get isSaved() {

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -31,6 +31,10 @@ export default class Card extends Component {
     return this.evaluationStatus !== buttonStatusTypes.unrecorded;
   }
 
+  get isTutorialSaved() {
+    return this.savingStatus !== buttonStatusTypes.unrecorded;
+  }
+
   get isSaveButtonDisabled() {
     return this.savingStatus === buttonStatusTypes.pending;
   }

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -27,7 +27,7 @@ export default class Card extends Component {
     return this.savingStatus === buttonStatusTypes.recorded;
   }
 
-  get isEvaluateButtonDisabled() {
+  get isTutorialEvaluated() {
     return this.evaluationStatus !== buttonStatusTypes.unrecorded;
   }
 

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -46,6 +46,7 @@
   }
 
   &__actions {
+    justify-content: space-between;
     align-items: end;
     display: flex;
     flex: 1;

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -54,32 +54,69 @@
   }
 }
 
-.tutorial-card-v2-content-actions {
+.pix-action-chip {
+  $dark-blue: #2044DC;
 
-  &__save,
-  &__evaluate {
-    font-size: 0.813rem;
-    font-weight: $font-medium;
+  width: 36px;
+  height: 36px;
+  background: $white;
+  border-radius: 50%;
+  border: 1px solid $grey-10;
+  text-align: center;
+
+  &__icon {
+    left: calc(50% - 20px / 2);
+    top: 0%;
+    bottom: 0%;
     color: $grey-50;
-    letter-spacing: 0.028rem;
-    background: transparent;
-    border: none;
-    padding: 0;
-    display: block;
+    font-size: 18px;
+  }
 
-    svg {
-      margin-right: 4px;
+  &:hover {
+    cursor: pointer;
+    border: 1.4px solid $grey-50;
+    background: $grey-10;
+  }
+
+  &:disabled {
+    cursor: initial;
+    pointer-events: none;
+  }
+
+  &--selected {
+    border-color: $blue;
+
+    .pix-action-chip__icon {
+      color: $blue;
     }
 
     &:hover {
-      filter: brightness(70%);
-      cursor: pointer;
+      border-color: $dark-blue;
+
+      .pix-action-chip__icon {
+        color: $dark-blue;
+      }
     }
 
-    &:disabled {
-      color: $grey-30;
-      filter: brightness(90%);
-      cursor: auto;
+    &:focus-visible {
+      background-color: $blue;
+      box-shadow: 0 0 0 3px $blue;
+      border-color: $white;
+
+      .pix-action-chip__icon {
+        color: $white;
+      }
+    }
+  }
+
+  &:not(.pix-action-chip--selected):focus-visible {
+    background-color: $grey-60;
+    box-shadow: 0 0 0 3px $grey-60;
+    border-color: $white;
+    outline: none;
+
+    .pix-action-chip__icon {
+      color: $white;
     }
   }
 }

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -19,7 +19,7 @@ $yellow: #FFBE00;
 $yellow-hover: darken($yellow, 8%);
 $light-blue: #388AFF;
 $pure-orange: #F45C00;
-$pole-emploi:#1B2E57;
+$pole-emploi: #1B2E57;
 $purple: #8845FF;
 
 // extended

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -31,25 +31,25 @@ describe('Acceptance | Tutorial | Actions', function () {
     it('should display tutorial item in competence page with actions', async function () {
       // then
       expect(find('.tutorial-card-v2')).to.exist;
-      expect(find('.tutorial-card-v2-content-actions__save')).to.exist;
-      expect(find('.tutorial-card-v2-content-actions__evaluate')).to.exist;
+      expect(find('[aria-label="Donner mon avis sur ce tuto"]')).to.exist;
+      expect(find('[aria-label="Enregistrer"]')).to.exist;
     });
 
     it('should disable evaluate action on click', async function () {
       // when
-      await click('.tutorial-card-v2-content-actions__evaluate');
+      await click('[aria-label="Donner mon avis sur ce tuto"]');
 
       // then
-      expect(find('.tutorial-card-v2-content-actions__evaluate').disabled).to.be.true;
+      expect(find('[aria-label="Tuto utile"]').disabled).to.be.true;
     });
 
     describe('when save action is clicked', function () {
       it('should display remove action button', async function () {
         // when
-        await click('.tutorial-card-v2-content-actions__save');
+        await click('[aria-label="Enregistrer"]');
 
         // then
-        expect(find('.tutorial-card-v2-content-actions__save').attributes['aria-label'].value).to.include('Retirer');
+        expect(find('[aria-label="Retirer"]')).to.exist;
       });
     });
   });

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Tutorial | Actions', function () {
         await click('.tutorial-card-v2-content-actions__save');
 
         // then
-        expect(find('.tutorial-card-v2-content-actions__save').textContent).to.include('Retirer');
+        expect(find('.tutorial-card-v2-content-actions__save').attributes['aria-label'].value).to.include('Retirer');
       });
     });
   });

--- a/mon-pix/tests/acceptance/user-tutorials-v2/actions_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/actions_test.js
@@ -20,9 +20,9 @@ describe('Acceptance | User-tutorials-v2 | Actions', function () {
     it('should disable evaluate action on click', async function () {
       await visit('/mes-tutos-v2/recommandes');
 
-      await click('.tutorial-card-v2-content-actions__evaluate');
+      await click(find('[aria-label="Donner mon avis sur ce tuto"]'));
 
-      expect(find('.tutorial-card-v2-content-actions__evaluate').disabled).to.be.true;
+      expect(find('[aria-label="Tuto utile"]').disabled).to.be.true;
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-tutorials-v2/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/recommended_test.js
@@ -38,7 +38,7 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
         await visit('/mes-tutos-v2/recommandes');
 
         // when
-        await click(find('.tutorial-card-v2-content-actions__save'));
+        await click(find('[aria-label="Donner mon avis sur ce tuto"]'));
 
         // then
         expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);

--- a/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
@@ -37,7 +37,7 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
         await visit('/mes-tutos-v2/enregistres');
 
         // when
-        await click('.tutorial-card-v2-content-actions__save');
+        await click('[aria-label="Retirer"]');
 
         // then
         expect(findAll('.tutorial-card-v2')).to.be.lengthOf(9);

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -33,6 +33,7 @@ describe('Integration | Component | Tutorials | Card', function () {
       .and.contains('vidéo')
       .and.contains('une minute');
     expect(find('.tutorial-card-v2-content__actions')).to.exist;
-    expect(find('.tutorial-card-v2-content-actions__evaluate')).to.exist;
+    expect(find('[aria-label="Tuto utile"]')).to.exist;
+    expect(find('[aria-label="Retirer"]')).to.exist;
   });
 });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -33,9 +33,6 @@ describe('Integration | Component | Tutorials | Card', function () {
       .and.contains('vidéo')
       .and.contains('une minute');
     expect(find('.tutorial-card-v2-content__actions')).to.exist;
-    expect(find('.tutorial-card-v2-content-actions__save'))
-      .to.have.property('textContent')
-      .that.contains(this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.label'));
     expect(find('.tutorial-card-v2-content-actions__evaluate')).to.exist;
   });
 });

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -58,7 +58,7 @@ describe('Unit | Component | Tutorial | card item', function () {
   describe('#isTutorialSaved', function () {
     it('should return false when the tutorial has not already been saved', function () {
       // given
-      component.evaluationStatus = 'unrecorded';
+      component.savingStatus = 'unrecorded';
 
       // when
       const result = component.isTutorialSaved;
@@ -69,7 +69,7 @@ describe('Unit | Component | Tutorial | card item', function () {
 
     it('should return true when the tutorial has already been saved', function () {
       // given
-      component.evaluationStatus = 'recorded';
+      component.savingStatus = 'recorded';
 
       // when
       const result = component.isTutorialSaved;
@@ -80,7 +80,7 @@ describe('Unit | Component | Tutorial | card item', function () {
 
     it('should return true when saving is in progress', function () {
       // given
-      component.evaluationStatus = 'pending';
+      component.savingStatus = 'pending';
 
       // when
       const result = component.isTutorialSaved;

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -20,13 +20,13 @@ describe('Unit | Component | Tutorial | card item', function () {
     component.intl = intl;
   });
 
-  describe('#isEvaluateButtonDisabled', function () {
+  describe('#isTutorialEvaluated', function () {
     it('should return false when the tutorial has not already been evaluated', function () {
       // given
       component.evaluationStatus = 'unrecorded';
 
       // when
-      const result = component.isEvaluateButtonDisabled;
+      const result = component.isTutorialEvaluated;
 
       // then
       expect(result).to.equal(false);
@@ -37,7 +37,7 @@ describe('Unit | Component | Tutorial | card item', function () {
       component.evaluationStatus = 'recorded';
 
       // when
-      const result = component.isEvaluateButtonDisabled;
+      const result = component.isTutorialEvaluated;
 
       // then
       expect(result).to.equal(true);
@@ -48,7 +48,7 @@ describe('Unit | Component | Tutorial | card item', function () {
       component.evaluationStatus = 'pending';
 
       // when
-      const result = component.isEvaluateButtonDisabled;
+      const result = component.isTutorialEvaluated;
 
       // then
       expect(result).to.equal(true);

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -55,6 +55,41 @@ describe('Unit | Component | Tutorial | card item', function () {
     });
   });
 
+  describe('#isTutorialSaved', function () {
+    it('should return false when the tutorial has not already been saved', function () {
+      // given
+      component.evaluationStatus = 'unrecorded';
+
+      // when
+      const result = component.isTutorialSaved;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return true when the tutorial has already been saved', function () {
+      // given
+      component.evaluationStatus = 'recorded';
+
+      // when
+      const result = component.isTutorialSaved;
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should return true when saving is in progress', function () {
+      // given
+      component.evaluationStatus = 'pending';
+
+      // when
+      const result = component.isTutorialSaved;
+
+      // then
+      expect(result).to.equal(true);
+    });
+  });
+
   describe('#isSaved', function () {
     it('should return false when the tutorial has not already been saved', function () {
       // when


### PR DESCRIPTION
## :unicorn: Problème

Les boutons d'actions (sauvegarde et évaluation) des nouveaux tutoriels ont un style et un comportement qui ne correspondent pas aux maquettes et attentes.

## :robot: Solution
- Mise à jour du Scss pour que cela correspond aux maquettes

## :rainbow: Remarques
/

## :100: Pour tester

- Aller sur l'app
- Faire une épreuve pour activer des tutos.
-  Se rendre sur mes tutos
- Vérifier  que le status `pix-action-chip-selected` est ajouté si on clique sur une des icons.
- Vérifier le bon comportement (navigation souris et clavier) pour les icons en fonction des maquettes dispo [ici](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=240%3A1490) 
