### PR TITLE
[FEATURE] Modifier "Ajouter des candidats" en "Inscrire des candidats" dans Pix Certif (PIX-3007).

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -98,7 +98,7 @@
             type="button"
             class="bottom-action-bar__actions--add-button {{if this.shouldEnableAddButton '' 'button--disabled'}}"
           >
-            Ajouter
+            Inscrire
           </PixButton>
         </div>
       </div>

--- a/certif/app/components/certification-candidates-sco.hbs
+++ b/certif/app/components/certification-candidates-sco.hbs
@@ -1,9 +1,9 @@
 <div class="panel">
   <div class="certification-candidates-sco-actions">
     <img src="/images/adding_candidate.svg" alt="" role="none" />
-    <p>Ajouter une liste d'élèves et c'est partix !</p>
+    <p>Inscrivez des élèves et c'est partix !</p>
     <PixButtonLink @route="authenticated.sessions.add-student" @model={{@sessionId}}>
-      Ajouter des candidats
+      Inscrire des candidats
     </PixButtonLink>
   </div>
 </div>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -9,7 +9,7 @@
         @model={{@sessionId}}
         class="enrolled-candidate__add-students"
       >
-        Ajouter des candidats
+        Inscrire des candidats
       </PixButtonLink>
     {{else}}
       <PixButton
@@ -18,7 +18,7 @@
         @triggerAction={{this.openNewCertificationCandidateModal}}
         @size="small"
       >
-        Ajouter un candidat
+        Inscrire un candidat
       </PixButton>
     {{/if}}
   </div>

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -4,7 +4,7 @@
       <div class="panel-actions__header-icon">
         <FaIcon @icon="info" />
       </div>
-      <div class="panel-actions__header-title">Ajouter des candidats</div>
+      <div class="panel-actions__header-title">Inscrire des candidats</div>
     </div>
     <div class="panel-actions__action-row">
       <div class="panel-actions__action-icon">
@@ -12,10 +12,10 @@
       </div>
       <div class="panel-actions__description">
         <div class="panel-actions__title">Télécharger le modèle de liste des candidats</div>
-        <div>Pour ajouter des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document.
+        <div>Pour inscrire des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document.
           <br />
           Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les
-          informations des candidats ajoutés à la session.
+          informations des candidats inscrits à la session.
         </div>
       </div>
       <div class="panel-actions__button">
@@ -66,7 +66,7 @@
         <div class="panel-actions__description">
           <strong class="panel-actions__warning">
             La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la
-            liste, vous pouvez ajouter un candidat directement dans le tableau ci-dessous.
+            liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.
           </strong>
         </div>
       {{/if}}

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -322,7 +322,7 @@
       Fermer
     </PixButton>
     <PixButton @type="submit" form="new-certification-candidate-form">
-      Ajouter le candidat
+      Inscrire le candidat
     </PixButton>
   </:footer>
 </PixModal>

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -7,7 +7,7 @@
     class="add-student__return-to"
   >Retour à la session</PixReturnTo>
 
-  <h1 class="add-student__title">Ajouter des candidats</h1>
+  <h1 class="add-student__title">Inscrire des candidats</h1>
   <PixMessage @type="info" @withIcon={{true}} class="add-student__info-message">
     Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.<br
     />

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -75,19 +75,19 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
     test('it should be possible to access student add page', async function (assert) {
       // when
       await visit(`/sessions/${session.id}/candidats`);
-      await clickByLabel('Ajouter des candidats');
+      await clickByLabel('Inscrire des candidats');
 
       // then
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(currentURL(), `/sessions/${session.id}/ajout-eleves`);
-      assert.dom('.add-student__title').hasText('Ajouter des candidats');
+      assert.dom('.add-student__title').hasText('Inscrire des candidats');
     });
 
     test('it should be possible to return to candidates page from add student page', async function (assert) {
       // when
       await visit(`/sessions/${session.id}/candidats`);
-      await clickByLabel('Ajouter des candidats');
+      await clickByLabel('Inscrire des candidats');
       await clickByLabel('Retour à la session');
 
       // then
@@ -100,7 +100,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       test('it should show a empty list', async function (assert) {
         // when
         await visit(`/sessions/${session.id}/candidats`);
-        await clickByLabel('Ajouter des candidats');
+        await clickByLabel('Inscrire des candidats');
 
         // then
         assert.dom('.add-student-list').doesNotExist();
@@ -121,7 +121,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
         // when
         await visit(`/sessions/${session.id}/candidats`);
-        await clickByLabel('Ajouter des candidats');
+        await clickByLabel('Inscrire des candidats');
         await click('.pix-multi-select-header__search-input');
         await clickByLabel('3A');
 
@@ -141,7 +141,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
           // when
           await visit(`/sessions/${session.id}/candidats`);
-          await clickByLabel('Ajouter des candidats');
+          await clickByLabel('Inscrire des candidats');
 
           // then
           const allRow = document.querySelectorAll(rowSelector);
@@ -158,7 +158,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             // given
             server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
             await visit(`/sessions/${session.id}/candidats`);
-            await clickByLabel('Ajouter des candidats');
+            await clickByLabel('Inscrire des candidats');
 
             // when
             const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
@@ -183,7 +183,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             // given
             server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
             await visit(`/sessions/${session.id}/candidats`);
-            await clickByLabel('Ajouter des candidats');
+            await clickByLabel('Inscrire des candidats');
 
             // given
             const checkbox = document.querySelector(rowSelector + ' ' + checkboxSelector);
@@ -203,12 +203,12 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
               // given
               server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
               await visit(`/sessions/${session.id}/candidats`);
-              await clickByLabel('Ajouter des candidats');
+              await clickByLabel('Inscrire des candidats');
               const checkbox = document.querySelector(rowSelector + ' ' + checkboxSelector);
               await click(checkbox);
 
               // when
-              await clickByLabel('Ajouter');
+              await clickByLabel('Inscrire');
 
               // then
               // TODO: Fix this the next time the file is edited.
@@ -220,7 +220,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
               // given
               server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
               await visit(`/sessions/${session.id}/candidats`);
-              await clickByLabel('Ajouter des candidats');
+              await clickByLabel('Inscrire des candidats');
               const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
               const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
               const thirdCheckbox = document.querySelector(rowSelector + ':nth-child(3) ' + checkboxSelector);
@@ -230,7 +230,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
               const detailController = this.owner.lookup('controller:authenticated.sessions.details');
 
               // when
-              await clickByLabel('Ajouter');
+              await clickByLabel('Inscrire');
 
               // then
               const certificationCandidates = await detailController.model.certificationCandidates;
@@ -258,7 +258,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             sessionId: sessionWithEnrolledStudent.id,
           });
           await visit(`/sessions/${sessionWithEnrolledStudent.id}/candidats`);
-          await clickByLabel('Ajouter des candidats');
+          await clickByLabel('Inscrire des candidats');
         });
 
         test('it should show "1 candidat sélectionné | 1 candidat déjà ajouté à la session"', async function (assert) {

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -233,7 +233,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           assert
             .dom('.panel-actions__warning')
             .hasText(
-              'La session a débuté, vous ne pouvez plus importer une liste de candidats.Si vous souhaitez modifier la liste, vous pouvez ajouter un candidat directement dans le tableau ci-dessous.'
+              'La session a débuté, vous ne pouvez plus importer une liste de candidats.Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.'
             );
         });
       });
