### PR TITLE
[BUGFIX] Pagination des tutoriels : Gérer la suppression d'une page

### DIFF
--- a/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/recommended.hbs
@@ -1,4 +1,4 @@
-{{#if @model}}
+{{#if @model.meta.rowCount}}
   <div class="user-tutorials-content-v2__container">
     <Tutorials::Cards @tutorials={{@model}} />
     <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} />

--- a/mon-pix/app/templates/user-tutorials-v2/saved.hbs
+++ b/mon-pix/app/templates/user-tutorials-v2/saved.hbs
@@ -1,4 +1,4 @@
-{{#if @model}}
+{{#if @model.meta.rowCount}}
   <div class="user-tutorials-content-v2__container">
     <Tutorials::Cards @tutorials={{@model}} @afterRemove={{this.refresh}} />
     <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} />

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.194.0",
+      "version": "3.195.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/pix-ui": "^13.4.2",
+        "@1024pix/pix-ui": "^13.5.0",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.2.tgz",
-      "integrity": "sha512-pk+slG8oPbgzjSfh0WdfkcT3M7FZ4VxZ4xJUFKA7VpumRVfX2P2VjauX4FdMf0CDx+YvA9e8y7NbmFbp1drHog==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.5.0.tgz",
+      "integrity": "sha512-HXevWYFqcOdCl9QfblYUONsjK/zfpyf+TF6A4pI8P72UOnYeA36ehV9sXrLsqrAniz0GgI+ktOMJmXq8IaxFRw==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -38923,9 +38923,9 @@
   },
   "dependencies": {
     "@1024pix/pix-ui": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.4.2.tgz",
-      "integrity": "sha512-pk+slG8oPbgzjSfh0WdfkcT3M7FZ4VxZ4xJUFKA7VpumRVfX2P2VjauX4FdMf0CDx+YvA9e8y7NbmFbp1drHog==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.5.0.tgz",
+      "integrity": "sha512-HXevWYFqcOdCl9QfblYUONsjK/zfpyf+TF6A4pI8P72UOnYeA36ehV9sXrLsqrAniz0GgI+ktOMJmXq8IaxFRw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
-    "@1024pix/pix-ui": "^13.4.2",
+    "@1024pix/pix-ui": "^13.5.0",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",


### PR DESCRIPTION
## :unicorn: Problème

Sur la page "tutos enregistrés", à partir du moment où on a plusieurs pages, si on "supprime" tous les éléments de la dernière page, on se retrouve avec le message de liste vide à tort.

## :robot: Solution

 - Mettre à jour pix-ui pour bénéficier du fix du composant de pagination : https://github.com/1024pix/pix-ui/pull/209
 - Afficher le message de liste vide en se basant sur les informations de pagination renvoyées par l'api (la variable `rowCount`)

## :rainbow: Remarques

N/A

## :100: Pour tester

 - Enregistrer au moins 11 tutos.
 - Se rendre sur la page "tutos enregistrés"
 - Aller sur la dernière page
 - Supprimer tous les éléments présents sur la page

On doit revenir automatiquement sur la page précédente.