### PR TITLE
[FEATURE] Enregistrer le prénom et nom reçu du GAR lors du rajout de la connexion GAR à un utilisateur existant (PIX-4770)

### DIFF
--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -70,12 +70,13 @@ async function _addGarAuthenticationMethod({
   authenticationMethodRepository,
   userRepository,
 }) {
-  const samlId = tokenService.extractSamlId(externalUserToken);
-  if (!samlId) {
+  const tokenData = await tokenService.extractExternalUserFromIdToken(externalUserToken);
+  if (!tokenData) {
     throw new InvalidExternalUserTokenError(
       'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.'
     );
   }
+  const { samlId, firstName, lastName } = tokenData;
 
   await _checkIfSamlIdIsNotReconciledWithAnotherUser({ samlId, userId, userRepository });
 
@@ -83,6 +84,10 @@ async function _addGarAuthenticationMethod({
     identityProvider: AuthenticationMethod.identityProviders.GAR,
     externalIdentifier: samlId,
     userId,
+    authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
+      firstName,
+      lastName,
+    }),
   });
   await authenticationMethodRepository.create({ authenticationMethod: garAuthenticationMethod });
 }

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -4,7 +4,6 @@ const {
   PasswordNotMatching,
   UserShouldChangePasswordError,
   UnexpectedUserAccountError,
-  InvalidExternalUserTokenError,
   UserAlreadyExistsWithAuthenticationMethodError,
 } = require('../errors');
 
