### PR TITLE
[TECH] Gerer les volets Pix Edu en BDD via la colonne source (PIX-4746)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-course-result.js
+++ b/api/db/database-builder/factory/build-complementary-certification-course-result.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 module.exports = function buildComplementaryCertificationCourseResult({
   complementaryCertificationCourseId,
   partnerKey,
-  temporaryPartnerKey,
+  source = 'PIX',
   acquired = true,
 }) {
   complementaryCertificationCourseId = _.isUndefined(complementaryCertificationCourseId)
@@ -15,7 +15,7 @@ module.exports = function buildComplementaryCertificationCourseResult({
     : complementaryCertificationCourseId;
   return databaseBuffer.objectsToInsert.push({
     tableName: 'complementary-certification-course-results',
-    values: { complementaryCertificationCourseId, partnerKey, temporaryPartnerKey, acquired },
+    values: { complementaryCertificationCourseId, partnerKey, source, acquired },
   });
 };
 

--- a/api/db/migrations/20220411134827_add-column-source-to-complementary-certification-results.js
+++ b/api/db/migrations/20220411134827_add-column-source-to-complementary-certification-results.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'complementary-certification-course-results';
+const COLUMN_NAME = 'source';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo('PIX').notNullable();
+  });
+
+  await knex.raw(`
+    ALTER TABLE "complementary-certification-course-results" ADD CONSTRAINT "complementary-certification-course-results_source_check"
+      CHECK ( "source" IN ( 'PIX', 'EXTERNAL'))
+  `);
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20220411140819_migrate-complementary-certification-results-sources.js
+++ b/api/db/migrations/20220411140819_migrate-complementary-certification-results-sources.js
@@ -1,0 +1,58 @@
+const TABLE_NAME = 'complementary-certification-course-results';
+const TEMPORARY_PARTNER_KEY_COLUMN_NAME = 'temporaryPartnerKey';
+
+exports.up = async function (knex) {
+  await knex.raw(`
+  INSERT INTO "complementary-certification-course-results" ("partnerKey", "complementaryCertificationCourseId", "acquired", "source")
+    SELECT "partnerKey", "complementaryCertificationCourseId", "acquired", 'EXTERNAL'
+    FROM "complementary-certification-course-results"
+    WHERE "partnerKey" IS NOT NULL AND "temporaryPartnerKey" IS NOT NULL
+    `);
+
+  await knex.raw(`
+    UPDATE "complementary-certification-course-results"
+      SET "partnerKey" = "temporaryPartnerKey" 
+      WHERE "partnerKey" IS NULL 
+      AND "temporaryPartnerKey" IS NOT NULL
+  `);
+
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(TEMPORARY_PARTNER_KEY_COLUMN_NAME);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(TEMPORARY_PARTNER_KEY_COLUMN_NAME).references('badges.key').nullable();
+  });
+  await knex.raw(`
+    UPDATE "complementary-certification-course-results" AS ccr_pix
+      SET "temporaryPartnerKey" = ccr_pix."partnerKey", "partnerKey" = ccr_ext."partnerKey"
+      FROM "complementary-certification-course-results" AS ccr_ext
+      WHERE ccr_pix."source" = 'PIX' AND ccr_ext."source" = 'EXTERNAL'  
+          AND ccr_pix."complementaryCertificationCourseId" = ccr_ext."complementaryCertificationCourseId"
+  `);
+
+  await knex.raw(`
+    UPDATE "complementary-certification-course-results"
+      SET "temporaryPartnerKey" = "partnerKey"
+      WHERE "source" = 'PIX' 
+      AND "partnerKey" IN (
+        'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
+        'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE',
+        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT',
+        'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE',
+        'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT'
+      )
+  `);
+
+  await knex.raw(`
+    DELETE FROM "complementary-certification-course-results"
+      WHERE "source" = 'EXTERNAL' 
+  `);
+};

--- a/api/lib/domain/models/CertificationAttestation.js
+++ b/api/lib/domain/models/CertificationAttestation.js
@@ -26,7 +26,7 @@ class CertificationAttestation {
     deliveredAt,
     certificationCenter,
     pixScore,
-    acquiredComplementaryCertifications,
+    certifiedBadges,
     resultCompetenceTree = null,
     verificationCode,
     maxReachableLevelOnCertificationDate,
@@ -42,7 +42,7 @@ class CertificationAttestation {
     this.deliveredAt = deliveredAt;
     this.certificationCenter = certificationCenter;
     this.pixScore = pixScore;
-    this.acquiredComplementaryCertifications = acquiredComplementaryCertifications;
+    this.certifiedBadges = certifiedBadges;
     this.resultCompetenceTree = resultCompetenceTree;
     this.verificationCode = verificationCode;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
@@ -54,13 +54,13 @@ class CertificationAttestation {
   }
 
   getAcquiredCleaCertification() {
-    return this.acquiredComplementaryCertifications.find(
+    return this.certifiedBadges.find(
       ({ partnerKey }) => partnerKey === PIX_EMPLOI_CLEA || partnerKey === PIX_EMPLOI_CLEA_V2
     )?.partnerKey;
   }
 
   getAcquiredPixPlusDroitCertification() {
-    return this.acquiredComplementaryCertifications.find(
+    return this.certifiedBadges.find(
       ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF || partnerKey === PIX_DROIT_EXPERT_CERTIF
     )?.partnerKey;
   }
@@ -101,11 +101,11 @@ class CertificationAttestation {
   }
 
   hasAcquiredAnyComplementaryCertifications() {
-    return this.acquiredComplementaryCertifications.length > 0;
+    return this.certifiedBadges.length > 0;
   }
 
   _findByPartnerKey(key) {
-    return this.acquiredComplementaryCertifications.find(({ partnerKey }) => partnerKey === key);
+    return this.certifiedBadges.find(({ partnerKey }) => partnerKey === key);
   }
 }
 

--- a/api/lib/domain/models/CertificationAttestation.js
+++ b/api/lib/domain/models/CertificationAttestation.js
@@ -67,11 +67,11 @@ class CertificationAttestation {
 
   getAcquiredPixPlusEduCertification() {
     return (
-      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) ||
-      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME) ||
-      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME) ||
-      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) ||
-      this._findByPartnerKeyOrTemporaryPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT)
+      this._findByPartnerKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) ||
+      this._findByPartnerKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME) ||
+      this._findByPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME) ||
+      this._findByPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) ||
+      this._findByPartnerKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT)
     );
   }
 
@@ -81,33 +81,21 @@ class CertificationAttestation {
       return null;
     }
 
-    const { partnerKey, temporaryPartnerKey } = acquiredPixPlusEduCertification;
-    if (
-      partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE ||
-      temporaryPartnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
-    ) {
+    const { partnerKey } = acquiredPixPlusEduCertification;
+    if (partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) {
       return 'Initié (entrée dans le métier)';
     }
     if (
       [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
         partnerKey
-      ) ||
-      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
-        temporaryPartnerKey
       )
     ) {
       return 'Confirmé';
     }
