### PR TITLE
[FEATURE] Afficher un message d'erreur si un prescrit à déjà une participation à une campagne (PIX-4674).

### DIFF
--- a/api/tests/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipant_test.js
@@ -15,12 +15,15 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           multipleSendings: true,
           idPixLabel: null,
         });
-        const schoolingRegistrationId = 12;
+        const organizationLearnerId = 12;
         const userIdentity = { id: 13 };
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          schoolingRegistrationId,
+          organizationLearner: {
+            id: organizationLearnerId,
+            hasParticipated: false,
+          },
         });
         campaignParticipant.start({ participantExternalId: null });
 
@@ -28,7 +31,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           campaignId: campaignToStartParticipation.id,
           status: 'STARTED',
           userId: userIdentity.id,
-          schoolingRegistrationId,
+          schoolingRegistrationId: organizationLearnerId,
         });
       });
 
@@ -38,12 +41,15 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           multipleSendings: true,
           idPixLabel: null,
         });
-        const schoolingRegistrationId = 12;
+        const organizationLearnerId = 12;
         const userIdentity = { id: 13 };
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          schoolingRegistrationId,
+          organizationLearner: {
+            id: organizationLearnerId,
+            hasParticipated: false,
+          },
         });
         campaignParticipant.start({ participantExternalId: null });
 
@@ -70,6 +76,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             campaignToStartParticipation,
             previousCampaignParticipation,
             userIdentity,
+            organizationLearner: {
+              id: null,
+              hasParticipated: false,
+            },
           });
           campaignParticipant.start({ participantExternalId: null });
 
@@ -97,6 +107,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
               status: 'SHARED',
               validatedSkillsCount: 2,
             },
+            organizationLearner: {
+              id: null,
+              hasParticipated: false,
+            },
           });
           const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
@@ -121,6 +135,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
               status: 'SHARED',
               validatedSkillsCount: 3,
             },
+            organizationLearner: {
+              id: null,
+              hasParticipated: false,
+            },
           });
           const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
@@ -139,13 +157,16 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           idPixLabel: null,
           skillCount: 0,
         });
-        const schoolingRegistrationId = 12;
+        const organizationLearnerId = 12;
         const userIdentity = { id: 13 };
         const participantExternalId = 'some participant external id';
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          schoolingRegistrationId,
+          organizationLearner: {
+            id: organizationLearnerId,
+            hasParticipated: false,
+          },
         });
         campaignParticipant.start({ participantExternalId });
 
@@ -153,7 +174,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           campaignId: campaignToStartParticipation.id,
           status: 'TO_SHARE',
           userId: userIdentity.id,
-          schoolingRegistrationId,
+          schoolingRegistrationId: organizationLearnerId,
         });
       });
 
@@ -166,6 +187,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
         campaignParticipant.start({ participantExternalId: null });
 
@@ -185,6 +210,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             campaignToStartParticipation,
             previousCampaignParticipation,
             userIdentity,
+            organizationLearner: {
+              id: null,
+              hasParticipated: false,
+            },
           });
 
           expect(() => campaignParticipant.start({ participantExternalId: null })).to.not.throw();
@@ -207,7 +236,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation: restrictedCampaign,
           userIdentity,
-          schoolingRegistrationId: null,
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
         const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
@@ -219,7 +251,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation: restrictedCampaign,
           userIdentity,
-          schoolingRegistrationId: 1,
+          organizationLearner: {
+            id: 1,
+            hasParticipated: false,
+          },
         });
 
         campaignParticipant.start({ participantExternalId: null });
