### PR TITLE
[TECH] Réparer le lancement des test de l'algo. 

### DIFF
--- a/high-level-tests/test-algo/AlgoResult.js
+++ b/high-level-tests/test-algo/AlgoResult.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { v4: uuidv4 } = require('uuid');
 const CsvFile = require('./utils/CsvFile');
 
@@ -31,12 +30,7 @@ class AlgoResult {
   }
 
   get _skillNames() {
-    const skillsName = _
-      .chain(this._challenges)
-      .map((challenge) => challenge.skills)
-      .flatMap()
-      .map((skill) => skill.name)
-      .value();
+    const skillsName = this._challenges.map((challenge) => challenge.skill.name);
     const uniqSkillNames = new Set(skillsName);
     return [...uniqSkillNames];
   }

--- a/high-level-tests/test-algo/tests/AlgoResult_test.js
+++ b/high-level-tests/test-algo/tests/AlgoResult_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon } = require('./test-helpers');
 const AlgoResult = require('../AlgoResult');
 const AnswerStatus = require('../../../api/lib/domain/models/AnswerStatus');
+const domainBuilder = require('../../../api/tests/tooling/domain-builder/domain-builder');
 const CsvFile = require('../utils/CsvFile');
 
 describe('AlgoResult', () => {
@@ -9,8 +10,8 @@ describe('AlgoResult', () => {
     it('should return total challenge asked', () => {
       // given
       const algoResult = new AlgoResult();
-      const challenge1 = { id: 'rec1', skills: [] };
-      const challenge2 = { id: 'rec2', skills: [] };
+      const challenge1 = domainBuilder.buildChallenge({ id: 'rec1', skill: {} });
+      const challenge2 = domainBuilder.buildChallenge({ id: 'rec2', skill: {} });
       algoResult.addChallenge(challenge1);
       algoResult.addChallenge(challenge2);
 
@@ -24,8 +25,8 @@ describe('AlgoResult', () => {
     it('should return challengeIds asked', () => {
       // given
       const algoResult = new AlgoResult();
-      const challenge1 = { id: 'rec1', skills: [] };
-      const challenge2 = { id: 'rec2', skills: [] };
+      const challenge1 = domainBuilder.buildChallenge({ id: 'rec1', skill: {} });
+      const challenge2 = domainBuilder.buildChallenge({ id: 'rec2', skill: {} });
       algoResult.addChallenge(challenge1);
       algoResult.addChallenge(challenge2);
 
@@ -56,9 +57,9 @@ describe('AlgoResult', () => {
     it('should return unique names of the skills', () => {
       // given
       const algoResult = new AlgoResult();
-      const challenge1 = { skills: [{ name: 'skill1' }] };
-      const challenge2 = { skills: [{ name: 'skill1' }] };
-      const challenge3 = { skills: [{ name: 'skill2' }] };
+      const challenge1 = domainBuilder.buildChallenge({ skill: { name: 'skill1' } });
+      const challenge2 = domainBuilder.buildChallenge({ skill: { name: 'skill1' } });
+      const challenge3 = domainBuilder.buildChallenge({ skill: { name: 'skill2' } });
       algoResult.addChallenge(challenge1);
       algoResult.addChallenge(challenge2);
       algoResult.addChallenge(challenge3);
@@ -157,8 +158,8 @@ describe('AlgoResult', () => {
     beforeEach(() => {
       // given
       const algoResult = new AlgoResult();
-      const challenge1 = { id: 'rec1', skills: [{ name: 'skill1' }] };
-      const challenge2 = { id: 'rec2', skills: [{ name: 'skill2' }] };
+      const challenge1 = domainBuilder.buildChallenge({ id: 'rec1', skill: { name: 'skill1' } });
+      const challenge2 = domainBuilder.buildChallenge({ id: 'rec2', skill: { name: 'skill2' } });
       algoResult.addChallenge(challenge1);
       algoResult.addChallenge(challenge2);
       algoResult.addChallengeLevel(2);
@@ -229,8 +230,8 @@ describe('AlgoResult', () => {
     it('should get results and write it in file', () => {
       // given
       const algoResult = new AlgoResult();
-      const challenge1 = { id: 'rec1', skills: [{ name: 'skill1' }] };
-      const challenge2 = { id: 'rec2', skills: [{ name: 'skill2' }] };
+      const challenge1 = domainBuilder.buildChallenge({ id: 'rec1', skill: { name: 'skill1' } });
+      const challenge2 = domainBuilder.buildChallenge({ id: 'rec2', skill: { name: 'skill2' } });
       algoResult.addChallenge(challenge1);
       algoResult.addChallenge(challenge2);
       algoResult.addChallengeLevel(2);


### PR DESCRIPTION
## :unicorn: Problème
Depuis la PR #4040, nous désormais plus qu'un seul acquis dans un challenge. Cependant, l'implémentation des tests de l'algo n'a pas suivie et s'attend toujours à recevoir plusieurs acquis pour un challenge.

## :robot: Solution
- Réparer l'implémentation des tests de l'algo 
- Utiliser dans les tests des tests de l'algo (🤯) le `domainBuilder` qui en principe suit le modèle challenge et donc nous protège en cas de changement du modèle.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre dans le dossier : `high-level-tests/test-algo`
- Lancer le script avec `npm start -- --competenceId recsvLz0W2ShyfD63 --userResult ok`
- Vérifier le bon fonctionnement