-    if (
-      partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE ||
-      temporaryPartnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
-    ) {
+    if (partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) {
       return 'Avancé';
     }
-    if (
-      partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT ||
-      temporaryPartnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
-    ) {
+    if (partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT) {
       return 'Expert';
     }
   }
@@ -116,10 +104,8 @@ class CertificationAttestation {
     return this.acquiredComplementaryCertifications.length > 0;
   }
 
-  _findByPartnerKeyOrTemporaryPartnerKey(key) {
-    return this.acquiredComplementaryCertifications.find(
-      ({ partnerKey, temporaryPartnerKey }) => partnerKey === key || temporaryPartnerKey === key
-    );
+  _findByPartnerKey(key) {
+    return this.acquiredComplementaryCertifications.find(({ partnerKey }) => partnerKey === key);
   }
 }
 

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -1,12 +1,13 @@
 class ComplementaryCertificationCourseResult {
-  constructor({ certificationCourseId, partnerKey, acquired } = {}) {
+  constructor({ certificationCourseId, partnerKey, source, acquired } = {}) {
     this.certificationCourseId = certificationCourseId;
     this.partnerKey = partnerKey;
     this.acquired = acquired;
+    this.source = source;
   }
 
-  static from({ certificationCourseId, partnerKey, acquired }) {
-    return new ComplementaryCertificationCourseResult({ certificationCourseId, partnerKey, acquired });
+  static from({ certificationCourseId, partnerKey, acquired, source }) {
+    return new ComplementaryCertificationCourseResult({ certificationCourseId, partnerKey, acquired, source });
   }
 }
 

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -1,13 +1,57 @@
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('./Badge').keys;
+
 class ComplementaryCertificationCourseResult {
-  constructor({ certificationCourseId, partnerKey, source, acquired } = {}) {
+  constructor({ certificationCourseId, complementaryCertificationCourseId, partnerKey, source, acquired } = {}) {
     this.certificationCourseId = certificationCourseId;
+    this.complementaryCertificationCourseId = complementaryCertificationCourseId;
     this.partnerKey = partnerKey;
     this.acquired = acquired;
     this.source = source;
   }
 
-  static from({ certificationCourseId, partnerKey, acquired, source }) {
-    return new ComplementaryCertificationCourseResult({ certificationCourseId, partnerKey, acquired, source });
+  static from({ certificationCourseId, complementaryCertificationCourseId, partnerKey, acquired, source }) {
+    return new ComplementaryCertificationCourseResult({
+      certificationCourseId,
+      complementaryCertificationCourseId,
+      partnerKey,
+      acquired,
+      source,
+    });
+  }
+
+  isPixEdu() {
+    return this.isPixEdu1erDegre() || this.isPixEdu2ndDegre();
+  }
+
+  isPixEdu1erDegre() {
+    return [
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+    ].includes(this.partnerKey);
+  }
+
+  isPixEdu2ndDegre() {
+    return [
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    ].includes(this.partnerKey);
   }
 }
 

--- a/api/lib/domain/models/PartnerCertificationScoring.js
+++ b/api/lib/domain/models/PartnerCertificationScoring.js
@@ -2,15 +2,22 @@ const Joi = require('joi').extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 const { NotImplementedError } = require('../errors');
 
+const SOURCES = {
+  PIX: 'PIX',
+  EXTERNAL: 'EXTERNAL',
+};
+
 class PartnerCertificationScoring {
-  constructor({ complementaryCertificationCourseId, partnerKey, temporaryPartnerKey = null } = {}) {
+  constructor({ complementaryCertificationCourseId, partnerKey, source = 'PIX' } = {}) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
     this.partnerKey = partnerKey;
-    this.temporaryPartnerKey = temporaryPartnerKey;
+    this.source = source;
     const schema = Joi.object({
       complementaryCertificationCourseId: Joi.number().integer().required(),
       partnerKey: Joi.string().allow(null).required(),
-      temporaryPartnerKey: Joi.string().allow(null).required(),
+      source: Joi.string()
+        .required()
+        .valid(...Object.values(SOURCES)),
     });
     validateEntity(schema, this);
   }

--- a/api/lib/domain/models/PixPlusEduCertificationScoring.js
+++ b/api/lib/domain/models/PixPlusEduCertificationScoring.js
@@ -9,8 +9,8 @@ class PixPlusEduCertificationScoring extends PartnerCertificationScoring {
   } = {}) {
     super({
       complementaryCertificationCourseId,
-      partnerKey: null,
-      temporaryPartnerKey: certifiableBadgeKey,
+      partnerKey: certifiableBadgeKey,
+      source: 'PIX',
     });
 
     this.reproducibilityRate = reproducibilityRate;

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -27,9 +27,9 @@ class CertifiedBadgeImage {
     });
   }
 
-  static fromPartnerKey(partnerKey, temporaryPartnerKey) {
-    const badgeKey = partnerKey || temporaryPartnerKey;
-    const isTemporaryBadge = !partnerKey;
+  static fromPartnerKey(partnerKey, source) {
+    const badgeKey = partnerKey;
+    const isTemporaryBadge = source === 'PIX' && _isPartnerKeyInPixEduBadges(partnerKey);
 
     if (badgeKey === PIX_DROIT_MAITRE_CERTIF) {
       return CertifiedBadgeImage.finalFromPath('https://images.pix.fr/badges-certifies/pix-droit/maitre.svg');
@@ -107,6 +107,21 @@ class CertifiedBadgeImage {
       });
     }
   }
+}
+
+function _isPartnerKeyInPixEduBadges(partnerKey) {
+  return [
+    PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+    PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+    PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+    PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+    PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+    PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+  ].includes(partnerKey);
 }
 
 module.exports = CertifiedBadgeImage;

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -27,9 +27,8 @@ class CertifiedBadgeImage {
     });
   }
 
-  static fromPartnerKey(partnerKey, source) {
+  static fromPartnerKey(partnerKey, isTemporaryBadge) {
     const badgeKey = partnerKey;
-    const isTemporaryBadge = source === 'PIX' && _isPartnerKeyInPixEduBadges(partnerKey);
 
     if (badgeKey === PIX_DROIT_MAITRE_CERTIF) {
       return CertifiedBadgeImage.finalFromPath('https://images.pix.fr/badges-certifies/pix-droit/maitre.svg');
@@ -107,21 +106,6 @@ class CertifiedBadgeImage {
       });
     }
   }
-}
-
-function _isPartnerKeyInPixEduBadges(partnerKey) {
-  return [
-    PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-    PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-    PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-    PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-    PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-    PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-    PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-    PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-  ].includes(partnerKey);
 }
 
 module.exports = CertifiedBadgeImage;