@@ -70,14 +69,7 @@ async function _addGarAuthenticationMethod({
   authenticationMethodRepository,
   userRepository,
 }) {
-  const tokenData = await tokenService.extractExternalUserFromIdToken(externalUserToken);
-  if (!tokenData) {
-    throw new InvalidExternalUserTokenError(
-      'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.'
-    );
-  }
-  const { samlId, firstName, lastName } = tokenData;
-
+  const { samlId, firstName, lastName } = await tokenService.extractExternalUserFromIdToken(externalUserToken);
   await _checkIfSamlIdIsNotReconciledWithAnotherUser({ samlId, userId, userRepository });
 
   const garAuthenticationMethod = new AuthenticationMethod({

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -274,6 +274,10 @@ describe('Acceptance | Controller | authentication-controller', function () {
           externalIdentifier: 'SAMLJACKSONID',
         });
         expect(authenticationMethods.length).to.equal(1);
+        expect(authenticationMethods[0].authenticationComplement).to.deep.equal({
+          firstName: 'saml',
+          lastName: 'jackson',
+        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -8,7 +8,6 @@ const {
   PasswordNotMatching,
   UserShouldChangePasswordError,
   UnexpectedUserAccountError,
-  InvalidExternalUserTokenError,
   UserAlreadyExistsWithAuthenticationMethodError,
 } = require('../../../../lib/domain/errors');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
@@ -159,34 +158,6 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
     });
 
     context('when adding GAR authentication method', function () {
-      it('should throw an error if external user token is invalid', async function () {
-        // given
-        const password = 'Azerty123*';
-        const user = createUserWithValidCredentials({
-          password,
-          authenticationService,
-          userRepository,
-        });
-
-        const invalidExternalUserToken = 'INVALID_EXTERNAL_USER_TOKEN';
-        tokenService.extractExternalUserFromIdToken.withArgs(invalidExternalUserToken).returns(null);
-
-        // when
-        const error = await catchErr(authenticateExternalUser)({
-          username: user.email,
-          password,
-          externalUserToken: invalidExternalUserToken,
-          expectedUserId: user.id,
-          tokenService,
-          authenticationService,
-          authenticationMethodRepository,
-          userRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(InvalidExternalUserTokenError);
-      });
-
       it('should throw an error if user from external user token is not the same as found user from credentials', async function () {
         // given
         const password = 'Azerty123*';

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -23,7 +23,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
   beforeEach(function () {
     tokenService = {
       createAccessTokenForSaml: sinon.stub(),
-      extractSamlId: sinon.stub(),
+      extractExternalUserFromIdToken: sinon.stub(),
     };
     authenticationService = {
       getUserByUsernameAndPassword: sinon.stub(),
@@ -169,7 +169,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         });
 
         const invalidExternalUserToken = 'INVALID_EXTERNAL_USER_TOKEN';
-        tokenService.extractSamlId.withArgs(invalidExternalUserToken).returns(null);
+        tokenService.extractExternalUserFromIdToken.withArgs(invalidExternalUserToken).returns(null);
 
         // when
         const error = await catchErr(authenticateExternalUser)({
@@ -198,7 +198,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
 
         const externalUserToken = 'EXTERNAL_USER_TOKEN';
         const samlId = 'samlId';
-        tokenService.extractSamlId.withArgs(externalUserToken).returns(samlId);
+        tokenService.extractExternalUserFromIdToken.withArgs(externalUserToken).returns({ samlId });
 
         const userFromExternalUserToken = domainBuilder.buildUser({ id: userFromCredentials.id + 1 });
         userRepository.getBySamlId.withArgs(samlId).resolves(userFromExternalUserToken);
@@ -234,6 +234,8 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           user,
           externalUserToken,
           samlId,
+          firstName: 'Hervé',
+          lastName: 'Le Terrier',
           tokenService,
           userRepository,
           authenticationMethodRepository,
@@ -256,6 +258,10 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier: samlId,
           userId: user.id,
+          authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
+            firstName: 'Hervé',
+            lastName: 'Le Terrier',
+          }),
         });
         expect(authenticationMethodRepository.create).to.have.been.calledWith({
           authenticationMethod: expectedAuthenticationMethod,
@@ -279,6 +285,8 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           user,
           externalUserToken,
           samlId: externalIdentifier,
+          firstName: 'Monique',
+          lastName: 'Samoëns',
           tokenService,
           userRepository,
           authenticationMethodRepository,
@@ -301,6 +309,10 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           identityProvider: AuthenticationMethod.identityProviders.GAR,
           externalIdentifier,
           userId: user.id,
+          authenticationComplement: new AuthenticationMethod.GARAuthenticationComplement({
+            firstName: 'Monique',
+            lastName: 'Samoëns',
+          }),
         });
         expect(authenticationMethodRepository.create).to.have.been.calledWith({
           authenticationMethod: expectedAuthenticationMethod,
@@ -454,8 +466,10 @@ function _stubToEnableAddGarAuthenticationMethod({
   tokenService,
   userRepository,
   authenticationMethodRepository,
+  firstName = 'Hervé',
+  lastName = 'Le Terrier',
 }) {
-  tokenService.extractSamlId.withArgs(externalUserToken).returns(samlId);
+  tokenService.extractExternalUserFromIdToken.withArgs(externalUserToken).returns({ samlId, firstName, lastName });
   userRepository.getBySamlId.withArgs(samlId).resolves(user);
   authenticationMethodRepository.create.resolves();
 }


### PR DESCRIPTION
## :unicorn: Problème

On enregistre les noms et prénoms de l'utilisateur venant du GAR lorsqu'un compte est créé à sa première connexion, mais s'il possède déjà un compte avec une autre méthode de connexion, l'information n'est pas enregistrée.

## :robot: Solution

Enregistrer ces informations aussi lorsque le compte existe déjà et qu'une méthode de connexion supplémentaire est ajoutée.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

1. Choisir un utilisateur qui a une méthode de connexion autre que le GAR (exemple: identifiant), et est réconcilié avec un établissement SCO (ex: Blue Ivy Carter née le 07 01 2012)
3. Accéder à Pix depuis le GAR Simulé avec cet utilisateur
4. Entrer un code parcours (ex: SCOBADGE1)
5. Entrer la date de naissance de l'utilisateur (ex: pour Blue Ivy, le 07 01 2012)
6. Cliquer sur *Continuer avec mon compte pix*
7. Se connecter avec l'identifiant de l'utilisateur (ex blueivy.carter0701)
8. En base, constater que l`authentication-method` ajouté pour cet utilisateur a bien l'`authentication-completement` avec son nom et son prénom.