### PR TITLE
[FEATURE] Enregistrer le niveau obtenu au volet jury (PIX-4512)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-course-result.js
+++ b/api/db/database-builder/factory/build-complementary-certification-course-result.js
@@ -3,11 +3,12 @@ const buildComplementaryCertificationCourse = require('./build-complementary-cer
 const buildComplementaryCertification = require('./build-complementary-certification');
 const buildCertificationCourse = require('./build-certification-course');
 const _ = require('lodash');
+const ComplementaryCertificationCourseResult = require('../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 module.exports = function buildComplementaryCertificationCourseResult({
   complementaryCertificationCourseId,
   partnerKey,
-  source = 'PIX',
+  source = ComplementaryCertificationCourseResult.sources.PIX,
   acquired = true,
 }) {
   complementaryCertificationCourseId = _.isUndefined(complementaryCertificationCourseId)

--- a/api/lib/application/complementary-certification-course-results/complementary-certification-course-results-controller.js
+++ b/api/lib/application/complementary-certification-course-results/complementary-certification-course-results-controller.js
@@ -1,0 +1,13 @@
+const usecases = require('../../domain/usecases');
+
+module.exports = {
+  async saveJuryComplementaryCertificationCourseResult(request, h) {
+    const { complementaryCertificationCourseId, juryLevel } = request.payload.data.attributes;
+
+    await usecases.saveJuryComplementaryCertificationCourseResult({
+      complementaryCertificationCourseId,
+      juryLevel,
+    });
+    return h.response().code(200);
+  },
+};

--- a/api/lib/application/complementary-certification-course-results/index.js
+++ b/api/lib/application/complementary-certification-course-results/index.js
@@ -1,0 +1,54 @@
+const Joi = require('joi');
+const Badge = require('../../domain/models/Badge');
+const identifiersType = require('../../domain/types/identifiers-type');
+const securityPreHandlers = require('../security-pre-handlers');
+const complementaryCertificationCourseResultsController = require('./complementary-certification-course-results-controller');
+
+exports.register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/complementary-certification-course-results',
+      config: {
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                juryLevel: Joi.string()
+                  .valid(
+                    Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+                    Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+                    Badge.keys.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+                    Badge.keys.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+                    'REJECTED'
+                  )
+                  .required(),
+                complementaryCertificationCourseId: identifiersType.complementaryCertificationCourseId,
+              },
+            },
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        handler: complementaryCertificationCourseResultsController.saveJuryComplementaryCertificationCourseResult,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs Super Admin authentifiés**\n',
+          "- Elle permet de sauvergarder le volet jury d'une certification complémentaire Pix+ Edu",
+        ],
+        tags: ['api', 'complementary-certification-course-results', 'Pix+ Édu'],
+      },
+    },
+  ]);
+};
+
+exports.name = 'complementary-certification-course-results-api';

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -33,6 +33,32 @@ class ComplementaryCertificationCourseResult {
     });
   }
 
+  static buildFromJuryLevel({ complementaryCertificationCourseId, juryLevel, pixPartnerKey }) {
+    if (juryLevel === 'REJECTED') {
+      return new ComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId,
+        partnerKey: pixPartnerKey,
+        acquired: false,
+        source: sources.EXTERNAL,
+      });
+    }
+
+    return new ComplementaryCertificationCourseResult({
+      complementaryCertificationCourseId,
+      partnerKey: juryLevel,
+      acquired: true,
+      source: sources.EXTERNAL,
+    });
+  }
+
+  isFromPixSource() {
+    return this.source === sources.PIX;
+  }
+
+  isFromExternalSource() {
+    return this.source === sources.EXTERNAL;
+  }
+
   isPixEdu() {
     return this.isPixEdu1erDegre() || this.isPixEdu2ndDegre();
   }

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -11,6 +11,11 @@ const {
   PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
 } = require('./Badge').keys;
 
+const sources = {
+  EXTERNAL: 'EXTERNAL',
+  PIX: 'PIX',
+};
+
 class ComplementaryCertificationCourseResult {
   constructor({ certificationCourseId, complementaryCertificationCourseId, partnerKey, source, acquired } = {}) {
     this.certificationCourseId = certificationCourseId;
@@ -54,5 +59,7 @@ class ComplementaryCertificationCourseResult {
     ].includes(this.partnerKey);
   }
 }
+
+ComplementaryCertificationCourseResult.sources = sources;
 
 module.exports = ComplementaryCertificationCourseResult;

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -59,6 +59,10 @@ class ComplementaryCertificationCourseResult {
     return this.source === sources.EXTERNAL;
   }
 
+  isAcquired() {
+    return this.acquired;
+  }
+
   isPixEdu() {
     return this.isPixEdu1erDegre() || this.isPixEdu2ndDegre();
   }

