### PR TITLE
[FEATURE] Empêcher la duplication de candidats côté BDD (PIX-4772).

### DIFF
--- a/api/db/migrations/20220412120723_prevent-candidate-duplicate.js
+++ b/api/db/migrations/20220412120723_prevent-candidate-duplicate.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('certification-candidates', function (table) {
+    table.unique(['sessionId', 'firstName', 'lastName', 'birthdate']);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('certification-candidates', function (table) {
+    table.dropUnique(['sessionId', 'firstName', 'lastName', 'birthdate']);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
https://github.com/1024pix/pix/pull/4251

Il y a des doublons en production: la requête suivante renvoie des enregistrements
```
SELECT
   "sessionId", "firstName", "lastName", "birthdate", COUNT(1)
FROM "certification-candidates"
GROUP BY "sessionId", "firstName", "lastName", "birthdate"
HAVING COUNT(1) > 1;
```

Cela concerne tous les types de centre de certification
```sql
WITH duplicate AS (
    SELECT
       "sessionId", "firstName", "lastName", "birthdate", COUNT(1)
    FROM "certification-candidates"
    GROUP BY "sessionId", "firstName", "lastName", "birthdate"
    HAVING COUNT(1) > 1 )
SELECT
    crt_cnt.type,
    COUNT(1)
FROM "certification-candidates" cc INNER JOIN duplicate ON
    duplicate."sessionId" = cc."sessionId"
    AND duplicate."firstName" = cc."firstName"
    AND duplicate."lastName" = cc."lastName"
    AND duplicate.birthdate = cc.birthdate
    INNER JOIN "sessions" crt_ssn ON cc."sessionId" = crt_ssn.id
    INNER JOIN "certification-centers" crt_cnt ON crt_ssn."certificationCenterId" = crt_cnt.id
GROUP BY  crt_cnt.type;
```

```
 type | count 
------+-------
 PRO  |    10
 SCO  |    84
 SUP  |   456
```

Ils sont récents, le dernier est du ` 2022-04-11 09:56:32.891474+00`

```sql
WITH duplicate AS (
    SELECT
       "sessionId", "firstName", "lastName", "birthdate", COUNT(1)
    FROM "certification-candidates"
    GROUP BY "sessionId", "firstName", "lastName", "birthdate"
    HAVING COUNT(1) > 1 )
SELECT
    MAX("createdAt")
FROM "certification-candidates" cc INNER JOIN duplicate ON
    duplicate."sessionId" = cc."sessionId"
    AND duplicate."firstName" = cc."firstName"
    AND duplicate."lastName" = cc."lastName"
    AND duplicate.birthdate = cc.birthdate
```

Parfois , le critère qui les départage est le `organizationalLearnerId`, mais cela n'a pas de sens fonctionnel.
Pour une session donnée, un candidat n'est lié qu'à une seule organisation :thinking: 

Pourtant, le cas est mentionné [dans les tests](http://github.com/1024pix/pix/blob/dev/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js#L111-L111)

Les doublons n'incluent pas de candidats ayant rejoint le parcours (`userId` renseigné)

## :robot: Solution

### Supprimer les doublons existants

Supprimer les doublons
- n'ayant pas rejoint le parcours `userId` est NULL
- sur les sessions finalisées

Sur les sessions non finalisées, communiquer aux centres de certification ?

### Empêcher la création en base de données
Modifier [l'implémentation existante](http://github.com/1024pix/pix/blob/dev/api/lib/infrastructure/repositories/certification-candidate-repository.js#L23-L27) du repo

## :rainbow: Remarques
La correction de la cause d'origine (plusieurs soumissions depuis même fenêtre PixCertif)  n'est pas inclue dans ce ticket

## :100: Pour tester
Exécuter la migration

Vérifier la présence de la contrainte
```shell
\d "certification-candidates"
Indexes:
    "certification-candidates_pkey" PRIMARY KEY, btree (id)
    "certification_candidates_sessionid_firstname_lastname_birthdate" UNIQUE CONSTRAINT, btree ("sessionId", "firstName", "lastName", birthdate)
```

Tenter d'insérer un doublon

```sql
INSERT INTO "certification-candidates"
    ("firstName", "lastName", "birthCity", "externalId", birthdate, "sessionId", "extraTimePercentage", "birthProvinceCode", "birthCountry", "userId", email, "resultRecipientEmail", "organizationLearnerId", "birthPostalCode", "birthINSEECode", sex, "authorizedToStart", "billingMode", "prepaymentCode")
VALUES
    ('anne', 'success', 'Ici', 'externalId', '2000-01-01', 2, 0.30, '66', 'France', null, 'somemail@example.net', 'destinaire-des-resulats@example.net', null, '75001', '75101', 'M', false, null, null);
```

Vérifier la présence du message 
```
[23505] ERROR: duplicate key value violates unique constraint "certification_candidates_sessionid_firstname_lastname_birthdate"
```