### PR TITLE
[HOTFIX] Correction du nom d'index de Knowledge-elements (PIX-4784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pix Changelog
 
+## v3.196.1 (12/04/2022)
+
+
+### :bug: Correction
+- [#4327](https://github.com/1024pix/pix/pull/4327) [HOTFIX] Correction du nom d'index de Knowledge-elements (PIX-4784)
+
 ## v3.196.0 (12/04/2022)
 
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "private": false,
   "description": "Interface d'administration pour les Pix Masters.",
   "license": "AGPL-3.0",

--- a/api/db/migrations/20220406083222_add_index_for_table_knowledge_elements_on_column_assessmentId.js
+++ b/api/db/migrations/20220406083222_add_index_for_table_knowledge_elements_on_column_assessmentId.js
@@ -1,9 +1,9 @@
 exports.up = (knex) => {
   return knex.raw(
-    'CREATE INDEX IF NOT EXISTS "knowledge_elements_assessmentid_index" on "knowledge-elements" ("assessmentId")'
+    'CREATE INDEX IF NOT EXISTS "knowledge-elements_assessmentId_idx" on "knowledge-elements" ("assessmentId")'
   );
 };
 
 exports.down = function (knex) {
-  return knex.raw('DROP INDEX "knowledge_elements_assessmentid_index"');
+  return knex.raw('DROP INDEX "knowledge-elements_assessmentId_idx"');
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "private": false,
   "description": "Plateforme en ligne de gestion des sessions de certification",
   "license": "AGPL-3.0",

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "0.303.0",
+  "version": "0.303.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "0.303.0",
+  "version": "0.303.1",
   "description": "Permet d'exécuter des tests de bout en bout sur la plateforme Pix",
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "1.302.0",
+  "version": "1.302.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "1.302.0",
+  "version": "1.302.1",
   "description": "Permet d'exécuter des tests de charge sur l'API de la plateforme Pix.",
   "homepage": "https://github.com/1024pix/pix/tree/dev/high-level-tests/load-testing#readme",
   "author": "GIP Pix",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "private": false,
   "description": "Plateforme en ligne de gestion de campagne d'évaluation",
   "license": "AGPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "3.196.0",
+  "version": "3.196.1",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## :unicorn: Problème
La migration inclue dans la PR https://github.com/1024pix/pix/pull/4294 provoque une création d'index en production. 

## :robot: Solution
Modifier la migration afin qu'elle reflète la vérité de la production

## :rainbow: Remarques
Les environnements en amonts ont joué cette migration, nous y avons donc renommé l'index à la main 
 ```sql
ALTER INDEX IF EXISTS "knowledge_elements_assessmentid_index" RENAME TO "knowledge-elements_assessmentId_idx"
 ```

Vérifier que les migrations ne sont pas jouées en intégration et recette
``` sqk
 Postdeploy hook detected, starting 'npm run postdeploy'
2022-04-13 16:05:27.505869347 +0200 CEST [manager] container [postdeploy-7906] (6256d8934e1ec34f3fb82166) started with the command 'npm run postdeploy'
2022-04-13 16:05:28.567394170 +0200 CEST [postdeploy-7906] Already up to date
```