### PR TITLE
[FEATURE] Création de plusieurs lots d'acquis via un script pour le badge Cléa (PIX-4749).

### DIFF
--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -44,7 +44,6 @@ async function main() {
       )
     );
   });
-  console.log('ok');
 }
 
 async function checkBadgeExistence(badgeId) {

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -36,7 +36,12 @@ async function main() {
   console.log('Saving badge criteria... ');
   return DomainTransaction.execute(async (domainTransaction) => {
     await Promise.all(
-      jsonFile.criteria.map((badgeCriterion) => badgeCriteriaRepository.save({ badgeCriterion }, domainTransaction))
+      jsonFile.criteria.map((badgeCriterion) =>
+        badgeCriteriaRepository.save(
+          { badgeCriterion: { ...badgeCriterion, badgeId: jsonFile.badgeId } },
+          domainTransaction
+        )
+      )
     );
   });
   console.log('ok');

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -1,0 +1,35 @@
+('use strict');
+const { NotFoundError } = require('../lib/domain/errors');
+const badgeRepository = require('../lib/infrastructure/repositories/badge-repository');
+
+async function main() {
+  console.log('Starting creating badge');
+
+  const filePath = process.argv[2];
+
+  console.log('Reading json data file... ');
+  const jsonFile = require(filePath);
+  console.log('ok');
+
+  await checkBadgeExistence(jsonFile.badgeId);
+}
+
+async function checkBadgeExistence(badgeId) {
+  try {
+    await badgeRepository.get(badgeId);
+  } catch (error) {
+    throw new NotFoundError(`Badge ${badgeId} not found`);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = { checkBadgeExistence };

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -7,8 +7,25 @@ const badgeCriteriaRepository = require('../lib/infrastructure/repositories/badg
 const DomainTransaction = require('../lib/infrastructure/DomainTransaction');
 const { knex } = require('../db/knex-database-connection');
 
+// Usage: node scripts/create-badge-criteria-for-specified-badge path/data.json
+// data.json
+// {
+//   "badgeId": 112,
+//   "criteria": [
+//     {
+//       "threshold": 23,
+//       "scope": "CampaignParticipation",
+//       "skillSetIds": null
+//     },
+//     {
+//       "threshold": 26,
+//       "scope": "SkillSet",
+//       "skillSetIds": [100683, 100687]
+//     }
+//   ]
+// }
 async function main() {
-  console.log('Starting creating badge');
+  console.log('Starting creating badge criteria');
 
   const filePath = process.argv[2];
 

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -363,6 +363,16 @@ describe('Integration | Repository | Badge', function () {
       expect(myBadge.badgeCriteria.length).to.equal(1);
       expect(myBadge.skillSets.length).to.equal(1);
     });
+
+    describe('when badge does not exist', function () {
+      it('should throw an error', async function () {
+        const notExistingBadgeId = 123;
+
+        const error = await catchErr(badgeRepository.get)(notExistingBadgeId);
+
+        expect(error).to.be.instanceOf(Error);
+      });
+    });
   });
 
   describe('#getByKey', function () {

--- a/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
+++ b/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
@@ -2,6 +2,7 @@ const { expect, catchErr, databaseBuilder } = require('../../test-helper');
 const {
   checkBadgeExistence,
   checkCriteriaFormat,
+  checkSkillSetIds,
 } = require('../../../scripts/create-badge-criteria-for-specified-badge.js');
 const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
 
@@ -121,6 +122,41 @@ describe('Integration | Scripts | create-badge-criteria-for-specified-badge', fu
             'Badge criterion is invalid : SkillSetIds should be provided for SkillSet scope'
           );
         });
+      });
+    });
+  });
+
+  describe('#checkSkillSetIds', function () {
+    context('when all skillSetIds exist', function () {
+      it('should not throw an error', async function () {
+        // given
+        const skillSetIds = [
+          databaseBuilder.factory.buildSkillSet().id,
+          databaseBuilder.factory.buildSkillSet().id,
+          databaseBuilder.factory.buildSkillSet().id,
+        ];
+        await databaseBuilder.commit();
+
+        // when & then
+        expect(await checkSkillSetIds(skillSetIds)).not.to.throw;
+      });
+    });
+
+    context('when there is at least one skillSetId that does not exist', function () {
+      it('should throw an error', async function () {
+        // given
+        const skillSetIds = [
+          databaseBuilder.factory.buildSkillSet().id,
+          databaseBuilder.factory.buildSkillSet().id,
+          '1233',
+        ];
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(checkSkillSetIds)(skillSetIds);
+
+        expect(error).to.be.instanceof(Error);
+        expect(error.message).to.be.equal('At least one skillSetId does not exist');
       });
     });
   });

--- a/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
+++ b/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
@@ -1,7 +1,11 @@
 const { expect, catchErr, databaseBuilder } = require('../../test-helper');
-const { checkBadgeExistence } = require('../../../scripts/create-badge-criteria-for-specified-badge.js');
+const {
+  checkBadgeExistence,
+  checkCriteriaFormat,
+} = require('../../../scripts/create-badge-criteria-for-specified-badge.js');
+const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
 
