### PR TITLE
[TECH] Suppression de la variable d'environnement FT_NEW_TUTORIALS_PAGE de l'api (PIX-4838).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -167,9 +167,7 @@ module.exports = (function () {
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
     },
 
-    featureToggles: {
-      isNewTutorialsPageEnabled: isFeatureEnabled(process.env.FT_NEW_TUTORIALS_PAGE),
-    },
+    featureToggles: {},
 
     infra: {
       concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -26,7 +26,6 @@ const schema = Joi.object({
   LOG_OPS_METRICS: Joi.string().optional().valid('true', 'false'),
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
-  FT_NEW_TUTORIALS_PAGE: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -18,17 +18,6 @@
 #
 
 # =======
-# FEATURE-TOGGLE
-# =======
-
-# Prevent user from seeing the tutorial page in progress
-#
-# presence: optional
-# type: boolean
-# default: false
-FT_NEW_TUTORIALS_PAGE
-
-# =======
 # CACHING
 # =======
 

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -20,9 +20,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
       const expectedData = {
         data: {
           id: '0',
-          attributes: {
-            'is-new-tutorials-page-enabled': false,
-          },
           type: 'feature-toggles',
         },
       };


### PR DESCRIPTION
## :unicorn: Problème

Nous remplaçons bientôt la toute première version de la page de tutoriels par une nouvelle. La variable d'env n'est plus nécessaire.

## :robot: Solution

Suppression de la variable d'env côté API et côté RA

## :rainbow: Remarques
N/A

## :100: Pour tester

Vérifier que la nouvelle page de tutos sur `pix-app` s'affiche normalement et que les fonctionnalités d'enregistrement et d'appréciation des tutoriels fonctionne.