--- a/api/lib/domain/read-models/CertifiedBadges.js
+++ b/api/lib/domain/read-models/CertifiedBadges.js
@@ -1,0 +1,99 @@
+const _ = require('lodash');
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../models/Badge').keys;
+
+class CertifiedBadges {
+  constructor({ complementaryCertificationCourseResults }) {
+    this.complementaryCertificationCourseResults = complementaryCertificationCourseResults;
+  }
+
+  getCertifiedBadgesDTO() {
+    const complementaryCertificationCourseResultsByPartnerKey = _.groupBy(
+      this.complementaryCertificationCourseResults,
+      'complementaryCertificationCourseId'
+    );
+
+    return Object.values(complementaryCertificationCourseResultsByPartnerKey).map(
+      (complementaryCertificationCourseResults) => {
+        const partnerKey = complementaryCertificationCourseResults[0].partnerKey;
+        if (complementaryCertificationCourseResults[0].isPixEdu()) {
+          if (complementaryCertificationCourseResults.length === 1) {
+            return { partnerKey, isTemporaryBadge: true };
+          } else {
+            let lowestPartnerKey;
+            if (complementaryCertificationCourseResults[0].isPixEdu2ndDegre()) {
+              lowestPartnerKey = this._getLowestPartnerKeyForPixEdu2ndDegreBadge(
+                complementaryCertificationCourseResults
+              );
+            }
+            if (complementaryCertificationCourseResults[0].isPixEdu1erDegre()) {
+              lowestPartnerKey = this._getLowestPartnerKeyForPixEdu1erDegreBadge(
+                complementaryCertificationCourseResults
+              );
+            }
+
+            return { partnerKey: lowestPartnerKey, isTemporaryBadge: false };
+          }
+        }
+
+        return { partnerKey, isTemporaryBadge: false };
+      }
+    );
+  }
+
+  _getLowestPartnerKeyForPixEdu2ndDegreBadge(complementaryCertificationCourseResults) {
+    const firstIndexOf = [
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    ].indexOf(complementaryCertificationCourseResults[0].partnerKey);
+
+    const secondIndexOf = [
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    ].indexOf(complementaryCertificationCourseResults[1].partnerKey);
+
+    return firstIndexOf <= secondIndexOf
+      ? complementaryCertificationCourseResults[0].partnerKey
+      : complementaryCertificationCourseResults[1].partnerKey;
+  }
+
+  _getLowestPartnerKeyForPixEdu1erDegreBadge(complementaryCertificationCourseResults) {
+    const firstIndexOf = [
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+    ].indexOf(complementaryCertificationCourseResults[0].partnerKey);
+
+    const secondIndexOf = [
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+    ].indexOf(complementaryCertificationCourseResults[1].partnerKey);
+
+    return firstIndexOf <= secondIndexOf
+      ? complementaryCertificationCourseResults[0].partnerKey
+      : complementaryCertificationCourseResults[1].partnerKey;
+  }
+}
+
+module.exports = CertifiedBadges;

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -147,7 +147,7 @@ async function _getAcquiredPartnerCertification(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
   ];
   const complementaryCertificationCourseResults = await knex
