### PR TITLE
[BUGFIX] Fixer la valeur de `updatedAt` des invitations quand on archive une organisation (PIX-4780).

### DIFF
--- a/api/lib/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/organization-for-admin-repository.js
@@ -81,7 +81,7 @@ module.exports = {
 
     await knex('organization-invitations')
       .where({ organizationId: id, status: OrganizationInvitation.StatusType.PENDING })
-      .update({ status: OrganizationInvitation.StatusType.CANCELLED });
+      .update({ status: OrganizationInvitation.StatusType.CANCELLED, updatedAt: archiveDate });
 
     await knex('campaigns').where({ organizationId: id, archivedAt: null }).update({ archivedAt: archiveDate });
 

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -197,17 +197,26 @@ describe('Integration | Repository | Organization-for-admin', function () {
         organizationId,
         status: pendingStatus,
       });
-      const cancelledInvitations = await knex('organization-invitations').where({
+      expect(pendingInvitations).to.have.lengthOf(0);
+
+      const allCancelledInvitations = await knex('organization-invitations').where({
         organizationId,
         status: cancelledStatus,
       });
+      expect(allCancelledInvitations).to.have.lengthOf(3);
+
+      const newlyCancelledInvitations = await knex('organization-invitations').where({
+        organizationId,
+        status: cancelledStatus,
+        updatedAt: now,
+      });
+      expect(newlyCancelledInvitations).to.have.lengthOf(2);
+
       const acceptedInvitations = await knex('organization-invitations').where({
         organizationId,
         status: acceptedStatus,
       });
-      expect(pendingInvitations).to.have.lengthOf(0);
       expect(acceptedInvitations).to.have.lengthOf(1);
-      expect(cancelledInvitations).to.have.lengthOf(3);
     });
 
     it('should archive active campaigns of a given organization', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Quand on archive une organisation, les invitations à cette organisation sont annulées mais la colonne updatedAt n’est pas mise à jour.

## :robot: Solution
Fixer la valeur de `updatedAt` à la date de l'archivage.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Connectez vous à Pix Admin en pix master
- Cliquez sur une organisation non archivée
- Envoyez une invitation à cette organisation
- Archivez l'organisation
- Vérifiez en bdd que `updatedAt` de `organization-invitations` à bien la date d'aujourd'hui
