### PR TITLE
[BUGFIX] Corriger l'erreur sur la pagination des tutoriels enregistrés (PIX-4842).

### DIFF
--- a/api/db/database-builder/factory/build-user-saved-tutorial.js
+++ b/api/db/database-builder/factory/build-user-saved-tutorial.js
@@ -5,9 +5,10 @@ module.exports = function buildUserSavedTutorial({
   tutorialId,
   userId,
   skillId = null,
+  createdAt = new Date(),
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'user-saved-tutorials',
-    values: { id, userId, tutorialId, skillId },
+    values: { id, userId, tutorialId, skillId, createdAt },
   });
 };

--- a/api/lib/domain/models/UserSavedTutorial.js
+++ b/api/lib/domain/models/UserSavedTutorial.js
@@ -1,9 +1,10 @@
 class UserSavedTutorial {
-  constructor({ id, userId, tutorialId, skillId } = {}) {
+  constructor({ id, userId, tutorialId, skillId, createdAt } = {}) {
     this.id = id;
     this.userId = userId;
     this.tutorialId = tutorialId;
     this.skillId = skillId;
+    this.createdAt = createdAt;
   }
 }
 

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -32,7 +32,7 @@ module.exports = {
 
     const tutorialsForUser = _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
 
-    const sortedTutorialsForUser = _.orderBy(tutorialsForUser, ['userTutorial.id'], ['desc']);
+    const sortedTutorialsForUser = _.orderBy(tutorialsForUser, ['userTutorial.createdAt'], ['desc']);
     const { results: models, pagination: meta } = paginateModule.paginate(sortedTutorialsForUser, page);
 
     return { models, meta };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   async findPaginatedForCurrentUser({ userId, page }) {
-    const { models: userTutorials, meta } = await userTutorialRepository.findPaginated({ userId, page });
+    const userTutorials = await userTutorialRepository.find({ userId });
     const [tutorials, tutorialEvaluations] = await Promise.all([
       tutorialDatasource.findByRecordIds(userTutorials.map(({ tutorialId }) => tutorialId)),
       tutorialEvaluationRepository.find({ userId }),
@@ -32,7 +32,9 @@ module.exports = {
 
     const tutorialsForUser = _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
 
-    return { models: tutorialsForUser, meta };
+    const { pagination: meta, results: models } = paginateModule.paginate(tutorialsForUser, page);
+
+    return { models, meta };
   },
 
   async get(id) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -32,7 +32,8 @@ module.exports = {
 
     const tutorialsForUser = _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
 
-    const { pagination: meta, results: models } = paginateModule.paginate(tutorialsForUser, page);
+    const sortedTutorialsForUser = _.orderBy(tutorialsForUser, ['userTutorial.id'], ['desc']);
+    const { results: models, pagination: meta } = paginateModule.paginate(sortedTutorialsForUser, page);
 
     return { models, meta };
   },

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -17,7 +17,7 @@ module.exports = {
   },
 
   async find({ userId }) {
-    const userSavedTutorials = await knex(TABLE_NAME).where({ userId });
+    const userSavedTutorials = await knex(TABLE_NAME).where({ userId }).orderBy('id', 'desc');
     return userSavedTutorials.map(_toDomain);
   },
 

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -45,5 +45,6 @@ function _toDomain(userSavedTutorial) {
     tutorialId: userSavedTutorial.tutorialId,
     userId: userSavedTutorial.userId,
     skillId: userSavedTutorial.skillId,
+    createdAt: userSavedTutorial.createdAt,
   });
 }

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -17,7 +17,7 @@ module.exports = {
   },
 
   async find({ userId }) {
-    const userSavedTutorials = await knex(TABLE_NAME).where({ userId }).orderBy('id', 'desc');
+    const userSavedTutorials = await knex(TABLE_NAME).where({ userId }).orderBy('createdAt', 'desc');
     return userSavedTutorials.map(_toDomain);
   },
 

--- a/api/lib/infrastructure/repositories/user-tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/user-tutorial-repository.js
@@ -3,7 +3,6 @@ const Tutorial = require('../../domain/models/Tutorial');
 const UserSavedTutorial = require('../../domain/models/UserSavedTutorial');
 const UserSavedTutorialWithTutorial = require('../../domain/models/UserSavedTutorialWithTutorial');
 const tutorialDatasource = require('../datasources/learning-content/tutorial-datasource');
-const { fetchPage } = require('../utils/knex-utils');
 
 const TABLE_NAME = 'user-saved-tutorials';
 
@@ -20,13 +19,6 @@ module.exports = {
   async find({ userId }) {
     const userSavedTutorials = await knex(TABLE_NAME).where({ userId });
     return userSavedTutorials.map(_toDomain);
-  },
-
-  async findPaginated({ userId, page }) {
-    const query = knex(TABLE_NAME).where({ userId });
-    const { results, pagination } = await fetchPage(query, page);
-    const userSavedTutorials = results.map(_toDomain);
-    return { models: userSavedTutorials, meta: pagination };
   },
 
   // TODO delete when tutorial V2 becomes main version

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -675,9 +675,24 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
 
         mockLearningContent(learningContentObjects);
 
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 101, userId: 4444, tutorialId: 'tuto1' });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 102, userId: 4444, tutorialId: 'tuto2' });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 103, userId: 4444, tutorialId: 'tuto3' });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          id: 101,
+          userId: 4444,
+          tutorialId: 'tuto1',
+          createdAt: new Date('2022-05-03'),
+        });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          id: 102,
+          userId: 4444,
+          tutorialId: 'tuto2',
+          createdAt: new Date('2022-05-04'),
+        });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          id: 103,
+          userId: 4444,
+          tutorialId: 'tuto3',
+          createdAt: new Date('2022-05-05'),
+        });
 
         await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -684,19 +684,24 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
         const expectedUserSavedTutorials = [
           {
             attributes: {
-              duration: '00:00:54',
-              format: 'video',
-              link: 'http://www.example.com/this-is-an-example.html',
+              duration: '00:03:31',
+              format: 'vidéo',
+              link: 'http://www.example.com/this-is-an-example3.html',
               source: 'tuto.com',
-              title: 'tuto1',
+              title: 'tuto3',
             },
+            id: 'tuto3',
             relationships: {
-              'user-tutorial': { data: { id: '101', type: 'user-tutorial' } },
               'tutorial-evaluation': {
                 data: null,
               },
+              'user-tutorial': {
+                data: {
+                  id: '103',
+                  type: 'user-tutorial',
+                },
+              },
             },
-            id: 'tuto1',
             type: 'tutorials',
           },
           {
@@ -707,13 +712,18 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               source: 'tuto.com',
               title: 'tuto2',
             },
+            id: 'tuto2',
             relationships: {
-              'user-tutorial': { data: { id: '102', type: 'user-tutorial' } },
               'tutorial-evaluation': {
                 data: null,
               },
+              'user-tutorial': {
+                data: {
+                  id: '102',
+                  type: 'user-tutorial',
+                },
+              },
             },
-            id: 'tuto2',
             type: 'tutorials',
           },
         ];

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -139,7 +139,7 @@ describe('Integration | Repository | tutorial-repository', function () {
     });
 
     context('when user has saved tutorials', function () {
-      it('should return tutorial with user tutorial belonging to given user ordered by userTutorial Id desc', async function () {
+      it('should return tutorials with user tutorials belonging to given user ordered by descending date of creation', async function () {
         // given
         const tutorialId1 = 'rec1Tutorial';
         const tutorialId2 = 'rec2Tutorial';
@@ -149,8 +149,16 @@ describe('Integration | Repository | tutorial-repository', function () {
         };
         mockLearningContent(learningContent);
 
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 1, tutorialId: tutorialId1, userId });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 2, tutorialId: tutorialId2, userId });
+        const firstUserSavedTutorial = databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: tutorialId1,
+          userId,
+          createdAt: new Date('2022-05-01'),
+        });
+        const lastUserSavedTutorial = databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: tutorialId2,
+          userId,
+          createdAt: new Date('2022-05-02'),
+        });
         await databaseBuilder.commit();
 
         // when