@@ -241,45 +276,54 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
       });
 
       context('when the user is not associated yet', function () {
-        it('creates a new schooling registration', function () {
+        it('creates a new organizationLearner', function () {
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation: campaign,
             userIdentity,
-            schoolingRegistrationId: null,
+            organizationLearner: {
+              id: null,
+              hasParticipated: false,
+            },
           });
 
           campaignParticipant.start({ participantExternalId: null });
 
-          expect(campaignParticipant.schoolingRegistration.userId).to.equal(userIdentity.id);
-          expect(campaignParticipant.schoolingRegistration.organizationId).to.equal(campaign.organizationId);
-          expect(campaignParticipant.schoolingRegistration.firstName).to.equal(userIdentity.firstName);
-          expect(campaignParticipant.schoolingRegistration.lastName).to.equal(userIdentity.lastName);
+          expect(campaignParticipant.organizationLearner.userId).to.equal(userIdentity.id);
+          expect(campaignParticipant.organizationLearner.organizationId).to.equal(campaign.organizationId);
+          expect(campaignParticipant.organizationLearner.firstName).to.equal(userIdentity.firstName);
+          expect(campaignParticipant.organizationLearner.lastName).to.equal(userIdentity.lastName);
         });
       });
 
       context('when the user is already associated', function () {
-        it('use the existed schooling registration', function () {
+        it('use the existing organizationLearner', function () {
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation: campaign,
             userIdentity,
-            schoolingRegistrationId: 77,
+            organizationLearner: {
+              id: 77,
+              hasParticipated: false,
+            },
           });
 
           campaignParticipant.start({ participantExternalId: null });
 
-          expect(campaignParticipant.schoolingRegistrationId).to.equal(77);
+          expect(campaignParticipant.organizationLearnerId).to.equal(77);
         });
 
-        it('does not create new schooling registration', function () {
+        it('does not create new organizationLearner', function () {
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation: campaign,
             userIdentity,
-            schoolingRegistrationId: 77,
+            organizationLearner: {
+              id: 77,
+              hasParticipated: false,
+            },
           });
 
           campaignParticipant.start({ participantExternalId: null });
 
-          expect(campaignParticipant.schoolingRegistration).to.be.null;
+          expect(campaignParticipant.organizationLearner).to.be.undefined;
         });
       });
     });
@@ -296,6 +340,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
 
         const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
@@ -307,6 +355,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
 
         const expectedParticipantExternalId = 'YvoLol';
@@ -330,6 +382,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             participantExternalId: expectedParticipantExternalId,
           },
           userIdentity,
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
 
         campaignParticipant.start({ participantExternalId: null });
@@ -350,6 +406,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           campaignToStartParticipation,
           previousCampaignParticipation,
           userIdentity,
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
         campaignParticipant.start({ participantExternalId: null });
 
@@ -367,6 +427,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           userIdentity,
           previousCampaignParticipation: {
             status: 'STARTED',
+          },
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
           },
         });
         const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
@@ -391,6 +455,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             status: 'SHARED',
             isDeleted: true,
           },
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
         const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
@@ -409,6 +477,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
       const campaignParticipant = new CampaignParticipant({
         campaignToStartParticipation,
         userIdentity,
+        organizationLearner: {
+          id: null,
+          hasParticipated: false,
+        },
       });
       const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
@@ -428,6 +500,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           campaignToStartParticipation,
           userIdentity,
           previousCampaignParticipation: { id: 1, status: 'SHARED' },
+          organizationLearner: {
+            id: null,
+            hasParticipated: false,
+          },
         });
         const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
 
@@ -436,6 +512,26 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           `User ${userIdentity.id} has already a campaign participation with campaign ${campaignToStartParticipation.id}`
         );
       });