-    .select('partnerKey', 'temporaryPartnerKey')
+    .select('partnerKey', 'source')
     .from('complementary-certification-course-results')
     .innerJoin(
       'complementary-certification-courses',
@@ -156,7 +156,7 @@ async function _getAcquiredPartnerCertification(certificationCourseId) {
     )
     .where({ certificationCourseId, acquired: true })
     .where(function () {
-      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+      this.whereIn('partnerKey', handledBadgeKeys);
     });
 
   return complementaryCertificationCourseResults;

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -17,6 +17,8 @@ const { NotFoundError } = require('../../../lib/domain/errors');
 const competenceTreeRepository = require('./competence-tree-repository');
 const ResultCompetenceTree = require('../../domain/models/ResultCompetenceTree');
 const CompetenceMark = require('../../domain/models/CompetenceMark');
+const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
+const CertifiedBadges = require('../../domain/read-models/CertifiedBadges');
 
 module.exports = {
   async get(id) {
@@ -147,7 +149,7 @@ async function _getAcquiredPartnerCertification(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
   ];
   const complementaryCertificationCourseResults = await knex
-    .select('partnerKey', 'source')
+    .select('complementary-certification-course-results.*')
     .from('complementary-certification-course-results')
     .innerJoin(
       'complementary-certification-courses',
@@ -159,7 +161,7 @@ async function _getAcquiredPartnerCertification(certificationCourseId) {
       this.whereIn('partnerKey', handledBadgeKeys);
     });
 
-  return complementaryCertificationCourseResults;
+  return complementaryCertificationCourseResults.map(ComplementaryCertificationCourseResult.from);
 }
 
 function _toDomain(certificationCourseDTO, competenceTree, acquiredComplementaryCertifications) {
@@ -174,9 +176,13 @@ function _toDomain(certificationCourseDTO, competenceTree, acquiredComplementary
     assessmentResultId: certificationCourseDTO.assessmentResultId,
   });
 
+  const certifiedBadgesDTO = new CertifiedBadges({
+    complementaryCertificationCourseResults: acquiredComplementaryCertifications,
+  }).getCertifiedBadgesDTO();
+
   return new CertificationAttestation({
     ...certificationCourseDTO,
     resultCompetenceTree,
-    acquiredComplementaryCertifications,
+    certifiedBadges: certifiedBadgesDTO,
   });
 }

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -42,6 +42,7 @@ module.exports = {
     const partnerCertificationToSave = new ComplementaryCertificationCourseResultBookshelf(
       _adaptModelToDB({
         ...partnerCertificationScoring,
+        source: 'PIX',
         complementaryCertificationCourseId: partnerCertificationScoring.complementaryCertificationCourseId,
         acquired: partnerCertificationScoring.isAcquired(),
       })
@@ -53,10 +54,6 @@ module.exports = {
       .where({
         complementaryCertificationCourseId: partnerCertificationScoring.complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
-      })
-      .orWhere({
-        complementaryCertificationCourseId: partnerCertificationScoring.complementaryCertificationCourseId,
-        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
       })
       .first();
 
@@ -74,8 +71,8 @@ module.exports = {
   },
 };
 
-function _adaptModelToDB({ complementaryCertificationCourseId, partnerKey, temporaryPartnerKey, acquired }) {
-  return { complementaryCertificationCourseId, partnerKey, temporaryPartnerKey, acquired };
+function _adaptModelToDB({ complementaryCertificationCourseId, partnerKey, source, acquired }) {
+  return { complementaryCertificationCourseId, partnerKey, source, acquired };
 }
 
 async function _getAcquiredCleaBadgeKey(userId, certificationCourseId, domainTransaction) {

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -3,6 +3,7 @@ const { knex } = require('../../../db/knex-database-connection');
 const PrivateCertificate = require('../../domain/models/PrivateCertificate');
 const CleaCertificationResult = require('../../../lib/domain/models/CleaCertificationResult');
 const CertifiedBadgeImage = require('../../../lib/domain/read-models/CertifiedBadgeImage');
+const CertifiedBadges = require('../../../lib/domain/read-models/CertifiedBadges');
 const {
   PIX_EMPLOI_CLEA,
   PIX_EMPLOI_CLEA_V2,
@@ -23,6 +24,7 @@ const { NotFoundError } = require('../../../lib/domain/errors');
 const competenceTreeRepository = require('./competence-tree-repository');
 const ResultCompetenceTree = require('../../domain/models/ResultCompetenceTree');
 const CompetenceMark = require('../../domain/models/CompetenceMark');
+const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
 
 module.exports = {
   async get(id) {
@@ -148,7 +150,7 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
   ];
   const results = await knex
-    .select('partnerKey', 'source')
+    .select('complementary-certification-course-results.*')
     .from('complementary-certification-course-results')
     .innerJoin(
       'complementary-certification-courses',
@@ -161,7 +163,24 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     })
     .orderBy('partnerKey');
 
-  return _.compact(_.map(results, ({ partnerKey, source }) => CertifiedBadgeImage.fromPartnerKey(partnerKey, source)));
+  const complementaryCertificationCourseResults = results.map(
+    ({ partnerKey, complementaryCertificationCourseId, acquired, source }) =>
+      ComplementaryCertificationCourseResult.from({
+        certificationCourseId,
+        complementaryCertificationCourseId,
+        partnerKey,
+        acquired,
+        source,
+      })
+  );
+
+  const certifiedBadgesDTO = new CertifiedBadges({ complementaryCertificationCourseResults }).getCertifiedBadgesDTO();
+
+  return _.compact(
+    _.map(certifiedBadgesDTO, ({ partnerKey, isTemporaryBadge }) =>
+      CertifiedBadgeImage.fromPartnerKey(partnerKey, isTemporaryBadge)
+    )
+  );
 }
 
 function _toDomain({ certificationCourseDTO, competenceTree, cleaCertificationResult, certifiedBadgeImages }) {

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -148,7 +148,7 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
   ];
   const results = await knex
-    .select('partnerKey', 'temporaryPartnerKey')
+    .select('partnerKey', 'source')
     .from('complementary-certification-course-results')
     .innerJoin(
       'complementary-certification-courses',
@@ -157,15 +157,11 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     )
     .where({ certificationCourseId, acquired: true })
     .where(function () {
-      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+      this.whereIn('partnerKey', handledBadgeKeys);
     })
     .orderBy('partnerKey');
 
-  return _.compact(
-    _.map(results, ({ partnerKey, temporaryPartnerKey }) =>
-      CertifiedBadgeImage.fromPartnerKey(partnerKey, temporaryPartnerKey)
-    )
-  );
+  return _.compact(_.map(results, ({ partnerKey, source }) => CertifiedBadgeImage.fromPartnerKey(partnerKey, source)));
 }
 
 function _toDomain({ certificationCourseDTO, competenceTree, cleaCertificationResult, certifiedBadgeImages }) {

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -124,7 +124,7 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
   ];
   const results = await knex
-    .select('partnerKey', 'temporaryPartnerKey')
+    .select('partnerKey', 'source')
     .from('complementary-certification-course-results')
     .innerJoin(
       'complementary-certification-courses',
@@ -133,14 +133,10 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     )
     .where({ certificationCourseId, acquired: true })
     .where(function () {
-      this.whereIn('partnerKey', handledBadgeKeys).orWhereIn('temporaryPartnerKey', handledBadgeKeys);
+      this.whereIn('partnerKey', handledBadgeKeys);
     })
     .orderBy('partnerKey');
-  return _.compact(
-    _.map(results, ({ partnerKey, temporaryPartnerKey }) =>
-      CertifiedBadgeImage.fromPartnerKey(partnerKey, temporaryPartnerKey)
-    )
-  );
+  return _.compact(_.map(results, ({ partnerKey, source }) => CertifiedBadgeImage.fromPartnerKey(partnerKey, source)));
 }
 
 function _toDomain(shareableCertificateDTO, competenceTree, cleaCertificationResult, certifiedBadgeImages) {

--- a/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
+++ b/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
@@ -109,9 +109,9 @@ class AttestationViewModel {
     let pixPlusEduTemporaryBadgeMessage;
     if (certificate.getAcquiredPixPlusEduCertification()) {
       hasAcquiredPixPlusEduCertification = true;
-      const { partnerKey, temporaryPartnerKey } = certificate.getAcquiredPixPlusEduCertification();
-      pixPlusEduCertificationImagePath = getImagePathByBadgeKey(partnerKey || temporaryPartnerKey);
-      if (temporaryPartnerKey && !partnerKey) {
+      const { partnerKey, source } = certificate.getAcquiredPixPlusEduCertification();
+      pixPlusEduCertificationImagePath = getImagePathByBadgeKey(partnerKey);
+      if (source === 'PIX') {
         pixPlusEduTemporaryBadgeMessage = toArrayOfFixedLengthStringsConservingWords(
           `Vous avez obtenu le niveau “${certificate.getPixPlusEduBadgeDisplayName()}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
           45

--- a/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
+++ b/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
@@ -109,9 +109,9 @@ class AttestationViewModel {
     let pixPlusEduTemporaryBadgeMessage;
     if (certificate.getAcquiredPixPlusEduCertification()) {
       hasAcquiredPixPlusEduCertification = true;
-      const { partnerKey, source } = certificate.getAcquiredPixPlusEduCertification();
+      const { partnerKey, isTemporaryBadge } = certificate.getAcquiredPixPlusEduCertification();
       pixPlusEduCertificationImagePath = getImagePathByBadgeKey(partnerKey);
-      if (source === 'PIX') {
+      if (isTemporaryBadge) {
         pixPlusEduTemporaryBadgeMessage = toArrayOfFixedLengthStringsConservingWords(
           `Vous avez obtenu le niveau “${certificate.getPixPlusEduBadgeDisplayName()}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
           45

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -63,7 +63,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
       await _buildIncomplete(certificationAttestationData);
@@ -92,7 +92,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
       await _buildCancelled(certificationAttestationData);
@@ -121,7 +121,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
@@ -150,7 +150,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
       await _buildRejected(certificationAttestationData);
@@ -183,7 +183,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);
@@ -216,7 +216,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
 
@@ -296,7 +296,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
         sessionId: 789,
       };
       await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
@@ -317,17 +317,17 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
     context('acquired certifiable badges', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
-        PIX_EMPLOI_CLEA,
-        PIX_EMPLOI_CLEA_V2,
-        PIX_DROIT_EXPERT_CERTIF,
-        PIX_DROIT_MAITRE_CERTIF,
-        PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-        PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-      ].forEach((badgeKey) => {
-        it(`should get the certified badge ${badgeKey} when acquired`, async function () {
+        { partnerKey: PIX_EMPLOI_CLEA, isTemporaryBadge: false },
+        { partnerKey: PIX_EMPLOI_CLEA_V2, isTemporaryBadge: false },
+        { partnerKey: PIX_DROIT_EXPERT_CERTIF, isTemporaryBadge: false },
+        { partnerKey: PIX_DROIT_MAITRE_CERTIF, isTemporaryBadge: false },
+        { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, isTemporaryBadge: true },
+        { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, isTemporaryBadge: true },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME, isTemporaryBadge: true },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, isTemporaryBadge: true },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, isTemporaryBadge: true },
+      ].forEach(({ partnerKey, isTemporaryBadge }) => {
+        it(`should get the certified badge ${partnerKey} when acquired`, async function () {
           // given
           const learningContentObjects = learningContentBuilder.buildLearningContent(minimalLearningContent);
           mockLearningContent(learningContentObjects);
@@ -345,11 +345,11 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
             deliveredAt: new Date('2021-05-05'),
             certificationCenter: 'Centre des poules bien dodues',
             pixScore: 51,
-            acquiredComplementaryCertifications: [{ partnerKey: badgeKey, source: 'PIX' }],
+            certifiedBadges: [{ partnerKey, isTemporaryBadge }],
             sessionId: 789,
           };
           await _buildValidCertificationAttestation(certificationAttestationData);
-          databaseBuilder.factory.buildBadge({ key: badgeKey });
+          databaseBuilder.factory.buildBadge({ key: partnerKey });
           databaseBuilder.factory.buildBadge({ key: 'some-other-badge-e' });
           databaseBuilder.factory.buildComplementaryCertificationCourse({
             id: 998,
@@ -357,7 +357,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           });
           databaseBuilder.factory.buildComplementaryCertificationCourseResult({
             complementaryCertificationCourseId: 998,
-            partnerKey: badgeKey,
+            partnerKey,
             acquired: true,
           });
           databaseBuilder.factory.buildComplementaryCertificationCourseResult({
@@ -386,13 +386,11 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         mockLearningContent(learningContentObjects);
         const certificationAttestationData = {
           id: 123,
-          acquiredComplementaryCertifications: [{ partnerKey: PIX_DROIT_EXPERT_CERTIF, source: 'PIX' }],
+          certifiedBadges: [{ partnerKey: PIX_DROIT_EXPERT_CERTIF, isTemporaryBadge: false }],
         };
         const certificationAttestationData2 = {
           id: 124,
-          acquiredComplementaryCertifications: [
-            { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, source: 'PIX' },
-          ],
+          certifiedBadges: [{ partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, isTemporaryBadge: false }],
         };
         databaseBuilder.factory.buildBadge({ key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE });
         databaseBuilder.factory.buildBadge({ key: PIX_DROIT_EXPERT_CERTIF });
@@ -426,8 +424,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         const certificationAttestation = await certificationAttestationRepository.get(123);
 
         // then
-        expect(certificationAttestation.acquiredComplementaryCertifications).to.deep.equals([
-          { partnerKey: PIX_DROIT_EXPERT_CERTIF, source: 'PIX' },
+        expect(certificationAttestation.certifiedBadges).to.deep.equals([
+          { partnerKey: PIX_DROIT_EXPERT_CERTIF, isTemporaryBadge: false },
         ]);
       });
     });
@@ -450,7 +448,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, source: 'PIX' }],
+        certifiedBadges: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, isTemporaryBadge: false }],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -345,7 +345,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
             deliveredAt: new Date('2021-05-05'),
             certificationCenter: 'Centre des poules bien dodues',
             pixScore: 51,
-            acquiredComplementaryCertifications: [{ partnerKey: badgeKey, temporaryPartnerKey: null }],
+            acquiredComplementaryCertifications: [{ partnerKey: badgeKey, source: 'PIX' }],
             sessionId: 789,
           };
           await _buildValidCertificationAttestation(certificationAttestationData);
@@ -386,12 +386,12 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         mockLearningContent(learningContentObjects);
         const certificationAttestationData = {
           id: 123,
-          acquiredComplementaryCertifications: [{ partnerKey: PIX_DROIT_EXPERT_CERTIF, temporaryPartnerKey: null }],
+          acquiredComplementaryCertifications: [{ partnerKey: PIX_DROIT_EXPERT_CERTIF, source: 'PIX' }],
         };
         const certificationAttestationData2 = {
           id: 124,
           acquiredComplementaryCertifications: [
-            { partnerKey: null, temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE },
+            { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, source: 'PIX' },
           ],
         };
         databaseBuilder.factory.buildBadge({ key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE });
@@ -416,7 +416,8 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         });
         databaseBuilder.factory.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 999,
-          temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          source: 'PIX',
           acquired: true,
         });
         await databaseBuilder.commit();
@@ -426,7 +427,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
 
         // then
         expect(certificationAttestation.acquiredComplementaryCertifications).to.deep.equals([
-          { partnerKey: PIX_DROIT_EXPERT_CERTIF, temporaryPartnerKey: null },
+          { partnerKey: PIX_DROIT_EXPERT_CERTIF, source: 'PIX' },
         ]);
       });
     });
