### PR TITLE
[TECH] Ajout d'informations configurables dans les logs des frontaux

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -9,7 +9,17 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"';
+  ' user_agent="$http_user_agent"'<%#
+    To allow dynamic logging format for nginx,
+    create a json that contains the key/value pairs
+    you want to add to nginx logging.
+    For the logs to be correctly parsed, use the nginx_logger_version parameter.
+    For example:
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+  %><%
+    require 'json';
+    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
+  ' <%= nginx_key %>="<%= value %>"'<% end %>;
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -9,7 +9,17 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"';
+  ' user_agent="$http_user_agent"'<%#
+    To allow dynamic logging format for nginx,
+    create a json that contains the key/value pairs
+    you want to add to nginx logging.
+    For the logs to be correctly parsed, use the nginx_logger_version parameter.
+    For example:
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+  %><%
+    require 'json';
+    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
+  ' <%= nginx_key %>="<%= value %>"'<% end %>;
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -9,11 +9,17 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"'
-  ' bln_ja3="$http_bln_ssl_ja3_hash"'
-  ' bln_fate="$http_bln_request_fate"'
-  ' bln_fate_action="$http_bln_request_fate_action"'
-  ' bln_debug_path="$http_bln_debug_path"';
+  ' user_agent="$http_user_agent"'<%#
+    To allow dynamic logging format for nginx,
+    create a json that contains the key/value pairs
+    you want to add to nginx logging.
+    For the logs to be correctly parsed, use the nginx_logger_version parameter.
+    For example:
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+  %><%
+    require 'json';
+    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
+  ' <%= nginx_key %>="<%= value %>"'<% end %>;
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -9,7 +9,11 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"';
+  ' user_agent="$http_user_agent"'
+  ' bln_ja3="$http_bln_ssl_ja3_hash"'
+  ' bln_fate="$http_bln_request_fate"'
+  ' bln_fate_action="$http_bln_request_fate_action"'
+  ' bln_debug_path="$http_bln_debug_path"';
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -9,7 +9,17 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"';
+  ' user_agent="$http_user_agent"'<%#
+    To allow dynamic logging format for nginx,
+    create a json that contains the key/value pairs
+    you want to add to nginx logging.
+    For the logs to be correctly parsed, use the nginx_logger_version parameter.
+    For example:
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+  %><%
+    require 'json';
+    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
+  ' <%= nginx_key %>="<%= value %>"'<% end %>;
 
 # In order to avoid logging access twice per request
 # it is necessary to turn off the top-level (e.g. http) buildpack default access_log


### PR DESCRIPTION
## :unicorn: Problème
Nous manquons d'informations dans les logs pour le suivi des requêtes sur la plateforme

## :robot: Solution
Dumper les headers présents lors de la requête au front via Nginx, en les listant dans une variable d'environnement, et en utilisant cette liste en tant que paramètre pour la configuration Nginx. 

## :100: Pour tester
Appeler le site de test de Baleen branché sur la RA
Appeler en direct l'application sur scalingo
Vérifier que les logs correspondent bien à ceux définis dans les variables d'environnement
