### PR TITLE
[FEATURE] Empêcher la tentative de création de candidat pendant un appel API (PIX-4804).

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -321,7 +321,12 @@
     >
       Fermer
     </PixButton>
-    <PixButton @type="submit" form="new-certification-candidate-form">
+    <PixButton
+      @type="submit"
+      @isLoading={{this.isLoading}}
+      @isDisabled={{this.isLoading}}
+      form="new-certification-candidate-form"
+    >
       Inscrire le candidat
     </PixButton>
   </:footer>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -14,6 +14,8 @@ export default class NewCertificationCandidateModal extends Component {
   @tracked selectedCountryInseeCode = FRANCE_INSEE_CODE;
   @tracked maskedBirthdate;
 
+  @tracked isLoading = false;
+
   focus(element) {
     element.focus();
   }
@@ -71,7 +73,12 @@ export default class NewCertificationCandidateModal extends Component {
   @action
   async onFormSubmit(event) {
     event.preventDefault();
-    await this.args.saveCandidate(this.args.candidateData);
+    this.isLoading = true;
+    try {
+      await this.args.saveCandidate(this.args.candidateData);
+    } finally {
+      this.isLoading = false;
+    }
   }
 
   get isBirthGeoCodeRequired() {


### PR DESCRIPTION
## :unicorn: Problème
Voir https://github.com/1024pix/pix/pull/4251

## :robot: Solution
Désactiver le bouton durant l'appel API.
Le réactiver ensuite ou en cas d'erreur.

## :rainbow: Remarques
Utilisation de la propriété `isLoading` de [Pix-Button](https://github.com/1024pix/pix-ui/blob/dev/addon/components/pix-button.hbs)

## :100: Pour tester

### Passant
Forcer un retard sur le retour de l'appel API
- via browser (Slow network)
- soit en modifiant la route `POST /api/sessions/{id}/certification-candidates`
```js
    function delay(ms) {
      return new Promise((resolve) => {
        setTimeout(resolve, ms);
      });
    }

    await delay(1000);
```

Cliquer plusieurs fois sur le bouton "Créer un candidat" et vérifier :
- qu'il n'y a qu'un seul appel API
- que le candidat est créé.
 
### Erreur
Forcer une erreur sur le retour de l'appel API
- via browser (Slow network)
- soit en modifiant la route `POST /api/sessions/{id}/certification-candidates`
```js
	throw new Error("AppleSauce");
```

Cliquer plusieurs fois sur le bouton "Créer un candidat" et vérifier: 
- que le message d'erreur est affiché;
- que le bouton est actif.