### PR TITLE
[FEATURE] Empêcher la suppression des cartes sur la page recommandés (PIX-4736).

### DIFF
--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -59,11 +59,11 @@ export default class Card extends Component {
     this.savingStatus = buttonStatusTypes.pending;
     try {
       await this.args.tutorial.userTutorial.destroyRecord({ adapterOptions: { tutorialId: this.args.tutorial.id } });
-      await this.args.tutorial.unloadRecord();
       this.savingStatus = buttonStatusTypes.unrecorded;
     } catch (e) {
       this.savingStatus = buttonStatusTypes.recorded;
     }
+    await this.args.afterRemove?.();
   }
 
   @action

--- a/mon-pix/app/components/tutorials/cards.hbs
+++ b/mon-pix/app/components/tutorials/cards.hbs
@@ -1,5 +1,5 @@
 <div class="user-tutorials-content-v2__cards">
   {{#each @tutorials as |tutorial|}}
-    <Tutorials::Card @tutorial={{tutorial}} />
+    <Tutorials::Card @tutorial={{tutorial}} @afterRemove={{@afterRemove}} />
   {{/each}}
 </div>

--- a/mon-pix/app/controllers/user-tutorials-v2/saved.js
+++ b/mon-pix/app/controllers/user-tutorials-v2/saved.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 
 export default class SavedController extends Controller {
   pageOptions = [
@@ -8,7 +9,8 @@ export default class SavedController extends Controller {
     { label: '100', value: 100 },
   ];
 
-  unloadRecord(tutorial) {
-    return tutorial.unloadRecord();
+  @action
+  refresh() {
+    this.send('refreshModel');
   }
 }

--- a/mon-pix/app/controllers/user-tutorials-v2/saved.js
+++ b/mon-pix/app/controllers/user-tutorials-v2/saved.js
@@ -7,4 +7,8 @@ export default class SavedController extends Controller {
     { label: '50', value: 50 },
     { label: '100', value: 100 },
   ];
+
+  unloadRecord(tutorial) {
+    return tutorial.unloadRecord();
+  }
 }

--- a/mon-pix/app/routes/user-tutorials-v2/saved.js
+++ b/mon-pix/app/routes/user-tutorials-v2/saved.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
 export default class UserTutorialsSavedRoute extends Route {
   @service featureToggles;
   @service router;
@@ -31,5 +33,10 @@ export default class UserTutorialsSavedRoute extends Route {
     if (isExiting) {
       controller.set('pageNumber', null);
     }
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/mon-pix/app/templates/user-tutorials-v2/saved.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/saved.hbs
@@ -1,6 +1,6 @@
 {{#if @model}}
   <div class="user-tutorials-content-v2__container">
-    <Tutorials::Cards @tutorials={{@model}} @afterRemove={{this.unloadRecord}} />
+    <Tutorials::Cards @tutorials={{@model}} @afterRemove={{this.refresh}} />
     <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} />
   </div>
 {{else}}

--- a/mon-pix/app/templates/user-tutorials-v2/saved.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/saved.hbs
@@ -1,6 +1,6 @@
 {{#if @model}}
   <div class="user-tutorials-content-v2__container">
-    <Tutorials::Cards @tutorials={{@model}} />
+    <Tutorials::Cards @tutorials={{@model}} @afterRemove={{this.unloadRecord}} />
     <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} />
   </div>
 {{else}}

--- a/mon-pix/mirage/handlers/find-paginated-saved-tutorials.js
+++ b/mon-pix/mirage/handlers/find-paginated-saved-tutorials.js
@@ -3,10 +3,13 @@ import { getPaginationFromQueryParams, applyPagination } from './pagination-util
 export function findPaginatedSavedTutorials(schema, request) {
   const queryParams = request.queryParams;
   const tutorials = schema.tutorials.all().models;
-  const rowCount = tutorials.length;
+  const userTutorialIds = schema.userTutorials.all().models.map((userTutorial) => userTutorial.tutorialId);
+  const savedTutorials = tutorials.filter((tutorial) => userTutorialIds.includes(tutorial.id));
+
+  const rowCount = savedTutorials.length;
 
   const pagination = getPaginationFromQueryParams(queryParams);
-  const paginatedTutorials = applyPagination(tutorials, pagination);
+  const paginatedTutorials = applyPagination(savedTutorials, pagination);
 
   const json = this.serialize({ modelName: 'tutorial', models: paginatedTutorials }, 'tutorial');
 

--- a/mon-pix/tests/acceptance/user-tutorials-v2/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/recommended_test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { visit, findAll, find } from '@ember/test-helpers';
+import { visit, findAll, find, click } from '@ember/test-helpers';
 import { authenticateByEmail } from '../../helpers/authentication';
 
 describe('Acceptance | User-tutorials-v2 | Recommended', function () {
@@ -11,20 +11,38 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
   let user;
 
   beforeEach(async function () {
-    const numberOfTutorials = 100;
     user = server.create('user', 'withEmail');
     server.create('feature-toggle', { id: 0, isNewTutorialsPageEnabled: true });
     await authenticateByEmail(user);
     await server.db.tutorials.remove();
-    server.createList('tutorial', numberOfTutorials);
   });
 
   describe('When there are recommended tutorials', () => {
     it('should display paginated tutorial cards', async function () {
+      // given
+      server.createList('tutorial', 100);
+
+      // when
       await visit('/mes-tutos-v2/recommandes');
+
+      //then
       expect(findAll('.tutorial-card-v2')).to.exist;
       expect(findAll('.tutorial-card-v2')).to.be.lengthOf(10);
       expect(find('.pix-pagination__navigation').textContent).to.contain('Page 1 / 10');
+    });
+
+    describe('when a tutorial is saved', function () {
+      it('should not remove it from the list when clicking on the remove button', async function () {
+        // given
+        server.createList('tutorial', 1, 'withUserTutorial');
+        await visit('/mes-tutos-v2/recommandes');
+
+        // when
+        await click(find('.tutorial-card-v2-content-actions__save'));
+
+        // then
+        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);
+      });
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials-v2/saved_test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { visit, click, find, findAll } from '@ember/test-helpers';
+import { visit, find, findAll, click } from '@ember/test-helpers';
 import { authenticateByEmail } from '../../helpers/authentication';
 
 describe('Acceptance | User-tutorials-v2 | Saved', function () {
@@ -32,6 +32,7 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
         // given
         const numberOfTutorials = 10;
         await server.db.tutorials.remove();
+        await server.db.userTutorials.remove();
         server.createList('tutorial', numberOfTutorials, 'withUserTutorial');
         await visit('/mes-tutos-v2/enregistres');
 


### PR DESCRIPTION
## :unicorn: Problème

La suppression de l'enregistrement d'un tutoriel sur la page `recommandés` entraîne la disparition non voulue de la carte associée.

## :robot: Solution

Remontée de l'action dans le parent afin de vérifier si celle-ci est nécessaire.

## :rainbow: Remarques

Quand il y a 2 pages, si on supprime tous les éléments se trouvant sur la page 2, au lieu de redescendre à la page 1 on se retrouve avec le message de liste vide, ce sera corriger dans une autre PR.

## :100: Pour tester

Sur la page `recommandés`, enregistrer un tutoriel.
Appuyer sur `retirer`, constater que la carte est toujours présente.
Enregistrer un nouveau tutoriel.
Aller sur la page `enregistres`, appuyer sur le bouton `retirer` de ce tutoriel nouvellement enregistré et constater de la suppression de la carte.
