### PR TITLE
[BUGFIX] Corriger le script de rattachement de profils cibles (PIX-4866)

### DIFF
--- a/api/scripts/helpers/organizations-by-external-id-helper.js
+++ b/api/scripts/helpers/organizations-by-external-id-helper.js
@@ -5,7 +5,6 @@ function organizeOrganizationsByExternalId(organizations) {
 
   organizations.forEach((organization) => {
     if (organization.externalId) {
-      organization.externalId = organization.externalId.toUpperCase();
       organizationsByExternalId[organization.externalId] = organization;
     }
   });

--- a/api/scripts/prod/add-target-profile-shares-to-organizations.js
+++ b/api/scripts/prod/add-target-profile-shares-to-organizations.js
@@ -12,22 +12,21 @@ const { parseCsv } = require('../helpers/csvHelpers');
 
 function checkData({ csvData }) {
   return csvData
-    .map(([externalIdLowerCase, targetProfileList]) => {
-      if (!externalIdLowerCase && !targetProfileList) {
+    .map(([externalId, targetProfileList]) => {
+      if (!externalId && !targetProfileList) {
         if (require.main === module) process.stdout.write('Found empty line in input file.');
         return null;
       }
-      if (!externalIdLowerCase) {
+      if (!externalId) {
         if (require.main === module)
           process.stdout.write(`A line is missing an externalId for target profile ${targetProfileList}`);
         return null;
       }
       if (!targetProfileList) {
         if (require.main === module)
-          process.stdout.write(`A line is missing a targetProfileIdList for external id ${externalIdLowerCase}`);
+          process.stdout.write(`A line is missing a targetProfileIdList for external id ${externalId}`);
         return null;
       }
-      const externalId = externalIdLowerCase.toUpperCase();
       const targetProfileIdList = targetProfileList.split('-').filter((targetProfile) => !!targetProfile.trim());
 
       return { externalId, targetProfileIdList };
@@ -50,6 +49,8 @@ async function addTargetProfileSharesToOrganizations({ organizationsByExternalId
         targetProfileIdList,
       });
       if (require.main === module) process.stdout.write('===> ✔');
+    } else if (require.main === module) {
+      process.stdout.write(`Organization ${externalId} not found`);
     }
   }
 }

--- a/api/tests/unit/scripts/add-target-profile-shares-to-organizations_test.js
+++ b/api/tests/unit/scripts/add-target-profile-shares-to-organizations_test.js
@@ -53,11 +53,11 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
 
       const expectedResult = [
         {
-          externalId: 'A100',
+          externalId: 'a100',
           targetProfileIdList: ['1', '2', '999'],
         },
         {
-          externalId: 'B200',
+          externalId: 'b200',
           targetProfileIdList: ['1', '3', '6'],
         },
       ];
@@ -78,7 +78,7 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
 
       const expectedResult = [
         {
-          externalId: 'A100',
+          externalId: 'a100',
           targetProfileIdList: ['1', '2', '999'],
         },
       ];
@@ -99,7 +99,7 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
 
       const expectedResult = [
         {
-          externalId: 'A100',
+          externalId: 'a100',
           targetProfileIdList: ['1', '2', '999'],
         },
       ];
@@ -114,7 +114,7 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
     it('should keep only one data when targetProfileIds is missing', async function () {
       // given
       const csvData = [
-        ['a100', '1-2-999'],
+        ['A100', '1-2-999'],
         ['b200', ''],
       ];
 
@@ -135,7 +135,7 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
     it('should keep all data except the empty targetProfileId', async function () {
       // given
       const csvData = [
-        ['a100', '1-2-999'],
+        ['A100', '1-2-999'],
         ['b200', '1-3-'],
       ];
 
@@ -145,7 +145,7 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
           targetProfileIdList: ['1', '2', '999'],
         },
         {
-          externalId: 'B200',
+          externalId: 'b200',
           targetProfileIdList: ['1', '3'],
         },
       ];
@@ -166,11 +166,11 @@ describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js',
 
       const expectedResult = [
         {
-          externalId: 'A100',
+          externalId: 'a100',
           targetProfileIdList: ['1', '2', '999'],
         },
         {
-          externalId: 'B200',
+          externalId: 'b200',
           targetProfileIdList: ['1 ', ' 3 ', ' 6'],
         },
       ];

--- a/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
+++ b/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
@@ -16,13 +16,13 @@ describe('Unit | Scripts | organizations-by-external-id-helper.js', function () 
       ];
 
       const expectedResult = {
-        A100: {
+        a100: {
           id: 1,
-          externalId: 'A100',
+          externalId: 'a100',
         },
-        B200: {
+        b200: {
           id: 2,
-          externalId: 'B200',
+          externalId: 'b200',
         },
       };
 


### PR DESCRIPTION
## :unicorn: Problème
Parfois lors de l'utilisation du script certaines organisations ne sont pas rattachées aux profils cibles.

## :robot: Solution
Ne pas passer les ids externes des organisations en UpperCase.

## :rainbow: Remarques
Le code n'est pas correctement testé et n'est pas testable (console log qui traîne un peu partout)

## :100: Pour tester

Lancer le script en utilisant des organisations qui ont des ids externes avec des minuscules.
[orgas.csv](https://github.com/1024pix/pix/files/8622309/orgas.csv)
[target-profile.csv](https://github.com/1024pix/pix/files/8622310/target-profile.csv)

