### PR TITLE
[BUGFIX] Un utilisateur pouvait voir plusieurs fois la même habilitation à cocher lors d'une inscription de candidat en certification (PIX-4797)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -95,7 +95,7 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
     )
     .whereIn('certification-centers.id', certificationCenterIds)
     .orderBy('certification-centers.id')
-    .groupByRaw('1, 2, 3, 4, 5');
+    .groupByRaw('1, 2, 3, 4, 5, 6');
 
   return _.map(allowedCertificationCenterAccessDTOs, (allowedCertificationCenterAccessDTO) => {
     return new AllowedCertificationCenterAccess({
@@ -103,16 +103,19 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
       isRelatedToManagingStudentsOrganization: Boolean(
         allowedCertificationCenterAccessDTO.isRelatedToManagingStudentsOrganization
       ),
-      relatedOrganizationTags: _cleanEmptyTags(allowedCertificationCenterAccessDTO),
-      habilitations: _cleanEmptyHabilitations(allowedCertificationCenterAccessDTO),
+      relatedOrganizationTags: _cleanTags(allowedCertificationCenterAccessDTO),
+      habilitations: _cleanHabilitations(allowedCertificationCenterAccessDTO),
     });
   });
 
-  function _cleanEmptyTags(allowedCertificationCenterAccessDTO) {
-    return _.compact(allowedCertificationCenterAccessDTO.tags);
+  function _cleanTags(allowedCertificationCenterAccessDTO) {
+    return _(allowedCertificationCenterAccessDTO.tags).compact().uniq().value();
   }
 
-  function _cleanEmptyHabilitations(allowedCertificationCenterAccessDTO) {
-    return allowedCertificationCenterAccessDTO.habilitations.filter((habilitation) => Boolean(habilitation.id));
+  function _cleanHabilitations(allowedCertificationCenterAccessDTO) {
+    return _(allowedCertificationCenterAccessDTO.habilitations)
+      .filter((habilitation) => Boolean(habilitation.id))
+      .uniqBy('id')
+      .value();
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire :
Choisir un utilisateur de centre de certification et associer un de ses centres de certification à une organisation ayant plusieurs tags ET s'assurer que le centre de certification a une ou plusieurs habilitations.
Créer une session puis essayer d'inscrire un candidat, et en principe on devrait voir plusieurs fois les mêmes habilitations à cocher en bas.

## :robot: Solution
La requête SQL pour récupérer les infos nécessaires à l'instanciation d'un modèle CertificationPointOfContact est une petite fiesta de jointures. Du coup, lorsque le centre de certif est lié à une orga ayant plusieurs tags, ça doublonne des lignes de résultats et ça peut fausser la liste des tags ainsi que la liste des habilitations.
Nous allons donc simplement filtrer correctement ces deux listes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de reproduire le bug sur cette branche et échouer !

Localiser une organisation liée à plusieurs tags
```sql
SELECT
  o.name,
  COUNT(1)
FROM
     organizations o INNER JOIN "organization-tags" ot ON ot."organizationId" = o.id
         INNER JOIN tags t ON t.id = ot."tagId"
GROUP BY o.name
HAVING COUNT(1) > 1;
```
Localiser (ou créer) un centre de certification lié à cette organisation (même `externalId`)

```sql
-- Certification center + organization
SELECT
    'organization=>'
    ,o.id
    ,o.name
    ,o."externalId"
    ,o.type
    ,o."isManagingStudents"
    ,'certification-center=>'
    ,cc.id
    ,cc.name
FROM
     "certification-centers" cc INNER JOIN organizations o on cc."externalId" = o."externalId"
WHERE 1=1
      AND cc."externalId" = 'EXTERNAL-ID';
```

Vérifier qu'il est habilité à des certifications complémentaires

```sql
SELECT
    'certification-center=>'
    ,crt_cnt.id
    ,crt_cnt.name
    ,'complementary certification=>'
    ,crt_cmp.id
    ,crt_cmp.name
    ,'habilitation=>'
    ,crt_cmp_hbl."createdAt"
FROM
     "certification-centers" crt_cnt
         INNER JOIN "complementary-certification-habilitations" crt_cmp_hbl ON crt_cmp_hbl."certificationCenterId" = crt_cnt.id
         INNER JOIN "complementary-certifications" crt_cmp ON crt_cmp.id = crt_cmp_hbl."complementaryCertificationId"
WHERE 1=1
    AND crt_cnt."externalId" = 'EXTERNAL-ID';
```