### PR TITLE
[FEATURE] Ajouter dans Pix Admin la liste des places détenu par les organisations (PIX-4775) 

### DIFF
--- a/admin/app/adapters/organization-place.js
+++ b/admin/app/adapters/organization-place.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationPlaceAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForQuery(query) {
+    const organizationId = query.organizationId;
+    delete query.organizationId;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/places`;
+  }
+}

--- a/admin/app/components/organizations/places.hbs
+++ b/admin/app/components/organizations/places.hbs
@@ -1,0 +1,48 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">Historique des lots</h2>
+  </header>
+  {{#if @places}}
+    <table
+      class="table-admin"
+      summary="Affichage des lots de place disponible triés par ordre anti-chronologique d'activation puis d'expiration"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Nombre</th>
+          <th scope="col">Catégorie</th>
+          <th scope="col">Date d'activation</th>
+          <th scope="col">Statut</th>
+          <th scope="col">Référence</th>
+          <th scope="col">Créé par</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each @places as |place|}}
+          <tr aria-label="Lot de Places">
+            <td class="td--bold">{{place.count}}</td>
+            <td class="td--bold" scope="row">{{place.categoryLabel}}</td>
+            <td>
+              Du:
+              {{moment-format place.activationDate "DD/MM/YYYY"}}
+              {{#if place.hasExpiredDate}}
+                <br />
+                Au:
+                {{moment-format place.expiredDate "DD/MM/YYYY"}}
+              {{/if}}
+            </td>
+            <td class="table__column table__column--center">
+              <PixTag @color={{if (eq place.status "ACTIVE") "blue" "grey"}}>{{place.displayStatus}}</PixTag>
+            </td>
+            <td>{{place.reference}}</td>
+            <td>{{place.creatorFullName}}</td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  {{/if}}
+
+  {{#unless @places}}
+    <div class="table-admin-empty">Aucun lot de places saisi</div>
+  {{/unless}}
+</section>

--- a/admin/app/models/organization-place.js
+++ b/admin/app/models/organization-place.js
@@ -1,0 +1,37 @@
+import Model, { attr } from '@ember-data/model';
+
+const statuses = {
+  ACTIVE: 'Actif',
+  EXPIRED: 'Expiré',
+  PENDING: 'À venir',
+};
+
+const categories = {
+  FREE_RATE: 'Tarif gratuit',
+  PUBLIC_RATE: 'Tarif public',
+  REDUCE_RATE: 'Tarif réduit',
+  SPECIAL_REDUCE_RATE: 'Tarif réduit spécial',
+  FULL_RATE: 'Tarif plein',
+};
+export default class OrganizationPlace extends Model {
+  @attr('number') count;
+  @attr('string') reference;
+  @attr('string') category;
+  @attr('string') status;
+  @attr('date') activationDate;
+  @attr('date') expiredDate;
+  @attr('date') createdAt;
+  @attr('string') creatorFullName;
+
+  get displayStatus() {
+    return statuses[this.status];
+  }
+
+  get categoryLabel() {
+    return categories[this.category];
+  }
+
+  get hasExpiredDate() {
+    return Boolean(this.expiredDate);
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -30,6 +30,7 @@ Router.map(function () {
         this.route('target-profiles');
         this.route('campaigns');
         this.route('all-tags');
+        this.route('places');
         this.route('invitations');
       });
     });

--- a/admin/app/routes/authenticated/organizations/get/places.js
+++ b/admin/app/routes/authenticated/organizations/get/places.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class Places extends Route {
+  @service store;
+
+  async model() {
+    const organization = this.modelFor('authenticated.organizations.get');
+    const places = await this.store.query('organization-place', {
+      organizationId: organization.id,
+    });
+
+    return { organization, places };
+  }
+}

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -45,11 +45,11 @@
         display: flex;
         align-items: center;
         margin-bottom: 20px;
+      }
 
-        &__title {
-          font-size: 1.2rem;
-          font-weight: 600;
-        }
+      &__title {
+        font-size: 1.2rem;
+        font-weight: 600;
       }
 
       &__content {

--- a/admin/app/styles/globals/tables.scss
+++ b/admin/app/styles/globals/tables.scss
@@ -37,6 +37,10 @@ th {
   text-overflow: ellipsis;
 }
 
+td.td--bold {
+  font-weight: $font-medium;
+}
+
 .table__column {
   width: 16%;
 

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -35,6 +35,10 @@
       Campagnes
     </LinkTo>
 
+    <LinkTo @route="authenticated.organizations.get.places" @model={{@model}} class="navbar-item">
+      Places
+    </LinkTo>
+
     <LinkTo @route="authenticated.organizations.get.all-tags" @model={{@model}} class="navbar-item">
       Tags
     </LinkTo>

--- a/admin/app/templates/authenticated/organizations/get/places.hbs
+++ b/admin/app/templates/authenticated/organizations/get/places.hbs
@@ -1,0 +1,2 @@
+{{page-title "Orga " @model.organization.id " | Places"}}
+<Organizations::Places @places={{@model.places}} />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -22,6 +22,7 @@ import {
   archiveOrganization,
   findPaginatedOrganizationMemberships,
   getOrganizationInvitations,
+  getOrganizationPlaces,
 } from './handlers/organizations';
 import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 
@@ -132,6 +133,7 @@ export default function () {
   this.get('/organizations/:id/target-profiles', getOrganizationTargetProfiles);
   this.post('/organizations/:id/target-profiles', attachTargetProfiles);
   this.get('/admin/organizations/:id/invitations', getOrganizationInvitations);
+  this.get('/admin/organizations/:id/places', getOrganizationPlaces);
   this.get('/admin/badges/:id', getBadge);
   this.post('/admin/badges/:id/badge-criteria', createBadgeCriterion);
   this.post('/admin/target-profiles');

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -1,6 +1,10 @@
 import get from 'lodash/get';
 import slice from 'lodash/slice';
 
+function getOrganizationPlaces(schema) {
+  return schema.organizationPlaces.all();
+}
+
 function getOrganizationInvitations(schema, request) {
   const ownerOrganizationId = request.params.id;
   return schema.organizationInvitations.where({ ownerOrganizationId });
@@ -46,4 +50,4 @@ function _applyPagination(memberships, { page, pageSize }) {
   return slice(memberships, start, end);
 }
 
-export { archiveOrganization, getOrganizationInvitations, findPaginatedOrganizationMemberships };
+export { archiveOrganization, getOrganizationInvitations, getOrganizationPlaces, findPaginatedOrganizationMemberships };

--- a/admin/tests/acceptance/authenticated/organizations/places_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/places_test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Organizations | places', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+  });
+
+  test('should display organization places', async function (assert) {
+    // given
+    const ownerOrganizationId = this.server.create('organization').id;
+    this.server.create('organizationPlace', {
+      count: 7777,
+      reference: 'FFVII',
+      category: 'SquareEnix',
+      status: 'ACTIVE',
+      activationDate: '1997-01-31',
+      expiredDate: '2100-12-31',
+      createdAt: '1996-01-12',
+      creatorFullName: 'Hironobu Sakaguchi',
+    });
+
+    // when
+    const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+
+    // then
+    assert.dom(screen.getByText('FFVII')).exists();
+  });
+});

--- a/admin/tests/integration/components/organizations/places_test.js
+++ b/admin/tests/integration/components/organizations/places_test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Organizations | places', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('Display places', function () {
+    test('it should display title and no results text', async function (assert) {
+      //Given
+      this.set('places', []);
+
+      // when
+      const screen = await render(hbs`<Organizations::Places @places={{this.places}}/>`);
+
+      // then
+      assert.dom(screen.getByText('Historique des lots')).exists();
+
+      assert.dom(screen.queryByText('Nombre')).doesNotExist();
+      assert.dom(screen.queryByText('Catégorie')).doesNotExist();
+      assert.dom(screen.queryByText("Date d'activation")).doesNotExist();
+      assert.dom(screen.queryByText('Référence')).doesNotExist();
+      assert.dom(screen.queryByText('Statut')).doesNotExist();
+      assert.dom(screen.queryByText('Créé par')).doesNotExist();
+
+      assert.dom(screen.getByText('Aucun lot de places saisi')).exists();
+    });
+
+    test('it should display places', async function (assert) {
+      // given
+      const places = store.createRecord('organizationPlace', {
+        count: 7777,
+        reference: 'FFVII',
+        category: 'FULL_RATE',
+        status: 'ACTIVE',
+        activationDate: '1997-01-31',
+        expiredDate: '2100-12-31',
+        createdAt: '1996-01-12',
+        creatorFullName: 'Hironobu Sakaguchi',
+      });
+
+      this.set('places', [places]);
+
+      // when
+      const screen = await render(hbs`<Organizations::Places @places={{this.places}}/>`);
+
+      // then
+      assert.dom(screen.queryByText('Aucun résultat')).doesNotExist();
+
+      assert.dom(screen.getByText('Nombre')).exists();
+      assert.dom(screen.getByText('Catégorie')).exists();
+      assert.dom(screen.getByText("Date d'activation")).exists();
+      assert.dom(screen.getByText('Référence')).exists();
+      assert.dom(screen.getByText('Statut')).exists();
+      assert.dom(screen.getByText('Créé par')).exists();
+
+      assert.dom(screen.getByText('7777')).exists();
+      assert.dom(screen.getByText('FFVII')).exists();
+      assert.dom(screen.getByText('Tarif plein')).exists();
+      assert.dom(screen.getByText('Actif')).exists();
+      assert.dom(screen.getByText('Hironobu Sakaguchi')).exists();
+
+      assert.dom(screen.getByText(/Du: 31\/01\/1997/)).exists();
+      assert.dom(screen.getByText(/Au: 31\/12\/2100/)).exists();
+    });
+  });
+});

--- a/admin/tests/unit/models/organization-place_test.js
+++ b/admin/tests/unit/models/organization-place_test.js
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | organization place', function (hooks) {
+  setupTest(hooks);
+
+  module('#displayStatus', function () {
+    test('it formats status ACTIVE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      // when
+      const model = store.createRecord('organizationPlace', { status: 'ACTIVE' });
+
+      // then
+      assert.strictEqual(model.displayStatus, 'Actif');
+    });
+
+    test('it formats status EXPIRED', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      // when
+      const model = store.createRecord('organizationPlace', { status: 'EXPIRED' });
+
+      // then
+      assert.strictEqual(model.displayStatus, 'Expiré');
+    });
+
+    test('it formats status PENDING', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      // when
+      const model = store.createRecord('organizationPlace', { status: 'PENDING' });
+
+      // then
+      assert.strictEqual(model.displayStatus, 'À venir');
+    });
+  });
+
+  module('#categoryLabel', function () {
+    test('it return label for FREE_RATE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      // when
+      const model = store.createRecord('organizationPlace', {
+        category: 'FREE_RATE',
+      });
+
+      // then
+      assert.strictEqual(model.categoryLabel, 'Tarif gratuit');
+    });
+
+    test('it return label for PUBLIC_RATE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      // when
+      const model = store.createRecord('organizationPlace', {
+        category: 'PUBLIC_RATE',
+      });
+
+      // then
+      assert.strictEqual(model.categoryLabel, 'Tarif public');
+    });
+
+    test('it return label for REDUCE_RATE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      // when
+      const model = store.createRecord('organizationPlace', {
+        category: 'REDUCE_RATE',
+      });
+
+      // then
+      assert.strictEqual(model.categoryLabel, 'Tarif réduit');
+    });
+
+    test('it return label for SPECIAL_REDUCE_RATE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      // when
+      const model = store.createRecord('organizationPlace', {
+        category: 'SPECIAL_REDUCE_RATE',
+      });
+
+      // then
+      assert.strictEqual(model.categoryLabel, 'Tarif réduit spécial');
+    });
+
+    test('it return label for FULL_RATE', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      // when
+      const model = store.createRecord('organizationPlace', {
+        category: 'FULL_RATE',
+      });
+
+      // then
+      assert.strictEqual(model.categoryLabel, 'Tarif plein');
+    });
+  });
+});

--- a/api/db/database-builder/factory/build-organization-place.js
+++ b/api/db/database-builder/factory/build-organization-place.js
@@ -1,0 +1,37 @@
+const databaseBuffer = require('../database-buffer');
+const buildOrganization = require('./build-organization');
+const buildUser = require('./build-user');
+
+const buildOrganizationPlace = function buildOrganizationPlace({
+  id = databaseBuffer.getNextId(),
+  organizationId,
+  count = 7777,
+  activationDate = new Date('2014-05-13'),
+  expiredDate,
+  reference = 'Godzilla',
+  category = 'T0',
+  createdBy,
+  createdAt = new Date('1997-07-01'),
+} = {}) {
+  organizationId = organizationId || buildOrganization().id;
+  createdBy = createdBy || buildUser.withRole({ firstName: 'Gareth', lastName: 'Edwards' }).id;
+
+  const values = {
+    id,
+    count,
+    organizationId,
+    activationDate,
+    expiredDate,
+    reference,
+    category,
+    createdBy,
+    createdAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'organization-places',
+    values,
+  });
+};
+
+module.exports = buildOrganizationPlace;

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -43,6 +43,7 @@ module.exports = {
   buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildMembership: require('./build-membership'),
   buildOrganization: require('./build-organization'),
+  buildOrganizationPlace: require('./build-organization-place'),
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationLearner: require('./build-organization-learner'),
   buildOrganizationLearnerWithUser: require('./build-organization-learner-with-user'),

--- a/api/db/migrations/20220415083318_add-organization-places-table.js
+++ b/api/db/migrations/20220415083318_add-organization-places-table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'organization-places';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('count');
+    t.integer('organizationId').index().references('organizations.id').notNullable();
+    t.dateTime('activationDate').notNullable();
+    t.dateTime('expiredDate').nullable();
+    t.text('reference').notNullable();
+    t.text('category').notNullable();
+    t.integer('createdBy').references('users.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/organization-places-pro-builder.js
+++ b/api/db/seeds/data/organization-places-pro-builder.js
@@ -1,0 +1,82 @@
+const { PRO_COMPANY_ID } = require('./organizations-pro-builder');
+const { PIX_SUPER_ADMIN_ID } = require('./users-builder');
+function organizationPlacesProBuilder({ databaseBuilder }) {
+  const activationDate = new Date();
+  const expiredDate = new Date();
+  const createdDate = new Date();
+
+  // Expired
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 20,
+    activationDate: new Date('2020-01-01'),
+    expiredDate: new Date('2020-12-31'),
+    reference: 'TheOfficeS02EP01',
+    category: 'T1',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date('2019-12-01'),
+  });
+
+  // Expired
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 19,
+    activationDate: new Date('2021-01-01'),
+    expiredDate: new Date('2022-01-01'),
+    reference: 'TheOfficeS02EP01',
+    category: 'T0',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date('2019-12-25'),
+  });
+
+  // Active
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 700,
+    activationDate: new Date(activationDate.setMonth(activationDate.getMonth() - 1)),
+    expiredDate: new Date(expiredDate.setMonth(expiredDate.getMonth() + 8)),
+    reference: 'TheOfficeS02EP02',
+    category: 'T2',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date(createdDate.setMonth(createdDate.getMonth() - 2)),
+  });
+
+  // Active with same activationDate on another
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 45,
+    activationDate: new Date(activationDate),
+    expiredDate: new Date(expiredDate.setMonth(expiredDate.getMonth() + 2)),
+    reference: 'TheOfficeS02EP03',
+    category: 'T3',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date(createdDate),
+  });
+
+  // Active with same expired Date on another
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 77,
+    activationDate: new Date(activationDate.setMonth(activationDate.getMonth() - 1)),
+    expiredDate: new Date(expiredDate),
+    reference: 'TheOfficeS02EP06',
+    category: 'T2',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date(createdDate),
+  });
+
+  // Not Active Yet
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 700,
+    activationDate: new Date(activationDate.setMonth(activationDate.getMonth() + 4)),
+    reference: 'TheOfficeS02EP03',
+    category: 'T2bis',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date(createdDate.setMonth(createdDate.getMonth() - 2)),
+  });
+}
+
+module.exports = {
+  organizationPlacesProBuilder,
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -23,6 +23,7 @@ const certificationCenterMembershipsBuilder = require('./data/certification/cert
 const { organizationsProBuilder } = require('./data/organizations-pro-builder');
 const { organizationsScoBuilder } = require('./data/organizations-sco-builder');
 const { organizationsSupBuilder } = require('./data/organizations-sup-builder');
+const { organizationPlacesProBuilder } = require('./data/organization-places-pro-builder');
 const { badgesBuilder } = require('./data/badges-builder');
 const tagsBuilder = require('./data/tags-builder');
 const { targetProfilesBuilder } = require('./data/target-profiles-builder');
@@ -49,8 +50,12 @@ exports.seed = async (knex) => {
 
   // Organizations
   tagsBuilder({ databaseBuilder });
+
   organizationsProBuilder({ databaseBuilder });
+  organizationPlacesProBuilder({ databaseBuilder });
+
   organizationsScoBuilder({ databaseBuilder });
+
   organizationsSupBuilder({ databaseBuilder });
 
   // Target Profiles

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -210,6 +210,29 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/admin/organizations/{id}/places',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationController.findOrganizationPlaces,
+        tags: ['api', 'organizations'],
+        notes: [
+          'Cette route est restreinte aux administrateurs authentifiés',
+          "Elle retourne la liste des commandes de places faites par l'organisation",
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/organizations/{id}/memberships',
       config: {
         pre: [

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -13,6 +13,7 @@ const higherSchoolingRegistrationWarningSerializer = require('../../infrastructu
 const organizationAttachTargetProfilesSerializer = require('../../infrastructure/serializers/jsonapi/organization-attach-target-profiles-serializer');
 const TargetProfileForSpecifierSerializer = require('../../infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer');
 const organizationMemberIdentitySerializer = require('../../infrastructure/serializers/jsonapi/organization-member-identity-serializer');
+const organizationPlaceSerializer = require('../../infrastructure/serializers/jsonapi/organization/organization-place-serializer');
 const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const {
@@ -123,6 +124,12 @@ module.exports = {
     const organizationId = request.params.id;
     const members = await usecases.getOrganizationMemberIdentities({ organizationId });
     return organizationMemberIdentitySerializer.serialize(members);
+  },
+
+  async findOrganizationPlaces(request) {
+    const organizationId = request.params.id;
+    const places = await usecases.findOrganizationPlaces({ organizationId });
+    return organizationPlaceSerializer.serialize(places);
   },
 
   async downloadCertificationAttestationsForDivision(request, h) {

--- a/api/lib/domain/read-models/OrganizationPlace.js
+++ b/api/lib/domain/read-models/OrganizationPlace.js
@@ -1,0 +1,45 @@
+const statuses = {
+  ACTIVE: 'ACTIVE',
+  EXPIRED: 'EXPIRED',
+  PENDING: 'PENDING',
+};
+
+const categories = {
+  T0: 'FREE_RATE',
+  T1: 'PUBLIC_RATE',
+  T2: 'REDUCE_RATE',
+  T2bis: 'SPECIAL_REDUCE_RATE',
+  T3: 'FULL_RATE',
+};
+
+class OrganizationPlace {
+  constructor({ id, count, activationDate, expiredDate, reference, category, creatorFirstName, creatorLastName } = {}) {
+    this.id = id;
+    this.count = count;
+    this.activationDate = activationDate;
+    this.expiredDate = expiredDate;
+    this.reference = reference;
+    this.category = categories[category];
+    this.creatorFullName = `${creatorFirstName} ${creatorLastName}`;
+    this.status = _setStatus(activationDate, expiredDate);
+  }
+}
+
+function _setStatus(activationDate, expiredDate) {
+  const today = new Date();
+
+  if (Boolean(expiredDate) && expiredDate < today) {
+    return statuses.EXPIRED;
+  }
+
+  if (activationDate < today) {
+    return statuses.ACTIVE;
+  }
+
+  return statuses.PENDING;
+}
+
+OrganizationPlace.statuses = statuses;
+OrganizationPlace.categories = categories;
+
+module.exports = OrganizationPlace;

--- a/api/lib/domain/usecases/find-organization-places.js
+++ b/api/lib/domain/usecases/find-organization-places.js
@@ -1,0 +1,3 @@
+module.exports = async function findOrganizationPlaces({ organizationId, organizationPlaceRepository }) {
+  return organizationPlaceRepository.find(organizationId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -242,6 +242,7 @@ module.exports = injectDependencies(
     findFinalizedSessionsToPublish: require('./find-finalized-sessions-to-publish'),
     findFinalizedSessionsWithRequiredAction: require('./find-finalized-sessions-with-required-action'),
     findGroupsByOrganization: require('./find-groups-by-organization'),
+    findOrganizationPlaces: require('./find-organization-places'),
     findPaginatedCampaignParticipantsActivities: require('./find-paginated-campaign-participants-activities'),
     findPaginatedCampaignManagements: require('./find-paginated-campaign-managements'),
     findPaginatedCertificationCenterSessionSummaries: require('./find-paginated-certification-center-session-summaries'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -90,6 +90,7 @@ const dependencies = {
   organizationMemberIdentityRepository: require('../../infrastructure/repositories/organization-member-identity-repository'),
   organizationForAdminRepository: require('../../infrastructure/repositories/organization-for-admin-repository'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
+  organizationPlaceRepository: require('../../infrastructure/repositories/organizations/organization-place-repository'),
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
   organizationInvitedUserRepository: require('../../infrastructure/repositories/organization-invited-user-repository'),
   organizationTagRepository: require('../../infrastructure/repositories/organization-tag-repository'),

--- a/api/lib/infrastructure/repositories/organizations/organization-place-repository.js
+++ b/api/lib/infrastructure/repositories/organizations/organization-place-repository.js
@@ -1,0 +1,29 @@
+const { knex } = require('../../../../db/knex-database-connection');
+const OrganizationPlace = require('../../../domain/read-models/OrganizationPlace');
+
+async function find(organizationId) {
+  const results = await knex('organization-places')
+    .select(
+      'organization-places.id AS id',
+      'count',
+      'activationDate',
+      'expiredDate',
+      'reference',
+      'category',
+      'users.firstName AS creatorFirstName',
+      'users.lastName AS creatorLastName'
+    )
+    .join('users', 'users.id', 'createdBy')
+    .where({ organizationId })
+    .orderBy('activationDate', 'desc')
+    .orderBy('expiredDate', 'desc')
+    .orderBy('organization-places.createdAt', 'desc');
+
+  return results.map((result) => {
+    return new OrganizationPlace(result);
+  });
+}
+
+module.exports = {
+  find,
+};

--- a/api/lib/infrastructure/serializers/jsonapi/organization/organization-place-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/organization-place-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(places) {
+    return new Serializer('organization-place', {
+      attributes: ['count', 'activationDate', 'expiredDate', 'reference', 'category', 'status', 'creatorFullName'],
+    }).serialize(places);
+  },
+};

--- a/api/tests/acceptance/application/organizations/find-organization-places_test.js
+++ b/api/tests/acceptance/application/organizations/find-organization-places_test.js
@@ -1,0 +1,75 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Route | Organizations', function () {
+  describe('GET /api/admin/organizations/{id}/places', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+
+      const adminUser = await insertUserWithRoleSuperAdmin();
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        count: 18,
+        activationDate: new Date('2020-01-01'),
+        expiredDate: new Date('2021-01-01'),
+        reference: 'Godzilla',
+        category: 'Toho',
+        createdBy: adminUser.id,
+      });
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/organizations/${organizationId}/places`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return list of places', async function () {
+      // given
+      const server = await createServer();
+
+      const adminUser = await insertUserWithRoleSuperAdmin();
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const place = databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        createdBy: adminUser.id,
+      });
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/organizations/${organizationId}/places`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.result.data.length).to.equal(1);
+
+      expect(response.result.data[0].id).to.equal(place.id.toString());
+      expect(response.result.data[0].attributes.reference).to.equal(place.reference);
+    });
+  });
+});

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -147,6 +147,28 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
+  describe('GET /api/admin/organizations/:id/places', function () {
+    it('should call the controller to archive the organization', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/organizations/1/places';
+
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(organizationController, 'findOrganizationPlaces')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(organizationController.findOrganizationPlaces).to.have.been.calledOnce;
+    });
+  });
+
   describe('POST /api/organizations/:id/invitations', function () {
     it('should call the organization controller to send invitations', async function () {
       // given

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -24,10 +24,12 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(usecases, 'findCertificationAttestationsForDivision');
     sandbox.stub(usecases, 'findGroupsByOrganization');
     sandbox.stub(usecases, 'findDivisionsByOrganization');
+    sandbox.stub(usecases, 'findOrganizationPlaces');
 
     sandbox.stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer');
 
     sandbox.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
+    sandbox.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganizationManagingStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToSupOrganizationAndManagesStudents');
@@ -212,6 +214,31 @@ describe('Integration | Application | Organizations | organization-controller', 
 
         // when
         const response = await httpTestServer.request('GET', '/api/organizations/1/invitations');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
+
+  describe('#findOrganizationPlaces', function () {
+    context('Success cases', function () {
+      it('should return an HTTP response with status code 200', async function () {
+        // given
+        const organizationId = domainBuilder.buildOrganization().id;
+        const place = domainBuilder.buildOrganizationPlace({
+          organizationId,
+          count: 18,
+          activationDate: new Date('2020-01-01'),
+          expiredDate: new Date('2021-01-01'),
+          reference: 'Toho Godzilla',
+          category: 'T2',
+        });
+        usecases.findOrganizationPlaces.resolves([place]);
+        securityPreHandlers.checkUserHasRoleSuperAdmin.returns(true);
+
+        // when
+        const response = await httpTestServer.request('GET', `/api/admin/organizations/${organizationId}/places`);
 
         // then
         expect(response.statusCode).to.equal(200);

--- a/api/tests/integration/infrastructure/repositories/organizations/organization-place-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organizations/organization-place-repository_test.js
@@ -1,0 +1,187 @@
+const { expect, databaseBuilder } = require('../../../../test-helper');
+const organizationPlaceRepository = require('../../../../../lib/infrastructure/repositories/organizations/organization-place-repository');
+const OrganizationPlace = require('../../../../../lib/domain/read-models/OrganizationPlace');
+
+describe('Integration | Repository | Organization Place', function () {
+  describe('#find', function () {
+    it('should return organization place model for given id', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const user = databaseBuilder.factory.buildUser.withRole({ firstName: 'Gareth', lastName: 'Edwards' });
+      const placeGZ = databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        count: 66,
+        category: 'T2',
+        reference: 'Godzilla',
+        activationDate: new Date('2014-05-13'),
+        expiredDate: new Date('2021-07-01'),
+        createdBy: user.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+
+      // then
+      expect(foundOrganizationPlace[0].id).to.equal(placeGZ.id);
+      expect(foundOrganizationPlace[0].count).to.equal(placeGZ.count);
+      expect(foundOrganizationPlace[0].status).to.equal(OrganizationPlace.statuses.EXPIRED);
+      expect(foundOrganizationPlace[0].category).to.equal(OrganizationPlace.categories[placeGZ.category]);
+      expect(foundOrganizationPlace[0].reference).to.equal(placeGZ.reference);
+      expect(foundOrganizationPlace[0].creatorFullName).to.equal(`${user.firstName} ${user.lastName}`);
+
+      expect(foundOrganizationPlace[0].activationDate).to.deep.equal(placeGZ.activationDate);
+      expect(foundOrganizationPlace[0].expiredDate).to.deep.equal(placeGZ.expiredDate);
+    });
+
+    it('should return organization places for given id', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const placeSG1 = databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        reference: 'Stargate SG-1',
+      });
+
+      const placeAtlantis = databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        reference: 'Stargate Atlantis',
+      });
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId: otherOrganizationId,
+        reference: 'Stargate Universe',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+
+      // then
+      expect(foundOrganizationPlace.length).to.equal(2);
+      expect([foundOrganizationPlace[0].reference, foundOrganizationPlace[1].reference]).to.have.members([
+        placeSG1.reference,
+        placeAtlantis.reference,
+      ]);
+    });
+
+    it('should return empty when no places defined', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+      // then
+      expect(foundOrganizationPlace.length).to.equal(0);
+    });
+
+    it("should return creator place's name for given id", async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser({ firstName: 'Jack', lastName: "O'Neill" });
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        reference: 'Stargate SG-1',
+        createdBy: user.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+
+      // then
+      expect(foundOrganizationPlace[0].creatorFullName).to.equal(`${user.firstName} ${user.lastName}`);
+    });
+
+    describe('When activationDate are different', function () {
+      it('should return organization places in descending order for activationDate', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+        const organizationPlace1 = databaseBuilder.factory.buildOrganizationPlace({
+          organizationId,
+          activationDate: new Date('1994-10-28'),
+        });
+
+        const organizationPlace2 = databaseBuilder.factory.buildOrganizationPlace({
+          organizationId,
+          activationDate: new Date('1997-07-27'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+
+        // then
+        expect(foundOrganizationPlace[0].id).to.deep.equal(organizationPlace2.id);
+        expect(foundOrganizationPlace[1].id).to.deep.equal(organizationPlace1.id);
+      });
+    });
+
+    describe('When activationDate are identical', function () {
+      it('should return organization places in descending order for expiredDate', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+        const organizationPlace1 = databaseBuilder.factory.buildOrganizationPlace({
+          organizationId,
+          activationDate: new Date('1997-07-27'),
+          expiredDate: new Date('2011-05-09'),
+        });
+
+        const organizationPlace2 = databaseBuilder.factory.buildOrganizationPlace({
+          organizationId,
+          activationDate: new Date('1997-07-27'),
+          expiredDate: new Date('2007-03-13'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+
+        // then
+        expect(foundOrganizationPlace[0].id).to.deep.equal(organizationPlace1.id);
+        expect(foundOrganizationPlace[1].id).to.deep.equal(organizationPlace2.id);
+      });
+    });
+
+    describe('When activationDate and expiredDate are identical', function () {
+      it('should return organization places in descending order for createdAt', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+        const organizationPlace1 = databaseBuilder.factory.buildOrganizationPlace({
+          organizationId,
+          activationDate: new Date('1997-07-27'),
+          expiredDate: new Date('2007-03-13'),
+          createdAt: new Date('1994-10-28'),
+        });
+
+        const organizationPlace2 = databaseBuilder.factory.buildOrganizationPlace({
+          organizationId,
+          activationDate: new Date('1997-07-27'),
+          expiredDate: new Date('2007-03-13'),
+          createdAt: new Date('1997-07-27'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganizationPlace = await organizationPlaceRepository.find(organizationId);
+
+        // then
+        expect(foundOrganizationPlace[0].id).to.deep.equal(organizationPlace2.id);
+        expect(foundOrganizationPlace[1].id).to.deep.equal(organizationPlace1.id);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-organization-place.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-place.js
@@ -1,0 +1,29 @@
+const OrganizationPlace = require('../../../../lib/domain/read-models/OrganizationPlace');
+
+function buildOrganizationPlace({
+  id,
+  count,
+  organizationId,
+  activationDate,
+  expiredDate,
+  reference,
+  category,
+  creatorLastName,
+  creatorFirstName,
+  createdAt,
+} = {}) {
+  return new OrganizationPlace({
+    id,
+    count,
+    organizationId,
+    activationDate,
+    expiredDate,
+    reference,
+    category,
+    creatorLastName,
+    creatorFirstName,
+    createdAt,
+  });
+}
+
+module.exports = buildOrganizationPlace;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -72,6 +72,7 @@ module.exports = {
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildMembership: require('./build-membership'),
   buildOrganization: require('./build-organization'),
+  buildOrganizationPlace: require('./build-organization-place'),
   buildOrganizationForAdmin: require('./build-organization-for-admin'),
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationLearner: require('./build-organization-learner'),

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -318,12 +318,47 @@ describe('Unit | Router | organization-router', function () {
     });
   });
 
+  describe('GET /api/admin/organizations/{id}/places', function () {
+    it('should return BadRequest (400) if id is not numeric', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const idNotNumeric = 'foo';
+      const method = 'GET';
+      const url = `/api/admin/organizations/${idNotNumeric}/places`;
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return an empty list when no places is found', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+      sinon.stub(usecases, 'findOrganizationPlaces').returns([]);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'GET';
+      const url = '/api/admin/organizations/1/places';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([]);
+    });
+  });
+
   describe('GET /api/organizations/{id}/invitations', function () {
     it('should return an empty list when no organization is found', async function () {
       // given
       sinon.stub(usecases, 'findPendingOrganizationInvitations').resolves([]);
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
-      sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -21,6 +21,7 @@ const campaignReportSerializer = require('../../../../lib/infrastructure/seriali
 const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 const organizationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
 const organizationForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer');
+const organizationPlacesSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization/organization-place-serializer');
 const TargetProfileForSpecifierSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer');
 const userWithSchoolingRegistrationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
 const organizationAttachTargetProfilesSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-attach-target-profiles-serializer');
@@ -53,6 +54,28 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
       // then
       expect(result).to.equal(organizationDetailsSerialized);
+    });
+  });
+
+  describe('#findOrganizationPlaces', function () {
+    it('should call the usecase and serialize the response', async function () {
+      // given
+      const organizationId = 1234;
+      const request = { params: { id: organizationId } };
+
+      const organizationPlaces = Symbol('organizationPlaces');
+      const organizationPlacesSerialized = Symbol('organizationPlacesSerialized');
+      sinon.stub(usecases, 'findOrganizationPlaces').withArgs({ organizationId }).resolves(organizationPlaces);
+      sinon
+        .stub(organizationPlacesSerializer, 'serialize')
+        .withArgs(organizationPlaces)
+        .returns(organizationPlacesSerialized);
+
+      // when
+      const result = await organizationController.findOrganizationPlaces(request, hFake);
+
+      // then
+      expect(result).to.equal(organizationPlacesSerialized);
     });
   });
 

--- a/api/tests/unit/domain/read-models/OrganizationPlace_test.js
+++ b/api/tests/unit/domain/read-models/OrganizationPlace_test.js
@@ -1,0 +1,186 @@
+const { expect, sinon } = require('../../../test-helper');
+const OrganizationPlace = require('../../../../lib/domain/read-models/OrganizationPlace');
+
+describe('Unit | Domain | ReadModels | OrganizationPlace', function () {
+  describe('constructor', function () {
+    it('should build an Organization Place from raw JSON', function () {
+      // given
+      const rawData = {
+        id: 1,
+        count: 777,
+        activationDate: new Date('1986-05-01'),
+        expiredDate: new Date('2086-01-01'),
+        reference: 'Stargate',
+        category: 'T1',
+        creatorFirstName: 'Jack',
+        creatorLastName: "O'Neill",
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.id).to.equal(rawData.id);
+      expect(organizationPlace.count).to.equal(rawData.count);
+      expect(organizationPlace.activationDate).to.equal(rawData.activationDate);
+      expect(organizationPlace.expiredDate).to.equal(rawData.expiredDate);
+      expect(organizationPlace.reference).to.equal(rawData.reference);
+      expect(organizationPlace.category).to.equal(OrganizationPlace.categories[rawData.category]);
+      expect(organizationPlace.creatorFullName).to.equal(`${rawData.creatorFirstName} ${rawData.creatorLastName}`);
+    });
+  });
+
+  describe('#status', function () {
+    let clock;
+    const now = new Date('2021-05-01');
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers(now);
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('have expired status when expiredDate has passed.', function () {
+      // given
+      const rawData = {
+        activationDate: new Date('2020-01-12'),
+        expiredDate: new Date('2021-01-01'),
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.status).to.equal(OrganizationPlace.statuses.EXPIRED);
+    });
+
+    it('have active status when place is currently active', function () {
+      // given
+      const rawData = {
+        activationDate: new Date('2020-01-12'),
+        expiredDate: new Date('2021-05-15'),
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.status).to.equal(OrganizationPlace.statuses.ACTIVE);
+    });
+
+    it('have pending status when the place is not yet active', function () {
+      // given
+      const rawData = {
+        activationDate: new Date('2021-05-04'),
+        expiredDate: new Date('2022-05-04'),
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.status).to.equal(OrganizationPlace.statuses.PENDING);
+    });
+
+    describe('#ExpiredDate to null', function () {
+      it('have active status when place is currently active', function () {
+        const expiredDate = null;
+        // given
+        const rawData = {
+          activationDate: new Date('2020-01-12'),
+          expiredDate,
+        };
+
+        // when
+        const organizationPlace = new OrganizationPlace(rawData);
+
+        // then
+        expect(organizationPlace.status).to.equal(OrganizationPlace.statuses.ACTIVE);
+      });
+
+      it('have pending status when the place is not yet active', function () {
+        const expiredDate = null;
+        // given
+        const rawData = {
+          activationDate: new Date('2021-05-28'),
+          expiredDate,
+        };
+
+        // when
+        const organizationPlace = new OrganizationPlace(rawData);
+
+        // then
+        expect(organizationPlace.status).to.equal(OrganizationPlace.statuses.PENDING);
+      });
+    });
+  });
+
+  describe('#category', function () {
+    it('have a free rate category when the given category is T0', function () {
+      // given
+      const rawData = {
+        category: 'T0',
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.category).to.equal(OrganizationPlace.categories.T0);
+    });
+
+    it('have a public rate category when the given category is T1', function () {
+      // given
+      const rawData = {
+        category: 'T1',
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.category).to.equal(OrganizationPlace.categories.T1);
+    });
+
+    it('have a reduce rate category when the given category is T2', function () {
+      // given
+      const rawData = {
+        category: 'T2',
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.category).to.equal(OrganizationPlace.categories.T2);
+    });
+
+    it('have a special reduce rate category when the given category is T2bis', function () {
+      // given
+      const rawData = {
+        category: 'T2bis',
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.category).to.equal(OrganizationPlace.categories.T2bis);
+    });
+
+    it('have a full rate category when the given category is T3', function () {
+      // given
+      const rawData = {
+        category: 'T3',
+      };
+
+      // when
+      const organizationPlace = new OrganizationPlace(rawData);
+
+      // then
+      expect(organizationPlace.category).to.equal(OrganizationPlace.categories.T3);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-organization-places_test.js
+++ b/api/tests/unit/domain/usecases/find-organization-places_test.js
@@ -1,0 +1,23 @@
+const { expect, sinon } = require('../../../test-helper');
+const findOrganizationPlaces = require('../../../../lib/domain/usecases/find-organization-places');
+
+describe('Unit | Domain | Use Cases | find-organization-places', function () {
+  it('should get the organization places', async function () {
+    // given
+    const organizationId = Symbol('organizationId');
+    const expectedOrganizationPlaces = Symbol('OrganizationPlaces');
+    const organizationPlaceRepository = {
+      find: sinon.stub(),
+    };
+    organizationPlaceRepository.find.withArgs(organizationId).resolves(expectedOrganizationPlaces);
+
+    // when
+    const organizationPlace = await findOrganizationPlaces({
+      organizationId,
+      organizationPlaceRepository,
+    });
+
+    // then
+    expect(organizationPlace).to.equal(expectedOrganizationPlaces);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-place-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-place-serializer_test.js
@@ -1,0 +1,69 @@
+const { expect, domainBuilder } = require('../../../../../test-helper');
+const serializer = require('../../../../../../lib/infrastructure/serializers/jsonapi/organization/organization-place-serializer');
+const OrganizationPlace = require('../../../../../../lib/domain/read-models/OrganizationPlace');
+describe('Unit | Serializer | JSONAPI | organization-place-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an Organization model object into JSON API data', function () {
+      // given
+      const organizationPlaces = [
+        domainBuilder.buildOrganizationPlace({
+          id: 777,
+          count: 77,
+          category: 'T1',
+          reference: 'Independance Day',
+          activationDate: new Date('1996-07-04'),
+          expiredDate: new Date('2016-07-04'),
+          creatorFirstName: 'Roland',
+          creatorLastName: 'Emmerich',
+        }),
+        domainBuilder.buildOrganizationPlace({
+          id: 666,
+          count: 66,
+          category: 'T2',
+          reference: 'Godzilla',
+          activationDate: new Date('2014-05-13'),
+          expiredDate: new Date('2021-07-01'),
+          creatorFirstName: 'Gareth',
+          creatorLastName: 'Edwards',
+        }),
+      ];
+
+      const expectedJSON = {
+        data: [
+          {
+            type: 'organization-places',
+            id: organizationPlaces[0].id.toString(),
+            attributes: {
+              count: organizationPlaces[0].count,
+              category: OrganizationPlace.categories.T1,
+              reference: organizationPlaces[0].reference,
+              'activation-date': organizationPlaces[0].activationDate,
+              'expired-date': organizationPlaces[0].expiredDate,
+              'creator-full-name': organizationPlaces[0].creatorFullName,
+              status: OrganizationPlace.statuses.EXPIRED,
+            },
+          },
+          {
+            type: 'organization-places',
+            id: organizationPlaces[1].id.toString(),
+            attributes: {
+              count: organizationPlaces[1].count,
+              category: OrganizationPlace.categories.T2,
+              reference: organizationPlaces[1].reference,
+              'activation-date': organizationPlaces[1].activationDate,
+              'expired-date': organizationPlaces[1].expiredDate,
+              'creator-full-name': organizationPlaces[1].creatorFullName,
+              status: OrganizationPlace.statuses.EXPIRED,
+            },
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serialize(organizationPlaces);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas la possibilité actuellement d'avoir un tableau précis des places actives disponible par les organisations.

## :robot: Solution
Afin de pouvoir suivre le nombre de places actives par organisation nous allons permettre au Pixou en interne d’ajouter le nombre de places au sein de Pix Admin.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
