### PR TITLE
[CLEANUP] Mise à jour de l'auto merge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: pascalgn/automerge-action@v0.14.3
+        uses: pascalgn/automerge-action@v0.15.2
         env:
           GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
           MERGE_LABELS: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -20,3 +20,4 @@ jobs:
           UPDATE_LABELS: ':rocket: Ready to Merge'
           UPDATE_METHOD: rebase
           MERGE_FORKS: 'false'
+          MERGE_REQUIRED_APPROVALS: 1


### PR DESCRIPTION
## :unicorn: Problème
L'action d'automerge n'est pas a jour et ne vérifie pas que la PR est approuvé.

## :robot: Solution
Mettre à jour l'automerge et rajouter l’obligation d'au moins une review

## :100: Pour tester
:shrug: 
