### PR TITLE
[BUGFIX] Copier les skill-sets pour les utiliser dans un autre badge dans le script de création de badge-criteria (PIX-4789).

### DIFF
--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -52,15 +52,10 @@ async function main() {
 
   console.log('Creating badge criteria... ');
   console.log('Saving badge criteria... ');
-  const newBadgeId = jsonFile.badgeId;
   return DomainTransaction.execute(async (domainTransaction) => {
     await Promise.all(
       jsonFile.criteria.map(async (badgeCriterion) => {
-        const newSkillSetIds = await copySkillSets({ skillSetIds: badgeCriterion.skillSetIds, newBadgeId });
-        return badgeCriteriaRepository.save(
-          { badgeCriterion: { ...badgeCriterion, skillSetIds: newSkillSetIds, badgeId: newBadgeId } },
-          domainTransaction
-        );
+        return _createBadgeCriterion({ ...badgeCriterion, badgeId: jsonFile.badgeId }, domainTransaction);
       })
     );
   });
@@ -104,6 +99,17 @@ async function checkSkillSetIds(skillSetIds) {
   if (count !== skillSetIds.length) {
     throw new Error('At least one skillSetId does not exist');
   }
+}
+
+async function _createBadgeCriterion(badgeCriterion, domainTransaction) {
+  const newSkillSetIds = await copySkillSets({
+    skillSetIds: badgeCriterion.skillSetIds,
+    newBadgeId: badgeCriterion.badgeId,
+  });
+  return badgeCriteriaRepository.save(
+    { badgeCriterion: { ...badgeCriterion, skillSetIds: newSkillSetIds } },
+    domainTransaction
+  );
 }
 
 async function copySkillSets({ skillSetIds, newBadgeId }) {


### PR DESCRIPTION
## :unicorn: Problème
Le script créé dans le PR #4321, ne fonctionne pas en l'état. En effet, la façon dont sont remontés les skill-sets nécessitent qu'un skillSet soit utilisé pour un seul badge. Ce qui n'avait pas été pris en compte dans le précédent script. Le skill-set n'était alors pas remonté dans Pix Admin.

## :robot: Solution
- Copier les caractéristiques des skillSets souhaités pour les lier au badge passé dans le fichier du script. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Construire sur Pix Admin un profil cible
- Y construire 2 badges comportant des skill-sets
- Créer un 3ème badge avec un `threshold` sur la campagne.
- Créer un fichier json : 
```json
{
	"badgeId": <l'id du badge créé>,
	"criteria": [
		{
			"threshold": 20,
			"skillSetIds": [à compléter avec les ids de vos badges précédemment créés]
		}
	]
}
```
- `scalingo -a pix-api-review-pr4332 run --file <nom-de-votre-fichier>.json node scripts/create-badge-criteria-for-specified-badge.js /tmp/uploads/<nom-de-votre-fichier.json>`
- Vérifier sur Pix Admin sur la badge du badge spécifié que les skill-sets remontent bien. 
