### PR TITLE
[BUGFIX] Renommer la méthode Build en Get pour le scoring Cléa (PIX-4874)

### DIFF
--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -21,7 +21,7 @@ async function handleCleaCertificationScoring({
     return;
   }
 
-  const cleaCertificationScoring = await partnerCertificationScoringRepository.buildCleaCertificationScoring({
+  const cleaCertificationScoring = await partnerCertificationScoringRepository.getCleaCertificationScoring({
     complementaryCertificationCourseId,
     certificationCourseId,
     userId,

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -105,7 +105,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
     });
   });
 
-  describe('#buildCleaCertificationScoring', function () {
+  describe('#getCleaCertificationScoring', function () {
     context('when the user does not have no cleA badge', function () {
       it('should get a CleaCertificationScoring that throws a NotEligibleCandidateError', async function () {
         // given

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -15,7 +15,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
 
   beforeEach(function () {
     partnerCertificationScoringRepository = {
-      buildCleaCertificationScoring: sinon.stub(),
+      getCleaCertificationScoring: sinon.stub(),
       save: sinon.stub(),
     };
 
@@ -130,7 +130,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           });
           const date = '2021-01-01';
 
-          partnerCertificationScoringRepository.buildCleaCertificationScoring
+          partnerCertificationScoringRepository.getCleaCertificationScoring
             .withArgs({
               complementaryCertificationCourseId,
               certificationCourseId,
@@ -242,7 +242,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           });
           const date = '2021-01-01';
 
-          partnerCertificationScoringRepository.buildCleaCertificationScoring
+          partnerCertificationScoringRepository.getCleaCertificationScoring
             .withArgs({
               complementaryCertificationCourseId,
               certificationCourseId,


### PR DESCRIPTION
## :unicorn: Problème
Lors du renommage de la méthode buildCleaCertificationScoring du repository en getCleaCertificationScoring dans la pix-4831, une méthode a été renommée mais le renommage n’a pas été fait dans le fichier handle clea certification scoring.

## :robot: Solution
Reporter le renommage dans le fichier handle-clea-certification-scoring.

## :100: Pour tester
Tester le scoring Cléa