### PR TITLE
[FEATURE] Voir l'id d'un membre et le détail si l'on clique dessus (PIX-4781)

### DIFF
--- a/admin/app/components/member-item.hbs
+++ b/admin/app/components/member-item.hbs
@@ -1,4 +1,6 @@
-<td>{{@membership.id}}</td>
+<td><LinkTo @route="authenticated.users.get" @model={{@membership.user}}>
+    {{@membership.user.id}}
+  </LinkTo></td>
 <td>{{@membership.user.firstName}}</td>
 <td>{{@membership.user.lastName}}</td>
 <td>{{@membership.user.email}}</td>
@@ -64,7 +66,7 @@
         @triggerAction={{this.toggleDisplayConfirm}}
         class="member-item-actions__button"
       >
-        <FaIcon @icon="trash" />Désactiver le membre
+        <FaIcon @icon="trash" />Désactiver
       </PixButton>
     {{/if}}
   </div>

--- a/admin/app/components/member-item.hbs
+++ b/admin/app/components/member-item.hbs
@@ -45,30 +45,26 @@
         </PixButton>
       </div>
     {{else}}
-      {{#if @membership.isSaving}}
-        <PixButton @isDisabled={{true}} @size="small" class="member-item-actions__button">
-          <FaIcon @icon="edit" />Modifier le rôle
-        </PixButton>
-      {{else}}
-        <PixButton @triggerAction={{this.editRoleOfMember}} @size="small" class="member-item-actions__button">
-          <FaIcon @icon="edit" />Modifier le rôle
-        </PixButton>
-      {{/if}}
-    {{/if}}
-    {{#if @membership.isSaving}}
-      <PixButton @size="small" @backgroundColor="red" @isDisabled={{true}} class="member-item-actions__button">
-        <FaIcon @icon="trash" />Désactiver
-      </PixButton>
-    {{else}}
       <PixButton
+        @isDisabled={{@membership.isSaving}}
         @size="small"
-        @backgroundColor="red"
-        @triggerAction={{this.toggleDisplayConfirm}}
         class="member-item-actions__button"
+        aria-label="Modifier le rôle"
+        @triggerAction={{this.editRoleOfMember}}
       >
-        <FaIcon @icon="trash" />Désactiver
+        <FaIcon @icon="edit" />Modifier le rôle
       </PixButton>
     {{/if}}
+    <PixButton
+      @size="small"
+      @backgroundColor="red"
+      @isDisabled={{@membership.isSaving}}
+      class="member-item-actions__button"
+      aria-label="Désactiver le membre"
+      @triggerAction={{this.toggleDisplayConfirm}}
+    >
+      <FaIcon @icon="trash" />Désactiver
+    </PixButton>
   </div>
 </td>
 

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -8,7 +8,7 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--id">ID Membre</th>
+            <th class="table__column table__column--id">ID user</th>
             <th class="table__column table__column--wide">Prénom</th>
             <th class="table__column table__column--wide">Nom</th>
             <th class="table__column table__column--wide">Adresse e-mail</th>
@@ -16,6 +16,7 @@
             <th class="table__column">Actions</th>
           </tr>
           <tr>
+            <td class="table__column"></td>
             <td class="table__column"></td>
             <td class="table__column table__column--wide">
               <input

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -16,9 +16,7 @@ module('Acceptance | Organizations | List', function (hooks) {
       await visit('/organizations/list');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/login');
+      assert.strictEqual(currentURL(), '/login');
     });
   });
 
@@ -33,9 +31,7 @@ module('Acceptance | Organizations | List', function (hooks) {
       await visit('/organizations/list');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/organizations/list');
+      assert.strictEqual(currentURL(), '/organizations/list');
     });
 
     test('it should list the organizations', async function (assert) {
@@ -88,9 +84,7 @@ module('Acceptance | Organizations | List', function (hooks) {
       await click(screen.getByRole('link', { name: '1' }));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/organizations/1/team');
+      assert.strictEqual(currentURL(), '/organizations/1/team');
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -171,7 +171,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
     test('should deactivate a member', async function (assert) {
       // given
       const screen = await visit(`/organizations/${organization.id}/team`);
-      await clickByName('Désactiver');
+      await clickByName('Désactiver le membre');
 
       // when
       await clickByName('Confirmer');

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -22,9 +22,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
     await visit(`/organizations/${organization.id}`);
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), `/organizations/${organization.id}/team`);
+    assert.strictEqual(currentURL(), `/organizations/${organization.id}/team`);
   });
 
   module('listing members', function (hooks) {
@@ -62,6 +60,21 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
 
       // then
       assert.dom('#organizationRole').hasValue('ADMIN');
+    });
+
+    test('it should redirect to user details on user id click', async function (assert) {
+      // given
+      const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
+      this.server.create('membership', { user, organization });
+
+      // when
+      const screen = await visit(`/organizations/${organization.id}/team`);
+
+      // when
+      await click(screen.getByRole('link', { name: '2' }));
+
+      // then
+      assert.strictEqual(currentURL(), '/users/2');
     });
   });
 
@@ -144,9 +157,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       await clickByName('Enregistrer');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(membership.organizationRole, 'MEMBER');
+      assert.strictEqual(membership.organizationRole, 'MEMBER');
       assert.dom(screen.getByText('Le rôle du membre a été mis à jour avec succès.')).exists();
     });
   });
