### PR TITLE
[FEATURE] Ajout des nouvelles cartes tutos sur les pages checkpoint (PIX-4601).

### DIFF
--- a/mon-pix/app/components/learning-more-panel.hbs
+++ b/mon-pix/app/components/learning-more-panel.hbs
@@ -4,7 +4,11 @@
       <h3 class="learning-more-panel__hint-title"><span>{{t "pages.learning-more.title"}}</span></h3>
       <div class="learning-more-panel__list-container">
         {{#each @learningMoreTutorials as |learningMoreTutorial|}}
-          <TutorialItem @tutorial={{learningMoreTutorial}} />
+          {{#if this.areNewTutorialsEnabled}}
+            <Tutorials::Card @tutorial={{learningMoreTutorial}} />
+          {{else}}
+            <TutorialItem @tutorial={{learningMoreTutorial}} />
+          {{/if}}
         {{/each}}
         <div class="learning-more-panel__tutorial-info">{{t "pages.learning-more.info"}}</div>
       </div>

--- a/mon-pix/app/components/learning-more-panel.js
+++ b/mon-pix/app/components/learning-more-panel.js
@@ -1,8 +1,15 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class LearningMorePanel extends Component {
+  @service featureToggles;
+
   get hasLearningMoreItems() {
     const learningMoreTutorials = this.args.learningMoreTutorials || [];
     return learningMoreTutorials.length > 0;
+  }
+
+  get areNewTutorialsEnabled() {
+    return this.featureToggles.featureToggles.isNewTutorialsPageEnabled;
   }
 }

--- a/mon-pix/app/components/tutorial-panel.hbs
+++ b/mon-pix/app/components/tutorial-panel.hbs
@@ -21,7 +21,11 @@
       {{#if this.shouldDisplayTutorial}}
         <div class="tutorial-panel__tutorials-container">
           {{#each this.limitedTutorials as |tutorial|}}
-            <TutorialItem @tutorial={{tutorial}} />
+            {{#if this.areNewTutorialsEnabled}}
+              <Tutorials::Card @tutorial={{tutorial}} />
+            {{else}}
+              <TutorialItem @tutorial={{tutorial}} />
+            {{/if}}
           {{/each}}
         </div>
         <div class="tutorial-panel__tutorial-info">{{t "pages.tutorial-panel.info"}}</div>

--- a/mon-pix/app/components/tutorial-panel.js
+++ b/mon-pix/app/components/tutorial-panel.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class TutorialPanel extends Component {
+  @service featureToggles;
+
   get shouldDisplayHintOrTuto() {
     const tutorials = this.args.tutorials || [];
     const hint = this.args.hint || [];
@@ -20,5 +23,9 @@ export default class TutorialPanel extends Component {
 
   get limitedTutorials() {
     return this.args.tutorials.slice(0, 3);
+  }
+
+  get areNewTutorialsEnabled() {
+    return this.featureToggles.featureToggles.isNewTutorialsPageEnabled;
   }
 }

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -11,6 +11,10 @@
   @include device-is('desktop') {
     margin: 25px 40px;
   }
+
+  & .tutorial-card-v2 {
+    margin-bottom: 16px;
+  }
 }
 
 .learning-more-panel__hint-title {

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -31,6 +31,10 @@
 .tutorial-panel__tutorials-container {
   display: flex;
   flex-direction: column;
+
+  & .tutorial-card-v2 {
+    margin-bottom: 16px;
+  }
 }
 
 .tutorial-panel__tutorial-info {

--- a/mon-pix/tests/integration/components/learning-more-panel_test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel_test.js
@@ -2,22 +2,64 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
+import { A } from '@ember/array';
+import Service from '@ember/service';
+import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | learning-more-panel', function () {
   setupIntlRenderingTest();
 
-  it('renders a list item when there is at least one learningMore item', async function () {
-    // given
-    this.set('learningMoreTutorials', [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }]);
+  beforeEach(function () {
+    class FeatureTogglesService extends Service {
+      featureToggles = {
+        isNewTutorialsPageEnabled: false,
+      };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesService);
+  });
 
-    // when
-    await render(hbs`<LearningMorePanel @learningMoreTutorials={{this.learningMoreTutorials}}/>`);
+  describe('when there is at least one learningMore item', function () {
+    it('renders a list item when there is at least one learningMore item', async function () {
+      // given
+      this.set('learningMoreTutorials', [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }]);
 
-    // then
-    expect(findAll('.learning-more-panel__container')).to.have.length(1);
-    expect(findAll('.learning-more-panel__list-container')).to.have.length(1);
-    expect(find('.learning-more-panel__container').textContent).to.contains(this.intl.t('pages.learning-more.title'));
+      // when
+      await render(hbs`<LearningMorePanel @learningMoreTutorials={{this.learningMoreTutorials}}/>`);
+
+      // then
+      expect(findAll('.learning-more-panel__container')).to.have.length(1);
+      expect(findAll('.learning-more-panel__list-container')).to.have.length(1);
+      expect(find('.learning-more-panel__container').textContent).to.contains(this.intl.t('pages.learning-more.title'));
+    });
+
+    describe('when newTutorials FT is enabled', function () {
+      it('should display a list of new tutorial cards', async function () {
+        // given
+        class FeatureTogglesService extends Service {
+          featureToggles = {
+            isNewTutorialsPageEnabled: true,
+          };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesService);
+        const tuto1 = EmberObject.create({
+          title: 'Tuto 1.1',
+          tubeName: '@first_tube',
+          tubePracticalTitle: 'Practical Title',
+          duration: '00:15:10',
+        });
+
+        const tutorials = A([tuto1]);
+
+        this.set('learningMoreTutorials', tutorials);
+
+        // when
+        await render(hbs`<LearningMorePanel @learningMoreTutorials={{this.learningMoreTutorials}} />`);
+
+        // then
+        expect(findAll('.tutorial-card-v2')).to.have.lengthOf(1);
+      });
+    });
   });
 
   it('should not render a list when there is no LearningMore elements', async function () {

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -2,11 +2,20 @@ import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | tutorial panel', function () {
   setupIntlRenderingTest();
+
+  beforeEach(function () {
+    class FeatureTogglesService extends Service {
+      featureToggles = {
+        isNewTutorialsPageEnabled: false,
+      };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesService);
+  });
 
   context('when the result is not ok', function () {
     context('and a hint is present', function () {
@@ -65,6 +74,24 @@ describe('Integration | Component | tutorial panel', function () {
           expect(find('.tutorial-content__duration')).to.exist;
           expect(find('.tutorial-content-actions__save')).to.exist;
           expect(find('.tutorial-content-actions__evaluate')).to.exist;
+        });
+
+        context('when newTutorials FT is enabled', function () {
+          it('should display a list of new tutorial cards', async function () {
+            // given
+            class FeatureTogglesService extends Service {
+              featureToggles = {
+                isNewTutorialsPageEnabled: true,
+              };
+            }
+            this.owner.register('service:featureToggles', FeatureTogglesService);
+
+            // when
+            await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);
+
+            // then
+            expect(findAll('.tutorial-card-v2')).to.have.lengthOf(1);
+          });
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les nouvelles cartes des tutoriels sont utilisées que dans la page des tutoriels et compétences. Il reste donc les pages checkpoints sur lesquelles nous devons afficher les nouveaux designs

## :robot: Solution
Afficher les nouvelles cartes de tutoriels dans les pages checkpoint lorsque le FT : `FT_NEW_TUTORIALS_PAGE` est activé.  

## :rainbow: Remarques
N/A

## :100: Pour tester
 - Se connecter sur Pix App 
 - Passer des épreuves et constater la présence des nouvelles cartes des tutos sur les pages checkpoint