### PR TITLE
[A11Y] Ajouter un rôle img au contenant des paliers + ajouter un texte alternatif (PIX-4244)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-stage.hbs
+++ b/orga/app/components/campaign/charts/participants-by-stage.hbs
@@ -9,8 +9,9 @@
             @count={{stage.index}}
             @total={{this.totalStage}}
             @color="blue"
+            @alt={{t "charts.participants-by-stage.label-a11y" stage=stage.index totalStage=this.totalStage}}
             class="participants-by-stage__stars"
-            aria-hidden="true"
+            role="img"
           />
           <div class="participants-by-stage__values">
             {{t "charts.participants-by-stage.participants" count=stage.value}}

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -90,7 +90,8 @@
       "loader": "Loading and sorting the participants grouped by success rates",
       "participants": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}}",
       "percentage": "{percentage} %",
-      "title": "Distribution of participants grouped by success rate"
+      "title": "Distribution of participants grouped by success rate",
+      "label-a11y": "{stage} out of {totalStage} stages"
     },
     "participants-by-status": {
       "labels-tooltip": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -90,7 +90,8 @@
       "loader": "Chargement de la répartition des participants par paliers",
       "participants": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",
       "percentage": "{percentage} %",
-      "title": "Répartition des participants par paliers"
+      "title": "Répartition des participants par paliers",
+      "label-a11y": "Palier {stage} sur {totalStage}"
     },
     "participants-by-status": {
       "labels-tooltip": {


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'audit accessibilité de l'application Pix Orga pour la page Résultat d'une campagne d'évaluation dans le graphe "Répartition des participations par paliers", lorsqu'elle en possède, les paliers sont affichés sous forme de groupe d'étoiles.
Ce groupe d'étoiles n'avait pas de rôle, ce qui provoquait une lecture de tout ce qui était à l'intérieur et donc qui alourdissait le rendu des lecteur d'écrans.
De plus, ce groupe d'image à la possibilité d'avoir une description, mais dans notre cas cette description était vide.

## :robot: Solution
Ajouter au groupe d'étoiles un rôle img afin de le considérer comme une image à part entière et lui ajouter une description adequate.

## :rainbow: Remarques
Le groupe d'étoiles est en fait constitué de plusieurs fois le même svg. Mais ce svg, n'a pas de role=img. Il faudrait donc rajouter ce role coté pix-ui.

## :100: Pour tester
- se connecter à pix orga et choisir une campagne d'éval avec paliers.
- constater qu'il y a un role=img et un sr-only rempli au groupe d'étoiles dans le graphe "Répartition des participations par paliers"