--- a/api/lib/domain/models/ComplementaryCertificationCourseResult.js
+++ b/api/lib/domain/models/ComplementaryCertificationCourseResult.js
@@ -17,17 +17,15 @@ const sources = {
 };
 
 class ComplementaryCertificationCourseResult {
-  constructor({ certificationCourseId, complementaryCertificationCourseId, partnerKey, source, acquired } = {}) {
-    this.certificationCourseId = certificationCourseId;
+  constructor({ complementaryCertificationCourseId, partnerKey, source, acquired } = {}) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
     this.partnerKey = partnerKey;
     this.acquired = acquired;
     this.source = source;
   }
 
-  static from({ certificationCourseId, complementaryCertificationCourseId, partnerKey, acquired, source }) {
+  static from({ complementaryCertificationCourseId, partnerKey, acquired, source }) {
     return new ComplementaryCertificationCourseResult({
-      certificationCourseId,
       complementaryCertificationCourseId,
       partnerKey,
       acquired,

--- a/api/lib/domain/models/PixPlusEduCertificationScoring.js
+++ b/api/lib/domain/models/PixPlusEduCertificationScoring.js
@@ -1,3 +1,4 @@
+const ComplementaryCertificationCourseResult = require('./ComplementaryCertificationCourseResult');
 const PartnerCertificationScoring = require('./PartnerCertificationScoring');
 
 class PixPlusEduCertificationScoring extends PartnerCertificationScoring {
@@ -10,7 +11,7 @@ class PixPlusEduCertificationScoring extends PartnerCertificationScoring {
     super({
       complementaryCertificationCourseId,
       partnerKey: certifiableBadgeKey,
-      source: 'PIX',
+      source: ComplementaryCertificationCourseResult.sources.PIX,
     });
 
     this.reproducibilityRate = reproducibilityRate;

--- a/api/lib/domain/read-models/CertifiedBadges.js
+++ b/api/lib/domain/read-models/CertifiedBadges.js
@@ -28,8 +28,17 @@ class CertifiedBadges {
         const partnerKey = complementaryCertificationCourseResults[0].partnerKey;
         if (complementaryCertificationCourseResults[0].isPixEdu()) {
           if (complementaryCertificationCourseResults.length === 1) {
+            if (!complementaryCertificationCourseResults[0].isAcquired()) {
+              return;
+            }
             return { partnerKey, isTemporaryBadge: true };
-          } else {
+          }
+
+          if (complementaryCertificationCourseResults.length > 1) {
+            if (!this._hasAcquiredExternalSourceCertifiedBadge(complementaryCertificationCourseResults)) {
+              return;
+            }
+
             let lowestPartnerKey;
             if (complementaryCertificationCourseResults[0].isPixEdu2ndDegre()) {
               lowestPartnerKey = this._getLowestPartnerKeyForPixEdu2ndDegreBadge(
@@ -95,6 +104,14 @@ class CertifiedBadges {
     return firstIndexOf <= secondIndexOf
       ? complementaryCertificationCourseResults[0].partnerKey
       : complementaryCertificationCourseResults[1].partnerKey;
+  }
+
+  _hasAcquiredExternalSourceCertifiedBadge(complementaryCertificationCourseResults) {
+    return complementaryCertificationCourseResults.some(
+      (complementaryCertificationCourseResult) =>
+        complementaryCertificationCourseResult.isAcquired() &&
+        complementaryCertificationCourseResult.isFromExternalSource()
+    );
   }
 }
 

--- a/api/lib/domain/read-models/CertifiedBadges.js
+++ b/api/lib/domain/read-models/CertifiedBadges.js
@@ -17,14 +17,14 @@ class CertifiedBadges {
     this.complementaryCertificationCourseResults = complementaryCertificationCourseResults;
   }
 
-  getCertifiedBadgesDTO() {
+  getAcquiredCertifiedBadgesDTO() {
     const complementaryCertificationCourseResultsByPartnerKey = _.groupBy(
       this.complementaryCertificationCourseResults,
       'complementaryCertificationCourseId'
     );
 
-    return Object.values(complementaryCertificationCourseResultsByPartnerKey).map(
-      (complementaryCertificationCourseResults) => {
+    return Object.values(complementaryCertificationCourseResultsByPartnerKey)
+      .map((complementaryCertificationCourseResults) => {
         const partnerKey = complementaryCertificationCourseResults[0].partnerKey;
         if (complementaryCertificationCourseResults[0].isPixEdu()) {
           if (complementaryCertificationCourseResults.length === 1) {
@@ -46,9 +46,11 @@ class CertifiedBadges {
           }
         }
 
-        return { partnerKey, isTemporaryBadge: false };
-      }
-    );
+        if (complementaryCertificationCourseResults[0].isAcquired()) {
+          return { partnerKey, isTemporaryBadge: false };
+        }
+      })
+      .filter(Boolean);
   }
 
   _getLowestPartnerKeyForPixEdu2ndDegreBadge(complementaryCertificationCourseResults) {

--- a/api/lib/domain/read-models/CertifiedBadges.js
+++ b/api/lib/domain/read-models/CertifiedBadges.js
@@ -35,21 +35,11 @@ class CertifiedBadges {
           }
 
           if (complementaryCertificationCourseResults.length > 1) {
-            if (!this._hasAcquiredExternalSourceCertifiedBadge(complementaryCertificationCourseResults)) {
+            if (this._hasRejectedJuryCertifiedBadge(complementaryCertificationCourseResults)) {
               return;
             }
 
-            let lowestPartnerKey;
-            if (complementaryCertificationCourseResults[0].isPixEdu2ndDegre()) {
-              lowestPartnerKey = this._getLowestPartnerKeyForPixEdu2ndDegreBadge(
-                complementaryCertificationCourseResults
-              );
-            }
-            if (complementaryCertificationCourseResults[0].isPixEdu1erDegre()) {
-              lowestPartnerKey = this._getLowestPartnerKeyForPixEdu1erDegreBadge(
-                complementaryCertificationCourseResults
-              );
-            }
+            const lowestPartnerKey = this._getLowestPartnerKey(complementaryCertificationCourseResults);
 
             return { partnerKey: lowestPartnerKey, isTemporaryBadge: false };
           }
@@ -60,6 +50,15 @@ class CertifiedBadges {
         }
       })
       .filter(Boolean);
+  }
+
+  _getLowestPartnerKey(complementaryCertificationCourseResults) {
+    if (complementaryCertificationCourseResults[0].isPixEdu2ndDegre()) {
+      return this._getLowestPartnerKeyForPixEdu2ndDegreBadge(complementaryCertificationCourseResults);
+    }
+    if (complementaryCertificationCourseResults[0].isPixEdu1erDegre()) {
+      return this._getLowestPartnerKeyForPixEdu1erDegreBadge(complementaryCertificationCourseResults);
+    }
   }
 
   _getLowestPartnerKeyForPixEdu2ndDegreBadge(complementaryCertificationCourseResults) {
@@ -106,10 +105,10 @@ class CertifiedBadges {
       : complementaryCertificationCourseResults[1].partnerKey;
   }
 
-  _hasAcquiredExternalSourceCertifiedBadge(complementaryCertificationCourseResults) {
+  _hasRejectedJuryCertifiedBadge(complementaryCertificationCourseResults) {
     return complementaryCertificationCourseResults.some(
       (complementaryCertificationCourseResult) =>
-        complementaryCertificationCourseResult.isAcquired() &&
+        !complementaryCertificationCourseResult.isAcquired() &&
         complementaryCertificationCourseResult.isFromExternalSource()
     );
   }

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -36,6 +36,7 @@ const typesPositiveInteger32bits = [
   'certificationCenterMembershipId',
   'certificationCourseId',
   'certificationIssueReportId',
+  'complementaryCertificationCourseId',
   'membershipId',
   'organizationId',
   'organizationInvitationId',

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -360,6 +360,7 @@ module.exports = injectDependencies(
     retrieveLastOrCreateCertificationCourse: require('./retrieve-last-or-create-certification-course'),
     revokeRefreshToken: require('./revoke-refresh-token'),
     saveCertificationIssueReport: require('./save-certification-issue-report'),
+    saveJuryComplementaryCertificationCourseResult: require('./save-jury-complementary-certification-course-result'),
     sendEmailForAccountRecovery: require('./account-recovery/send-email-for-account-recovery'),
     sendScoInvitation: require('./send-sco-invitation'),
     sendVerificationCode: require('./send-verification-code'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -64,6 +64,7 @@ const dependencies = {
   complementaryCertificationHabilitationRepository: require('../../infrastructure/repositories/complementary-certification-habilitation-repository'),
   complementaryCertificationRepository: require('../../infrastructure/repositories/complementary-certification-repository'),
   complementaryCertificationSubscriptionRepository: require('../../infrastructure/repositories/complementary-certification-subscription-repository'),
+  complementaryCertificationCourseResultRepository: require('../../infrastructure/repositories/complementary-certification-course-result-repository'),
   correctionRepository: require('../../infrastructure/repositories/correction-repository'),
   countryRepository: require('../../infrastructure/repositories/country-repository'),
   courseRepository: require('../../infrastructure/repositories/course-repository'),

--- a/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
+++ b/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
@@ -1,0 +1,32 @@
+const { NotFoundError } = require('../errors');
+const ComplementaryCertificationCourseResult = require('../models/ComplementaryCertificationCourseResult');
+
+module.exports = async function saveJuryComplementaryCertificationCourseResult({
+  complementaryCertificationCourseId,
+  juryLevel,
+  complementaryCertificationCourseResultRepository,
+}) {
+  const complementaryCertificationCourseResults =
+    await complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId({
+      complementaryCertificationCourseId,
+    });
+
+  const pixEduAndFromPixSourceComplementaryCertificationCourseResult = complementaryCertificationCourseResults.find(
+    (complementaryCertificationCourseResult) =>
+      complementaryCertificationCourseResult.isPixEdu() && complementaryCertificationCourseResult.isFromPixSource()
+  );
+
+  if (!pixEduAndFromPixSourceComplementaryCertificationCourseResult) {
+    throw new NotFoundError("Aucun résultat Pix+ Edu n'a été trouvé pour cette certification.");
+  }
+
+  const { partnerKey: pixPartnerKey } = pixEduAndFromPixSourceComplementaryCertificationCourseResult;
+
+  const externalComplementaryCertificationCourseResult = ComplementaryCertificationCourseResult.buildFromJuryLevel({
+    juryLevel,
+    pixPartnerKey,
+    complementaryCertificationCourseId,
+  });
+
+  return complementaryCertificationCourseResultRepository.save(externalComplementaryCertificationCourseResult);
+};

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -38,7 +38,7 @@ module.exports = {
     }
 
     const competenceTree = await competenceTreeRepository.get();
-    const acquiredComplementaryCertifications = await _getAcquiredPartnerCertification(certificationCourseDTO.id);
+    const acquiredComplementaryCertifications = await _getPartnerCertification(certificationCourseDTO.id);
 
     return _toDomain(certificationCourseDTO, competenceTree, acquiredComplementaryCertifications);
   },
@@ -142,7 +142,7 @@ function _filterMostRecentCertificationCoursePerSchoolingRegistration(DTOs) {
   return mostRecent;
 }
 
-async function _getAcquiredPartnerCertification(certificationCourseId) {
+async function _getPartnerCertification(certificationCourseId) {
   const handledBadgeKeys = [
     PIX_EMPLOI_CLEA_V1,
     PIX_EMPLOI_CLEA_V2,
@@ -190,7 +190,7 @@ function _toDomain(certificationCourseDTO, competenceTree, acquiredComplementary
 
   const certifiedBadgesDTO = new CertifiedBadges({
     complementaryCertificationCourseResults: acquiredComplementaryCertifications,
-  }).getCertifiedBadgesDTO();
+  }).getAcquiredCertifiedBadgesDTO();
 
   return new CertificationAttestation({
     ...certificationCourseDTO,

--- a/api/lib/infrastructure/repositories/certification-attestation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-attestation-repository.js
@@ -168,7 +168,7 @@ async function _getPartnerCertification(certificationCourseId) {
       'complementary-certification-courses.id',
       'complementary-certification-course-results.complementaryCertificationCourseId'
     )
-    .where({ certificationCourseId, acquired: true })
+    .where({ certificationCourseId })
     .where(function () {
       this.whereIn('partnerKey', handledBadgeKeys);
     });

--- a/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -1,0 +1,48 @@
+const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
+const { knex } = require('../bookshelf');
+
+module.exports = {
+  async getFromComplementaryCertificationCourseId({ complementaryCertificationCourseId }) {
+    const complementaryCertificationCourseResults = await knex
+      .select('complementary-certification-course-results.*')
+      .from('complementary-certification-course-results')
+      .where({ complementaryCertificationCourseId });
+
+    return complementaryCertificationCourseResults.map((complementaryCertificationCourseResult) =>
+      ComplementaryCertificationCourseResult.from({
+        complementaryCertificationCourseId: complementaryCertificationCourseResult.complementaryCertificationCourseId,
+        partnerKey: complementaryCertificationCourseResult.partnerKey,
+        acquired: complementaryCertificationCourseResult.acquired,
+        source: complementaryCertificationCourseResult.source,
+      })
+    );
+  },
+
+  async save({ complementaryCertificationCourseId, partnerKey, acquired, source }) {
+    const existingComplementaryCertificationCourseResult = await knex('complementary-certification-course-results')
+      .where({
+        complementaryCertificationCourseId,
+        source,
+      })
+      .first();
+
+    if (existingComplementaryCertificationCourseResult) {
+      return knex('complementary-certification-course-results')
+        .where({
+          complementaryCertificationCourseId,
+          source,
+        })
+        .update({
+          partnerKey,
+          acquired,
+        });
+    }
+
+    return knex('complementary-certification-course-results').insert({
+      complementaryCertificationCourseId,
+      partnerKey,
+      acquired,
+      source,
+    });
+  },
+};

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -3,6 +3,7 @@ const DomainTransaction = require('../DomainTransaction');
 const ComplementaryCertificationCourseResultBookshelf = require('../orm-models/ComplementaryCertificationCourseResult');
 const CleaCertificationScoring = require('../../domain/models/CleaCertificationScoring');
 const Badge = require('../../domain/models/Badge');
+const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
 
 module.exports = {
   async getCleaCertificationScoring({
@@ -32,7 +33,7 @@ module.exports = {
     const partnerCertificationToSave = new ComplementaryCertificationCourseResultBookshelf(
       _adaptModelToDB({
         ...partnerCertificationScoring,
-        source: 'PIX',
+        source: ComplementaryCertificationCourseResult.sources.PIX,
         complementaryCertificationCourseId: partnerCertificationScoring.complementaryCertificationCourseId,
         acquired: partnerCertificationScoring.isAcquired(),
       })

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -175,7 +175,9 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
       })
   );
 
-  const certifiedBadgesDTO = new CertifiedBadges({ complementaryCertificationCourseResults }).getCertifiedBadgesDTO();
+  const certifiedBadgesDTO = new CertifiedBadges({
+    complementaryCertificationCourseResults,
+  }).getAcquiredCertifiedBadgesDTO();
 
   return _.compact(
     _.map(certifiedBadgesDTO, ({ partnerKey, isTemporaryBadge }) =>

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -158,7 +158,7 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
       'complementary-certification-courses.id',
       'complementary-certification-course-results.complementaryCertificationCourseId'
     )
-    .where({ certificationCourseId, acquired: true })
+    .where({ certificationCourseId })
     .where(function () {
       this.whereIn('partnerKey', handledBadgeKeys);
     })

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -143,7 +143,6 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
   const complementaryCertificationCourseResults = results.map(
     ({ partnerKey, complementaryCertificationCourseId, acquired, source }) =>
       ComplementaryCertificationCourseResult.from({
-        certificationCourseId,
         complementaryCertificationCourseId,
         partnerKey,
         acquired,

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -150,7 +150,9 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
       })
   );
 
-  const certifiedBadgesDTO = new CertifiedBadges({ complementaryCertificationCourseResults }).getCertifiedBadgesDTO();
+  const certifiedBadgesDTO = new CertifiedBadges({
+    complementaryCertificationCourseResults,
+  }).getAcquiredCertifiedBadgesDTO();
 
   return _.compact(
     _.map(certifiedBadgesDTO, ({ partnerKey, isTemporaryBadge }) =>

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -134,7 +134,7 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
       'complementary-certification-courses.id',
       'complementary-certification-course-results.complementaryCertificationCourseId'
     )
-    .where({ certificationCourseId, acquired: true })
+    .where({ certificationCourseId })
     .where(function () {
       this.whereIn('partnerKey', handledBadgeKeys);
     })

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -21,6 +21,7 @@ module.exports = [
   require('./application/challenges'),
   require('./application/competence-evaluations'),
   require('./application/complementary-certifications'),
+  require('./application/complementary-certification-course-results'),
   require('./application/countries'),
   require('./application/courses'),
   require('./application/feature-toggles'),

--- a/api/tests/acceptance/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -1,0 +1,62 @@
+const {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
+const Badge = require('../../../../lib/domain/models/Badge');
+
+describe('Acceptance | API | Certifications', function () {
+  describe('POST /api/complementary-certification-course-results', function () {
+    it('should return 201 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const badge = databaseBuilder.factory.buildBadge({
+        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+      });
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 1,
+        name: 'Pix+Edu',
+      });
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 456,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationCourse({
+        id: 1234,
+        certificationCourseId: 456,
+        complementaryCertificationId: 1,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId: 1234,
+        partnerKey: badge.key,
+        source: ComplementaryCertificationCourseResult.sources.PIX,
+      });
+
+      await databaseBuilder.commit();
+
+      const userId = (await insertUserWithRoleSuperAdmin()).id;
+      const options = {
+        method: 'POST',
+        url: '/api/complementary-certification-course-results',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            attributes: {
+              juryLevel: badge.key,
+              complementaryCertificationCourseId: 1234,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -1,0 +1,119 @@
+const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const usecases = require('../../../../lib/domain/usecases');
+const moduleUnderTest = require('../../../../lib/application/complementary-certification-course-results');
+
+describe('Integration | Application | complementary-certification-course-results | complementary-certification-course-results-controller', function () {
+  let sandbox;
+  let httpTestServer;
+
+  beforeEach(async function () {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(usecases, 'saveJuryComplementaryCertificationCourseResult');
+    sandbox.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin');
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('#saveJuryComplementaryCertificationCourseResult', function () {
+    context('Success cases', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
+        'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE',
+        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT',
+        'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE',
+        'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+        'REJECTED',
+      ].forEach((juryLevel) => {
+        it(`should resolve a 200 HTTP response for ${juryLevel} juryLevel`, async function () {
+          // given
+          const payload = {
+            data: {
+              attributes: {
+                juryLevel,
+                complementaryCertificationCourseId: 123456,
+              },
+            },
+          };
+          usecases.saveJuryComplementaryCertificationCourseResult.resolves();
+          securityPreHandlers.checkUserHasRoleSuperAdmin.callsFake((request, h) => h.response(true));
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/complementary-certification-course-results',
+            payload
+          );
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
+      });
+    });
+
+    context('Error cases', function () {
+      context('when juryLevel is not valid', function () {
+        it('should resolve a 400 HTTP response', async function () {
+          // given
+          const payload = {
+            data: {
+              attributes: {
+                juryLevel: 'INVALID_JURY_LEVEL',
+                complementaryCertificationCourseId: 123456,
+              },
+            },
+          };
+          usecases.saveJuryComplementaryCertificationCourseResult.resolves();
+          securityPreHandlers.checkUserHasRoleSuperAdmin.callsFake((request, h) => h.response(true));
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/complementary-certification-course-results',
+            payload
+          );
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
+      context('when user is not allowed to access resource', function () {
+        it('should resolve a 403 HTTP response', async function () {
+          // given
+          const payload = {
+            data: {
+              attributes: {
+                juryLevel: 'REJECTED',
+                complementaryCertificationCourseId: 123456,
+              },
+            },
+          };
+          securityPreHandlers.checkUserHasRoleSuperAdmin.callsFake((request, h) => {
+            return Promise.resolve(h.response().code(403).takeover());
+          });
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/complementary-certification-course-results',
+            payload
+          );
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/integration/application/complementary-certification-course-results/index_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/index_test.js
@@ -1,0 +1,37 @@
+const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const moduleUnderTest = require('../../../../lib/application/complementary-certification-course-results');
+const complementaryCertificationCourseResultsController = require('../../../../lib/application/complementary-certification-course-results/complementary-certification-course-results-controller');
+
+describe('Integration | Application | Route | Certifications', function () {
+  let httpTestServer;
+
+  beforeEach(async function () {
+    sinon
+      .stub(complementaryCertificationCourseResultsController, 'saveJuryComplementaryCertificationCourseResult')
+      .callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('POST /api/complementary-certification-course-results', function () {
+    it('should exist', async function () {
+      // given
+      const payload = {
+        data: {
+          attributes: {
+            juryLevel: 'REJECTED',
+            complementaryCertificationCourseId: 123456,
+          },
+        },
+      };
+      // when
+      const response = await httpTestServer.request('POST', '/api/complementary-certification-course-results', payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -27,6 +27,7 @@ const {
   PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
 } = require('../../../../lib/domain/models/Badge').keys;
 const certificationAttestationRepository = require('../../../../lib/infrastructure/repositories/certification-attestation-repository');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 describe('Integration | Infrastructure | Repository | Certification Attestation', function () {
   const minimalLearningContent = [
@@ -427,7 +428,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         databaseBuilder.factory.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 999,
           partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-          source: 'PIX',
+          source: ComplementaryCertificationCourseResult.sources.PIX,
           acquired: true,
         });
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -1,0 +1,181 @@
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
+const { knex } = require('../../../../lib/infrastructure/bookshelf');
+const _ = require('lodash');
+const complementaryCertificationCourseResultRepository = require('../../../../lib/infrastructure/repositories/complementary-certification-course-result-repository');
+const Badge = require('../../../../lib/domain/models/Badge');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
+
+describe('Integration | Repository | complementary-certification-courses-result-repository', function () {
+  describe('#getFromComplementaryCertificationCourseId', function () {
+    describe('when a ComplementaryCertificationCourseResult matches the complementaryCertificationCourseId', function () {
+      it('returns ComplementaryCertificationCourseResult as an array', async function () {
+        // given
+        databaseBuilder.factory.buildComplementaryCertification({
+          id: 1,
+          name: 'Pix+Edu',
+        });
+        databaseBuilder.factory.buildCertificationCourse({ id: 99 });
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          id: 999,
+          certificationCourseId: 99,
+          complementaryCertificationId: 1,
+        });
+
+        databaseBuilder.factory.buildBadge({
+          key: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId: 999,
+          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+          acquired: true,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const [result] =
+          await complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId({
+            complementaryCertificationCourseId: 999,
+          });
+
+        // then
+        expect(result).to.deepEqualInstance(
+          domainBuilder.buildComplementaryCertificationCourseResult({
+            acquired: true,
+            complementaryCertificationCourseId: 999,
+            partnerKey: 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
+            source: ComplementaryCertificationCourseResult.sources.PIX,
+          })
+        );
+      });
+    });
+
+    describe('when no ComplementaryCertificationCourseResult matches the complementaryCertificationCourseId', function () {
+      it('returns an empty array', async function () {
+        // when
+        const result = await complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId(
+          {
+            complementaryCertificationCourseId: 99,
+          }
+        );
+
+        // then
+        expect(result).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('#save', function () {
+    afterEach(function () {
+      return knex('complementary-certification-course-results').delete();
+    });
+    describe('when the ComplementaryCertificationCourseResult does not exist', function () {
+      it('saves the ComplementaryCertificationCourseResult', async function () {
+        // given
+        databaseBuilder.factory.buildComplementaryCertification({
+          id: 1,
+          name: 'Pix+Edu',
+        });
+        databaseBuilder.factory.buildCertificationCourse({ id: 99 });
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          id: 999,
+          certificationCourseId: 99,
+          complementaryCertificationId: 1,
+        });
+
+        databaseBuilder.factory.buildBadge({
+          key: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        });
+
+        await databaseBuilder.commit();
+
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          acquired: true,
+          complementaryCertificationCourseId: 999,
+          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+        });
+
+        // when
+        await complementaryCertificationCourseResultRepository.save(complementaryCertificationCourseResult);
+
+        // then
+        const savedComplementaryCertificationCourseResult = await knex('complementary-certification-course-results')
+          .where({
+            acquired: true,
+            complementaryCertificationCourseId: 999,
+            partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            source: ComplementaryCertificationCourseResult.sources.PIX,
+          })
+          .first();
+
+        expect(_.omit(savedComplementaryCertificationCourseResult, 'id')).to.deep.equal({
+          acquired: true,
+          complementaryCertificationCourseId: 999,
+          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+        });
+      });
+    });
+
+    describe('when the ComplementaryCertificationCourseResult already exists', function () {
+      it('updates the ComplementaryCertificationCourseResult', async function () {
+        // given
+        databaseBuilder.factory.buildComplementaryCertification({
+          id: 1,
+          name: 'Pix+Edu',
+        });
+        databaseBuilder.factory.buildCertificationCourse({ id: 99 });
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          id: 999,
+          certificationCourseId: 99,
+          complementaryCertificationId: 1,
+        });
+
+        databaseBuilder.factory.buildBadge({
+          key: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        });
+
+        databaseBuilder.factory.buildBadge({
+          key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+          acquired: true,
+          complementaryCertificationCourseId: 999,
+          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+        });
+
+        await databaseBuilder.commit();
+
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          acquired: true,
+          complementaryCertificationCourseId: 999,
+          partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+        });
+
+        // when
+        await complementaryCertificationCourseResultRepository.save(complementaryCertificationCourseResult);
+
+        // then
+        const results = await knex('complementary-certification-course-results').where({
+          acquired: true,
+          complementaryCertificationCourseId: 999,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+        });
+
+        expect(results).to.have.lengthOf(1);
+        expect(_.omit(results[0], 'id')).to.deep.equal({
+          acquired: true,
+          complementaryCertificationCourseId: 999,
+          partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -13,6 +13,7 @@ const skillRepository = require('../../../../lib/infrastructure/repositories/ski
 const Badge = require('../../../../lib/domain/models/Badge');
 const { NotEligibleCandidateError } = require('../../../../lib/domain/errors');
 const { CleaCertificationScoring } = require('../../../../lib/domain/models');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 describe('Integration | Repository | Partner Certification Scoring', function () {
   const COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE_NAME = 'complementary-certification-course-results';
@@ -56,7 +57,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: true,
-        source: 'PIX',
+        source: ComplementaryCertificationCourseResult.sources.PIX,
       });
     });
 
@@ -76,7 +77,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
-        source: 'PIX',
+        source: ComplementaryCertificationCourseResult.sources.PIX,
       });
       await databaseBuilder.commit();
       sinon.stub(partnerCertificationScoring, 'isAcquired').returns(false);
@@ -99,7 +100,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
         complementaryCertificationCourseId,
         partnerKey: partnerCertificationScoring.partnerKey,
         acquired: false,
-        source: 'PIX',
+        source: ComplementaryCertificationCourseResult.sources.PIX,
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -18,6 +18,7 @@ const {
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
 } = require('../../../../lib/domain/models/Badge').keys;
 const _ = require('lodash');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 describe('Integration | Infrastructure | Repository | Private Certificate', function () {
   const minimalLearningContent = [
@@ -988,7 +989,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
       complementaryCertificationCourseId,
       partnerKey: badgeKey,
       acquired: true,
-      source: 'PIX',
+      source: ComplementaryCertificationCourseResult.sources.PIX,
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const shareableCertificateRepository = require('../../../../lib/infrastructure/repositories/shareable-certificate-repository');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 const {
   PIX_EMPLOI_CLEA_V1,
   PIX_EMPLOI_CLEA_V2,
@@ -592,7 +593,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           certificationCourseId: otherCertificateId,
           partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
           acquired: true,
-          source: 'PIX',
+          source: ComplementaryCertificationCourseResult.sources.PIX,
         });
         await databaseBuilder.commit();
 
@@ -708,7 +709,7 @@ async function _buildValidShareableCertificateWithAcquiredAndNotAcquiredBadges({
       complementaryCertificationCourseId,
       partnerKey: badgeKey,
       acquired: true,
-      source: 'PIX',
+      source: ComplementaryCertificationCourseResult.sources.PIX,
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result.js
@@ -1,15 +1,15 @@
 const ComplementaryCertificationCourseResult = require('./../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 module.exports = function buildComplementaryCertificationCourseResult({
-  certificationCourseId = 1,
   complementaryCertificationCourseId = 2,
   partnerKey = 'PARTNER_KEY',
   acquired = false,
+  source = ComplementaryCertificationCourseResult.sources.PIX,
 } = {}) {
   return new ComplementaryCertificationCourseResult({
-    certificationCourseId,
     complementaryCertificationCourseId,
     partnerKey,
     acquired,
+    source,
   });
 };

--- a/api/tests/unit/domain/models/CertificationAttestation_test.js
+++ b/api/tests/unit/domain/models/CertificationAttestation_test.js
@@ -1,3 +1,4 @@
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 const { expect, domainBuilder } = require('../../../test-helper');
 const {
   PIX_EMPLOI_CLEA_V1,
@@ -144,14 +145,20 @@ describe('Unit | Domain | Models | CertificationAttestation', function () {
       it(`should return the acquired ${badgeKey} badge`, function () {
         // given
         const certificationAttestation = domainBuilder.buildCertificationAttestation({
-          certifiedBadges: [{ partnerKey: 'OTHER_BADGE' }, { partnerKey: badgeKey, source: 'PIX' }],
+          certifiedBadges: [
+            { partnerKey: 'OTHER_BADGE' },
+            { partnerKey: badgeKey, source: ComplementaryCertificationCourseResult.sources.PIX },
+          ],
         });
 
         // when
         const acquiredPixPlusEduCertification = certificationAttestation.getAcquiredPixPlusEduCertification();
 
         // expect
-        expect(acquiredPixPlusEduCertification).to.deep.equal({ partnerKey: badgeKey, source: 'PIX' });
+        expect(acquiredPixPlusEduCertification).to.deep.equal({
+          partnerKey: badgeKey,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+        });
       });
     });
 

--- a/api/tests/unit/domain/models/ComplementaryCertificationCourseResult_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationCourseResult_test.js
@@ -1,3 +1,4 @@
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 const { expect, domainBuilder } = require('../../../test-helper');
 const {
   PIX_DROIT_MAITRE_CERTIF,
@@ -211,6 +212,130 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResult', func
 
         // then
         expect(result).to.equal(expected);
+      });
+    });
+  });
+
+  describe('#buildFromJuryLevel', function () {
+    describe('when the jury level is not "REJECTED"', function () {
+      it('should return an acquired ComplementaryCertificationCourseResult with an external source', function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+          acquired: true,
+          complementaryCertificationCourseId: 12,
+        });
+
+        // when
+        const result = ComplementaryCertificationCourseResult.buildFromJuryLevel({
+          juryLevel: complementaryCertificationCourseResult.partnerKey,
+          complementaryCertificationCourseId: 12,
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        });
+
+        // then
+        expect(result).to.deepEqualInstance(
+          new ComplementaryCertificationCourseResult({
+            acquired: true,
+            partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+            complementaryCertificationCourseId: 12,
+          })
+        );
+      });
+    });
+
+    describe('when the jury level is "REJECTED"', function () {
+      it('should return an acquired ComplementaryCertificationCourseResult with an external source', function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey: 'REJECTED',
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+          acquired: true,
+          complementaryCertificationCourseId: 12,
+        });
+
+        // when
+        const result = ComplementaryCertificationCourseResult.buildFromJuryLevel({
+          juryLevel: complementaryCertificationCourseResult.partnerKey,
+          complementaryCertificationCourseId: 12,
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        });
+
+        // then
+        expect(result).to.deepEqualInstance(
+          new ComplementaryCertificationCourseResult({
+            acquired: false,
+            partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+            complementaryCertificationCourseId: 12,
+          })
+        );
+      });
+    });
+  });
+
+  describe('#isFromPixSource', function () {
+    describe('when source is PIX', function () {
+      it('should return true', function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+          acquired: true,
+          complementaryCertificationCourseId: 12,
+        });
+
+        // when then
+        expect(complementaryCertificationCourseResult.isFromPixSource()).to.be.true;
+      });
+    });
+
+    describe('when source is not PIX', function () {
+      it('should return false', function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+          acquired: true,
+          complementaryCertificationCourseId: 12,
+        });
+
+        // when then
+        expect(complementaryCertificationCourseResult.isFromPixSource()).to.be.false;
+      });
+    });
+  });
+
+  describe('#isFromExternalSource', function () {
+    describe('when source is EXTERNAL', function () {
+      it('should return true', function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+          acquired: true,
+          complementaryCertificationCourseId: 12,
+        });
+
+        // when then
+        expect(complementaryCertificationCourseResult.isFromExternalSource()).to.be.true;
+      });
+    });
+
+    describe('when source is not EXTERNAL', function () {
+      it('should return false', function () {
+        // given
+        const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          source: ComplementaryCertificationCourseResult.sources.PIX,
+          acquired: true,
+          complementaryCertificationCourseId: 12,
+        });
+
+        // when then
+        expect(complementaryCertificationCourseResult.isFromExternalSource()).to.be.false;
       });
     });
   });

--- a/api/tests/unit/domain/models/ComplementaryCertificationCourseResult_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertificationCourseResult_test.js
@@ -16,6 +16,40 @@ const {
 } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Models | ComplementaryCertificationCourseResult', function () {
+  describe('#isAcquired', function () {
+    it('should return true if acquired is true', function () {
+      // given
+      const complementaryCertificationCourseResult = new ComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId: 'complementaryCertificationCourseId',
+        partnerKey: 'partnerKey',
+        acquired: true,
+        source: 'source',
+      });
+
+      // when
+      const result = complementaryCertificationCourseResult.isAcquired();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if acquired is false', function () {
+      // given
+      const complementaryCertificationCourseResult = new ComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId: 'complementaryCertificationCourseId',
+        partnerKey: 'partnerKey',
+        acquired: false,
+        source: 'source',
+      });
+
+      // when
+      const result = complementaryCertificationCourseResult.isAcquired();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
   describe('#isPixEdu1erDegre', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -42,36 +42,38 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
         });
       });
 
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      [
-        PIX_DROIT_EXPERT_CERTIF,
-        PIX_DROIT_MAITRE_CERTIF,
-        PIX_EMPLOI_CLEA_V1,
-        PIX_EMPLOI_CLEA_V2,
-        PIX_EMPLOI_CLEA_V3,
-      ].forEach((partnerKey) => {
-        it(`returns a non temporary acquired badge for ${partnerKey}`, function () {
-          // given
-          const complementaryCertificationCourseResults = [
-            domainBuilder.buildComplementaryCertificationCourseResult({
-              complementaryCertificationCourseId: 456,
-              partnerKey,
-              acquired: true,
-            }),
-          ];
+      context('when badge is acquired', function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        [
+          PIX_DROIT_EXPERT_CERTIF,
+          PIX_DROIT_MAITRE_CERTIF,
+          PIX_EMPLOI_CLEA_V1,
+          PIX_EMPLOI_CLEA_V2,
+          PIX_EMPLOI_CLEA_V3,
+        ].forEach((partnerKey) => {
+          it(`returns a non temporary acquired badge for ${partnerKey}`, function () {
+            // given
+            const complementaryCertificationCourseResults = [
+              domainBuilder.buildComplementaryCertificationCourseResult({
+                complementaryCertificationCourseId: 456,
+                partnerKey,
+                acquired: true,
+              }),
+            ];
 
-          // when
-          const certifiedBadgesDTO = new CertifiedBadges({
-            complementaryCertificationCourseResults,
-          }).getAcquiredCertifiedBadgesDTO();
+            // when
+            const certifiedBadgesDTO = new CertifiedBadges({
+              complementaryCertificationCourseResults,
+            }).getAcquiredCertifiedBadgesDTO();
 
-          // then
-          expect(certifiedBadgesDTO).to.deepEqualArray([
-            {
-              partnerKey,
-              isTemporaryBadge: false,
-            },
-          ]);
+            // then
+            expect(certifiedBadgesDTO).to.deepEqualArray([
+              {
+                partnerKey,
+                isTemporaryBadge: false,
+              },
+            ]);
+          });
         });
       });
     });
@@ -135,7 +137,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
         });
 
         context('when there is more than one complementaryCertificationCourseResult', function () {
-          describe('when source is "EXTERNAL" and acquired', function () {
+          describe('when there is an "EXTERNAL" and acquired badge', function () {
             it(`returns a non temporary badge for ${partnerKey}`, function () {
               // given
               const complementaryCertificationCourseResults = [
@@ -167,7 +169,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             });
           });
 
-          describe('when source is "EXTERNAL" and not acquired', function () {
+          describe('when there is an "EXTERNAL" and not acquired badge', function () {
             it(`returns an empty array`, function () {
               // given
               const complementaryCertificationCourseResults = [

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -1,3 +1,4 @@
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 const CertifiedBadges = require('../../../../lib/domain/read-models/CertifiedBadges');
 const { expect, domainBuilder } = require('../../../test-helper');
 
@@ -100,12 +101,12 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
                 complementaryCertificationCourseId: 456,
 
                 partnerKey,
-                source: 'PIX',
+                source: ComplementaryCertificationCourseResult.sources.PIX,
               }),
               domainBuilder.buildComplementaryCertificationCourseResult({
                 partnerKey,
                 complementaryCertificationCourseId: 456,
-                source: 'EXTERNAL',
+                source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
               }),
             ];
 
@@ -224,12 +225,12 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             domainBuilder.buildComplementaryCertificationCourseResult({
               partnerKey: sourcePix,
               complementaryCertificationCourseId: 456,
-              source: 'PIX',
+              source: ComplementaryCertificationCourseResult.sources.PIX,
             }),
             domainBuilder.buildComplementaryCertificationCourseResult({
               partnerKey: sourceExternal,
               complementaryCertificationCourseId: 456,
-              source: 'EXTERNAL',
+              source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
             }),
           ];
 

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -90,12 +90,13 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
         PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
       ].forEach((partnerKey) => {
         context('when there is only one complementaryCertificationCourseResult', function () {
-          it(`returns a temporary badge for ${partnerKey}`, function () {
+          it(`returns a temporary badge for acquired ${partnerKey}`, function () {
             // given
             const complementaryCertificationCourseResults = [
               domainBuilder.buildComplementaryCertificationCourseResult({
                 complementaryCertificationCourseId: 456,
                 partnerKey,
+                acquired: true,
               }),
             ];
 
@@ -112,21 +113,14 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
               },
             ]);
           });
-        });
-        context('when there is more than one complementaryCertificationCourseResult', function () {
-          it(`returns a non temporary badge for ${partnerKey}`, function () {
+
+          it(`returns an empty array for non acquired ${partnerKey}`, function () {
             // given
             const complementaryCertificationCourseResults = [
               domainBuilder.buildComplementaryCertificationCourseResult({
                 complementaryCertificationCourseId: 456,
-
                 partnerKey,
-                source: ComplementaryCertificationCourseResult.sources.PIX,
-              }),
-              domainBuilder.buildComplementaryCertificationCourseResult({
-                partnerKey,
-                complementaryCertificationCourseId: 456,
-                source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+                acquired: false,
               }),
             ];
 
@@ -136,12 +130,68 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             }).getAcquiredCertifiedBadgesDTO();
 
             // then
-            expect(certifiedBadgesDTO).to.deepEqualArray([
-              {
-                partnerKey,
-                isTemporaryBadge: false,
-              },
-            ]);
+            expect(certifiedBadgesDTO).to.deepEqualArray([]);
+          });
+        });
+
+        context('when there is more than one complementaryCertificationCourseResult', function () {
+          describe('when source is "EXTERNAL" and acquired', function () {
+            it(`returns a non temporary badge for ${partnerKey}`, function () {
+              // given
+              const complementaryCertificationCourseResults = [
+                domainBuilder.buildComplementaryCertificationCourseResult({
+                  complementaryCertificationCourseId: 456,
+                  partnerKey,
+                  source: ComplementaryCertificationCourseResult.sources.PIX,
+                }),
+                domainBuilder.buildComplementaryCertificationCourseResult({
+                  partnerKey,
+                  complementaryCertificationCourseId: 456,
+                  source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+                  acquired: true,
+                }),
+              ];
+
+              // when
+              const certifiedBadgesDTO = new CertifiedBadges({
+                complementaryCertificationCourseResults,
+              }).getAcquiredCertifiedBadgesDTO();
+
+              // then
+              expect(certifiedBadgesDTO).to.deepEqualArray([
+                {
+                  partnerKey,
+                  isTemporaryBadge: false,
+                },
+              ]);
+            });
+          });
+
+          describe('when source is "EXTERNAL" and not acquired', function () {
+            it(`returns an empty array`, function () {
+              // given
+              const complementaryCertificationCourseResults = [
+                domainBuilder.buildComplementaryCertificationCourseResult({
+                  complementaryCertificationCourseId: 456,
+                  partnerKey,
+                  source: ComplementaryCertificationCourseResult.sources.PIX,
+                }),
+                domainBuilder.buildComplementaryCertificationCourseResult({
+                  partnerKey,
+                  complementaryCertificationCourseId: 456,
+                  source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+                  acquired: false,
+                }),
+              ];
+
+              // when
+              const certifiedBadgesDTO = new CertifiedBadges({
+                complementaryCertificationCourseResults,
+              }).getAcquiredCertifiedBadgesDTO();
+
+              // then
+              expect(certifiedBadgesDTO).to.deepEqualArray([]);
+            });
           });
         });
       });
@@ -251,6 +301,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
               partnerKey: sourceExternal,
               complementaryCertificationCourseId: 456,
               source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+              acquired: true,
             }),
           ];
 

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -21,8 +21,27 @@ const {
 } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Read-models | CertifiedBadges', function () {
-  describe('#getCertifiedBadgesDTO', function () {
+  describe('#getAcquiredCertifiedBadgesDTO', function () {
     context('when badge is not "PIX_EDU', function () {
+      context('when badge is not acquired', function () {
+        it('should return an empty array', function () {
+          // given
+          const complementaryCertificationCourseResults = [
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              acquired: false,
+              partnerKey: PIX_DROIT_EXPERT_CERTIF,
+            }),
+          ];
+          // when
+          const acquiredCertifiedBadgesDTO = new CertifiedBadges({
+            complementaryCertificationCourseResults,
+          }).getAcquiredCertifiedBadgesDTO();
+
+          // then
+          expect(acquiredCertifiedBadgesDTO).to.be.empty;
+        });
+      });
+
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
         PIX_DROIT_EXPERT_CERTIF,
@@ -31,19 +50,20 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
         PIX_EMPLOI_CLEA_V2,
         PIX_EMPLOI_CLEA_V3,
       ].forEach((partnerKey) => {
-        it(`returns a non temporary badge for ${partnerKey}`, function () {
+        it(`returns a non temporary acquired badge for ${partnerKey}`, function () {
           // given
           const complementaryCertificationCourseResults = [
             domainBuilder.buildComplementaryCertificationCourseResult({
               complementaryCertificationCourseId: 456,
               partnerKey,
+              acquired: true,
             }),
           ];
 
           // when
           const certifiedBadgesDTO = new CertifiedBadges({
             complementaryCertificationCourseResults,
-          }).getCertifiedBadgesDTO();
+          }).getAcquiredCertifiedBadgesDTO();
 
           // then
           expect(certifiedBadgesDTO).to.deepEqualArray([
@@ -82,7 +102,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             // when
             const certifiedBadgesDTO = new CertifiedBadges({
               complementaryCertificationCourseResults,
-            }).getCertifiedBadgesDTO();
+            }).getAcquiredCertifiedBadgesDTO();
 
             // then
             expect(certifiedBadgesDTO).to.deepEqualArray([
@@ -113,7 +133,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
             // when
             const certifiedBadgesDTO = new CertifiedBadges({
               complementaryCertificationCourseResults,
-            }).getCertifiedBadgesDTO();
+            }).getAcquiredCertifiedBadgesDTO();
 
             // then
             expect(certifiedBadgesDTO).to.deepEqualArray([
@@ -237,7 +257,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
           // when
           const certifiedBadgesDTO = new CertifiedBadges({
             complementaryCertificationCourseResults,
-          }).getCertifiedBadgesDTO();
+          }).getAcquiredCertifiedBadgesDTO();
 
           // then
           expect(certifiedBadgesDTO).to.deepEqualArray([

--- a/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
+++ b/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
@@ -5,7 +5,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 const Badge = require('../../../../lib/domain/models/Badge');
 
-describe('Unit | UseCase | save-jury-complementary-certification-course-result', function () {
+describe('Unit | UseCase | save-jury-complementary-certification-course-results', function () {
   describe('#saveJuryComplementaryCertificationCourseResult', function () {
     let complementaryCertificationCourseResultRepository;
 

--- a/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
+++ b/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
@@ -1,0 +1,111 @@
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+
+const saveJuryComplementaryCertificationCourseResult = require('../../../../lib/domain/usecases/save-jury-complementary-certification-course-result');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
+const Badge = require('../../../../lib/domain/models/Badge');
+
+describe('Unit | UseCase | save-jury-complementary-certification-course-result', function () {
+  describe('#saveJuryComplementaryCertificationCourseResult', function () {
+    let complementaryCertificationCourseResultRepository;
+
+    beforeEach(function () {
+      complementaryCertificationCourseResultRepository = {
+        save: sinon.stub(),
+        getFromComplementaryCertificationCourseId: sinon.stub(),
+      };
+    });
+
+    context('when no Pix Edu complementaryCertificationCourseResult is found', function () {
+      it('should throw an error', async function () {
+        // given
+        const complementaryCertificationCourseId = 12345;
+        const juryLevel = 'juryLevel';
+        complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId
+          .withArgs({ complementaryCertificationCourseId })
+          .resolves([]);
+
+        // when
+        const error = await catchErr(saveJuryComplementaryCertificationCourseResult)({
+          complementaryCertificationCourseId,
+          juryLevel,
+          complementaryCertificationCourseResultRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.be.equal("Aucun résultat Pix+ Edu n'a été trouvé pour cette certification.");
+      });
+    });
+
+    context('when no Pix Edu complementaryCertificationCourseResult from PIX source is found', function () {
+      it('should throw an error', async function () {
+        // given
+        const complementaryCertificationCourseId = 12345;
+        const juryLevel = Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE;
+        const pixEduComplementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          juryLevel,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+        });
+        complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId
+          .withArgs({ complementaryCertificationCourseId })
+          .resolves([pixEduComplementaryCertificationCourseResult]);
+
+        // when
+        const error = await catchErr(saveJuryComplementaryCertificationCourseResult)({
+          complementaryCertificationCourseId,
+          juryLevel,
+          complementaryCertificationCourseResultRepository,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.be.equal("Aucun résultat Pix+ Edu n'a été trouvé pour cette certification.");
+      });
+    });
+
+    context('when a Pix Edu complementaryCertificationCourseResult from PIX source is found', function () {
+      it('should save the result', async function () {
+        // given
+        const complementaryCertificationCourseId = 1234;
+        const partnerKey = Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE;
+
+        const pixEduComplementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
+          partnerKey,
+          complementaryCertificationCourseId,
+          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+        });
+        const pixEduAndFromPixSourceComplementaryCertificationCourseResult =
+          domainBuilder.buildComplementaryCertificationCourseResult({
+            partnerKey,
+            complementaryCertificationCourseId,
+            source: ComplementaryCertificationCourseResult.sources.PIX,
+          });
+        complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId
+          .withArgs({ complementaryCertificationCourseId })
+          .resolves([
+            pixEduComplementaryCertificationCourseResult,
+            pixEduAndFromPixSourceComplementaryCertificationCourseResult,
+          ]);
+
+        // when
+        await saveJuryComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId,
+          juryLevel: partnerKey,
+          complementaryCertificationCourseResultRepository,
+        });
+
+        // then
+        expect(complementaryCertificationCourseResultRepository.save).to.have.been.calledWith(
+          new ComplementaryCertificationCourseResult({
+            partnerKey,
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+            acquired: true,
+            complementaryCertificationCourseId:
+              pixEduAndFromPixSourceComplementaryCertificationCourseResult.complementaryCertificationCourseId,
+          })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du volet 2 pour les certifications complémentaires, on veut  permettre depuis Pix Admin, de renseigner le niveau obtenu au volet jury, ce qui n’est pas possible pour le moment.

## :robot: Solution
- permettre l’enregistrement en bdd du niveau obtenu au volet jury

- permettre le calcul du niveau final obtenu à la certif Pix+ Edu = niveau le plus bas obtenu par le candidat entre le niveau du volet pix et le niveau du volet jury

- bien gérer ces 3 données :

  - niveau obtenu au volet pix

  - niveau obtenu au volet jury

  - niveau final

## :100: Pour tester
- Passer avec succès une certif complémentaire pix Edu ( ex: certifedu.2nd.initiale@example.net)
- Finaliser puis publier la session
- Vérifier la présence du badge '2nd degrés confirmé' et de la  mention temporaire sur les certificats
- Utiliser la route pour poster un volet jury acquis avec un token valide
```
localhost:3000/api/complementary-certification-course-results
```

```
{
	"data": {
		"attributes": {
			"juryLevel": "PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME",
			"complementaryCertificationCourseId": <ID_DU_COMPLEMENTARY_CERTIFICATION_COURSE>
		}
	}
}
```

- vérifier que le badge est présent sans mention temporaire



- supprimer la ligne nouvellement crée dans ```complementary-certification-course-results```
- Poster à nouveau la requête avec 'REJECTED' comme valeur pour juryLevel
- vérifier que le badge pix edu n'apparaît plus sur l'ensembe des certificats



- supprimer à nouveau la ligne nouvellement crée dans ```complementary-certification-course-results```
- Poster à nouveau la requête avec un niveau de badge inférieur au badge obtenu lors du volet pix comme valeur pour juryLevel
```
{
	"data": {
		"attributes": {
			"juryLevel": "PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE",
			"complementaryCertificationCourseId": <ID_DU_COMPLEMENTARY_CERTIFICATION_COURSE>
		}
	}
}
```
- Vérifier que le badge initié apparaît sur l'ensemble des certificats sans mention temporaire