@@ -449,7 +450,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         deliveredAt: new Date('2021-05-05'),
         certificationCenter: 'Centre des poules bien dodues',
         pixScore: 51,
-        acquiredComplementaryCertifications: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, temporaryPartnerKey: null }],
+        acquiredComplementaryCertifications: [{ partnerKey: PIX_DROIT_MAITRE_CERTIF, source: 'PIX' }],
         sessionId: 789,
       };
       await _buildValidCertificationAttestation(certificationAttestationData);

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -55,11 +55,11 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: true,
-        temporaryPartnerKey: null,
+        source: 'PIX',
       });
     });
 
-    it('should update the existing complementary certification course results if it exists by partnerKey', async function () {
+    it('should update the existing complementary certification course results if it exists', async function () {
       // given
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
       const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -75,6 +75,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
+        source: 'PIX',
       });
       await databaseBuilder.commit();
       sinon.stub(partnerCertificationScoring, 'isAcquired').returns(false);
@@ -97,79 +98,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: false,
-        temporaryPartnerKey: null,
-      });
-    });
-
-    it('should insert the complementary certification course results in db if it does not already exists by temporaryPartnerKey', async function () {
-      // given
-      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
-      const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
-        certificationCourseId,
-      }).id;
-      const partnerCertificationScoring = domainBuilder.buildPixPlusEduCertificationScoring({
-        complementaryCertificationCourseId,
-      });
-      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.temporaryPartnerKey });
-      await databaseBuilder.commit();
-      sinon.stub(partnerCertificationScoring, 'isAcquired').returns(true);
-
-      // when
-      await partnerCertificationScoringRepository.save({ partnerCertificationScoring });
-
-      // then
-      const complementaryCertificationCourseResultSaved = await knex(
-        COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE_NAME
-      ).select();
-      expect(complementaryCertificationCourseResultSaved).to.have.length(1);
-      const complementaryCertificationCourseResultSavedWithoutId = omit(
-        complementaryCertificationCourseResultSaved[0],
-        'id'
-      );
-      expect(complementaryCertificationCourseResultSavedWithoutId).to.deep.equal({
-        complementaryCertificationCourseId,
-        partnerKey: null,
-        acquired: true,
-        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
-      });
-    });
-
-    it('should update the existing complementary certification course results if it exists by temporaryPartnerKey', async function () {
-      // given
-      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
-
-      const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
-        id: 998,
-        certificationCourseId,
-      }).id;
-      const partnerCertificationScoring = domainBuilder.buildPixPlusEduCertificationScoring({
-        complementaryCertificationCourseId,
-      });
-      databaseBuilder.factory.buildBadge({ key: partnerCertificationScoring.temporaryPartnerKey });
-      databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-        complementaryCertificationCourseId,
-        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
-      });
-      await databaseBuilder.commit();
-      sinon.stub(partnerCertificationScoring, 'isAcquired').returns(false);
-
-      // when
-      await partnerCertificationScoringRepository.save({ partnerCertificationScoring });
-
-      // then
-      const complementaryCertificationCourseResultSaved = await knex(
-        COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE_NAME
-      ).select();
-      expect(complementaryCertificationCourseResultSaved).to.have.length(1);
-      const complementaryCertificationCourseResultSavedWithoutId = omit(
-        complementaryCertificationCourseResultSaved[0],
-        'id'
-      );
-      expect(complementaryCertificationCourseResultSavedWithoutId).to.deep.equal({
-        complementaryCertificationCourseId,
-        partnerKey: null,
-        acquired: false,
-        temporaryPartnerKey: partnerCertificationScoring.temporaryPartnerKey,
+        source: 'PIX',
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -939,8 +939,9 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     });
     databaseBuilder.factory.buildComplementaryCertificationCourseResult({
       complementaryCertificationCourseId,
-      temporaryPartnerKey: badgeKey,
+      partnerKey: badgeKey,
       acquired: true,
+      source: 'PIX',
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -549,8 +549,9 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         databaseBuilder.factory.buildBadge({ key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE });
         databaseBuilder.factory.buildComplementaryCertificationCourseResult({
           certificationCourseId: otherCertificateId,
-          temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
           acquired: true,
+          source: 'PIX',
         });
         await databaseBuilder.commit();
 
@@ -664,8 +665,9 @@ async function _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
     });
     databaseBuilder.factory.buildComplementaryCertificationCourseResult({
       complementaryCertificationCourseId,
-      temporaryPartnerKey: badgeKey,
+      partnerKey: badgeKey,
       acquired: true,
+      source: 'PIX',
     });
   });
 

