### PR TITLE
[BUGFIX] Permettre de commencer une campagne si la participation du prescrit est supprimée (PIX-4875).

### DIFF
--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -11,7 +11,7 @@ class CampaignParticipant {
     this.organizationLearnerId = organizationLearner?.id;
     this.userIdentity = userIdentity;
     this.previousCampaignParticipation = previousCampaignParticipation;
-    this.organizationLearnerHasParticipated = organizationLearner.hasParticipated;
+    this.organizationLearnerHasParticipatedForAnotherUser = organizationLearner.hasParticipated;
   }
 
   start({ participantExternalId }) {
@@ -91,7 +91,7 @@ class CampaignParticipant {
       });
     }
 
-    if (this.organizationLearnerHasParticipated) {
+    if (this.organizationLearnerHasParticipatedForAnotherUser) {
       throw new AlreadyExistingCampaignParticipationError('ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED');
     }
   }

--- a/api/lib/domain/models/CampaignParticipant.js
+++ b/api/lib/domain/models/CampaignParticipant.js
@@ -6,11 +6,16 @@ const couldNotJoinCampaignErrorMessage = "Vous n'êtes pas autorisé à rejoindr
 const couldNotImproveCampaignErrorMessage = 'Vous ne pouvez pas repasser la campagne';
 
 class CampaignParticipant {
-  constructor({ campaignToStartParticipation, organizationLearner, userIdentity, previousCampaignParticipation }) {
+  constructor({
+    campaignToStartParticipation,
+    organizationLearner,
+    userIdentity,
+    previousCampaignParticipationForUser,
+  }) {
     this.campaignToStartParticipation = campaignToStartParticipation;
     this.organizationLearnerId = organizationLearner?.id;
     this.userIdentity = userIdentity;
-    this.previousCampaignParticipation = previousCampaignParticipation;
+    this.previousCampaignParticipationForUser = previousCampaignParticipationForUser;
     this.organizationLearnerHasParticipatedForAnotherUser = organizationLearner.hasParticipated;
   }
 
@@ -18,11 +23,11 @@ class CampaignParticipant {
     this._checkCanParticipateToCampaign(participantExternalId);
 
     const participantExternalIdToUse =
-      this.previousCampaignParticipation?.participantExternalId || participantExternalId;
+      this.previousCampaignParticipationForUser?.participantExternalId || participantExternalId;
     let startAgainCampaign = false;
-    if (this.previousCampaignParticipation) {
+    if (this.previousCampaignParticipationForUser) {
       startAgainCampaign = true;
-      this.previousCampaignParticipation.isImproved = true;
+      this.previousCampaignParticipationForUser.isImproved = true;
     }
 
     if (this._shouldCreateOrganizationLearner()) {
@@ -63,17 +68,17 @@ class CampaignParticipant {
       throw new ForbiddenAccess(couldNotJoinCampaignErrorMessage);
     }
 
-    if (this.previousCampaignParticipation && !this.campaignToStartParticipation.multipleSendings) {
+    if (this.previousCampaignParticipationForUser && !this.campaignToStartParticipation.multipleSendings) {
       throw new AlreadyExistingCampaignParticipationError(
         `User ${this.userIdentity.id} has already a campaign participation with campaign ${this.campaignToStartParticipation.id}`
       );
     }
 
-    if (this.previousCampaignParticipation?.isDeleted) {
+    if (this.previousCampaignParticipationForUser?.isDeleted) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
     }
 
-    if (['STARTED', 'TO_SHARE'].includes(this.previousCampaignParticipation?.status)) {
+    if (['STARTED', 'TO_SHARE'].includes(this.previousCampaignParticipationForUser?.status)) {
       throw new ForbiddenAccess(couldNotImproveCampaignErrorMessage);
     }
     if (this._canImproveResults()) {
@@ -99,14 +104,16 @@ class CampaignParticipant {
   _canImproveResults() {
     return (
       this.campaignToStartParticipation.isAssessment &&
-      this.previousCampaignParticipation &&
-      this.previousCampaignParticipation.validatedSkillsCount >= this.campaignToStartParticipation.skillCount
+      this.previousCampaignParticipationForUser &&
+      this.previousCampaignParticipationForUser.validatedSkillsCount >= this.campaignToStartParticipation.skillCount
     );
   }
 
   _isMissingParticipantExternalId(participantExternalId) {
     return (
-      this.campaignToStartParticipation.idPixLabel && !participantExternalId && !this.previousCampaignParticipation
+      this.campaignToStartParticipation.idPixLabel &&
+      !participantExternalId &&
+      !this.previousCampaignParticipationForUser
     );
   }
 }

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -142,6 +142,8 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
         this.on('campaign-participations.organizationLearnerId', 'organization-learners.id');
         this.on('campaign-participations.campaignId', 'campaigns.id');
         this.on('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
+        this.on('campaign-participations.isImproved', knex.raw('IS'), knex.raw('false'));
+        this.on('campaign-participations.userId', '!=', 'organization-learners.userId');
       },
       'organization-learners.id'
     )

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -3,6 +3,7 @@ const CampaignParticipant = require('../../domain/models/CampaignParticipant');
 const CampaignToStartParticipation = require('../../domain/models/CampaignToStartParticipation');
 const { AlreadyExistingCampaignParticipationError, NotFoundError } = require('../../domain/errors');
 const skillDatasource = require('../datasources/learning-content/skill-datasource');
+const { knex } = require('../../../db/knex-database-connection');
 
 async function save(campaignParticipant, domainTransaction) {
   const newlyCreatedOrganizationLearnerId = await _createNewOrganizationLearner(
@@ -140,6 +141,7 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
       function () {
         this.on('campaign-participations.organizationLearnerId', 'organization-learners.id');
         this.on('campaign-participations.campaignId', 'campaigns.id');
+        this.on('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
       },
       'organization-learners.id'
     )

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -15,7 +15,7 @@ async function save(campaignParticipant, domainTransaction) {
   }
 
   await _updatePreviousParticipation(
-    campaignParticipant.previousCampaignParticipation,
+    campaignParticipant.previousCampaignParticipationForUser,
     domainTransaction.knexTransaction
   );
   const campaignParticipationId = await _createNewCampaignParticipation(
@@ -85,13 +85,17 @@ async function get({ userId, campaignId, domainTransaction }) {
 
   const organizationLearner = await _getOrganizationLearner(campaignId, userId, domainTransaction);
 
-  const previousCampaignParticipation = await _findPreviousCampaignParticipation(campaignId, userId, domainTransaction);
+  const previousCampaignParticipationForUser = await _findpreviousCampaignParticipationForUser(
+    campaignId,
+    userId,
+    domainTransaction
+  );
 
   return new CampaignParticipant({
     userIdentity,
     campaignToStartParticipation,
     organizationLearner,
-    previousCampaignParticipation,
+    previousCampaignParticipationForUser,
   });
 }
 
@@ -142,7 +146,7 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
         this.on('campaign-participations.organizationLearnerId', 'organization-learners.id');
         this.on('campaign-participations.campaignId', 'campaigns.id');
         this.on('campaign-participations.deletedAt', knex.raw('IS'), knex.raw('NULL'));
-        this.on('campaign-participations.isImproved', knex.raw('IS'), knex.raw('false'));
+        this.on('campaign-participations.isImproved', knex.raw('false'));
         this.on('campaign-participations.userId', '!=', 'organization-learners.userId');
       },
       'organization-learners.id'
@@ -161,7 +165,7 @@ async function _getOrganizationLearner(campaignId, userId, domainTransaction) {
   return organizationLearner;
 }
 
-async function _findPreviousCampaignParticipation(campaignId, userId, domainTransaction) {
+async function _findpreviousCampaignParticipationForUser(campaignId, userId, domainTransaction) {
   const campaignParticipationAttributes = await domainTransaction
     .knexTransaction('campaign-participations')
     .select('id', 'participantExternalId', 'validatedSkillsCount', 'status', 'deletedAt')

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -137,7 +137,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
             hasParticipated: false,
           },
           userIdentity,
-          previousCampaignParticipation: null,
+          previousCampaignParticipationForUser: null,
         });
 
         campaignParticipant.start({ participantExternalId: null });
@@ -168,7 +168,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
             hasParticipated: false,
           },
           userIdentity,
-          previousCampaignParticipation: null,
+          previousCampaignParticipationForUser: null,
         });
 
         campaignParticipant.start({ participantExternalId: null });
@@ -204,7 +204,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
             hasParticipated: false,
           },
           userIdentity,
-          previousCampaignParticipation: null,
+          previousCampaignParticipationForUser: null,
         });
 
         campaignParticipant.start({ participantExternalId: null });
@@ -227,7 +227,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         const campaign = databaseBuilder.factory.buildCampaign({
           multipleSendings: true,
         });
-        const { id: previousCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        const { id: previousCampaignParticipationForUserId } = databaseBuilder.factory.buildCampaignParticipation({
           userId: userIdentity.id,
           campaignId: campaign.id,
           isImproved: false,
@@ -240,8 +240,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          previousCampaignParticipation: {
-            id: previousCampaignParticipationId,
+          previousCampaignParticipationForUser: {
+            id: previousCampaignParticipationForUserId,
             status: 'SHARED',
             validatedSkillsCount: 0,
           },
@@ -261,7 +261,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         //THEN
         const campaignParticipation = await knex('campaign-participations')
           .select('isImproved')
-          .where({ id: previousCampaignParticipationId })
+          .where({ id: previousCampaignParticipationForUserId })
           .first();
 
         expect(campaignParticipation.isImproved).to.deep.equal(true);
@@ -284,7 +284,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           campaignId: campaign.id,
           isImproved: false,
         });
-        const { id: previousCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        const { id: previousCampaignParticipationForUserId } = databaseBuilder.factory.buildCampaignParticipation({
           userId: userIdentity.id,
           campaignId: campaign.id,
           isImproved: false,
@@ -296,8 +296,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          previousCampaignParticipation: {
-            id: previousCampaignParticipationId,
+          previousCampaignParticipationForUser: {
+            id: previousCampaignParticipationForUserId,
             status: 'SHARED',
             validatedSkillsCount: 0,
           },
@@ -317,7 +317,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         //THEN
         const campaignParticipations = await knex('campaign-participations').pluck('id').where({ isImproved: true });
 
-        expect(campaignParticipations).to.deep.equal([previousCampaignParticipationId]);
+        expect(campaignParticipations).to.deep.equal([previousCampaignParticipationForUserId]);
       });
     });
 
@@ -423,7 +423,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           multipleSendings: true,
           idPixLabel: null,
         });
-        const { id: previousCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        const { id: previousCampaignParticipationForUserId } = databaseBuilder.factory.buildCampaignParticipation({
           userId: userIdentity.id,
           campaignId: campaign.id,
           isImproved: false,
@@ -435,8 +435,8 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          previousCampaignParticipation: {
-            id: previousCampaignParticipationId,
+          previousCampaignParticipationForUser: {
+            id: previousCampaignParticipationForUserId,
             status: 'SHARED',
             validatedSkillsCount: 0,
           },
@@ -459,7 +459,9 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         const campaignParticipations = await knex('campaign-participations').select(['id', 'isImproved']);
         const assessments = await knex('assessments');
 
-        expect(campaignParticipations).to.deep.equal([{ id: previousCampaignParticipationId, isImproved: false }]);
+        expect(campaignParticipations).to.deep.equal([
+          { id: previousCampaignParticipationForUserId, isImproved: false },
+        ]);
         expect(assessments).to.be.empty;
       });
     });
@@ -533,7 +535,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           });
         });
 
