### PR TITLE
[TECH] Supprimer le support des clés sans préfixe dans redis (PIX-4693)

### DIFF
--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -24,26 +24,12 @@ module.exports = class RedisClient {
       { retryCount: 0 }
     );
 
+    this.get = promisify(this._wrapWithPrefix(this._client.get)).bind(this._client);
     this.set = promisify(this._wrapWithPrefix(this._client.set)).bind(this._client);
+    this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);
     this.ping = promisify(this._client.ping).bind(this._client);
     this.flushall = promisify(this._client.flushall).bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
-  }
-
-  async del(key, ...args) {
-    await promisify(this._client.del).call(this._client, this._prefix + key, ...args);
-    // TODO: this should be useless after 7 days in production
-    await promisify(this._client.del).call(this._client, key.replace(/^.*:/, ''), ...args);
-  }
-
-  async get(key, ...args) {
-    const promisifiedGet = promisify(this._client.get);
-    let value = await promisifiedGet.call(this._client, this._prefix + key, ...args);
-    if (!value) {
-      // TODO: this should be useless after 7 days in production
-      value = await promisifiedGet.call(this._client, key.replace(/^.*:/, ''), ...args);
-    }
-    return value;
   }
 
   _wrapWithPrefix(fn) {

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -45,32 +45,5 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
       await redisClient1.del('key');
       await redisClient2.del('key');
     });
-
-    it('should allow retrieve without prefix a value with a prefix', async function () {
-      // given
-      const value = new Date().toISOString();
-      const redisClientWithoutPrefix = new RedisClient(process.env.REDIS_URL);
-      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
-      await redisClientWithoutPrefix.set('key', value);
-
-      // when / then
-      expect(await redisClientWithPrefix.get('storage-prefix:key')).to.equal(value);
-      await redisClientWithPrefix.del('storage-prefix:key');
-    });
-
-    it('should allow delete a value without prefix', async function () {
-      // given
-      const value = new Date().toISOString();
-      const redisClientWithoutPrefix = new RedisClient(process.env.REDIS_URL);
-      const redisClientWithPrefix = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
-      await redisClientWithoutPrefix.set('key', value);
-
-      // when
-      await redisClientWithPrefix.del('storage-prefix:key');
-
-      // then
-      expect(await redisClientWithPrefix.get('storage-prefix:key')).to.be.null;
-      await redisClientWithPrefix.del('storage-prefix:key');
-    });
   }
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'ajout de la ségrégation des usages dans redis : https://github.com/1024pix/pix/pull/4240, des cas de replis ont été ajouté pour couvrir les 2 cas (avec le préfix et sans). Cependant maintenant, il n'est plus nécessaire de couvrir l'ancien fonctionnement. 

## :robot: Solution
Supprimer le code permettant de couvrir les 2 cas

## :rainbow: Remarques
Le code qui ajoutait la gestion temporaire des clés sans préfixe a été mis en production dans la version 3.193.0 le 4/4/2022. Ce code devait être en production pendant au moins 7 jours pour couvrir la durée de vie des refresh token qui est de 7j, le délai est donc couvert.

## :100: Pour tester
- Cloner la branche en local
- Vérifier le bon fonctionnement des tests du `RedisClient` en ayant au préalable mis la variable d'environnement `REDIS_TEST_URL`. 