+    });
+  });
+
+  context('when the organization learner has already participated', function () {
+    it('throws an error', async function () {
+      const campaignToStartParticipation = domainBuilder.buildCampaignToStartParticipation({ idPixLabel: null });
+      const organizationLearnerId = 12;
+      const userIdentity = { id: 13 };
+      const campaignParticipant = new CampaignParticipant({
+        campaignToStartParticipation,
+        userIdentity,
+        organizationLearner: {
+          id: organizationLearnerId,
+          hasParticipated: true,
+        },
+      });
+      const error = await catchErr(campaignParticipant.start, campaignParticipant)({ participantExternalId: null });
+
+      expect(error).to.be.an.instanceof(AlreadyExistingCampaignParticipationError);
+      expect(error.message).to.equal('ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED');
     });
   });
 });

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -22,7 +22,11 @@ describe('Unit | UseCase | start-campaign-participation', function () {
     // given
     const domainTransaction = Symbol('transaction');
     const campaignToStartParticipation = domainBuilder.buildCampaignToStartParticipation();
-    const campaignParticipant = new CampaignParticipant({ campaignToStartParticipation, userIdentity: { id: userId } });
+    const campaignParticipant = new CampaignParticipant({
+      campaignToStartParticipation,
+      organizationLearner: { id: null, hasParticipated: false },
+      userIdentity: { id: userId },
+    });
     const campaignParticipationAttributes = { campaignId: 12, participantExternalId: 'YvoLoL' };
     const expectedCampaignParticipation = domainBuilder.buildCampaignParticipation({ id: 12 });
 

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -97,6 +97,7 @@ Router.map(function () {
       this.route('tutorial', { path: '/didacticiel' });
       this.route('skill-review', { path: '/resultats' });
     });
+    this.route('existing-participation', { path: '/participation-existante' });
   });
 
   this.route('competences', { path: '/competences/:competence_id' }, function () {

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -54,6 +54,9 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
         this.campaignStorage.set(campaign.code, 'participantExternalId', null);
         return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
       }
+      if (error.detail === 'ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED') {
+        return this.replaceWith('campaigns.existing-participation', campaign.code);
+      }
 
       throw err;
     }