@@ -160,7 +171,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
     test('should deactivate a member', async function (assert) {
       // given
       const screen = await visit(`/organizations/${organization.id}/team`);
-      await clickByName('Désactiver le membre');
+      await clickByName('Désactiver');
 
       // when
       await clickByName('Confirmer');

--- a/admin/tests/integration/components/member-item_test.js
+++ b/admin/tests/integration/components/member-item_test.js
@@ -9,7 +9,8 @@ module('Integration | Component | member-item', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    const user = EmberObject.create({ firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
+    const user = EmberObject.create({ id: 123, firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
+
     this.membership = EmberObject.create({ id: 1, user, displayedOrganizationRole: 'Administrateur' });
   });
 
@@ -18,13 +19,13 @@ module('Integration | Component | member-item', function (hooks) {
     const screen = await render(hbs`<MemberItem @membership={{this.membership}} />`);
 
     // then
-    assert.dom(screen.getByText('1')).exists();
+    assert.dom(screen.getByText('123')).exists();
     assert.dom(screen.getByText('Jojo')).exists();
     assert.dom(screen.getByText('La Gringue')).exists();
     assert.dom(screen.getByText('jojo@lagringue.fr')).exists();
     assert.dom(screen.getByText('Administrateur')).exists();
     assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Désactiver le membre' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();
   });
 
   module("when editing organization's role", function () {
@@ -106,7 +107,7 @@ module('Integration | Component | member-item', function (hooks) {
       );
 
       // when
-      await clickByName('Désactiver le membre');
+      await clickByName('Désactiver');
 
       // then
       assert.dom(screen.getByRole('heading', { name: "Désactivation d'un membre" })).exists();
@@ -120,7 +121,7 @@ module('Integration | Component | member-item', function (hooks) {
       const screen = await render(
         hbs`<MemberItem @membership={{this.membership}} @disableMembership={{this.disableMembership}} />`
       );
-      await clickByName('Désactiver le membre');
+      await clickByName('Désactiver');
 
       // when
       await clickByName('Annuler');
@@ -135,7 +136,7 @@ module('Integration | Component | member-item', function (hooks) {
       this.disableMembership = sinon.spy();
       await render(hbs`<MemberItem @membership={{this.membership}} @disableMembership={{this.disableMembership}} />`);
 
-      await clickByName('Désactiver le membre');
+      await clickByName('Désactiver');
 
       // when
       await clickByName('Confirmer');

--- a/admin/tests/integration/components/member-item_test.js
+++ b/admin/tests/integration/components/member-item_test.js
@@ -25,7 +25,7 @@ module('Integration | Component | member-item', function (hooks) {
     assert.dom(screen.getByText('jojo@lagringue.fr')).exists();
     assert.dom(screen.getByText('Administrateur')).exists();
     assert.dom(screen.getByRole('button', { name: 'Modifier le rôle' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Désactiver' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Désactiver le membre' })).exists();
   });
 
   module("when editing organization's role", function () {
@@ -73,9 +73,7 @@ module('Integration | Component | member-item', function (hooks) {
 
       // then
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.membership.organizationRole, 'MEMBER');
+      assert.strictEqual(this.membership.organizationRole, 'MEMBER');
       assert.ok(this.updateMembership.called);
     });
 
@@ -107,7 +105,7 @@ module('Integration | Component | member-item', function (hooks) {
       );
 
       // when
-      await clickByName('Désactiver');
+      await clickByName('Désactiver le membre');
 
       // then
       assert.dom(screen.getByRole('heading', { name: "Désactivation d'un membre" })).exists();
@@ -121,7 +119,7 @@ module('Integration | Component | member-item', function (hooks) {
       const screen = await render(
         hbs`<MemberItem @membership={{this.membership}} @disableMembership={{this.disableMembership}} />`
       );
-      await clickByName('Désactiver');
+      await clickByName('Désactiver le membre');
 
       // when
       await clickByName('Annuler');
@@ -136,7 +134,7 @@ module('Integration | Component | member-item', function (hooks) {
       this.disableMembership = sinon.spy();
       await render(hbs`<MemberItem @membership={{this.membership}} @disableMembership={{this.disableMembership}} />`);
 
-      await clickByName('Désactiver');
+      await clickByName('Désactiver le membre');
 
       // when
       await clickByName('Confirmer');


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de détail d’une orga et dans l’onglet “Equipe”, les admins aimerait voir l'id de l'utilisateur et accéder directement à  la page qui de détail de ce membre en cliquant dessus.

## :robot: Solution
Une colonne “ID user” a été rajoutée à droite de “ID Membre”. L'id est cliquable et amène l'utilisateur sur la page de détail de l'utilisateur.

## :rainbow: Remarques
Les boutons d'action "Modifier le rôle" et "Désactiver le membre" sont rognés dès que l'écran diminue en taille car la page n'est pas responsive. Le pb s'est aggravé avec l'ajout d'une nouvelle colonne.

## :100: Pour tester
- Se connecter en tant que pix master
- cliquer sur une organisation pour voir le détail
- cliquer sur l'id d'un utilisateur et vérifier que vous êtes bien redirigé(e) vers la page de détail de cet utilisateur