### PR TITLE
[FEATURE] Mettre le focus automatiquement sur le champ texte de résolution de signalement lorsqu'on ouvre la pop-up de résolution sur PixAdmin (PIX-4786)

### DIFF
--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -6,6 +6,7 @@
       type="text"
       maxLength="255"
       {{on "change" this.onChangeLabel}}
+      {{focus}}
     />
   </:content>
 

--- a/admin/app/modifiers/focus.js
+++ b/admin/app/modifiers/focus.js
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => {
+  element.focus();
+});

--- a/admin/tests/integration/modifiers/focus_test.js
+++ b/admin/tests/integration/modifiers/focus_test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifiers | focus', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should focus the item', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<Input placeholder="Je suis pas focus"/><Input placeholder="Je suis focus" {{focus}}/>`
+    );
+
+    // then
+    const focusedElement = document.activeElement;
+    assert.deepEqual(focusedElement, screen.getByPlaceholderText('Je suis focus'));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Quand on souhaite résoudre un signalement, la seule "action" à faire est d'indiquer une raison de résolution. Lorsqu'on clique sur "résoudre un signalement", concrètement une fenêtre pop-up s'ouvre avec un champ texte à remplir. Aujourd'hui, ce champ texte n'a pas le focus automatiquement, et le pôle certif trouverait plus pratique que ce soit le cas.

## :robot: Solution
J'ai fait plus d'exploration que ce que je pensais faire. D'abord, j'ai imaginé qu'un attribut style focus ou autofocus ferait l'affaire... Eh bien non ! Ces attributs n'existent pas !
J'ai donc ensuite envisagé "simplement" à ajouter ce code-ci dans le .js de la modale :
🔴 **BAD CODE**
```js
export default class CertificationIssueReportModal extends Component {
  @service notifications;
  @tracked label = null;

  constructor(arguments) {
     super(arguments);
     document.getElementById('ID DU CHAMP TEXTE').focus();
  }
  /*...*/
}
```
Bon déjà, je trouve perso le code plutôt moche. C'est dommage de se rendre dépendant de l'ID - d'une part parce que c'est un ID, d'autre part car ce code ne marche plus si on modifie l'ID.
De toute façon, ce code ne marche pas car tant que le constructeur n'est pas arrivé à son terme, le rendu n'est pas fait, donc l'élément n'est pas trouvé à ce moment-là.
Je me suis donc rendue sur la doc d'Ember pour voir le cycle de vie d'un component et voir où pouvais-je brancher ce morceau de code.
https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_calling-methods-on-first-render
Il semble qu'il existe un add-on, ember-render-modifiers, qui permet d'utiliser des modifiers dans les hbs pour déclencher du code basé sur l'"ancien" cycle de vie Ember (pré version 3), notamment sur les `didRender`, `didInsert` etc... Problème, quand on lit le readme du répo, on lit ceci :

> However, we strongly encourage you to take this opportunity to rethink your functionality rather than use these modifiers as a crutch. In many cases, classic lifecycle hooks like didInsertElement can be rewritten as custom modifiers that internalize functionality manipulating or generating state from a DOM element.

J'ai donc bourlingué sur les internets pour trouver une alternative à réutiliser ces vieux hooks. Je suis tombée sur le site du fameux NullVoxPopuli (ceux qui squattent le discord Ember doivent savoir qui c'est 😄 ), lequel a posté l'article suivant :
https://nullvoxpopuli.com/avoiding-lifecycle/
qui invite donc à éviter d'utiliser les hooks du cycle de vie du composant. Il donne une alternative en invitant à définir un `modifier` custom, qui renforce la "separation of concerns", qui est facilement testable unitairement et qui peut être utilisé dans tous les hbs. (pour info, les modifiers sont les trucs style {{on ...}}, etc...). 

TLDR : J'ai donc opté pour la création d'un modifier `focus` !

## :rainbow: Remarques
1. Je trouve que c'est le mieux d'après mon cheminement de recherche / de pensée. Je suis ouverte à la contre-idée, critique, amélioration car cette PR peut potentiellement donner le ton sur comment on focus par défaut dans une page.
2. Je me demandais si je ne devais pas plutôt appeler le modifier `autofocus`.
3. La testing library est vraiment chouette, première fois que je l'utilise

## :100: Pour tester
Aller sur PixAdmin, dans la liste des sessions, choisir la session 6, aller dans les certifications, choisir la première de la liste, essayer de résoudre le signalement et constater que le champ est bien focus dans la pop-up. (NE PAS VALIDER LA RESOLUTION SINON VOUS EMPECHEZ VOS PETITS CAMARADES DE TESTER FACILEMENT 🔉 🔉 )
