### PR TITLE
[A11Y] Ajouter un texte aux boutons de retour sur Pix Certif (PIX-4773).

### DIFF
--- a/certif/app/styles/components/finalize.scss
+++ b/certif/app/styles/components/finalize.scss
@@ -5,7 +5,8 @@
 
 .finalize__title {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .finalize__subtitle {

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -14,9 +14,11 @@
 }
 
 .session-details-header {
+
   &__title {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
     min-width: 300px;
   }
 
@@ -28,6 +30,7 @@
 }
 
 .session-details-header-datetime {
+
   &__date {
     padding-right: 40px;
     margin-right: 40px;
@@ -125,6 +128,7 @@ $details-content-margin: 8px;
 }
 
 .session-details {
+
   &__controls {
     display: flex;
     justify-content: space-between;

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -2,7 +2,9 @@
 <div class="session-details-page">
   <div class="page__title session-details__header">
     <div class="session-details-header__title">
-      <PixReturnTo @route="authenticated.sessions.list" class="session-details-content__return-button" />
+      <PixReturnTo @route="authenticated.sessions.list">
+        Retour à la liste des sessions
+      </PixReturnTo>
       <h1 class="page-title">Session {{this.session.id}}</h1>
     </div>
 

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -1,11 +1,9 @@
 {{page-title this.pageTitle replace=true}}
 <div class="page__title finalize">
   <div class="finalize__title">
-    <PixReturnTo
-      @route="authenticated.sessions.details"
-      @model={{this.session.id}}
-      class="session-details-content__return-button"
-    />
+    <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}}>
+      Retour à la session
+    </PixReturnTo>
     <h1 class="page-title">Finaliser la session {{this.session.id}}</h1>
   </div>
   <div class="finalize__subtitle">

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -51,6 +51,15 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
       await authenticateSession(certificationPointOfContact.id);
     });
 
+    test('it should redirect from candidates to session list on click on return button', async function (assert) {
+      // when
+      const screen = await visitScreen(`/sessions/${session.id}/candidats`);
+      await click(screen.getByRole('link', { name: 'Retour à la liste des sessions' }));
+
+      // then
+      assert.deepEqual(currentURL(), '/sessions/liste');
+    });
+
     module('when current certification center is blocked', function () {
       test('should redirect to espace-ferme URL', async function (assert) {
         // given

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
-import { visit } from '@1024pix/ember-testing-library';
+import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -69,13 +69,11 @@ module('Acceptance | Session Details', function (hooks) {
 
     test('it should redirect to session list on click on return button', async function (assert) {
       // when
-      await visit(`/sessions/${session.id}`);
-      await click('.session-details-content__return-button');
+      const screen = await visitScreen(`/sessions/${session.id}`);
+      await click(screen.getByRole('link', { name: 'Retour à la liste des sessions' }));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/liste');
+      assert.deepEqual(currentURL(), '/sessions/liste');
     });
 
     test('it should show the number of candidates on tab', async function (assert) {

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -3,7 +3,7 @@ import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
-import { visit } from '@1024pix/ember-testing-library';
+import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -88,6 +88,15 @@ module('Acceptance | Session Finalization', function (hooks) {
 
       // then
       assert.dom(screen.queryByText('Écran de fin du test vu')).exists();
+    });
+
+    test('it should redirect to session details on click on return button', async function (assert) {
+      // when
+      const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
+      await click(screen.getByRole('link', { name: 'Retour à la session' }));
+
+      // then
+      assert.deepEqual(currentURL(), `/sessions/${session.id}`);
     });
 
     module('When certificationPointOfContact click on "Finaliser" button', function () {

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -60,7 +60,7 @@ When('je remplis le formulaire de création de session de certification', () => 
 });
 
 When(`je clique sur le bouton de retour de la page de détails d'une session`, () => {
-  cy.get('.session-details-content__return-button').click();
+  cy.contains('Retour à la liste des sessions').click();
 });
 
 When('je clique sur la session de certification dont la salle est {string}', (roomLabel) => {


### PR DESCRIPTION
## :unicorn: Problème
Pour valider le point d'accessibilité "Test 6.2.1 : Dans chaque page web, chaque lien a-t-il un intitulé entre <a> et </a> ?" Il faut rajouter un texte sur les liens qui n'en ont pas.

## :robot: Solution
Rajouter un texte sur les boutons Flèche de retour sur les pages Détails, Candidats et Finalisation.

## :100: Pour tester
- Lancer Pix Certif
- Se rendre sur la page de détails d'une session, constater la présence d'un texte sur le bouton de retour.
- Se rendre sur la page des candidats d'une session, constater la présence d'un texte sur le bouton de retour.
- Se rendre sur la page de finalisation d'une session, constater la présence d'un texte sur le bouton de retour.