### PR TITLE
[FEATURE] Ajout d'un title aux nouvelles cartes de tutos (PIX-4836).

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -17,17 +17,18 @@
       {{moment-duration @tutorial.duration}}
     </p>
     <div class="tutorial-card-v2-content__actions">
-      <button
-        class="pix-action-chip {{if this.isTutorialEvaluated "pix-action-chip--selected"}}"
-        aria-label={{this.evaluateInformation}}
-        title={{this.evaluateInformation}}
-        type="button"
-        {{on "click" this.evaluateTutorial}}
-        disabled={{this.isTutorialEvaluated}}
-        aria-disabled="{{this.isTutorialEvaluated}}"
-      >
-        <FaIcon class="pix-action-chip__icon" @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
-      </button>
+      <div class="tutorial-card-v2-content-actions__evaluate" title={{this.evaluateInformation}}>
+        <button
+          class="pix-action-chip {{if this.isTutorialEvaluated "pix-action-chip--selected"}}"
+          aria-label={{this.evaluateInformation}}
+          type="button"
+          {{on "click" this.evaluateTutorial}}
+          disabled={{this.isTutorialEvaluated}}
+          aria-disabled="{{this.isTutorialEvaluated}}"
+        >
+          <FaIcon class="pix-action-chip__icon" @prefix={{if this.isTutorialEvaluated "fas" "far"}} @icon="thumbs-up" />
+        </button>
+      </div>
       <button
         class="pix-action-chip {{if this.isTutorialSaved "pix-action-chip--selected"}}"
         aria-label={{this.saveInformation}}

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -19,7 +19,8 @@
     <div class="tutorial-card-v2-content__actions">
       <button
         class="pix-action-chip {{if this.isTutorialEvaluated "pix-action-chip--selected"}}"
-        aria-label={{this.evaluateLabel}}
+        aria-label={{this.evaluateInformation}}
+        title={{this.evaluateInformation}}
         type="button"
         {{on "click" this.evaluateTutorial}}
         disabled={{this.isTutorialEvaluated}}
@@ -29,7 +30,8 @@
       </button>
       <button
         class="pix-action-chip {{if this.isTutorialSaved "pix-action-chip--selected"}}"
-        aria-label={{this.saveLabel}}
+        aria-label={{this.saveInformation}}
+        title={{this.saveInformation}}
         type="button"
         {{on "click" this.toggleSaveTutorial}}
         disabled={{this.isSaveButtonDisabled}}

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -17,13 +17,13 @@ export default class Card extends Component {
     this.evaluationStatus = args.tutorial.isEvaluated ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
   }
 
