### PR TITLE
[FEATURE] Afficher un message spécifique dans PixOrga lorsque l'utilisateur se rend sur l'onglet Certifications et que l'établissement n'a pas encore importé d'élèves (PIX-2294)

### DIFF
--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -12,7 +12,7 @@ export default class AuthenticatedCertificationsController extends Controller {
 
   @tracked selectedDivision = '';
 
-  get hasImportedStudents() {
+  get hasDivisions() {
     return this.model.options.length !== 0;
   }
 

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -12,6 +12,10 @@ export default class AuthenticatedCertificationsController extends Controller {
 
   @tracked selectedDivision = '';
 
+  get hasImportedStudents() {
+    return this.model.options.length !== 0;
+  }
+
   @action
   onSelectDivision(event) {
     this.selectedDivision = event.target.value;

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -12,9 +12,7 @@ export default class AuthenticatedCertificationsRoute extends Route {
 
   async model() {
     const divisions = await this.currentUser.organization.divisions;
-
     const options = divisions.map(({ name }) => ({ label: name, value: name }));
-
     return { options };
   }
 }

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -2,34 +2,40 @@
 
 <div class="certifications-page">
   <h1 class="page__title page-title">{{t "pages.certifications.title"}}</h1>
-  <p class="certifications-page__text">
-    {{t "pages.certifications.description" htmlSafe=true}}
-  </p>
+  {{#if this.hasImportedStudents}}
+    <p class="certifications-page__text">
+      {{t "pages.certifications.description" htmlSafe=true}}
+    </p>
 
-  <form class="certifications-page__action" {{on "submit" this.downloadSessionResultFile}}>
-    <label for="certifications-page-action__select">{{t "pages.certifications.select-label"}}</label>
-    <PixSelect
-      id="certifications-page-action__select"
-      @options={{@model.options}}
-      @selectedOption={{this.selectedDivision}}
-      @onChange={{this.onSelectDivision}}
-      @isSearchable={{true}}
-      @isValidationActive={{true}}
-      placeholder={{this.firstTwoDivisions}}
-      required={{true}}
-    />
-    <PixButton @type="submit" id="download_results" @size="small">
-      {{t "pages.certifications.download-button"}}
-    </PixButton>
-    <PixButton @triggerAction={{this.downloadAttestation}} id="download_attestations" @size="small">
-      {{t "pages.certifications.download-attestations-button"}}
-    </PixButton>
-  </form>
+    <form class="certifications-page__action" {{on "submit" this.downloadSessionResultFile}}>
+      <label for="certifications-page-action__select">{{t "pages.certifications.select-label"}}</label>
+      <PixSelect
+        id="certifications-page-action__select"
+        @options={{@model.options}}
+        @selectedOption={{this.selectedDivision}}
+        @onChange={{this.onSelectDivision}}
+        @isSearchable={{true}}
+        @isValidationActive={{true}}
+        placeholder={{this.firstTwoDivisions}}
+        required={{true}}
+      />
+      <PixButton @type="submit" id="download_results" @size="small">
+        {{t "pages.certifications.download-button"}}
+      </PixButton>
+      <PixButton @triggerAction={{this.downloadAttestation}} id="download_attestations" @size="small">
+        {{t "pages.certifications.download-attestations-button"}}
+      </PixButton>
+    </form>
 
-  <PixMessage @withIcon={{true}}>
-    {{t "pages.certifications.documentation-link-notice"}}
-    <a href={{t "pages.certifications.documentation-link"}} target="_blank" rel="noopener noreferrer">{{t
-        "pages.certifications.documentation-link-label"
-      }}</a>
-  </PixMessage>
+    <PixMessage @withIcon={{true}}>
+      {{t "pages.certifications.documentation-link-notice"}}
+      <a href={{t "pages.certifications.documentation-link"}} target="_blank" rel="noopener noreferrer">{{t
+          "pages.certifications.documentation-link-label"
+        }}</a>
+    </PixMessage>
+  {{else}}
+    <p class="certifications-page__text">
+      {{t "pages.certifications.no-students-imported-yet" htmlSafe=true}}
+    </p>
+  {{/if}}
 </div>

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -2,7 +2,7 @@
 
 <div class="certifications-page">
   <h1 class="page__title page-title">{{t "pages.certifications.title"}}</h1>
-  {{#if this.hasImportedStudents}}
+  {{#if this.hasDivisions}}
     <p class="certifications-page__text">
       {{t "pages.certifications.description" htmlSafe=true}}
     </p>

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -21,6 +21,9 @@ export default JSONAPISerializer.extend({
       groups: {
         related: `/api/organizations/${organization.id}/groups`,
       },
+      divisions: {
+        related: `/api/organizations/${organization.id}/divisions`,
+      },
     };
   },
 });

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -17,21 +17,6 @@ module('Acceptance | Certifications page', function (hooks) {
   });
 
   module('When user arrives on certifications page', function () {
-    test('should show Certifications page', async function (assert) {
-      // given / when
-      await visit('/certifications');
-
-      // then
-      assert
-        .dom('.certifications-page__text')
-        .containsText(
-          'Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les attestations (.pdf). Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.'
-        );
-      assert.contains('Exporter les résultats');
-      assert.contains('Certifications');
-      assert.contains('Classe');
-    });
-
     test('should not show any banner', async function (assert) {
       // given / when
       await visit('/certifications');
@@ -41,20 +26,59 @@ module('Acceptance | Certifications page', function (hooks) {
       assert.dom('.pix-banner').doesNotExist();
     });
 
-    test('should show documentation about certification results link', async function (assert) {
-      // given / when
-      await visit('/certifications');
+    module('When organizations has no students imported yet', function () {
+      test('should show warning message inviting user to import students on Certifications page', async function (assert) {
+        // given / when
+        await visit('/certifications');
 
-      // then
-      assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
+        // then
+        assert
+          .dom('.certifications-page__text')
+          .containsText(
+            'Dans cet onglet, vous retrouverez les résultats et les attestations de certification des élèves. Vous devez, dans un premier temps, importer la base élèves de votre établissement.'
+          );
+      });
     });
 
-    test('should display attestation download button', async function (assert) {
-      // when
-      await visit('/certifications');
+    module('When organizations has imported students', function (hooks) {
+      hooks.beforeEach(async () => {
+        const division = server.create('division', {
+          name: '3eme',
+        });
+        const organization = server.schema.organizations.all().models[0];
+        organization.update({ divisions: [division] });
+      });
 
-      // then
-      assert.dom('button[id="download_attestations"]').exists();
+      test('should show Certifications page', async function (assert) {
+        // given / when
+        await visit('/certifications');
+
+        // then
+        assert
+          .dom('.certifications-page__text')
+          .containsText(
+            'Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification (.csv) ou télécharger les attestations (.pdf). Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.'
+          );
+        assert.contains('Exporter les résultats');
+        assert.contains('Certifications');
+        assert.contains('Classe');
+      });
+
+      test('should show documentation about certification results link', async function (assert) {
+        // given / when
+        await visit('/certifications');
+
+        // then
+        assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
+      });
+
+      test('should display attestation download button', async function (assert) {
+        // when
+        await visit('/certifications');
+
+        // then
+        assert.dom('button[id="download_attestations"]').exists();
+      });
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -6,7 +6,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Unit | Controller | authenticated/certifications', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('#get hasImportedStudents', function () {
+  module('#get hasDivisions', function () {
     test('should return true when organization has divisions', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/certifications');
@@ -16,10 +16,10 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
       };
 
       // when
-      const hasImportedStudents = controller.hasImportedStudents;
+      const hasDivisions = controller.hasDivisions;
 
       // then
-      assert.true(hasImportedStudents);
+      assert.true(hasDivisions);
     });
 
     test("should return false when organization doesn't have divisions", async function (assert) {
@@ -31,10 +31,10 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
       };
 
       // when
-      const hasImportedStudents = controller.hasImportedStudents;
+      const hasDivisions = controller.hasDivisions;
 
       // then
-      assert.false(hasImportedStudents);
+      assert.false(hasDivisions);
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -6,6 +6,38 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Unit | Controller | authenticated/certifications', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  module('#get hasImportedStudents', function () {
+    test('should return true when organization has divisions', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications');
+
+      controller.model = {
+        options: [{ label: '3èmeA', value: '3èmeA' }],
+      };
+
+      // when
+      const hasImportedStudents = controller.hasImportedStudents;
+
+      // then
+      assert.true(hasImportedStudents);
+    });
+
+    test("should return false when organization doesn't have divisions", async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications');
+
+      controller.model = {
+        options: [],
+      };
+
+      // when
+      const hasImportedStudents = controller.hasImportedStudents;
+
+      // then
+      assert.false(hasImportedStudents);
+    });
+  });
+
   module('#onSelectDivision', function () {
     test('should change the value of the selected division', async function (assert) {
       // given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -549,6 +549,7 @@
         "no-results": "No certification results for the class {selectedDivision}.",
         "no-certificates": "No certificates for the class {selectedDivision}."
       },
+      "no-students-imported-yet": "In this tab, you will find the certification results and certificates of the students. You will first need to import the students database of your school.",
       "select-label": "Class"
     },
     "login": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -549,6 +549,7 @@
         "no-results": "Aucun résultat de certification pour la classe {selectedDivision}.",
         "no-certificates": "Aucune attestation de certification pour la classe {selectedDivision}."
       },
+      "no-students-imported-yet": "Dans cet onglet, vous retrouverez les résultats et les attestations de certification des élèves. Vous devez, dans un premier temps, importer la base élèves de votre établissement. ",
       "select-label": "Classe"
     },
     "login": {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, si un utilisateur PixOrga d'un établissement scolaire se rend sur l'onglet Certifications alors qu'aucun élève n'a encore été importé, il voit la page s'afficher avec les fonctionnalités dispo (mais qui ne vont pas fonctionner of course), sans autre forme d'indication.


## :robot: Solution
Cacher les différentes fonctionnalités liées à la récupération de résultats de certification tant que l'import n'a pas été fait. En contrepartie, on affiche un message explicatif.

## :rainbow: Remarques
En attente de la trad anglaise, on ne merge pas avant, mais c'est en cours.

## :100: Pour tester
A faire dans un environnement différent de cette PR, et dans la RA de cette PR.
Se connecter avec sco.admin@example.net / pix123 (Collège "The Night Watch") sur PixOrga, et dans les deux environnements constater l'affichage des fonctionnalités de récupération de données de certification dans l'onglet "Certifications".
![ok1](https://user-images.githubusercontent.com/48727874/163034298-7baf5c02-7ccd-4d9c-9310-06c6e6bcddba.png)

Puis, aller sur PixAdmin et créer une orga SCO isManagingStudents, ajouter un membre (certif1@example.net / pix123 par exemple).

Se connecter sur PixOrga avec le membre nouvellement ajouté à l'orga fraîchement créée.
Se rendre sur l'onglet "Certifications".
Sur dév, on voit ça :
![ok3](https://user-images.githubusercontent.com/48727874/163034656-41fc06a5-9a4e-4366-adfa-931041da20cb.png)

Sur la PR, on voit ça :
![ok2](https://user-images.githubusercontent.com/48727874/163034595-b0177acc-d220-4e01-b97a-8dd640c9cc90.png)