-describe.only('Integration | Scripts | create-badge-criteria-for-specified-badge', function () {
+describe('Integration | Scripts | create-badge-criteria-for-specified-badge', function () {
   describe('#checkBadgeExistence', function () {
     it('should throw an error if the badge does not exist', async function () {
       // given
@@ -22,6 +26,102 @@ describe.only('Integration | Scripts | create-badge-criteria-for-specified-badge
 
       // when
       expect(await checkBadgeExistence(badge.id)).not.to.throw;
+    });
+  });
+
+  describe('#checkCriteriaFormat', function () {
+    context('when badge criteria is valid', function () {
+      it('should not throw an error if the scope is SkillSet', function () {
+        // given
+        const badgeCriteria = [
+          {
+            threshold: 0,
+            scope: BadgeCriterion.SCOPES.SKILL_SET,
+            skillSetIds: [1, 2, 3],
+          },
+        ];
+
+        // when & then
+        expect(checkCriteriaFormat(badgeCriteria)).not.to.throw;
+      });
+
+      it('should not throw an error when the scope is CampaignParticipation and skillSetIds field is null', function () {
+        // given
+        const badgeCriteria = [
+          {
+            threshold: 0,
+            scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+            skillSetIds: null,
+          },
+        ];
+
+        // when & then
+        expect(checkCriteriaFormat(badgeCriteria)).not.to.throw;
+      });
+    });
+
+    describe('when one badge criterion is not valid', function () {
+      it('should throw an error', async function () {
+        // given
+        const badgeCriteria = [
+          {
+            threshold: -1,
+            scope: BadgeCriterion.SCOPES.SKILL_SET,
+            skillSetIds: [1, 2, 3],
+          },
+        ];
+
+        // when
+        const error = await catchErr(checkCriteriaFormat)(badgeCriteria);
+
+        // then
+        expect(error).to.be.an.instanceof(Error);
+        expect(error.message).to.equal('"threshold" must be greater than or equal to 0');
+      });
+
+      context('when scope is CampaignParticipation and skillSetIds are provided', function () {
+        it('should throw an error', async function () {
+          // given
+          const badgeCriteria = [
+            {
+              threshold: 1,
+              scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+              skillSetIds: [1, 2, 3],
+            },
+          ];
+
+          // when
+          const error = await catchErr(checkCriteriaFormat)(badgeCriteria);
+
+          // then
+          expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.equal(
+            'Badge criterion is invalid : SkillSetIds provided for CampaignParticipation scope'
+          );
+        });
+      });
+
+      context('when scope is SkillSet and skillSetIds are not provided', function () {
+        it('should throw an error', async function () {
+          // given
+          const badgeCriteria = [
+            {
+              threshold: 1,
+              scope: BadgeCriterion.SCOPES.SKILL_SET,
+              skillSetIds: null,
+            },
+          ];
+
+          // when
+          const error = await catchErr(checkCriteriaFormat)(badgeCriteria);
+
+          // then
+          expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.equal(
+            'Badge criterion is invalid : SkillSetIds should be provided for SkillSet scope'
+          );
+        });
+      });
     });
   });
 });

--- a/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
+++ b/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
@@ -1,0 +1,27 @@
+const { expect, catchErr, databaseBuilder } = require('../../test-helper');
+const { checkBadgeExistence } = require('../../../scripts/create-badge-criteria-for-specified-badge.js');
+
+describe.only('Integration | Scripts | create-badge-criteria-for-specified-badge', function () {
+  describe('#checkBadgeExistence', function () {
+    it('should throw an error if the badge does not exist', async function () {
+      // given
+      const badgeId = 123;
+
+      // when
+      const error = await catchErr(checkBadgeExistence)(badgeId);
+
+      // then
+      expect(error).to.be.an.instanceof(Error);
+      expect(error.message).to.equal(`Badge ${badgeId} not found`);
+    });
+
+    it('should not throw an error if the badge exists', async function () {
+      // given
+      const badge = databaseBuilder.factory.buildBadge();
+      await databaseBuilder.commit();
+
+      // when
+      expect(await checkBadgeExistence(badge.id)).not.to.throw;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'actualisation du badge Cléa, nous souhaitons pouvoir créer un RT avec plusieurs lots d'acquis (`skillsets`). 
Pix-Admin ne nous permet toutefois à l'heure actuelle que de créer un RT avec au maximum un seul lot d'acquis.

## :robot: Solution

Nous créeons le nouveau RT dans Pix-admin et créons les différents critères de badge (`badge-criteria`, qui incluent `CampaignParticipation` et `skillSet`) via un script important un fichier JSON ayant le format suivant :  (Il est possible bien sur d'ajouter autant de skillsets que nécessaire)

```
{
  "badgeId": number,
  "criteria": [
    {
      "threshold": number,
      "scope": "CampaignParticipation",
      "skillSetIds": Array
    }
  ]
}
```

## :rainbow: Remarques

Nous avons fait le choix de ne pas développer cette feature sur pix-admin en raison de la refonte à venir des profils cible sur l'application. 

## :100: Pour tester

En local, exécuter le script avec un fichier JSON ayant la configuration précédemment citée avec les caractéristiques suivantes : 

Cas passant :
```
{
  "badgeId": 112,
  "criteria": [
    {
      "threshold": 23,
      "scope": "CampaignParticipation",
      "skillSetIds": null
    },
    {
      "threshold": 26,
      "scope": "SkillSet",
      "skillSetIds": [100683, 100687]
    }
  ]
}
```

Vérifier que l'ensemble des critères de badges ont bien été créés en base de données. 