### PR TITLE
[TECH] Limiter les watchers nodemon (PIX-4745)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -138,6 +138,9 @@
     "test:lint": "npm test && npm run lint"
   },
   "nodemonConfig": {
-    "signal": "SIGTERM"
+    "signal": "SIGTERM",
+    "watch": ["lib", "bin/www", "server.js", "package.json", "db", "translations"],
+    "ignore": ["db/seeds", "db/migrations", "db/database-builder"],
+    "ext": "js"
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
En developpement, nodemon surveille tout les fichiers d’API
 
note: rien à tester sur les RA/Recette/production

## :robot: Solution
Limiter aux fichiers js dans "lib", "bin/www", "server.js"

## :rainbow: Remarques
![Screenshot 2022-04-08 at 12 06 37](https://user-images.githubusercontent.com/3769147/162420639-d52584b6-14f2-4ddd-98ba-59b43a8ddde6.png)


## :100: Pour tester
Lancer le watcher, constater que moins de fichiers sont en watch via ` npm run start:watch -- --verbose` 
constater que "ca va plus vite"
