### PR TITLE
[FEATURE] Ajouter un script permettant de lancer l'auto jury pour une session (PIX-4819).

### DIFF
--- a/api/scripts/launch-auto-jury-for-session.js
+++ b/api/scripts/launch-auto-jury-for-session.js
@@ -1,0 +1,59 @@
+'use strict';
+require('dotenv').config();
+const { knex } = require('../db/knex-database-connection');
+const SessionFinalized = require('../lib/domain/events/SessionFinalized');
+const certificationAssessmentRepository = require('../lib/infrastructure/repositories/certification-assessment-repository');
+const challengeRepository = require('../lib/infrastructure/repositories/challenge-repository');
+const certificationIssueReportRepository = require('../lib/infrastructure/repositories/certification-issue-report-repository');
+const certificationCourseRepository = require('../lib/infrastructure/repositories/certification-course-repository');
+const handleAutoJury = require('../lib/domain/events/handle-auto-jury');
+const events = require('../lib/domain/events');
+const logger = require('../lib/infrastructure/logger');
+
+async function main() {
+  const id = process.argv[2];
+  logger.info(`Launch auto jury for session ${id}`);
+
+  const { sessionId, finalizedAt, certificationCenterName, sessionDate, sessionTime, examinerGlobalComment } =
+    await knex('sessions')
+      .select(
+        'id as sessionId',
+        'certificationCenter as certificationCenterName',
+        'finalizedAt',
+        'date as sessionDate',
+        'time as sessionTime',
+        'examinerGlobalComment'
+      )
+      .where({ id })
+      .first();
+
+  const sessionFinalizedEvent = new SessionFinalized({
+    sessionId,
+    finalizedAt,
+    certificationCenterName,
+    sessionDate,
+    sessionTime,
+    hasExaminerGlobalComment: Boolean(examinerGlobalComment),
+  });
+  const event = await handleAutoJury({
+    event: sessionFinalizedEvent,
+    certificationIssueReportRepository,
+    certificationAssessmentRepository,
+    certificationCourseRepository,
+    challengeRepository,
+    logger,
+  });
+  await events.eventDispatcher.dispatch(event);
+
+  logger.info('Done !');
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      logger.error(err);
+      process.exit(1);
+    }
+  );
+}


### PR DESCRIPTION
## :unicorn: Problème
Il peut arriver que toutes les étapes de la finalisation d'une session ne s'effectuent pas correctement. Dans ce cas, la session apparaît comme finalisée mais l'auto-jury, le rescoring ainsi que l'ajout d'une entrée dans la table `finalized-sessions` ne se fait pas. Cela a pour conséquence de ne pas placer cette session dans les sessions à traiter ou à publier et empêche le pôle certification de pouvoir s'assigner la session. 

## :robot: Solution
Ajouter un script permettant de lancer l'auto jury pour une session de certification.

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certifsup@example.net`
- Créer une session de certification et y ajouter un candidat
- Passer la certification avec le compte `certif-success@example.net`
- Aller dans la page de finalisation et ajouter un signalement E1: L'image ne s'affiche pas sur la question 1
- Aller en base et rajouter une date de finalisation à la session.
- Vérifier dans Pix Admin que la session ne se trouve ni dans la liste des sessions à publier ni dans celles à traiter
-  Exécuter le script pour la session `scalingo -a pix-api-review-pr4354 run "node scripts/launch-auto-jury-for-session.js <sessionId>"`
- Vérifier dans Pix Admin que la session est bien dans les sessions à traiter
- Aller dans le détail de la certification et vérifier que le signalement a bien été résolu 
