### PR TITLE
[FEATURE] Supprimer une participation depuis Pix Orga quand on est un admin ou propriétaire de la campagne (Pix-4578)

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -97,6 +97,20 @@ module.exports = {
     return campaignAssessmentParticipationSerializer.serialize(campaignAssessmentParticipation);
   },
 
+  async deleteParticipation(request, h) {
+    const { userId } = request.auth.credentials;
+    const { id, campaignParticipationId } = request.params;
+    await DomainTransaction.execute(async (domainTransaction) => {
+      await usecases.deleteCampaignParticipation({
+        userId,
+        campaignId: id,
+        campaignParticipationId,
+        domainTransaction,
+      });
+    });
+    return h.response({}).code(204);
+  },
+
   async getCampaignAssessmentParticipationResult(request) {
     const { userId } = request.auth.credentials;
     const { campaignId, campaignParticipationId } = request.params;

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -84,6 +84,25 @@ exports.register = async function (server) {
       },
     },
     {
+      method: 'DELETE',
+      path: '/api/campaigns/{id}/campaign-participations/{campaignParticipationId}',
+      config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignId,
+            campaignParticipationId: identifiersType.campaignParticipationId,
+          }),
+        },
+        handler: campaignParticipationController.deleteParticipation,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés, administrateurs de l'espace Pix Orga ou gestionnaire de la campagne**\n" +
+            '-Permet de supprimer une campaigne participation',
+        ],
+        tags: ['api', 'campaign-participation'],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/campaigns/{campaignId}/profiles-collection-participations/{campaignParticipationId}',
       config: {

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -16,6 +16,7 @@ class CampaignParticipation {
     status,
     sharedAt,
     deletedAt,
+    deletedBy,
     assessments,
     campaign,
     userId,
@@ -29,6 +30,7 @@ class CampaignParticipation {
     this.participantExternalId = participantExternalId;
     this.sharedAt = sharedAt;
     this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
     this.campaign = campaign;
     this.assessments = assessments;
     this.userId = userId;
@@ -81,6 +83,11 @@ class CampaignParticipation {
   improve() {
     this._canBeImproved();
     this.status = CampaignParticipationStatuses.STARTED;
+  }
+
+  delete(userId) {
+    this.deletedAt = new Date();
+    this.deletedBy = userId;
   }
 
   _canBeImproved() {

--- a/api/lib/domain/usecases/delete-campaign-participation.js
+++ b/api/lib/domain/usecases/delete-campaign-participation.js
@@ -1,0 +1,21 @@
+const bluebird = require('bluebird');
+
+module.exports = async function deleteCampaignParticipation({
+  userId,
+  campaignId,
+  domainTransaction,
+  campaignParticipationId,
+  campaignParticipationRepository,
+}) {
+  const campaignParticipations = await campaignParticipationRepository.getAllCampaignParticipationsForAUser({
+    campaignId,
+    campaignParticipationId,
+    domainTransaction,
+  });
+
+  await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
+    campaignParticipation.delete(userId);
+    const { id, deletedAt, deletedBy } = campaignParticipation;
+    await campaignParticipationRepository.delete({ id, deletedAt, deletedBy, domainTransaction });
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -215,6 +215,7 @@ module.exports = injectDependencies(
     createUser: require('./create-user'),
     createUserAndReconcileToSchoolingRegistrationFromExternalUser: require('./create-user-and-reconcile-to-schooling-registration-from-external-user'),
     createUserFromPoleEmploi: require('./create-user-from-pole-emploi'),
+    deleteCampaignParticipation: require('./delete-campaign-participation'),
     deleteCertificationIssueReport: require('./delete-certification-issue-report'),
     deleteSessionJuryComment: require('./delete-session-jury-comment'),
     deleteUnassociatedBadge: require('./delete-unassociated-badge'),

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -142,6 +142,7 @@ module.exports = {
       .from('campaign-participations')
       .where('campaign-participations.campaignId', '=', campaignId)
       .where('campaign-participations.isImproved', '=', false)
+      .where('campaign-participations.deletedAt', 'is', null)
       .limit(1);
 
     if (!result.length) return {};

--- a/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participations-stats-repository.js
@@ -16,7 +16,7 @@ const CampaignParticipationsStatsRepository = {
     return knex('campaign-participations')
       .select('masteryRate')
       .count()
-      .where({ campaignId, status: SHARED, isImproved: false })
+      .where({ campaignId, status: SHARED, isImproved: false, deletedAt: null })
       .whereNotNull('masteryRate')
       .groupBy('masteryRate')
       .orderBy('masteryRate', 'ASC');

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -94,6 +94,7 @@ module.exports = {
       .select('masteryRate')
       .where('isImproved', false)
       .andWhere('status', SHARED)
+      .andWhere('deletedAt', null)
       .andWhere({ campaignId });
     return results.map((result) => Number(result.masteryRate));
   },

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -281,6 +281,30 @@ describe('Acceptance | API | Campaign Participations', function () {
     });
   });
 
+  describe('DELETE /api/campaign/{campaignId}/campaign-participations/{campaignParticipationId}', function () {
+    it('should return 204 HTTP status code', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId, user }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
+      databaseBuilder.factory.buildMembership({ userId, organizationRole: 'ADMIN', organizationId });
+
+      await databaseBuilder.commit();
+      options = {
+        method: 'DELETE',
+        url: `/api/campaigns/${campaignId}/campaign-participations/${campaignParticipationId}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+
   describe('GET /api/campaigns/{campaignId}/profiles-collection-participations/{campaignParticipationId}', function () {
     beforeEach(function () {
       const learningObjects = learningContentBuilder.buildLearningContent([]);

--- a/api/tests/integration/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/delete-campaign-participation_test.js
@@ -1,0 +1,46 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+
+const deleteCampaignParticipation = require('../../../../lib/domain/usecases/delete-campaign-participation');
+
+describe('Integration | UseCases | delete-campaign-participation', function () {
+  it('should delete all campaignParticipations', async function () {
+    // given
+    const adminUserId = databaseBuilder.factory.buildUser().id;
+    const campaignId = databaseBuilder.factory.buildCampaign().id;
+    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+    databaseBuilder.factory.buildCampaignParticipation({
+      isImproved: true,
+      organizationLearnerId,
+      campaignId,
+    });
+    const campaignParticipationToDelete = databaseBuilder.factory.buildCampaignParticipation({
+      isImproved: false,
+      organizationLearnerId,
+      campaignId,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await DomainTransaction.execute((domainTransaction) => {
+      return deleteCampaignParticipation({
+        userId: adminUserId,
+        campaignId,
+        campaignParticipationId: campaignParticipationToDelete.id,
+        campaignParticipationRepository,
+        domainTransaction,
+      });
+    });
+
+    // then
+    const results = await knex('campaign-participations').where({ organizationLearnerId });
+
+    expect(results.length).to.equal(2);
+    results.forEach((campaignParticipaton) => {
+      expect(campaignParticipaton.deletedAt).not.to.equal(null);
+      expect(campaignParticipaton.deletedBy).to.equal(adminUserId);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -970,6 +970,20 @@ describe('Integration | Repository | Campaign Participation', function () {
       expect(result).to.deep.equal({ 1: 1, 2: 0, 3: 0 });
     });
 
+    it('returns the distribution for not deleted participations', async function () {
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0, deletedAt: null });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        masteryRate: 0,
+        deletedAt: new Date('2019-03-13'),
+      });
+      await databaseBuilder.commit();
+
+      const result = await campaignParticipationRepository.countParticipationsByStage(campaignId, stagesBoundaries);
+
+      expect(result).to.deep.equal({ 1: 1, 2: 0, 3: 0 });
+    });
+
     it('returns the distribution of participations by stage', async function () {
       databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0 });
       databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.05 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -150,6 +150,24 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
       });
     });
 
+    context('When there are deleted participations', function () {
+      it('counts only not deleted participations', async function () {
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1 });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          masteryRate: 0.2,
+          deletedAt: new Date('2021-05-29'),
+        });
+
+        await databaseBuilder.commit();
+        const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({
+          campaignId,
+        });
+        expect(resultDistribution).to.exactlyContainInOrder([{ count: 1, masteryRate: '0.10' }]);
+      });
+    });
+
     context('When there are participation without mastery rate', function () {
       it('returns only participation count for participation with mastery rate', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -213,6 +213,23 @@ describe('Integration | Repository | Campaign-Report', function () {
       expect(result).to.deep.equal([0.3]);
     });
 
+    it('should only take into account participations not deleted', async function () {
+      // given
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1, deletedAt: null });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        masteryRate: 0.3,
+        deletedAt: new Date('2019-03-06'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await campaignReportRepository.findMasteryRates(campaignId);
+
+      // then
+      expect(result).to.deep.equal([0.1]);
+    });
+
     it('should only take into account shared participations', async function () {
       // given
       databaseBuilder.factory.buildCampaignParticipation({ campaignId, masteryRate: 0.1, sharedAt: new Date() });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
@@ -15,6 +15,7 @@ module.exports = function buildCampaignParticipation({
   status = SHARED,
   validatedSkillsCount,
   schoolingRegistrationId = null,
+  deletedBy = null,
 } = {}) {
   const isShared = status === SHARED;
   return new CampaignParticipation({
@@ -29,5 +30,6 @@ module.exports = function buildCampaignParticipation({
     userId,
     validatedSkillsCount,
     schoolingRegistrationId,
+    deletedBy,
   });
 };

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -388,4 +388,35 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       });
     });
   });
+
+  describe('#deleteParticipation', function () {
+    it('should call the usecase to delete the campaignParticipation', async function () {
+      // given
+      const campaignParticipationId = 1;
+      const campaignId = 6;
+      const userId = 2;
+      const request = {
+        params: { id: campaignId, campaignParticipationId },
+        auth: { credentials: { userId } },
+      };
+      const domainTransaction = Symbol();
+
+      DomainTransaction.execute = (lambda) => {
+        return lambda(domainTransaction);
+      };
+      sinon.stub(usecases, 'deleteCampaignParticipation');
+      usecases.deleteCampaignParticipation.resolves();
+
+      // when
+      await campaignParticipationController.deleteParticipation(request, hFake);
+
+      // then
+      expect(usecases.deleteCampaignParticipation).to.have.been.calledOnceWith({
+        campaignParticipationId,
+        campaignId,
+        userId,
+        domainTransaction,
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/campaignParticipations/index_test.js
+++ b/api/tests/unit/application/campaignParticipations/index_test.js
@@ -76,4 +76,79 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       expect(response.statusCode).to.equal(204);
     });
   });
+
+  describe('DELETE /api/campaigns/{campaignId}/campaign-participations/{campaignParticipationId}', function () {
+    it('should return the controller response', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToManageCampaign').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(campaignParticipationController, 'deleteParticipation')
+        .callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'DELETE';
+      const url = '/api/campaigns/4/campaign-participations/123';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    context('When the user is neither an admin nor the owner of the campaign', function () {
+      it('should return 403', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'checkAuthorizationToManageCampaign')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'DELETE';
+        const url = '/api/campaigns/1/campaign-participations/123';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('When the campaignId is not a number', function () {
+      it('should return 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'DELETE';
+        const url = '/api/campaigns/ERTYU/campaign-participations/123';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('When the campaignParticipationId is not a number', function () {
+      it('should return 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'DELETE';
+        const url = '/api/campaigns/12/campaign-participations/ERTYUI';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -236,4 +236,27 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
       });
     });
   });
+
+  describe('delete', function () {
+    let clock;
+    const now = new Date('2021-09-25');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now.getTime());
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('updates attributes deletedAt and deletedBy', function () {
+      const userId = 4567;
+      const campaignParticipation = new CampaignParticipation({ deletedAt: null, deletedBy: null });
+
+      campaignParticipation.delete(userId);
+
+      expect(campaignParticipation.deletedAt).to.deep.equal(now);
+      expect(campaignParticipation.deletedBy).to.deep.equal(userId);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/delete-campaign-participation_test.js
@@ -1,0 +1,78 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { deleteCampaignParticipation } = require('../../../../lib/domain/usecases');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+describe('Unit | UseCase | delete-campaign-participation', function () {
+  //given
+  let clock;
+  const now = new Date('2021-09-25');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(now.getTime());
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('should call repository method to delete a campaign participation', async function () {
+    const campaignParticipationRepository = {
+      getAllCampaignParticipationsForAUser: sinon.stub(),
+      delete: sinon.stub(),
+    };
+    const campaignParticipationId = 1234;
+    const domainTransaction = Symbol('domainTransaction');
+    const campaignId = domainBuilder.buildCampaign().id;
+    const ownerId = domainBuilder.buildUser().id;
+    const organizationLearnerId = domainBuilder.buildOrganizationLearner().id;
+
+    const campaignParticipation1 = new CampaignParticipation({
+      id: campaignParticipationId,
+      organizationLearnerId,
+      deletedAt: null,
+      deletedBy: null,
+      campaignId,
+    });
+
+    const campaignParticipation2 = new CampaignParticipation({
+      id: 1235,
+      deletedAt: null,
+      deletedBy: null,
+    });
+
+    const campaignParticipations = [campaignParticipation1, campaignParticipation2];
+
+    await campaignParticipationRepository.getAllCampaignParticipationsForAUser
+      .withArgs({
+        campaignId,
+        campaignParticipationId,
+        domainTransaction,
+      })
+      .resolves(campaignParticipations);
+
+    //when
+    await deleteCampaignParticipation({
+      userId: ownerId,
+      campaignId,
+      campaignParticipationId,
+      campaignParticipationRepository,
+      domainTransaction,
+    });
+
+    //then
+    expect(campaignParticipationRepository.delete).to.have.been.calledTwice;
+    campaignParticipations.forEach((campaignParticipation) => {
+      const deletedCampaignParticipation = new CampaignParticipation({
+        ...campaignParticipation,
+        deletedAt: now,
+        deletedBy: ownerId,
+      });
+      expect(campaignParticipationRepository.delete).to.have.been.calledWithExactly({
+        id: deletedCampaignParticipation.id,
+        deletedAt: deletedCampaignParticipation.deletedAt,
+        deletedBy: deletedCampaignParticipation.deletedBy,
+        domainTransaction,
+      });
+    });
+  });
+});

--- a/orga/app/adapters/campaign-participant-activity.js
+++ b/orga/app/adapters/campaign-participant-activity.js
@@ -8,4 +8,8 @@ export default class CampaignParticipantActivity extends ApplicationAdapter {
       return `${this.host}/${this.namespace}/campaigns/${campaignId}/participants-activity`;
     }
   }
+
+  urlForDeleteRecord(id, modelName, { adapterOptions }) {
+    return `${this.host}/${this.namespace}/campaigns/${adapterOptions.campaignId}/campaign-participations/${adapterOptions.campaignParticipationId}`;
+  }
 }

--- a/orga/app/components/campaign/activity/dashboard.hbs
+++ b/orga/app/components/campaign/activity/dashboard.hbs
@@ -1,4 +1,9 @@
-<section class="activity-dashboard" ...attributes>
+<section
+  class="activity-dashboard"
+  ...attributes
+  {{did-insert this.fetchDataForParticipationsByStatus}}
+  {{did-update this.fetchDataForParticipationsByStatus @totalParticipations}}
+>
   <div class="activity-dashboard__row">
     <Campaign::Cards::ParticipantsCount
       @value={{this.total}}
@@ -14,6 +19,7 @@
   <div class="activity-dashboard__row">
     <Campaign::Charts::ParticipantsByDay
       @campaignId={{@campaign.id}}
+      @totalParticipations={{@totalParticipations}}
       @isTypeAssessment={{@campaign.isTypeAssessment}}
       class="activity-dashboard__participations-by-day"
     />

--- a/orga/app/components/campaign/activity/dashboard.js
+++ b/orga/app/components/campaign/activity/dashboard.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import sumBy from 'lodash/sumBy';
 
@@ -11,13 +12,11 @@ export default class Dashboard extends Component {
   @tracked shared = 0;
   @tracked participantsByStatusLoading = true;
 
-  constructor(...args) {
-    super(...args);
-    const { campaign } = this.args;
-
+  @action
+  fetchDataForParticipationsByStatus() {
     const adapter = this.store.adapterFor('campaign-stats');
 
-    adapter.getParticipationsByStatus(campaign.id).then((response) => {
+    adapter.getParticipationsByStatus(this.args.campaign.id).then((response) => {
       const data = response.data.attributes;
       this.shared = data.shared;
       this.participantCountByStatus = Object.entries(data);

--- a/orga/app/components/campaign/activity/delete-participation-modal.hbs
+++ b/orga/app/components/campaign/activity/delete-participation-modal.hbs
@@ -1,0 +1,25 @@
+{{#if @isModalOpen}}
+  <PixModal @title={{t "pages.campaign-activity.delete-participation-modal.title"}} @onCloseButtonClick={{@closeModal}}>
+    <:content>
+      <p>
+        {{t
+          "pages.campaign-activity.delete-participation-modal.text"
+          lastName=@participation.lastName
+          firstName=@participation.firstName
+          htmlSafe=true
+        }}
+      </p>
+      <p class="warning-text">
+        {{t "pages.campaign-activity.delete-participation-modal.warning"}}
+      </p>
+    </:content>
+    <:footer>
+      <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{@closeModal}}>
+        {{t "pages.campaign-activity.delete-participation-modal.actions.cancel"}}
+      </PixButton>
+      <PixButton @backgroundColor="red" @triggerAction={{this.deleteCampaignParticipation}}>
+        {{t "pages.campaign-activity.delete-participation-modal.actions.confirmation"}}
+      </PixButton>
+    </:footer>
+  </PixModal>
+{{/if}}

--- a/orga/app/components/campaign/activity/delete-participation-modal.js
+++ b/orga/app/components/campaign/activity/delete-participation-modal.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class deleteParticipantModal extends Component {
+  @action
+  deleteCampaignParticipation() {
+    this.args.deleteCampaignParticipant(this.args.campaign.id, this.args.participation);
+    this.args.closeModal();
+  }
+}

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -20,6 +20,9 @@
           <col class="table__column--wide" />
         {{/if}}
         <col class="table__column--wide" />
+        {{#if this.canDeleteParticipation}}
+          <col class="table__column--small table__column--right hide-on-mobile" />
+        {{/if}}
       </colgroup>
       <thead>
         <tr>
@@ -29,6 +32,13 @@
             <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
           <Table::Header>{{t "pages.campaign-activity.table.column.status"}}</Table::Header>
+          {{#if this.canDeleteParticipation}}
+            <Table::Header class="hide-on-mobile">
+              <span class="sr-only">
+                {{t "pages.campaign-activity.table.column.delete"}}
+              </span>
+            </Table::Header>
+          {{/if}}
         </tr>
       </thead>
 
@@ -63,6 +73,20 @@
                   @isTypeAssessment={{@campaign.isTypeAssessment}}
                 />
               </td>
+              {{#if this.canDeleteParticipation}}
+                <td class="hide-on-mobile">
+                  <PixIconButton
+                    @ariaLabel={{t "pages.campaign-activity.table.delete-button-label"}}
+                    @withBackground={{true}}
+                    @icon="trash-alt"
+                    @triggerAction={{fn this.openModal participation}}
+                    @size="small"
+                    class="campaign-activity-table-actions__button campaign-activity-table-actions__button--delete"
+                  >
+                    <FaIcon />
+                  </PixIconButton>
+                </td>
+              {{/if}}
             </tr>
           {{/each}}
         </tbody>
@@ -77,4 +101,12 @@
   {{#if @participations}}
     <Table::PaginationControl @pagination={{@participations.meta}} />
   {{/if}}
+
+  <Campaign::Activity::DeleteParticipationModal
+    @participation={{this.participationToDelete}}
+    @campaign={{@campaign}}
+    @deleteCampaignParticipant={{@deleteCampaignParticipant}}
+    @closeModal={{this.closeModal}}
+    @isModalOpen={{this.isModalOpen}}
+  />
 </section>

--- a/orga/app/components/campaign/activity/participants-list.js
+++ b/orga/app/components/campaign/activity/participants-list.js
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ParticipantsList extends Component {
+  @service notifications;
+  @service currentUser;
+  @service store;
+  @service intl;
+
+  @tracked isModalOpen;
+  @tracked participationToDelete;
+
+  constructor() {
+    super(...arguments);
+    this.isModalOpen = false;
+  }
+
+  get canDeleteParticipation() {
+    return this.currentUser.isAdminInOrganization || this.args.campaign.ownerId == this.currentUser.prescriber.id;
+  }
+
+  @action
+  openModal(participation, event) {
+    event.stopPropagation();
+    this.isModalOpen = true;
+    this.participationToDelete = participation;
+  }
+
+  @action
+  closeModal() {
+    this.participationToDelete = null;
+    this.isModalOpen = false;
+  }
+}

--- a/orga/app/components/campaign/charts/participants-by-day.hbs
+++ b/orga/app/components/campaign/charts/participants-by-day.hbs
@@ -1,4 +1,9 @@
-<Ui::ChartCard @title={{t "charts.participants-by-day.title"}} ...attributes>
+<Ui::ChartCard
+  @title={{t "charts.participants-by-day.title"}}
+  {{did-insert this.fetchParticipationsByDay}}
+  {{did-update this.fetchParticipationsByDay @totalParticipations}}
+  ...attributes
+>
   {{#if this.loading}}
     <Campaign::Charts::ParticipantsByDayLoader />
   {{else}}

--- a/orga/app/components/campaign/charts/participants-by-day.js
+++ b/orga/app/components/campaign/charts/participants-by-day.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import moment from 'moment';
 import { TOOLTIP_CONFIG, LEGEND_CONFIG } from '../../ui/chart';
 import locales from 'date-fns/locale';
@@ -16,14 +17,10 @@ export default class ParticipantsByDay extends Component {
 
   @tracked loading = true;
 
-  constructor(...args) {
-    super(...args);
-    const { campaignId } = this.args;
-
-    this.isTypeAssessment = this.args.isTypeAssessment;
+  @action
+  fetchParticipationsByDay() {
     const adapter = this.store.adapterFor('campaign-stats');
-
-    adapter.getParticipationsByDay(campaignId).then((response) => {
+    adapter.getParticipationsByDay(this.args.campaignId).then((response) => {
       const { 'started-participations': startedParticipations, 'shared-participations': sharedParticipations } =
         response.data.attributes;
 
@@ -55,7 +52,7 @@ export default class ParticipantsByDay extends Component {
   }
 
   get labels() {
-    return this.isTypeAssessment ? LABELS_ASSESSMENT : LABELS_PROFILE_COLLECTIONS;
+    return this.args.isTypeAssessment ? LABELS_ASSESSMENT : LABELS_PROFILE_COLLECTIONS;
   }
 
   get data() {
@@ -136,7 +133,7 @@ export default class ParticipantsByDay extends Component {
     let startedLabel = '';
     let sharedLabel = '';
 
-    if (this.isTypeAssessment) {
+    if (this.args.isTypeAssessment) {
       startedLabel = LABELS_ASSESSMENT.started.a11y;
       sharedLabel = LABELS_ASSESSMENT.shared.a11y;
     } else {

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -61,4 +61,9 @@ export default class ActivityRoute extends Route {
       controller.groups = [];
     }
   }
+
+  @action
+  refreshModel() {
+    this.modelFor('authenticated.campaigns.campaign').reload();
+  }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -6,6 +6,10 @@
 .activity__participants-list {
   margin-bottom: 24px;
   padding: 0;
+
+  .warning-text {
+    font-size:0.825rem;
+  }
 }
 
 @media (max-width: 768px) {

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -34,7 +34,7 @@
 }
 
 .participant-filter-banner {
-  margin-bottom: 12px;
+  margin: 12px 0;
 
   &__multi-select {
     width: auto;

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -2,7 +2,11 @@
 <h2 class="sr-only">{{t "pages.campaign-activity.title"}}</h2>
 
 {{#if @model.campaign.hasParticipations}}
-  <Campaign::Activity::Dashboard @campaign={{@model.campaign}} class="activity__dashboard" />
+  <Campaign::Activity::Dashboard
+    @campaign={{@model.campaign}}
+    @totalParticipations={{@model.participations.length}}
+    @class="activity__dashboard"
+  />
 
   <h3 class="sr-only">{{t "pages.campaign-activity.table.title"}}</h3>
 
@@ -16,6 +20,7 @@
     @rowCount={{@model.participations.meta.rowCount}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}
+    @deleteCampaignParticipant={{this.deleteCampaignParticipant}}
     class="activity__participants-list"
   />
 {{else}}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -472,4 +472,13 @@ export default function () {
     request.queryParams.include = ['competences.thematics', 'competences.thematics.tubes'].join(',');
     return schema.areas.all();
   });
+
+  this.delete('/campaigns/:campaignId/campaign-participations/:campaignParticipationId', (schema, request) => {
+    const campaignParticipationId = request.params.campaignParticipationId;
+
+    const campaignParticipation = schema.campaignParticipantActivities.find(campaignParticipationId);
+    campaignParticipation.destroy();
+
+    return new Response(204);
+  });
 }

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^14.1.0",
+    "@1024pix/pix-ui": "^14.1.1",
     "@ember/optional-features": "^2.0.0",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",
     "@formatjs/intl-locale": "^2.4.14",

--- a/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
+++ b/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
@@ -1,0 +1,66 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import { t } from 'ember-intl/test-support';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::Activity::DeleteParticipationModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('#deleteParticipation', function () {
+    module('when the user click to delete the campaign participation', function (hooks) {
+      let participation;
+      let campaign;
+      const deleteCampaignParticipant = sinon.stub();
+      const closeModal = sinon.stub();
+
+      hooks.beforeEach(async function () {
+        campaign = { id: 90, idPixLabel: 'id', type: 'ASSESSMENT' };
+        participation = {
+          id: 56,
+          firstName: 'Joe',
+          lastName: 'La frite',
+          status: 'TO_SHARE',
+          participantExternalId: 'patate',
+        };
+
+        this.set('campaign', campaign);
+        this.set('participation', participation);
+        this.closeModal = closeModal;
+        this.deleteCampaignParticipant = deleteCampaignParticipant;
+        this.isModalOpen = true;
+
+        await render(hbs`<Campaign::Activity::DeleteParticipationModal
+            @campaign={{this.campaign}}
+            @participation={{this.participation}}
+            @isModalOpen={{this.isModalOpen}}
+            @closeModal={{this.closeModal}}
+            @deleteCampaignParticipant={{this.deleteCampaignParticipant}}
+          />`);
+      });
+
+      test('it displays the modal to confirm the deletion', async function (assert) {
+        assert.contains(t('pages.campaign-activity.delete-participation-modal.title'));
+        assert.contains(t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
+        assert.contains(t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
+      });
+
+      module('When the user clicks on cancel button', function () {
+        test('it closes the modal and not delete the campaign participation', async function (assert) {
+          await clickByName(t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
+
+          assert.ok(closeModal.calledOnce);
+        });
+      });
+
+      module('When the user clicks on confirmation button', function () {
+        test('it deletes the campaign participation', async function (assert) {
+          await clickByName(t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
+
+          assert.ok(deleteCampaignParticipant.calledWith(campaign.id, participation));
+        });
+      });
+    });
+  });
+});

--- a/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
@@ -1,11 +1,10 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { find, click } from '@ember/test-helpers';
-import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
+import { find } from '@ember/test-helpers';
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import { t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Activity::ParticipantsList', function (hooks) {
@@ -125,68 +124,6 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           />`);
 
         assert.dom('[aria-label="Supprimer la participation"]').doesNotExist();
-      });
-    });
-
-    module('when the user click to delete the campaign participation', function (hooks) {
-      let participation;
-      let campaign;
-      let screen;
-      const deleteCampaignParticipant = sinon.stub();
-
-      hooks.beforeEach(async function () {
-        class CurrentUserStub extends Service {
-          isAdminInOrganization = true;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        campaign = { id: 90, idPixLabel: 'id', type: 'ASSESSMENT' };
-        participation = {
-          id: 56,
-          firstName: 'Joe',
-          lastName: 'La frite',
-          status: 'TO_SHARE',
-          participantExternalId: 'patate',
-        };
-
-        this.set('campaign', campaign);
-        this.set('participations', [participation]);
-        this.onClickParticipant = sinon.stub();
-        this.deleteCampaignParticipant = deleteCampaignParticipant;
-
-        screen = await render(hbs`<Campaign::Activity::ParticipantsList
-            @campaign={{this.campaign}}
-            @participations={{this.participations}}
-            @onClickParticipant={{this.onClickParticipant}}
-            @deleteCampaignParticipant={{this.deleteCampaignParticipant}}
-          />`);
-      });
-
-      test('it displays the modal to confirm the deletion', async function (assert) {
-        await click('[aria-label="Supprimer la participation"]');
-
-        assert.contains(t('pages.campaign-activity.delete-participation-modal.title'));
-        assert.contains(t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
-        assert.contains(t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
-      });
-
-      module('When the user clicks on cancel button', function () {
-        test('it closes the modal and not delete the campaign participation', async function (assert) {
-          await click('[aria-label="Supprimer la participation"]');
-          await clickByName(t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
-
-          assert.dom(screen.queryByText(t('pages.campaign-activity.delete-participation-modal.title'))).doesNotExist();
-          assert.contains('Joe');
-        });
-      });
-
-      module('When the user clicks on confirmation button', function () {
-        test('it deletes the campaign participation', async function (assert) {
-          await click('[aria-label="Supprimer la participation"]');
-          await clickByName(t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
-
-          assert.ok(deleteCampaignParticipant.calledWith(campaign.id, participation));
-        });
       });
     });
   });

--- a/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
@@ -1,29 +1,38 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { render, find } from '@ember/test-helpers';
-import { fillByLabel } from '@1024pix/ember-testing-library';
+import { find, click } from '@ember/test-helpers';
+import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
+import { t } from 'ember-intl/test-support';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Activity::ParticipantsList', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it should display participations details', async function (assert) {
-    this.campaign = { idPixLabel: 'id', type: 'ASSESSMENT' };
-    this.participations = [
+    class CurrentUserStub extends Service {
+      isAdminInOrganization = true;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    this.set('campaign', { idPixLabel: 'id', type: 'ASSESSMENT' });
+
+    this.set('participations', [
       {
         firstName: 'Joe',
         lastName: 'La frite',
         status: 'TO_SHARE',
         participantExternalId: 'patate',
       },
-    ];
-    this.onClickParticipant = sinon.stub();
+    ]);
+    this.set('onClickParticipant', sinon.stub());
 
     await render(hbs`<Campaign::Activity::ParticipantsList
-        @campaign={{campaign}}
-        @participations={{participations}}
-        @onClickParticipant={{onClickParticipant}}
+        @campaign={{this.campaign}}
+        @participations={{this.participations}}
+        @onClickParticipant={{this.onClickParticipant}}
       />`);
 
     assert.contains('Joe');
@@ -32,35 +41,193 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
     assert.contains("En attente d'envoi");
   });
 
+  module('#deleteParticipation', function () {
+    module('when the user is admin', function () {
+      test('it should display the trash to delete the participation', async function (assert) {
+        class CurrentUserStub extends Service {
+          isAdminInOrganization = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        this.campaign = { idPixLabel: 'id', type: 'ASSESSMENT' };
+        this.participations = [
+          {
+            firstName: 'Joe',
+            lastName: 'La frite',
+            status: 'TO_SHARE',
+            participantExternalId: 'patate',
+          },
+        ];
+        this.onClickParticipant = sinon.stub();
+
+        await render(hbs`<Campaign::Activity::ParticipantsList
+            @campaign={{this.campaign}}
+            @participations={{this.participations}}
+            @onClickParticipant={{this.onClickParticipant}}
+          />`);
+
+        assert.dom('[aria-label="Supprimer la participation"]').exists();
+      });
+    });
+
+    module('when the user is the owner of the campaign', function () {
+      test('it displays the trash to delete the participation', async function (assert) {
+        class CurrentUserStub extends Service {
+          isAdminInOrganization = false;
+          prescriber = EmberObject.create({ id: 109 });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        this.campaign = { idPixLabel: 'id', type: 'ASSESSMENT', ownerId: 109 };
+        this.participations = [
+          {
+            firstName: 'Joe',
+            lastName: 'La frite',
+            status: 'TO_SHARE',
+            participantExternalId: 'patate',
+          },
+        ];
+        this.onClickParticipant = sinon.stub();
+
+        await render(hbs`<Campaign::Activity::ParticipantsList
+            @campaign={{this.campaign}}
+            @participations={{this.participations}}
+            @onClickParticipant={{this.onClickParticipant}}
+          />`);
+
+        assert.dom('[aria-label="Supprimer la participation"]').exists();
+      });
+    });
+
+    module('when the user is neither an admin nor the owner of the campaign', function () {
+      test('it should not display the trash to delete the participation', async function (assert) {
+        class CurrentUserStub extends Service {
+          isAdminInOrganization = false;
+          prescriber = EmberObject.create({ id: 109 });
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        this.campaign = { idPixLabel: 'id', type: 'ASSESSMENT', ownerId: 1 };
+        this.participations = [
+          {
+            firstName: 'Joe',
+            lastName: 'La frite',
+            status: 'TO_SHARE',
+            participantExternalId: 'patate',
+          },
+        ];
+        this.onClickParticipant = sinon.stub();
+
+        await render(hbs`<Campaign::Activity::ParticipantsList
+            @campaign={{this.campaign}}
+            @participations={{this.participations}}
+            @onClickParticipant={{this.onClickParticipant}}
+          />`);
+
+        assert.dom('[aria-label="Supprimer la participation"]').doesNotExist();
+      });
+    });
+
+    module('when the user click to delete the campaign participation', function (hooks) {
+      let participation;
+      let campaign;
+      let screen;
+      const deleteCampaignParticipant = sinon.stub();
+
+      hooks.beforeEach(async function () {
+        class CurrentUserStub extends Service {
+          isAdminInOrganization = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        campaign = { id: 90, idPixLabel: 'id', type: 'ASSESSMENT' };
+        participation = {
+          id: 56,
+          firstName: 'Joe',
+          lastName: 'La frite',
+          status: 'TO_SHARE',
+          participantExternalId: 'patate',
+        };
+
+        this.set('campaign', campaign);
+        this.set('participations', [participation]);
+        this.onClickParticipant = sinon.stub();
+        this.deleteCampaignParticipant = deleteCampaignParticipant;
+
+        screen = await render(hbs`<Campaign::Activity::ParticipantsList
+            @campaign={{this.campaign}}
+            @participations={{this.participations}}
+            @onClickParticipant={{this.onClickParticipant}}
+            @deleteCampaignParticipant={{this.deleteCampaignParticipant}}
+          />`);
+      });
+
+      test('it displays the modal to confirm the deletion', async function (assert) {
+        await click('[aria-label="Supprimer la participation"]');
+
+        assert.contains(t('pages.campaign-activity.delete-participation-modal.title'));
+        assert.contains(t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
+        assert.contains(t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
+      });
+
+      module('When the user clicks on cancel button', function () {
+        test('it closes the modal and not delete the campaign participation', async function (assert) {
+          await click('[aria-label="Supprimer la participation"]');
+          await clickByName(t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
+
+          assert.dom(screen.queryByText(t('pages.campaign-activity.delete-participation-modal.title'))).doesNotExist();
+          assert.contains('Joe');
+        });
+      });
+
+      module('When the user clicks on confirmation button', function () {
+        test('it deletes the campaign participation', async function (assert) {
+          await click('[aria-label="Supprimer la participation"]');
+          await clickByName(t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
+
+          assert.ok(deleteCampaignParticipant.calledWith(campaign.id, participation));
+        });
+      });
+    });
+  });
+
   module('status filter', function () {
     test('should set default', async function (assert) {
+      class CurrentUserStub extends Service {
+        isAdminInOrganization = false;
+        prescriber = 1;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       this.campaign = { type: 'ASSESSMENT' };
       this.participations = [];
       this.selectedStatus = 'TO_SHARE';
       this.onClickParticipant = sinon.stub();
 
       await render(hbs`<Campaign::Activity::ParticipantsList
-        @campaign={{campaign}}
-        @participations={{participations}}
+        @campaign={{this.campaign}}
+        @participations={{this.participations}}
         @selectedStatus={{selectedStatus}}
-        @onClickParticipant={{onClickParticipant}}
+        @onClickParticipant={{this.onClickParticipant}}
       />`);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('[aria-label="Statut"]').selectedOptions[0].value, 'TO_SHARE');
+      assert.strictEqual(find('[aria-label="Statut"]').selectedOptions[0].value, 'TO_SHARE');
     });
 
     test('should filter on participations status', async function (assert) {
+      class CurrentUserStub extends Service {
+        isAdminInOrganization = false;
+        prescriber = 1;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       this.campaign = { type: 'ASSESSMENT' };
       this.participations = [];
       this.onClickParticipant = sinon.stub();
       this.onFilter = sinon.stub();
 
       await render(hbs`<Campaign::Activity::ParticipantsList
-          @campaign={{campaign}}
-          @participations={{participations}}
-          @onClickParticipant={{onClickParticipant}}
+          @campaign={{this.campaign}}
+          @participations={{this.participations}}
+          @onClickParticipant={{this.onClickParticipant}}
           @onFilter={{onFilter}}
         />`);
 

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupIntl, t } from 'ember-intl/test-support';
+import { render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Cards::StageAverage', function (hooks) {
@@ -12,9 +12,11 @@ module('Integration | Component | Campaign::Cards::StageAverage', function (hook
     this.averageResult = 0.5;
     this.stages = [{ threshold: 20 }, { threshold: 70 }];
 
-    await render(hbs`<Campaign::Cards::StageAverage @value={{averageResult}} @stages={{stages}} />`);
+    const screen = await render(hbs`<Campaign::Cards::StageAverage @value={{averageResult}} @stages={{stages}} />`);
 
     assert.contains(t('cards.participants-average-stages.title'));
-    assert.contains(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 }));
+    assert
+      .dom(screen.getByLabelText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 })))
+      .exists();
   });
 });

--- a/orga/tests/integration/components/campaign/stage-stars_test.js
+++ b/orga/tests/integration/components/campaign/stage-stars_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Campaign::StageStars', function (hooks) {
@@ -18,12 +18,8 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     const unacquiredStars = this.element.querySelectorAll('.pix-stars__unacquired');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(acquiredStars.length, 1);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(unacquiredStars.length, 1);
+    assert.strictEqual(acquiredStars.length, 1);
+    assert.strictEqual(unacquiredStars.length, 1);
   });
 
   test('should render a star only when threshold > 0 and reached', async function (assert) {
@@ -38,12 +34,8 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     const unacquiredStars = this.element.querySelectorAll('.pix-stars__unacquired');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(acquiredStars.length, 1);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(unacquiredStars.length, 1);
+    assert.strictEqual(acquiredStars.length, 1);
+    assert.strictEqual(unacquiredStars.length, 1);
   });
 
   test('should render a screen reader message', async function (assert) {
@@ -52,14 +44,10 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     this.stages = [{ threshold: 20 }, { threshold: 70 }];
 
     // when
-    await render(hbs`<Campaign::StageStars @result={{this.result}} @stages={{this.stages}} />`);
-
-    const srOnly = this.element.querySelector('.sr-only');
+    const screen = await render(hbs`<Campaign::StageStars @result={{this.result}} @stages={{this.stages}} />`);
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(srOnly.textContent.trim(), '1 étoiles sur 2');
+    assert.dom(screen.getByLabelText('1 étoiles sur 2')).exists();
   });
 
   test('should not display tooltip by default', async function (assert) {

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { setupIntl, t } from 'ember-intl/test-support';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Participant::Assessment::Header', function (hooks) {
@@ -127,13 +127,14 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
             isShared: true,
           };
 
-          await render(
+          const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{participation}} @campaign={{campaign}} />`
           );
 
+          assert.dom(`[aria-label="${t('pages.assessment-individual-results.stages.label')}"]`).exists();
           assert
-            .dom(`[aria-label="${t('pages.assessment-individual-results.stages.label')}"]`)
-            .containsText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 }));
+            .dom(screen.getByLabelText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 })))
+            .exists();
         });
       });
 

--- a/orga/tests/unit/adapters/campaign-participant-activity_test.js
+++ b/orga/tests/unit/adapters/campaign-participant-activity_test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapters | campaign-participant-activity', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:campaign-participant-activity');
+  });
+
+  module('#urlForQuery', () => {
+    test('should build query url from campaign', async function (assert) {
+      const query = { campaignId: 'campaignId1' };
+      const url = await adapter.urlForQuery(query);
+
+      assert.ok(url.endsWith('/api/campaigns/campaignId1/participants-activity'));
+
+      assert.strictEqual(query.campaignId, undefined);
+    });
+  });
+
+  module('#urlForDeleteRecord', () => {
+    test('should build query url from adapterOptions', async function (assert) {
+      const adapterOptions = { campaignId: 'campaignId1', campaignParticipationId: 'campaignParticipationId1' };
+      const url = await adapter.urlForDeleteRecord(null, null, { adapterOptions });
+
+      assert.ok(url.endsWith('/api/campaigns/campaignId1/campaign-participations/campaignParticipationId1'));
+    });
+  });
+});

--- a/orga/tests/unit/components/campaign/activity/dashboard_test.js
+++ b/orga/tests/unit/components/campaign/activity/dashboard_test.js
@@ -28,14 +28,12 @@ module('Unit | Component | Campaign::Activity::Dashboard', (hooks) => {
     component = await createGlimmerComponent('component:campaign/activity/dashboard', {
       campaign: { id: 1 },
     });
+    await component.fetchDataForParticipationsByStatus();
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.total, 3);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.shared, 1);
+
+    assert.strictEqual(component.total, 3);
+    assert.strictEqual(component.shared, 1);
     assert.deepEqual(component.participantCountByStatus, [
       ['started', 1],
       ['completed', 1],

--- a/orga/tests/unit/components/campaign/charts/participants-by-day_test.js
+++ b/orga/tests/unit/components/campaign/charts/participants-by-day_test.js
@@ -26,7 +26,7 @@ module('Unit | Component | Campaign::Charts::ParticipantsByDay', (hooks) => {
 
     // when
     component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
-
+    await component.fetchParticipationsByDay();
     // then
     assert.deepEqual(component.startedDatasets, []);
     assert.deepEqual(component.sharedDatasets, []);
@@ -45,7 +45,7 @@ module('Unit | Component | Campaign::Charts::ParticipantsByDay', (hooks) => {
 
     // when
     component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
-
+    await component.fetchParticipationsByDay();
     // then
     assert.deepEqual(component.startedDatasets, [{ day: '2021-06-01', count: '1' }]);
     assert.deepEqual(component.sharedDatasets, [{ day: '2021-06-01', count: '1' }]);
@@ -64,7 +64,7 @@ module('Unit | Component | Campaign::Charts::ParticipantsByDay', (hooks) => {
 
     // when
     component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
-
+    await component.fetchParticipationsByDay();
     // then
     assert.deepEqual(component.sharedDatasets, [
       { day: '2021-06-01', count: '0' },
@@ -89,7 +89,7 @@ module('Unit | Component | Campaign::Charts::ParticipantsByDay', (hooks) => {
 
       // when
       component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
-
+      await component.fetchParticipationsByDay();
       // then
       assert.deepEqual(component.sharedDatasets, [
         { day: '2021-06-01', count: '1' },
@@ -115,7 +115,7 @@ module('Unit | Component | Campaign::Charts::ParticipantsByDay', (hooks) => {
 
       // when
       component = await createGlimmerComponent('component:campaign/charts/participants-by-day');
-
+      await component.fetchParticipationsByDay();
       // then
       assert.deepEqual(component.startedDatasets, [
         { day: '2021-06-01', count: '2' },

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -11,28 +11,30 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
   });
 
   module('#action goToParticipantPage', function () {
-    test('it should call transitionToRoute with appropriate arguments for profiles collection', function (assert) {
+    test('it should call transitionTo with appropriate arguments for profiles collection', function (assert) {
       // given
-      controller.transitionToRoute = sinon.stub();
+      controller.router = { transitionTo: sinon.stub() };
       controller.model = { campaign: { isTypeAssessment: false } };
 
       // when
       controller.send('goToParticipantPage', 123, 456);
 
       // then
-      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.participant-profile', 123, 456));
+      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.participant-profile', 123, 456));
     });
 
-    test('it should call transitionToRoute with appropriate arguments for assessment', function (assert) {
+    test('it should call transitionTo with appropriate arguments for assessment', function (assert) {
       // given
-      controller.transitionToRoute = sinon.stub();
+      controller.router = { transitionTo: sinon.stub() };
       controller.model = { campaign: { isTypeAssessment: true } };
 
       // when
       controller.send('goToParticipantPage', 123, 456);
 
       // then
-      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.participant-assessment', 123, 456));
+      assert.true(
+        controller.router.transitionTo.calledWith('authenticated.campaigns.participant-assessment', 123, 456)
+      );
     });
   });
 
@@ -52,13 +54,9 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED', groups: ['L3'] });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.pageNumber, null);
+      assert.strictEqual(controller.pageNumber, null);
       assert.deepEqual(controller.divisions, ['A1']);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.status, 'STARTED');
+      assert.strictEqual(controller.status, 'STARTED');
       assert.deepEqual(controller.groups, ['L3']);
     });
 
@@ -73,13 +71,9 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { status: 'COMPLETED' });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, null);
+        assert.strictEqual(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A2']);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, 'COMPLETED');
+        assert.strictEqual(controller.status, 'COMPLETED');
       });
     });
 
@@ -94,13 +88,9 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { status: 'COMPLETED' });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, null);
+        assert.strictEqual(controller.pageNumber, null);
         assert.deepEqual(controller.groups, ['A2']);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, 'COMPLETED');
+        assert.strictEqual(controller.status, 'COMPLETED');
       });
     });
 
@@ -115,13 +105,9 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { divisions: ['A1'] });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, null);
+        assert.strictEqual(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A1']);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, 'SHARED');
+        assert.strictEqual(controller.status, 'SHARED');
       });
     });
 
@@ -135,9 +121,36 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.send('triggerFiltering', { status: '' });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, '');
+        assert.strictEqual(controller.status, '');
+      });
+    });
+  });
+
+  module('#action deleteCampaignParticipant', function (hooks) {
+    hooks.beforeEach(function () {
+      controller.model = { campaign: { isTypeAssessment: false, id: 7 } };
+    });
+
+    module('when the deleteCampaignParticipant works', function () {
+      test('it should called destroyRecord', async function (assert) {
+        // given
+        const campaignParticipantActivity = {
+          id: 89,
+          destroyRecord: sinon.stub(),
+        };
+        const campaignId = controller.model.campaign.id;
+        controller.send = sinon.stub();
+        // when
+        await controller.deleteCampaignParticipant(campaignId, campaignParticipantActivity);
+
+        //then
+        assert.true(
+          campaignParticipantActivity.destroyRecord.calledWith({
+            adapterOptions: { campaignId, campaignParticipationId: campaignParticipantActivity.id },
+          })
+        );
+
+        assert.true(controller.send.calledWith('refreshModel'));
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -273,13 +273,18 @@
       }
     },
     "campaign-activity": {
+      "actions": {
+        "delete": "Delete"
+      },
       "title": "Activity",
       "table": {
         "column": {
+          "delete": "Delete participation",
           "first-name": "First name",
           "last-name": "Last name",
           "status": "Status"
         },
+        "delete-button-label": "Delete participation",
         "empty": "No participants",
         "row-title": "Participant",
         "title": "List of participants"
@@ -290,6 +295,18 @@
         "SHARED-assessment": "Submitted results",
         "TO_SHARE-profile": "Pending profile",
         "SHARED-profile": "Submitted profile"
+      },
+      "delete-participation-modal": {
+        "actions": {
+          "cancel": "No",
+        "confirmation": "Yes, delete"
+        },
+        "error": "An error occurred while removing this participation.",
+        "success": "The participation has been successfully deleted",
+        "title": "Delete this participation ?",
+        "text": "You are about to delete the participation of <strong>{firstName} {lastName}</strong>, it will no longer be visible nor included in the statistics of the campaign.",
+        "warning": "The participant will be able to complete their customised test but will no longer be able to submit their results. They will also not be able to participate in the campaign again."
+
       }
     },
     "campaign-creation": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -273,13 +273,18 @@
       }
     },
     "campaign-activity": {
+      "actions": {
+        "delete": "Supprimer"
+      },
       "title": "Activité",
       "table": {
         "column": {
+          "delete": "Supprimer la participation",
           "first-name": "Prénom",
           "last-name": "Nom",
           "status": "Statut"
         },
+        "delete-button-label": "Supprimer la participation",
         "empty": "Aucun participant",
         "row-title": "Participant",
         "title": "Liste des participants"
@@ -290,6 +295,17 @@
         "SHARED-assessment": "Résultats reçus",
         "TO_SHARE-profile": "En attente d'envoi",
         "SHARED-profile": "Profil reçu"
+      },
+      "delete-participation-modal": {
+        "actions": {
+          "cancel": "Non",
+          "confirmation": "Oui, je supprime"
+        },
+        "error": "Un problème est survenu lors de la suppression de la participation.",
+        "success": "La participation a été supprimée avec succès.",
+        "title": "Supprimer cette participation ?",
+        "text": "Vous êtes sur le point de supprimer la participation de <strong>{firstName} {lastName}</strong>, celle-ci ne sera plus visible ni comprise dans les statistiques de la campagne.",
+        "warning": "Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne."
       }
     },
     "campaign-creation": {


### PR DESCRIPTION
## :unicorn: Problème
C'est la dernière US de l'épix "suppression d'une participation".
Avant quand un prescrit se retrouvait avec 2 participations, il était impossible pour prescripteur de supprimer la participation problématique

## :robot: Solution
Permettre la suppression directement dans l'onglet Activité d'une campagne, seulement si le prescripteur est admin de l'orga ou propriétaire de la campagne

## :rainbow: Remarques


## :100: Pour tester
- 1er Cas: prescripteur admin ou propriétaire
   -  Se connecter à Pix Orga
   - Aller dans l'onglet `Activité` d'une campagne avec des participations
   - Cliquer sur la poubelle, voir apparaitre la pop-up et confirmer la suppression

- 2ème cas: prescripteur n'est  ni admin ni propriétaire
   -  Se connecter à Pix Orga
   - Aller dans l'onglet `Activité` d'une campagne avec des participations
   - Constater l'absence de la poubelle
   
- 3ème cas (peut être fait en même temps que cas n°1)
   - Aller dans Pix app
   - Participer à une campagne à envois multiples et envoyer ses résultats
   - Repasser cette même campagne et envoyer de nouveau ses résultats
   -  Se connecter à Pix Orga
   - Aller dans l'onglet `Activité` de la  campagne passée
   -  Cliquer sur la poubelle, voir apparaitre la pop-up et confirmer la suppression
   - Aller voir BDD si toutes les campaignParticipations sont deleted
