### PR TITLE
[BOOTCAMP] Permettre de choisir une couleur sur le profil utilisateur

### DIFF
--- a/api/db/database-builder/factory/build-user-settings.js
+++ b/api/db/database-builder/factory/build-user-settings.js
@@ -1,0 +1,17 @@
+import { buildUser } from './build-user.js';
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildUserSettings = function ({ id = databaseBuffer.getNextId(), color = 'red', userId = buildUser().id } = {}) {
+  const values = {
+    id,
+    color,
+    userId,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'user-settings',
+    values,
+  });
+};
+
+export { buildUserSettings };

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -174,6 +174,14 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     values,
   });
 
+  databaseBuffer.pushInsertable({
+    tableName: 'user-settings',
+    values: {
+      id: databaseBuffer.getNextId(),
+      userId: user.id,
+    },
+  });
+
   _buildPixAuthenticationMethod({
     userId: user.id,
     rawPassword,

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -62,6 +62,7 @@ import { buildSupervisorAccess } from './build-supervisor-access.js';
 import { buildTag } from './build-tag.js';
 import { buildTargetProfile } from './build-target-profile.js';
 import { buildTargetProfileSkill } from './build-target-profile-skill.js';
+import { buildUserSettings } from './build-user-settings.js';
 import { buildTargetProfileShare } from './build-target-profile-share.js';
 import { buildTargetProfileTraining } from './build-target-profile-training.js';
 import { buildTargetProfileTube } from './build-target-profile-tube.js';
@@ -154,6 +155,7 @@ export {
   buildUserLogin,
   buildUserOrgaSettings,
   buildUserSavedTutorial,
+  buildUserSettings,
   buildUserRecommendedTraining,
   campaignParticipationOverviewFactory,
   knowledgeElementSnapshotFactory,

--- a/api/db/migrations/20220412091502_create-user-settings-table.js
+++ b/api/db/migrations/20220412091502_create-user-settings-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'user-settings';
+const COLUMN_NAME = 'color';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments().primary();
+    table.string(COLUMN_NAME).nullable();
+    table.integer('userId').unsigned().unique().notNullable().references('users.id');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/api/lib/application/user-settings/index.js
+++ b/api/lib/application/user-settings/index.js
@@ -1,0 +1,53 @@
+import Joi from 'joi';
+
+import { identifiersType } from '../../domain/types/identifiers-type.js';
+import { userSettingsController } from './user-settings-controller.js';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/user-settings/{userId}',
+      config: {
+        handler: userSettingsController.getUserSettings,
+        validate: {
+          params: Joi.object({
+            userId: identifiersType.userId,
+          }),
+        },
+        tags: ['api', 'user-settings'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Retourne les paramètres de l'utilisateur passé en paramètre \n",
+        ],
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/api/user-settings',
+      config: {
+        handler: userSettingsController.updateUserColor,
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                color: Joi.string(),
+              }),
+            }),
+          }),
+        },
+        tags: ['api', 'user-settings'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Mise à jour de la couleur de préférence par l‘utilisateur courant\n',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'user-settings';
+export { register, name };

--- a/api/lib/application/user-settings/user-settings-controller.js
+++ b/api/lib/application/user-settings/user-settings-controller.js
@@ -1,0 +1,23 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+import * as UserSettingsSerializer from '../../infrastructure/serializers/jsonapi/user-settings-serializer.js';
+
+const getUserSettings = async function (request, h, dependencies = { UserSettingsSerializer }) {
+  const { userId } = request.params;
+
+  const userSettings = await usecases.getUserSettings({ userId });
+
+  return h.response(dependencies.UserSettingsSerializer.serialize(userSettings));
+};
+
+const updateUserColor = async function (request, h, dependencies = { UserSettingsSerializer }) {
+  const { userId } = request.auth.credentials;
+  const { color } = dependencies.UserSettingsSerializer.deserialize(request.payload);
+
+  const updatedUserSettings = await usecases.updateUserColor({ userId, color });
+
+  return h.response(dependencies.UserSettingsSerializer.serialize(updatedUserSettings)).created();
+};
+
+const userSettingsController = { getUserSettings, updateUserColor };
+export { userSettingsController };

--- a/api/lib/domain/models/UserSettings.js
+++ b/api/lib/domain/models/UserSettings.js
@@ -1,0 +1,9 @@
+class UserSettings {
+  constructor({ id, userId, color }) {
+    this.id = id;
+    this.userId = userId;
+    this.color = color;
+  }
+}
+
+export { UserSettings };

--- a/api/lib/domain/read-models/UserSettings.js
+++ b/api/lib/domain/read-models/UserSettings.js
@@ -1,0 +1,11 @@
+class UserSettings {
+  constructor({ id, color, userId, createdAt, updatedAt }) {
+    this.id = id;
+    this.color = color;
+    this.userId = userId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}
+
+export { UserSettings };

--- a/api/lib/domain/usecases/get-user-settings.js
+++ b/api/lib/domain/usecases/get-user-settings.js
@@ -1,0 +1,6 @@
+const getUserSettings = async function ({ userId, userSettingsRepository }) {
+  const userSettings = await userSettingsRepository.get(userId);
+  return userSettings;
+};
+
+export { getUserSettings };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -167,6 +167,7 @@ import * as tutorialEvaluationRepository from '../../infrastructure/repositories
 import * as tutorialRepository from '../../infrastructure/repositories/tutorial-repository.js';
 import * as userEmailRepository from '../../infrastructure/repositories/user-email-repository.js';
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
+import * as userSettingsRepository from '../../infrastructure/repositories/user-settings-repository.js';
 import * as userOrgaSettingsRepository from '../../infrastructure/repositories/user-orga-settings-repository.js';
 import * as userRecommendedTrainingRepository from '../../infrastructure/repositories/user-recommended-training-repository.js';
 import * as userReconciliationService from '../services/user-reconciliation-service.js';
@@ -418,6 +419,7 @@ import { getUserCampaignParticipationToCampaign } from './get-user-campaign-part
 import { getUserCertificationEligibility } from './get-user-certification-eligibility.js';
 import { getUserDetailsForAdmin } from './get-user-details-for-admin.js';
 import { getUserProfile } from './get-user-profile.js';
+import { getUserSettings } from './get-user-settings.js';
 import { getUserProfileSharedForCampaign } from './get-user-profile-shared-for-campaign.js';
 import { handleBadgeAcquisition } from './handle-badge-acquisition.js';
 import { handleTrainingRecommendation } from './handle-training-recommendation.js';
@@ -485,6 +487,7 @@ import { updateTraining } from './update-training.js';
 import { updateUserDetailsForAdministration } from './update-user-details-for-administration.js';
 import { updateUserEmailWithValidation } from './update-user-email-with-validation.js';
 import { updateUserForAccountRecovery } from './account-recovery/update-user-for-account-recovery.js';
+import { updateUserColor } from './update-user-color.js';
 import { updateUserPassword } from './update-user-password.js';
 import { validateSessions } from './sessions-mass-import/validate-sessions.js';
 import { getOrganizationDetails } from './organizations-administration/get-organization-details.js';
@@ -682,6 +685,7 @@ const dependencies = {
   userToCreateRepository,
   userRepository,
   userService,
+  userSettingsRepository,
   userSavedTutorialRepository,
   verifyCertificateCodeService,
   organizationInvitationService,
@@ -920,6 +924,7 @@ const usecasesWithoutInjectedDependencies = {
   getUserDetailsForAdmin,
   getUserProfile,
   getUserProfileSharedForCampaign,
+  getUserSettings,
   handleBadgeAcquisition,
   handleTrainingRecommendation,
   importCertificationCandidatesFromCandidatesImportSheet,
@@ -988,6 +993,7 @@ const usecasesWithoutInjectedDependencies = {
   updateUserEmailWithValidation,
   updateUserForAccountRecovery,
   updateUserPassword,
+  updateUserColor,
   validateSessions,
 };
 

--- a/api/lib/domain/usecases/update-user-color.js
+++ b/api/lib/domain/usecases/update-user-color.js
@@ -1,0 +1,17 @@
+import { UserSettings } from '../models/UserSettings.js';
+
+const updateUserColor = async function ({ userId, color, userSettingsRepository }) {
+  let userSettings;
+
+  try {
+    userSettings = await userSettingsRepository.get(userId);
+  } catch (e) {
+    userSettings = new UserSettings({ userId });
+  }
+
+  userSettings.color = color;
+
+  return userSettingsRepository.save(userSettings);
+};
+
+export { updateUserColor };

--- a/api/lib/infrastructure/repositories/user-settings-repository.js
+++ b/api/lib/infrastructure/repositories/user-settings-repository.js
@@ -1,0 +1,22 @@
+import { UserSettings } from '../../domain/read-models/UserSettings.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { NotFoundError } from '../../domain/errors.js';
+
+async function save(userSettings) {
+  const [rawUserSettings] = await knex('user-settings')
+    .insert({ ...userSettings, updatedAt: knex.fn.now() })
+    .onConflict(['userId'])
+    .merge()
+    .returning('*');
+  return new UserSettings(rawUserSettings);
+}
+
+async function get(userId) {
+  const userSettings = await knex('user-settings').where({ userId }).first();
+  if (!userSettings) {
+    throw new NotFoundError('User settings not found');
+  }
+  return new UserSettings(userSettings);
+}
+
+export { save, get };

--- a/api/lib/infrastructure/serializers/jsonapi/user-settings-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-settings-serializer.js
@@ -1,0 +1,14 @@
+import { Serializer } from 'jsonapi-serializer';
+
+const deserialize = function (payload) {
+  return {
+    color: payload.data.attributes.color,
+  };
+};
+const serialize = function (userSettings = {}) {
+  return new Serializer('user-setting', {
+    attributes: ['color', 'createdAt', 'updatedAt', 'user-id'],
+  }).serialize(userSettings);
+};
+
+export { deserialize, serialize };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -58,6 +58,7 @@ import * as tutorialEvaluations from './application/tutorial-evaluations/index.j
 import * as userOrgaSettings from './application/user-orga-settings/index.js';
 import * as userTutorials from './application/user-tutorials/index.js';
 import * as users from './application/users/index.js';
+import * as userSettings from './application/user-settings/index.js';
 
 const routes = [
   accountRecovery,
@@ -119,6 +120,7 @@ const routes = [
   userOrgaSettings,
   userTutorials,
   users,
+  userSettings,
 ];
 
 export { routes };

--- a/api/tests/acceptance/application/user-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-settings-controller_test.js
@@ -1,0 +1,124 @@
+import { expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex } from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+
+describe('Acceptance | Controller | user-settings-controller', function () {
+  let server;
+  let userId;
+
+  beforeEach(async function () {
+    server = await createServer();
+    userId = await databaseBuilder.factory.buildUser().id;
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async function () {
+    return knex('user-settings').delete();
+  });
+
+  describe('GET /api/user-settings/{userId}', function () {
+    let options;
+
+    beforeEach(async function () {
+      options = {
+        method: 'GET',
+        url: '/api/user-settings/' + userId,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+    });
+
+    describe('nominal case', function () {
+      it('should respond with a 200 and return user-settings', async function () {
+        // given
+        await databaseBuilder.factory.buildUserSettings({ userId, color: 'red' });
+        await databaseBuilder.commit();
+        const expectedUserSettings = {
+          data: {
+            type: 'user-settings',
+            attributes: {
+              color: 'red',
+              'user-id': userId,
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes.color).to.equal(expectedUserSettings.data.attributes.color);
+      });
+
+      it('should respond with a 404 when user-settings does not exist', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    describe('error cases', function () {
+      it('should respond with a 401 when user is not logged in', async function () {
+        // given
+        options.headers.authorization = undefined;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+  describe('PUT /api/user-settings', function () {
+    let options;
+
+    beforeEach(async function () {
+      options = {
+        method: 'PUT',
+        url: '/api/user-settings',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+    });
+
+    describe('nominal case', function () {
+      it('should respond with a 201 and return user-settings created', async function () {
+        // given
+        const expectedUserSettings = {
+          data: {
+            type: 'user-settings',
+            attributes: {
+              color: 'red',
+            },
+          },
+        };
+        options.payload = { data: { attributes: { color: 'red' } } };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+        expect(response.result.data.attributes.color).to.equal(expectedUserSettings.data.attributes.color);
+      });
+    });
+
+    describe('error cases', function () {
+      it('should respond with a 401 when user is not logged in', async function () {
+        // given
+        options.headers.authorization = undefined;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/get-user-color_test.js
+++ b/api/tests/integration/domain/usecases/get-user-color_test.js
@@ -1,0 +1,44 @@
+import { expect, databaseBuilder, knex, catchErr } from '../../../test-helper.js';
+
+import { getUserSettings } from '../../../../lib/domain/usecases/get-user-settings.js';
+import * as userSettingsRepository from '../../../../lib/infrastructure/repositories/user-settings-repository.js';
+
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Integration | UseCases | getUserSettings', function () {
+  afterEach(async function () {
+    await knex('user-settings').delete();
+  });
+
+  describe('when user settings does not exist', function () {
+    it('should return undefined', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(getUserSettings)({ userId, userSettingsRepository });
+
+      // then
+      expect(error).to.be.an.instanceof(NotFoundError);
+    });
+  });
+
+  describe('when user settings exist', function () {
+    it('should return user settings', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserSettings({ userId, color: 'green' });
+      await databaseBuilder.commit();
+
+      // when
+      const userSettings = await getUserSettings({ userId, userSettingsRepository });
+
+      // then
+      expect(userSettings.color).to.equal('green');
+      expect(userSettings.userId).to.equal(userId);
+      expect(userSettings.createdAt).to.be.a('date');
+      expect(userSettings.updatedAt).to.be.a('date');
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/update-user-color_test.js
+++ b/api/tests/integration/domain/usecases/update-user-color_test.js
@@ -1,0 +1,53 @@
+import { expect, databaseBuilder, knex } from '../../../test-helper.js';
+
+import { updateUserColor } from '../../../../lib/domain/usecases/update-user-color.js';
+import * as userSettingsRepository from '../../../../lib/infrastructure/repositories/user-settings-repository.js';
+
+describe('Integration | UseCases | updateUserColor', function () {
+  afterEach(async function () {
+    await knex('user-settings').delete();
+  });
+
+  describe('when user settings does not exist', function () {
+    it('should set the user color', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      await updateUserColor({ userId, color: 'blue', userSettingsRepository });
+
+      // then
+      const userSettings = await knex('user-settings').where({ userId }).first();
+      expect(userSettings.color).to.equal('blue');
+    });
+
+    it('returns newly created userSettings', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const userSettings = await updateUserColor({ userId, color: 'blue', userSettingsRepository });
+
+      // then
+      expect(userSettings.color).to.equal('blue');
+    });
+  });
+
+  describe('when user settings exist', function () {
+    it('should set the user color', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserSettings({ userId, color: 'green' });
+      await databaseBuilder.commit();
+
+      // when
+      await updateUserColor({ userId, color: 'red', userSettingsRepository });
+
+      // then
+      const userSettings = await knex('user-settings').where({ userId }).first();
+      expect(userSettings.color).to.equal('red');
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/user-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-settings-repository_test.js
@@ -1,0 +1,73 @@
+import { expect, databaseBuilder, domainBuilder, knex, catchErr } from '../../../test-helper.js';
+import * as userSettingsRepository from '../../../../lib/infrastructure/repositories/user-settings-repository.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Integration | Repository | user-settings-repository', function () {
+  afterEach(function () {
+    return knex('user-settings').delete();
+  });
+
+  describe('#get', function () {
+    it('should return the user settings related to userId', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const expectedUserSettingsId = databaseBuilder.factory.buildUserSettings({ userId, color: 'blue' }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const userSettings = await userSettingsRepository.get(userId);
+
+      // then
+      expect(userSettings.id).to.equal(expectedUserSettingsId);
+    });
+
+    it('should return null if user does not have user settings', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUserSettings({ userId, color: 'blue' }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(userSettingsRepository.get)(otherUserId);
+
+      // then
+      expect(error).to.be.an.instanceof(NotFoundError);
+    });
+  });
+
+  describe('#save', function () {
+    describe('when user settings does not exists yet', function () {
+      it('should save user settings', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+        const userSettings = domainBuilder.buildUserSettings({ userId, color: 'blue' });
+
+        // when
+        await userSettingsRepository.save(userSettings);
+
+        // then
+        const savedUserSettings = await knex('user-settings').where({ userId }).first();
+        expect(savedUserSettings.color).to.equal('blue');
+      });
+    });
+  });
+
+  describe('when user settings does exists', function () {
+    it('should update user settings', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const userSettingsId = databaseBuilder.factory.buildUserSettings({ userId, color: 'blue' }).id;
+      await databaseBuilder.commit();
+      const userSettings = domainBuilder.buildUserSettings({ userSettingsId, userId, color: 'green' });
+
+      // when
+      await userSettingsRepository.save(userSettings);
+
+      // then
+      const savedUserSettings = await knex('user-settings').where({ userId }).first();
+      expect(savedUserSettings.color).to.equal('green');
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-user-settings.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-settings.js
@@ -1,0 +1,10 @@
+import { UserSettings } from '../../../../lib/domain/models/UserSettings.js';
+
+function buildUserSettings({ userId, color = 'red' } = {}) {
+  return new UserSettings({
+    userId,
+    color,
+  });
+}
+
+export { buildUserSettings };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -137,6 +137,7 @@ import { buildTube } from './build-tube.js';
 import { buildTutorial } from './build-tutorial.js';
 import { buildTutorialForUser } from './build-tutorial-for-user.js';
 import { buildUser } from './build-user.js';
+import { buildUserSettings } from './build-user-settings.js';
 import { buildUserCompetence } from './build-user-competence.js';
 import { buildUserDetailsForAdmin } from './build-user-details-for-admin.js';
 import { buildUserOrgaSettings } from './build-user-orga-settings.js';
@@ -292,6 +293,7 @@ export {
   buildUserScorecard,
   buildUserSavedTutorial,
   buildUserSavedTutorialWithTutorial,
+  buildUserSettings,
   buildValidation,
   buildValidator,
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-settings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-settings-serializer_test.js
@@ -1,0 +1,52 @@
+import { expect } from '../../../../test-helper.js';
+import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/user-settings-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | user-settings-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize', function () {
+      // given
+      const userSettings = {
+        id: 'userSettingsId',
+        userId: 'userId',
+        color: 'red',
+        createdAt: 'createdAt',
+        updatedAt: 'updatedAt',
+      };
+      const expectedJsonUserSettings = {
+        data: {
+          type: 'user-settings',
+          id: 'userSettingsId',
+          attributes: {
+            color: 'red',
+            'user-id': 'userId',
+            'created-at': 'createdAt',
+            'updated-at': 'updatedAt',
+          },
+        },
+      };
+      // when
+      const json = serializer.serialize(userSettings);
+
+      // then
+      expect(json).to.be.deep.equal(expectedJsonUserSettings);
+    });
+  });
+  describe('#deserialize', function () {
+    it('should convert JSON API data into a JS Object', function () {
+      // given
+      const jsonUserSettings = {
+        data: {
+          attributes: {
+            color: 'red',
+          },
+        },
+      };
+
+      // when
+      const userSettings = serializer.deserialize(jsonUserSettings);
+
+      // then
+      expect(userSettings.color).to.be.equal('red');
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-settings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-settings-serializer_test.js
@@ -18,7 +18,6 @@ describe('Unit | Serializer | JSONAPI | user-settings-serializer', function () {
           id: 'userSettingsId',
           attributes: {
             color: 'red',
-            'user-id': 'userId',
             'created-at': 'createdAt',
             'updated-at': 'updatedAt',
           },

--- a/mon-pix/app/adapters/user-setting.js
+++ b/mon-pix/app/adapters/user-setting.js
@@ -1,0 +1,13 @@
+import ApplicationAdapter from './application';
+
+export default class UserSetting extends ApplicationAdapter {
+  createRecord(store, type, snapshot) {
+    const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+    return this.ajax(url, 'PUT', { data: snapshot.serialize() });
+  }
+
+  updateRecord(store, type, snapshot) {
+    const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+    return this.ajax(url, 'PUT', { data: snapshot.serialize() });
+  }
+}

--- a/mon-pix/app/components/user-settings-form.hbs
+++ b/mon-pix/app/components/user-settings-form.hbs
@@ -1,0 +1,24 @@
+<div class="user-settings page-container">
+  <PixBlock @shadow="heavy" class="user-settings__form">
+    <h1 class="user-settings__title">{{t "pages.user-settings.title"}}
+      <PixTag @color="light-blue" class="user-settings__last-modified">
+        {{t "pages.user-settings.last-modified"}}
+        {{moment-format this.lastModified "D MMMM YYYY HH:mm:ss"}}
+      </PixTag>
+    </h1>
+    <PixSelect
+      @label={{t "pages.user-settings.color-label"}}
+      @id="preferred-color"
+      @options={{this.options}}
+      @onChange={{this.onChange}}
+      @selectedOption={{this.selectedColor}}
+      @emptyOptionLabel={{t "pages.user-settings.empty-color"}}
+      @isSearchable={{false}}
+      @isValidationActive={{false}}
+      @emptyOptionNotSelectable={{false}}
+    />
+    <PixButton @triggerAction={{this.onSubmit}} class="user-settings__submit">
+      {{t "pages.user-settings.submit"}}
+    </PixButton>
+  </PixBlock>
+</div>

--- a/mon-pix/app/components/user-settings-form.js
+++ b/mon-pix/app/components/user-settings-form.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class UserSettingsFormComponent extends Component {
+  @tracked selectedColor;
+
+  constructor() {
+    super(...arguments);
+
+    this.selectedColor = this.args.userSettings.color;
+  }
+
+  get options() {
+    return [
+      { value: 'red', label: 'red' },
+      { value: 'blue', label: 'blue' },
+      { value: 'green', label: 'green' },
+      { value: 'yellow', label: 'yellow' },
+    ];
+  }
+
+  get lastModified() {
+    return this.args.userSettings.updatedAt;
+  }
+
+  @action
+  onChange(e) {
+    this.selectedColor = e.target.value;
+  }
+
+  @action
+  onSubmit() {
+    this.args.userSettings.color = this.selectedColor;
+    this.args.userSettings.save();
+  }
+}

--- a/mon-pix/app/models/user-setting.js
+++ b/mon-pix/app/models/user-setting.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class UserSetting extends Model {
+  @attr('string') color;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -23,6 +23,8 @@ Router.map(function () {
     this.route('index', { path: '' });
     this.route('user-dashboard', { path: '/accueil' });
     this.route('profile', { path: '/competences' });
+    this.route('user-settings', { path: '/preferences' });
+
     this.route('user-tests', { path: '/mes-parcours' });
     this.route('sitemap', { path: '/plan-du-site' });
 

--- a/mon-pix/app/routes/user-settings.js
+++ b/mon-pix/app/routes/user-settings.js
@@ -1,0 +1,14 @@
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+
+export default class UserSettingsRoute extends Route.extend(SecuredRouteMixin) {
+  @service currentUser;
+
+  async model() {
+    const userSettings = await this.store.findRecord('user-setting', this.currentUser.user.id);
+    return {
+      userSettings,
+    };
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -40,6 +40,7 @@
 @import 'components/circle-chart';
 @import 'components/comparison-window';
 @import 'components/choice-chip';
+@import 'components/user-settings';
 
 /* we need this to be before competence-card-default because of a mix
 of an adaptative/mobile-first approach — refactoring is welcome here */

--- a/mon-pix/app/styles/components/_user-settings.scss
+++ b/mon-pix/app/styles/components/_user-settings.scss
@@ -1,0 +1,28 @@
+$header-height: 101px;
+
+.user-settings {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - #{$header-height} - #{$footer-height});
+
+  &__title {
+    display: flex;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+
+  &__submit {
+    margin-top: 16px;
+    margin-left: auto;
+  }
+
+  &__last-modified {
+    margin-left: 16px;
+  }
+
+  /* Fix pour https://1024pix.slack.com/archives/C0149DV4873/p1652093702342479 */
+  select {
+    width: 100%;
+  }
+}

--- a/mon-pix/app/templates/user-settings.hbs
+++ b/mon-pix/app/templates/user-settings.hbs
@@ -1,0 +1,12 @@
+{{page-title (t "pages.user-settings.title")}}
+
+<BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
+  <burger.outlet>
+
+    <NavbarHeader @burger={{burger}} />
+
+    <UserSettingsForm @userSettings={{@model.userSettings}} />
+
+    <Footer />
+  </burger.outlet>
+</BurgerMenu>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -30,6 +30,7 @@ import deleteUserSavedTutorial from './routes/delete-user-saved-tutorial';
 import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import postSharedCertifications from './routes/post-shared-certifications';
 import loadUserTutorialsRoutes from './routes/get-user-tutorials';
+import loadUserSettingsRoutes from './routes/get-user-settings';
 
 /* eslint max-statements: off */
 export default function () {
@@ -52,6 +53,7 @@ export default function () {
   loadUserRoutes(this);
   loadAccountRecoveryRoutes(this);
   loadUserTutorialsRoutes(this);
+  loadUserSettingsRoutes(this);
 
   this.get('/assessments/:id/competence-evaluations', getCompetenceEvaluationsByAssessment);
 

--- a/mon-pix/mirage/routes/get-user-settings.js
+++ b/mon-pix/mirage/routes/get-user-settings.js
@@ -1,0 +1,13 @@
+export default function index(config) {
+  config.get('/user-settings/:userId', () => {
+    return {
+      data: {
+        id: 1,
+        type: 'user-setting',
+        attributes: {
+          'created-at': '2020-12-11T14:30:40.109Z',
+        },
+      },
+    };
+  });
+}

--- a/mon-pix/tests/acceptance/user-settings_test.js
+++ b/mon-pix/tests/acceptance/user-settings_test.js
@@ -1,0 +1,28 @@
+import { visit } from '@ember/test-helpers';
+import { beforeEach, describe, it } from 'mocha';
+import { authenticateByEmail } from '../helpers/authentication';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { contains } from '../helpers/contains';
+
+describe('Acceptance | User settings', function () {
+  setupApplicationTest();
+  setupMirage();
+
+  let user;
+
+  beforeEach(async function () {
+    //given
+    user = server.create('user', 'withEmail');
+    await authenticateByEmail(user);
+  });
+
+  it('should display form to edit user settings', async function () {
+    // when
+    await visit('/preferences');
+
+    // then
+    expect(contains('Préférences utilisateur')).to.exist;
+  });
+});

--- a/mon-pix/tests/integration/components/user-settings-form_test.js
+++ b/mon-pix/tests/integration/components/user-settings-form_test.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { render, find, fillIn, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { contains } from '../../helpers/contains';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
+
+describe('Integration | Component | UserSettingsForm', function () {
+  setupIntlRenderingTest();
+
+  it('should display date of creation', async function () {
+    // given
+    const userSettings = EmberObject.create({
+      updatedAt: '2020-12-11T14:30:40.109Z',
+    });
+    this.set('userSettings', userSettings);
+
+    // when
+    await render(hbs`<UserSettingsForm @userSettings={{this.userSettings}} />`);
+
+    // then
+    expect(contains('11 décembre 2020')).to.exist;
+  });
+
+  it('should display a placeholder when no color is selected', async function () {
+    // given
+    const userSettings = EmberObject.create({
+      updatedAt: '2020-12-11T14:30:40.109Z',
+    });
+    this.set('userSettings', userSettings);
+
+    // when
+    await render(hbs`<UserSettingsForm @userSettings={{this.userSettings}} />`);
+
+    // then
+    expect(find('select').value).to.equal('');
+    expect(contains('Sélectionner une couleur')).to.exist;
+  });
+
+  it('should display selected color', async function () {
+    // given
+    const userSettings = EmberObject.create({
+      updatedAt: '2020-12-11T14:30:40.109Z',
+      color: 'red',
+    });
+    this.set('userSettings', userSettings);
+
+    // when
+    await render(hbs`<UserSettingsForm @userSettings={{this.userSettings}} />`);
+
+    // then
+    expect(find('select').value).to.equal('red');
+  });
+
+  it('should save color', async function () {
+    // given
+    const saveStub = sinon.stub().resolves();
+    const userSettings = EmberObject.create({
+      updatedAt: '2020-12-11T14:30:40.109Z',
+      color: 'red',
+      save: saveStub,
+    });
+    this.set('userSettings', userSettings);
+
+    // when
+    await render(hbs`<UserSettingsForm @userSettings={{this.userSettings}} />`);
+    await fillIn('select', 'green');
+    await click('button');
+
+    // then
+    sinon.assert.calledOnce(saveStub);
+    expect(userSettings.color).to.equal('green');
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -150,6 +150,13 @@
     "mobile-button-title": "Open menu"
   },
   "pages": {
+    "user-settings": {
+      "title": "User preferences",
+      "color-label": "Preferred color",
+      "last-modified": "Last modified on",
+      "empty-color": "Pick a color",
+      "submit": "Save"
+    },
     "assessment-banner": {
       "modal": {
         "title": "Do you need a break?",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -150,6 +150,13 @@
     "mobile-button-title": "Ouvrir le menu"
   },
   "pages": {
+    "user-settings": {
+      "title": "Préférences utilisateur",
+      "color-label": "Couleur préférée",
+      "last-modified": "Dernière modification le",
+      "empty-color": "Sélectionner une couleur",
+      "submit": "Sauvegarder"
+    },
     "assessment-banner": {
       "modal": {
         "title": "Besoin d'une pause ?",


### PR DESCRIPTION
## :unicorn: Problème
Des exemples simples et complets de routes API manquent pour le bootcamp.

## :robot: Solution

Ajouter la fonctionnalité de préférence utilisateur:
- choisir, depuis pix-app, dans le profil, une couleur;
- sauvegarde en BDD dans la table `user-settings` via la route `POST api/users/{id}/settings`;
- visualiser, depuis pix-app, la couleur via la route `GET api/users/{id}/settings`  (read-model).

Le premier commit contient le code terminé.
Les commits suivant suppriment une partie afin de le faire en live-coding.

## :rainbow: Remarques
Cette PR ne doit pas être mergée.

## :100: Pour tester
Se mettre sur le commit terminé, tester le changement de couleur

## Pour démarrer le bootcamp API
Supprimer le commit _[[EMBER] Start of ember bootcamp](https://github.com/1024pix/pix/pull/4326/commits/6395128608bc48f527d137215b16f807823282e2)_ pour avoir la partie front OK. 

Les tests automatisés sont déjà implémentés.
Faire passer les tests automatisés : implémenter la route.
Tester manuellement depuis pix-app.