### PR TITLE
[FEATURE] Harmoniser les messages d'erreur lors de la création d'une session (PIX-4809).

### DIFF
--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -9,11 +9,13 @@ const validationConfiguration = { abortEarly: false, allowUnknown: true };
 
 const sessionValidationJoiSchema = Joi.object({
   address: Joi.string().required().messages({
-    'string.empty': 'Veuillez donner un nom de site.',
+    'string.base': 'Veuillez indiquer un nom de site.',
+    'string.empty': 'Veuillez indiquer un nom de site.',
   }),
 
   room: Joi.string().required().messages({
-    'string.empty': 'Veuillez donner un nom de salle.',
+    'string.base': 'Veuillez indiquer un nom de salle.',
+    'string.empty': 'Veuillez indiquer un nom de salle.',
   }),
 
   date: Joi.string().isoDate().required().messages({
@@ -24,11 +26,13 @@ const sessionValidationJoiSchema = Joi.object({
     .pattern(/^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/)
     .required()
     .messages({
+      'string.base': 'Veuillez indiquer une heure de début.',
       'string.empty': 'Veuillez indiquer une heure de début.',
       'string.pattern.base': 'Veuillez indiquer une heure de début.',
     }),
 
   examiner: Joi.string().required().messages({
+    'string.base': 'Veuillez indiquer un(e) surveillant(e).',
     'string.empty': 'Veuillez indiquer un(e) surveillant(e).',
   }),
 });

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -32,7 +32,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const expectedErrors = [
             {
               attribute: 'address',
-              message: 'Veuillez donner un nom de site.',
+              message: 'Veuillez indiquer un nom de site.',
             },
           ];
           session.address = MISSING_VALUE;
@@ -54,7 +54,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const expectedErrors = [
             {
               attribute: 'room',
-              message: 'Veuillez donner un nom de salle.',
+              message: 'Veuillez indiquer un nom de salle.',
             },
           ];
           session.room = MISSING_VALUE;


### PR DESCRIPTION
## :unicorn: Problème
Dans le formulaire de création d'une session, si un champ n'est pas saisi (pas de clic mais un `<Tab>`), le payload envoyé à l'API contient null et le message affiché est "XXX must be a string".

Alors que s'il est saisi (clic ou Tab) sans rentrer de valeurs, le message d'erreur custom est utilisé,ex: 'Veuillez indiquer un(e) surveillant(e).'. 

Les assistants de saisie font parfois de l'auto-complétion, donc attention pour reproduire le cas !

## :robot: Solution
Ajouter la clause Joi `string.base` dans le validateur API.

## :rainbow: Remarques
Le cas de la date non renseignée n'est pas corrigé, car le champ `date` est absent du paylad
```json
{
	"data": {
		"attributes": {
			"access-code": null,
			"address": "a",
			"certification-center-id": 3,
			"description": null,
			"examiner": "a",
			"examiner-global-comment": null,
			"has-supervisor-access": false,
			"room": "a",
			"status": null,
			"supervisor-password": null,
			"time": "12:00"
		},
		"type": "sessions"
	}
}
```

## :100: Pour tester
- Indiquer une date (sinon, pas de retour côté IHM)
- Ne pas saisir un champ et vérifier que le message d'erreur n'est pas "XXX must be a string".