--- a/mon-pix/app/routes/campaigns/existing-participation.js
+++ b/mon-pix/app/routes/campaigns/existing-participation.js
@@ -1,0 +1,16 @@
+import Route from '@ember/routing/route';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
+
+export default class ExistingParticipation extends Route.extend(SecuredRouteMixin) {
+  @service store;
+  @service currentUser;
+
+  model() {
+    const { code } = this.paramsFor('campaigns');
+    return this.store.queryRecord('schooling-registration-user-association', {
+      userId: this.currentUser.user.id,
+      campaignCode: code,
+    });
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -139,6 +139,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/personal-information';
 @import 'pages/connection-methods';
 @import 'pages/language';
+@import 'pages/existing-campagne';
 
 * {
   box-sizing: border-box;

--- a/mon-pix/app/styles/pages/_existing-campagne.scss
+++ b/mon-pix/app/styles/pages/_existing-campagne.scss
@@ -1,0 +1,14 @@
+.inaccessible-campaign-message {
+  padding: 0 32px;
+  display: inline;
+
+  &__username {
+    font-weight: $font-bold;
+    padding: 0;
+  }
+}
+
+.inaccessible-campaign-info {
+  margin-top: 6px;
+  padding: 0 32px;
+}

--- a/mon-pix/app/templates/campaigns/existing-participation.hbs
+++ b/mon-pix/app/templates/campaigns/existing-participation.hbs
@@ -1,0 +1,9 @@
+<InaccessibleCampaign>
+  <span class="inaccessible-campaign-message">
+    <span>{{t "pages.campaign.errors.existing-participation"}}</span>
+    <span class="inaccessible-campaign-message__username">{{this.model.firstName}} {{this.model.lastName}}.</span>
+  </span>
+  <span class="inaccessible-campaign-info">
+    {{t "pages.campaign.errors.existing-participation-info"}}
+  </span>
+</InaccessibleCampaign>

--- a/mon-pix/tests/acceptance/existing-participation-test.js
+++ b/mon-pix/tests/acceptance/existing-participation-test.js
@@ -1,0 +1,36 @@
+import { describe, it, beforeEach } from 'mocha';
+import { visit } from '@ember/test-helpers';
+import { expect } from 'chai';
+import { authenticateByEmail } from '../helpers/authentication';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../helpers/setup-intl';
+import { contains } from '../helpers/contains';
+
+describe('Acceptance | Existing Participation', function () {
+  setupApplicationTest();
+  setupMirage();
+  setupIntl();
+
+  describe('Authenticated cases as simple user', function () {
+    beforeEach(async function () {
+      const user = server.create('user', 'withEmail');
+      server.create('campaign', { code: '123' });
+      server.create('schooling-registration-user-association', {
+        firstName: 'First',
+        lastName: 'Last',
+        campaignCode: '123',
+      });
+      await authenticateByEmail(user);
+    });
+
+    it('displays an error message', async function () {
+      await visit('/campagnes/123/participation-existante');
+      expect(contains("Le parcours n'est pas accessible pour vous.")).to.exist;
+      expect(contains('Il y a déjà une participation associée au nom de')).to.exist;
+      expect(contains('First Last.')).to.exist;
+      expect(contains("Rapprochez-vous de votre enseignant pour qu'il supprime votre participation dans Pix Orga.")).to
+        .exist;
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -132,6 +132,22 @@ describe('Unit | Route | Entrance', function () {
       sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
     });
 
+    it('should abort campaign participation and redirect to already participated', async function () {
+      //given
+      campaign = EmberObject.create({
+        code: 'SOMECODE',
+      });
+      route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(false);
+      campaignParticipationStub.save.rejects({
+        errors: [{ status: 412, detail: 'ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED' }],
+      });
+
+      //when
+      await route.afterModel(campaign);
+
+      sinon.assert.calledWith(route.replaceWith, 'campaigns.existing-participation', campaign.code);
+    });
+
     it('should redirect to profiles-collection when campaign is of type PROFILES COLLECTION', async function () {
       //given
       campaign = EmberObject.create({

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -133,7 +133,10 @@
     "campaign": {
       "errors": {
         "no-longer-accessible": "Oops, the requested page is not available.",
-        "not-accessible": "Oops, the requested page is not available."
+        "not-accessible": "Oops, the requested page is not available.",
+        "existing-participation": "You cannot take this customised test. There is already a participation associated with the name ",
+        "existing-participation-info": "Please contact your teacher so that they can delete your previous participation in Pix Orga."
+
       }
     },
     "campaign-landing": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -133,7 +133,9 @@
     "campaign": {
       "errors": {
         "no-longer-accessible": "Oups, la page demandée n’est plus accessible.",
-        "not-accessible": "Oups, la page demandée n’est pas accessible."
+        "not-accessible": "Oups, la page demandée n’est pas accessible.",
+        "existing-participation": "Le parcours n'est pas accessible pour vous. Il y a déjà une participation associée au nom de ",
+        "existing-participation-info": "Rapprochez-vous de votre enseignant pour qu'il supprime votre participation dans Pix Orga."
       }
     },
     "campaign-landing": {


### PR DESCRIPTION
## :unicorn: Problème
En cas de dissociation un participant peut ne pas avoir de participation à une campagne, mais le prescrit peut être associé à une participation.

## :robot: Solution
Vérifier que le prescrit n'a pas de participation pour la campagne.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Participer à la campagne SCOBADGE1 en tant que first last 10/10/2010 avec un premier compte.
Dissocier l'utilisateur et le prescrit.
Participer à la campagne SCOBADGE1 en tant que first last 10/10/2010 avec un second compte.
Cette fois l'application invite l'utilisateur à contacter le prescripteur pour régler le problème.
 
1.
  Je suis A je participe à la campagne C en tant que prescrit P
  On me dissocie de P
  On supprime ma participation
  Je suis A je participe à la campagne C en tant que prescrit P2
  Je peux participer à la campagne 
  _Impossible on ne me laisse pas me réconcilié et je reprend ma participation_


2.
  Je suis A je participe à la campagne C en tant que prescrit P
  On me dissocie de P
  On supprime ma participation
  Je suis B je participe à la campagne C en tant que prescrit P
  Je peux participer à la campagne
  OK

3.
  Je suis A je participe à la campagne C en tant que prescrit P
  On me dissocie de P
  Je suis B je participe à la campagne C en tant que prescrit P
  Je ne peux pas participer à la campagne => faut supprimer la participation 
  OK

4.
  Je suis A je participe à la campagne C en tant que prescrit P
  On me dissocie de P
  Je suis A je participe à la campagne C en tant que prescrit P2
 J’arrive sur mes résultats / ma participation
  _Impossible on ne me laisse pas me réconcilié et je reprend ma participation_