### PR TITLE
[FEATURE] Ajouter la page "Équipe" dans Pix Admin qui liste les membres Pix Admin existants (PIX-4003)

### DIFF
--- a/admin/app/adapters/admin-member.js
+++ b/admin/app/adapters/admin-member.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class AdminMemberAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -15,7 +15,7 @@
       <PixTooltip @position="right">
         <:triggerElement>
           <LinkTo @route="authenticated.users.list" class="menu-bar__link">
-            <FaIcon @icon="users" @title="Utilisateurs" />
+            <FaIcon @icon="user" @title="Utilisateurs" />
           </LinkTo>
         </:triggerElement>
         <:tooltip>Utilisateurs</:tooltip>
@@ -59,6 +59,16 @@
           </LinkTo>
         </:triggerElement>
         <:tooltip>Profils cibles</:tooltip>
+      </PixTooltip>
+    </li>
+    <li class="menu-bar__entry">
+      <PixTooltip @position="right">
+        <:triggerElement>
+          <LinkTo @route="authenticated.team" class="menu-bar__link">
+            <FaIcon @icon="users" @title="Équipe" />
+          </LinkTo>
+        </:triggerElement>
+        <:tooltip>Équipe</:tooltip>
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -1,0 +1,28 @@
+<div class="content-text content-text--small">
+  <table class="table-admin">
+    <thead>
+      <tr>
+        <th>Prénom</th>
+        <th>Nom</th>
+        <th>E-mail</th>
+        <th>Rôle</th>
+      </tr>
+    </thead>
+    {{#if @members}}
+      <tbody>
+        {{#each @members as |member|}}
+          <tr aria-label={{concat member.firstName " " member.lastName}}>
+            <td>{{member.firstName}}</td>
+            <td>{{member.lastName}}</td>
+            <td>{{member.email}}</td>
+            <td>{{member.role}}</td>
+          </tr>
+        {{/each}}
+      </tbody>
+    {{/if}}
+  </table>
+
+  {{#unless @members}}
+    <div class="table__empty content-text">Aucun résultat</div>
+  {{/unless}}
+</div>

--- a/admin/app/models/admin-member.js
+++ b/admin/app/models/admin-member.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AdminMember extends Model {
+  @attr('string') lastName;
+  @attr('string') firstName;
+  @attr('string') email;
+  @attr('string') role;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -48,6 +48,10 @@ Router.map(function () {
       this.route('get', { path: '/:user_id' });
     });
 
+    this.route('team', { path: '/equipe' }, function () {
+      this.route('list', { path: '/' });
+    });
+
     this.route('certification-centers', function () {
       this.route('get', { path: '/:certification_center_id' });
       this.route('list');

--- a/admin/app/routes/authenticated/team/list.js
+++ b/admin/app/routes/authenticated/team/list.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class ListRoute extends Route {
+  async model() {
+    return this.store.query('admin-member', {});
+  }
+}

--- a/admin/app/templates/authenticated/team.hbs
+++ b/admin/app/templates/authenticated/team.hbs
@@ -1,0 +1,3 @@
+<div class="page">
+  {{outlet}}
+</div>

--- a/admin/app/templates/authenticated/team/list.hbs
+++ b/admin/app/templates/authenticated/team/list.hbs
@@ -1,0 +1,11 @@
+{{page-title "Équipe"}}
+
+<header class="page-header">
+  <h1 class="page-title">Équipe</h1>
+</header>
+
+<main class="page-body">
+  <section class="page-section">
+    <Team::List @members={{@model}} />
+  </section>
+</main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -38,6 +38,10 @@ export default function () {
     return schema.campaignParticipations.all();
   });
 
+  this.get('/admin/admin-members', (schema) => {
+    return schema.adminMembers.all();
+  });
+
   this.get('/admin/sessions', findPaginatedAndFilteredSessions);
   this.get('/admin/sessions/to-publish', (schema) => {
     const toBePublishedSessions = schema.toBePublishedSessions.all();

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -57,7 +57,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       const screen = await visit(`/organizations/${organization.id}/team`);
 
       // then
-      assert.dom(screen.queryByLabelText('Équipe')).doesNotExist();
+      assert.dom(screen.queryByLabelText('Équipe', { selector: 'a' })).doesNotExist();
       assert.strictEqual(currentURL(), `/organizations/${organization.id}/target-profiles`);
     });
 

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Team | List', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user is not logged in', function () {
+    test('it should not be accessible by an unauthenticated user', async function (assert) {
+      // when
+      await visit('/equipe');
+
+      // then
+      assert.strictEqual(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function (hooks) {
+    hooks.beforeEach(async () => {
+      const user = server.create('user');
+      await createAuthenticateSession({ userId: user.id });
+    });
+
+    test('it should be accessible for an authenticated user', async function (assert) {
+      // when
+      await visit('/equipe');
+
+      // then
+      assert.strictEqual(currentURL(), '/equipe');
+    });
+
+    test('it should list all team members', async function (assert) {
+      // given
+      server.create('admin-member', { id: 1, firstName: 'Marie', lastName: 'Tim' });
+      server.create('admin-member', { id: 2, firstName: 'Alain', lastName: 'Térieur' });
+
+      // when
+      const screen = await visit('/equipe');
+
+      // then
+      assert.dom(screen.getByLabelText('Marie Tim')).exists();
+      assert.dom(screen.getByLabelText('Alain Térieur')).exists();
+    });
+  });
+});

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -14,6 +14,14 @@ module('Integration | Component | menu-bar', function (hooks) {
     assert.dom(screen.getByTitle('Organisations')).exists();
   });
 
+  test('should contain link to "team" management page', async function (assert) {
+    // when
+    const screen = await render(hbs`{{menu-bar}}`);
+
+    // then
+    assert.dom(screen.getByTitle('Équipe')).exists();
+  });
+
   test('should contain link to "users" management page', async function (assert) {
     // when
     const screen = await render(hbs`{{menu-bar}}`);

--- a/admin/tests/integration/components/team/list_test.js
+++ b/admin/tests/integration/components/team/list_test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | team | list', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should display the list of members', async function (assert) {
+    // given
+    this.set('members', [
+      {
+        firstName: 'Marie',
+        lastName: 'Tim',
+        email: 'marie.tim@example.net',
+        role: 'SUPER_ADMIN',
+      },
+    ]);
+
+    // when
+    const screen = await render(hbs`<Team::List @members={{this.members}}/>`);
+
+    // then
+    assert.dom(screen.getByText('Marie')).exists();
+    assert.dom(screen.getByText('Tim')).exists();
+    assert.dom(screen.getByText('marie.tim@example.net')).exists();
+    assert.dom(screen.getByText('SUPER_ADMIN')).exists();
+  });
+
+  test('should display no results in table', async function (assert) {
+    // given
+    this.set('members', []);
+
+    // when
+    const screen = await render(hbs`<Team::List @members={{this.members}}/>`);
+
+    // then
+    assert.dom(screen.getByText('Aucun résultat')).exists();
+  });
+});

--- a/api/lib/application/admin-members/admin-member-controller.js
+++ b/api/lib/application/admin-members/admin-member-controller.js
@@ -1,0 +1,9 @@
+const adminMemberSerializer = require('../../infrastructure/serializers/jsonapi/admin-member-serializer');
+const usecases = require('../../domain/usecases');
+
+module.exports = {
+  async findAll() {
+    const adminMembers = await usecases.getAdminMembers();
+    return adminMemberSerializer.serialize(adminMembers);
+  },
+};

--- a/api/lib/application/admin-members/index.js
+++ b/api/lib/application/admin-members/index.js
@@ -1,0 +1,27 @@
+const adminMemberController = require('./admin-member-controller');
+const securityPreHandlers = require('../security-pre-handlers');
+
+exports.register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/admin-members',
+      config: {
+        handler: adminMemberController.findAll,
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs Super Admin authentifiés**\n' +
+            '- Lister les utilisateurs ayant accès à Pix Admin \n',
+        ],
+        tags: ['api', 'admin-members'],
+      },
+    },
+  ]);
+};
+
+exports.name = 'admin-members-api';

--- a/api/lib/domain/read-models/AdminMember.js
+++ b/api/lib/domain/read-models/AdminMember.js
@@ -1,0 +1,9 @@
+module.exports = class AdminMember {
+  constructor({ id, firstName, lastName, email, role }) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.role = role;
+  }
+};

--- a/api/lib/domain/usecases/get-admin-members.js
+++ b/api/lib/domain/usecases/get-admin-members.js
@@ -1,0 +1,3 @@
+module.exports = async function getAdminMembers({ adminMemberRepository }) {
+  return adminMemberRepository.findAll();
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -305,6 +305,7 @@ module.exports = injectDependencies(
     getOrganizationInvitation: require('./get-organization-invitation'),
     getParticipantsDivision: require('./get-participants-division'),
     getParticipantsGroup: require('./get-participants-group'),
+    getAdminMembers: require('./get-admin-members'),
     getPoleEmploiSendings: require('./get-pole-emploi-sendings'),
     getPrescriber: require('./get-prescriber'),
     getPrivateCertificate: require('./certificate/get-private-certificate'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,5 +1,6 @@
 const dependencies = {
   accountRecoveryDemandRepository: require('../../infrastructure/repositories/account-recovery-demand-repository'),
+  adminMemberRepository: require('../../infrastructure/repositories/admin-member-repository'),
   algorithmDataFetcherService: require('../../domain/services/algorithm-methods/data-fetcher'),
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   areaRepository: require('../../infrastructure/repositories/area-repository'),

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -1,0 +1,14 @@
+const { knex } = require('../bookshelf');
+const AdminMember = require('../../domain/read-models/AdminMember');
+
+module.exports = {
+  findAll: async function () {
+    const members = await knex
+      .select('users.id', 'firstName', 'lastName', 'email', 'role')
+      .from('pix-admin-roles')
+      .join('users', 'users.id', 'pix-admin-roles.userId')
+      .where('pix-admin-roles.disabledAt', null)
+      .orderBy(['firstName', 'lastName']);
+    return members.map((member) => new AdminMember(member));
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/admin-member-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/admin-member-serializer.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(adminMembers, meta) {
+    return new Serializer('admin-member', {
+      attributes: ['firstName', 'lastName', 'email', 'role'],
+      meta,
+    }).serialize(adminMembers);
+  },
+};

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,5 +1,6 @@
 module.exports = [
   require('./application/account-recovery'),
+  require('./application/admin-members'),
   require('./application/answers'),
   require('./application/assessment-results'),
   require('./application/assessments'),

--- a/api/tests/acceptance/application/admin-members/admin-members-route-get_test.js
+++ b/api/tests/acceptance/application/admin-members/admin-members-route-get_test.js
@@ -1,0 +1,32 @@
+const {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Application | Admin-members | Routes', function () {
+  describe('GET /api/admin/admin-members', function () {
+    it('should return 200 http status code', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildPixAdminRole({ userId: user.id, role: 'SUPER_ADMIN' });
+      const admin = await insertUserWithRoleSuperAdmin();
+      await databaseBuilder.commit();
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(admin.id),
+        },
+        method: 'GET',
+        url: `/api/admin/admin-members`,
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -1,0 +1,88 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
+const AdminMember = require('../../../../lib/domain/read-models/AdminMember');
+const PixAdminRole = require('../../../../lib/domain/models/PixAdminRole');
+
+describe('Integration | Infrastructure | Repository | adminMemberRepository', function () {
+  describe('#findAll', function () {
+    it('should return all users with a pix admin role', async function () {
+      // given
+      const userWithPixAdminRole = _buildUserWithPixAdminRole();
+      const otherUserWithPixAdminRole = _buildUserWithPixAdminRole();
+      await databaseBuilder.commit();
+
+      // when
+      const members = await adminMemberRepository.findAll();
+
+      // then
+      expect(members.length).to.equal(2);
+      expect(members).to.deep.include(
+        new AdminMember({
+          id: userWithPixAdminRole.id,
+          firstName: userWithPixAdminRole.firstName,
+          lastName: userWithPixAdminRole.lastName,
+          email: userWithPixAdminRole.email,
+          role: 'SUPER_ADMIN',
+        })
+      );
+      expect(members[1].id).to.deep.equal(otherUserWithPixAdminRole.id);
+    });
+
+    it('should not return users without a pix admin role', async function () {
+      // given
+      _buildUserWithPixAdminRole();
+      const userWithoutPixAdminRole = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      // when
+      const members = await adminMemberRepository.findAll();
+
+      // then
+      expect(members.length).to.equal(1);
+      expect(members[0].id).to.not.equal(userWithoutPixAdminRole.id);
+    });
+
+    it('should return users sorted by first, then last name', async function () {
+      // given
+      _buildUserWithPixAdminRole({ firstName: 'Dmitri', lastName: 'Karamazov' });
+      _buildUserWithPixAdminRole({ firstName: 'Alexei', lastName: 'Karamazov' });
+      _buildUserWithPixAdminRole({ firstName: 'Dmitri', lastName: 'Fiodorovitch' });
+      await databaseBuilder.commit();
+
+      // when
+      const members = await adminMemberRepository.findAll();
+
+      // then
+      expect(members[0].firstName).to.equal('Alexei');
+      expect(members[1].firstName).to.equal('Dmitri');
+      expect(members[2].firstName).to.equal('Dmitri');
+      expect(members[0].lastName).to.equal('Karamazov');
+      expect(members[1].lastName).to.equal('Fiodorovitch');
+      expect(members[2].lastName).to.equal('Karamazov');
+    });
+
+    it('should not return users with disabled pix admin roles', async function () {
+      // given
+      _buildUserWithPixAdminRole();
+      const userWithDisabledPixAdminRole = _buildUserWithPixAdminRole({ disabledAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const members = await adminMemberRepository.findAll();
+
+      // then
+      expect(members.length).to.equal(1);
+      expect(members[0].id).to.not.equal(userWithDisabledPixAdminRole.id);
+    });
+  });
+});
+
+function _buildUserWithPixAdminRole({ firstName, lastName, disabledAt, role } = {}) {
+  const userWithPixAdminRole = databaseBuilder.factory.buildUser({ firstName, lastName });
+  databaseBuilder.factory.buildPixAdminRole({
+    userId: userWithPixAdminRole.id,
+    disabledAt,
+    role: role ?? PixAdminRole.roles.SUPER_ADMIN,
+  });
+  return userWithPixAdminRole;
+}

--- a/api/tests/tooling/domain-builder/factory/build-admin-member.js
+++ b/api/tests/tooling/domain-builder/factory/build-admin-member.js
@@ -1,0 +1,12 @@
+const AdminMember = require('../../../../lib/domain/read-models/AdminMember');
+const PixAdminRole = require('../../../../lib/domain/models/PixAdminRole');
+
+module.exports = function buildAdminMember({
+  id = 1,
+  firstName = 'Dimitri',
+  lastName = 'Kramatorsk',
+  email = 'dimitri.k@pix.fr',
+  role = PixAdminRole.roles.SUPER_ADMIN,
+} = {}) {
+  return new AdminMember({ id, firstName, lastName, email, role });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -79,6 +79,7 @@ module.exports = {
   buildOrganizationTag: require('./build-organization-tag'),
   buildParticipationForCampaignManagement: require('./build-participation-for-campaign-management'),
   buildComplementaryCertificationCourseResult: require('./build-complementary-certification-course-result'),
+  buildAdminMember: require('./build-admin-member'),
   buildPixPlusDroitCertificationResult: require('./build-pix-plus-droit-certification-result'),
   buildPixPlusDroitCertificationScoring: require('./build-pix-plus-droit-certification-scoring'),
   buildPixPlusEduCertificationScoring: require('./build-pix-plus-edu-certification-scoring'),

--- a/api/tests/unit/application/admin-members/admin-member-controller_test.js
+++ b/api/tests/unit/application/admin-members/admin-member-controller_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+
+const adminMemberController = require('../../../../lib/application/admin-members/admin-member-controller');
+const usecases = require('../../../../lib/domain/usecases');
+const adminMemberSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/admin-member-serializer');
+
+describe('Unit | Controller | admin-member-controller', function () {
+  describe('#findAll', function () {
+    it('should return the serialized admin members', async function () {
+      // given
+      const member = domainBuilder.buildAdminMember();
+      const otherMember = domainBuilder.buildAdminMember();
+      sinon.stub(usecases, 'getAdminMembers').resolves([member, otherMember]);
+      const serializedMembers = Symbol('serializedMembers');
+      sinon.stub(adminMemberSerializer, 'serialize').withArgs([member, otherMember]).returns(serializedMembers);
+
+      // when
+      const result = await adminMemberController.findAll();
+
+      // then
+      expect(usecases.getAdminMembers).to.have.been.calledOnce;
+      expect(result).to.equal(serializedMembers);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-admin-members_test.js
+++ b/api/tests/unit/domain/usecases/get-admin-members_test.js
@@ -1,0 +1,20 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const getAdminMembers = require('../../../../lib/domain/usecases/get-admin-members');
+
+describe('Unit | UseCase | get-admin-members', function () {
+  it('should return all admin members', async function () {
+    // given
+    const adminMemberRepository = {
+      findAll: sinon.stub(),
+    };
+    const adminMember = domainBuilder.buildAdminMember();
+    const otherAdminMember = domainBuilder.buildAdminMember();
+    adminMemberRepository.findAll.resolves([adminMember, otherAdminMember]);
+
+    // when
+    const adminMembers = await getAdminMembers({ adminMemberRepository });
+
+    // then
+    expect(adminMembers).to.deep.equal([adminMember, otherAdminMember]);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/admin-member-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/admin-member-serializer_test.js
@@ -1,0 +1,34 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/admin-member-serializer');
+
+describe('Unit | Serializer | JSONAPI | admin-member-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an AdminMember model object into JSON API data', function () {
+      // given
+      const adminMember = domainBuilder.buildAdminMember({
+        id: 12,
+        firstName: 'Ivan',
+        lastName: 'Iakovlievitch',
+        email: 'ivan.iakovlievitch@pix.fr',
+        role: 'SUPER_ADMIN',
+      });
+
+      // when
+      const serializedAdminMember = serializer.serialize(adminMember);
+
+      // then
+      expect(serializedAdminMember).to.deep.equal({
+        data: {
+          type: 'admin-members',
+          id: '12',
+          attributes: {
+            'first-name': 'Ivan',
+            'last-name': 'Iakovlievitch',
+            email: 'ivan.iakovlievitch@pix.fr',
+            role: 'SUPER_ADMIN',
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Pix Admin doit pouvoir permettre de voir les utilisateurs ayant accès à Pix Admin.

## :robot: Solution

Création d’un nouveau menu dans Pix Admin:
- nom du menu:  ‘Equipe’
- Picto: Users
A positionner en dernière position, au dessus de ‘Outils’

Dans cette page, on veut afficher la liste des utilisateurs actuels de Pix Admin dans un tableau, avec les colonnes suivantes:
- Prénom
- Nom
- Adresse e-mail
- Role

TODO :

- [x] Repository
- [x] Usecase
- [x] Controller
- [x] Route
- [x] Ordonner par ordre alphabétique sur le prénom, puis le nom
- [x] Afficher les membres actifs (where disabledAT IS NOT NULL). Ne pas afficher les membres qui ont été désactivés.
- [x] Front

## :rainbow: Remarques

*RAS*

## :100: Pour tester
- Connectez vous a Pix Admin avec le user `superadmin@example.net`
- Vérifiez que le picto apparaît bien dans le menu à gauche
- Cliquez sur le picto et validez que la page Équipe s'affiche bien avec le user Super Admin dans la liste