### PR TITLE
[TECH] Disposer d'un mot de passe par défaut sur les données de seed.

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -14,12 +14,13 @@ const buildMembership = require('./build-membership');
 const buildCertificationCenter = require('./build-certification-center');
 const buildCertificationCenterMembership = require('./build-certification-center-membership');
 
+const { DEFAULT_PASSWORD } = require('../../seeds/data/users-builder');
 const PIX_MASTER_ROLE_ID = 1;
 
 function _buildPixAuthenticationMethod({
   id = databaseBuffer.getNextId(),
   userId,
-  rawPassword = 'Password123',
+  rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword,
   createdAt,
   updatedAt,
@@ -116,7 +117,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   hasSeenAssessmentInstructions = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-  rawPassword = 'Password123',
+  rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
 } = {}) {
   email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
@@ -173,7 +174,7 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
   createdAt = new Date(),
   updatedAt = new Date(),
 
-  rawPassword = 'Password123',
+  rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
 } = {}) {
   email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
@@ -230,7 +231,7 @@ buildUser.withMembership = function buildUserWithMemberships({
   updatedAt = new Date(),
   organizationRole = Membership.roles.ADMIN,
   organizationId = null,
-  rawPassword = 'Password123',
+  rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
 } = {}) {
   email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;

--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -113,7 +113,7 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   });
 
   // A candidate that has started the session
-  const userId = databaseBuilder.factory.buildUser().id;
+  const userId = databaseBuilder.factory.buildUser.withRawPassword().id;
   const candidateWithStartedTest = {
     firstName: 'Jean-Pierre',
     lastName: 'Acommencé',


### PR DESCRIPTION
## :unicorn: Problème
Les comptes utilisateurs de test manuel (seeds) sont associés à des mots de passe.
Il existe plusieurs mot de passe:
- `pix123`
- `Password123`

Lors de la connexion, cela peut demander plusieurs essais de trouver le bon.

## :robot: Solution
Utiliser le même mot de passe par défaut partout, vertsion courte, à savoir `pix123`.

Pour l'instant, il est stocké dans le fichier de seed et importé depuis le builder, c'est pas top.
Mieux vaudrait stocker le mot de passe par défaut dans le builder..

## :rainbow: Remarques
Ajout d'une méthode de connexion manquante lors de la création de compte.
## :100: Pour tester
Sur [PixApp](https://app-pr4306.review.pix.fr/), se connecter avec `billy.thekid106013@example.net`, mot de passe  `pix123`
Vérifier qu'on arrive sur la page de profil
