### PR TITLE
[BUGFIX] ajouter une marge au bloque d'information dans la page de création de campagne (PIX-4812)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -186,12 +186,12 @@
   {{/if}}
 
   {{#if this.isCampaignGoalProfileCollection}}
-    <div class="form__field-with-info">
-      <div class="form__field" aria-labelledby="multiple-sendings-label" role="radiogroup">
-        <p id="multiple-sendings-label" class="label">
-          <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "pages.campaign-creation.multiple-sendings.question-label"}}
-        </p>
+    <div class="form__field">
+      <p id="multiple-sendings-label" class="label">
+        <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
+        {{t "pages.campaign-creation.multiple-sendings.question-label"}}
+      </p>
+      <div class="form__field-with-info" aria-labelledby="multiple-sendings-label" role="radiogroup">
         <div class="form__radio-button">
           <input
             type="radio"
@@ -215,13 +215,13 @@
           />
           <label for="multiple-sendings-disabled">{{t "pages.campaign-creation.no"}}</label>
         </div>
-      </div>
-      <div class="form__field-info" id="multiple-sendings-info">
-        <span class="form__field-info-title">
-          <FaIcon @icon="info-circle" class="form__field-info-icon" />
-          <span>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</span>
-        </span>
-        <span class="form__field-info-message">{{t "pages.campaign-creation.multiple-sendings.info"}}</span>
+        <div class="form__field-info" id="multiple-sendings-info">
+          <span class="form__field-info-title">
+            <FaIcon @icon="info-circle" class="form__field-info-icon" />
+            <span>{{t "pages.campaign-creation.multiple-sendings.info-title"}}</span>
+          </span>
+          <span class="form__field-info-message">{{t "pages.campaign-creation.multiple-sendings.info"}}</span>
+        </div>
       </div>
     </div>
   {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
les bloques d'informations étaient verticalement collés lors qu'on sélectionnait "collecte de profils" lors de la création d'une campagne.

![image](https://user-images.githubusercontent.com/35958509/165313473-bc6401e0-3329-4823-a8fe-66b28a7b5422.png)

## :robot: Solution
Aligner le block info de droite du choix multiple aux radio-buttons de droites plutôt qu'au label. Cela permet de gagner un peu de marge sans pour autant trop modifier le fichier et l'apparence

## :rainbow: Remarques
Merci @yaelle6 <3

## :100: Pour tester
 1. se connecter à Pix Orga
 2. aller sur la page de création de campagne
 3. selectionner "Collecter les profils Pix des participants"
 4. Admirer les bloques à droite de la page et tester le responsive.
 5. Tadaaaa