### PR TITLE
[FEATURE] Rendre configurable les critères d'obtention de la certification CléA Numérique (PIX-4832).

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -4,11 +4,15 @@ module.exports = function buildComplementaryCertification({
   id = databaseBuffer.getNextId(),
   name = 'UneSuperCertifComplémentaire',
   createdAt = new Date('2020-01-01'),
+  minimumReproducibilityRate,
+  minimumEarnedPix,
 } = {}) {
   const values = {
     id,
     name,
     createdAt,
+    minimumReproducibilityRate,
+    minimumEarnedPix,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'complementary-certifications',

--- a/api/db/migrations/20220429143417_add-scoring-columns-to-table-complementary-certifications.js
+++ b/api/db/migrations/20220429143417_add-scoring-columns-to-table-complementary-certifications.js
@@ -1,0 +1,20 @@
+exports.up = async function (knex) {
+  await knex.schema.table('complementary-certifications', (table) => {
+    table.decimal('minimumReproducibilityRate', 5, 2).nullable();
+    table.integer('minimumEarnedPix').nullable();
+  });
+
+  await knex('complementary-certifications')
+    .update({
+      minimumReproducibilityRate: 50.0,
+      minimumEarnedPix: 70,
+    })
+    .where({ name: 'CléA Numérique' });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table('complementary-certifications', (table) => {
+    table.dropColumn('minimumReproducibilityRate');
+    table.dropColumn('minimumEarnedPix');
+  });
+};

--- a/api/lib/domain/models/CleaCertificationScoring.js
+++ b/api/lib/domain/models/CleaCertificationScoring.js
@@ -3,8 +3,6 @@ const { NotEligibleCandidateError } = require('../errors');
 const Joi = require('joi');
 const { validateEntity } = require('../validators/entity-validator');
 
-const { ReproducibilityRate } = require('./ReproducibilityRate');
-
 class CleaCertificationScoring extends PartnerCertificationScoring {
   constructor({
     complementaryCertificationCourseId,
@@ -13,6 +11,8 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     isBadgeAcquisitionStillValid = true,
     cleaBadgeKey,
     pixScore,
+    minimumEarnedPix,
+    minimumReproducibilityRate,
   } = {}) {
     super({
       complementaryCertificationCourseId,
@@ -24,6 +24,8 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
     this.isBadgeAcquisitionStillValid = isBadgeAcquisitionStillValid;
     this.reproducibilityRate = reproducibilityRate;
     this.pixScore = pixScore;
+    this.minimumEarnedPix = minimumEarnedPix;
+    this.minimumReproducibilityRate = minimumReproducibilityRate;
 
     const schema = Joi.object({
       hasAcquiredBadge: Joi.boolean().required(),
@@ -53,14 +55,15 @@ class CleaCertificationScoring extends PartnerCertificationScoring {
 
   isAcquired() {
     if (!this.hasAcquiredBadge) throw new NotEligibleCandidateError();
-
-    const reproducibilityRate = new ReproducibilityRate(this.reproducibilityRate);
-
-    return reproducibilityRate.isEnoughToBeCertified() && this._isAboveMinimumScore();
+    return this._isAboveMinimumReproducibilityRate() && this._isAboveMinimumScore();
   }
 
   _isAboveMinimumScore() {
-    return this.pixScore >= 70;
+    return this.pixScore >= this.minimumEarnedPix;
+  }
+
+  _isAboveMinimumReproducibilityRate() {
+    return this.reproducibilityRate >= this.minimumReproducibilityRate;
   }
 }
 

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -4,6 +4,8 @@ const ComplementaryCertificationCourseResultBookshelf = require('../orm-models/C
 const CleaCertificationScoring = require('../../domain/models/CleaCertificationScoring');
 const Badge = require('../../domain/models/Badge');
 const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
+const ComplementaryCertification = require('../../domain/models/ComplementaryCertification');
+const _ = require('lodash');
 
 module.exports = {
   async getCleaCertificationScoring({
@@ -19,6 +21,7 @@ module.exports = {
       return CleaCertificationScoring.buildNotEligible({ complementaryCertificationCourseId });
     }
     const pixScore = await _getLatestPixScoreByCertificationCourseId(certificationCourseId);
+    const { minimumEarnedPix, minimumReproducibilityRate } = await _getMinimumReproducibilityRateAndMinimumEarnedPix();
 
     return new CleaCertificationScoring({
       complementaryCertificationCourseId,
@@ -26,6 +29,8 @@ module.exports = {
       reproducibilityRate,
       cleaBadgeKey,
       pixScore,
+      minimumEarnedPix,
+      minimumReproducibilityRate,
     });
   },
 
@@ -97,4 +102,16 @@ async function _getLatestPixScoreByCertificationCourseId(certificationCourseId) 
     .first();
 
   return pixScore;
+}
+
+async function _getMinimumReproducibilityRateAndMinimumEarnedPix() {
+  const { minimumReproducibilityRate, minimumEarnedPix } = await knex('complementary-certifications')
+    .select('minimumReproducibilityRate', 'minimumEarnedPix')
+    .where({ name: ComplementaryCertification.CLEA })
+    .first();
+
+  return {
+    minimumEarnedPix,
+    minimumReproducibilityRate: _.toNumber(minimumReproducibilityRate),
+  };
 }

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -14,6 +14,7 @@ const Badge = require('../../../../lib/domain/models/Badge');
 const { NotEligibleCandidateError } = require('../../../../lib/domain/errors');
 const { CleaCertificationScoring } = require('../../../../lib/domain/models');
 const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
+const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Integration | Repository | Partner Certification Scoring', function () {
   const COMPLEMENTARY_CERTIFICATION_COURSE_RESULTS_TABLE_NAME = 'complementary-certification-course-results';
@@ -205,6 +206,11 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
             pixScore: 89,
             createdAt: new Date('2020-01-01'),
           });
+          databaseBuilder.factory.buildComplementaryCertification({
+            name: ComplementaryCertification.CLEA,
+            minimumReproducibilityRate: 66.5,
+            minimumEarnedPix: 33,
+          });
           await databaseBuilder.commit();
           mockLearningContent(learningContent);
           const expectedCleaCertificationScoring = new CleaCertificationScoring({
@@ -214,6 +220,8 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
             isBadgeAcquisitionStillValid: true,
             cleaBadgeKey: 'PIX_EMPLOI_CLEA',
             pixScore: 42,
+            minimumReproducibilityRate: 66.5,
+            minimumEarnedPix: 33,
           });
 
           // when

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification-scoring.js
@@ -8,6 +8,8 @@ module.exports = function buildCleaCertificationScoring({
   reproducibilityRate = 50,
   cleaBadgeKey = 'some-clea_key',
   pixScore,
+  minimumEarnedPix,
+  minimumReproducibilityRate,
 } = {}) {
   return new CleaCertificationScoring({
     complementaryCertificationCourseId,
@@ -17,5 +19,7 @@ module.exports = function buildCleaCertificationScoring({
     reproducibilityRate,
     cleaBadgeKey,
     pixScore,
+    minimumEarnedPix,
+    minimumReproducibilityRate,
   });
 };

--- a/api/tests/unit/domain/models/CleaCertificationScoring_test.js
+++ b/api/tests/unit/domain/models/CleaCertificationScoring_test.js
@@ -118,95 +118,120 @@ describe('Unit | Domain | Models | CleaCertificationScoring', function () {
       expect(error).to.be.instanceOf(NotEligibleCandidateError);
     });
 
-    context('reproducibility rate is above success level', function () {
+    context('reproducibility rate is equal or greater than minimum reproducibility rate', function () {
+      const minimumReproducibilityRate = 70;
+
       // eslint-disable-next-line mocha/no-setup-in-describe
-      [50, 70, 90].forEach((reproducibilityRate) => {
-        context(`when reproducibility rate is ${reproducibilityRate}`, function () {
-          context('pix score is equal or greater than 70', function () {
-            it('should return true', async function () {
-              // given
-              const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
-                reproducibilityRate,
-                pixScore: 70,
-              });
-
-              // when
-              const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
-
-              // then
-              expect(hasAcquiredCertif).to.be.true;
+      [70, 80, 90].forEach((reproducibilityRate) => {
+        context('pix score is equal or greater than minimum earned pix', function () {
+          it('should return true', async function () {
+            // given
+            const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
+              reproducibilityRate,
+              minimumReproducibilityRate,
+              pixScore: 120,
+              minimumEarnedPix: 120,
             });
+
+            // when
+            const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
+
+            // then
+            expect(hasAcquiredCertif).to.be.true;
           });
+        });
 
-          context('pix score is lesser than 70', function () {
-            it('should return false', async function () {
-              // given
-              const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
-                reproducibilityRate,
-                pixScore: 69,
-              });
-
-              // when
-              const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
-
-              // then
-              expect(hasAcquiredCertif).to.be.false;
+        context('pix score is lower than minimum earned pix', function () {
+          it('should return false', async function () {
+            // given
+            const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
+              reproducibilityRate,
+              minimumReproducibilityRate,
+              pixScore: 119,
+              minimumEarnedPix: 120,
             });
+
+            // when
+            const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
+
+            // then
+            expect(hasAcquiredCertif).to.be.false;
           });
         });
       });
     });
 
-    context('reproducibility rate is below success level', function () {
+    context('reproducibility rate is lower than minimum reproducibility rate', function () {
+      const minimumReproducibilityRate = 70;
+
       // eslint-disable-next-line mocha/no-setup-in-describe
-      [1, 49].forEach((reproducibilityRate) =>
-        context(`when reproducibility rate is ${reproducibilityRate}`, function () {
-          context('pix score is equal or greater than 70', function () {
-            it('should return false', async function () {
-              // given
-              const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
-                reproducibilityRate,
-                pixScore: 70,
-              });
-
-              // when
-              const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
-
-              // then
-              expect(hasAcquiredCertif).to.be.false;
+      [1, 50, 69].forEach((reproducibilityRate) => {
+        context('pix score is equal or greater than minimum earned pix', function () {
+          it('should return false', async function () {
+            // given
+            const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
+              reproducibilityRate,
+              minimumReproducibilityRate,
+              pixScore: 120,
+              minimumEarnedPix: 120,
             });
+
+            // when
+            const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
+
+            // then
+            expect(hasAcquiredCertif).to.be.false;
           });
+        });
 
-          context('pix score is lesser than 70', function () {
-            it('should return false', async function () {
-              // given
-              const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
-                reproducibilityRate,
-                pixScore: 69,
-              });
-
-              // when
-              const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
-
-              // then
-              expect(hasAcquiredCertif).to.be.false;
+        context('pix score is lower than minimum earned pix', function () {
+          it('should return false', async function () {
+            // given
+            const cleaCertificationScoring = await _buildCleaCertificationScoringWithBadge({
+              reproducibilityRate,
+              minimumReproducibilityRate,
+              pixScore: 119,
+              minimumEarnedPix: 120,
             });
+
+            // when
+            const hasAcquiredCertif = cleaCertificationScoring.isAcquired();
+
+            // then
+            expect(hasAcquiredCertif).to.be.false;
           });
-        })
-      );
+        });
+      });
     });
   });
 });
 
-function _buildCleaCertificationScoringWithBadge({ reproducibilityRate, pixScore } = {}) {
-  return _buildCleaCertificationScoring({ withBadge: true, reproducibilityRate, pixScore });
+function _buildCleaCertificationScoringWithBadge({
+  reproducibilityRate,
+  pixScore,
+  minimumEarnedPix,
+  minimumReproducibilityRate,
+} = {}) {
+  return _buildCleaCertificationScoring({
+    withBadge: true,
+    reproducibilityRate,
+    pixScore,
+    minimumEarnedPix,
+    minimumReproducibilityRate,
+  });
 }
 
 function _buildCleaCertificationScoringWithoutBadge() {
   return _buildCleaCertificationScoring({ withBadge: false });
 }
 
-function _buildCleaCertificationScoring({ withBadge = false, reproducibilityRate = 0, pixScore = 0 }) {
+function _buildCleaCertificationScoring({
+  withBadge = false,
+  reproducibilityRate = 0,
+  pixScore = 0,
+  minimumEarnedPix,
+  minimumReproducibilityRate,
+}) {
   const certificationCourseId = 42;
   const complementaryCertificationCourseId = 999;
 
@@ -217,5 +242,7 @@ function _buildCleaCertificationScoring({ withBadge = false, reproducibilityRate
     reproducibilityRate,
     cleaBadgeKey: 'pix_clea_badge_key',
     pixScore,
+    minimumEarnedPix,
+    minimumReproducibilityRate,
   });
 }


### PR DESCRIPTION
## :unicorn: Problème
Les règles de scoring de la certif Cléa numérique vont être simplifiées : un taux de repro et un nombre de pix minimum vont être définis pour valider ou non l’obtention du Cléa. Ces critères (taux de repro et nombre de pix min) peuvent évoluer dans le temps, il faut donc pouvoir rendre configurable ces critères sans besoin d'une nouvelle version de l'API. 

## :robot: Solution
- Rajouter les colonnes `minimumReproducibilityRate` et `minimumEarnedPix` à la table `complementary-certifications`.
- Utiliser les valeurs dans cette table pour effectuer le scoring d'une certification CléA.

## :rainbow: Remarques
- Il n'y a pas de d'erreur envoyée si les valeurs ne sont/peuvent pas être récupérées, il y a peut-être mieux à faire. 
- Est-ce que la constante `MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED` doit être supprimée ?

## :100: Pour tester
- Aller sur Pix Certif et créer une session.
- Inscrire un candidat à une certification CléA Numérique.
- Passer la certification avec le compte `certif-success@example.net` en passant certaines questions (il est possible de suivre l score et le taux de repro en directe depuis la page de détail de la certification). L'objectif ici est d'obtenir un taux de repro > 50 %.
- Vérifier que la certification Pix est validée.
- Jouer avec les valeurs `minimumReproducibilityRate` et `minimumEarnedPix` en BDD afin de :
   - Certification Cléa validée car le taux de repro obtenu est supérieur au taux minimum et le score obtenu et supérieur au minimum de Pix.
   - Certification Cléa rejetée car taux de repro minimum inférieur au taux obtenu alors que le score est bon
   - Certification Cléa rejetée car le score otbtenu est inférieur au score minimum alors que le taux de repro est bon.