-        expect(campaignParticipant.previousCampaignParticipation).to.deep.equal(expectedAttributes);
+        expect(campaignParticipant.previousCampaignParticipationForUser).to.deep.equal(expectedAttributes);
       });
     });
 
@@ -555,7 +557,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           });
         });
 
-        expect(campaignParticipant.previousCampaignParticipation).to.be.null;
+        expect(campaignParticipant.previousCampaignParticipationForUser).to.be.null;
       });
     });
 
@@ -973,7 +975,7 @@ async function makeCampaignParticipant({
     campaignToStartParticipation,
     organizationLearner,
     userIdentity,
-    previousCampaignParticipation: null,
+    previousCampaignParticipationForUser: null,
   });
 
   campaignParticipant.start({ participantExternalId });

--- a/api/tests/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipant_test.js
@@ -71,10 +71,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             skillCount: 1,
           });
           const userIdentity = { id: 13 };
-          const previousCampaignParticipation = { status: 'SHARED', validatedSkillsCount: 0, id: 1 };
+          const previousCampaignParticipationForUser = { status: 'SHARED', validatedSkillsCount: 0, id: 1 };
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation,
-            previousCampaignParticipation,
+            previousCampaignParticipationForUser,
             userIdentity,
             organizationLearner: {
               id: null,
@@ -103,7 +103,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation,
             userIdentity,
-            previousCampaignParticipation: {
+            previousCampaignParticipationForUser: {
               status: 'SHARED',
               validatedSkillsCount: 2,
             },
@@ -131,7 +131,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation,
             userIdentity,
-            previousCampaignParticipation: {
+            previousCampaignParticipationForUser: {
               status: 'SHARED',
               validatedSkillsCount: 3,
             },
@@ -205,10 +205,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
             multipleSendings: true,
             idPixLabel: null,
           });
-          const previousCampaignParticipation = { status: 'SHARED', validatedSkillsCount: null, id: 1 };
+          const previousCampaignParticipationForUser = { status: 'SHARED', validatedSkillsCount: null, id: 1 };
           const campaignParticipant = new CampaignParticipant({
             campaignToStartParticipation,
-            previousCampaignParticipation,
+            previousCampaignParticipationForUser,
             userIdentity,
             organizationLearner: {
               id: null,
@@ -376,7 +376,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const expectedParticipantExternalId = 'YvoLol';
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
-          previousCampaignParticipation: {
+          previousCampaignParticipationForUser: {
             status: 'SHARED',
             validatedSkillsCount: 0,
             participantExternalId: expectedParticipantExternalId,
@@ -401,10 +401,10 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
           idPixLabel: null,
         });
         const userIdentity = { id: 13 };
-        const previousCampaignParticipation = { status: 'SHARED', id: 1 };
+        const previousCampaignParticipationForUser = { status: 'SHARED', id: 1 };
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
-          previousCampaignParticipation,
+          previousCampaignParticipationForUser,
           userIdentity,
           organizationLearner: {
             id: null,
@@ -413,7 +413,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         });
         campaignParticipant.start({ participantExternalId: null });
 
-        expect(campaignParticipant.previousCampaignParticipation.isImproved).to.equal(true);
+        expect(campaignParticipant.previousCampaignParticipationForUser.isImproved).to.equal(true);
       });
 
       it('throws a AlreadyExistingCampaignParticipationError exception when the previous participation is not shared', async function () {
@@ -425,7 +425,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          previousCampaignParticipation: {
+          previousCampaignParticipationForUser: {
             status: 'STARTED',
           },
           organizationLearner: {
@@ -451,7 +451,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          previousCampaignParticipation: {
+          previousCampaignParticipationForUser: {
             status: 'SHARED',
             isDeleted: true,
           },
@@ -499,7 +499,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation,
           userIdentity,
-          previousCampaignParticipation: { id: 1, status: 'SHARED' },
+          previousCampaignParticipationForUser: { id: 1, status: 'SHARED' },
           organizationLearner: {
             id: null,
             hasParticipated: false,

--- a/mon-pix/app/styles/pages/_existing-campagne.scss
+++ b/mon-pix/app/styles/pages/_existing-campagne.scss
@@ -1,6 +1,5 @@
 .inaccessible-campaign-message {
   padding: 0 32px;
-  display: inline;
 
   &__username {
     font-weight: $font-bold;
@@ -9,6 +8,6 @@
 }
 
 .inaccessible-campaign-info {
-  margin-top: 6px;
+  margin-top: 32px;
   padding: 0 32px;
 }

--- a/mon-pix/app/templates/campaigns/existing-participation.hbs
+++ b/mon-pix/app/templates/campaigns/existing-participation.hbs
@@ -1,6 +1,7 @@
-<InaccessibleCampaign>
+*<InaccessibleCampaign>
   <span class="inaccessible-campaign-message">
-    <span>{{t "pages.campaign.errors.existing-participation"}}</span>
+    <div>{{t "pages.campaign.errors.existing-participation"}}</div>
+    <span>{{t "pages.campaign.errors.existing-participation-user-info"}}</span>
     <span class="inaccessible-campaign-message__username">{{this.model.firstName}} {{this.model.lastName}}.</span>
   </span>
   <span class="inaccessible-campaign-info">

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -134,7 +134,8 @@
       "errors": {
         "no-longer-accessible": "Oops, the requested page is not available.",
         "not-accessible": "Oops, the requested page is not available.",
-        "existing-participation": "You cannot take this customised test. There is already a participation associated with the name ",
+        "existing-participation": "You cannot take this customised test.",
+        "existing-participation-user-info": "There is already a participation associated with the name ",
         "existing-participation-info": "Please contact your teacher so that they can delete your previous participation in Pix Orga."
 
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -134,7 +134,8 @@
       "errors": {
         "no-longer-accessible": "Oups, la page demandée n’est plus accessible.",
         "not-accessible": "Oups, la page demandée n’est pas accessible.",
-        "existing-participation": "Le parcours n'est pas accessible pour vous. Il y a déjà une participation associée au nom de ",
+        "existing-participation": "Le parcours n'est pas accessible pour vous.",
+        "existing-participation-user-info": "Il y a déjà une participation associée au nom de ",
         "existing-participation-info": "Rapprochez-vous de votre enseignant pour qu'il supprime votre participation dans Pix Orga."
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Après une dissociation et une suppression un nouvelle utilisateur ne peut pas participer à la campagne car le prescrit à déjà une participation.

## :robot: Solution
Ne pas prendre en compte les participations supprimées du prescrit.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Participer à la campagne SCOBADGE1 en tant First, Last; 10/10/2010
Supprimer la participation et faire la dissociation
Participer à la campagne SCOBADGE1 en tant First, Last; 10/10/2010 avec un autre compte.
Vous devez pouvoir participer à la campagne.