-  get saveLabel() {
+  get saveInformation() {
     return this.savingStatus === buttonStatusTypes.recorded
       ? this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.label')
       : this.intl.t('pages.user-tutorials.list.tutorial.actions.save.label');
   }
 
-  get evaluateLabel() {
+  get evaluateInformation() {
     return this.evaluationStatus === buttonStatusTypes.recorded
       ? this.intl.t('pages.user-tutorials.list.tutorial.actions.evaluate.label')
       : this.intl.t('pages.user-tutorials.list.tutorial.actions.evaluate.extra-information');

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -54,6 +54,13 @@
   }
 }
 
+.tutorial-card-v2-content-actions {
+
+  &__evaluate {
+    display: inline-block;
+  }
+}
+
 .pix-action-chip {
   $dark-blue: #2044DC;
 

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -30,16 +30,16 @@ describe('Acceptance | Tutorial | Actions', function () {
     it('should display tutorial item in competence page with actions', async function () {
       // then
       expect(find('.tutorial-card-v2')).to.exist;
-      expect(find('[aria-label="Donner mon avis sur ce tuto"]')).to.exist;
+      expect(find('[aria-label="Marquer ce tuto comme utile"]')).to.exist;
       expect(find('[aria-label="Enregistrer"]')).to.exist;
     });
 
     it('should disable evaluate action on click', async function () {
       // when
-      await click('[aria-label="Donner mon avis sur ce tuto"]');
+      await click('[aria-label="Marquer ce tuto comme utile"]');
 
       // then
-      expect(find('[aria-label="Tuto utile"]').disabled).to.be.true;
+      expect(find('[aria-label="Ce tuto m\'a été utile"]').disabled).to.be.true;
     });
 
     describe('when save action is clicked', function () {

--- a/mon-pix/tests/acceptance/user-tutorials/actions_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/actions_test.js
@@ -19,9 +19,9 @@ describe('Acceptance | User-tutorials-v2 | Actions', function () {
     it('should disable evaluate action on click', async function () {
       await visit('/mes-tutos/recommandes');
 
-      await click(find('[aria-label="Donner mon avis sur ce tuto"]'));
+      await click(find('[aria-label="Marquer ce tuto comme utile"]'));
 
-      expect(find('[aria-label="Tuto utile"]').disabled).to.be.true;
+      expect(find('[aria-label="Ce tuto m\'a été utile"]').disabled).to.be.true;
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -37,7 +37,7 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
         await visit('/mes-tutos/recommandes');
 
         // when
-        await click(find('[aria-label="Donner mon avis sur ce tuto"]'));
+        await click(find('[aria-label="Marquer ce tuto comme utile"]'));
 
         // then
         expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -5,7 +5,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | tutorial panel', function () {
+describe('Integration | Component | Tutorial Panel', function () {
   setupIntlRenderingTest();
 
   context('when the result is not ok', function () {
@@ -65,6 +65,7 @@ describe('Integration | Component | tutorial panel', function () {
           expect(find('.tutorial-card-v2-content__actions')).to.exist;
           expect(find('[aria-label="Donner mon avis sur ce tuto"]')).to.exist;
           expect(find('[aria-label="Enregistrer"]')).to.exist;
+          expect(find('[title="Marquer ce tuto comme utile"]')).to.exist;
         });
       });
 

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -63,7 +63,7 @@ describe('Integration | Component | Tutorial Panel', function () {
           expect(find('.tutorial-card-v2__content')).to.exist;
           expect(find('.tutorial-card-v2-content__details')).to.exist;
           expect(find('.tutorial-card-v2-content__actions')).to.exist;
-          expect(find('[aria-label="Donner mon avis sur ce tuto"]')).to.exist;
+          expect(find('[aria-label="Marquer ce tuto comme utile"]')).to.exist;
           expect(find('[aria-label="Enregistrer"]')).to.exist;
           expect(find('[title="Marquer ce tuto comme utile"]')).to.exist;
         });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -33,7 +33,7 @@ describe('Integration | Component | Tutorials | Card', function () {
       .and.contains('vidéo')
       .and.contains('une minute');
     expect(find('.tutorial-card-v2-content__actions')).to.exist;
-    expect(find('[aria-label="Tuto utile"]')).to.exist;
+    expect(find('[aria-label="Ce tuto m\'a été utile"]')).to.exist;
     expect(find('[aria-label="Retirer"]')).to.exist;
     expect(find('[title="Ce tuto m\'a été utile"]')).to.exist;
   });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -35,5 +35,6 @@ describe('Integration | Component | Tutorials | Card', function () {
     expect(find('.tutorial-card-v2-content__actions')).to.exist;
     expect(find('[aria-label="Tuto utile"]')).to.exist;
     expect(find('[aria-label="Retirer"]')).to.exist;
+    expect(find('[title="Ce tuto m\'a été utile"]')).to.exist;
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1489,8 +1489,8 @@
         "tutorial": {
           "actions": {
             "evaluate": {
-              "extra-information": "Give feedback on this tutorial",
-              "label": "Useful tutorial"
+              "extra-information": "Mark this tutorial as helpful",
+              "label": "This tutorial was useful to me"
             },
             "remove": {
               "extra-information": "Remove from my list of tutorials",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1488,8 +1488,8 @@
         "tutorial": {
           "actions": {
             "evaluate": {
-              "extra-information": "Donner mon avis sur ce tuto",
-              "label": "Tuto utile"
+              "extra-information": "Marquer ce tuto comme utile",
+              "label": "Ce tuto m'a été utile"
             },
             "remove": {
               "extra-information": "Retirer de ma liste de tutos",


### PR DESCRIPTION
## :unicorn: Problème

Sur les cartes de tutos, nous disposons à l'heure actuelle d'un `aria-label` permettant aux personnes ayant recours à des lecteurs d'écran d'avoir les informations relatives aux icônes d'enregistrement et d'appréciation des tutos.
Toutefois, pour les personnes n'étant pas familières aux icônes, nous souhaitons ajouter un attribut `title` permettant l'affichage natif des tooltips des navigateurs.

## :robot: Solution

Ajout d'un attribut `title` reprenant les mêmes descriptions que l'attribut `aria-label`

## :rainbow: Remarques

Nous modifions également les traductions de manière à être plus explicite.

## :100: Pour tester

Sur la page de tutos, vérifier que les boutons des cartes disposent à la fois des attributs `aria-label` et `title` avec les mêmes textes. (FR et ENG)