--- a/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -29,7 +29,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
+      certifiedBadges: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full.pdf';
 
@@ -56,7 +56,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [{ partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, source: 'PIX' }],
+      certifiedBadges: [{ partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, isTemporaryBadge: true }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full_edu_temporary.pdf';
 
@@ -83,9 +83,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [
-        { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, source: 'EXTERNAL' },
-      ],
+      certifiedBadges: [{ partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, isTemporaryBadge: false }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full_edu.pdf';
 
@@ -112,14 +110,14 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
+      certifiedBadges: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
     });
     const certificateWithCleaAndPixPlusDroitExpert = domainBuilder.buildCertificationAttestation({
       id: 2,
       firstName: 'Harry',
       lastName: 'Covert',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
+      certifiedBadges: [{ partnerKey: PIX_EMPLOI_CLEA }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
     });
     const certificateWithoutCleaNorPixPlusDroit = domainBuilder.buildCertificationAttestation({
       ...certificateWithCleaAndPixPlusDroitMaitre,
@@ -128,7 +126,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       lastName: 'Decaffé',
       cleaCertificationImagePath: null,
       pixPlusDroitCertificationImagePath: null,
-      acquiredComplementaryCertifications: [],
+      certifiedBadges: [],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_several_pages.pdf';
 

--- a/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -56,7 +56,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [{ temporaryPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE }],
+      acquiredComplementaryCertifications: [{ partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, source: 'PIX' }],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full_edu_temporary.pdf';
 
@@ -83,7 +83,9 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
       firstName: 'Jean',
       lastName: 'Bon',
       resultCompetenceTree,
-      acquiredComplementaryCertifications: [{ partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE }],
+      acquiredComplementaryCertifications: [
+        { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, source: 'EXTERNAL' },
+      ],
     });
     const referencePdfPath = __dirname + '/certification-attestation-pdf_test_full_edu.pdf';
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-attestation.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-attestation.js
@@ -14,7 +14,7 @@ module.exports = function buildCertificationAttestation({
   pixScore = 123,
   maxReachableLevelOnCertificationDate = 5,
   verificationCode = 'P-SOMECODE',
-  acquiredComplementaryCertifications = [],
+  certifiedBadges = [],
   resultCompetenceTree = null,
 } = {}) {
   return new CertificationAttestation({
@@ -31,7 +31,7 @@ module.exports = function buildCertificationAttestation({
     pixScore,
     maxReachableLevelOnCertificationDate,
     verificationCode,
-    acquiredComplementaryCertifications,
+    certifiedBadges,
     resultCompetenceTree,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result.js
@@ -2,11 +2,13 @@ const ComplementaryCertificationCourseResult = require('./../../../../lib/domain
 
 module.exports = function buildComplementaryCertificationCourseResult({
   certificationCourseId = 1,
+  complementaryCertificationCourseId = 2,
   partnerKey = 'PARTNER_KEY',
   acquired = false,
 } = {}) {
   return new ComplementaryCertificationCourseResult({
     certificationCourseId,
+    complementaryCertificationCourseId,
     partnerKey,
     acquired,
   });

--- a/api/tests/unit/domain/models/CertificationAttestation_test.js
+++ b/api/tests/unit/domain/models/CertificationAttestation_test.js
@@ -30,7 +30,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_EMPLOI_CLEA badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA }],
+        certifiedBadges: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA }],
       });
 
       // when
@@ -43,7 +43,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_EMPLOI_CLEA_V2 badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA_V2 }],
+        certifiedBadges: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_EMPLOI_CLEA_V2 }],
       });
 
       // when
@@ -56,7 +56,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no clea badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
+        certifiedBadges: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
       });
 
       // when
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_DROIT_MAITRE_CERTIF badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
+        certifiedBadges: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_MAITRE_CERTIF }],
       });
 
       // when
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return the acquired PIX_DROIT_EXPERT_CERTIF badge', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
+        certifiedBadges: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: PIX_DROIT_EXPERT_CERTIF }],
       });
 
       // when
@@ -97,7 +97,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no Pix+ Droit badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
+        certifiedBadges: [{ partnerKey: 'OTHER_BADGE_1' }, { partnerKey: 'OTHER_BADGE_2' }],
       });
 
       // when
@@ -120,7 +120,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return the acquired ${badgeKey} badge`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: badgeKey, source: 'PIX' }],
+          certifiedBadges: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: badgeKey, source: 'PIX' }],
         });
 
         // when
@@ -134,7 +134,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return undefined if no Pix+ Edu badge has been acquired', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: ['OTHER_BADGE_1', 'OTHER_BADGE_2'],
+        certifiedBadges: ['OTHER_BADGE_1', 'OTHER_BADGE_2'],
       });
 
       // when
@@ -160,7 +160,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return ${expectedDisplayName} for badge key ${badgeKey}`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredComplementaryCertifications: [{ partnerKey: badgeKey }],
+          certifiedBadges: [{ partnerKey: badgeKey }],
         });
 
         // when
