### PR TITLE
[FEATURE] Ajout de la version condensée de la pagination sur les pages de tutoriels (PIX-4837).

### DIFF
--- a/mon-pix/app/templates/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/user-tutorials/recommended.hbs
@@ -1,7 +1,7 @@
 {{#if @model.meta.rowCount}}
   <div class="user-tutorials-content-v2__container">
     <Tutorials::Cards @tutorials={{@model}} />
-    <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} />
+    <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} @isCondensed="true" />
   </div>
 {{else}}
   <Tutorials::RecommendedEmpty />

--- a/mon-pix/app/templates/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/user-tutorials/saved.hbs
@@ -1,7 +1,7 @@
 {{#if @model.meta.rowCount}}
   <div class="user-tutorials-content-v2__container">
     <Tutorials::Cards @tutorials={{@model}} @afterRemove={{this.refresh}} />
-    <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} />
+    <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} @isCondensed="true" />
   </div>
 {{else}}
   <Tutorials::SavedEmpty />


### PR DESCRIPTION
## :unicorn: Problème

Nous ne souhaitons pas avoir accès au choix du nombre d'éléments par page sur les deux nouvelles pages de tutos.

## :robot: Solution

Ajout de la propriété `@isCondensed=true` au composant de pagination sur les deux nouvelles pages.

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur les pages de tutos `recommandes` et `enregistres`, vérifier que le sélecteur du nombre d'éléments à afficher par page ne soit pas affiché dans le composant de pagination.
