### PR TITLE
[TECH] Réparation d'un test flaky sur le test auto du script de création de badge-criteria à partir d'un fichier JSON (PIX-4828)

### DIFF
--- a/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
+++ b/api/tests/integration/scripts/create-badge-criteria-for-specified-badge_test.js
@@ -168,14 +168,16 @@ describe('Integration | Scripts | create-badge-criteria-for-specified-badge', fu
       const oldBadgeId = databaseBuilder.factory.buildBadge({ key: 'OLD' }).id;
       const newBadgeId = databaseBuilder.factory.buildBadge({ key: 'NEW' }).id;
       const skillSet1 = databaseBuilder.factory.buildSkillSet({
+        id: 123,
         badgeId: oldBadgeId,
         skillIds: ['skillABC123', 'skillDEF456'],
       });
       const skillSet2 = databaseBuilder.factory.buildSkillSet({
+        id: 456,
         badgeId: oldBadgeId,
         skillIds: ['skillHIJ789', 'skillKLM123'],
       });
-      const skillSetIds = [skillSet1.id, skillSet2.id];
+      const skillSetIds = [123, 456];
       await databaseBuilder.commit();
 
       // when
@@ -184,7 +186,7 @@ describe('Integration | Scripts | create-badge-criteria-for-specified-badge', fu
       // then
       expect(newSkillSetIds).to.have.lengthOf(2);
 
-      const [newSkillSet1, newSkillSet2] = await knex('skill-sets').whereIn('id', newSkillSetIds);
+      const [newSkillSet1, newSkillSet2] = await knex('skill-sets').whereIn('id', newSkillSetIds).orderBy('id');
       expect(newSkillSet1.skillIds).to.deep.equal(skillSet1.skillIds);
       expect(newSkillSet1.badgeId).to.equal(newBadgeId);
       expect(newSkillSet2.skillIds).to.deep.equal(skillSet2.skillIds);


### PR DESCRIPTION
## :unicorn: Problème
Un des tests auto du script `create-badge-criteria-for-specified-badge_test.js` est flaky.
![flaky_test](https://user-images.githubusercontent.com/48727874/164527520-4019e41c-8985-488c-bd1a-62ff1416aa90.png)
Quand on y regarde de plus près, on compare une liste d'IDs récupérés depuis une requête SQL qui n'a pas d'`orderBy`

## :robot: Solution
- Ajouter un `orderBy` dans la requête pour garantir l'ordre de récupération des résultats
- De plus, j'ai remarqué l'usage honni de `Promise.all` dans le script, je me suis permis de le remplacer par `bluebird.mapSeries`

## :rainbow: Remarques
Pourquoi favoriser `bluebird.mapSeries` à `Promise.all` ?
- La perte de temps liée au fait de traiter les items les uns après les autres est loin d'être remarquable
- Un Promise.all dont la callback contient des appels BDD est très risqué. En effet, si jamais `n` items sont contenus dans la collection parcourue, alors les `n` appels BDD correspondant vont être lancés en même temps. Donc ce script réservera `n` connexions à la BDD, privant l'API parfois surchargée de ces précieuses connexions. Aucun intérêt de tout faire en même temps.

