### PR TITLE
[FEATURE] Utiliser le vocabulaire métier "Inscrire un candidat" (PIX-4835).

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -81,7 +81,7 @@
           <span class="bottom-action-bar__seperator"></span>
           <p class="bottom-action-bar__informations--candidates-already-added">
             {{this.numberOfStudentsAlreadyCandidate}}
-            candidat(s) déjà ajouté(s) à la session
+            candidat(s) déjà inscrit(s) à la session
           </p>
         </div>
 

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -73,9 +73,9 @@ export default class AddStudentList extends Component {
     try {
       await this.args.session.save({ adapterOptions: { studentListToAdd, sessionId } });
       this.args.returnToSessionCandidates(sessionId);
-      this.notifications.success('Le(s) candidat(s) ont été ajouté(s) avec succès.');
+      this.notifications.success('Le(s) candidat(s) ont été inscrit(s) avec succès.');
     } catch (error) {
-      let errorMessage = 'Une erreur est survenue au moment d‘enregistrer les candidats...';
+      let errorMessage = 'Une erreur est survenue au moment d‘inscrire les candidats...';
       if (error.errors?.[0]?.status === '422') errorMessage = error.errors?.[0]?.detail;
       this.notifications.error(errorMessage);
     }

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -105,7 +105,7 @@ export default class EnrolledCandidates extends Component {
         adapterOptions: { registerToSession: true, sessionId: this.args.sessionId },
       });
       this.args.reloadCertificationCandidate();
-      this.notifications.success('Le candidat a été ajouté avec succès.');
+      this.notifications.success('Le candidat a été inscrit avec succès.');
       return true;
     } catch (err) {
       if (this._hasConflict(err)) {

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,4 +1,4 @@
-<PixModal @title="Ajouter un candidat" @onCloseButtonClick={{@closeModal}} class="new-certification-candidate-modal">
+<PixModal @title="Inscrire un candidat" @onCloseButtonClick={{@closeModal}} class="new-certification-candidate-modal">
   <:content>
     <form
       id="new-certification-candidate-form"

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -30,7 +30,7 @@ Router.map(function () {
         this.route('parameters', { path: '/' });
         this.route('certification-candidates', { path: '/candidats' });
       });
-      this.route('add-student', { path: '/:session_id/ajout-eleves' });
+      this.route('add-student', { path: '/:session_id/inscription-eleves' });
     });
     this.route('team', { path: '/equipe' });
   });

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -45,9 +45,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await visit(`/sessions/${session.id}/ajout-eleves`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -66,9 +64,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
         await visit(`/sessions/${session.id}/ajout-eleves`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/espace-ferme');
+        assert.strictEqual(currentURL(), '/espace-ferme');
       });
     });
 
