### PR TITLE
[FEATURE] Ajout d'un texte RGPD dans la liste des participations d'une campagne dans pix admin (PIX-4651).

### DIFF
--- a/admin/app/components/campaigns/participations-section.hbs
+++ b/admin/app/components/campaigns/participations-section.hbs
@@ -1,7 +1,10 @@
 <section class="page-section mb_10">
-  <header class="page-section__header">
-    <h2 class="page-section__title">Liste des participations</h2>
+  <header>
+    <h2 class="participations-section__title">Liste des participations</h2>
   </header>
+  <p class="participations-section__subtitle">
+    Attention toute modification sur une participation nécessite un accord écrit du prescripteur.
+  </p>
   <div class="content-text content-text--small">
     <div class="table-admin">
       <table>

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -78,3 +78,4 @@
 @import 'components/target-profiles/stage-form';
 @import 'components/badges/badge';
 @import 'components/campaigns/update';
+@import 'components/campaigns/participations-section';

--- a/admin/app/styles/components/campaigns/participations-section.scss
+++ b/admin/app/styles/components/campaigns/participations-section.scss
@@ -1,0 +1,8 @@
+.participations-section__title {
+  margin-bottom: 0;
+}
+
+.participations-section__subtitle {
+  font-size: 0.875rem;
+  color: $grey-50;
+}


### PR DESCRIPTION
## :unicorn: Problème
La fonctionnalité de modification d’un identifiant externe dans la liste des participants manque une explication RGPD lorsque l'on a envie de modifier une participation

## :robot: Solution
Ajout d’un texte "Attention toute modification sur une participation nécessite un accord écrit du prescripteur." en dessous du titre et avant le tableaux des participations. 

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix Admin , sélectionner une organisation puis une campagne 
constater que le texte "Attention toute modification sur une participation nécessite un accord écrit du prescripteur." est bien affiché après le titre et avant la liste des participations.