### PR TITLE
[BUGFIX] Uniformiser la taille du contenu de la page "Mes Certifications" sur Pix App (PIX-4825).

### DIFF
--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -81,7 +81,7 @@
       'main main main certif'
       'main main main certif'
       'main main main certif';
-    padding: 0 20px;
+    padding: 0;
 
     .dashboard-banner {
       display: none;

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -1,4 +1,4 @@
 .page-container {
-  max-width: 1280px;
+  max-width: 1240px;
   margin: 0 auto;
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la page "Mes Certifications" sur Pix App n'a pas un alignement uniforme par rapport aux autres pages sur l'application.

## :robot: Solution
Corriger cet alignement.

## :rainbow: Remarques
Toutes les pages ont un format en 1240 pixels.

## :100: Pour tester
- Se connecter sur Pix App avec l'utilisateur `sco.admin@example.net`
- Cliquer sur le menu en haut à droite
- Cliquer sur le bouton Mes Certifications
- Constater que le contenu est aligné : 
  - Sur le domaine FR > entre le logo de la Marianne sur la barre de navigation et le titre "Mes Certifications"
  - Sur le domaine ORG > entre le logo Pix de la barre de navigation et le titre "Mes Certifications"