@@ -78,9 +74,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await clickByLabel('Inscrire des candidats');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/sessions/${session.id}/ajout-eleves`);
+      assert.strictEqual(currentURL(), `/sessions/${session.id}/ajout-eleves`);
       assert.dom('.add-student__title').hasText('Inscrire des candidats');
     });
 
@@ -91,9 +85,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await clickByLabel('Retour à la session');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
+      assert.strictEqual(currentURL(), `/sessions/${session.id}/candidats`);
     });
 
     module('when there are no students', function () {
@@ -127,9 +119,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
         // then
         const studentRows = document.querySelectorAll(rowSelector);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(studentRows.length, 2);
+        assert.strictEqual(studentRows.length, 2);
       });
 
       module('when there are no enrolled students', function () {
@@ -145,9 +135,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
           // then
           const allRow = document.querySelectorAll(rowSelector);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
+          assert.strictEqual(allRow.length, DEFAULT_PAGE_SIZE);
         });
 
         module('when selecting some students', function () {
@@ -170,13 +158,9 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
             // then
             const allRow = document.querySelectorAll(rowSelector);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
+            assert.strictEqual(allRow.length, DEFAULT_PAGE_SIZE);
             const checkboxChecked = document.querySelectorAll(checkboxCheckedSelector);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(checkboxChecked.length, 3);
+            assert.strictEqual(checkboxChecked.length, 3);
           });
 
           test('it should be possible to cancel enrolling students', async function (assert) {
@@ -193,9 +177,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             await clickByLabel('Annuler');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
+            assert.strictEqual(currentURL(), `/sessions/${session.id}/candidats`);
           });
 
           module('when clicking on "Ajout"', function () {
@@ -211,9 +193,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
               await clickByLabel('Inscrire');
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
+              assert.strictEqual(currentURL(), `/sessions/${session.id}/candidats`);
             });
 
             test('it should add students as certification candidates', async function (assert) {
@@ -234,9 +214,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
 
               // then
               const certificationCandidates = await detailController.model.certificationCandidates;
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(certificationCandidates.length, 3);
+              assert.strictEqual(certificationCandidates.length, 3);
             });
           });
         });

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -42,7 +42,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
   module('When certificationPointOfContact is not logged in', function () {
     test('it should not be accessible by an unauthenticated certificationPointOfContact', async function (assert) {
       // when
-      await visit(`/sessions/${session.id}/ajout-eleves`);
+      await visit(`/sessions/${session.id}/inscription-eleves`);
 
       // then
       assert.strictEqual(currentURL(), '/connexion');
@@ -61,7 +61,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
         allowedCertificationCenterAccess.update({ isAccessBlockedCollege: true });
 
         // when
-        await visit(`/sessions/${session.id}/ajout-eleves`);
+        await visit(`/sessions/${session.id}/inscription-eleves`);
 
         // then
         assert.strictEqual(currentURL(), '/espace-ferme');
@@ -74,7 +74,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await clickByLabel('Inscrire des candidats');
 
       // then
-      assert.strictEqual(currentURL(), `/sessions/${session.id}/ajout-eleves`);
+      assert.strictEqual(currentURL(), `/sessions/${session.id}/inscription-eleves`);
       assert.dom('.add-student__title').hasText('Inscrire des candidats');
     });
 

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -216,6 +216,27 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
               const certificationCandidates = await detailController.model.certificationCandidates;
               assert.strictEqual(certificationCandidates.length, 3);
             });
+
+            test('it should display confirmation message', async function (assert) {
+              // given
+              server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
+              await visit(`/sessions/${session.id}/candidats`);
+              await clickByLabel('Inscrire des candidats');
+              const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
+              const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
+              const thirdCheckbox = document.querySelector(rowSelector + ':nth-child(3) ' + checkboxSelector);
+              await click(firstCheckbox);
+              await click(secondCheckbox);
+              await click(thirdCheckbox);
+
+              // when
+              await clickByLabel('Inscrire');
+
+              // then
+              assert
+                .dom('[data-test-notification-message="success"]')
+                .hasText('Le(s) candidat(s) ont été inscrit(s) avec succès.');
+            });
           });
         });
       });

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -239,7 +239,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
           await clickByLabel('Inscrire des candidats');
         });
 
-        test('it should show "1 candidat sélectionné | 1 candidat déjà ajouté à la session"', async function (assert) {
+        test('it should show label accordingly', async function (assert) {
           // given
           const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
           const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
@@ -250,7 +250,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
           await click(firstCheckbox);
 
           // then
-          assert.dom(candidatesEnrolledSelector).includesText('1 candidat(s) déjà ajouté(s) à la session');
+          assert.dom(candidatesEnrolledSelector).includesText('1 candidat(s) déjà inscrit(s) à la session');
           assert.dom(candidatesSelectedSelector).includesText('1 candidat(s) sélectionné(s)');
         });
 
@@ -280,7 +280,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
             await click(toggleAllCheckBox);
 
             // then
-            assert.dom(candidatesEnrolledSelector).includesText('1 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesEnrolledSelector).includesText('1 candidat(s) déjà inscrit(s) à la session');
             assert.dom(candidatesSelectedSelector).includesText('1 candidat(s) sélectionné(s)');
           });
         });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -312,7 +312,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
             // then
-            assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été ajouté avec succès.');
+            assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été inscrit avec succès.');
           });
 
           test('it should add a new candidate', async function (assert) {

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -284,7 +284,7 @@ module('Integration | Component | add-student-list', function (hooks) {
         });
 
         module('when there are 2 selected students', () => {
-          test('it should show "2 candidat(s) sélectionné(s) | 0 candidat déjà ajoutés à la session"', async function (assert) {
+          test('it should display a label accordingly', async function (assert) {
             // given
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
             const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
@@ -316,7 +316,7 @@ module('Integration | Component | add-student-list', function (hooks) {
             </AddStudentList>`);
 
             // then
-            assert.dom(candidatesEnrolledSelector).includesText('0 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesEnrolledSelector).includesText('0 candidat(s) déjà inscrit(s) à la session');
             assert.dom(candidatesSelectedSelector).includesText('2 candidat(s) sélectionné(s)');
           });
         });
@@ -353,11 +353,11 @@ module('Integration | Component | add-student-list', function (hooks) {
             </AddStudentList>`);
           });
 
-          test('it should show "Aucun candidat sélectionné | 2 candidat(s) déjà ajouté(s) à la session"', async function (assert) {
+          test('it should display a label accordingly', async function (assert) {
             // then
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
             const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
-            assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà inscrit(s) à la session');
             assert.dom(candidatesSelectedSelector).includesText('Aucun candidat sélectionné');
           });
 
@@ -400,11 +400,11 @@ module('Integration | Component | add-student-list', function (hooks) {
             </AddStudentList>`);
           });
 
-          test('it should show "2 candidat(s) sélectionné(s) | 2 candidat(s) déjà ajouté(s) à la session"', async function (assert) {
+          test('it should display a label accordingly', async function (assert) {
             // then
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
             const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
-            assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà inscrit(s) à la session');
             assert.dom(candidatesSelectedSelector).includesText('2 candidat(s) sélectionné(s)');
           });
 
@@ -443,7 +443,7 @@ module('Integration | Component | add-student-list', function (hooks) {
           await click(addButton);
           assert.ok(
             notificationMessagesService.error.calledOnceWith(
-              'Une erreur est survenue au moment d‘enregistrer les candidats...'
+              'Une erreur est survenue au moment d‘inscrire les candidats...'
             )
           );
         });


### PR DESCRIPTION
## :unicorn: Problème
L'inscription de candidat est encore désignée comme ajout de candidats dans certains endroits après  #4357 .

## :robot: Solution
Utiliser "Inscrire des candidats"

## :rainbow: Remarques
Modification des libellés de test .
Ajout d'un test manquant.

## :100: Pour tester

Inscrire 
- un candidat PRO
- un candidat dans une organisation `isManagingStudents === true` (ex: `certifsco@example.net`)

Vérifier
- nom de la modale
- message de confirmation

![image](https://user-images.githubusercontent.com/56302715/165300538-938b9d20-a44c-440c-b8b9-7d7e58946ee6.png)
![image](https://user-images.githubusercontent.com/56302715/165300647-5be0608c-0fb6-4eae-8636-043ea96b13fb.png)

