### PR TITLE
[BUGFIX] Ne pas afficher le message d'alerte de sortie de focus lorsque l'user reprend un nouvel assessment (PIX-4787).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -20,11 +20,14 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
   @tracked challengeTitle = defaultPageTitle;
   @tracked hasFocusedOutOfChallenge = false;
-  @tracked hasFocusedOutOfWindow = this.model.assessment.hasFocusedOutChallenge;
   @tracked hasUserConfirmedTimedChallengeWarning = false;
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
+  }
+
+  get hasFocusedOutOfWindow() {
+    return this.model.assessment.hasFocusedOutChallenge;
   }
 
   get pageTitle() {
@@ -78,7 +81,6 @@ export default class ChallengeController extends Controller {
 
   @action
   async focusedOutOfWindow() {
-    this.hasFocusedOutOfWindow = true;
     this.model.assessment.lastQuestionState = 'focusedout';
     await this.model.assessment.save({
       adapterOptions: {
@@ -120,15 +122,12 @@ export default class ChallengeController extends Controller {
   @action
   resetAllChallengeInfo() {
     this._resetNonContextualChallengeInfo();
-    this.hasFocusedOutOfWindow = false;
     this.model.assessment.lastQuestionState = 'asked';
   }
 
   @action
   resetChallengeInfoOnResume() {
     this._resetNonContextualChallengeInfo();
-    // Keep focused out of window state
-    this.hasFocusedOutOfWindow = this.model.assessment.hasFocusedOutChallenge;
   }
 
   get displayHomeLink() {

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -121,7 +121,6 @@ export default class ChallengeRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.set('hasFocusedOutOfChallenge', false);
-      controller.set('hasFocusedOutOfWindow', false);
     }
   }
 }

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -117,4 +117,11 @@ export default class ChallengeRoute extends Route {
   error() {
     return true;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('hasFocusedOutOfChallenge', false);
+      controller.set('hasFocusedOutOfWindow', false);
+    }
+  }
 }

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -265,6 +265,32 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             expect(find('[data-test="default-focused-out-error-message"]')).to.exist;
           });
         });
+
+        describe('when user has focused out of the window, leaves the challenge and goes to another assessment', function () {
+          it('should not display a warning alert saying it has been focused out', async function () {
+            // given
+            const user = server.create('user', 'withEmail', {
+              hasSeenFocusedChallengeTooltip: true,
+            });
+            await authenticateByEmail(user);
+            const assessment1 = server.create(
+              'assessment',
+              'ofCompetenceEvaluationType',
+              'withCurrentChallengeUnfocus'
+            );
+            const assessment2 = server.create('assessment', 'ofCompetenceEvaluationType');
+            server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+            await visit(`/assessments/${assessment1.id}/challenges/0`);
+
+            // when
+            await triggerEvent(document, 'focusedout');
+            await click('.assessment-banner__home-link');
+            await visit(`/assessments/${assessment2.id}/challenges/0`);
+
+            // then
+            expect(find('[data-test="default-focused-out-error-message"]')).not.to.exist;
+          });
+        });
       });
 
       [

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -266,29 +266,51 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           });
         });
 