@@ -263,10 +263,10 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
         // when
         const screen = await visitScreen(`/sessions/${sessionWithoutCandidates.id}/candidats`);
-        await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
+        await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
 
         // then
-        assert.contains('Ajouter le candidat');
+        assert.contains('Inscrire le candidat');
       });
 
       module('when the new candidate form is submitted', function () {
@@ -290,9 +290,9 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
           // when
           const screen = await visitScreen(`/sessions/${session.id}/candidats`);
-          await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
+          await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
           await _fillFormWithCorrectData(screen);
-          await click(screen.getByRole('button', { name: 'Ajouter le candidat' }));
+          await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
           // then
           assert.dom('[data-test-notification-message="error"]').hasText('An error message');
@@ -307,9 +307,9 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           test('it should display a success notification', async function (assert) {
             // when
             const screen = await visitScreen(`/sessions/${session.id}/candidats`);
-            await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
+            await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
             await _fillFormWithCorrectData(screen);
-            await click(screen.getByRole('button', { name: 'Ajouter le candidat' }));
+            await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
             // then
             assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été ajouté avec succès.');
@@ -318,9 +318,9 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           test('it should add a new candidate', async function (assert) {
             // when
             const screen = await visitScreen(`/sessions/${session.id}/candidats`);
-            await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
+            await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
             await _fillFormWithCorrectData(screen);
-            await click(screen.getByRole('button', { name: 'Ajouter le candidat' }));
+            await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
             // then
             assert.dom('table tbody tr').exists({ count: 1 });
@@ -332,7 +332,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               allowedCertificationCenterAccess.update({ type: 'SUP' });
 
               const screen = await visitScreen(`/sessions/${session.id}/candidats`);
-              await click(screen.getByRole('button', { name: 'Ajouter un candidat' }));
+              await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
               await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
               await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
               await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
@@ -345,7 +345,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               await fillIn(screen.getByLabelText('Code de prépaiement'), '12345');
 
               // when
-              await click(screen.getByRole('button', { name: 'Ajouter le candidat' }));
+              await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
               // then
               assert.dom('table tbody tr').exists({ count: 1 });

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -192,11 +192,11 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
         // then
         if (multipleButtonVisible) {
-          assert.dom(screen.getByRole('link', { name: 'Ajouter des candidats' })).isVisible();
-          assert.dom(screen.queryByRole('button', { name: 'Ajouter un candidat' })).isNotVisible();
+          assert.dom(screen.getByRole('link', { name: 'Inscrire des candidats' })).isVisible();
+          assert.dom(screen.queryByRole('button', { name: 'Inscrire un candidat' })).isNotVisible();
         } else {
-          assert.dom(screen.queryByRole('link', { name: 'Ajouter des candidats' })).isNotVisible();
-          assert.dom(screen.getByRole('button', { name: 'Ajouter un candidat' })).isVisible();
+          assert.dom(screen.queryByRole('link', { name: 'Inscrire des candidats' })).isNotVisible();
+          assert.dom(screen.getByRole('button', { name: 'Inscrire un candidat' })).isVisible();
         }
       })
     );

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -463,7 +463,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       );
       await fillIn(screen.getByLabelText('E-mail de convocation'), 'roooooar@example.net');
 
-      await clickByLabel('Ajouter le candidat');
+      await clickByLabel('Inscrire le candidat');
 
       // then
       // TODO: Fix this the next time the file is edited.


### PR DESCRIPTION
## :unicorn: Problème
Lors d’un event storming certif, nous avons acté que l’action d’ajouter un candidat à une session de certification correspond en fait à inscrire un candidat. Il s’agit donc de répercuter cette notion dans Pix Certif.

## :robot: Solution
Modifier "Ajouter des candidats" en "Inscrire des candidats" dans Pix Certif

## :100: Pour tester
Checker les pages impactées
