### PR TITLE
[BUGFIX] Traduire les intitulés sur la présélection de profil cible (PIX-4855)

### DIFF
--- a/api/lib/domain/usecases/get-framework-areas.js
+++ b/api/lib/domain/usecases/get-framework-areas.js
@@ -18,7 +18,7 @@ module.exports = async function getFrameworkAreas({
   const competences = areasWithCompetences.flatMap((area) => area.competences);
 
   const competenceIds = competences.map(({ id: competenceId }) => competenceId);
-  const thematics = await thematicRepository.findByCompetenceIds(competenceIds);
+  const thematics = await thematicRepository.findByCompetenceIds(competenceIds, locale);
 
   const tubeIds = thematics.flatMap((thematic) => thematic.tubeIds);
   const tubes = await tubeRepository.findActiveByRecordIds(tubeIds, locale);

--- a/api/lib/domain/usecases/get-framework-areas.js
+++ b/api/lib/domain/usecases/get-framework-areas.js
@@ -13,7 +13,7 @@ module.exports = async function getFrameworkAreas({
     frameworkId = framework.id;
   }
 
-  const areasWithCompetences = await areaRepository.findByFrameworkIdWithCompetences(frameworkId);
+  const areasWithCompetences = await areaRepository.findByFrameworkIdWithCompetences({ frameworkId, locale });
 
   const competences = areasWithCompetences.flatMap((area) => area.competences);
 

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -1,21 +1,26 @@
 const Area = require('../../domain/models/Area');
 const areaDatasource = require('../datasources/learning-content/area-datasource');
 const competenceRepository = require('./competence-repository');
+const { getTranslatedText } = require('../../domain/services/get-translated-text');
 const _ = require('lodash');
 
-function _toDomain(areaData) {
+function _toDomain({ areaData, locale }) {
+  const translatedTitle = getTranslatedText(locale, {
+    frenchText: areaData.titleFrFr,
+    englishText: areaData.titleEnUs,
+  });
   return new Area({
     id: areaData.id,
     code: areaData.code,
     name: areaData.name,
-    title: areaData.titleFrFr,
+    title: translatedTitle,
     color: areaData.color,
   });
 }
 
 async function list() {
   const areaDataObjects = await areaDatasource.list();
-  return areaDataObjects.map(_toDomain);
+  return areaDataObjects.map((areaData) => _toDomain({ areaData }));
 }
 
 async function listWithPixCompetencesOnly({ locale } = {}) {
@@ -26,9 +31,9 @@ async function listWithPixCompetencesOnly({ locale } = {}) {
   return _.filter(areas, ({ competences }) => !_.isEmpty(competences));
 }
 
-async function findByFrameworkIdWithCompetences(frameworkId) {
+async function findByFrameworkIdWithCompetences({ frameworkId, locale }) {
   const areaDatas = await areaDatasource.findByFrameworkId(frameworkId);
-  const areas = areaDatas.map(_toDomain);
+  const areas = areaDatas.map((areaData) => _toDomain({ areaData, locale }));
   const competences = await competenceRepository.list();
   areas.forEach((area) => {
     area.competences = _.filter(competences, { area: { id: area.id } });

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -34,7 +34,7 @@ async function listWithPixCompetencesOnly({ locale } = {}) {
 async function findByFrameworkIdWithCompetences({ frameworkId, locale }) {
   const areaDatas = await areaDatasource.findByFrameworkId(frameworkId);
   const areas = areaDatas.map((areaData) => _toDomain({ areaData, locale }));
-  const competences = await competenceRepository.list();
+  const competences = await competenceRepository.list({ locale });
   areas.forEach((area) => {
     area.competences = _.filter(competences, { area: { id: area.id } });
   });

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -1,10 +1,15 @@
 const Thematic = require('../../domain/models/Thematic');
 const thematicDatasource = require('../datasources/learning-content/thematic-datasource');
+const { getTranslatedText } = require('../../domain/services/get-translated-text');
 
-function _toDomain(thematicData) {
+function _toDomain(thematicData, locale) {
+  const translatedName = getTranslatedText(locale, {
+    frenchText: thematicData.name,
+    englishText: thematicData.nameEnUs,
+  });
   return new Thematic({
     id: thematicData.id,
-    name: thematicData.name,
+    name: translatedName,
     index: thematicData.index,
     tubeIds: thematicData.tubeIds,
   });
@@ -16,8 +21,8 @@ module.exports = {
     return thematicData.map(_toDomain);
   },
 
-  async findByCompetenceIds(competenceIds) {
+  async findByCompetenceIds(competenceIds, locale) {
     const thematicDatas = await thematicDatasource.findByCompetenceIds(competenceIds);
-    return thematicDatas.map(_toDomain);
+    return thematicDatas.map((thematicData) => _toDomain(thematicData, locale));
   },
 };

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -10,7 +10,7 @@ describe('Integration | Repository | area-repository', function () {
       code: 'area0code',
       name: 'area0name',
       titleFrFr: 'area0titleFr',
-      titleEn: 'area0titleEn',
+      titleEnUs: 'area0titleEn',
       color: 'area0color',
       competenceIds: ['recCompetence0'],
     };
@@ -19,7 +19,7 @@ describe('Integration | Repository | area-repository', function () {
       code: 'area1code',
       name: 'area1name',
       titleFrFr: 'area1titleFr',
-      titleEn: 'area1titleEn',
+      titleEnUs: 'area1titleEn',
       color: 'area1color',
       competenceIds: [],
     };
@@ -67,7 +67,7 @@ describe('Integration | Repository | area-repository', function () {
             code: 'area0code',
             name: 'area0name',
             titleFrFr: 'area0titleFr',
-            titleEn: 'area0titleEn',
+            titleEnUs: 'area0titleEn',
             color: 'area0color',
             competenceIds: ['recCompetence0'],
           },
@@ -94,7 +94,7 @@ describe('Integration | Repository | area-repository', function () {
         code: 'area0code',
         name: 'area0name',
         titleFrFr: 'area0titleFr',
-        titleEn: 'area0titleEn',
+        titleEnUs: 'area0titleEn',
         color: 'area0color',
         competenceIds: ['recCompetence0', 'recCompetence1'],
       };
@@ -104,7 +104,7 @@ describe('Integration | Repository | area-repository', function () {
         code: 'area1code',
         name: 'area1name',
         titleFrFr: 'area1titleFr',
-        titleEn: 'area1titleEn',
+        titleEnUs: 'area1titleEn',
         color: 'area1color',
         competenceIds: ['recCompetence2', 'recCompetence3'],
       };
@@ -158,7 +158,7 @@ describe('Integration | Repository | area-repository', function () {
       code: 'area0code',
       name: 'area0name',
       titleFrFr: 'area0titleFr',
-      titleEn: 'area0titleEn',
+      titleEnUs: 'area0titleEn',
       color: 'area0color',
       frameworkId: 'framework1',
       competenceIds: ['recCompetence0', 'recCompetence1'],
@@ -169,7 +169,7 @@ describe('Integration | Repository | area-repository', function () {
       code: 'area1code',
       name: 'area1name',
       titleFrFr: 'area1titleFr',
-      titleEn: 'area1titleEn',
+      titleEnUs: 'area1titleEn',
       color: 'area1color',
       frameworkId: 'framework2',
       competenceIds: ['recCompetence2', 'recCompetence3'],
@@ -190,7 +190,7 @@ describe('Integration | Repository | area-repository', function () {
 
     it('should return a list of areas from the proper framework', async function () {
       // when
-      const areas = await areaRepository.findByFrameworkIdWithCompetences('framework1');
+      const areas = await areaRepository.findByFrameworkIdWithCompetences({ frameworkId: 'framework1' });
 
       // then
       expect(areas).to.have.lengthOf(1);
@@ -200,6 +200,25 @@ describe('Integration | Repository | area-repository', function () {
         code: area0.code,
         name: area0.name,
         title: area0.titleFrFr,
+        color: area0.color,
+      });
+      expect(areas[0].competences).to.have.lengthOf(2);
+      expect(areas[0].competences[0].id).to.equal('recCompetence0');
+      expect(areas[0].competences[1].id).to.equal('recCompetence1');
+    });
+
+    it('should return a list of areas in english', async function () {
+      // when
+      const areas = await areaRepository.findByFrameworkIdWithCompetences({ frameworkId: 'framework1', locale: 'en' });
+
+      // then
+      expect(areas).to.have.lengthOf(1);
+      expect(areas[0]).to.be.instanceof(Area);
+      expect(_.omit(areas[0], 'competences')).to.deep.equal({
+        id: area0.id,
+        code: area0.code,
+        name: area0.name,
+        title: area0.titleEnUs,
         color: area0.color,
       });
       expect(areas[0].competences).to.have.lengthOf(2);

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -178,10 +178,38 @@ describe('Integration | Repository | area-repository', function () {
     const learningContent = {
       areas: [area0, area1],
       competences: [
-        { id: 'recCompetence0', areaId: 'recArea0' },
-        { id: 'recCompetence1', areaId: 'recArea0' },
-        { id: 'recCompetence2', areaId: 'recArea1' },
-        { id: 'recCompetence3', areaId: 'recArea1' },
+        {
+          id: 'recCompetence0',
+          areaId: 'recArea0',
+          nameFrFr: 'competence0NameFr',
+          nameEnUs: 'competence0NameEn',
+          descriptionFrFr: 'competence0DescriptionFr',
+          descriptionEnUs: 'competence0DescriptionEn',
+        },
+        {
+          id: 'recCompetence1',
+          areaId: 'recArea0',
+          nameFrFr: 'competence1NameFr',
+          nameEnUs: 'competence1NameEn',
+          descriptionFrFr: 'competence1DescriptionFr',
+          descriptionEnUs: 'competence1DescriptionEn',
+        },
+        {
+          id: 'recCompetence2',
+          areaId: 'recArea1',
+          nameFrFr: 'competence2NameFr',
+          nameEnUs: 'competence2NameEn',
+          descriptionFrFr: 'competence2DescriptionFr',
+          descriptionEnUs: 'competence2DescriptionEn',
+        },
+        {
+          id: 'recCompetence3',
+          areaId: 'recArea1',
+          nameFrFr: 'competence3NameFr',
+          nameEnUs: 'competence3NameEn',
+          descriptionFrFr: 'competence3DescriptionFr',
+          descriptionEnUs: 'competence3DescriptionEn',
+        },
       ],
     };
     beforeEach(function () {
@@ -204,7 +232,11 @@ describe('Integration | Repository | area-repository', function () {
       });
       expect(areas[0].competences).to.have.lengthOf(2);
       expect(areas[0].competences[0].id).to.equal('recCompetence0');
+      expect(areas[0].competences[0].name).to.equal('competence0NameFr');
+      expect(areas[0].competences[0].description).to.equal('competence0DescriptionFr');
       expect(areas[0].competences[1].id).to.equal('recCompetence1');
+      expect(areas[0].competences[1].name).to.equal('competence1NameFr');
+      expect(areas[0].competences[1].description).to.equal('competence1DescriptionFr');
     });
 
     it('should return a list of areas in english', async function () {
@@ -223,7 +255,11 @@ describe('Integration | Repository | area-repository', function () {
       });
       expect(areas[0].competences).to.have.lengthOf(2);
       expect(areas[0].competences[0].id).to.equal('recCompetence0');
+      expect(areas[0].competences[0].name).to.equal('competence0NameEn');
+      expect(areas[0].competences[0].description).to.equal('competence0DescriptionEn');
       expect(areas[0].competences[1].id).to.equal('recCompetence1');
+      expect(areas[0].competences[1].name).to.equal('competence1NameEn');
+      expect(areas[0].competences[1].description).to.equal('competence1DescriptionEn');
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -23,51 +23,93 @@ describe('Integration | Repository | thematic-repository', function () {
   });
 
   describe('#findByCompetenceId', function () {
-    it('should return thematics of a competence', async function () {
-      const competenceId = 'competence0';
+    const competenceId = 'competence0';
 
-      // given
-      const thematic0 = {
-        id: 'recThematic0',
-        name: 'thematic0',
+    // given
+    const thematic0 = {
+      id: 'recThematic0',
+      name: 'thematic0',
+      nameEnUs: 'thematic0EnUs',
+      index: 1,
+      tubeIds: ['recTube0'],
+      competenceId,
+    };
+
+    const thematic1 = {
+      id: 'recThematic1',
+      name: 'thematic1',
+      nameEnUs: 'thematic1EnUs',
+      index: 1,
+      tubeIds: ['recTube1'],
+      competenceId,
+    };
+
+    const thematics = [
+      thematic0,
+      thematic1,
+      {
+        id: 'recThematic2',
+        name: 'thematic2',
+        nameEnUs: 'thematic2EnUs',
         index: 1,
-        tubeIds: ['recTube0'],
-        competenceId,
-      };
+        tubeIds: ['recTube2'],
+        competenceId: 'competence1',
+      },
+    ];
 
-      const thematic1 = {
-        id: 'recThematic1',
-        name: 'thematic1',
-        index: 1,
-        tubeIds: ['recTube1'],
-        competenceId,
-      };
+    const learningContent = {
+      thematics,
+    };
 
-      const thematics = [
-        thematic0,
-        thematic1,
-        {
-          id: 'recThematic1',
-          name: 'thematic1',
-          index: 1,
-          tubeIds: ['recTube1'],
-          competenceId: 'competence1',
-        },
-      ];
-
-      const learningContent = {
-        thematics,
-      };
-
+    beforeEach(function () {
       mockLearningContent(learningContent);
+    });
 
+    it('should return thematics of a competence', async function () {
       // when
       const foundThematics = await thematicRepository.findByCompetenceIds([competenceId]);
 
       // then
       expect(foundThematics).to.have.lengthOf(2);
-      expect(foundThematics[0]).to.deep.equal(new Thematic(thematic0));
-      expect(foundThematics[1]).to.deep.equal(new Thematic(thematic1));
+      expect(foundThematics[0]).to.deep.equal({
+        id: 'recThematic0',
+        name: 'thematic0',
+        index: 1,
+        tubeIds: ['recTube0'],
+      });
+      expect(foundThematics[0]).to.be.instanceOf(Thematic);
+      expect(foundThematics[1]).to.deep.equal({
+        id: 'recThematic1',
+        name: 'thematic1',
+        index: 1,
+        tubeIds: ['recTube1'],
+      });
+      expect(foundThematics[1]).to.be.instanceOf(Thematic);
+    });
+
+    describe('When locale is en', function () {
+      it('should return the translated name in english', async function () {
+        const locale = 'en';
+        // when
+        const foundThematics = await thematicRepository.findByCompetenceIds([competenceId], locale);
+
+        // then
+        expect(foundThematics).to.have.lengthOf(2);
+        expect(foundThematics[0]).to.deep.equal({
+          id: 'recThematic0',
+          name: 'thematic0EnUs',
+          index: 1,
+          tubeIds: ['recTube0'],
+        });
+        expect(foundThematics[0]).to.be.instanceOf(Thematic);
+        expect(foundThematics[1]).to.deep.equal({
+          id: 'recThematic1',
+          name: 'thematic1EnUs',
+          index: 1,
+          tubeIds: ['recTube1'],
+        });
+        expect(foundThematics[1]).to.be.instanceOf(Thematic);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-framework-areas_test.js
+++ b/api/tests/unit/domain/usecases/get-framework-areas_test.js
@@ -60,7 +60,10 @@ describe('Unit | UseCase | get-framework-areas', function () {
     expect(challengeRepository.findValidatedPrototype).to.have.been.calledWithExactly();
     expect(tubeRepository.findActiveByRecordIds).to.have.been.calledWith(['tubeId1'], 'locale');
     expect(thematicRepository.findByCompetenceIds).to.have.been.calledWith(['competenceId1']);
-    expect(areaRepository.findByFrameworkIdWithCompetences).to.have.been.calledWithExactly('frameworkId');
+    expect(areaRepository.findByFrameworkIdWithCompetences).to.have.been.calledWith({
+      frameworkId: 'frameworkId',
+      locale: 'locale',
+    });
   });
 
   it('should a get framework by name', async function () {
@@ -82,7 +85,10 @@ describe('Unit | UseCase | get-framework-areas', function () {
     expect(challengeRepository.findValidatedPrototype).to.have.been.calledWithExactly();
     expect(tubeRepository.findActiveByRecordIds).to.have.been.calledWith(['tubeId1'], 'locale');
     expect(thematicRepository.findByCompetenceIds).to.have.been.calledWith(['competenceId1']);
-    expect(areaRepository.findByFrameworkIdWithCompetences).to.have.been.calledWithExactly('frameworkId');
+    expect(areaRepository.findByFrameworkIdWithCompetences).to.have.been.calledWith({
+      frameworkId: 'frameworkId',
+      locale: 'locale',
+    });
     expect(frameworkRepository.getByName).to.have.been.calledWithExactly('framework');
   });
 

--- a/api/tests/unit/domain/usecases/get-framework-areas_test.js
+++ b/api/tests/unit/domain/usecases/get-framework-areas_test.js
@@ -59,7 +59,7 @@ describe('Unit | UseCase | get-framework-areas', function () {
     });
     expect(challengeRepository.findValidatedPrototype).to.have.been.calledWithExactly();
     expect(tubeRepository.findActiveByRecordIds).to.have.been.calledWith(['tubeId1'], 'locale');
-    expect(thematicRepository.findByCompetenceIds).to.have.been.calledWith(['competenceId1']);
+    expect(thematicRepository.findByCompetenceIds).to.have.been.calledWith(['competenceId1'], 'locale');
     expect(areaRepository.findByFrameworkIdWithCompetences).to.have.been.calledWith({
       frameworkId: 'frameworkId',
       locale: 'locale',
@@ -84,7 +84,7 @@ describe('Unit | UseCase | get-framework-areas', function () {
     });
     expect(challengeRepository.findValidatedPrototype).to.have.been.calledWithExactly();
     expect(tubeRepository.findActiveByRecordIds).to.have.been.calledWith(['tubeId1'], 'locale');
-    expect(thematicRepository.findByCompetenceIds).to.have.been.calledWith(['competenceId1']);
+    expect(thematicRepository.findByCompetenceIds).to.have.been.calledWith(['competenceId1'], 'locale');
     expect(areaRepository.findByFrameworkIdWithCompetences).to.have.been.calledWith({
       frameworkId: 'frameworkId',
       locale: 'locale',


### PR DESCRIPTION
## :unicorn: Problème

Sur la page "Présélection d'un profil cible", les intitulés ne sont pas tous traduits.
Si on force la langue en anglais en ajoutant `?lang=en` dans l’URL, les intitulés des thématiques, areas, etc. ne sont pas traduits, contrairement au reste de la page.

## :robot: Solution

Traduire tous les intitulés :
 - Areas
 - Competences
 - Thematics

## :rainbow: Remarques

En attente de #4362

Nécessite l'ajout du champ `nameEnUs` sur la thématique dans la release de LCMS, voir https://github.com/1024pix/pix-editor/pull/51

## :100: Pour tester

 - Vérifier qu'il n'y a pas de régression sur la page en français : https://orga-pr4375.review.pix.fr/selection-sujets
 - Vérifier que tous les intitulés sont bien traduites sur la page en anglais https://orga-pr4375.review.pix.org/selection-sujets?lang=en