-        describe('when user has focused out of the window, leaves the challenge and goes to another assessment', function () {
-          it('should not display a warning alert saying it has been focused out', async function () {
-            // given
+        describe('when user has focused out of the window and leaves the challenge', function () {
+          beforeEach(async function () {
             const user = server.create('user', 'withEmail', {
               hasSeenFocusedChallengeTooltip: true,
             });
             await authenticateByEmail(user);
-            const assessment1 = server.create(
-              'assessment',
-              'ofCompetenceEvaluationType',
-              'withCurrentChallengeUnfocus'
-            );
-            const assessment2 = server.create('assessment', 'ofCompetenceEvaluationType');
-            server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
-            await visit(`/assessments/${assessment1.id}/challenges/0`);
+          });
 
-            // when
-            await triggerEvent(document, 'focusedout');
-            await click('.assessment-banner__home-link');
-            await visit(`/assessments/${assessment2.id}/challenges/0`);
+          describe('when user goes to another assessment', () => {
+            it('should not display a warning alert saying it has been focused out', async function () {
+              // given
+              const assessment1 = server.create(
+                'assessment',
+                'ofCompetenceEvaluationType',
+                'withCurrentChallengeUnfocus'
+              );
+              const assessment2 = server.create('assessment', 'ofCompetenceEvaluationType');
+              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              await visit(`/assessments/${assessment1.id}/challenges/0`);
 
-            // then
-            expect(find('[data-test="default-focused-out-error-message"]')).not.to.exist;
+              // when
+              await triggerEvent(document, 'focusedout');
+              await click('.assessment-banner__home-link');
+              await visit(`/assessments/${assessment2.id}/challenges/0`);
+
+              // then
+              expect(find('[data-test="default-focused-out-error-message"]')).not.to.exist;
+            });
+          });
+
+          describe('when user returns to the same assessment', () => {
+            it('should display a warning alert saying it has been focused out', async function () {
+              // given
+              const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+              server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
+              await visit(`/assessments/${assessment.id}/challenges/0`);
+
+              // when
+              await triggerEvent(document, 'focusedout');
+              await click('.assessment-banner__home-link');
+              await visit(`/assessments/${assessment.id}/challenges/0`);
+
+              // then
+              expect(find('[data-test="default-focused-out-error-message"]')).to.exist;
+            });
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix App, lorsqu'un utilisateur sort d'une épreuve focus, puis quitte l'épreuve et commence/reprend un autre assessment alors il aura encore le message qui lui indique qu'il est sorti de l'épreuve, alors même que l'épreuve peut ne pas être focus.

### Avant
![focus-before](https://user-images.githubusercontent.com/26384707/163626561-4cde8152-0a05-410c-a1cb-77fbd00da2b5.gif)

### Après
![focus-after](https://user-images.githubusercontent.com/26384707/163626575-972d29aa-8c52-444c-91e5-7232a3796eb1.gif)

## :robot: Solution
Les controllers d'Ember sont des singletons, c'est-à-dire que lorsqu'on accède à plusieurs assessments on utilise en réalité la même instance du controller auquel on passe juste des paramètres différents. 

Nous utilisions une propriété trackée qui dépendait du model puis que nous la redéfinissons par un booléen.

Au début du controller :
```
@tracked hasFocusedOutOfWindow = this.model.assessment.hasFocusedOutChallenge;
```

Puis lors de la réassignation : 
```
hasFocusedOutOfWindow = false;
```

Comme il s'agit d'un singleton, lorsqu'on réutilise le controller, nous ne regardons pas la propriété du model comme la propriété est juste égale à un booléen. 
Il fallait alors utiliser un `get`  car les attributs du model sont trackés + le `get` est appelé de nouveau à chaque affichage. Nous obtenons alors : 
```js
 get hasFocusedOutOfWindow() {
   return this.model.assessment.hasFocusedOutChallenge;
 }
```
Grâce à ça dès que nous changeons le modèle le getter fait bien son boulot en mettant à jour l'affichage, ce qui fait que nous n'avons plus besoin de changer la valeur de `hasFocusedOutOfWindow`.

D'autre part, nous ne lui indiquons pas que certains champs doivent être remis à 0. Pour faire cela, il existe la méthode `resetController` qui est déclenchée lorsque la route est quittée ou change (cf : [doc resetController](https://api.emberjs.com/ember/3.28/classes/Route/methods/resetController?anchor=resetController)).  Nous utilisons alors cette méthode pour gérer ce cas. 

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à Pix APP
- Passer une compétence jusqu'à avoir une épreuve focus
- Sortir de la fenêtre de l'épreuve pour perdre le focus
- Quitter l'épreuve à l'aide du bouton en haut à droite
- Reprendre une autre compétence et constater qu'il n'y a pas le message de sortie d'épreuve. 
