### PR TITLE
[FEATURE] Renommer le nom des labels des champs adresse email (PIX-4856).

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -69,7 +69,7 @@
             />
           </div>
           <div class="form-field">
-            <label for="email" class="form-field__label">Adresse e-mail (SCO)</label>
+            <label for="email" class="form-field__label">Adresse e-mail d'activation SCO</label>
             {{#if (v-get this.form "email" "isInvalid")}}
               <div class="form-field__error">
                 {{v-get this.form "email" "message"}}
@@ -196,7 +196,7 @@
                     "Non"
                   }}</span><br />
               {{/if}}
-              Adresse e-mail:
+              Adresse e-mail d'activation SCO :
               <span class="organization'__email">{{@organization.email}}</span><br />
               Affichage des acquis dans l'export de résultats :
               <span class="organization__showSkills">{{if @organization.showSkills "Oui" "Non"}}</span><br />


### PR DESCRIPTION
## :unicorn: Problème
Besoin d'uniformiser le wording des champs adresse email sur les pages d'information d'organisations pour éviter la confusion avec un autre champ adresse email qu'on va bientôt rajouter.

## :robot: Solution
Renommer les champs "adresse email" en "Adresse e-mail d'activation SCO" dans l'affichage et l'édition.

## :rainbow: Remarques
RAS.

## :100: Pour tester
1. Se connecter à PIX admin avec le compte superadmin@example.net
2. Se rendre sur la page de détails d'une organisation (en cliquant sur son id dans la liste d'organisations)
3. Admirer le nouveau label du champ "Adresse e-mail d'activation SCO"
4. Cliquer sur Editer
5. Admirer (à nouveau) le nouveau label du champ "Adresse e-mail d'activation SCO"
6. Tadaaaaa