@@ -176,7 +176,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return true if certified badge images for attestation is not empty', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [PIX_EMPLOI_CLEA],
+        certifiedBadges: [PIX_EMPLOI_CLEA],
       });
 
       // when
@@ -190,7 +190,7 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
     it('should return false if certified badge images for attestation is empty', function () {
       // given
       const certificationAttestation = domainBuilder.buildCertificationAttestation({
-        acquiredComplementaryCertifications: [],
+        certifiedBadges: [],
       });
 
       // when

--- a/api/tests/unit/domain/models/CertificationAttestation_test.js
+++ b/api/tests/unit/domain/models/CertificationAttestation_test.js
@@ -120,14 +120,14 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return the acquired ${badgeKey} badge`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { temporaryPartnerKey: badgeKey }],
+          acquiredComplementaryCertifications: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: badgeKey, source: 'PIX' }],
         });
 
         // when
         const acquiredPixPlusEduCertification = certificationAttestation.getAcquiredPixPlusEduCertification();
 
         // expect
-        expect(acquiredPixPlusEduCertification).to.deep.equal({ temporaryPartnerKey: badgeKey });
+        expect(acquiredPixPlusEduCertification).to.deep.equal({ partnerKey: badgeKey, source: 'PIX' });
       });
     });
 

--- a/api/tests/unit/domain/models/ComplementaryCertificationCourseResult_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationCourseResult_test.js
@@ -1,0 +1,217 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../../../../lib/domain/models/Badge').keys;
+
+describe('Unit | Domain | Models | ComplementaryCertificationCourseResult', function () {
+  describe('#isPixEdu1erDegre', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_DROIT_MAITRE_CERTIF,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_DROIT_EXPERT_CERTIF,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        expected: false,
+      },
+    ].forEach(({ partnerKey, expected }) => {
+      it(`should return ${expected} when partnerKey is ${partnerKey}`, function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey,
+        });
+
+        // when
+        const result = complementaryCertificationCourseResult.isPixEdu1erDegre();
+
+        // then
+        expect(result).to.equal(expected);
+      });
+    });
+  });
+  describe('#isPixEdu2ndDegre', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_DROIT_MAITRE_CERTIF,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_DROIT_EXPERT_CERTIF,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        expected: true,
+      },
+    ].forEach(({ partnerKey, expected }) => {
+      it(`should return ${expected} when partnerKey is ${partnerKey}`, function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey,
+        });
+
+        // when
+        const result = complementaryCertificationCourseResult.isPixEdu2ndDegre();
+
+        // then
+        expect(result).to.equal(expected);
+      });
+    });
+  });
+
+  describe('#isPixEdu', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        partnerKey: PIX_DROIT_MAITRE_CERTIF,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_DROIT_EXPERT_CERTIF,
+        expected: false,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        expected: true,
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        expected: true,
+      },
+    ].forEach(({ partnerKey, expected }) => {
+      it(`should return ${expected} when partnerKey is ${partnerKey}`, function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey,
+        });
+
+        // when
+        const result = complementaryCertificationCourseResult.isPixEdu();
+
+        // then
+        expect(result).to.equal(expected);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/PixPlusEduCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/PixPlusEduCertificationScoring_test.js
@@ -3,7 +3,7 @@ const PixPlusEduCertificationScoring = require('../../../../lib/domain/models/Pi
 
 describe('Unit | Domain | Models | PixPlusEduCertificationScoring', function () {
   context('#constructor', function () {
-    it('set partnerKey and temporaryPartnerKey', function () {
+    it('set partnerKey and source', function () {
       // given
       const reproducibilityRate = domainBuilder.buildReproducibilityRate({ value: 71 });
 
@@ -16,8 +16,8 @@ describe('Unit | Domain | Models | PixPlusEduCertificationScoring', function () 
       });
 
       // then
-      expect(pixPlusEduCertificationScoring.temporaryPartnerKey).to.equal('BADGE');
-      expect(pixPlusEduCertificationScoring.partnerKey).to.be.null;
+      expect(pixPlusEduCertificationScoring.source).to.equal('PIX');
+      expect(pixPlusEduCertificationScoring.partnerKey).to.equal('BADGE');
     });
   });
   context('#isAcquired', function () {

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -73,11 +73,16 @@ const pixPlusEdu1erDegreBadgesInfos = {
 describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
   describe('#fromPartnerKey', function () {
     context('when badge is final', function () {
-      const badges = { ...pixPlusDroitBadgesInfos, ...pixPlusEdu2ndDegreBadgesInfos, ...pixPlusEdu1erDegreBadgesInfos };
+      const badges = {
+        ...pixPlusDroitBadgesInfos,
+        ...pixPlusEdu2ndDegreBadgesInfos,
+        ...pixPlusEdu1erDegreBadgesInfos,
+      };
       for (const badgeKey in badges) {
         it(`returns final badge image for partner key ${badgeKey}`, function () {
           // when
-          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey);
+          const isTemporaryBadge = false;
+          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge);
 
           // then
           const { path, levelName } = badges[badgeKey];
@@ -91,8 +96,8 @@ describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
       for (const badgeKey in badges) {
         it(`returns temporary badge image for "PIX" source ${badgeKey}`, function () {
           // when
-          const source = 'PIX';
-          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, source);
+          const isTemporaryBadge = true;
+          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge);
 
           // then
           const { path, levelName } = badges[badgeKey];

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -89,9 +89,10 @@ describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
     context('when badge is temporary', function () {
       const badges = { ...pixPlusEdu2ndDegreBadgesInfos, ...pixPlusEdu1erDegreBadgesInfos };
       for (const badgeKey in badges) {
-        it(`returns temporary badge image for temporary partner key ${badgeKey}`, function () {
+        it(`returns temporary badge image for "PIX" source ${badgeKey}`, function () {
           // when
-          const result = CertifiedBadgeImage.fromPartnerKey(null, badgeKey);
+          const source = 'PIX';
+          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, source);
 
           // then
           const { path, levelName } = badges[badgeKey];

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -19,7 +19,7 @@ const {
 } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Read-models | CertifiedBadges', function () {
-  describe('#getCertifiedBadges', function () {
+  describe('#getCertifiedBadgesDTO', function () {
     context('when badge is not "PIX_EDU', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF, PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].forEach((partnerKey) => {
@@ -33,12 +33,12 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
           ];
 
           // when
-          const certifiedBadges = new CertifiedBadges({
+          const certifiedBadgesDTO = new CertifiedBadges({
             complementaryCertificationCourseResults,
-          }).getCertifiedBadges();
+          }).getCertifiedBadgesDTO();
 
           // then
-          expect(certifiedBadges).to.deepEqualArray([
+          expect(certifiedBadgesDTO).to.deepEqualArray([
             {
               partnerKey,
               isTemporaryBadge: false,
@@ -72,12 +72,12 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             ];
 
             // when
-            const certifiedBadges = new CertifiedBadges({
+            const certifiedBadgesDTO = new CertifiedBadges({
               complementaryCertificationCourseResults,
-            }).getCertifiedBadges();
+            }).getCertifiedBadgesDTO();
 
             // then
-            expect(certifiedBadges).to.deepEqualArray([
+            expect(certifiedBadgesDTO).to.deepEqualArray([
               {
                 partnerKey,
                 isTemporaryBadge: true,
@@ -103,12 +103,12 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             ];
 
             // when
-            const certifiedBadges = new CertifiedBadges({
+            const certifiedBadgesDTO = new CertifiedBadges({
               complementaryCertificationCourseResults,
-            }).getCertifiedBadges();
+            }).getCertifiedBadgesDTO();
 
             // then
-            expect(certifiedBadges).to.deepEqualArray([
+            expect(certifiedBadgesDTO).to.deepEqualArray([
               {
                 partnerKey,
                 isTemporaryBadge: false,
@@ -227,12 +227,12 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
           ];
 
           // when
-          const certifiedBadges = new CertifiedBadges({
+          const certifiedBadgesDTO = new CertifiedBadges({
             complementaryCertificationCourseResults,
-          }).getCertifiedBadges();
+          }).getCertifiedBadgesDTO();
 
           // then
-          expect(certifiedBadges).to.deepEqualArray([
+          expect(certifiedBadgesDTO).to.deepEqualArray([
             {
               partnerKey: expectedLowestBadge,
               isTemporaryBadge: false,

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -1,0 +1,245 @@
+const CertifiedBadges = require('../../../../lib/domain/read-models/CertifiedBadges');
+const { expect, domainBuilder } = require('../../../test-helper');
+
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EMPLOI_CLEA,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../../../../lib/domain/models/Badge').keys;
+
+describe('Unit | Domain | Read-models | CertifiedBadges', function () {
+  describe('#getCertifiedBadges', function () {
+    context('when badge is not "PIX_EDU', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF, PIX_EMPLOI_CLEA, PIX_EMPLOI_CLEA_V2].forEach((partnerKey) => {
+        it(`returns a non temporary badge for ${partnerKey}`, function () {
+          // given
+          const complementaryCertificationCourseResults = [
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              complementaryCertificationCourseId: 456,
+              partnerKey,
+            }),
+          ];
+
+          // when
+          const certifiedBadges = new CertifiedBadges({
+            complementaryCertificationCourseResults,
+          }).getCertifiedBadges();
+
+          // then
+          expect(certifiedBadges).to.deepEqualArray([
+            {
+              partnerKey,
+              isTemporaryBadge: false,
+            },
+          ]);
+        });
+      });
+    });
+    context('when badge is "PIX_EDU', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+      ].forEach((partnerKey) => {
+        context('when there is only one complementaryCertificationCourseResult', function () {
+          it(`returns a temporary badge for ${partnerKey}`, function () {
+            // given
+            const complementaryCertificationCourseResults = [
+              domainBuilder.buildComplementaryCertificationCourseResult({
+                complementaryCertificationCourseId: 456,
+                partnerKey,
+              }),
+            ];
+
+            // when
+            const certifiedBadges = new CertifiedBadges({
+              complementaryCertificationCourseResults,
+            }).getCertifiedBadges();
+
+            // then
+            expect(certifiedBadges).to.deepEqualArray([
+              {
+                partnerKey,
+                isTemporaryBadge: true,
+              },
+            ]);
+          });
+        });
+        context('when there is more than one complementaryCertificationCourseResult', function () {
+          it(`returns a non temporary badge for ${partnerKey}`, function () {
+            // given
+            const complementaryCertificationCourseResults = [
+              domainBuilder.buildComplementaryCertificationCourseResult({
+                complementaryCertificationCourseId: 456,
+
+                partnerKey,
+                source: 'PIX',
+              }),
+              domainBuilder.buildComplementaryCertificationCourseResult({
+                partnerKey,
+                complementaryCertificationCourseId: 456,
+                source: 'EXTERNAL',
+              }),
+            ];
+
+            // when
+            const certifiedBadges = new CertifiedBadges({
+              complementaryCertificationCourseResults,
+            }).getCertifiedBadges();
+
+            // then
+            expect(certifiedBadges).to.deepEqualArray([
+              {
+                partnerKey,
+                isTemporaryBadge: false,
+              },
+            ]);
+          });
+        });
+      });
+
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        {
+          sourcePix: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          sourceExternal: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          expectedLowestBadge: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          sourceExternal: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          expectedLowestBadge: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          expectedLowestBadge: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          sourceExternal: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          expectedLowestBadge: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          sourceExternal: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          expectedLowestBadge: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          expectedLowestBadge: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        },
+        {
+          sourcePix: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          sourceExternal: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        },
+      ].forEach(({ sourcePix, sourceExternal, expectedLowestBadge }) => {
+        it(`should return ${expectedLowestBadge} when the 'PIX' source level is ${sourcePix} and the 'ETERNAL' source level is ${sourceExternal}`, function () {
+          // given
+          const complementaryCertificationCourseResults = [
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: sourcePix,
+              complementaryCertificationCourseId: 456,
+              source: 'PIX',
+            }),
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: sourceExternal,
+              complementaryCertificationCourseId: 456,
+              source: 'EXTERNAL',
+            }),
+          ];
+
+          // when
+          const certifiedBadges = new CertifiedBadges({
+            complementaryCertificationCourseResults,
+          }).getCertifiedBadges();
+
+          // then
+          expect(certifiedBadges).to.deepEqualArray([
+            {
+              partnerKey: expectedLowestBadge,
+              isTemporaryBadge: false,
+            },
+          ]);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix Pix+ Edu nous souhaiterions faire apparaître la notion de source de résultat plutôt que de se baser sur une notion de badge temporaire

## :robot: Solution
- Ajouter une colonne 'source' à la table complementary-certification-course-results
- Supprimer la colonne 'temporaryPartnerKey'

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Passer une certif avec un profil Edu second degrès ```certifedu.2nd.initiale@example.net```
- Finaliser et publier la session
- Vérifier que le badge est visible sur le certifica et l'attestation

![image](https://user-images.githubusercontent.com/37305474/163223935-3d861de7-1ec0-4ff9-8d26-7bd4b86b4522.png)

![image](https://user-images.githubusercontent.com/37305474/163223981-b56edd2c-2131-467c-b540-f1e685c9bdfa.png)

- Insérer un badge avec une source 'EXTERNAL' avec le même complementaryCertificationCourseId et constater que la mention temporaire n'apparaît plus


![image](https://user-images.githubusercontent.com/37305474/163230227-5f7af255-9da4-4e53-b52e-293ffa12167f.png)


