### PR TITLE
[TECH] Améliorer le message d'erreur du script OGA lorsque l'organisation existe déjà (PIX-4823)

### DIFF
--- a/api/lib/domain/usecases/create-pro-organizations-with-tags.js
+++ b/api/lib/domain/usecases/create-pro-organizations-with-tags.js
@@ -78,11 +78,13 @@ function _checkIfOrganizationsDataAreNotEmptyAndUnique(organizations) {
 }
 
 async function _checkIfOrganizationsAlreadyExistInDatabase(organizations, organizationRepository) {
-  const organizationIds = await organizationRepository.findByExternalIdsFetchingIdsOnly(
+  const foundOrganizations = await organizationRepository.findByExternalIdsFetchingIdsOnly(
     map(organizations, 'externalId')
   );
-  if (!isEmpty(organizationIds)) {
-    throw new OrganizationAlreadyExistError();
+  if (!isEmpty(foundOrganizations)) {
+    const organizationIds = organizations.map((foundOrganization) => foundOrganization.externalId);
+    const message = `Les organisations avec les externalIds suivants existent déjà : ${organizationIds.join(', ')}`;
+    throw new OrganizationAlreadyExistError(message);
   }
 }
 

--- a/api/tests/unit/domain/usecases/create-pro-organizations-with-tags_test.js
+++ b/api/tests/unit/domain/usecases/create-pro-organizations-with-tags_test.js
@@ -82,6 +82,7 @@ describe('Unit | UseCase | create-pro-organizations-with-tags', function () {
 
       // then
       expect(error).to.be.an.instanceOf(OrganizationAlreadyExistError);
+      expect(error.message).to.equal('Les organisations avec les externalIds suivants existent déjà : externalId');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on lance le script de création d'organisation, il arrive souvent que nous ayons des erreurs.
Lorsque le fichier CSV passé en paramètre contient une organisation déjà existante, l’erreur est laconique et oblige à faire une enquête supplémentaire pour savoir de quel organization il s’agit.

## :robot: Solution
Rendre le message plus explicite en y ajoutant la liste des externalIds des organisations déjà présentes en base de données

## :rainbow: Remarques

## :100: Pour tester
Executer deux fois de suite le script sur le même fichier csv et constater que le message d'erreur précise le ou les externalId(s) déjà présent(s) en base de données