### PR TITLE
[TECH] Nettoyage des tests de Pix Admin avec Testing Library (the end.) (PIX-4782). 

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -86,19 +86,15 @@
           </form>
         </div>
       {{else}}
-        <div class="page-section__details">
-          ID :
-          {{@badge.id}}<br />
-          Nom du badge :
-          {{@badge.title}}<br />
-          Nom de l'image :
-          {{this.imageName}}<br />
-          Clé :
-          {{@badge.key}}<br />
-          Message :
-          {{@badge.message}}<br />
-          Message alternatif :
-          {{@badge.altMessage}}<br />
+        <div>
+          <ul class="badge-data__list">
+            <li>ID : {{@badge.id}}</li>
+            <li>Nom du badge : {{@badge.title}}</li>
+            <li>Nom de l'image : {{this.imageName}}</li>
+            <li>Clé : {{@badge.key}}</li>
+            <li>Message : {{@badge.message}}</li>
+            <li>Message alternatif : {{@badge.altMessage}}</li>
+          </ul>
           {{#if @badge.isCertifiable}}
             <PixTag @color={{this.isCertifiableColor}} class="badge-data__tags">{{this.isCertifiableText}}</PixTag><br
             />
@@ -121,7 +117,7 @@
 
   <section class="page-section">
     <div class="page-section__header">
-      <h2 class="page-section__title">Critères</h2>
+      <h1 class="page-section__title">Critères</h1>
     </div>
 
     <div class="page-section__details table-admin">

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -109,7 +109,7 @@
             @isBorderVisible={{true}}
             @size="small"
             @triggerAction={{this.toggleEditMode}}
-          >Editer</PixButton>
+          >Éditer</PixButton>
         </div>
       {{/if}}
     </div>

--- a/admin/app/components/campaigns/participation-row.hbs
+++ b/admin/app/components/campaigns/participation-row.hbs
@@ -10,7 +10,7 @@
       <PixInput
         id="participantExternalId"
         type="text"
-        aria-label="Modifier"
+        aria-label="Modifier l'identifiant externe du participant"
         value={{@participation.participantExternalId}}
         onchange={{this.handleChange}}
         class="table-admin-input form-control"

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -124,7 +124,6 @@
             @isBorderVisible={{true}}
             @size="small"
             @triggerAction={{this.enterEditMode}}
-            aria-label="Editer"
           >Editer les informations
           </PixButton>
         </div>

--- a/admin/app/components/certification-centers/list-items.hbs
+++ b/admin/app/components/certification-centers/list-items.hbs
@@ -50,7 +50,7 @@
     {{#if @certificationCenters}}
       <tbody>
         {{#each @certificationCenters as |certificationCenter|}}
-          <tr aria-label="Centre de certification">
+          <tr aria-label="Centre de certification {{certificationCenter.name}}">
             <td class="table__column table__column--id">
               <LinkTo @route="authenticated.certification-centers.get" @model={{certificationCenter.id}}>
                 {{certificationCenter.id}}

--- a/admin/app/components/certifications/competence-list.hbs
+++ b/admin/app/components/certifications/competence-list.hbs
@@ -1,6 +1,9 @@
 {{#if @edition}}
   {{#each this.competenceList as |competenceItem key|}}
-    <div class="row form-group certification-info-field">
+    <div
+      class="row form-group certification-info-field"
+      aria-label="Informations de la compétence {{competenceItem}} éditable"
+    >
       <label class="col-sm-1 col-form-label" for={{concat "certification-info-score_" key}}>{{competenceItem}}</label>
       <div class="col-sm-2 certificate">
         <Input
@@ -28,7 +31,7 @@
   {{/each}}
 {{else}}
   {{#each @competences as |competence|}}
-    <div class="row certification-info-field">
+    <div class="row certification-info-field" aria-label="Informations de la compétence {{competence.index}}">
       <div class="col-sm-3 certification-info-competence-index">
         {{competence.index}}
       </div>

--- a/admin/app/components/certifications/details-answer.hbs
+++ b/admin/app/components/certifications/details-answer.hbs
@@ -24,16 +24,15 @@
     </div>
   </div>
   <div class="card-footer">
-    <div class={{this.resultClass}}>
-      <PowerSelect
-        @options={{this.resultOptions}}
-        @selected={{this.selectedOption}}
-        @searchEnabled={{false}}
-        @onChange={{this.selectOption}}
-        as |result|
-      >
-        {{result.label}}
-      </PowerSelect>
-    </div>
+    <PixSelect
+      @onChange={{this.selectOption}}
+      @options={{this.resultOptions}}
+      aria-label="Sélectionner un résultat"
+      @isSearchable={{false}}
+      class={{this.resultClass}}
+      as |result|
+    >
+      {{result.label}}
+    </PixSelect>
   </div>
 </div>

--- a/admin/app/components/certifications/details-answer.js
+++ b/admin/app/components/certifications/details-answer.js
@@ -29,7 +29,7 @@ export default class CertificationDetailsAnswer extends Component {
   }
 
   get resultClass() {
-    return this.hasJuryResult ? 'answer-result jury' : 'answer-result';
+    return this.hasJuryResult ? 'jury' : null;
   }
 
   get linkToChallengePreviewInPixApp() {
@@ -41,10 +41,10 @@ export default class CertificationDetailsAnswer extends Component {
   }
 
   @action
-  selectOption(selected) {
+  selectOption(event) {
     const answer = this.args.answer;
     const answerResult = this._answerResultValue();
-    const newResult = this.getOption(selected.value);
+    const newResult = this.getOption(event.target.value);
     answer.jury = answerResult.value !== newResult.value ? newResult.value : null;
     this.selectedOption = newResult ?? answerResult;
     this.hasJuryResult = !!newResult;

--- a/admin/app/components/certifications/info-field.hbs
+++ b/admin/app/components/certifications/info-field.hbs
@@ -8,27 +8,13 @@
     >
       {{@label}}
     </label>
-    {{#if @isDate}}
-      <EmberFlatpickr
-        @id={{@fieldId}}
-        @altFormat="d/m/Y"
-        @altInput={{true}}
-        @onChange={{@onUpdateCertificationBirthdate}}
-        @dateFormat="Y-m-d"
-        @locale="fr"
-        @date={{@value}}
-        @name={{@fieldId}}
-        @class="form-control"
-      />
+    {{#if @isTextarea}}
+      <Textarea id={{@fieldId}} @value={{@value}} class="form-control" />
     {{else}}
-      {{#if @isTextarea}}
-        <Textarea id={{@fieldId}} @value={{@value}} class="form-control" />
-      {{else}}
-        <Input id={{@fieldId}} @type="text" @value={{@value}} class="form-control" />
-      {{/if}}
-      {{#if @suffix}}
-        <span class="certification-info-field__suffix">{{@suffix}}</span>
-      {{/if}}
+      <Input id={{@fieldId}} @type="text" @value={{@value}} class="form-control" />
+    {{/if}}
+    {{#if @suffix}}
+      <span class="certification-info-field__suffix">{{@suffix}}</span>
     {{/if}}
   </div>
 {{else}}

--- a/admin/app/components/certifications/info-field.hbs
+++ b/admin/app/components/certifications/info-field.hbs
@@ -1,7 +1,7 @@
 {{#if @edition}}
   <div class="row form-group certification-info-field edited">
     <label
-      for={{@id}}
+      for={{@fieldId}}
       class="col-form-label certification-info-field__label--editing
         {{if @isTextarea "certification-info-field__label--large"}}
         {{if @suffix "certification-info-field__label--small"}}"
@@ -33,19 +33,21 @@
   </div>
 {{else}}
   <div class="row certification-info-field">
-    <div class="certification-info-field__label">{{@label}}</div>
-    <div class="certification-info-value {{@class}}">
+    <p>
+      {{@label}}
       {{#if @linkRoute}}
         <LinkTo @route={{@linkRoute}} @model={{@value}}>
           {{this.valueWithSuffix}}
         </LinkTo>
       {{else}}
-        {{#if @isDate}}
-          {{moment-format @value "DD/MM/YYYY" allow-empty=true}}
-        {{else}}
-          {{if this.valueWithSuffix this.valueWithSuffix " - "}}
-        {{/if}}
+        <span class={{@class}}>
+          {{#if @isDate}}
+            {{moment-format @value "DD/MM/YYYY" allow-empty=true}}
+          {{else}}
+            {{if this.valueWithSuffix this.valueWithSuffix " - "}}
+          {{/if}}
+        </span>
       {{/if}}
-    </div>
+    </p>
   </div>
 {{/if}}

--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -1,16 +1,16 @@
 <li class="certification-issue-report">
   {{#if (or (not @issueReport.isImpactful) @issueReport.resolvedAt)}}
     <FaIcon
-      aria-label="Résolu"
+      aria-label="Signalement résolu"
       aria-hidden="false"
-      class="certification-issue-report__resolution-status certification-issue-report__resolution-status--resolved"
+      class="certification-issue-report__resolution-status--resolved"
       @icon="check-circle"
     />
   {{else}}
     <FaIcon
-      aria-label="Non résolu"
+      aria-label="Signalement non résolu"
       aria-hidden="false"
-      class="certification-issue-report__resolution-status certification-issue-report__resolution-status--unresolved"
+      class="certification-issue-report__resolution-status--unresolved"
       @icon="times-circle"
     />
   {{/if}}

--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -3,9 +3,9 @@
     <div class="organization__logo">
       <figure class="organization__logo-figure">
         {{#if @organization.logoUrl}}
-          <img src={{@organization.logoUrl}} alt={{@organization.name}} />
+          <img src={{@organization.logoUrl}} alt="" role="presentation" />
         {{else}}
-          <img src="{{this.rootURL}}/logo-placeholder.png" alt="placeholder" />
+          <img src="{{this.rootURL}}/logo-placeholder.png" alt="" role="presentation" />
         {{/if}}
 
         <FileUpload @name="logo" @accept="image/*" @onfileadd={{this.updateLogo}} />
@@ -177,56 +177,44 @@
 
         <div class="organization-information-section__content">
           <div class="organization-information-section__details">
-            <p>
-              Type :
-              <span>{{@organization.type}}</span><br />
+            <ul>
+              <li>Type : {{@organization.type}}</li>
               {{#if @organization.externalId}}
-                Identifiant externe :
-                <span>{{@organization.externalId}}</span><br />
+                <li>Identifiant externe : {{@organization.externalId}}</li>
               {{/if}}
               {{#if @organization.provinceCode}}
-                Département :
-                <span>{{@organization.provinceCode}}</span><br />
+                <li>Département : {{@organization.provinceCode}}</li>
               {{/if}}
               {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
-                Gestion d’élèves/étudiants :
-                <span class="organization__isManagingStudents">{{if
-                    @organization.isManagingStudents
-                    "Oui"
-                    "Non"
-                  }}</span><br />
+                <li>Gestion d’élèves/étudiants : {{if @organization.isManagingStudents "Oui" "Non"}}</li>
               {{/if}}
-              Adresse e-mail d'activation SCO :
-              <span class="organization'__email">{{@organization.email}}</span><br />
-              Affichage des acquis dans l'export de résultats :
-              <span class="organization__showSkills">{{if @organization.showSkills "Oui" "Non"}}</span><br />
-              Affichage du Net Promoter Score :
-              <span>{{if @organization.showNPS "Oui" "Non"}}</span><br />
-              Lien vers le formulaire du Net Promoter Score :
-              {{#if @organization.formNPSUrl}}
-                <a
-                  href="{{@organization.formNPSUrl}}"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >{{@organization.formNPSUrl}}</a>
-              {{else}}
-                Non spécifié
-              {{/if}}
-              <br />
-              Crédits :
-              <span>{{@organization.credit}}</span>
-              <br />
-              Lien vers la documentation :
-              {{#if @organization.documentationUrl}}
-                <a
-                  href="{{@organization.documentationUrl}}"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >{{@organization.documentationUrl}}</a>
-              {{else}}
-                Non spécifié
-              {{/if}}
-            </p>
+              <li>Adresse e-mail d'activation SCO : {{@organization.email}}</li>
+              <li>Affichage des acquis dans l'export de résultats : {{if @organization.showSkills "Oui" "Non"}}</li>
+              <li>Affichage du Net Promoter Score : {{if @organization.showNPS "Oui" "Non"}}</li>
+              <li>Lien vers le formulaire du Net Promoter Score :
+                {{#if @organization.formNPSUrl}}
+                  <a
+                    href="{{@organization.formNPSUrl}}"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >{{@organization.formNPSUrl}}</a>
+                {{else}}
+                  Non spécifié
+                {{/if}}
+              </li>
+              <li>Crédits : {{@organization.credit}}</li>
+              <li>Lien vers la documentation :
+                {{#if @organization.documentationUrl}}
+                  <a
+                    href="{{@organization.documentationUrl}}"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >{{@organization.documentationUrl}}</a>
+                {{else}}
+                  Non spécifié
+                {{/if}}
+              </li>
+            </ul>
             <div class="form-actions">
               <PixButton
                 @backgroundColor="transparent-light"

--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -90,7 +90,7 @@
               </div>
             {{/if}}
             <Input
-              id="credit"
+              id="credits"
               @type="number"
               class={{if (v-get this.form "credit" "isInvalid") "form-control is-invalid" "form-control"}}
               @value={{this.form.credit}}

--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -51,7 +51,7 @@
       {{#if @organizations}}
         <tbody>
           {{#each @organizations as |organization|}}
-            <tr aria-label="Organisation">
+            <tr aria-label="Organisation {{organization.name}}">
               <td class="table__column table__column--id">
                 <LinkTo @route="authenticated.organizations.get" @model={{organization.id}}>
                   {{organization.id}}

--- a/admin/app/components/pagination-control.hbs
+++ b/admin/app/components/pagination-control.hbs
@@ -4,6 +4,7 @@
     <div class="page-size__choice">
       <PixSelect
         id="pageSize"
+        aria-label="Nombre d'éléments à afficher par page"
         @options={{this.options}}
         @onChange={{this.changePageSize}}
         @selectedOption={{@pagination.pageSize}}
@@ -25,11 +26,7 @@
         <FaIcon @icon="arrow-left" />
       </LinkTo>
     </div>
-    <div class="page-navigation__body">
-      <div class="page-navigation__label">Page&nbsp;:</div>
-      <div class="page-navigation__current-page">{{@pagination.page}}</div>
-      <div class="page-navigation__last-page">/&nbsp;{{@pagination.pageCount}}</div>
-    </div>
+    <span>Page&nbsp;: {{@pagination.page}} /&nbsp;{{@pagination.pageCount}}</span>
     <div
       class="page-navigation__arrow page-navigation__arrow--next
         {{if (eq @pagination.page @pagination.pageCount) "page-navigation__arrow--disabled"}}"

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -79,7 +79,7 @@
     {{#if @sessions}}
       <tbody>
         {{#each @sessions as |session|}}
-          <tr>
+          <tr aria-label="Informations de la session de certification {{session.id}}">
             <td class="table__column table__column--id">
               <LinkTo @route="authenticated.sessions.session" @model={{session.id}}>
                 {{session.id}}

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -2,77 +2,77 @@
   <table class="table-admin table-admin__auto-width">
     <thead>
       <tr>
-        <th class="table__column table__column--id">ID</th>
-        <th>Centre de certification</th>
-        <th>Identifiant externe</th>
-        <th>Catégorie</th>
-        <th>Date de session</th>
-        <th>Statut</th>
-        <th>Date de finalisation</th>
-        <th>Date de publication</th>
-        <th>Date de diffusion au prescripteur</th>
+        <th class="table__column table__column--id" id="session-id">ID</th>
+        <th id="certification-center-name">Centre de certification</th>
+        <th id="session-external-id">Identifiant externe</th>
+        <th id="certification-center-category">Catégorie</th>
+        <th id="session-date">Date de session</th>
+        <th id="session-status">Statut</th>
+        <th id="session-finalization-date">Date de finalisation</th>
+        <th id="session-publication-date">Date de publication</th>
+        <th id="session-results-sent-to-prescriber">Date de diffusion au prescripteur</th>
       </tr>
       <tr>
-        <th class="table__column table__column--id">
+        <td class="table__column table__column--id">
           <input
-            id="id"
+            aria-label="Filtrer les sessions avec un id"
             type="text"
             value={{@id}}
             oninput={{perform @triggerFiltering "id"}}
             class="table-admin-input"
           />
-        </th>
-        <th>
+        </td>
+        <td>
           <input
-            id="certificationCenterName"
+            aria-label="Filtrer les sessions avec le nom d'un centre de certification"
             type="text"
             value={{@certificationCenterName}}
             oninput={{perform @triggerFiltering "certificationCenterName"}}
             class="table-admin-input"
           />
-        </th>
-        <th>
+        </td>
+        <td>
           <input
-            id="certificationCenterExternalId"
+            aria-label="Filtrer les sessions avec un identifiant externe"
             type="text"
             value={{@certificationCenterExternalId}}
             oninput={{perform @triggerFiltering "certificationCenterExternalId"}}
             class="table-admin-input"
           />
-        </th>
-        <th>
+        </td>
+        <td>
           <PixSelect
-            id="certificationCenterType"
+            aria-label="Filtrer les sessions en sélectionnant un type de centre de certification"
             name="certificationCenterType"
             class="sessions-list-items__select"
             @options={{this.certificationCenterTypeOptions}}
             @onChange={{this.selectCertificationCenterType}}
             @selectedOption={{@certificationCenterType}}
           />
-        </th>
-        <th></th>
-        <th>
+        </td>
+        <td></td>
+        <td>
           <PixSelect
-            id="status"
+            aria-label="Filtrer les sessions en sélectionnant un statut"
             name="status"
             class="sessions-list-items__select"
             @options={{this.sessionStatusOptions}}
             @onChange={{this.selectSessionStatus}}
             @selectedOption={{@status}}
           />
-        </th>
-        <th></th>
-        <th></th>
-        <th>
+        </td>
+        <td></td>
+        <td></td>
+        <td>
           <PixSelect
-            id="resultsSentToPrescriberAt"
+            aria-label="Filtrer les sessions par leurs résultats diffusés ou non diffusés"
             name="resultsSentToPrescriberAt"
             class="sessions-list-items__select"
             @options={{this.sessionResultsSentToPrescriberOptions}}
             @onChange={{this.selectSessionResultsSentToPrescriber}}
             @selectedOption={{@resultsSentToPrescriberAt}}
           />
-        </th>
+        </td>
       </tr>
     </thead>
 
@@ -80,23 +80,25 @@
       <tbody>
         {{#each @sessions as |session|}}
           <tr aria-label="Informations de la session de certification {{session.id}}">
-            <td class="table__column table__column--id">
+            <td headers="session-id" class="table__column table__column--id">
               <LinkTo @route="authenticated.sessions.session" @model={{session.id}}>
                 {{session.id}}
               </LinkTo>
             </td>
-            <td>{{session.certificationCenterName}}</td>
-            <td>{{session.certificationCenterExternalId}}</td>
+            <td headers="certification-center-name">{{session.certificationCenterName}}</td>
+            <td headers="session-external-id">{{session.certificationCenterExternalId}}</td>
             {{#if session.certificationCenterType}}
-              <td class="session-list__item--align-center">{{session.certificationCenterType}}</td>
+              <td headers="certification-center-category" class="session-list__item--align-center">
+                {{session.certificationCenterType}}
+              </td>
             {{else}}
-              <td class="session-list__item--align-center">-</td>
+              <td headers="certification-center-category" class="session-list__item--align-center">-</td>
             {{/if}}
-            <td>{{format-date session.date}} à {{session.time}}</td>
-            <td>{{session.displayStatus}}</td>
-            <td>{{format-date session.finalizedAt}}</td>
-            <td>{{format-date session.publishedAt}}</td>
-            <td>{{format-date session.resultsSentToPrescriberAt}}</td>
+            <td headers="session-date">{{format-date session.date}} à {{session.time}}</td>
+            <td headers="session-status">{{session.displayStatus}}</td>
+            <td headers="session-finalization-date">{{format-date session.finalizedAt}}</td>
+            <td headers="session-publication-date">{{format-date session.publishedAt}}</td>
+            <td headers="session-results-sent-to-prescriber">{{format-date session.resultsSentToPrescriberAt}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -6,10 +6,17 @@
       <Input id="title" class="form-control" @type="text" @value={{this.badge.title}} />
     </div>
     <div class="badge-form__text-field">
-      <label for="image-url">Nom de l'image (svg) :
-        <a href="https://images.pix.fr/badges.html" target="_blank" rel="noopener noreferrer">
-          Voir la liste des badges</a>
-      </label>
+      <label for="image-name" class="badge-form__label">Nom de l'image (svg) :</label>
+      <p class="badge-form__information">
+        <a
+          class="badge-form__information--link"
+          href="https://images.pix.fr/badges.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Voir la liste des badges
+        </a>
+      </p>
       <Input
         id="image-name"
         required="true"
@@ -102,7 +109,7 @@
 
       <div class="badge-form-criteria">
         <div class="badge-form__text-field badge-form-criteria__threshold">
-          <label for="campaignParticipationThreshold">Taux de réussite :</label>
+          <label for="campaignParticipationThreshold">Taux de réussite global :</label>
           <Input
             id="campaignParticipationThreshold"
             class="form-control"

--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -14,7 +14,7 @@
       </thead>
       <tbody>
         {{#each @badges as |badge|}}
-          <tr>
+          <tr aria-label="Informations du badge {{badge.title}}">
             <td class="table__column table__column--id">{{badge.id}}</td>
             <td class="badges-table__image"><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
             <td>{{badge.key}}</td>
@@ -23,7 +23,7 @@
             <td>
               <Common::TickOrCross @isTrue={{badge.isAlwaysVisible}} />
             </td>
-            <td aria-label="Informations du badge {{badge.title}}" class="badges-table__actions">
+            <td class="badges-table__actions">
               <PixButtonLink
                 @backgroundColor="transparent-light"
                 @isBorderVisible={{true}}
@@ -31,6 +31,7 @@
                 @size="small"
                 @model={{badge.id}}
                 class="badges-table-actions__button"
+                aria-label="Détails du badge {{badge.title}}"
               >Voir détail</PixButtonLink>
               <PixButton
                 @size="small"

--- a/admin/app/components/target-profiles/list-items.hbs
+++ b/admin/app/components/target-profiles/list-items.hbs
@@ -3,30 +3,30 @@
     <table>
       <thead>
         <tr>
-          <th class="table__column table__column--id">ID</th>
-          <th>Nom</th>
-          <th class="col-status">Statut</th>
+          <th class="table__column table__column--id" id="target-profile-id">ID</th>
+          <th id="target-profile-name">Nom</th>
+          <th class="col-status" id="target-profile-status">Statut</th>
         </tr>
         <tr>
-          <th class="table__column table__column--id">
+          <td class="table__column table__column--id">
             <input
-              id="id"
               type="text"
               value={{@id}}
               oninput={{perform @triggerFiltering "id"}}
               class="table-admin-input"
+              aria-label="Filtrer les profils cible par un id"
             />
-          </th>
-          <th>
+          </td>
+          <td>
             <input
-              id="name"
               type="text"
               value={{@name}}
               oninput={{perform @triggerFiltering "name"}}
               class="table-admin-input"
+              aria-label="Filtrer les profils cible par un nom"
             />
-          </th>
-          <th></th>
+          </td>
+          <td></td>
         </tr>
       </thead>
 
@@ -34,13 +34,13 @@
         <tbody>
           {{#each @targetProfiles as |targetProfile|}}
             <tr aria-label="Profil cible">
-              <td class="table__column table__column--id">{{targetProfile.id}}</td>
-              <td>
+              <td headers="target-profile-id" class="table__column table__column--id">{{targetProfile.id}}</td>
+              <td headers="target-profile-name">
                 <LinkTo @route="authenticated.target-profiles.target-profile" @model={{targetProfile.id}}>
                   {{targetProfile.name}}
                 </LinkTo>
               </td>
-              <td class="target-profile-table-column__status">
+              <td headers="target-profile-status" class="target-profile-table-column__status">
                 {{if targetProfile.outdated "Obsolète" "Actif"}}
               </td>
             </tr>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -23,7 +23,7 @@
           </thead>
           <tbody>
             {{#each @stages as |stage|}}
-              <tr>
+              <tr aria-label="Informations sur le palier {{stage.title}}">
                 <td class="table__column table__column--id">{{stage.id}}</td>
                 <td class="stages-table__image">
                   <img src={{@targetProfile.imageUrl}} alt="" role="presentation" />
@@ -36,6 +36,7 @@
                         @type="number"
                         required="true"
                         @value={{stage.threshold}}
+                        aria-label="Seuil du palier"
                       />
                       {{#if stage.errors.threshold}}
                         <div class="form-field__error">
@@ -58,6 +59,7 @@
                         }}
                         required="true"
                         @value={{stage.title}}
+                        aria-label="Titre du palier"
                       />
                       {{#if stage.errors.title}}
                         <div class="form-field__error">
@@ -72,7 +74,12 @@
                 <td>
                   {{#if stage.isNew}}
                     <div class="form-field">
-                      <Input class="form-control" required="true" @value={{stage.message}} />
+                      <Input
+                        class="form-control"
+                        required="true"
+                        @value={{stage.message}}
+                        aria-label="Message du palier"
+                      />
                     </div>
                   {{else}}
                     {{stage.message}}

--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -12,7 +12,7 @@
     {{#if @users}}
       <tbody>
         {{#each @users as |user|}}
-          <tr>
+          <tr aria-label="Informations de l'utilisateur {{user.firstName}} {{user.lastName}}">
             <td class="table__column table__column--id"><LinkTo @route="authenticated.users.get" @model={{user.id}}>
                 {{user.id}}
               </LinkTo></td>

--- a/admin/app/components/users/user-detail-personal-information/user-overview.hbs
+++ b/admin/app/components/users/user-detail-personal-information/user-overview.hbs
@@ -18,7 +18,7 @@
       <Input
         id="firstName"
         @type="text"
-        class="form-control user-edit-form__first-name {{if (v-get this.form "firstName" "isInvalid") "is-invalid"}}"
+        class="form-control {{if (v-get this.form "firstName" "isInvalid") "is-invalid"}}"
         @value={{this.form.firstName}}
       />
     </div>
@@ -35,7 +35,7 @@
       <Input
         id="lastName"
         @type="text"
-        class="form-control user-edit-form__last-name {{if (v-get this.form "lastName" "isInvalid") "is-invalid"}}"
+        class="form-control {{if (v-get this.form "lastName" "isInvalid") "is-invalid"}}"
         @value={{this.form.lastName}}
       />
     </div>
@@ -53,7 +53,7 @@
         <Input
           id="email"
           @type="email"
-          class="form-control user-edit-form__email {{if (v-get this.form "email" "isInvalid") "is-invalid"}}"
+          class="form-control {{if (v-get this.form "email" "isInvalid") "is-invalid"}}"
           @value={{this.form.email}}
         />
       </div>
@@ -72,7 +72,7 @@
         <Input
           id="username"
           @type="text"
-          class="form-control user-edit-form__username {{if (v-get this.form "username" "isInvalid") "is-invalid"}}"
+          class="form-control {{if (v-get this.form "username" "isInvalid") "is-invalid"}}"
           @value={{this.form.username}}
         />
       </div>

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -21,7 +21,7 @@
   }
 
   &__complementary-certification--acquired {
-    color: $success;
+    color: $green;
     font-weight: bold;
   }
 

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -12,6 +12,11 @@
   &__action {
     margin-top: 12px;
   }
+
+  &__list {
+    list-style: none;
+    padding: 0;
+  }
 }
 
 .badge-criteria-competences {

--- a/admin/app/styles/components/card.scss
+++ b/admin/app/styles/components/card.scss
@@ -18,4 +18,9 @@
     padding: 11px 32px;
     font-family: $font-roboto;
   }
+
+  &-footer {
+    display: flex;
+    justify-content: center;
+  }
 }

--- a/admin/app/styles/components/certification-details-answer.scss
+++ b/admin/app/styles/components/certification-details-answer.scss
@@ -30,12 +30,7 @@
     font-size: 0.875rem;
   }
 
-  .jury select {
+  .jury {
     color: $error;
-  }
-
-  .answer-result {
-    display: flex;
-    justify-content: center;
   }
 }

--- a/admin/app/styles/components/certification-info-field.scss
+++ b/admin/app/styles/components/certification-info-field.scss
@@ -1,6 +1,5 @@
 .certification-info-field {
   padding: 0 15px;
-  align-items: center;
 
   &__label {
     margin-right: 5px;
@@ -16,6 +15,10 @@
     &--small {
       max-width: 54px;
     }
+  }
+
+  p {
+    margin: 0;
   }
 
   textarea {

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -11,12 +11,9 @@
   }
 
   &__details {
-    overflow: hidden;
 
-    p {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
+    ul {
+      padding: 0;
     }
 
     .form-actions {

--- a/admin/app/styles/components/pagination-control.scss
+++ b/admin/app/styles/components/pagination-control.scss
@@ -38,19 +38,4 @@
       }
     }
   }
-
-  &__body {
-    display: flex;
-  }
-
-  &__label {
-    margin-right: 4px;
-  }
-
-  &__current-page,
-  &__last-page {
-    display: flex;
-    justify-content: center;
-    width: 30px;
-  }
 }

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -4,6 +4,20 @@
     font-weight: $font-semi-bold;
   }
 
+  &__label {
+    margin-bottom: 2px;
+  }
+
+  &__information {
+    font-size: 0.75rem;
+    margin-bottom: 10px;
+
+    &--link {
+      color: $dark-blue-pro;
+      text-decoration: underline;
+    }
+  }
+
   &__text-field {
     display: flex;
     flex-direction: column;
@@ -39,7 +53,7 @@
     margin-bottom: 16px;
 
     &__threshold {
-      width: 160px;
+      width: 200px;
     }
 
     &__skill-set {

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -16,6 +16,7 @@
 
     .page-title {
       font-weight: 500;
+      font-size: 1rem;
 
       a {
         color: $blue;

--- a/admin/app/templates/authenticated/certification-centers/list.hbs
+++ b/admin/app/templates/authenticated/certification-centers/list.hbs
@@ -1,6 +1,6 @@
 {{page-title "Centres de certification"}}
 <header class="page-header">
-  <div class="page-title">Tous les centres de certification</div>
+  <h1 class="page-title">Tous les centres de certification</h1>
   <div class="page-actions">
     <PixButton
       @route="authenticated.certification-centers.new"

--- a/admin/app/templates/authenticated/certifications.hbs
+++ b/admin/app/templates/authenticated/certifications.hbs
@@ -2,7 +2,7 @@
 {{page-title "Certifications"}}
 <div class="page">
   <header class="page-header">
-    <div class="page-title"> Certifications </div>
+    <h1 class="page-title"> Certifications </h1>
     <div class="page-actions">
       <form class="form-inline" {{on "submit" this.loadCertification}}>
         <Input placeholder="Identifiant" @type="text" @value={{this.inputId}} />

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -1,6 +1,6 @@
 {{page-title "Organisations"}}
 <header class="page-header">
-  <div class="page-title">Toutes les organisations</div>
+  <h1 class="page-title">Toutes les organisations</h1>
   <div class="page-actions">
     <PixButton
       @route="authenticated.organizations.new"

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -1,6 +1,6 @@
 {{page-title "Toutes les sessions"}}
 <header class="session-list">
-  <h1 class="page-header page-title session-list__title">Sessions de certifications</h1>
+  <h1 class="page-header session-list__title">Sessions de certifications</h1>
   <nav class="navbar session-list__navbar">
     <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
       Sessions à traiter ({{this.sessionsWithRequiredActionCount}})

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -50,21 +50,19 @@
       {{#if this.sessionModel.finalizedAt}}
         <div class="row">
           <div class="col">Date de finalisation :</div>
-          <div class="col" data-test-id="session-info__finalized-at">{{format-date this.sessionModel.finalizedAt}}</div>
+          <div class="col">{{format-date this.sessionModel.finalizedAt}}</div>
         </div>
       {{/if}}
       {{#if this.sessionModel.publishedAt}}
         <div class="row">
           <div class="col">Date de publication :</div>
-          <div class="col" data-test-id="session-info__published-at">{{format-date this.sessionModel.publishedAt}}</div>
+          <div class="col">{{format-date this.sessionModel.publishedAt}}</div>
         </div>
       {{/if}}
       {{#if this.sessionModel.resultsSentToPrescriberAt}}
         <div class="row">
           <div class="col">Date d'envoi des résultats au prescripteur :</div>
-          <div class="col" data-test-id="session-info__sent-to-prescriber-at">{{format-date
-              this.sessionModel.resultsSentToPrescriberAt
-            }}</div>
+          <div class="col">{{format-date this.sessionModel.resultsSentToPrescriberAt}}</div>
         </div>
       {{/if}}
     </div>
@@ -73,10 +71,7 @@
       <div class="session-info__stats">
         <div class="row">
           <div class="col">Nombre de signalements impactants non résolus:</div>
-          <div
-            class="col"
-            data-test-id="session-info__number-of-blocking-report"
-          >{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</div>
+          <div class="col">{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</div>
         </div>
         <div class="row">
           <div class="col">Nombre de signalements :</div>
@@ -96,10 +91,7 @@
         {{/unless}}
         <div class="row">
           <div class="col">Certifications non terminées traitées automatiquement :</div>
-          <div
-            class="col"
-            data-test-id="session-info__number-of-not-checked-end-screen"
-          >{{this.sessionModel.countCertificationsFlaggedAsAborted}}</div>
+          <div class="col">{{this.sessionModel.countCertificationsFlaggedAsAborted}}</div>
         </div>
         <div class="row">
           <div class="col">Nombre de certifications démarrées/en erreur :</div>
@@ -111,10 +103,7 @@
         {{#if this.sessionModel.hasExaminerGlobalComment}}
           <div class="row">
             <div class="col">Commentaire global :</div>
-            <div
-              class="col"
-              data-test-id="session-info__examiner-global-comment"
-            >{{this.sessionModel.examinerGlobalComment}}</div>
+            <div class="col">{{this.sessionModel.examinerGlobalComment}}</div>
           </div>
         {{/if}}
       </div>

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <div class="page-title">Tous les profils cibles</div>
+  <h1 class="page-title">Tous les profils cibles</h1>
   <div class="page-actions">
     <PixButton
       @route="authenticated.target-profiles.new"

--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -1,7 +1,7 @@
 {{page-title "Outils"}}
 <div class="page">
   <header class="page-header">
-    <div class="page-title">Outils</div>
+    <h1 class="page-title">Outils</h1>
     <div class="page-actions">
     </div>
   </header>

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -263,7 +263,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
 
       // when
-      await clickByName('Editer');
+      await clickByName('Editer les informations');
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
@@ -281,7 +281,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         isSupervisorAccessEnabled: false,
       });
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Editer');
+      await clickByName('Editer les informations');
       this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
@@ -312,7 +312,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       server.create('habilitation', { name: 'Pix+Autre' });
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Editer');
+      await clickByName('Editer les informations');
       this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
@@ -339,7 +339,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       });
       this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 422);
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Editer');
+      await clickByName('Editer les informations');
 
       // when
       await clickByName('Enregistrer');

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -158,10 +158,9 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
 
       // then
-      assert.dom(screen.getByText('Ajouter un membre')).exists();
-      assert.dom(screen.getByLabelText('Adresse e-mail du nouveau membre')).exists();
-      assert.dom(screen.getByText('Valider')).exists();
-      assert.dom('.error').notExists;
+      assert.dom(screen.getByRole('heading', { name: 'Ajouter un membre' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail du nouveau membre' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Ajouter le membre' })).exists();
     });
 
     test('should disable button if email is empty or contains spaces', async function (assert) {
@@ -221,7 +220,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Ajouter le membre' })).hasNoAttribute('disabled');
-      assert.dom('.error').notExists;
+      assert.dom(screen.queryByText("L'adresse e-mail saisie n'est pas valide.")).doesNotExist();
     });
 
     test('should display new certification-center-membership', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -177,7 +177,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // when
       await fillByLabel('Adresse e-mail du nouveau membre', spacesEmail);
-      await triggerEvent('#userEmailToAdd', 'focusout');
+      const input = screen.getByRole('textbox', { name: 'Adresse e-mail du nouveau membre' });
+      await triggerEvent(input, 'focusout');
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Ajouter le membre' })).hasAttribute('disabled');
@@ -196,7 +197,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // when
       await fillByLabel('Adresse e-mail du nouveau membre', 'an invalid email');
-      await triggerEvent('#userEmailToAdd', 'focusout');
+      const input = screen.getByRole('textbox', { name: 'Adresse e-mail du nouveau membre' });
+      await triggerEvent(input, 'focusout');
 
       // then
       assert.dom(screen.getByText("L'adresse e-mail saisie n'est pas valide.")).exists();
@@ -216,7 +218,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // when
       await fillByLabel('Adresse e-mail du nouveau membre', 'test@example.net');
-      await triggerEvent('#userEmailToAdd', 'focusout');
+      const input = screen.getByRole('textbox', { name: 'Adresse e-mail du nouveau membre' });
+      await triggerEvent(input, 'focusout');
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Ajouter le membre' })).hasNoAttribute('disabled');
@@ -235,7 +238,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       const email = 'test@example.net';
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await fillByLabel('Adresse e-mail du nouveau membre', email);
-      await triggerEvent('#userEmailToAdd', 'focusout');
+      const input = screen.getByRole('textbox', { name: 'Adresse e-mail du nouveau membre' });
+      await triggerEvent(input, 'focusout');
 
       // when
       await clickByName('Ajouter le membre');

--- a/admin/tests/acceptance/authenticated/certification-centers/list_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list_test.js
@@ -58,10 +58,10 @@ module('Acceptance | Certification Centers | List', function (hooks) {
       server.createList('certification-center', 3, { type: 'SUP' });
 
       // when
-      await visit('/certification-centers/list?type=sup');
+      const screen = await visit('/certification-centers/list?type=sup');
 
       // then
-      assert.dom('#type').hasValue('sup');
+      assert.dom(screen.getByRole('textbox', { name: 'Type' })).hasValue('sup');
     });
 
     test('should go to certification center page when line is clicked', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certification-centers/list_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list_test.js
@@ -41,13 +41,14 @@ module('Acceptance | Certification Centers | List', function (hooks) {
 
     test('it should list the certification-centers', async function (assert) {
       // given
-      server.createList('certification-center', 12);
-
+      const certificationCenter = server.createList('certification-center', 3);
       // when
-      await visit('/certification-centers/list');
+      const screen = await visit('/certification-centers/list');
 
       // then
-      assert.dom('.table-admin tbody tr').exists({ count: 12 });
+      assert.dom(screen.getByLabelText(`Centre de certification ${certificationCenter[0].name}`)).exists();
+      assert.dom(screen.getByLabelText(`Centre de certification ${certificationCenter[1].name}`)).exists();
+      assert.dom(screen.getByLabelText(`Centre de certification ${certificationCenter[2].name}`)).exists();
     });
 
     test('it should display the current filter when certification-centers are filtered', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -461,11 +461,11 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         certification.update({ certificationIssueReports: [certificationIssueReportImpactful] });
 
         // when
-        await visit('/certifications/123');
+        const screen = await visit('/certifications/123');
 
         // then
-        assert.dom('.certification-issue-report__resolution-status--resolved').exists();
-        assert.dom('.certification-issue-report__resolution-status--unresolved').doesNotExist();
+        assert.dom(screen.getByLabelText('Signalement résolu')).exists();
+        assert.dom(screen.queryByLabelText('Signalement non résolu')).doesNotExist();
       });
 
       test('should display a non-resolved issue report when not resolved', async function (assert) {
@@ -479,11 +479,11 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         certification.update({ certificationIssueReports: [certificationIssueReportImpactful] });
 
         // when
-        await visit('/certifications/123');
+        const screen = await visit('/certifications/123');
 
         // then
-        assert.dom('.certification-issue-report__resolution-status--resolved').doesNotExist();
-        assert.dom('.certification-issue-report__resolution-status--unresolved').exists();
+        assert.dom(screen.getByLabelText('Signalement non résolu')).exists();
+        assert.dom(screen.queryByLabelText('Signalement résolu')).doesNotExist();
       });
 
       module('when Resolve button is clicked on issue report', function () {
@@ -520,7 +520,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
                 // then
                 assert.dom(screen.getByText('Le signalement a été résolu.')).exists();
-                assert.dom('.certification-issue-report__details').containsText('Fraud');
+                assert.dom(screen.getByText('Résolution : Fraud')).exists();
               });
             });
           });

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -36,13 +36,15 @@ module('Acceptance | Organizations | List', function (hooks) {
 
     test('it should list the organizations', async function (assert) {
       // given
-      server.createList('organization', 12);
+      server.create('organization', { name: 'Tic' });
+      server.create('organization', { name: 'Tac' });
 
       // when
-      await visit('/organizations/list');
+      const screen = await visit('/organizations/list');
 
       // then
-      assert.dom('.table-admin tbody tr').exists({ count: 12 });
+      assert.dom(screen.getByLabelText('Organisation Tic')).exists();
+      assert.dom(screen.getByLabelText('Organisation Tac')).exists();
     });
 
     module('when filters are used', function (hooks) {

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -54,26 +54,26 @@ module('Acceptance | Organizations | List', function (hooks) {
 
       test('it should display the current filter when organizations are filtered by name', async function (assert) {
         // when
-        await visit('/organizations/list?name=sav');
+        const screen = await visit('/organizations/list?name=sav');
 
         // then
-        assert.dom('#name').hasValue('sav');
+        assert.dom(screen.getByRole('textbox', { name: 'Nom' })).hasValue('sav');
       });
 
       test('it should display the current filter when organizations are filtered by type', async function (assert) {
         // when
-        await visit('/organizations/list?type=SCO');
+        const screen = await visit('/organizations/list?type=SCO');
 
         // then
-        assert.dom('#type').hasValue('SCO');
+        assert.dom(screen.getByRole('textbox', { name: 'Type' })).hasValue('SCO');
       });
 
       test('it should display the current filter when organizations are filtered by externalId', async function (assert) {
         // when
-        await visit('/organizations/list?externalId=1234567A');
+        const screen = await visit('/organizations/list?externalId=1234567A');
 
         // then
-        assert.dom('#externalId').hasValue('1234567A');
+        assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).hasValue('1234567A');
       });
     });
 

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -32,34 +32,34 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
 
     test('it should display the current filter when memberships are filtered by firstName', async function (assert) {
       // when
-      await visit(`/organizations/${organization.id}/team?firstName=sav`);
+      const screen = await visit(`/organizations/${organization.id}/team?firstName=sav`);
 
       // then
-      assert.dom('#firstName').hasValue('sav');
+      assert.dom(screen.getByRole('textbox', { name: 'Rechercher par prénom' })).hasValue('sav');
     });
 
     test('it should display the current filter when organizations are filtered by lastName', async function (assert) {
       // when
-      await visit(`/organizations/${organization.id}/team?lastName=tro`);
+      const screen = await visit(`/organizations/${organization.id}/team?lastName=tro`);
 
       // then
-      assert.dom('#lastName').hasValue('tro');
+      assert.dom(screen.getByRole('textbox', { name: 'Rechercher par nom' })).hasValue('tro');
     });
 
     test('it should display the current filter when organizations are filtered by email', async function (assert) {
       // when
-      await visit(`/organizations/${organization.id}/team?email=fri`);
+      const screen = await visit(`/organizations/${organization.id}/team?email=fri`);
 
       // then
-      assert.dom('#email').hasValue('fri');
+      assert.dom(screen.getByRole('textbox', { name: 'Rechercher par adresse e-mail' })).hasValue('fri');
     });
 
     test('it should display the current filter when organizations are filtered by role', async function (assert) {
       // when
-      await visit(`/organizations/${organization.id}/team?organizationRole=ADMIN`);
+      const screen = await visit(`/organizations/${organization.id}/team?organizationRole=ADMIN`);
 
       // then
-      assert.dom('#organizationRole').hasValue('ADMIN');
+      assert.dom(screen.getByRole('combobox', { name: 'Rechercher par rôle' })).hasValue('ADMIN');
     });
 
     test('it should redirect to user details on user id click', async function (assert) {
@@ -95,7 +95,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       assert.dom(screen.getByText('John')).exists();
       assert.dom(screen.getByText('Doe')).exists();
       assert.dom(screen.getByText('user@example.com')).exists();
-      assert.dom('#userEmailToAdd').hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: "Adresse e-mail de l'utilisateur à ajouter" })).hasNoValue();
     });
 
     test('should not do anything when the membership was already existing for given user email and organization', async function (assert) {
@@ -117,8 +117,9 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
 
       // then
       assert.strictEqual(screen.getAllByLabelText('Membre').length, 1);
-      assert.dom(screen.getByText('Denise')).exists();
-      assert.dom('#userEmailToAdd').hasValue('denise@example.com');
+      assert
+        .dom(screen.getByRole('textbox', { name: "Adresse e-mail de l'utilisateur à ajouter" }))
+        .hasValue('denise@example.com');
     });
 
     test('should not do anything when no user was found for the input email', async function (assert) {
@@ -137,7 +138,9 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       // then
       assert.strictEqual(screen.getAllByLabelText('Membre').length, 1);
       assert.dom(screen.getByText('Erica')).exists();
-      assert.dom('#userEmailToAdd').hasValue('unexisting@example.com');
+      assert
+        .dom(screen.getByRole('textbox', { name: "Adresse e-mail de l'utilisateur à ajouter" }))
+        .hasValue('unexisting@example.com');
     });
   });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -56,18 +56,18 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
       test('it should display the current filter when target profiles are filtered by name', async function (assert) {
         // when
-        await visit('/target-profiles/list?name=sav');
+        const screen = await visit('/target-profiles/list?name=sav');
 
         // then
-        assert.dom('input#name').hasValue('sav');
+        assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un nom' })).hasValue('sav');
       });
 
       test('it should display the current filter when target profiles are filtered by id', async function (assert) {
         // when
-        await visit('/target-profiles/list?id=123');
+        const screen = await visit('/target-profiles/list?id=123');
 
         // then
-        assert.dom('input#id').hasValue('123');
+        assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un id' })).hasValue('123');
       });
     });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -1,5 +1,5 @@
-import { click, currentURL, fillIn, findAll } from '@ember/test-helpers';
-import { visit, clickByName } from '@1024pix/ember-testing-library';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { visit, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
@@ -31,8 +31,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
     // then
     assert.dom(screen.getByLabelText('Informations du badge My badge')).exists();
     assert.dom(screen.getByLabelText('Informations du badge My badge 2')).exists();
-    assert.dom('.stages-table tbody tr').exists({ count: 1 });
-    assert.dom('.stages-table tbody').containsText('My stage');
+    assert.dom(screen.getByLabelText('Informations sur le palier My stage')).exists();
   });
 
   module('badges', function () {
@@ -41,7 +40,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await visit(`/target-profiles/${targetProfile.id}/insights`);
 
       // when
-      await click('.insights__section:nth-child(1) a');
+      await clickByName('Détails du badge My badge');
 
       //then
       // TODO: Fix this the next time the file is edited.
@@ -97,7 +96,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
     test('should be able to add a new stage', async function (assert) {
       const screen = await visit(`/target-profiles/${targetProfile.id}/insights`);
 
-      const stageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      const stageCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stageCount, 1);
@@ -108,19 +107,20 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
       assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
       assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-      const newTableRowCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+
+      const newTableRowCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newTableRowCount, 2);
 
-      fillIn('.insights__section:nth-child(2) tbody tr td:nth-child(3) input', '0');
-      fillIn('.insights__section:nth-child(2) tbody tr td:nth-child(4) input', 'My stage title');
-      fillIn('.insights__section:nth-child(2) tbody tr td:nth-child(5) input', 'My stage message');
+      await fillByLabel('Seuil du palier', '0');
+      await fillByLabel('Titre du palier', 'My stage title');
+      await fillByLabel('Message du palier', 'My stage message');
 
       await clickByName('Enregistrer');
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
 
-      const newStageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      const newStageCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newStageCount, 2);
@@ -128,8 +128,8 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
     test('should reset stage creation data after cancellation', async function (assert) {
       // when
-      await visit(`/target-profiles/${targetProfile.id}/insights`);
-      const stageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      const screen = await visit(`/target-profiles/${targetProfile.id}/insights`);
+      const stageCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stageCount, 1);
@@ -137,7 +137,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await clickByName('Annuler');
 
       // then
-      const newStageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      const newStageCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newStageCount, 1);
@@ -146,7 +146,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
     test('should remove one line of a new stage', async function (assert) {
       // when
       const screen = await visit(`/target-profiles/${targetProfile.id}/insights`);
-      const stageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      const stageCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(stageCount, 1);
@@ -155,7 +155,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await click(screen.getAllByLabelText('Supprimer palier')[1]);
 
       // then
-      const newStageCount = findAll('.insights__section:nth-child(2) tbody tr').length;
+      const newStageCount = screen.getAllByLabelText('Informations sur le palier', { exact: false }).length;
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(newStageCount, 2);

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { visit, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -79,10 +79,11 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
       await visit(`/target-profiles/${targetProfile.id}/badges/new`);
 
       // when
-      await fillIn('input#badge-key', 'clé_du_badge');
-      await fillIn('input#image-name', 'nom_de_limage');
-      await fillIn('input#alt-message', 'texte alternatif à l‘image');
-      await fillIn('input#campaignParticipationThreshold', '65');
+      await fillByLabel('Nom du badge :', 'clé_du_badge');
+      await fillByLabel("Nom de l'image (svg) :", 'nom_de_limage');
+      await fillByLabel("Texte alternatif pour l'image :", 'texte alternatif à l‘image');
+      await fillByLabel("Clé (texte unique , vérifier qu'il n'existe pas) :", 'clé unique');
+      await fillByLabel('Taux de réussite global :', '65');
       await clickByName('Créer le badge');
 
       // then

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
@@ -38,7 +38,7 @@ module('Acceptance | Target Profiles | Target Profile | Organizations', function
     await fillByLabel('Rattacher une ou plusieurs organisation(s)', '42');
     await clickByName('Valider le rattachement');
 
-    assert.dom(screen.getByLabelText('Organisation')).includesText('42');
+    assert.dom(screen.getByLabelText('Organisation Organization 42')).includesText('42');
   });
 
   test('should be able to attach an organization with given target profile', async function (assert) {
@@ -47,6 +47,6 @@ module('Acceptance | Target Profiles | Target Profile | Organizations', function
     await fillByLabel("Rattacher les organisations d'un profil cible existant", '43');
     await clickByName('Valider le rattachement à partir de ce profil cible');
 
-    assert.dom(screen.getByLabelText('Organisation')).includesText('Organization for target profile 43');
+    assert.dom(screen.getByLabelText('Organisation Organization for target profile 43')).exists();
   });
 });

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
@@ -38,7 +38,8 @@ module('Acceptance | Session page', function (hooks) {
 
       // when
       const screen = await visit(`/sessions/${session.id}`);
-      assert.dom('div.session-info__details').exists();
+
+      assert.dom(screen.getByText('Centre :')).exists();
       assert.dom(screen.queryByText('Date de finalisation :')).doesNotExist();
     });
 
@@ -49,7 +50,6 @@ module('Acceptance | Session page', function (hooks) {
       // when
       const screen = await visit(`/sessions/${session.id}`);
 
-      assert.dom('div.session-info__details').exists();
       assert.dom(screen.getByText('Date de finalisation :')).exists();
       assert.dom(screen.getByText('10/03/2019')).exists();
     });

--- a/admin/tests/acceptance/organization-invitations-management_test.js
+++ b/admin/tests/acceptance/organization-invitations-management_test.js
@@ -49,7 +49,7 @@ module('Acceptance | organization invitations management', function (hooks) {
       // then
       assert.dom(screen.getByText("Un email a bien a été envoyé à l'adresse user@example.com.")).exists();
       assert.dom(screen.getByText(moment(now).format('DD/MM/YYYY [-] HH:mm'))).exists();
-      assert.dom('#userEmailToInvite').hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' })).hasNoValue();
     });
 
     test('should display an error if the creation has failed', async function (assert) {

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -35,7 +35,7 @@ module('Acceptance | Session pages', function (hooks) {
         certificationCenterName: 'Centre des Staranne',
         certificationCenterId: 1234,
         status: FINALIZED,
-        finalizedAt: new Date('2020-01-01T03:00:00Z'),
+        finalizedAt: new Date('2020-01-01'),
         examinerGlobalComment: 'Commentaire du surveillant',
       });
     });
@@ -111,8 +111,8 @@ module('Acceptance | Session pages', function (hooks) {
 
           // then
           assert.dom(screen.getByRole('link', { name: session.certificationCenterName })).exists();
-          assert.dom('[data-test-id="session-info__finalized-at"]').hasText('01/01/2020');
-          assert.dom('[data-test-id="session-info__examiner-global-comment"]').hasText(session.examinerGlobalComment);
+          assert.dom(screen.getByText('01/01/2020')).exists();
+          assert.dom(screen.getByText(session.examinerGlobalComment)).exists();
         });
 
         test('it displays a link to a certification center and redirects to it', async function (assert) {

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, click, fillIn } from '@ember/test-helpers';
+import { currentURL, click } from '@ember/test-helpers';
 import { visit, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
@@ -64,12 +64,12 @@ module('Acceptance | Session List', function (hooks) {
           const screen = await visit('/sessions/list');
 
           // then
-          assert.dom('select#pageSize').hasValue('10');
+          assert.dom(screen.getByRole('combobox', { name: "Nombre d'éléments à afficher par page" })).hasValue('10');
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
             exact: false,
           }).length;
           assert.strictEqual(sessionCount, 10);
-          assert.dom('div.page-navigation__current-page').hasText('1');
+          assert.dom(screen.getByText('Page : 1 / 4')).exists();
         });
       });
 
@@ -80,12 +80,12 @@ module('Acceptance | Session List', function (hooks) {
           await click(screen.getByLabelText('Aller à la page suivante'));
 
           // then
-          assert.dom('select#pageSize').hasValue('10');
+          assert.dom(screen.getByRole('combobox', { name: "Nombre d'éléments à afficher par page" })).hasValue('10');
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
             exact: false,
           }).length;
           assert.strictEqual(sessionCount, 10);
-          assert.dom('div.page-navigation__current-page').hasText('2');
+          assert.dom(screen.getByText('Page : 2 / 4')).exists();
         });
       });
 
@@ -93,15 +93,15 @@ module('Acceptance | Session List', function (hooks) {
         test('it should display all the finalized sessions', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await fillIn('select#pageSize', '25');
+          await selectByLabelAndOption("Nombre d'éléments à afficher par page", '25');
 
           // then
-          assert.dom('select#pageSize').hasValue('25');
+          assert.dom(screen.getByRole('combobox', { name: "Nombre d'éléments à afficher par page" })).hasValue('25');
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
             exact: false,
           }).length;
           assert.strictEqual(sessionCount, 25);
-          assert.dom('div.page-navigation__current-page').hasText('1');
+          assert.dom(screen.getByText('Page : 1 / 2')).exists();
         });
       });
 

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -61,11 +61,14 @@ module('Acceptance | Session List', function (hooks) {
       module('Default display', function () {
         test('it should display the first page of finalized sessions', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
 
           // then
           assert.dom('select#pageSize').hasValue('10');
-          assert.dom('.table-admin tbody tr').exists({ count: 10 });
+          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionCount, 10);
           assert.dom('div.page-navigation__current-page').hasText('1');
         });
       });
@@ -78,7 +81,10 @@ module('Acceptance | Session List', function (hooks) {
 
           // then
           assert.dom('select#pageSize').hasValue('10');
-          assert.dom('.table-admin tbody tr').exists({ count: 10 });
+          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionCount, 10);
           assert.dom('div.page-navigation__current-page').hasText('2');
         });
       });
@@ -86,12 +92,15 @@ module('Acceptance | Session List', function (hooks) {
       module('when selecting a different pageSize', function () {
         test('it should display all the finalized sessions', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
           await fillIn('select#pageSize', '25');
 
           // then
           assert.dom('select#pageSize').hasValue('25');
-          assert.dom('.table-admin tbody tr').exists({ count: 25 });
+          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionCount, 25);
           assert.dom('div.page-navigation__current-page').hasText('1');
         });
       });
@@ -99,13 +108,13 @@ module('Acceptance | Session List', function (hooks) {
       module('when invalid filter value are typed in', function () {
         test('it should display an empty list', async function (assert) {
           // given
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
 
           // when
           await fillIn('#id', 'azere');
 
           //then
-          assert.dom('.table__empty').hasText('Aucun résultat');
+          assert.dom(screen.getByText('Aucun résultat')).exists();
         });
       });
     });
@@ -121,11 +130,11 @@ module('Acceptance | Session List', function (hooks) {
 
         test('it should display the session with the ID specified in the input field', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
           await fillIn('#id', expectedSession.id);
 
           // then
-          assert.dom('.table-admin tbody tr').exists({ count: 1 });
+          assert.dom(screen.getByRole('link', { name: '1' })).exists();
         });
       });
 
@@ -133,17 +142,22 @@ module('Acceptance | Session List', function (hooks) {
         let expectedSession;
 
         hooks.beforeEach(function () {
-          expectedSession = server.create('session', 'finalized');
+          expectedSession = server.create('session', {
+            certificationCenterName: 'Erdman, Bode and Walker',
+            status: 'finalized',
+          });
           server.createList('session', 10, 'finalized');
         });
 
         test('it should display the session with a certification center name alike the one specified in the field', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
           await fillIn('#certificationCenterName', expectedSession.certificationCenterName.toUpperCase());
 
           // then
-          assert.dom('.table-admin tbody tr').exists({ count: 1 });
+          assert
+            .dom(screen.getByLabelText('Informations de la session de certification 1'))
+            .containsText('Erdman, Bode and Walker');
         });
       });
 
@@ -155,11 +169,14 @@ module('Acceptance | Session List', function (hooks) {
 
         test('it should display the session with status as specified in the dropdown', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
           await fillIn('select#status', 'processed');
 
           // then
-          assert.dom('.table-admin tbody tr').exists({ count: 5 });
+          const sessionProcessedCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionProcessedCount, 5);
         });
       });
 
@@ -171,28 +188,37 @@ module('Acceptance | Session List', function (hooks) {
 
         test('it should display sessions regardless the results have been sent or not', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
 
           // then
-          assert.dom('.table-admin tbody tr').exists({ count: 8 });
+          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionCount, 8);
         });
 
         test('it should only display sessions which results have been sent', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
           await fillIn('select#resultsSentToPrescriberAt', 'true');
 
           // then
-          assert.dom('.table-admin tbody tr').exists({ count: 5 });
+          const sessionWithResultSentCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionWithResultSentCount, 5);
         });
 
         test('it should only display sessions which results have not been sent', async function (assert) {
           // when
-          await visit('/sessions/list');
+          const screen = await visit('/sessions/list');
           await fillIn('select#resultsSentToPrescriberAt', 'false');
 
           // then
-          assert.dom('.table-admin tbody tr').exists({ count: 3 });
+          const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
+            exact: false,
+          }).length;
+          assert.strictEqual(sessionCount, 3);
         });
       });
     });

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { currentURL, click, fillIn } from '@ember/test-helpers';
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
@@ -111,7 +111,7 @@ module('Acceptance | Session List', function (hooks) {
           const screen = await visit('/sessions/list');
 
           // when
-          await fillIn('#id', 'azere');
+          await fillByLabel('Filtrer les sessions avec un id', 'azere');
 
           //then
           assert.dom(screen.getByText('Aucun résultat')).exists();
@@ -131,7 +131,7 @@ module('Acceptance | Session List', function (hooks) {
         test('it should display the session with the ID specified in the input field', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await fillIn('#id', expectedSession.id);
+          await fillByLabel('Filtrer les sessions avec un id', expectedSession.id);
 
           // then
           assert.dom(screen.getByRole('link', { name: '1' })).exists();
@@ -152,7 +152,10 @@ module('Acceptance | Session List', function (hooks) {
         test('it should display the session with a certification center name alike the one specified in the field', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await fillIn('#certificationCenterName', expectedSession.certificationCenterName.toUpperCase());
+          await fillByLabel(
+            "Filtrer les sessions avec le nom d'un centre de certification",
+            expectedSession.certificationCenterName.toUpperCase()
+          );
 
           // then
           assert
@@ -170,7 +173,7 @@ module('Acceptance | Session List', function (hooks) {
         test('it should display the session with status as specified in the dropdown', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await fillIn('select#status', 'processed');
+          await selectByLabelAndOption('Filtrer les sessions en sélectionnant un statut', 'processed');
 
           // then
           const sessionProcessedCount = screen.getAllByLabelText('Informations de la session de certification', {
@@ -200,7 +203,7 @@ module('Acceptance | Session List', function (hooks) {
         test('it should only display sessions which results have been sent', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await fillIn('select#resultsSentToPrescriberAt', 'true');
+          await selectByLabelAndOption('Filtrer les sessions par leurs résultats diffusés ou non diffusés', 'true');
 
           // then
           const sessionWithResultSentCount = screen.getAllByLabelText('Informations de la session de certification', {
@@ -212,7 +215,7 @@ module('Acceptance | Session List', function (hooks) {
         test('it should only display sessions which results have not been sent', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await fillIn('select#resultsSentToPrescriberAt', 'false');
+          await selectByLabelAndOption('Filtrer les sessions par leurs résultats diffusés ou non diffusés', 'false');
 
           // then
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {

--- a/admin/tests/acceptance/tools_test.js
+++ b/admin/tests/acceptance/tools_test.js
@@ -90,6 +90,6 @@ module('Acceptance | tools', function (hooks) {
 
     // then
     assert.dom(screen.getByText('Le tag a bien été créé !')).exists();
-    assert.dom('#tagNameInput').hasNoValue();
+    assert.dom(screen.getByRole('textbox', { name: 'Nom du tag' })).hasNoValue();
   });
 });

--- a/admin/tests/acceptance/user-list_test.js
+++ b/admin/tests/acceptance/user-list_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
@@ -39,15 +40,14 @@ module('Acceptance | User List', function (hooks) {
 
     test('it should not list the users at loading page', async function (assert) {
       // when
-      await visit('/users/list');
+      const screen = await visit('/users/list');
 
       // then
-      assert.dom('.table-admin tbody tr').doesNotExist();
+      assert.dom(screen.getByText('Aucun résultat')).exists();
     });
 
     test('it should display the current filter when users are filtered', async function (assert) {
       // given
-      const expectedUsersCount = 1;
       const result = {
         data: [
           {
@@ -65,10 +65,11 @@ module('Acceptance | User List', function (hooks) {
       this.server.get('/users', () => result);
 
       // when
-      await visit('/users/list?email=example.net');
+      const screen = await visit('/users/list?email=example.net');
 
       // then
-      assert.dom('.table-admin tbody tr').exists({ count: expectedUsersCount });
+      assert.dom(screen.getByLabelText("Informations de l'utilisateur Pix Aile")).containsText('userpix1@example.net');
+      assert.strictEqual(screen.queryAllByLabelText("Informations de l'utilisateur", { exact: false }).length, 1);
     });
   });
 });

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
-import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { fillByLabel, render, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
@@ -79,7 +78,7 @@ module('Integration | Component | Badges::Badge', function (hooks) {
       await render(hbs`<Badges::Badge @badge={{this.badge}} />`);
 
       // when
-      await click('button[type="button"]');
+      await clickByName('Éditer');
       await fillByLabel('* Titre :', 'mon titre mis à jour');
       await fillByLabel('* Clé :', 'ma clef mise à jour');
       await fillByLabel('Message :', 'mon message mis à jour');
@@ -87,7 +86,7 @@ module('Integration | Component | Badges::Badge', function (hooks) {
       await fillByLabel("* Nom de l'image (svg) :", 'mon url image mise à jour');
       await fillByLabel('Certifiable :', false);
       await fillByLabel('Lacunes :', true);
-      await click('button[type="submit"]');
+      await clickByName('Enregistrer');
 
       // then
       sinon.assert.calledWith(findRecordStub, 'badge', badge.id);

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
@@ -51,15 +51,13 @@ module('Integration | Component | Badges::Badge', function (hooks) {
     const screen = await render(hbs`<Badges::Badge @badge={{this.badge}} />`);
 
     //then
-    assert.dom('.page-section__details').exists();
-    const detailsContent = find('.page-section__details').textContent;
-    assert.ok(detailsContent.match(badge.title), 'title');
-    assert.ok(detailsContent.match(badge.key), 'key');
-    assert.ok(detailsContent.match(badge.message), 'message');
-    assert.ok(detailsContent.match(badge.id), 'id');
-    assert.ok(detailsContent.match(badge.altMessage), 'altMessage');
-    assert.ok(detailsContent.match('Certifiable'), 'Certifiable');
-    assert.dom('.page-section__details img').exists();
+    assert.dom(screen.getByText(`ID : ${badge.id}`)).exists();
+    assert.dom(screen.getByText(`Nom du badge : ${badge.title}`)).exists();
+    assert.dom(screen.getByText(`Message : ${badge.message}`)).exists();
+    assert.dom(screen.getByText(`Clé : ${badge.key}`)).exists();
+    assert.dom(screen.getByText(`Message alternatif : ${badge.altMessage}`)).exists();
+    assert.dom(screen.getByText('Certifiable')).exists();
+    assert.dom(screen.getByRole('presentation')).exists();
     assert.dom(screen.getByText('85%')).exists();
     assert
       .dom(screen.getByText('L‘évalué doit obtenir sur l‘ensemble des acquis du target profile', { exact: false }))

--- a/admin/tests/integration/components/campaigns/participation-row_test.js
+++ b/admin/tests/integration/components/campaigns/participation-row_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn } from '@ember/test-helpers';
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
@@ -126,7 +125,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       await clickByName('Modifier');
 
       // when
-      await fillIn('#participantExternalId', '4567890');
+      await fillByLabel("Modifier l'identifiant externe du participant", '4567890');
       await clickByName('Enregistrer');
 
       // then
@@ -143,7 +142,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       await clickByName('Modifier');
 
       // when
-      await fillIn('#participantExternalId', '    ');
+      await fillByLabel("Modifier l'identifiant externe du participant", '   ');
       await clickByName('Enregistrer');
 
       // then
@@ -160,7 +159,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       await clickByName('Modifier');
 
       // when
-      await fillIn('#participantExternalId', '');
+      await fillByLabel("Modifier l'identifiant externe du participant", '');
       await clickByName('Enregistrer');
 
       // then
@@ -177,7 +176,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       await clickByName('Modifier');
 
       // when
-      await fillIn('#participantExternalId', '4567890');
+      await fillByLabel("Modifier l'identifiant externe du participant", '4567890');
       await clickByName('Annuler');
 
       // then

--- a/admin/tests/integration/components/campaigns/update_test.js
+++ b/admin/tests/integration/components/campaigns/update_test.js
@@ -26,7 +26,7 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
     assert.dom('label[for="name"]').hasText('* Nom de la campagne');
     assert.dom('label[for="customLandingPageText"]').hasText("Texte de la page d'accueil");
     assert.dom('textarea#customLandingPageText').hasAttribute('maxLength', '5000');
-    assert.dom('input#name').hasValue('Ceci est un nom');
+    assert.dom(screen.getByRole('textbox', { name: 'obligatoire Nom de la campagne' })).hasValue('Ceci est un nom');
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
   });
@@ -38,14 +38,14 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
 
     test('it should display items for assessment', async function (assert) {
       // when
-      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
+      const screen = await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
 
       // then
       assert.dom('label[for="title"]').hasText('Titre du parcours');
       assert.dom('label[for="customResultPageText"]').hasText('Texte de la page de fin de parcours');
       assert.dom('label[for="customResultPageButtonText"]').hasText('Texte du bouton de la page de fin de parcours');
       assert.dom('label[for="customResultPageButtonUrl"]').hasText('URL du bouton de la page de fin de parcours');
-      assert.dom('input#title').hasValue('Ceci est un titre');
+      assert.dom(screen.getByRole('textbox', { name: 'Titre du parcours' })).hasValue('Ceci est un titre');
     });
 
     test('it should display an error text when the customResultPageButtonText has more than 255 characters', async function (assert) {

--- a/admin/tests/integration/components/campaigns/update_test.js
+++ b/admin/tests/integration/components/campaigns/update_test.js
@@ -23,9 +23,7 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
     const screen = await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
 
     // then
-    assert.dom('label[for="name"]').hasText('* Nom de la campagne');
-    assert.dom('label[for="customLandingPageText"]').hasText("Texte de la page d'accueil");
-    assert.dom('textarea#customLandingPageText').hasAttribute('maxLength', '5000');
+    assert.dom(screen.getByRole('textbox', { name: "Texte de la page d'accueil" })).hasAttribute('maxLength', '5000');
     assert.dom(screen.getByRole('textbox', { name: 'obligatoire Nom de la campagne' })).hasValue('Ceci est un nom');
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
@@ -41,11 +39,10 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
       const screen = await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
 
       // then
-      assert.dom('label[for="title"]').hasText('Titre du parcours');
-      assert.dom('label[for="customResultPageText"]').hasText('Texte de la page de fin de parcours');
-      assert.dom('label[for="customResultPageButtonText"]').hasText('Texte du bouton de la page de fin de parcours');
-      assert.dom('label[for="customResultPageButtonUrl"]').hasText('URL du bouton de la page de fin de parcours');
       assert.dom(screen.getByRole('textbox', { name: 'Titre du parcours' })).hasValue('Ceci est un titre');
+      assert.dom(screen.getByRole('textbox', { name: 'Texte de la page de fin de parcours' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Texte du bouton de la page de fin de parcours' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'URL du bouton de la page de fin de parcours' })).exists();
     });
 
     test('it should display an error text when the customResultPageButtonText has more than 255 characters', async function (assert) {
@@ -94,13 +91,15 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
 
     test('it should display items for profiles collection', async function (assert) {
       // when
-      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
+      const screen = await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
 
       // then
-      assert.dom('label[for="title"]').doesNotExist();
-      assert.dom('label[for="customResultPageText"]').doesNotExist();
-      assert.dom('label[for="customResultPageButtonText"]').doesNotExist();
-      assert.dom('label[for="customResultPageButtonUrl"]').doesNotExist();
+      assert.dom(screen.queryByRole('textbox', { name: 'Titre du parcours' })).doesNotExist();
+      assert.dom(screen.queryByRole('textbox', { name: 'Texte de la page de fin de parcours' })).doesNotExist();
+      assert
+        .dom(screen.queryByRole('textbox', { name: 'Texte du bouton de la page de fin de parcours' }))
+        .doesNotExist();
+      assert.dom(screen.queryByRole('textbox', { name: 'URL du bouton de la page de fin de parcours' })).doesNotExist();
     });
   });
 
@@ -180,7 +179,7 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
       const screen = await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
 
       // then
-      assert.dom(screen.getByText('Envoi multiple')).exists();
+      assert.dom(screen.getByRole('checkbox', { name: 'Envoi multiple' })).exists();
     });
 
     test('it should not display multiple sendings checkbox when campaign has participations', async function (assert) {
@@ -188,10 +187,10 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
       this.campaign.totalParticipationsCount = 1;
 
       // when
-      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
+      const screen = await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
 
       // then
-      assert.dom('label[for="multipleSendings"]').doesNotExist();
+      assert.dom(screen.queryByRole('checkbox', { name: 'Envoi multiple' })).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/certification-centers/form_test.js
+++ b/admin/tests/integration/components/certification-centers/form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, find } from '@ember/test-helpers';
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { find } from '@ember/test-helpers';
+import { clickByName, render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import { A as EmberArray } from '@ember/array';
@@ -38,7 +38,7 @@ module('Integration | Component | certification-centers/form', function (hooks) 
       );
 
       // when
-      await fillIn('#certificationCenterTypeSelector', 'SCO');
+      await selectByLabelAndOption("Type d'établissement", 'SCO');
 
       // then
       assert.strictEqual(this.certificationCenter.type, 'SCO');

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -154,7 +154,7 @@ module('Integration | Component | certification-centers/information', function (
     // then
     assert.dom(screen.getByRole('heading', { name: 'Modifier un centre de certification' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Nom du centre' })).hasValue('Centre SCO');
-    assert.dom('select#certification-center-type').hasValue('SCO');
+    assert.dom(screen.getByRole('combobox', { name: 'Type' })).hasValue('SCO');
     assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).hasValue('AX129');
     assert.dom(screen.getByLabelText('Espace surveillant')).isNotChecked();
     assert.dom(screen.getByLabelText('Pix+Droit')).isChecked();

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import ArrayProxy from '@ember/array/proxy';
@@ -177,7 +176,7 @@ module('Integration | Component | certification-centers/information', function (
     );
 
     await clickByName('Editer');
-    await fillIn('#name', repeat('a', 256));
+    await fillByLabel('Nom du centre', repeat('a', 256));
 
     // then
     assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();
@@ -198,7 +197,7 @@ module('Integration | Component | certification-centers/information', function (
     );
 
     await clickByName('Editer');
-    await fillIn('#name', '');
+    await fillByLabel('Nom du centre', '');
 
     // then
     assert.dom(screen.getByText('Le nom ne peut pas être vide')).exists();
@@ -219,7 +218,7 @@ module('Integration | Component | certification-centers/information', function (
     );
 
     await clickByName('Editer');
-    await fillIn('#external-id', repeat('a', 256));
+    await fillByLabel('Identifiant externe', repeat('a', 256));
 
     // then
     assert.dom(screen.getByText("La longueur de l'identifiant externe ne doit pas excéder 255 caractères")).exists();
@@ -292,9 +291,9 @@ module('Integration | Component | certification-centers/information', function (
     );
 
     await clickByName('Editer');
-    await fillIn('#name', 'Centre SUP');
-    await fillIn('#certification-center-type', 'SUP');
-    await fillIn('#external-id', 'externalId');
+    await fillByLabel('Nom du centre', 'Centre SUP');
+    await fillByLabel('Type', 'SUP');
+    await fillByLabel('Identifiant externe', 'externalId');
     await clickByName('Espace surveillant');
     await clickByName('Cléa');
     await clickByName('Annuler');

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -67,7 +67,7 @@ module('Integration | Component | certification-centers/information', function (
     const screen = await render(
       hbs`<CertificationCenters::Information @certificationCenter={{this.certificationCenter}} @isEditMode={{this.isEditMode}} />`
     );
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
 
     // then
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
@@ -94,13 +94,13 @@ module('Integration | Component | certification-centers/information', function (
         @updateCertificationCenter={{this.updateCertificationCenter}}
  />`
     );
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
     await clickByName('Enregistrer');
 
     // then
-    assert.dom(screen.getByText('Editer les informations')).exists();
-    assert.dom(screen.queryByText('Annuler')).doesNotExist();
-    assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
+    assert.dom(screen.getByRole('button', { name: 'Editer les informations' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
     assert.dom(screen.queryByText('Nom du centre')).doesNotExist();
   });
 
@@ -119,14 +119,14 @@ module('Integration | Component | certification-centers/information', function (
     const screen = await render(
       hbs`<CertificationCenters::Information @certificationCenter={{this.certificationCenter}} />`
     );
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
 
     await clickByName('Annuler');
 
     // then
-    assert.dom(screen.getByText('Editer les informations')).exists();
-    assert.dom(screen.queryByText('Annuler')).doesNotExist();
-    assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
+    assert.dom(screen.getByRole('button', { name: 'Editer les informations' })).exists();
+    assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
     assert.dom(screen.queryByText('Nom du centre')).doesNotExist();
   });
 
@@ -149,13 +149,13 @@ module('Integration | Component | certification-centers/information', function (
     const screen = await render(
       hbs`<CertificationCenters::Information @availableHabilitations={{this.availableHabilitations}} @certificationCenter={{this.certificationCenter}} />`
     );
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Modifier un centre de certification' })).exists();
-    assert.dom('input#name').hasValue('Centre SCO');
+    assert.dom(screen.getByRole('textbox', { name: 'Nom du centre' })).hasValue('Centre SCO');
     assert.dom('select#certification-center-type').hasValue('SCO');
-    assert.dom('input#external-id').hasValue('AX129');
+    assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).hasValue('AX129');
     assert.dom(screen.getByLabelText('Espace surveillant')).isNotChecked();
     assert.dom(screen.getByLabelText('Pix+Droit')).isChecked();
     assert.dom(screen.getByLabelText('Cléa')).isNotChecked();
@@ -175,7 +175,7 @@ module('Integration | Component | certification-centers/information', function (
       hbs`<CertificationCenters::Information @certificationCenter={{this.certificationCenter}} />`
     );
 
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
     await fillByLabel('Nom du centre', repeat('a', 256));
 
     // then
@@ -196,7 +196,7 @@ module('Integration | Component | certification-centers/information', function (
       hbs`<CertificationCenters::Information @certificationCenter={{this.certificationCenter}} />`
     );
 
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
     await fillByLabel('Nom du centre', '');
 
     // then
@@ -217,7 +217,7 @@ module('Integration | Component | certification-centers/information', function (
       hbs`<CertificationCenters::Information @certificationCenter={{this.certificationCenter}} />`
     );
 
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
     await fillByLabel('Identifiant externe', repeat('a', 256));
 
     // then
@@ -246,7 +246,7 @@ module('Integration | Component | certification-centers/information', function (
         @certificationCenter={{this.certificationCenter}} />`
     );
 
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
     await fillByLabel('Nom du centre', 'Centre SUP');
     await fillByLabel('Type', 'SUP');
     await fillByLabel('Identifiant externe', 'externalId');
@@ -290,7 +290,7 @@ module('Integration | Component | certification-centers/information', function (
         @updateCertificationCenter={{this.updateCertificationCenter}} />`
     );
 
-    await clickByName('Editer');
+    await clickByName('Editer les informations');
     await fillByLabel('Nom du centre', 'Centre SUP');
     await fillByLabel('Type', 'SUP');
     await fillByLabel('Identifiant externe', 'externalId');

--- a/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
 import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
@@ -68,13 +67,13 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       ];
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
       );
 
       // then
-      assert.dom('#first-name').hasValue('Fabrice');
-      assert.dom('#last-name').hasValue('Gadjo');
+      assert.dom(screen.getByRole('textbox', { name: '* Prénom' })).hasValue('Fabrice');
+      assert.dom(screen.getByRole('textbox', { name: '* Nom de famille' })).hasValue('Gadjo');
       assert.dom('#birthdate').hasValue('2000-12-15');
     });
 
@@ -99,12 +98,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
-        assert.dom('#male').isChecked();
+        assert.dom(screen.getByRole('radio', { name: 'Homme' })).isChecked();
       });
 
       test('it should check "Femme" option when candidate is female', async function (assert) {
@@ -127,12 +126,12 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
-        assert.dom('#female').isChecked();
+        assert.dom(screen.getByRole('radio', { name: 'Femme' })).isChecked();
       });
     });
 
@@ -157,16 +156,15 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
-        assert.dom('#birth-insee-code').doesNotExist();
-        assert.dom('#birth-postal-code').doesNotExist();
-        const options = this.element.querySelectorAll('option');
-        assert.true(options.item(0).selected);
-        assert.dom('#birth-city').hasValue('Copenhague');
+        assert.dom(screen.queryByRole('textbox', { name: '* Code Insee de naissance' })).doesNotExist();
+        assert.dom(screen.queryByRole('textbox', { name: '* Code postal de naissance' })).doesNotExist();
+        assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('DANEMARK');
+        assert.dom(screen.getByRole('textbox', { name: '* Commune de naissance' })).hasValue('Copenhague');
       });
     });
 
@@ -191,16 +189,15 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
-        assert.dom('#birth-postal-code').hasValue('66440');
-        assert.dom('#birth-insee-code').doesNotExist();
-        assert.dom('#birth-city').hasValue('Torreilles');
-        const options = this.element.querySelectorAll('option');
-        assert.true(options.item(1).selected);
+        assert.dom(screen.getByRole('textbox', { name: '* Code postal de naissance' })).hasValue('66440');
+        assert.dom(screen.queryByRole('textbox', { name: '* Code Insee de naissance' })).doesNotExist();
+        assert.dom(screen.getByRole('textbox', { name: '* Commune de naissance' })).hasValue('Torreilles');
+        assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('FRANCE');
       });
     });
 
@@ -225,16 +222,15 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
-        assert.dom('#birth-insee-code').hasValue('66212');
-        assert.dom('#birth-postal-code').doesNotExist();
-        assert.dom('#birth-city').doesNotExist();
-        const options = this.element.querySelectorAll('option');
-        assert.true(options.item(1).selected);
+        assert.dom(screen.queryByRole('textbox', { name: '* Code postal de naissance' })).doesNotExist();
+        assert.dom(screen.getByRole('textbox', { name: '* Code Insee de naissance' })).hasValue('66212');
+        assert.dom(screen.queryByRole('textbox', { name: '* Commune de naissance' })).doesNotExist();
+        assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('FRANCE');
       });
     });
   });
@@ -258,15 +254,16 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
       ];
       this.onCancelButtonsClickedStub = sinon.stub();
-      await render(
+      const screen = await render(
         hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`
       );
+
       await fillByLabel('* Nom de famille', 'Belmans');
       await fillByLabel('* Prénom', 'Gideona');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
-      await click('#female');
+      await clickByName('Femme');
       await fillByLabel('Pays de naissance', '99100');
-      await click('#postal-code-choice');
+      await clickByName('Code postal');
       await fillByLabel('* Code postal de naissance', '75001');
       await fillByLabel('* Commune de naissance', 'PARIS 01');
 
@@ -274,15 +271,14 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       await clickByName('Annuler');
 
       // then
-      assert.dom('#first-name').hasValue('Fabrice');
-      assert.dom('#last-name').hasValue('Gadjo');
+      assert.dom(screen.getByRole('textbox', { name: '* Prénom' })).hasValue('Fabrice');
+      assert.dom(screen.getByRole('textbox', { name: '* Nom de famille' })).hasValue('Gadjo');
       assert.dom('#birthdate').hasValue('2000-12-15');
-      assert.dom('#male').isChecked;
-      assert.dom('#birth-insee-code').doesNotExist();
-      assert.dom('#birth-postal-code').doesNotExist();
-      assert.dom('#birth-city').hasValue('Copenhague');
-      const options = this.element.querySelectorAll('option');
-      assert.true(options.item(0).selected);
+      assert.dom(screen.getByRole('radio', { name: 'Homme' })).isChecked();
+      assert.dom(screen.queryByRole('textbox', { name: '* Code Insee de naissance' })).doesNotExist();
+      assert.dom(screen.queryByRole('textbox', { name: '* Code postal de naissance' })).doesNotExist();
+      assert.dom(screen.getByRole('textbox', { name: '* Commune de naissance' })).hasValue('Copenhague');
+      assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('DANEMARK');
     });
 
     test('it should not alter candidate information', async function (assert) {
@@ -310,9 +306,9 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       await fillByLabel('* Nom de famille', 'Belmans');
       await fillByLabel('* Prénom', 'Gideona');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
-      await click('#female');
+      await clickByName('Femme');
       await fillByLabel('Pays de naissance', '99100');
-      await click('#postal-code-choice');
+      await clickByName('Code postal');
       await fillByLabel('* Code postal de naissance', '75001');
       await fillByLabel('* Commune de naissance', 'PARIS 01');
 
@@ -382,9 +378,9 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       await fillByLabel('* Nom de famille', 'Belmans');
       await fillByLabel('* Prénom', 'Gideon');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
-      await click('#male');
+      await clickByName('Homme');
       await fillByLabel('Pays de naissance', '99100');
-      await click('#postal-code-choice');
+      await clickByName('Code postal');
       await fillByLabel('* Code postal de naissance', '75001');
       await fillByLabel('* Commune de naissance', 'PARIS 01');
 
@@ -466,7 +462,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         await fillByLabel('Pays de naissance', '99100');
-        await click('#insee-code-choice');
+        await clickByName('Code INSEE');
         await fillByLabel('* Code Insee de naissance', '66212');
         await clickByName('Enregistrer');
 
@@ -511,7 +507,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         await fillByLabel('Pays de naissance', '99100');
-        await click('#postal-code-choice');
+        await clickByName('Code postal');
         await fillByLabel('* Code postal de naissance', '66440');
         await fillByLabel('* Commune de naissance', 'Torreilles');
         await clickByName('Enregistrer');
@@ -584,7 +580,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
 
         // when
-        await click('#insee-code-choice');
+        await clickByName('Code INSEE');
 
         // then
         assert.dom(screen.getByLabelText('* Code Insee de naissance')).exists();
@@ -613,7 +609,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
 
         // when
-        await click('#postal-code-choice');
+        await clickByName('Code postal');
 
         // then
         assert.dom(screen.queryByText('Code INSEE de naissance')).doesNotExist();

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
-import { selectChoose } from 'ember-power-select/test-support/helpers';
 
 module('Integration | Component | certifications/details-answer', function (hooks) {
   setupRenderingTest(hooks);
@@ -30,7 +29,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     );
 
     // then
-    assert.dom(screen.getByText('Succès partiel')).exists();
+    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Succès partiel');
   });
 
   test('init answer displayed status with neutralized label when challenge is neutralized', async function (assert) {
@@ -46,7 +45,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     );
 
     // then
-    assert.dom(screen.getByText('Neutralisée')).exists();
+    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Neutralisée');
   });
 
   test('info are correctly displayed', async function (assert) {
@@ -66,7 +65,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     assert.dom(screen.getByText('@skill6')).exists();
     assert.dom(screen.getByText('rec1234')).exists();
     assert.dom(screen.getByText('coucou')).exists();
-    assert.dom(screen.getByText('Succès partiel')).exists();
+    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Succès partiel');
   });
 
   module('when chalenge has been skipped automatically', function () {
@@ -91,7 +90,7 @@ module('Integration | Component | certifications/details-answer', function (hook
       assert.dom(screen.getByText('@skill6')).exists();
       assert.dom(screen.getByText('rec1234')).exists();
       assert.dom(screen.getByText('coucou')).exists();
-      assert.dom(screen.getByText('Abandon')).exists();
+      assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Abandon');
     });
   });
 
@@ -101,13 +100,14 @@ module('Integration | Component | certifications/details-answer', function (hook
       answer: answerData,
       onUpdateRate: () => {},
     });
-    await render(hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`);
-
+    const screen = await render(
+      hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`
+    );
     // when
-    await selectChoose('.answer-result', 'Succès');
+    await selectByLabelAndOption('Sélectionner un résultat', 'ok');
 
     // then
-    assert.dom('.answer-result').hasClass('jury');
+    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).hasAttribute('class', 'jury');
   });
 
   test('update rate function is called when answer is modified and jury is set', async function (assert) {
@@ -126,7 +126,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     await render(hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`);
 
     // when
-    await selectChoose('.answer-result', 'Succès');
+    await selectByLabelAndOption('Sélectionner un résultat', 'ok');
   });
 
   test('jury is set back to false when answer is set to default value', async function (assert) {
@@ -138,10 +138,10 @@ module('Integration | Component | certifications/details-answer', function (hook
     await render(hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`);
 
     // when
-    await selectChoose('.answer-result', 'Succès');
-    await selectChoose('.answer-result', 'Succès partiel');
+    await selectByLabelAndOption('Sélectionner un résultat', 'ok');
+    await selectByLabelAndOption('Sélectionner un résultat', 'partially');
 
-    // Then
+    // then
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(answerData.jury, null);

--- a/admin/tests/integration/components/certifications/details-competence_test.js
+++ b/admin/tests/integration/components/certifications/details-competence_test.js
@@ -34,12 +34,14 @@ module('Integration | Component | certifications/details-competence', function (
     this.set('externalAction', () => resolve());
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Certifications::DetailsCompetence @competence={{competenceData}} rate={{60}} @juryRate={{false}} @onUpdateRate={{externalAction}}/>`
     );
 
     // then
-    assert.dom('.certification-details-competence').exists();
+    assert.dom(screen.getByText('1.1 Une compétence')).exists();
+    assert.dom(screen.getByLabelText('Jauge de compétences positionnées')).exists();
+    assert.dom(screen.getByLabelText('Jauge de compétences certifiées')).exists();
   });
 
   test('it should not render jury values when no jury values are set', async function (assert) {
@@ -48,12 +50,12 @@ module('Integration | Component | certifications/details-competence', function (
     this.set('externalAction', () => resolve());
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Certifications::DetailsCompetence @competence={{competenceData}} rate={{60}} @juryRate={{false}} @onUpdateRate={{externalAction}}/>`
     );
 
     // then
-    assert.dom('.jury').doesNotExist();
+    assert.dom(screen.queryByRole('progressbar', { name: 'Jauge de compétences corrigées' })).doesNotExist();
   });
 
   test('it should render jury values when these values are set', async function (assert) {
@@ -67,10 +69,9 @@ module('Integration | Component | certifications/details-competence', function (
     );
 
     // then
-    assert.strictEqual(screen.getAllByRole('progressbar').length, 3);
-    assert.dom(screen.getByLabelText('Jauge de compétences corrigées')).hasText('2');
-    assert.dom('.jury.competence-score').exists();
-    assert.dom('.jury.competence-score').hasText('18 Pix');
-    assert.dom(screen.getByLabelText('Jauge de compétences certifiées')).hasText('-1');
+    assert.dom(screen.getByRole('progressbar', { name: 'Jauge de compétences corrigées' })).hasText('2');
+    assert.dom(screen.getByRole('progressbar', { name: 'Jauge de compétences certifiées' })).hasText('-1');
+    assert.dom(screen.getByRole('progressbar', { name: 'Jauge de compétences positionnées' })).hasText('3');
+    assert.dom(screen.getByText('18 Pix')).exists();
   });
 });

--- a/admin/tests/integration/components/certifications/info-competences_test.js
+++ b/admin/tests/integration/components/certifications/info-competences_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | certifications/competence-list', function (hooks) {
@@ -10,17 +10,17 @@ module('Integration | Component | certifications/competence-list', function (hoo
     // given
     this.set('competences', [
       { index: '1.1', score: '30', level: '3' },
-      { index: '2.1', score: '30', level: '3' },
-      { index: '5.2', score: '30', level: '3' },
+      { index: '2.1', score: '20', level: '2' },
+      { index: '5.2', score: '10', level: '1' },
     ]);
 
     // when
-    await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} />`);
+    const screen = await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} />`);
 
     // then
-    assert.dom('.certification-info-competence-index').exists({ count: 3 });
-    assert.dom('.certification-info-competence-level').exists({ count: 3 });
-    assert.dom('.certification-info-competence-score').exists({ count: 3 });
+    assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).exists();
+    assert.dom(screen.getByLabelText('Informations de la compétence 2.1')).exists();
+    assert.dom(screen.getByLabelText('Informations de la compétence 5.2')).exists();
   });
 
   test('it should display competence index, score and level', async function (assert) {
@@ -28,12 +28,11 @@ module('Integration | Component | certifications/competence-list', function (hoo
     this.set('competences', [{ index: '1.1', score: '30', level: '3' }]);
 
     // when
-    await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} />`);
+    const screen = await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} />`);
 
     // then
-    assert.dom('.certification-info-competence-index').hasText('1.1');
-    assert.dom('.certification-info-competence-level').hasText('Niveau : 3');
-    assert.dom('.certification-info-competence-score').hasText('30 Pix');
+    assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).containsText('30 Pix');
+    assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).containsText('Niveau : 3');
   });
 
   test('it should display 16 entries in edition mode', async function (assert) {
@@ -45,10 +44,12 @@ module('Integration | Component | certifications/competence-list', function (hoo
     ]);
 
     // when
-    await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} @edition=true />`);
+    const screen = await render(
+      hbs`<Certifications::CompetenceList @competences={{this.competences}} @edition=true />`
+    );
 
     // then
-    assert.dom('.certification-info-field').exists({ count: 16 });
+    assert.strictEqual(screen.getAllByLabelText('Informations de la compétence', { exact: false }).length, 16);
   });
 
   test('it should display competence levels and scores at the right places in edition mode', async function (assert) {
@@ -56,18 +57,22 @@ module('Integration | Component | certifications/competence-list', function (hoo
     this.set('competences', [
       { index: '1.1', score: '30', level: '3' },
       { index: '2.1', score: '16', level: '2' },
-      { index: '5.2', score: '42', level: '5' },
+      { index: '2.2', score: '42', level: '5' },
     ]);
 
     // when
-    await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} @edition=true />`);
+    const screen = await render(
+      hbs`<Certifications::CompetenceList @competences={{this.competences}} @edition=true />`
+    );
 
     // then
-    assert.dom('#certification-info-score_0').hasValue('30');
-    assert.dom('#certification-info-level_0').hasValue('3');
-    assert.dom('#certification-info-score_3').hasValue('16');
-    assert.dom('#certification-info-level_3').hasValue('2');
-    assert.dom('#certification-info-score_15').hasValue('42');
-    assert.dom('#certification-info-level_15').hasValue('5');
+    assert.dom(screen.getByRole('textbox', { name: '1.1' })).hasValue('30');
+    assert.dom(screen.getByRole('textbox', { name: '2.1' })).hasValue('16');
+    assert.dom(screen.getByRole('textbox', { name: '2.2' })).hasValue('42');
+
+    const certificationInfoLevelInputs = screen.getAllByRole('textbox', { name: 'Niveau :' });
+    assert.dom(certificationInfoLevelInputs[0]).hasValue('3');
+    assert.dom(certificationInfoLevelInputs[3]).hasValue('2');
+    assert.dom(certificationInfoLevelInputs[4]).hasValue('5');
   });
 });

--- a/admin/tests/integration/components/certifications/info-field_test.js
+++ b/admin/tests/integration/components/certifications/info-field_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
 
@@ -9,94 +9,95 @@ module('Integration | Component | certifications/info-field', function (hooks) {
 
   module('[Consultation mode]', function () {
     test('it should be in "consultation (read only) mode" by default when @edition (optional) argument is not provided', async function (assert) {
-      // When
-      await render(hbs`<Certifications::InfoField @label='Field label:' @value='field_value' />`);
+      // given & when
+      const screen = await render(hbs`<Certifications::InfoField @label='Field label:' @value='field_value' />`);
 
-      // Then
-      assert.dom('.certification-info-field').doesNotHaveClass('edited');
+      // then
+      assert.dom(screen.queryByRole('textbox', { name: 'Field label:' })).doesNotExist();
     });
 
     test('it should render label and field value', async function (assert) {
-      // When
-      await render(hbs`<Certifications::InfoField @label='Field label:' @value='field_value' />`);
+      // given & when
+      const screen = await render(hbs`<Certifications::InfoField @label='Session:' @value='commencé' />`);
 
-      // Then
-      assert.dom('.certification-info-field .certification-info-field__label').hasText('Field label:');
-      assert.dom('.certification-info-field .certification-info-value').hasText('field_value');
+      // then
+      assert.dom(screen.getByText('Session:')).containsText('commencé');
     });
 
     test('it should render field value with suffix when @suffix (optional) argument is provided', async function (assert) {
-      // When
-      await render(hbs`<Certifications::InfoField @label='Field label:' @value='field_value' @suffix='unit(s)' />`);
+      // given & when
+      const screen = await render(
+        hbs`<Certifications::InfoField @label='Session:' @value='commencé' @suffix='unit(s)' />`
+      );
 
-      // Then
-      assert.dom('.certification-info-field .certification-info-value').hasText('field_value unit(s)');
+      // then
+      assert.dom(screen.getByText('Session:')).containsText('commencé unit(s)');
     });
 
     test('it should format value as date with format "DD/MM/YYYY" when @isDate (optional) argument is set to "true"', async function (assert) {
-      // Given
+      // given
       this.set('value', new Date('1961-08-04'));
 
-      // When
-      await render(hbs`<Certifications::InfoField @label='Birth date:' @value={{this.value}} @isDate=true />`);
+      // when
+      const screen = await render(
+        hbs`<Certifications::InfoField @label='Date de naissance:' @value={{this.value}} @isDate=true />`
+      );
 
-      // Then
-      assert.dom('.certification-info-field .certification-info-value').hasText('04/08/1961');
+      // then
+      assert.dom(screen.getByText('Date de naissance:')).containsText('04/08/1961');
     });
 
     test('it should display value as link when @linkRoute (optional) argument is provided', async function (assert) {
-      // Given
-      this.setProperties({
-        label: 'Field label:',
-        value: 'field_value',
-      });
-
-      // When
-      await render(
+      // given & when
+      const screen = await render(
         hbs`<Certifications::InfoField @label='Session:' @value=1234 @linkRoute="authenticated.sessions.session" />`
       );
 
-      // Then
-      assert.dom('.certification-info-field .certification-info-value').hasText('1234');
+      // then
+      assert.dom(screen.getByText('Session:')).containsText('1234');
+      assert.dom(screen.getByRole('link', { name: '1234' })).exists();
     });
   });
 
   module('[Edition mode]', function () {
     test('it should be in "edition (writable) mode" when @edition (optional) argument is set to "true"', async function (assert) {
-      // When
-      await render(hbs`<Certifications::InfoField @label='Field label:' @value='field_value' @edition=true />`);
+      // given & when
+      const screen = await render(
+        hbs`<Certifications::InfoField @label='Publiée :' @value='oui' @edition=true @fieldId="certification-publication" />`
+      );
 
-      // Then
-      assert.dom('.certification-info-field').hasClass('edited');
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Publiée :' })).exists();
     });
 
     test('it should display field value with suffix when @suffix (optional) argument is provided', async function (assert) {
-      // When
-      await render(
+      // given & when
+      const screen = await render(
         hbs`<Certifications::InfoField @label='Field label:' @value='field_value' @suffix='unit(s)' @edition=true />`
       );
 
-      // Then
-      assert.dom('.certification-info-field__suffix').hasText('unit(s)');
+      // then
+      assert.dom(screen.getByText('unit(s)')).exists();
     });
 
     test('it should render a flatpickr when @isDate (optional) argument is set to "true"', async function (assert) {
-      // Given
+      // given
       this.setProperties({
         value: new Date('2019-02-18'),
         onUpdateCertificationBirthdate: () => resolve(),
       });
 
-      // When
-      await render(hbs`<Certifications::InfoField
-            @label='Birth date:'
+      // when
+      const screen = await render(hbs`<Certifications::InfoField
+            @label='Date de naissance:'
+            @fieldId="certification-birthdate"
             @value={{this.value}}
             @edition=true
             @isDate=true
             @onUpdateCertificationBirthdate={{this.onUpdateCertificationBirthdate}} />`);
 
-      // Then
-      assert.dom('.ember-flatpickr-input').exists();
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Date de naissance:' })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/certifications/info-field_test.js
+++ b/admin/tests/integration/components/certifications/info-field_test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
-import { resolve } from 'rsvp';
 
 module('Integration | Component | certifications/info-field', function (hooks) {
   setupRenderingTest(hooks);
@@ -78,26 +77,6 @@ module('Integration | Component | certifications/info-field', function (hooks) {
 
       // then
       assert.dom(screen.getByText('unit(s)')).exists();
-    });
-
-    test('it should render a flatpickr when @isDate (optional) argument is set to "true"', async function (assert) {
-      // given
-      this.setProperties({
-        value: new Date('2019-02-18'),
-        onUpdateCertificationBirthdate: () => resolve(),
-      });
-
-      // when
-      const screen = await render(hbs`<Certifications::InfoField
-            @label='Date de naissance:'
-            @fieldId="certification-birthdate"
-            @value={{this.value}}
-            @edition=true
-            @isDate=true
-            @onUpdateCertificationBirthdate={{this.onUpdateCertificationBirthdate}} />`);
-
-      // then
-      assert.dom(screen.getByRole('textbox', { name: 'Date de naissance:' })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/certifications/status-select_test.js
+++ b/admin/tests/integration/components/certifications/status-select_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn } from '@ember/test-helpers';
-import { render } from '@1024pix/ember-testing-library';
+import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -30,10 +29,12 @@ module('Integration | Component | certifications/status-select', function (hooks
         this.set('certification', certification);
 
         // when
-        await render(hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`);
+        const screen = await render(
+          hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`
+        );
 
         // then
-        assert.dom('#certification-status-selector').exists();
+        assert.dom(screen.getByRole('combobox', { name: 'Statut :' })).exists();
       });
 
       test('it has values', async function (assert) {
@@ -71,7 +72,7 @@ module('Integration | Component | certifications/status-select', function (hooks
         await render(hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`);
 
         // when
-        await fillIn('#certification-status-selector', 'validated');
+        await selectByLabelAndOption('Statut :', 'validated');
 
         // then
         // TODO: Fix this the next time the file is edited.
@@ -88,10 +89,10 @@ module('Integration | Component | certifications/status-select', function (hooks
       this.set('certification', certification);
 
       // when
-      await render(hbs`<Certifications::StatusSelect @certification={{this.certification}} />`);
+      const screen = await render(hbs`<Certifications::StatusSelect @certification={{this.certification}} />`);
 
       // then
-      assert.dom('#certification-status-selector').doesNotExist();
+      assert.dom(screen.queryByRole('combobox', { name: 'Statut :' })).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/confirm-popup_test.js
+++ b/admin/tests/integration/components/confirm-popup_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
@@ -28,7 +27,7 @@ module('Integration | Component | confirm-popup', function (hooks) {
     const screen = await render(hbs`<ConfirmPopup @show={{this.display}} @cancel={{this.cancel}} />`);
 
     // when
-    await click('button.btn-secondary');
+    await clickByName('Annuler');
 
     // then
     assert.ok(this.cancel.called);
@@ -43,7 +42,7 @@ module('Integration | Component | confirm-popup', function (hooks) {
     await render(hbs`<ConfirmPopup @show={{this.display}} @confirm={{this.confirm}} />`);
 
     // when
-    await click('button.btn-primary');
+    await clickByName('Confirmer');
 
     // then
     assert.ok(this.confirm.called);

--- a/admin/tests/integration/components/login-form_test.js
+++ b/admin/tests/integration/components/login-form_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
-import { render, fillByLabel } from '@1024pix/ember-testing-library';
+import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { reject } from 'rsvp';
@@ -62,7 +61,7 @@ module('Integration | Component | login-form', function (hooks) {
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
       await fillByLabel('Mot de passe', 'JeMeLoggue1024');
-      await click('button.login-form__button');
+      await clickByName('Je me connecte');
 
       // then
       assert.dom('p.login-form__error').exists();
@@ -88,7 +87,7 @@ module('Integration | Component | login-form', function (hooks) {
       // when
       await fillByLabel('Adresse e-mail', 'pix@');
       await fillByLabel('Mot de passe', 'JeMeLoggue1024');
-      await click('button.login-form__button');
+      await clickByName('Je me connecte');
 
       // then
       assert.dom('p.login-form__error').exists();
@@ -107,7 +106,7 @@ module('Integration | Component | login-form', function (hooks) {
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
       await fillByLabel('Mot de passe', 'JeMeLoggue1024');
-      await click('button.login-form__button');
+      await clickByName('Je me connecte');
 
       // then
       assert.dom('p.login-form__error').exists();
@@ -133,7 +132,7 @@ module('Integration | Component | login-form', function (hooks) {
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
       await fillByLabel('Mot de passe', 'JeMeLoggue1024');
-      await click('button.login-form__button');
+      await clickByName('Je me connecte');
 
       // then
       assert.dom('p.login-form__error').exists();
@@ -152,7 +151,7 @@ module('Integration | Component | login-form', function (hooks) {
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
       await fillByLabel('Mot de passe', 'JeMeLoggue1024');
-      await click('button.login-form__button');
+      await clickByName('Je me connecte');
 
       // then
       assert.dom('p.login-form__error').exists();

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillIn } from '@ember/test-helpers';
-import { render, clickByName } from '@1024pix/ember-testing-library';
+import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -192,7 +192,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#name', '');
+      await fillByLabel('* Nom', '');
 
       // then
       assert.dom(screen.getByText('Le nom ne peut pas être vide')).exists();
@@ -204,7 +204,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#name', 'a'.repeat(256));
+      await fillByLabel('* Nom', 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();
@@ -216,7 +216,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#externalId', 'a'.repeat(256));
+      await fillByLabel('Identifiant externe', 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText("La longueur de l'identifiant externe ne doit pas excéder 255 caractères")).exists();
@@ -228,7 +228,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#provinceCode', 'a'.repeat(256));
+      await fillByLabel('Département (en 3 chiffres)', 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText('La longueur du département ne doit pas excéder 255 caractères')).exists();
@@ -240,7 +240,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#email', 'a'.repeat(256));
+      await fillByLabel('Adresse e-mail (SCO)', 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText("La longueur de l'email ne doit pas excéder 255 caractères.")).exists();
@@ -252,7 +252,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#email', 'not-valid-email-format');
+      await fillByLabel('Adresse e-mail (SCO)', 'not-valid-email-format');
 
       // then
       assert.dom(screen.getByText("L'e-mail n'a pas le bon format.")).exists();
@@ -264,7 +264,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#credits', 'credit');
+      await fillByLabel('Crédits', 'credit');
 
       // then
       assert.dom(screen.getByText('Le nombre de crédits doit être un nombre supérieur ou égal à 0.')).exists();
@@ -290,7 +290,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#documentationUrl', 'not-valid-url-format');
+      await fillByLabel('Lien vers la documentation', 'not-valid-url-format');
 
       // then
       assert.dom(screen.getByText("Le lien n'est pas valide.")).exists();

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -150,31 +150,40 @@ module('Integration | Component | organizations/information-section', function (
 
     test('it should toggle edition mode on click to edit button', async function (assert) {
       // given
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
       await clickByName('Éditer');
 
       // then
-      assert.dom('.organization__edit-form').exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
     });
 
     test('it should display organization edit form on click to edit button', async function (assert) {
       // given
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
       await clickByName('Éditer');
 
       // then
-      assert.dom('input#name').hasValue(organization.name);
-      assert.dom('input#externalId').hasValue(organization.externalId);
-      assert.dom('input#provinceCode').hasValue(organization.provinceCode);
-      assert.dom('input#email').hasValue(organization.email);
-      assert.dom('input#credit').hasValue(organization.credit.toString());
-      assert.dom('input#isManagingStudents').isNotChecked();
-      assert.dom('input#documentationUrl').hasValue(organization.documentationUrl);
-      assert.dom('input#showSkills').isNotChecked();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom' })).hasValue(organization.name);
+      assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).hasValue(organization.externalId);
+      assert
+        .dom(screen.getByRole('textbox', { name: 'Département (en 3 chiffres)' }))
+        .hasValue(organization.provinceCode);
+      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail (SCO)' })).hasValue(organization.email);
+      assert.dom(screen.getByRole('spinbutton', { name: 'Crédits' })).hasValue(organization.credit.toString());
+      assert.dom(screen.getByRole('checkbox', { name: 'Gestion d’élèves/étudiants' })).isNotChecked();
+      assert
+        .dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' }))
+        .hasValue(organization.documentationUrl);
+      assert
+        .dom(screen.getByRole('checkbox', { name: "Affichage des acquis dans l'export de résultats" }))
+        .isNotChecked();
     });
 
     test("it should show error message if organization's name is empty", async function (assert) {
@@ -255,7 +264,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillIn('#credit', 'credit');
+      await fillIn('#credits', 'credit');
 
       // then
       assert.dom(screen.getByText('Le nombre de crédits doit être un nombre supérieur ou égal à 0.')).exists();
@@ -263,14 +272,16 @@ module('Integration | Component | organizations/information-section', function (
 
     test('it should toggle display mode on click to cancel button', async function (assert) {
       // given
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
       await clickByName('Éditer');
 
       // when
       await clickByName('Annuler');
 
       // then
-      assert.dom('.organization__data').exists();
+      assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+      assert.dom(screen.getByRole('button', { name: "Archiver l'organisation" })).exists();
     });
 
     test("it should show error message if organization's documentationUrl is not valid", async function (assert) {
@@ -320,7 +331,7 @@ module('Integration | Component | organizations/information-section', function (
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', '  ');
-      await fillIn('input#credit', 50);
+      await fillIn('input#credits', 50);
       await clickByName('Gestion d’élèves/étudiants');
       await fillIn('input#documentationUrl', 'https://pix.fr/');
 
@@ -374,10 +385,10 @@ module('Integration | Component | organizations/information-section', function (
       this.organization.isManagingStudents = false;
 
       // when
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // then
-      assert.dom('.organization__isManagingStudents').doesNotExist();
+      assert.dom(screen.queryByRole('checkbox', { name: 'Gestion d’élèves/étudiants' })).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -10,14 +10,17 @@ module('Integration | Component | organizations/information-section', function (
 
   test('it renders', async function (assert) {
     // given
-    this.organization = EmberObject.create({ type: 'SUP', isManagingStudents: false });
+    this.organization = EmberObject.create({ type: 'SUP', isManagingStudents: false, name: 'SUPer Orga' });
 
     // when
     const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
     // then
     assert.dom(screen.queryByText('Archivée le')).doesNotExist();
-    assert.dom('.organization__information').exists();
+    assert.dom(screen.getByRole('heading', { name: 'SUPer Orga' })).exists();
+    assert.dom(screen.getByText('Type : SUP')).exists();
+    assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+    assert.dom(screen.getByRole('button', { name: "Archiver l'organisation" })).exists();
   });
 
   test('it should display credit', async function (assert) {
@@ -29,7 +32,7 @@ module('Integration | Component | organizations/information-section', function (
     const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
     // then
-    assert.dom(screen.getByText('350')).exists();
+    assert.dom(screen.getByText('Crédits : 350')).exists();
   });
 
   module('Displaying whether or not the items of this campaign will be exported in results', function () {
@@ -39,10 +42,10 @@ module('Integration | Component | organizations/information-section', function (
       this.set('organization', organization);
 
       // when
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // then
-      assert.dom('.organization__showSkills').hasText('Oui');
+      assert.dom(screen.getByText("Affichage des acquis dans l'export de résultats : Oui")).exists();
     });
 
     test("it should display 'Non' when showskills set to false", async function (assert) {
@@ -51,10 +54,10 @@ module('Integration | Component | organizations/information-section', function (
       this.set('organization', organization);
 
       // when
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // then
-      assert.dom('.organization__showSkills').hasText('Non');
+      assert.dom(screen.getByText("Affichage des acquis dans l'export de résultats : Non")).exists();
     });
   });
 
@@ -79,7 +82,7 @@ module('Integration | Component | organizations/information-section', function (
     const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
     // then
-    assert.dom(screen.getByText('Lien vers la documentation : Non spécifié', { exact: false })).exists();
+    assert.dom(screen.getByText('Lien vers la documentation : Non spécifié')).exists();
   });
 
   test('it should display tags', async function (assert) {
@@ -298,12 +301,12 @@ module('Integration | Component | organizations/information-section', function (
       await clickByName('Annuler');
 
       // then
-      assert.dom(screen.getByText(organization.name)).exists();
-      assert.dom(screen.getByText(organization.externalId)).exists();
-      assert.dom(screen.getByText(organization.provinceCode)).exists();
-      assert.dom('.organization__isManagingStudents').hasText('Non');
-      assert.dom(screen.getByText(organization.documentationUrl)).exists();
-      assert.dom('.organization__showSkills').hasText('Non');
+      assert.dom(screen.getByRole('heading', { name: organization.name })).exists();
+      assert.dom(screen.getByText(`Identifiant externe : ${organization.externalId}`)).exists();
+      assert.dom(screen.getByText(`Département : ${organization.provinceCode}`)).exists();
+      assert.dom(screen.getByRole('link', { name: organization.documentationUrl })).exists();
+      assert.dom(screen.getByText(`Gestion d’élèves/étudiants : Non`)).exists();
+      assert.dom(screen.getByText("Affichage des acquis dans l'export de résultats : Non")).exists();
     });
 
     test('it should submit the form if there is no error', async function (assert) {
@@ -325,12 +328,12 @@ module('Integration | Component | organizations/information-section', function (
       await clickByName('Enregistrer');
 
       // then
-      assert.dom('.organization__name').hasText('new name');
-      assert.dom(screen.getByText('new externalId')).exists();
+      assert.dom(screen.getByRole('heading', { name: 'new name' })).exists();
+      assert.dom(screen.getByText('Identifiant externe : new externalId')).exists();
       assert.dom(screen.queryByText('Département : ')).doesNotExist();
-      assert.dom(screen.getByText('50')).exists();
-      assert.dom('.organization__isManagingStudents').hasText('Oui');
-      assert.dom(screen.getByText('https://pix.fr/')).exists();
+      assert.dom(screen.getByText('Crédits : 50')).exists();
+      assert.dom(screen.getByText(`Gestion d’élèves/étudiants : Oui`)).exists();
+      assert.dom(screen.getByRole('link', { name: 'https://pix.fr/' })).exists();
     });
   });
 
@@ -339,22 +342,14 @@ module('Integration | Component | organizations/information-section', function (
       this.organization = EmberObject.create({ type: 'SCO', isOrganizationSCO: true, isManagingStudents: true });
     });
 
-    test('it should display if it is managing students', async function (assert) {
-      // when
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
-
-      // then
-      assert.dom('.organization__isManagingStudents').exists();
-    });
-
     test('it should display "Oui" if it is managing students', async function (assert) {
       // given
       this.organization.isManagingStudents = true;
 
       // when
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
-      assert.dom('.organization__isManagingStudents').hasText('Oui');
+      assert.dom(screen.getByText(`Gestion d’élèves/étudiants : Oui`)).exists();
     });
 
     test('it should display "Non" if managing students is false', async function (assert) {
@@ -362,10 +357,10 @@ module('Integration | Component | organizations/information-section', function (
       this.organization.isManagingStudents = false;
 
       // when
-      await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
+      const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // then
-      assert.dom('.organization__isManagingStudents').hasText('Non');
+      assert.dom(screen.getByText(`Gestion d’élèves/étudiants : Non`)).exists();
     });
   });
 

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn } from '@ember/test-helpers';
 import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
@@ -175,7 +174,7 @@ module('Integration | Component | organizations/information-section', function (
       assert
         .dom(screen.getByRole('textbox', { name: 'Département (en 3 chiffres)' }))
         .hasValue(organization.provinceCode);
-      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail (SCO)' })).hasValue(organization.email);
+      assert.dom(screen.getByRole('textbox', { name: "Adresse e-mail d'activation SCO" })).hasValue(organization.email);
       assert.dom(screen.getByRole('spinbutton', { name: 'Crédits' })).hasValue(organization.credit.toString());
       assert.dom(screen.getByRole('checkbox', { name: 'Gestion d’élèves/étudiants' })).isNotChecked();
       assert
@@ -240,7 +239,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillByLabel('Adresse e-mail (SCO)', 'a'.repeat(256));
+      await fillByLabel("Adresse e-mail d'activation SCO", 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText("La longueur de l'email ne doit pas excéder 255 caractères.")).exists();
@@ -252,7 +251,7 @@ module('Integration | Component | organizations/information-section', function (
 
       // when
       await clickByName('Éditer');
-      await fillByLabel('Adresse e-mail (SCO)', 'not-valid-email-format');
+      await fillByLabel("Adresse e-mail d'activation SCO", 'not-valid-email-format');
 
       // then
       assert.dom(screen.getByText("L'e-mail n'a pas le bon format.")).exists();
@@ -301,11 +300,12 @@ module('Integration | Component | organizations/information-section', function (
       const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       await clickByName('Éditer');
-      await fillIn('input#name', 'new name');
-      await fillIn('input#externalId', 'new externalId');
-      await fillIn('input#provinceCode', 'new provinceCode');
+
+      await fillByLabel('* Nom', 'new name');
+      await fillByLabel('Identifiant externe', 'new externalId');
+      await fillByLabel('Département (en 3 chiffres)', 'new provinceCode');
       await clickByName('Gestion d’élèves/étudiants');
-      await fillIn('input#documentationUrl', 'new documentationUrl');
+      await fillByLabel('Lien vers la documentation', 'new documentationUrl');
       await clickByName("Affichage des acquis dans l'export de résultats");
 
       // when
@@ -328,12 +328,12 @@ module('Integration | Component | organizations/information-section', function (
       );
       await clickByName('Éditer');
 
-      await fillIn('input#name', 'new name');
-      await fillIn('input#externalId', 'new externalId');
-      await fillIn('input#provinceCode', '  ');
-      await fillIn('input#credits', 50);
+      await fillByLabel('* Nom', 'new name');
+      await fillByLabel('Identifiant externe', 'new externalId');
+      await fillByLabel('Département (en 3 chiffres)', '   ');
+      await fillByLabel('Crédits', 50);
       await clickByName('Gestion d’élèves/étudiants');
-      await fillIn('input#documentationUrl', 'https://pix.fr/');
+      await fillByLabel('Lien vers la documentation', 'https://pix.fr/');
 
       // when
       await clickByName('Enregistrer');

--- a/admin/tests/integration/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/integration/components/organizations/target-profiles-section_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
-import { clickByName, fillByLabel } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
@@ -19,10 +18,10 @@ module('Integration | Component | organizations/target-profiles-section', functi
     this.set('organization', organization);
 
     // when
-    await render(hbs`<Organizations::TargetProfilesSection @organization={{organization}} />`);
+    const screen = await render(hbs`<Organizations::TargetProfilesSection @organization={{organization}} />`);
 
     // then
-    assert.dom('button').isDisabled();
+    assert.dom(screen.getByRole('button', { name: 'Valider' })).isDisabled();
   });
 
   test('it calls the organization action when the input is not empty and user clicks on button', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, render } from '@ember/test-helpers';
+import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/sessions | list-items', function (hooks) {
@@ -94,47 +94,43 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
   module('Input field for id filtering', function () {
     test('it should render a input field to filter on id', async function (assert) {
       // when
-      await render(hbs`<Sessions::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
+      const screen = await render(hbs`<Sessions::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
 
       // then
-      assert.dom('table thead tr:nth-child(2) th:nth-child(1) input').exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Filtrer les sessions avec un id' })).exists();
     });
   });
 
   module('Input field for certificationCenterName filtering', function () {
     test('it should render a input field to filter on certificationCenterName', async function (assert) {
       // when
-      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering}}`);
-      await render(hbs`<Sessions::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
+      const screen = await render(hbs`<Sessions::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
 
       // then
-      assert.dom('table thead tr:nth-child(2) th:nth-child(2) input').exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: "Filtrer les sessions avec le nom d'un centre de certification" }))
+        .exists();
     });
   });
 
   module('Dropdown menu for certification center type filtering', function () {
     test('it should render a dropdown menu to filter sessions on their certification center type', async function (assert) {
       // given
-      const expectedOptions = [
-        { value: 'all', label: 'Tous' },
-        { value: 'SCO', label: 'Sco' },
-        { value: 'SUP', label: 'Sup' },
-        { value: 'PRO', label: 'Pro' },
-      ];
+      const expectedLabels = { allType: 'Tous', scoType: 'Sco', supType: 'Sup', proType: 'Pro' };
 
       // when
-      await render(hbs`<Sessions::ListItems />`);
+      const screen = await render(hbs`<Sessions::ListItems />`);
 
       // then
-      const elementOptions = this.element.querySelectorAll('#certificationCenterType > option');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(elementOptions.length, 4);
-      elementOptions.forEach((elementOption, index) => {
-        const expectedOption = expectedOptions[index];
-        assert.dom(elementOption).hasText(expectedOption.label);
-        assert.dom(elementOption).hasValue(expectedOption.value);
-      });
+      assert
+        .dom(
+          screen.getByRole('combobox', {
+            name: 'Filtrer les sessions en sélectionnant un type de centre de certification',
+          })
+        )
+        .hasText(
+          `${expectedLabels.allType} ${expectedLabels.scoType} ${expectedLabels.supType} ${expectedLabels.proType}`
+        );
     });
 
     test('it should filter sessions on certification center type when it has changed', async function (assert) {
@@ -146,7 +142,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await fillIn('#certificationCenterType', 'PRO');
+      await selectByLabelAndOption('Filtrer les sessions en sélectionnant un type de centre de certification', 'PRO');
 
       // then
       // TODO: Fix this the next time the file is edited.
@@ -158,27 +154,27 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
   module('Dropdown menu for status filtering', function () {
     test('it should render a dropdown menu to filter sessions on their status', async function (assert) {
       // given
-      const expectedOptions = [
-        { value: 'all', label: 'Tous' },
-        { value: 'created', label: 'Créée' },
-        { value: 'finalized', label: 'Finalisée' },
-        { value: 'in_process', label: 'En cours de traitement' },
-        { value: 'processed', label: 'Résultats transmis par Pix' },
-      ];
+      const expectedLabels = {
+        allStatus: 'Tous',
+        createdStatus: 'Créée',
+        finalizedStatus: 'Finalisée',
+        inProcessStatus: 'En cours de traitement',
+        processedStatus: 'Résultats transmis par Pix',
+      };
 
       // when
-      await render(hbs`<Sessions::ListItems />`);
+      const screen = await render(hbs`<Sessions::ListItems />`);
 
       // then
-      const elementOptions = this.element.querySelectorAll('#status > option');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(elementOptions.length, 5);
-      elementOptions.forEach((elementOption, index) => {
-        const expectedOption = expectedOptions[index];
-        assert.dom(elementOption).hasText(expectedOption.label);
-        assert.dom(elementOption).hasValue(expectedOption.value);
-      });
+      assert
+        .dom(
+          screen.getByRole('combobox', {
+            name: 'Filtrer les sessions en sélectionnant un statut',
+          })
+        )
+        .hasText(
+          `${expectedLabels.allStatus} ${expectedLabels.createdStatus} ${expectedLabels.finalizedStatus} ${expectedLabels.inProcessStatus} ${expectedLabels.processedStatus}`
+        );
     });
 
     test('it should filter sessions on (session) "status" when it has changed', async function (assert) {
@@ -190,7 +186,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await fillIn('#status', 'created');
+      await selectByLabelAndOption('Filtrer les sessions en sélectionnant un statut', 'created');
 
       // then
       // TODO: Fix this the next time the file is edited.
@@ -202,25 +198,23 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
   module('Dropdown menu for resultsSentToPrescriberAt filtering', function () {
     test('it should render a dropdown menu to filter sessions on their results sending', async function (assert) {
       // given
-      const expectedOptions = [
-        { value: 'all', label: 'Tous' },
-        { value: 'true', label: 'Résultats diffusés' },
-        { value: 'false', label: 'Résultats non diffusés' },
-      ];
+      const expectedLabels = {
+        all: 'Tous',
+        resultsSent: 'Résultats diffusés',
+        resultsNotSent: 'Résultats non diffusés',
+      };
 
       // when
-      await render(hbs`<Sessions::ListItems />`);
+      const screen = await render(hbs`<Sessions::ListItems />`);
 
       // then
-      const elementOptions = this.element.querySelectorAll('#resultsSentToPrescriberAt > option');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(elementOptions.length, 3);
-      elementOptions.forEach((elementOption, index) => {
-        const expectedOption = expectedOptions[index];
-        assert.dom(elementOption).hasText(expectedOption.label);
-        assert.dom(elementOption).hasValue(expectedOption.value);
-      });
+      assert
+        .dom(
+          screen.getByRole('combobox', {
+            name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
+          })
+        )
+        .hasText(`${expectedLabels.all} ${expectedLabels.resultsSent} ${expectedLabels.resultsNotSent}`);
     });
 
     test('it should filter sessions on results sending status when it has changed', async function (assert) {
@@ -234,7 +228,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await fillIn('#resultsSentToPrescriberAt', 'false');
+      await selectByLabelAndOption('Filtrer les sessions par leurs résultats diffusés ou non diffusés', 'false');
 
       // then
       // TODO: Fix this the next time the file is edited.

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items_test.js
@@ -27,13 +27,13 @@ module('Integration | Component | routes/authenticated/target-profiles | list-it
 
   test('it should display search inputs', async function (assert) {
     // when
-    await render(
+    const screen = await render(
       hbs`<TargetProfiles::ListItems @triggerFiltering={{this.triggerFiltering}} @goToTargetProfilePage={{this.goToTargetProfilePage}}/>`
     );
 
     // then
-    assert.dom('input#name').exists();
-    assert.dom('input#id').exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un id' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Filtrer les profils cible par un nom' })).exists();
   });
 
   test('it should display target profiles list', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
@@ -96,7 +95,7 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
     await clickByName('Publier la session numéro 1');
 
     // when
-    await click('.btn-primary');
+    await clickByName('Confirmer');
 
     // then
     sinon.assert.calledWith(this.publishSession, session);

--- a/admin/tests/integration/components/stages/stage_test.js
+++ b/admin/tests/integration/components/stages/stage_test.js
@@ -36,9 +36,11 @@ module('Integration | Component | Stages::Stage', function (hooks) {
     );
 
     //then
-    assert.dom('button').exists();
     assert.dom(screen.getByRole('button', { name: 'Editer' })).exists();
-    assert.dom('.page-section__details').exists();
+    assert.dom(screen.getByText('ID : 34', { exact: false })).exists();
+    assert.dom(screen.getByText('Seuil : 60', { exact: false })).exists();
+    assert.dom(screen.getByText('Titre : palier 3', { exact: false })).exists();
+    assert.dom(screen.getByText('Message : mon message', { exact: false })).exists();
   });
 
   test('should call toggleEditMode function when the edit button is clicked', async function (assert) {
@@ -48,6 +50,7 @@ module('Integration | Component | Stages::Stage', function (hooks) {
     );
 
     await click('button');
+
     //then
     assert.ok(toggleEditMode.called);
   });
@@ -64,6 +67,6 @@ module('Integration | Component | Stages::Stage', function (hooks) {
     //then
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
-    assert.dom(screen.getByText('Titre pour le prescripteur')).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Titre pour le prescripteur' })).exists();
   });
 });

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -38,17 +38,6 @@ module('Integration | Component | UpdateStage', function (hooks) {
     );
 
     // then
-    assert.strictEqual(this.element.querySelector('label[for="threshold"]').textContent.trim(), 'Seuil');
-    assert.strictEqual(this.element.querySelector('label[for="title"]').textContent.trim(), 'Titre');
-    assert.strictEqual(this.element.querySelector('label[for="message"]').textContent.trim(), 'Message');
-    assert.strictEqual(
-      this.element.querySelector('label[for="prescriberTitle"]').textContent.trim(),
-      'Titre pour le prescripteur'
-    );
-    assert.strictEqual(
-      this.element.querySelector('label[for="prescriberDescription"]').textContent.trim(),
-      'Description pour le prescripteur'
-    );
     assert.dom(screen.getByRole('spinbutton', { name: 'Seuil' })).hasValue('50');
     assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasValue('Titre du palier');
     assert.dom(screen.getByRole('textbox', { name: 'Message' })).hasValue('Ceci est un message');

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn } from '@ember/test-helpers';
-import { render } from '@1024pix/ember-testing-library';
+import { fillIn } from '@ember/test-helpers';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
@@ -74,7 +74,7 @@ module('Integration | Component | UpdateStage', function (hooks) {
     //when
     await render(hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`);
     await fillIn('#prescriberTitle', 'Nouveau titre');
-    await click('button[type="submit"]');
+    await clickByName('Enregistrer');
 
     //then
     assert.ok(this.stage.save.called);
@@ -83,7 +83,7 @@ module('Integration | Component | UpdateStage', function (hooks) {
   test('it should call onCancel when form is cancel', async function (assert) {
     // when
     await render(hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`);
-    await click('button[type="button"]');
+    await clickByName('Enregistrer');
 
     // then
     assert.ok(toggleEditMode.called);

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -61,10 +61,13 @@ module('Integration | Component | UpdateStage', function (hooks) {
 
   test('it should display an error text when the title has more than 255 characters', async function (assert) {
     // when
-    await render(hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`);
+    const screen = await render(
+      hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`
+    );
     await fillIn('#prescriberTitle', 'a'.repeat(256));
+
     // then
-    assert.dom('.form-field__error').exists();
+    assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();
   });
 
   test('it should call updateStage when form is valid', async function (assert) {

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn } from '@ember/test-helpers';
-import { render, clickByName } from '@1024pix/ember-testing-library';
+import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
@@ -50,11 +49,13 @@ module('Integration | Component | UpdateStage', function (hooks) {
       this.element.querySelector('label[for="prescriberDescription"]').textContent.trim(),
       'Description pour le prescripteur'
     );
-    assert.strictEqual(this.element.querySelector('#threshold').value, '50');
-    assert.strictEqual(this.element.querySelector('#title').value, 'Titre du palier');
-    assert.strictEqual(this.element.querySelector('#message').value, 'Ceci est un message');
-    assert.strictEqual(this.element.querySelector('#prescriberTitle').value, 'Ceci est un titre');
-    assert.strictEqual(this.element.querySelector('#prescriberDescription').value, 'Ceci est une description');
+    assert.dom(screen.getByRole('spinbutton', { name: 'Seuil' })).hasValue('50');
+    assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasValue('Titre du palier');
+    assert.dom(screen.getByRole('textbox', { name: 'Message' })).hasValue('Ceci est un message');
+    assert.dom(screen.getByRole('textbox', { name: 'Titre pour le prescripteur' })).hasValue('Ceci est un titre');
+    assert
+      .dom(screen.getByRole('textbox', { name: 'Description pour le prescripteur' }))
+      .hasValue('Ceci est une description');
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
   });
@@ -64,7 +65,8 @@ module('Integration | Component | UpdateStage', function (hooks) {
     const screen = await render(
       hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`
     );
-    await fillIn('#prescriberTitle', 'a'.repeat(256));
+
+    await fillByLabel('Titre pour le prescripteur', 'a'.repeat(256));
 
     // then
     assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();
@@ -73,7 +75,7 @@ module('Integration | Component | UpdateStage', function (hooks) {
   test('it should call updateStage when form is valid', async function (assert) {
     //when
     await render(hbs`<Stages::UpdateStage @model={{this.stage}} @toggleEditMode={{this.toggleEditMode}} />`);
-    await fillIn('#prescriberTitle', 'Nouveau titre');
+    await fillByLabel('Titre pour le prescripteur', 'Nouveau titre');
     await clickByName('Enregistrer');
 
     //then

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
@@ -8,28 +8,30 @@ import sinon from 'sinon';
 module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display the form', async function (assert) {
+  test('it should display the heading in form', async function (assert) {
     // when
-    await render(hbs`<TargetProfiles::BadgeForm />`);
+    const screen = await render(hbs`<TargetProfiles::BadgeForm />`);
 
     // then
-    assert.dom('form').exists();
-    assert.dom('input').exists();
+    assert.dom(screen.getByRole('heading', { name: "Création d'un résultat thématique" })).exists();
   });
 
   test('it should display the expected number of inputs', async function (assert) {
     // given
-    const expectedNumberOfInputsInForm = 11;
-    const expectedNumberOfTextareasInForm = 2;
+    const expectedNumberOfInputsInForm = 7;
     const expectedNumberOfCheckboxesInForm = 2;
+    const expectedNumberOfSpinButtonsInForm = 2;
 
     // when
-    await render(hbs`<TargetProfiles::BadgeForm />`);
+    const screen = await render(hbs`<TargetProfiles::BadgeForm />`);
 
     // then
-    assert.dom('input, textarea').exists({ count: expectedNumberOfInputsInForm });
-    assert.dom('textarea').exists({ count: expectedNumberOfTextareasInForm });
-    assert.dom('input[type="checkbox"]').exists({ count: expectedNumberOfCheckboxesInForm });
+    const inputCount = screen.getAllByRole('textbox').length;
+    const checkboxCount = screen.getAllByRole('checkbox').length;
+    const spinButtonCount = screen.getAllByRole('spinbutton').length;
+    assert.strictEqual(inputCount, expectedNumberOfInputsInForm);
+    assert.strictEqual(checkboxCount, expectedNumberOfCheckboxesInForm);
+    assert.strictEqual(spinButtonCount, expectedNumberOfSpinButtonsInForm);
   });
 
   test('it should display form actions', async function (assert) {
@@ -54,12 +56,12 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfileId={{targetProfileId}} />`);
 
       // when
-      await fillIn('input#badge-key', 'clé_du_badge');
-      await fillIn('input#image-name', 'nom_de_limage.svg');
-      await fillIn('input#alt-message', 'texte alternatif à l‘image');
-      await fillIn('input#skillSetThreshold', '90');
-      await fillIn('input#skillSetName', 'skill-set-name');
+      await fillByLabel("Nom de l'image (svg) :", 'nom_de_limage.svg');
+      await fillByLabel("Texte alternatif pour l'image :", 'texte alternatif à l‘image');
+      await fillByLabel("Clé (texte unique , vérifier qu'il n'existe pas) :", 'clé_du_badge');
+      await fillByLabel('Nom de la liste :', 'skill-set-name');
       await fillByLabel('Liste des acquis :', 'skillSetId1,skillSetId2');
+      await fillByLabel('Taux de réussite :', '90');
       await fillByLabel('Taux de réussite global :', '50');
       await click(screen.getByRole('button', { name: 'Créer le badge' }));
 

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn } from '@ember/test-helpers';
-import { render } from '@1024pix/ember-testing-library';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
@@ -59,8 +59,8 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       await fillIn('input#alt-message', 'texte alternatif à l‘image');
       await fillIn('input#skillSetThreshold', '90');
       await fillIn('input#skillSetName', 'skill-set-name');
-      await fillIn('#skillSetSkills', 'skillSetId1,skillSetId2');
-      await fillIn('#campaignParticipationThreshold', '50');
+      await fillByLabel('Liste des acquis :', 'skillSetId1,skillSetId2');
+      await fillByLabel('Taux de réussite global :', '50');
       await click(screen.getByRole('button', { name: 'Créer le badge' }));
 
       // then

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, triggerEvent } from '@ember/test-helpers';
-import { render } from '@1024pix/ember-testing-library';
+import { triggerEvent } from '@ember/test-helpers';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -58,7 +58,7 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     assert.dom(screen.getByLabelText('Public :')).exists();
     assert.dom(screen.getByLabelText('Importer un profil cible .JSON')).exists();
     assert.dom(screen.getByLabelText("Identifiant de l'organisation de référence :")).exists();
-    assert.dom(screen.getByLabelText("Lien de l'image du profil cible :")).exists();
+    assert.dom(screen.getByLabelText("Lien de l'image du profil cible :", { exact: false })).exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Créer le profil cible' })).exists();
     assert.dom(screen.getByLabelText('Commentaire (usage interne) :')).exists();
@@ -107,7 +107,7 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
       @onSubmit={{this.onSubmit}}
       @onCancel={{this.onCancel}}/>`);
 
-    await click('button[type="button"]');
+    await clickByName('Annuler');
 
     // then
     assert.ok(onCancel.called);

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 
@@ -70,13 +69,13 @@ module('Integration | Component | users | user-detail-personal-information/authe
         this.set('user', { hasOnlyOneAuthenticationMethod: true });
 
         // when
-        await render(hbs`
+        const screen = await render(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
         />`);
 
         // then
-        assert.notOk(find('.user-authentication-method__remove-button'));
+        assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
       });
 
       module('When user does not have pix authentication method', function () {
@@ -111,7 +110,7 @@ module('Integration | Component | users | user-detail-personal-information/authe
           />`);
 
           // then
-          assert.dom(screen.queryByText('Ajouter une adresse e-mail')).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: 'Ajouter une adresse e-mail' })).doesNotExist();
         });
       });
     });

--- a/admin/tests/integration/components/users/user-detail-personal-information/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/user-overview_test.js
@@ -176,12 +176,12 @@ module('Integration | Component | users | user-detail-personal-information/user-
       this.set('user', user);
 
       // when
-      await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+      const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
       await clickByName('Modifier');
 
       // then
-      assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
-      assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
+      assert.dom(screen.getByRole('textbox', { name: 'Prénom :' })).hasValue(this.user.firstName);
+      assert.dom(screen.getByRole('textbox', { name: 'Nom :' })).hasValue(this.user.lastName);
     });
 
     module('when user has an email only', function () {
@@ -190,11 +190,11 @@ module('Integration | Component | users | user-detail-personal-information/user-
         this.set('user', user);
 
         // when
-        await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
         await clickByName('Modifier');
 
         // then
-        assert.dom('.user-edit-form__email').hasValue(this.user.email);
+        assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).hasValue(this.user.email);
       });
 
       test('should not display username in edit mode', async function (assert) {
@@ -206,7 +206,7 @@ module('Integration | Component | users | user-detail-personal-information/user-
         await clickByName('Modifier');
 
         // then
-        assert.dom(screen.queryByText('Identifiant :')).doesNotExist();
+        assert.dom(screen.queryByRole('textbox', { name: 'Identifiant :' })).doesNotExist();
       });
     });
 
@@ -222,11 +222,11 @@ module('Integration | Component | users | user-detail-personal-information/user-
         this.set('user', user);
 
         // when
-        await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
+        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
         await clickByName('Modifier');
 
         // then
-        assert.dom('.user-edit-form__username').hasValue(this.user.username);
+        assert.dom(screen.getByRole('textbox', { name: 'Identifiant :' })).hasValue(this.user.username);
       });
 
       test('should display email', async function (assert) {
@@ -244,7 +244,7 @@ module('Integration | Component | users | user-detail-personal-information/user-
         await clickByName('Modifier');
 
         // then
-        assert.dom(screen.getByText('Adresse e-mail :')).exists();
+        assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).exists();
       });
     });
 
@@ -264,7 +264,7 @@ module('Integration | Component | users | user-detail-personal-information/user-
         await clickByName('Modifier');
 
         // then
-        assert.dom(screen.queryByText('Adresse e-mail :')).doesNotExist();
+        assert.dom(screen.queryByRole('textbox', { name: 'Adresse e-mail :' })).doesNotExist();
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Sujet Tech time : 
Nous avons désormais [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js). Il est importé dans la grande majorité de nos applis Pix mais encore peu utilisé dans nos tests front.

Nous avons également des tests se basant sur du html, du css. 
Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :robot: Solution
Unifier nos tests sur Pix Admin en utilisants les méthodes du package et de testing library.

Trois PR ont été réalisé pour ce nettoyage. 🎉

## 🔥 Les méthodes conseillées

Testing Library préconise d'utiliser : 
1/ **getByRole**: je les cite 'Il n'y a pas grand-chose que vous ne pouvez pas obtenir avec cela'
On filtre avec l'option name, en utilisant les [noms](https://www.w3.org/TR/accname-1.1/) des éléments HTML.
2/ **getByLabelText**: Pratique pour les champs de formulaire.
3/ **getByText**: Cette méthode va être utilisée pour rechercher des éléments non interactifs (comme des divs, des spans et des paragraphes).

Ça c'est pour les get, mais il en existe pleins d'autres. Juste pour ByRole on a queryByRole, getAllByRole, queryAllByRole, findByRole, findAllByRole...

## 👀 Comment j'ai fonctionné : 

**Lorsque que l'on veut tester qu'un élément n'existe pas** =>`queryByRole` comme dans cet exemple `assert.dom(screen.queryByRole('heading', { name: 'Centre SUP et rieur' })).doesNotExist();`
Si c'est pas possible, le `queryByText`

**Lorsque que l'on veut tester qu'un élément existe** => `getByRole` en prio

**Lorsqu'on veut tester qu'il y a 2 lignes dans le tableau** => `getAllByRole` ou `getAllByLabelText`  et je fais un length dessus `assert.strictEqual(screen.getAllByLabelText('Membre').length, 2);`

**Lorsqu'on veut tester qu'un texte s'affiche (mais qu'il est éclaté dans plusieurs éléments)** =>
Soit on vérifie morceaux par morceaux ( pas idéal et pas très lisible ) soit on permet qu'il ne vérifie pas strictement le matching avec l'élément => option [exact](https://testing-library.com/docs/queries/about/#textmatch-examples) `screen.getByText('hello world', {exact: false})`

## :100: Pour tester
Les tests passent au vert ✅ 

Reproduire les scénarios ci-dessous et comparer avec dev en local (ou une autre RA) pour constater qu'il n'y a pas de régressions fonctionnelles. 👇

- Se connecter sur Pix Admin avec `superadmin@example.net`

**Scénario 1 (3ème commit, ici le composant PixSelect a été utilisé) :**
- aller sur `/certifications/106897/details`
- Changer un résultat (succès à succès partiel par exemple)
- Constater que le graphe au dessus est modifié par l'action et que le texte passe toujours en rouge (comparer avec dev)

**Scénario 2 (5ème commit, ici on utilise une liste plutôt qu'un paragraphe) :**
- aller sur les détails d'une organisation, par exemple `/organizations/15/target-profiles`
- Comparer avec dev et constater que le design reste le même

**Scénario 3 (7/8ème commit, on supprime un paramètre qui n'est jamais utilisé `{{#if @isDate}}`) :**
- aller sur les détails d'une certification, exemple `/certifications/106799`
- Comparer avec dev et constater que le design reste le même sur les cards
<img width="535" alt="Capture d’écran 2022-04-29 à 14 30 13" src="https://user-images.githubusercontent.com/58915422/165944628-6f204a3d-f7bd-4bf3-84fc-ea1e9a9f27bf.png">

**Scénario 4 (10ème commit, ajout de h1 manquants):**
- Aller sur chaque onglet de l'application (du menu de gauche) et constater qu'il y a systématiquement un `h1`

**Scénario 5 (15ème commit, ici on utilise une liste plutôt qu'un paragraphe):**
- aller sur les détails d'un badge, par exemple `/badges/114`
- Comparer avec dev et constater que le design reste le même