### PR TITLE
[TECH] Mettre le path de l'url d'authentification de Pole Emploi dans la variable d'environnement (PIX-4792)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -195,7 +195,7 @@ module.exports = (function () {
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
-      authUrl: process.env.POLE_EMPLOI_AUTHENTICATION_URL,
+      authUrl: process.env.POLE_EMPLOI_OIDC_AUTHENTICATION_URL,
       temporaryStorage: {
         expirationDelaySeconds:
           parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -66,7 +66,7 @@ async function getPoleEmploiUserInfo(idToken) {
 }
 
 function getPoleEmploiAuthUrl({ redirectUri }) {
-  const redirectTarget = new URL(`${settings.poleEmploi.authUrl}/connexion/oauth2/authorize`);
+  const redirectTarget = new URL(`${settings.poleEmploi.authUrl}`);
   const state = uuidv4();
   const nonce = uuidv4();
   const clientId = settings.poleEmploi.clientId;

--- a/api/sample.env
+++ b/api/sample.env
@@ -458,7 +458,7 @@ AUTH_SECRET=Change me!
 #
 # presence: required for POLE EMPLOI authentication, optional otherwise
 # type: URL
-# sample: POLE_EMPLOI_AUTHENTICATION_URL=
+# sample: POLE_EMPLOI_OIDC_AUTHENTICATION_URL=
 
 
 # ========

--- a/api/tests/acceptance/application/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi-controller_test.js
@@ -235,7 +235,6 @@ describe('Acceptance | API | Pole Emploi Controller', function () {
         const redirectTargetUrl = new URL(response.result.redirectTarget);
 
         expect(redirectTargetUrl.origin).to.equal('http://authurl.fr');
-        expect(redirectTargetUrl.pathname).to.equal('/connexion/oauth2/authorize');
         expect(redirectTargetUrl.searchParams.get('redirect_uri')).to.equal('http://app.pix.fr/connexion-pole-emploi');
         expect(redirectTargetUrl.searchParams.get('client_id')).to.equal('PIX_POLE_EMPLOI_CLIENT_ID');
         expect(redirectTargetUrl.searchParams.get('response_type')).to.equal('code');

--- a/mon-pix/app/routes/login-pole-emploi.js
+++ b/mon-pix/app/routes/login-pole-emploi.js
@@ -5,8 +5,6 @@ import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 import fetch from 'fetch';
 
-const { authEndpoint } = ENV.poleEmploi;
-
 export default class LoginPoleEmploiRoute extends Route {
   @service session;
   @service router;
@@ -19,10 +17,6 @@ export default class LoginPoleEmploiRoute extends Route {
   }
 
   beforeModel(transition) {
-    if (!authEndpoint) {
-      throw new Error('There is no authEndpoint configured.');
-    }
-
     const queryParams = transition.to ? transition.to.queryParams : transition.queryParams;
     if (!queryParams.code && queryParams.error) {
       return this.replaceWith('login');

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -44,7 +44,6 @@ module.exports = function (environment) {
 
     poleEmploi: {
       afterLogoutUri: process.env.POLE_EMPLOI_AFTER_LOGOUT_URI,
-      authEndpoint: '/connexion/oauth2/authorize',
       endSessionEndpoint: '/compte/deconnexion',
       expiresIn: 60000, // Short expire time (60s) for testing purpose,
       host: process.env.POLE_EMPLOI_AUTHENTICATION_URL,

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -46,7 +46,7 @@ module.exports = function (environment) {
       afterLogoutUri: process.env.POLE_EMPLOI_AFTER_LOGOUT_URI,
       endSessionEndpoint: '/compte/deconnexion',
       expiresIn: 60000, // Short expire time (60s) for testing purpose,
-      host: process.env.POLE_EMPLOI_AUTHENTICATION_URL,
+      host: process.env.POLE_EMPLOI_AUTHENTICATION_BASE_URL,
     },
 
     APP: {


### PR DESCRIPTION
## :unicorn: Problème
La variable d'env d'authorization url de Pole Emploi ne contient pas son path (il est noté en dur dans le code)

## :robot: Solution
Enlever la partie path en dur dans le code et la migrer dans la variable d'env

## :rainbow: Remarques
⚠️ **DONE** : ⚠️
- ajout `POLE_EMPLOI_OIDC_AUTHENTICATION_URL` sur l'env de l'api sur scalingo (lui rajouter `/connexion/oauth2/authorize`)
- ajout `POLE_EMPLOI_AUTHENTICATION_BASE_URL` sur l'env de mon-pix sur scalingo

Rajouter aussi ces variables :
- en intégration
- en recette
- en production

Après la mise en production on pourra supprimer : 
- `POLE_EMPLOI_AUTHENTICATION_URL` de l'env de mon-pix
- `POLE_EMPLOI_AUTHENTICATION_URL` de l'api


## :100: Pour tester
Dans son .env, remplacer `POLE_EMPLOI_AUTHENTICATION_URL`={{url}} par `POLE_EMPLOI_OIDC_AUTHENTICATION_URL`={{url}}/connexion/oauth2/authorize
- Se connecter avec Pole Emploi (`localhost.fr:4200`) 
