### PR TITLE
[TECH] Harmoniser le texte du formulaire de connexion sur Pix Admin (PIX-4852).

### DIFF
--- a/admin/app/components/login-form.hbs
+++ b/admin/app/components/login-form.hbs
@@ -30,6 +30,6 @@
   </div>
 
   <div class="login-form__control">
-    <PixButton @type="submit" @size="small" class="login-form__button">Connexion</PixButton>
+    <PixButton @type="submit" @size="small" class="login-form__button">Je me connecte</PixButton>
   </div>
 </form>

--- a/admin/tests/integration/components/login-form_test.js
+++ b/admin/tests/integration/components/login-form_test.js
@@ -20,7 +20,7 @@ module('Integration | Component | login-form', function (hooks) {
     // then
     assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).exists();
     assert.dom(screen.getByLabelText('Mot de passe')).exists();
-    assert.dom(screen.getByRole('button', { name: 'Connexion' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Je me connecte' })).exists();
   });
 
   test('should hide error message by default', async function (assert) {

--- a/admin/tests/integration/components/login-form_test.js
+++ b/admin/tests/integration/components/login-form_test.js
@@ -13,13 +13,14 @@ const NOT_SUPER_ADMIN_MSG = "Vous n'avez pas les droits pour vous connecter.";
 module('Integration | Component | login-form', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
+  test('it displays a entry form', async function (assert) {
     // when
     const screen = await render(hbs`<LoginForm />`);
 
     // then
     assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).exists();
     assert.dom(screen.getByLabelText('Mot de passe')).exists();
+    assert.dom(screen.getByRole('button', { name: 'Connexion' })).exists();
   });
 
   test('should hide error message by default', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Dans les app mon-pix/certif/orga, le texte est “Je me connecte”
Dans admin, le texte est “connexion”

## :robot: Solution
Mettre “Je me connecte” dans PixAdmin

## :rainbow: Remarques
Ajout d'un test manquant

## :100: Pour tester
Visiter https://admin-pr4373.review.pix.fr/