@@ -163,7 +171,10 @@ describe('Integration | Repository | tutorial-repository', function () {
         expect(tutorialsForUser[0]).to.be.instanceOf(TutorialForUser);
         expect(tutorialsForUser[0].userTutorial).to.be.instanceOf(UserSavedTutorial);
         expect(tutorialsForUser[0].userTutorial.userId).to.equal(userId);
-        expect(tutorialsForUser.map((tutorialForUser) => tutorialForUser.userTutorial.id)).to.deep.equal([2, 1]);
+        expect(tutorialsForUser.map((tutorialForUser) => tutorialForUser.userTutorial.createdAt)).to.deep.equal([
+          lastUserSavedTutorial.createdAt,
+          firstUserSavedTutorial.createdAt,
+        ]);
       });
 
       context('when user has evaluated tutorial ', function () {
@@ -226,11 +237,31 @@ describe('Integration | Repository | tutorial-repository', function () {
 
         mockLearningContent(learningContent);
 
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 1, tutorialId: 'tuto1', userId });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 2, tutorialId: 'tuto2', userId });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 3, tutorialId: 'tuto3', userId });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 4, tutorialId: 'tuto_erreurId', userId });
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 5, tutorialId: 'tuto4', userId });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'tuto1',
+          userId,
+          createdAt: new Date('2022-05-01'),
+        });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'tuto2',
+          userId,
+          createdAt: new Date('2022-05-02'),
+        });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'tuto3',
+          userId,
+          createdAt: new Date('2022-05-03'),
+        });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'tuto_erreurId',
+          userId,
+          createdAt: new Date('2022-05-04'),
+        });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'tuto4',
+          userId,
+          createdAt: new Date('2022-05-05'),
+        });
         await databaseBuilder.commit();
 
         const expectedTutorialIds = ['tuto4', 'tuto3', 'tuto2', 'tuto1'];

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -669,21 +669,17 @@ describe('Integration | Repository | tutorial-repository', function () {
         const { results } = await tutorialRepository.findPaginatedRecommendedByUserId({ userId });
 
         // then
-        expect(results.map((tutorial) => tutorial.tutorialEvaluation)).to.exactlyContain([
-          {
-            id: tutorialEvaluationId,
-            userId,
-            tutorialId: 'tuto4',
-          },
-        ]);
-        expect(results.map((tutorial) => tutorial.userTutorial)).to.exactlyContain([
-          {
-            id: userSavedTutorialId,
-            userId,
-            skillId: 'recSkill3',
-            tutorialId: 'tuto4',
-          },
-        ]);
+        expect(results[0].tutorialEvaluation).to.deep.equal({
+          id: tutorialEvaluationId,
+          userId,
+          tutorialId: 'tuto4',
+        });
+        expect(results[0].userTutorial).to.include({
+          id: userSavedTutorialId,
+          userId,
+          skillId: 'recSkill3',
+          tutorialId: 'tuto4',
+        });
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -121,10 +121,12 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
         const userSavedTutoId1 = databaseBuilder.factory.buildUserSavedTutorial({
           tutorialId: 'recTutorial',
           userId,
+          createdAt: '2022-04-29',
         }).id;
         const userSavedTutoId2 = databaseBuilder.factory.buildUserSavedTutorial({
           tutorialId: 'recTutorial2',
           userId,
+          createdAt: '2022-05-02',
         }).id;
         await databaseBuilder.commit();
 
@@ -133,9 +135,10 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
 
         // then
         expect(userTutorials).to.have.length(2);
+        expect(userTutorials[0]).to.be.instanceOf(UserSavedTutorial);
         expect(userTutorials[0]).to.have.property('tutorialId', 'recTutorial2');
         expect(userTutorials[0]).to.have.property('userId', userId);
-        expect(userTutorials[0]).to.be.instanceOf(UserSavedTutorial);
+        expect(userTutorials[0].createdAt).to.deep.equal(new Date('2022-05-02'));
         expect(userTutorials[0].skillId).to.equal(null);
         expect(userTutorials[0].id).to.equal(userSavedTutoId2);
         expect(userTutorials[1].id).to.equal(userSavedTutoId1);

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -3,7 +3,6 @@ const userTutorialRepository = require('../../../../lib/infrastructure/repositor
 const UserSavedTutorial = require('../../../../lib/domain/models/UserSavedTutorial');
 const UserTutorialWithTutorial = require('../../../../lib/domain/models/UserSavedTutorialWithTutorial');
 const Tutorial = require('../../../../lib/domain/models/Tutorial');
-const _ = require('lodash');
 
 describe('Integration | Infrastructure | Repository | user-tutorial-repository', function () {
   let userId;

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -145,57 +145,6 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
     });
   });
 
-  describe('#findPaginated', function () {
-    context('when user has saved tutorials', function () {
-      it('should return user-saved-tutorials belonging to given user', async function () {
-        // given
-        const tutorialId = 'recTutorial';
-        databaseBuilder.factory.buildUserSavedTutorial({ tutorialId, userId });
-        await databaseBuilder.commit();
-
-        // when
-        const { models: userTutorials } = await userTutorialRepository.findPaginated({ userId });
-
-        // then
-        expect(userTutorials).to.have.length(1);
-        expect(userTutorials[0]).to.have.property('tutorialId', tutorialId);
-        expect(userTutorials[0]).to.have.property('userId', userId);
-        expect(userTutorials[0]).to.be.instanceOf(UserSavedTutorial);
-        expect(userTutorials[0].tutorialId).to.equal(tutorialId);
-        expect(userTutorials[0].skillId).to.equal(null);
-      });
-    });
-
-    context('when user has not saved tutorial', function () {
-      it('should return an empty list', async function () {
-        const { models: userTutorials } = await userTutorialRepository.findPaginated({ userId });
-
-        // then
-        expect(userTutorials).to.deep.equal([]);
-      });
-    });
-
-    context('when user-tutorials amount exceed page size', function () {
-      it('should return page size number of user-tutorials', async function () {
-        // given
-        const page = { number: 2, size: 2 };
-        _.times(4, (i) => databaseBuilder.factory.buildUserSavedTutorial({ userId, tutorialId: i }));
-        const expectedPagination = { page: 2, pageSize: 2, pageCount: 2, rowCount: 4 };
-        await databaseBuilder.commit();
-
-        // when
-        const { models: userTutorials, meta: pagination } = await userTutorialRepository.findPaginated({
-          userId,
-          page,
-        });
-
-        // then
-        expect(userTutorials).to.have.lengthOf(2);
-        expect(pagination).to.include(expectedPagination);
-      });
-    });
-  });
-
   describe('#findWithTutorial', function () {
     context('when user has saved tutorials', function () {
       it('should return user-saved-tutorials belonging to given user', async function () {

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -116,22 +116,29 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
 
   describe('#find', function () {
     context('when user has saved tutorials', function () {
-      it('should return user-saved-tutorials belonging to given user', async function () {
+      it('should return user-saved-tutorials belonging to given user ordered by descending id', async function () {
         // given
-        const tutorialId = 'recTutorial';
-        databaseBuilder.factory.buildUserSavedTutorial({ tutorialId, userId });
+        const userSavedTutoId1 = databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'recTutorial',
+          userId,
+        }).id;
+        const userSavedTutoId2 = databaseBuilder.factory.buildUserSavedTutorial({
+          tutorialId: 'recTutorial2',
+          userId,
+        }).id;
         await databaseBuilder.commit();
 
         // when
         const userTutorials = await userTutorialRepository.find({ userId });
 
         // then
-        expect(userTutorials).to.have.length(1);
-        expect(userTutorials[0]).to.have.property('tutorialId', tutorialId);
+        expect(userTutorials).to.have.length(2);
+        expect(userTutorials[0]).to.have.property('tutorialId', 'recTutorial2');
         expect(userTutorials[0]).to.have.property('userId', userId);
         expect(userTutorials[0]).to.be.instanceOf(UserSavedTutorial);
-        expect(userTutorials[0].tutorialId).to.equal(tutorialId);
         expect(userTutorials[0].skillId).to.equal(null);
+        expect(userTutorials[0].id).to.equal(userSavedTutoId2);
+        expect(userTutorials[1].id).to.equal(userSavedTutoId1);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-tutorial-repository_test.js
@@ -118,16 +118,16 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
     context('when user has saved tutorials', function () {
       it('should return user-saved-tutorials belonging to given user ordered by descending id', async function () {
         // given
-        const userSavedTutoId1 = databaseBuilder.factory.buildUserSavedTutorial({
+        const userSavedTuto1 = databaseBuilder.factory.buildUserSavedTutorial({
           tutorialId: 'recTutorial',
           userId,
-          createdAt: '2022-04-29',
-        }).id;
-        const userSavedTutoId2 = databaseBuilder.factory.buildUserSavedTutorial({
+          createdAt: new Date('2022-04-29'),
+        });
+        const userSavedTuto2 = databaseBuilder.factory.buildUserSavedTutorial({
           tutorialId: 'recTutorial2',
           userId,
-          createdAt: '2022-05-02',
-        }).id;
+          createdAt: new Date('2022-05-02'),
+        });
         await databaseBuilder.commit();
 
         // when
@@ -138,10 +138,11 @@ describe('Integration | Infrastructure | Repository | user-tutorial-repository',
         expect(userTutorials[0]).to.be.instanceOf(UserSavedTutorial);
         expect(userTutorials[0]).to.have.property('tutorialId', 'recTutorial2');
         expect(userTutorials[0]).to.have.property('userId', userId);
-        expect(userTutorials[0].createdAt).to.deep.equal(new Date('2022-05-02'));
+        expect(userTutorials[0].createdAt).to.deep.equal(userSavedTuto2.createdAt);
         expect(userTutorials[0].skillId).to.equal(null);
-        expect(userTutorials[0].id).to.equal(userSavedTutoId2);
-        expect(userTutorials[1].id).to.equal(userSavedTutoId1);
+        expect(userTutorials[0].id).to.equal(userSavedTuto2.id);
+        expect(userTutorials[1].id).to.equal(userSavedTuto1.id);
+        expect(userTutorials[1].createdAt).to.deep.equal(userSavedTuto1.createdAt);
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-user-saved-tutorial.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-saved-tutorial.js
@@ -5,11 +5,13 @@ module.exports = function buildUserSavedTutorial({
   userId = '4044',
   tutorialId = '111',
   skillId = '1212',
+  createdAt = '2022-05-02',
 } = {}) {
   return new UserSavedTutorial({
     id,
     skillId,
     userId,
     tutorialId,
+    createdAt,
   });
 };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur la page des tutoriels enregistrés de pix app, il y a une erreur sur la pagination affichée. En effet, on peut parfois voir apparaître une pagination qui propose 1 à n élements, mais sans aucun tutoriels affichés à l'écran. Cela se produit lorsqu'un tutoriel a été enregistré par l'utilisateur, et qu'il a ensuite été supprimé du référentiel.

## :robot: Solution
Recalculer les élements méta de pagination juste avant de renvoyer la réponse de l'api.

## :rainbow: Remarques

## :100: Pour tester

- Se connecter à pix app
- Passer des compétences, et enregistrer par exemple 3 tutoriels quand ils sont proposés (écran intermédiaire de checkpoint, ou détail d'une compétence).
- Se connecter à la base de données de la review app :`scalingo -a pix-api-review-pr4384 pgsql-console`
- Chercher les user-saved-tutorials par rapport à son userID utilisé dans pix app
- Modifier un tutorialId avec un tutorialId Inexistant
- Retourner dans la page mes tutos, onglet enregistrés
- Vérifier la cohérence entre les données de pagination et le nombre d'éléments tutoriels affichés