### PR TITLE
[TECH] Stocker le taux de repro d'un parcours de certification (PIX-4757)

### DIFF
--- a/api/db/database-builder/factory/build-assessment-result.js
+++ b/api/db/database-builder/factory/build-assessment-result.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 module.exports = function buildAssessmentResult({
   id = databaseBuffer.getNextId(),
   pixScore = 456,
+  reproducibilityRate = null,
   level = null,
   status = AssessmentResult.status.VALIDATED,
   emitter = 'PIX_ALGO',
@@ -23,6 +24,7 @@ module.exports = function buildAssessmentResult({
   const values = {
     id,
     pixScore,
+    reproducibilityRate,
     level,
     status,
     emitter,

--- a/api/db/migrations/20220407193857_add-column-reproducibility-rate-in-assessment-results-table.js
+++ b/api/db/migrations/20220407193857_add-column-reproducibility-rate-in-assessment-results-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'assessment-results';
+const COLUMN_NAME = 'reproducibilityRate';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.decimal(COLUMN_NAME, 5, 2).defaultTo(null);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -105,6 +105,7 @@ async function _saveAssessmentResult(
   if (!certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted) {
     assessmentResult = AssessmentResult.buildNotTrustableAssessmentResult({
       pixScore: certificationAssessmentScore.nbPix,
+      reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
       status: certificationAssessmentScore.status,
       assessmentId: certificationAssessment.id,
       emitter: EMITTER,
@@ -113,6 +114,7 @@ async function _saveAssessmentResult(
   } else {
     assessmentResult = AssessmentResult.buildStandardAssessmentResult({
       pixScore: certificationAssessmentScore.nbPix,
+      reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
       status: certificationAssessmentScore.status,
       assessmentId: certificationAssessment.id,
       emitter: EMITTER,

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -104,6 +104,7 @@ function _createAssessmentResult({
 }) {
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult({
     pixScore: certificationAssessmentScore.nbPix,
+    reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
     status: certificationAssessmentScore.status,
     assessmentId: certificationAssessment.id,
     emitter: EMITTER,

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -8,7 +8,6 @@ const status = {
 };
 
 class AssessmentResult {
-  // FIXME: assessmentId && juryId to replace by assessment && jury domain objects
   constructor({
     id,
     commentForCandidate,
@@ -17,6 +16,7 @@ class AssessmentResult {
     createdAt,
     emitter,
     pixScore,
+    reproducibilityRate,
     status,
     competenceMarks = [],
     assessmentId,
@@ -29,6 +29,7 @@ class AssessmentResult {
     this.createdAt = createdAt;
     this.emitter = emitter;
     this.pixScore = pixScore;
+    this.reproducibilityRate = reproducibilityRate;
     this.status = status;
     this.competenceMarks = competenceMarks;
     this.assessmentId = assessmentId;
@@ -40,17 +41,19 @@ class AssessmentResult {
       emitter,
       commentForJury: error.message,
       pixScore: 0,
+      reproducibilityRate: 0,
       status: status.ERROR,
       assessmentId,
       juryId,
     });
   }
 
-  static buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId, emitter }) {
+  static buildStandardAssessmentResult({ pixScore, reproducibilityRate, status, assessmentId, juryId, emitter }) {
     return new AssessmentResult({
       emitter,
       commentForJury: 'Computed',
-      pixScore: pixScore,
+      pixScore,
+      reproducibilityRate,
       status,
       assessmentId,
       juryId,
@@ -64,7 +67,7 @@ class AssessmentResult {
     });
   }
 
-  static buildNotTrustableAssessmentResult({ pixScore, status, assessmentId, juryId, emitter }) {
+  static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, status, assessmentId, juryId, emitter }) {
     return new AssessmentResult({
       emitter,
       commentForCandidate:
@@ -80,6 +83,7 @@ class AssessmentResult {
         'et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).',
       commentForJury: 'Computed',
       pixScore,
+      reproducibilityRate,
       status,
       assessmentId,
       juryId,

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -10,6 +10,10 @@ const CompetenceMark = require('../../domain/models/CompetenceMark');
 function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
   const competenceMarks = competencesMarksDTO.map((competenceMark) => new CompetenceMark(competenceMark));
 
+  // TODO : Aceol ! You can do better than this !
+  const cleanReproducibilityRate = assessmentResultDTO.reproducibilityRate
+    ? _.toNumber(assessmentResultDTO.reproducibilityRate)
+    : null;
   return new AssessmentResult({
     id: assessmentResultDTO.id,
     assessmentId: assessmentResultDTO.assessmentId,
@@ -21,6 +25,7 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
     emitter: assessmentResultDTO.emitter,
     juryId: assessmentResultDTO.juryId,
     pixScore: assessmentResultDTO.pixScore,
+    reproducibilityRate: cleanReproducibilityRate,
     competenceMarks: competenceMarks,
   });
 }
@@ -29,6 +34,7 @@ module.exports = {
   async save(
     {
       pixScore,
+      reproducibilityRate,
       status,
       emitter,
       commentForJury,
@@ -46,6 +52,7 @@ module.exports = {
     try {
       const savedAssessmentResultBookshelf = await new BookshelfAssessmentResult({
         pixScore,
+        reproducibilityRate,
         status,
         emitter,
         commentForJury,

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -10,10 +10,7 @@ const CompetenceMark = require('../../domain/models/CompetenceMark');
 function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
   const competenceMarks = competencesMarksDTO.map((competenceMark) => new CompetenceMark(competenceMark));
 
-  // TODO : Aceol ! You can do better than this !
-  const cleanReproducibilityRate = assessmentResultDTO.reproducibilityRate
-    ? _.toNumber(assessmentResultDTO.reproducibilityRate)
-    : null;
+  const reproducibilityRateAsNumber = _.toNumber(assessmentResultDTO.reproducibilityRate) ?? null;
   return new AssessmentResult({
     id: assessmentResultDTO.id,
     assessmentId: assessmentResultDTO.assessmentId,
@@ -25,7 +22,7 @@ function _toDomain({ assessmentResultDTO, competencesMarksDTO }) {
     emitter: assessmentResultDTO.emitter,
     juryId: assessmentResultDTO.juryId,
     pixScore: assessmentResultDTO.pixScore,
-    reproducibilityRate: cleanReproducibilityRate,
+    reproducibilityRate: reproducibilityRateAsNumber,
     competenceMarks: competenceMarks,
   });
 }
@@ -63,7 +60,12 @@ module.exports = {
         assessmentId,
       }).save(null, { require: true, transacting: domainTransaction.knexTransaction });
 
-      return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessmentResult, savedAssessmentResultBookshelf);
+      const savedAssessmentResult = bookshelfToDomainConverter.buildDomainObject(
+        BookshelfAssessmentResult,
+        savedAssessmentResultBookshelf
+      );
+      savedAssessmentResult.reproducibilityRate = _.toNumber(savedAssessmentResult.reproducibilityRate) ?? null;
+      return savedAssessmentResult;
     } catch (error) {
       throw new AssessmentResultNotCreatedError();
     }

--- a/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -1,93 +1,135 @@
 const { expect, knex, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const assessmentResultRepository = require('../../../../lib/infrastructure/repositories/assessment-result-repository');
 const { MissingAssessmentId, AssessmentResultNotCreatedError } = require('../../../../lib/domain/errors');
-const Assessment = require('../../../../lib/domain/models/Assessment');
-const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 
 describe('Integration | Repository | AssessmentResult', function () {
   describe('#save', function () {
-    let assessmentResultToSave;
-    let assessmentResult;
-
-    describe('when entries are corrects', function () {
-      afterEach(function () {
-        return knex('assessment-results').where('id', assessmentResult.id).delete();
-      });
-
-      beforeEach(async function () {
-        const juryId = databaseBuilder.factory.buildUser().id;
-        const assessmentId = databaseBuilder.factory.buildAssessment().id;
-        assessmentResultToSave = domainBuilder.buildAssessmentResult({ juryId, assessmentId });
-        assessmentResultToSave.id = undefined;
-        await databaseBuilder.commit();
-      });
-
-      it('should persist the assessment result in db', async function () {
-        // when
-        assessmentResult = await assessmentResultRepository.save(assessmentResultToSave);
-
-        // then
-        const assessmentResultSaved = await knex('assessment-results').where('id', assessmentResult.id);
-        expect(assessmentResultSaved).to.have.lengthOf(1);
-      });
-
-      it('should save a cancelled assessment result', async function () {
-        // when
-        assessmentResultToSave.status = assessmentResultStatuses.CANCELLED;
-        assessmentResult = await assessmentResultRepository.save(assessmentResultToSave);
-
-        // then
-        const assessmentResultSaved = await knex('assessment-results').where('id', assessmentResult.id);
-        expect(assessmentResultSaved).to.have.lengthOf(1);
-      });
-
-      it('should return the saved assessment result', async function () {
-        // when
-        assessmentResult = await assessmentResultRepository.save(assessmentResultToSave);
-
-        // then
-        expect(assessmentResult).to.be.an.instanceOf(AssessmentResult);
-
-        expect(assessmentResult).to.have.property('id').and.not.to.be.null;
-      });
+    afterEach(function () {
+      return knex('assessment-results').delete();
     });
 
-    describe('when entries are incorrects', function () {
-      beforeEach(async function () {
-        const juryId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildAssessment().id;
-        assessmentResultToSave = domainBuilder.buildAssessmentResult({ juryId });
+    context('when save is successful', function () {
+      it('should return the saved assessment result', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        databaseBuilder.factory.buildUser({ id: 100 });
+        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
         await databaseBuilder.commit();
-      });
+        const assessmentResultToSave = domainBuilder.buildAssessmentResult({
+          pixScore: 33,
+          reproducibilityRate: 29.1,
+          status: AssessmentResult.status.VALIDATED,
+          emitter: 'some-emitter',
+          commentForCandidate: 'candidate',
+          commentForJury: 'jury',
+          commentForOrganization: 'orga',
+          createdAt: new Date('2021-10-29T03:06:00Z'),
+          juryId: 100,
+          assessmentId: 2,
+          competenceMarks: [],
+        });
+        assessmentResultToSave.id = undefined;
 
-      it('should throw a MissingAssessmentId error if assessmentId is null or undefined', async function () {
         // when
-        assessmentResultToSave.assessmentId = null;
+        const savedAssessmentResult = await assessmentResultRepository.save(assessmentResultToSave);
+
+        // then
+        expect(savedAssessmentResult).to.deepEqualInstanceOmitting(assessmentResultToSave, ['id', 'createdAt']);
+      });
+      it('should persist the assessment result in DB', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        databaseBuilder.factory.buildUser({ id: 100 });
+        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        await databaseBuilder.commit();
+        const assessmentResultToSave = domainBuilder.buildAssessmentResult({
+          pixScore: 33,
+          reproducibilityRate: 29.1,
+          status: AssessmentResult.status.VALIDATED,
+          emitter: 'some-emitter',
+          commentForCandidate: 'candidate',
+          commentForJury: 'jury',
+          commentForOrganization: 'orga',
+          createdAt: new Date('2021-10-29T03:06:00Z'),
+          juryId: 100,
+          assessmentId: 2,
+          competenceMarks: [],
+        });
+        assessmentResultToSave.id = undefined;
+
+        // when
+        await assessmentResultRepository.save(assessmentResultToSave);
+
+        // then
+        const actualAssessmentResult = await assessmentResultRepository.getByCertificationCourseId({
+          certificationCourseId: 1,
+        });
+        expect(actualAssessmentResult).to.deepEqualInstanceOmitting(assessmentResultToSave, ['id', 'createdAt']);
+        expect(actualAssessmentResult.id).to.exist;
+        expect(actualAssessmentResult.createdAt).to.exist;
+      });
+    });
+    context('when assessmentId attribute is not valid', function () {
+      it('should throw a MissingAssessmentId error', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        databaseBuilder.factory.buildUser({ id: 100 });
+        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        await databaseBuilder.commit();
+        const assessmentResultToSave = domainBuilder.buildAssessmentResult({
+          pixScore: 33,
+          reproducibilityRate: 29.1,
+          status: AssessmentResult.status.VALIDATED,
+          emitter: 'some-emitter',
+          commentForCandidate: 'candidate',
+          commentForJury: 'jury',
+          commentForOrganization: 'orga',
+          createdAt: new Date('2021-10-29T03:06:00Z'),
+          juryId: 100,
+          assessmentId: null,
+          competenceMarks: [],
+        });
+        assessmentResultToSave.id = undefined;
+
+        // when
         const result = await catchErr(assessmentResultRepository.save)(assessmentResultToSave);
 
         // then
         expect(result).to.be.instanceOf(MissingAssessmentId);
       });
+    });
+    context('when assessment result status attribute is not valid', function () {
+      it('should throw a AssessmentResultNotCreatedError error', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCourse({ id: 1 });
+        databaseBuilder.factory.buildUser({ id: 100 });
+        databaseBuilder.factory.buildAssessment({ id: 2, certificationCourseId: 1 });
+        await databaseBuilder.commit();
+        const assessmentResultToSave = domainBuilder.buildAssessmentResult({
+          pixScore: 33,
+          reproducibilityRate: 29.1,
+          status: 'kikou',
+          emitter: 'some-emitter',
+          commentForCandidate: 'candidate',
+          commentForJury: 'jury',
+          commentForOrganization: 'orga',
+          createdAt: new Date('2021-10-29T03:06:00Z'),
+          juryId: 100,
+          assessmentId: 2,
+          competenceMarks: [],
+        });
+        assessmentResultToSave.id = undefined;
 
-      it('should throw when assessment result status is invalid', async function () {
         // when
-        const result = await catchErr(assessmentResultRepository.save)({ state: 'invalid status' });
-
-        // then
-        expect(result).to.be.instanceOf(Error);
-      });
-
-      it('should throw an error in others cases', async function () {
-        // when
-        const result = await catchErr(assessmentResultRepository.save)({ assessmentId: 1 });
+        const result = await catchErr(assessmentResultRepository.save)(assessmentResultToSave);
 
         // then
         expect(result).to.be.instanceOf(AssessmentResultNotCreatedError);
       });
     });
   });
-
   describe('#findLatestLevelAndPixScoreByAssessmentId', function () {
     context('when assessment has one assessment result', function () {
       it('should return the level and pixScore', async function () {
@@ -98,17 +140,16 @@ describe('Integration | Repository | AssessmentResult', function () {
           level: 5,
           pixScore: 9000,
         });
-        databaseBuilder.factory.buildAssessmentResult({ level: 4, pixScore: 55, commentForJury: 'noise data' });
+        databaseBuilder.factory.buildAssessmentResult({ level: 4, pixScore: 55, commentForJury: 'comment for jury' });
         await databaseBuilder.commit();
 
         // when
-        const { level, pixScore } = await assessmentResultRepository.findLatestLevelAndPixScoreByAssessmentId({
+        const result = await assessmentResultRepository.findLatestLevelAndPixScoreByAssessmentId({
           assessmentId: 1,
         });
 
         // then
-        expect(level).to.equal(5);
-        expect(pixScore).to.equal(9000);
+        expect(result).to.deep.equal({ level: 5, pixScore: 9000 });
       });
     });
     context('when certification course has several assessment results', function () {
@@ -197,7 +238,6 @@ describe('Integration | Repository | AssessmentResult', function () {
       });
     });
   });
-
   describe('#getByCertificationCourseId', function () {
     context('when certification course has one assessment result', function () {
       it('should return the assessment result', async function () {
@@ -308,7 +348,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           commentForCandidate: 'candidates',
           commentForJury: 'jurys',
           commentForOrganization: 'orgas',
-          createdAt: new Date('2020-01-01T22:06:00Z'),
+          createdAt: new Date('1990-01-01T22:06:00Z'),
           juryId: 100,
           assessmentId: 2,
           competenceMarks: [competenceMark2],

--- a/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -161,6 +161,7 @@ describe('Integration | Repository | AssessmentResult', function () {
         const assessmentResultDTO = {
           id: 123,
           pixScore: 500,
+          reproducibilityRate: 25.99,
           status: AssessmentResult.status.VALIDATED,
           emitter: 'PIX_ALGO',
           commentForJury: 'Un commentaire pour le jury',
@@ -191,6 +192,7 @@ describe('Integration | Repository | AssessmentResult', function () {
           commentForJury: assessmentResultDTO.commentForJury,
           juryId: assessmentResultDTO.juryId,
           pixScore: assessmentResultDTO.pixScore,
+          reproducibilityRate: assessmentResultDTO.reproducibilityRate,
           createdAt: assessmentResultDTO.createdAt,
           emitter: assessmentResultDTO.emitter,
           competenceMarks: [

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -5,6 +5,7 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 const buildAssessmentResult = function ({
   id = 123,
   pixScore = 31,
+  reproducibilityRate = 75.5,
   status = assessmentResultStatuses.VALIDATED,
   emitter = 'PIX-ALGO',
   commentForJury = 'Comment for Jury',
@@ -17,6 +18,7 @@ const buildAssessmentResult = function ({
 } = {}) {
   return new AssessmentResult({
     pixScore,
+    reproducibilityRate,
     status,
     emitter,
     commentForJury,
@@ -33,6 +35,7 @@ const buildAssessmentResult = function ({
 buildAssessmentResult.validated = function ({
   id,
   pixScore,
+  reproducibilityRate,
   emitter,
   commentForJury,
   commentForCandidate,
@@ -45,6 +48,7 @@ buildAssessmentResult.validated = function ({
   return buildAssessmentResult({
     id,
     pixScore,
+    reproducibilityRate,
     status: assessmentResultStatuses.VALIDATED,
     emitter,
     commentForJury,
@@ -60,6 +64,7 @@ buildAssessmentResult.validated = function ({
 buildAssessmentResult.rejected = function ({
   id,
   pixScore,
+  reproducibilityRate,
   emitter,
   commentForJury,
   commentForCandidate,
@@ -72,6 +77,7 @@ buildAssessmentResult.rejected = function ({
   return buildAssessmentResult({
     id,
     pixScore,
+    reproducibilityRate,
     status: assessmentResultStatuses.REJECTED,
     emitter,
     commentForJury,
@@ -99,6 +105,7 @@ buildAssessmentResult.error = function ({
   return buildAssessmentResult({
     id,
     pixScore,
+    reproducibilityRate: 0,
     status: assessmentResultStatuses.ERROR,
     emitter,
     commentForJury,
@@ -126,6 +133,7 @@ buildAssessmentResult.started = function ({
   return buildAssessmentResult({
     id,
     pixScore,
+    reproducibilityRate: 0,
     status: Assessment.states.STARTED,
     emitter,
     commentForJury,
@@ -138,9 +146,17 @@ buildAssessmentResult.started = function ({
   });
 };
 
-buildAssessmentResult.notTrustable = function ({ pixScore, status, assessmentId, juryId, emitter } = {}) {
+buildAssessmentResult.notTrustable = function ({
+  pixScore,
+  reproducibilityRate,
+  status,
+  assessmentId,
+  juryId,
+  emitter,
+} = {}) {
   return AssessmentResult.buildNotTrustableAssessmentResult({
     pixScore,
+    reproducibilityRate,
     status,
     assessmentId,
     juryId,
@@ -148,9 +164,17 @@ buildAssessmentResult.notTrustable = function ({ pixScore, status, assessmentId,
   });
 };
 
-buildAssessmentResult.standard = function ({ pixScore, status, assessmentId, juryId, emitter } = {}) {
+buildAssessmentResult.standard = function ({
+  pixScore,
+  reproducibilityRate,
+  status,
+  assessmentId,
+  juryId,
+  emitter,
+} = {}) {
   return AssessmentResult.buildStandardAssessmentResult({
     pixScore,
+    reproducibilityRate,
     status,
     assessmentId,
     juryId,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -40,17 +40,15 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       .resolves(certificationAssessment);
     certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
 
-    const competenceMarkData2 = domainBuilder.buildCompetenceMark();
-    const competenceMarkData1 = domainBuilder.buildCompetenceMark();
-    const nbPix = Symbol('nbPix');
-    const status = Symbol('status');
-    const certificationAssessmentScore = {
-      nbPix,
-      status,
-      competenceMarks: [competenceMarkData1, competenceMarkData2],
+    const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 5 });
+    const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 4 });
+    const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+      nbPix: 9,
+      status: AssessmentResult.status.VALIDATED,
+      competenceMarks: [competenceMark1, competenceMark2],
       percentageCorrectAnswers: 80,
       hasEnoughNonNeutralizedChallengesToBeTrusted: true,
-    };
+    });
     scoringCertificationService.calculateCertificationAssessmentScore
       .withArgs({ certificationAssessment, continueOnError: false })
       .resolves(certificationAssessmentScore);
@@ -59,8 +57,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       id: undefined,
       commentForJury: 'Computed',
       emitter: 'PIX-ALGO-NEUTRALIZATION',
-      pixScore: nbPix,
-      status: status,
+      pixScore: 9,
+      reproducibilityRate: 80,
+      status: AssessmentResult.status.VALIDATED,
       assessmentId: 123,
       juryId: 7,
     });
@@ -83,10 +82,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
     // then
     expect(assessmentResultRepository.save).to.have.been.calledWith(assessmentResultToBeSaved);
-    competenceMarkData1.assessmentResultId = savedAssessmentResult.id;
-    competenceMarkData2.assessmentResultId = savedAssessmentResult.id;
-    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData1);
-    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData2);
+    competenceMark1.assessmentResultId = savedAssessmentResult.id;
+    competenceMark2.assessmentResultId = savedAssessmentResult.id;
+    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMark1);
+    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMark2);
     expect(certificationCourseRepository.update).to.have.been.calledWithExactly(expectedSaveCertificationCourse);
   });
 
@@ -120,11 +119,11 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         .withArgs({ certificationCourseId: 789 })
         .resolves(certificationAssessment);
       certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
-      const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
-      const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
+      const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
       const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
         status: AssessmentResult.status.VALIDATED,
-        competenceMarks: [competenceMarkData1, competenceMarkData2],
+        competenceMarks: [competenceMark1, competenceMark2],
         percentageCorrectAnswers: 80,
         hasEnoughNonNeutralizedChallengesToBeTrusted: false,
       });
@@ -135,6 +134,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.notTrustable({
         emitter: 'PIX-ALGO-NEUTRALIZATION',
         pixScore: 30,
+        reproducibilityRate: 80,
         status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 7,
@@ -193,11 +193,11 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         .withArgs({ certificationCourseId: 789 })
         .resolves(certificationAssessment);
       certificationCourseRepository.get.withArgs(789).resolves(certificationCourse);
-      const competenceMarkData2 = domainBuilder.buildCompetenceMark({ score: 12 });
-      const competenceMarkData1 = domainBuilder.buildCompetenceMark({ score: 18 });
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ score: 12 });
+      const competenceMark1 = domainBuilder.buildCompetenceMark({ score: 18 });
       const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
         status: AssessmentResult.status.VALIDATED,
-        competenceMarks: [competenceMarkData1, competenceMarkData2],
+        competenceMarks: [competenceMark1, competenceMark2],
         percentageCorrectAnswers: 80,
         hasEnoughNonNeutralizedChallengesToBeTrusted: true,
       });
@@ -208,6 +208,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       const assessmentResultToBeSaved = domainBuilder.buildAssessmentResult.standard({
         emitter: 'PIX-ALGO-NEUTRALIZATION',
         pixScore: 30,
+        reproducibilityRate: 80,
         status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 7,
@@ -255,11 +256,11 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       .resolves(certificationAssessment);
     certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
 
-    const certificationAssessmentScore = {
+    const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
       competenceMarks: [],
       percentageCorrectAnswers: 80,
       hasEnoughNonNeutralizedChallengesToBeTrusted: true,
-    };
+    });
     scoringCertificationService.calculateCertificationAssessmentScore
       .withArgs({ certificationAssessment, continueOnError: false })
       .resolves(certificationAssessmentScore);
@@ -323,6 +324,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       emitter: 'PIX-ALGO-NEUTRALIZATION',
       commentForJury: 'Oopsie',
       pixScore: 0,
+      reproducibilityRate: 0,
       status: 'error',
       assessmentId: 123,
       juryId: 7,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -169,11 +169,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
       const assessmentResultId = 99;
       let certificationCourse;
       let assessmentResult;
-      let competenceMarkData1;
-      let competenceMarkData2;
+      let competenceMark1;
+      let competenceMark2;
       let savedAssessmentResult;
-      let nbPix;
-      let status;
       let certificationAssessmentScore;
 
       beforeEach(function () {
@@ -182,17 +180,15 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           completedAt: null,
         });
         assessmentResult = Symbol('AssessmentResult');
-        competenceMarkData1 = domainBuilder.buildCompetenceMark({ assessmentResultId });
-        competenceMarkData2 = domainBuilder.buildCompetenceMark({ assessmentResultId });
+        competenceMark1 = domainBuilder.buildCompetenceMark({ assessmentResultId, score: 5 });
+        competenceMark2 = domainBuilder.buildCompetenceMark({ assessmentResultId, score: 4 });
         savedAssessmentResult = { id: assessmentResultId };
-        nbPix = Symbol('nbPix');
-        status = Symbol('status');
-        certificationAssessmentScore = {
-          nbPix,
-          status,
-          competenceMarks: [competenceMarkData1, competenceMarkData2],
+        certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScore({
+          nbPix: 9,
+          status: AssessmentResult.status.VALIDATED,
+          competenceMarks: [competenceMark1, competenceMark2],
           percentageCorrectAnswers: 80,
-        };
+        });
 
         sinon.stub(AssessmentResult, 'buildStandardAssessmentResult').returns(assessmentResult);
         assessmentResultRepository.save.resolves(savedAssessmentResult);
@@ -218,6 +214,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         // then
         expect(AssessmentResult.buildStandardAssessmentResult).to.have.been.calledWithExactly({
           pixScore: certificationAssessmentScore.nbPix,
+          reproducibilityRate: certificationAssessmentScore.percentageCorrectAnswers,
           status: certificationAssessmentScore.status,
           assessmentId: certificationAssessment.id,
           emitter: 'PIX-ALGO',

--- a/api/tests/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/unit/domain/models/AssessmentResult_test.js
@@ -26,6 +26,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
         commentForJury: 'message for jury',
         status: AssessmentResult.status.ERROR,
         pixScore: 0,
+        reproducibilityRate: 0,
         competenceMarks: [],
       });
       expectedAssessmentResult.id = undefined;
@@ -41,6 +42,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
       // when
       const actualAssessmentResult = AssessmentResult.buildStandardAssessmentResult({
         pixScore: 55,
+        reproducibilityRate: 90,
         status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 456,
@@ -55,6 +57,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
         commentForJury: 'Computed',
         status: AssessmentResult.status.VALIDATED,
         pixScore: 55,
+        reproducibilityRate: 90,
         competenceMarks: [],
       });
       expectedAssessmentResult.id = undefined;
@@ -70,6 +73,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
       // when
       const actualAssessmentResult = AssessmentResult.buildNotTrustableAssessmentResult({
         pixScore: 55,
+        reproducibilityRate: 50.25,
         status: AssessmentResult.status.VALIDATED,
         assessmentId: 123,
         juryId: 456,
@@ -84,6 +88,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
         commentForJury: 'Computed',
         status: AssessmentResult.status.VALIDATED,
         pixScore: 55,
+        reproducibilityRate: 50.25,
         competenceMarks: [],
         commentForCandidate:
           'Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification' +
@@ -122,6 +127,7 @@ describe('Unit | Domain | Models | AssessmentResult', function () {
       expectedAssessmentResult.emitter = undefined;
       expectedAssessmentResult.juryId = undefined;
       expectedAssessmentResult.pixScore = undefined;
+      expectedAssessmentResult.reproducibilityRate = undefined;
       expect(actualAssessmentResult).to.deepEqualInstance(expectedAssessmentResult);
     });
   });

--- a/api/tests/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/unit/domain/models/AssessmentResult_test.js
@@ -1,41 +1,8 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
-const BookshelfAssessmentResults = require('../../../../lib/infrastructure/orm-models/AssessmentResult');
+const { expect, domainBuilder } = require('../../../test-helper');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 
-describe('Unit | Domain | Models | BookshelfAssessmentResult', function () {
-  describe('validation', function () {
-    let rawData;
-
-    beforeEach(function () {
-      rawData = {
-        emitter: '',
-        status: null,
-      };
-    });
-
-    describe('the status field', function () {
-      it('should only accept specific values', function () {
-        // given
-        rawData.status = 'not_a_correct_status';
-        const certification = new BookshelfAssessmentResults(rawData);
-
-        // when
-        const promise = certification.save();
-
-        // then
-        return promise
-          .then(() => {
-            sinon.assert.fail('Cannot succeed');
-          })
-          .catch((err) => {
-            const status = err.data['status'];
-            expect(status).to.exist.and.to.deep.equal(["Le status de la certification n'est pas valide"]);
-          });
-      });
-    });
-  });
-
+describe('Unit | Domain | Models | AssessmentResult', function () {
   describe('#buildAlgoErrorResult', function () {
     it('should return an algo error AssessmentResult', function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Il est pénible de devoir, et dans le code et dans les requêtes Metabase par exemple, se retaper le calcul du taux de repro d'une certif. Cela demande des jointures et des calculs redondants. Ce taux de repro est calculé lors du scoring et du rescoring.

## :robot: Solution
Stocker ce taux de repro dans la table `assessment-result`.

## :rainbow: Remarques
- Cette PR ne rétro-calcule par les taux de repro, sera indiqué `null` dans le champ pour les `assessment-results` avant la mise en prod de cette PR.
- Taux de repro fixé à 0 en cas d'erreur lors du scoring
- Stockage de la valeur pourcentage telle quelle (donc 90,25 % est stockée en type decimal 90,25, et non pas 0,9025). Ce choix a été fait car ça faisait moins de changements à faire dans le code existant.
- Cette PR se charge de l'écriture de la donnée, mais pas de son exploitation. L'exploitation est un poil plus complexe car tous les assessment-results n'auront pas en leur sein le taux de repro. Vaut mieux le faire dans une deuxième PR car il faut gérer le fait de calculer le taux de repro si besoin.

## :100: Pour tester
Passer une certif jusqu'à son scoring (dernière question répondue) puis consulter dans la DB que l'assessment-result porte le taux de repro.
Finaliser la session, ajouter un signalement susceptible de changer le taux de repro (neutralisation d'épreuves) et vérifier que le nouvel assessment result contienne bien le nouveau taux de repro.
