### PR TITLE
[FEATURE] Voir le détail des niveaux obtenus aux différents volets d'une certif Pix+ Edu (PIX-4626)

### DIFF
--- a/admin/app/components/certifications/status-select.hbs
+++ b/admin/app/components/certifications/status-select.hbs
@@ -12,6 +12,7 @@
     />
   {{else}}
     <span>Statut :</span>
+    &nbsp;
     <span>{{@certification.statusLabelAndValue.label}}</span>
   {{/if}}
 </div>

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -42,13 +42,6 @@ export default class Certification extends Model {
   @attr() pixScore;
   @attr() competencesWithMark;
   @attr('boolean', { defaultValue: false }) isPublished;
-  @attr() cleaCertificationStatus;
-  @attr() pixPlusDroitMaitreCertificationStatus;
-  @attr() pixPlusDroitExpertCertificationStatus;
-  @attr() pixPlusEduInitieCertificationStatus;
-  @attr() pixPlusEduConfirmeCertificationStatus;
-  @attr() pixPlusEduAvanceCertificationStatus;
-  @attr() pixPlusEduExpertCertificationStatus;
 
   @hasMany('certification-issue-report') certificationIssueReports;
 
@@ -91,38 +84,6 @@ export default class Certification extends Model {
         result.push(indexedCompetences[value]);
         return result;
       }, []);
-  }
-
-  @computed('cleaCertificationStatus')
-  get cleaCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.cleaCertificationStatus];
-  }
-
-  @computed('pixPlusDroitMaitreCertificationStatus')
-  get pixPlusDroitMaitreCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.pixPlusDroitMaitreCertificationStatus];
-  }
-
-  @computed('pixPlusDroitExpertCertificationStatus')
-  get pixPlusDroitExpertCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.pixPlusDroitExpertCertificationStatus];
-  }
-
-  @computed('pixPlusEduInitieCertificationStatus')
-  get pixPlusEduInitieCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.pixPlusEduInitieCertificationStatus];
-  }
-  @computed('pixPlusEduConfirmeCertificationStatus')
-  get pixPlusEduConfirmeCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.pixPlusEduConfirmeCertificationStatus];
-  }
-  @computed('pixPlusEduAvanceCertificationStatus')
-  get pixPlusEduAvanceCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.pixPlusEduAvanceCertificationStatus];
-  }
-  @computed('pixPlusEduExpertCertificationStatus')
-  get pixPlusEduExpertCertificationStatusLabel() {
-    return partnerCertificationStatusToDisplayName[this.pixPlusEduExpertCertificationStatus];
   }
 
   get wasRegisteredBeforeCPF() {

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
 export const ACQUIRED = 'acquired';
@@ -42,8 +42,11 @@ export default class Certification extends Model {
   @attr() pixScore;
   @attr() competencesWithMark;
   @attr('boolean', { defaultValue: false }) isPublished;
+  @belongsTo('complementary-certification-course-results-with-external')
+  complementaryCertificationCourseResultsWithExternal;
 
   @hasMany('certification-issue-report') certificationIssueReports;
+  @hasMany('common-complementary-certification-course-result') commonComplementaryCertificationCourseResults;
 
   @computed('createdAt')
   get creationDate() {
@@ -64,6 +67,13 @@ export default class Certification extends Model {
   get publishedText() {
     const value = this.isPublished;
     return value ? 'Oui' : 'Non';
+  }
+
+  get hasComplementaryCertifications() {
+    return (
+      Boolean(this.commonComplementaryCertificationCourseResults.length) ||
+      Boolean(this.complementaryCertificationCourseResultsWithExternal.get('pixResult'))
+    );
   }
 
   @computed('competencesWithMark')

--- a/admin/app/models/common-complementary-certification-course-result.js
+++ b/admin/app/models/common-complementary-certification-course-result.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CommonComplementaryCertificationCourseResult extends Model {
+  @attr('string') label;
+  @attr('string') status;
+}

--- a/admin/app/models/complementary-certification-course-results-with-external.js
+++ b/admin/app/models/complementary-certification-course-results-with-external.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class ComplementaryCertificationCourseResultsWithExternal extends Model {
+  @attr('number') complementaryCertificationCourseId;
+  @attr('string') pixResult;
+  @attr('string') externalResult;
+  @attr('string') finalResult;
+}

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -20,14 +20,50 @@
     float: right;
   }
 
-  &__complementary-certification--acquired {
-    color: $green;
-    font-weight: bold;
-  }
+  &__complementary-certification {
 
-  &__complementary-certification--rejected {
-    color: $error;
-    font-weight: bold;
+    &__title {
+      margin-bottom: 24px;
+    }
+
+    &__non-pix-edu {
+      margin: 8px 0 8px 0;
+      font-size: 0.875rem;
+
+      span {
+        display: inline-block;
+        color: $grey-40;
+        min-width: 180px;
+      }
+
+      p {
+        margin: 0;
+      }
+    }
+
+    &__pix-edu {
+      margin-top: 24px;
+
+      &__row {
+        margin-top: 16px;
+        display: flex;
+        gap: 16px;
+
+        .card {
+          width: 550px;
+          background-color: $grey-5;
+          height: 110px;
+          text-align: center;
+          box-shadow: none;
+          border: 2px solid $grey-20;
+          font-weight: 500;
+
+          p {
+            color: $grey-40;
+          }
+        }
+      }
+    }
   }
 
   &__certification-issue-reports {

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -108,6 +108,54 @@
     </div>
   </div>
 
+  {{#if this.certification.hasComplementaryCertifications}}
+    <section class="card certification-informations__complementary-certification">
+      <div class="card-body">
+        <h5 class="card-title certification-informations__complementary-certification__title">Certifications
+          complémentaires</h5>
+        {{#each
+          this.certification.commonComplementaryCertificationCourseResults
+          as |commonComplementaryCertificationCourseResult|
+        }}
+          <div class="certification-informations__complementary-certification__non-pix-edu">
+            <p>
+              <span>
+                {{commonComplementaryCertificationCourseResult.label}}
+                :
+              </span>
+              {{commonComplementaryCertificationCourseResult.status}}
+            </p>
+          </div>
+        {{/each}}
+        {{#if this.certification.complementaryCertificationCourseResultsWithExternal}}
+          <section class="certification-informations__complementary-certification__pix-edu">
+            <h6>Résultats de la certification complémentaire Pix+ Edu :</h6>
+            <div class="certification-informations__complementary-certification__pix-edu__row">
+              <div class="card">
+                <div class="card-body">
+                  <p>VOLET PIX</p>
+                  {{this.certification.complementaryCertificationCourseResultsWithExternal.pixResult}}
+                </div>
+              </div>
+              <div class="card">
+                <div class="card-body">
+                  <p>VOLET JURY</p>
+                  {{this.certification.complementaryCertificationCourseResultsWithExternal.externalResult}}
+                </div>
+              </div>
+              <div class="card">
+                <div class="card-body">
+                  <p>NIVEAU FINAL</p>
+                  {{this.certification.complementaryCertificationCourseResultsWithExternal.finalResult}}
+                </div>
+              </div>
+            </div>
+          </section>
+        {{/if}}
+      </div>
+    </section>
+  {{/if}}
+
   {{#if this.hasIssueReports}}
     <section class="card certification-informations__certification-issue-reports">
       <div class="card-body">

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -47,62 +47,6 @@
               @edition={{false}}
               @label="Publiée :"
             />
-            {{#if this.certification.cleaCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.cleaCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification CléA numérique :"
-                @class="certification-informations__complementary-certification--{{this.certification.cleaCertificationStatus}}"
-              />
-            {{/if}}
-            {{#if this.certification.pixPlusDroitMaitreCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.pixPlusDroitMaitreCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification Pix+ Droit Maître :"
-                @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitMaitreCertificationStatus}}"
-              />
-            {{/if}}
-            {{#if this.certification.pixPlusDroitExpertCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.pixPlusDroitExpertCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification Pix+ Droit Expert :"
-                @class="certification-informations__complementary-certification--{{this.certification.pixPlusDroitExpertCertificationStatus}}"
-              />
-            {{/if}}
-            {{#if this.certification.pixPlusEduInitieCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.pixPlusEduInitieCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification Pix+ Édu Initié (entrée dans le métier) :"
-                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduInitieCertificationStatus}}"
-              />
-            {{/if}}
-            {{#if this.certification.pixPlusEduConfirmeCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.pixPlusEduConfirmeCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification Pix+ Édu Confirmé :"
-                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduConfirmeCertificationStatus}}"
-              />
-            {{/if}}
-            {{#if this.certification.pixPlusEduAvanceCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.pixPlusEduAvanceCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification Pix+ Édu Avancé :"
-                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduAvanceCertificationStatus}}"
-              />
-            {{/if}}
-            {{#if this.certification.pixPlusEduExpertCertificationStatusLabel}}
-              <Certifications::InfoField
-                @value={{this.certification.pixPlusEduExpertCertificationStatusLabel}}
-                @edition={{false}}
-                @label="Certification Pix+ Édu Expert :"
-                @class="certification-informations__complementary-certification--{{this.certification.pixPlusEduExpertCertificationStatus}}"
-              />
-            {{/if}}
           </div>
         </div>
       </div>

--- a/admin/mirage/serializers/certification.js
+++ b/admin/mirage/serializers/certification.js
@@ -1,6 +1,10 @@
 import ApplicationSerializer from './application';
 
-const include = ['certification-issue-reports'];
+const include = [
+  'certification-issue-reports',
+  'common-complementary-certification-course-results',
+  'complementary-certification-course-results-with-external',
+];
 
 export default ApplicationSerializer.extend({
   include,

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -86,6 +86,67 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       });
     });
 
+    test('it displays common complementary certifications result', async function (assert) {
+      //given
+      const commonComplementaryCertificationCourseResults = [
+        server.create('common-complementary-certification-course-result', {
+          label: 'CléA Numérique',
+          status: 'Validée',
+        }),
+        server.create('common-complementary-certification-course-result', {
+          label: 'Pix+ Droit Maître',
+          status: 'Validée',
+        }),
+        server.create('common-complementary-certification-course-result', {
+          label: 'Pix+ Droit Expert',
+          status: 'Rejetée',
+        }),
+      ];
+
+      certification.update({
+        commonComplementaryCertificationCourseResults,
+      });
+
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(screen.getByText('Certifications complémentaires')).exists();
+      assert.dom(screen.queryByText('Résultats de la certification complémentaire Pix+ Edu :')).doesNotExist();
+      assert.dom(screen.getByText('CléA Numérique :')).exists();
+      assert.dom(screen.getByText('Pix+ Droit Maître :')).exists();
+      assert.dom(screen.getByText('Pix+ Droit Expert :')).exists();
+      assert.strictEqual(screen.getAllByText('Validée').length, 2);
+      assert.strictEqual(screen.getAllByText('Rejetée').length, 1);
+    });
+
+    test('it displays external complementary certifications', async function (assert) {
+      //given
+      const complementaryCertificationCourseResultsWithExternal = server.create(
+        'complementary-certification-course-results-with-external',
+        {
+          complementaryCertificationCourseId: 1234,
+          pixResult: 'Pix+ Édu Initié (entrée dans le métier)',
+          externalResult: 'Pix+ Édu Avancé',
+          finalResult: 'Pix+ Édu Initié (entrée dans le métier)',
+        }
+      );
+      certification.update({
+        complementaryCertificationCourseResultsWithExternal,
+      });
+
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
+
+      // then
+      assert.dom(screen.getByText('Résultats de la certification complémentaire Pix+ Edu :')).exists();
+      assert.dom(screen.getByText('VOLET PIX')).exists();
+      assert.dom(screen.getByText('VOLET JURY')).exists();
+      assert.dom(screen.getByText('NIVEAU FINAL')).exists();
+      assert.strictEqual(screen.getAllByText('Pix+ Édu Initié (entrée dans le métier)').length, 2);
+      assert.strictEqual(screen.getAllByText('Pix+ Édu Avancé').length, 1);
+    });
+
     module('when candidate certification was enrolled with CPF data', function () {
       module('when editing candidate information succeeds', function () {
         test('should save the candidate information data when modifying them', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -39,13 +39,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       competencesWithMark: [],
       listChallengesAndAnswers: [],
       createdAt: new Date('2020-01-01'),
-      cleaCertificationStatus: 'not_taken',
-      pixPlusDroitMaitreCertificationStatus: 'not_taken',
-      pixPlusDroitExpertCertificationStatus: 'not_taken',
-      pixPlusEduInitieCertificationStatus: 'not_taken',
-      pixPlusEduConfirmeCertificationStatus: 'not_taken',
-      pixPlusEduAvanceCertificationStatus: 'not_taken',
-      pixPlusEduExpertCertificationStatus: 'not_taken',
     });
   });
 
@@ -62,83 +55,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
     assert.dom(screen.getByText('Code postal de naissance :')).exists();
     assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
-  });
-
-  test('it displays validated partner certifications', async function (assert) {
-    //given
-    certification.update({
-      cleaCertificationStatus: 'acquired',
-      pixPlusDroitMaitreCertificationStatus: 'acquired',
-      pixPlusDroitExpertCertificationStatus: 'acquired',
-      pixPlusEduInitieCertificationStatus: 'acquired',
-      pixPlusEduConfirmeCertificationStatus: 'acquired',
-      pixPlusEduAvanceCertificationStatus: 'acquired',
-      pixPlusEduExpertCertificationStatus: 'acquired',
-    });
-
-    // when
-    const screen = await visit(`/certifications/${certification.id}`);
-
-    // then
-    assert.dom(screen.getByText('Certification CléA numérique :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Droit Maître :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Droit Expert :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Initié (entrée dans le métier) :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Confirmé :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Avancé :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Expert :')).exists();
-    assert.strictEqual(screen.getAllByText('Validée').length, 7);
-  });
-
-  test('it displays rejected partner certifications', async function (assert) {
-    // given
-    certification.update({
-      cleaCertificationStatus: 'rejected',
-      pixPlusDroitMaitreCertificationStatus: 'rejected',
-      pixPlusDroitExpertCertificationStatus: 'rejected',
-      pixPlusEduInitieCertificationStatus: 'rejected',
-      pixPlusEduConfirmeCertificationStatus: 'rejected',
-      pixPlusEduAvanceCertificationStatus: 'rejected',
-      pixPlusEduExpertCertificationStatus: 'rejected',
-    });
-
-    // when
-    const screen = await visit(`/certifications/${certification.id}`);
-
-    // then
-    assert.dom(screen.getByText('Certification CléA numérique :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Droit Maître :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Droit Expert :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Initié (entrée dans le métier) :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Confirmé :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Avancé :')).exists();
-    assert.dom(screen.getByText('Certification Pix+ Édu Expert :')).exists();
-    assert.strictEqual(screen.getAllByText('Rejetée').length, 7);
-  });
-
-  test('it does not display not passed partner certifications', async function (assert) {
-    // given
-    certification.update({
-      cleaCertificationStatus: 'not_taken',
-      pixPlusDroitMaitreCertificationStatus: 'not_taken',
-      pixPlusDroitExpertCertificationStatus: 'not_taken',
-      pixPlusEduInitieCertificationStatus: 'not_taken',
-      pixPlusEduConfirmeCertificationStatus: 'not_taken',
-      pixPlusEduAvanceCertificationStatus: 'not_taken',
-      pixPlusEduExpertCertificationStatus: 'not_taken',
-    });
-
-    // when
-    const screen = await visit(`/certifications/${certification.id}`);
-
-    // then
-    assert.dom(screen.queryByLabelText('Certification CléA numérique :')).doesNotExist();
-    assert.dom(screen.queryByLabelText('Certification Pix+ Droit Maître :')).doesNotExist();
-    assert.dom(screen.queryByLabelText('Certification Pix+ Droit Expert :')).doesNotExist();
-    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Initié (entrée dans le métier) :')).doesNotExist();
-    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Confirmé :')).doesNotExist();
-    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Avancé :')).doesNotExist();
-    assert.dom(screen.queryByLabelText('Certification Pix+ Édu Expert :')).doesNotExist();
   });
 
   module('Candidate information edition', function () {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -190,9 +190,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       };
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.impactfulCertificationIssueReports.length, 2);
+      assert.strictEqual(controller.impactfulCertificationIssueReports.length, 2);
     });
   });
 
@@ -213,9 +211,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       };
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.unimpactfulCertificationIssueReports.length, 3);
+      assert.strictEqual(controller.unimpactfulCertificationIssueReports.length, 3);
     });
   });
 
@@ -228,9 +224,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(anExistingCompetenceCode, competences);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(aCompetence.score, 55);
+
+        assert.strictEqual(aCompetence.score, 55);
       });
     });
 
@@ -255,9 +250,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(aNewCompetenceCode, competences);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(aCompetence.score, 55);
+
+        assert.strictEqual(aCompetence.score, 55);
       });
     });
   });
@@ -271,9 +265,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(anExistingCompetenceCode, competences);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(aCompetence.level, 5);
+
+        assert.strictEqual(aCompetence.level, 5);
       });
     });
 
@@ -298,9 +291,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const competences = controller.certification.competencesWithMark;
         const aCompetence = _getCompetenceWithMark(aNewCompetenceCode, competences);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(aCompetence.level, 8);
+
+        assert.strictEqual(aCompetence.level, 8);
       });
     });
   });
@@ -333,9 +325,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         await controller.onCandidateResultsSaveConfirm();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.confirmAction, 'onCandidateResultsSave');
+        assert.strictEqual(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
         assert.notOk(controller.confirmErrorMessage);
@@ -362,9 +352,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         // then
         const levelErrorRegexp = `.*niveau.*${anExistingCompetenceCode}.*${controller.MAX_REACHABLE_LEVEL}`;
         const scoreErrorRegexp = `.*nombre de pix.*${anotherExistingCompetenceCode}.*${controller.MAX_REACHABLE_PIX_BY_COMPETENCE}`;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.confirmAction, 'onCandidateResultsSave');
+
+        assert.strictEqual(controller.confirmAction, 'onCandidateResultsSave');
         assert.ok(controller.displayConfirm);
         assert.ok(controller.confirmMessage);
         assert.ok(controller.confirmErrorMessage.match(new RegExp(levelErrorRegexp)));
@@ -426,9 +415,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         const state = await getSettledState();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certification.pixScore, score);
+        assert.strictEqual(controller.certification.pixScore, score);
         assert.deepEqual(controller.certification.competencesWithMark, expectedCompetencesWithMark);
         assert.ok(state.hasPendingTimers);
 
@@ -486,21 +473,14 @@ module('Unit | Controller | authenticated/certifications/certification/informati
 
     let aCompetence = _getCompetenceWithMark(anotherExistingCompetenceCode);
     let aCompetenceRef = _getCompetenceWithMark(anotherExistingCompetenceCode);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(aCompetence.score, aCompetenceRef.score);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(aCompetence.level, aCompetenceRef.level);
+
+    assert.strictEqual(aCompetence.score, aCompetenceRef.score);
+    assert.strictEqual(aCompetence.level, aCompetenceRef.level);
 
     aCompetence = _getCompetenceWithMark(anExistingCompetenceCode, competences);
     aCompetenceRef = _getCompetenceWithMark(anExistingCompetenceCode);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(aCompetence.score, aCompetenceRef.score);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(aCompetence.level, aCompetenceRef.level);
+    assert.strictEqual(aCompetence.score, aCompetenceRef.score);
+    assert.strictEqual(aCompetence.level, aCompetenceRef.level);
 
     sinon.assert.calledOnce(rollbackAttributes);
   });

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -128,6 +128,60 @@ module('Unit | Model | certification', function (hooks) {
     });
   });
 
+  module('#hasComplementaryCertifications', function () {
+    module('when there are no complementary certification results', function () {
+      test('should return false', function (assert) {
+        // given
+        const complementaryCertificationCourseResultsWithExternal = null;
+        const commonComplementaryCertificationCourseResults = [];
+        const certification = store.createRecord('certification', {
+          complementaryCertificationCourseResultsWithExternal,
+          commonComplementaryCertificationCourseResults,
+        });
+
+        //when / then
+        assert.false(certification.hasComplementaryCertifications);
+      });
+    });
+
+    module('when there is only an external complementary certification result', function () {
+      test('should return true', function (assert) {
+        // given
+        const complementaryCertificationCourseResultsWithExternal = store.createRecord(
+          'complementary-certification-course-results-with-external',
+          {
+            pixResult: 'TOTO',
+          }
+        );
+        const commonComplementaryCertificationCourseResults = [];
+        const certification = store.createRecord('certification', {
+          complementaryCertificationCourseResultsWithExternal,
+          commonComplementaryCertificationCourseResults,
+        });
+
+        //when / then
+        assert.true(certification.hasComplementaryCertifications);
+      });
+    });
+  });
+
+  module('when there is only a common complementary certification result', function () {
+    test('should return true', function (assert) {
+      // given
+      const complementaryCertificationCourseResultsWithExternal = null;
+      const commonComplementaryCertificationCourseResults = [
+        store.createRecord('common-complementary-certification-course-result'),
+      ];
+      const certification = store.createRecord('certification', {
+        complementaryCertificationCourseResultsWithExternal,
+        commonComplementaryCertificationCourseResults,
+      });
+
+      //when / then
+      assert.true(certification.hasComplementaryCertifications);
+    });
+  });
+
   module('#statusLabelAndValue', function () {
     [
       { value: 'started', label: 'Démarrée' },

--- a/admin/tests/unit/models/certification_test.js
+++ b/admin/tests/unit/models/certification_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { ACQUIRED, REJECTED, NOT_TAKEN } from 'pix-admin/models/certification';
 
 module('Unit | Model | certification', function (hooks) {
   setupTest(hooks);
@@ -9,55 +8,6 @@ module('Unit | Model | certification', function (hooks) {
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
-  });
-
-  const certificationStatusesAndExpectedLabel = new Map([
-    [ACQUIRED, 'Validée'],
-    [REJECTED, 'Rejetée'],
-  ]);
-
-  [
-    { domainName: 'cleaCertificationStatus', displayName: 'cleaCertificationStatusLabel' },
-    { domainName: 'pixPlusDroitMaitreCertificationStatus', displayName: 'pixPlusDroitMaitreCertificationStatusLabel' },
-    { domainName: 'pixPlusDroitExpertCertificationStatus', displayName: 'pixPlusDroitExpertCertificationStatusLabel' },
-    { domainName: 'pixPlusEduInitieCertificationStatus', displayName: 'pixPlusEduInitieCertificationStatusLabel' },
-    { domainName: 'pixPlusEduAvanceCertificationStatus', displayName: 'pixPlusEduAvanceCertificationStatusLabel' },
-    { domainName: 'pixPlusEduExpertCertificationStatus', displayName: 'pixPlusEduExpertCertificationStatusLabel' },
-    { domainName: 'pixPlusEduConfirmeCertificationStatus', displayName: 'pixPlusEduConfirmeCertificationStatusLabel' },
-  ].forEach(function ({ domainName, displayName }) {
-    module(`#${domainName}`, function () {
-      certificationStatusesAndExpectedLabel.forEach((expectedLabel, status) => {
-        module(`when ${displayName} is ${status}`, function () {
-          test(`${domainName} should be ${expectedLabel}`, function (assert) {
-            // given
-            const certification = store.createRecord('certification', {
-              [domainName]: status,
-            });
-
-            // when
-            const label = certification[displayName];
-
-            // then
-            assert.strictEqual(label, expectedLabel);
-          });
-        });
-      });
-
-      module(`when ${domainName} is not passed`, function () {
-        test(`${domainName} should be hidden`, function (assert) {
-          // given
-          const certification = store.createRecord('certification', {
-            [domainName]: NOT_TAKEN,
-          });
-
-          // when
-          const label = certification[displayName];
-
-          // then
-          assert.false(Boolean(label));
-        });
-      });
-    });
   });
 
   module('#publishedText', function () {

--- a/api/lib/domain/models/JuryCertification.js
+++ b/api/lib/domain/models/JuryCertification.js
@@ -1,26 +1,7 @@
-const _ = require('lodash');
 const CompetenceMark = require('./CompetenceMark');
-const {
-  PIX_EMPLOI_CLEA_V1,
-  PIX_EMPLOI_CLEA_V2,
-  PIX_EMPLOI_CLEA_V3,
-  PIX_DROIT_MAITRE_CERTIF,
-  PIX_DROIT_EXPERT_CERTIF,
-  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-} = require('../models/Badge').keys;
 
 const status = {
   CANCELLED: 'cancelled',
-};
-
-const complementaryCertificationStatus = {
-  ACQUIRED: 'acquired',
-  REJECTED: 'rejected',
-  NOT_TAKEN: 'not_taken',
 };
 
 class JuryCertification {
@@ -48,7 +29,8 @@ class JuryCertification {
     commentForOrganization,
     commentForJury,
     certificationIssueReports,
-    complementaryCertificationCourseResults,
+    complementaryCertificationCourseResultsWithExternal,
+    commonComplementaryCertificationCourseResults,
   }) {
     this.certificationCourseId = certificationCourseId;
     this.sessionId = sessionId;
@@ -73,11 +55,18 @@ class JuryCertification {
     this.commentForOrganization = commentForOrganization;
     this.commentForJury = commentForJury;
     this.certificationIssueReports = certificationIssueReports;
-    this.complementaryCertificationCourseResults = complementaryCertificationCourseResults;
+    this.complementaryCertificationCourseResultsWithExternal = complementaryCertificationCourseResultsWithExternal;
+    this.commonComplementaryCertificationCourseResults = commonComplementaryCertificationCourseResults;
   }
 
-  static from({ juryCertificationDTO, certificationIssueReports, complementaryCertificationCourseResults }) {
-    const competenceMarkDTOs = _.compact(juryCertificationDTO.competenceMarks).map(
+  static from({
+    juryCertificationDTO,
+    certificationIssueReports,
+    competenceMarkDTOs,
+    complementaryCertificationCourseResultsWithExternal,
+    commonComplementaryCertificationCourseResults,
+  }) {
+    const competenceMarks = competenceMarkDTOs.map(
       (competenceMarkDTO) =>
         new CompetenceMark({
           ...competenceMarkDTO,
@@ -103,56 +92,14 @@ class JuryCertification {
       isPublished: juryCertificationDTO.isPublished,
       juryId: juryCertificationDTO.juryId,
       pixScore: juryCertificationDTO.pixScore,
-      competenceMarks: competenceMarkDTOs,
+      competenceMarks,
       commentForCandidate: juryCertificationDTO.commentForCandidate,
       commentForOrganization: juryCertificationDTO.commentForOrganization,
       commentForJury: juryCertificationDTO.commentForJury,
       certificationIssueReports,
-      complementaryCertificationCourseResults,
+      complementaryCertificationCourseResultsWithExternal,
+      commonComplementaryCertificationCourseResults,
     });
-  }
-
-  getCleaCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3]);
-  }
-
-  getPixPlusDroitMaitreCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([PIX_DROIT_MAITRE_CERTIF]);
-  }
-
-  getPixPlusDroitExpertCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([PIX_DROIT_EXPERT_CERTIF]);
-  }
-
-  getPixPlusEduInitieCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]);
-  }
-
-  getPixPlusEduConfirmeCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([
-      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-    ]);
-  }
-
-  getPixPlusEduAvanceCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE]);
-  }
-
-  getPixPlusEduExpertCertificationStatus() {
-    return this._getStatusFromComplementaryCertification([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]);
-  }
-
-  _getStatusFromComplementaryCertification(complementaryCertificationKeys) {
-    const complementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(({ partnerKey }) =>
-      complementaryCertificationKeys.includes(partnerKey)
-    );
-    if (!complementaryCertificationCourseResult) {
-      return complementaryCertificationStatus.NOT_TAKEN;
-    }
-    return complementaryCertificationCourseResult.acquired
-      ? complementaryCertificationStatus.ACQUIRED
-      : complementaryCertificationStatus.REJECTED;
   }
 }
 

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification.js
@@ -1,0 +1,61 @@
+const {
+  PIX_EMPLOI_CLEA_V1,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_EMPLOI_CLEA_V3,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../models/Badge').keys;
+
+const complementaryCertificationStatus = {
+  ACQUIRED: 'Validée',
+  REJECTED: 'Rejetée',
+};
+
+const complementaryCertificationLabel = {
+  [PIX_EMPLOI_CLEA_V1]: 'CléA Numérique',
+  [PIX_EMPLOI_CLEA_V2]: 'CléA Numérique',
+  [PIX_EMPLOI_CLEA_V3]: 'CléA Numérique',
+  [PIX_DROIT_MAITRE_CERTIF]: 'Pix+ Droit Maître',
+  [PIX_DROIT_EXPERT_CERTIF]: 'Pix+ Droit Expert',
+  [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]: 'Pix+ Édu Initié (entrée dans le métier)',
+  [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE]: 'Pix+ Édu Avancé',
+  [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]: 'Pix+ Édu Expert',
+  [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE]: 'Pix+ Édu Initié (entrée dans le métier)',
+  [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE]: 'Pix+ Édu Avancé',
+  [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT]: 'Pix+ Édu Expert',
+};
+
+class ComplementaryCertificationCourseResultsForJuryCertification {
+  constructor({ id, partnerKey, acquired }) {
+    this.id = id;
+    this.partnerKey = partnerKey;
+    this.acquired = acquired;
+  }
+
+  get status() {
+    return this.acquired ? complementaryCertificationStatus.ACQUIRED : complementaryCertificationStatus.REJECTED;
+  }
+
+  get label() {
+    return complementaryCertificationLabel[this.partnerKey];
+  }
+}
+
+ComplementaryCertificationCourseResultsForJuryCertification.statuses = complementaryCertificationStatus;
+ComplementaryCertificationCourseResultsForJuryCertification.labels = complementaryCertificationLabel;
+
+module.exports = ComplementaryCertificationCourseResultsForJuryCertification;

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
@@ -74,6 +74,19 @@ class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
     });
   }
 
+  get pixResult() {
+    if (!this.pixSection.isEvaluated) return null;
+    if (!this.pixSection.acquired) return 'Rejetée';
+    return pixEduCertificationLabels[this.pixSection.partnerKey];
+  }
+
+  get externalResult() {
+    if (!this.pixSection.acquired) return '-';
+    if (!this.externalSection.isEvaluated) return 'En attente';
+    if (!this.externalSection.acquired) return 'Rejetée';
+    return pixEduCertificationLabels[this.externalSection.partnerKey];
+  }
+
   get finalResult() {
     if (!this.pixSection.acquired) return 'Rejetée';
     if (!this.externalSection.isEvaluated) return 'En attente volet jury';

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
@@ -1,0 +1,128 @@
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../models/Badge').keys;
+
+const pixEduCertificationLabels = {
+  [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]: 'Pix+ Édu Initié (entrée dans le métier)',
+  [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE]: 'Pix+ Édu Avancé',
+  [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]: 'Pix+ Édu Expert',
+  [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE]: 'Pix+ Édu Initié (entrée dans le métier)',
+  [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME]: 'Pix+ Édu Confirmé',
+  [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE]: 'Pix+ Édu Avancé',
+  [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT]: 'Pix+ Édu Expert',
+};
+
+const pixEdu1stDegreeBadges = [
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+];
+
+const pixEdu2ndDegreeBadges = [
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+];
+
+class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
+  constructor({
+    complementaryCertificationCourseId,
+    pixPartnerKey,
+    pixAcquired,
+    externalPartnerKey,
+    externalAcquired,
+  }) {
+    this.complementaryCertificationCourseId = complementaryCertificationCourseId;
+    this.pixSection = new PixEduSection({ partnerKey: pixPartnerKey, acquired: pixAcquired });
+    this.externalSection = new PixEduSection({ partnerKey: externalPartnerKey, acquired: externalAcquired });
+  }
+
+  static from(complementaryCertificationCourseResultsWithExternal) {
+    if (!complementaryCertificationCourseResultsWithExternal.length) {
+      return;
+    }
+    const pixComplementaryCertificationCourseResult = complementaryCertificationCourseResultsWithExternal.find(
+      ({ source }) => source === 'PIX'
+    );
+    const externalComplementaryCertificationCourseResult = complementaryCertificationCourseResultsWithExternal.find(
+      ({ source }) => source === 'EXTERNAL'
+    );
+
+    return new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+      complementaryCertificationCourseId:
+        complementaryCertificationCourseResultsWithExternal[0].complementaryCertificationCourseId,
+      pixPartnerKey: pixComplementaryCertificationCourseResult?.partnerKey,
+      pixAcquired: pixComplementaryCertificationCourseResult?.acquired,
+      externalPartnerKey: externalComplementaryCertificationCourseResult?.partnerKey,
+      externalAcquired: externalComplementaryCertificationCourseResult?.acquired,
+    });
+  }
+
+  get finalResult() {
+    if (!this.pixSection.acquired) return 'Rejetée';
+    if (!this.externalSection.isEvaluated) return 'En attente volet jury';
+    if (!this.externalSection.acquired) return 'Rejetée';
+    if (this.pixSection._isPixEdu1erDegre() && this.externalSection._isPixEdu1erDegre())
+      return this._getLowestPartnerKeyLabelForPixEdu1erDegreBadge();
+    if (this.pixSection._isPixEdu2ndDegre() && this.externalSection._isPixEdu2ndDegre())
+      return this._getLowestPartnerKeyLabelForPixEdu2ndDegreBadge();
+    throw new Error(`Badges edu incoherent !!! ${this.pixSection.partnerKey} et ${this.externalSection.partnerKey}`);
+  }
+
+  _getLowestPartnerKeyLabelForPixEdu2ndDegreBadge() {
+    const firstIndexOf = pixEdu2ndDegreeBadges.indexOf(this.pixSection.partnerKey);
+    const secondIndexOf = pixEdu2ndDegreeBadges.indexOf(this.externalSection.partnerKey);
+
+    return firstIndexOf <= secondIndexOf
+      ? pixEduCertificationLabels[this.pixSection.partnerKey]
+      : pixEduCertificationLabels[this.externalSection.partnerKey];
+  }
+
+  _getLowestPartnerKeyLabelForPixEdu1erDegreBadge() {
+    const firstIndexOf = pixEdu1stDegreeBadges.indexOf(this.pixSection.partnerKey);
+    const secondIndexOf = pixEdu1stDegreeBadges.indexOf(this.externalSection.partnerKey);
+
+    return firstIndexOf <= secondIndexOf
+      ? pixEduCertificationLabels[this.pixSection.partnerKey]
+      : pixEduCertificationLabels[this.externalSection.partnerKey];
+  }
+}
+
+class PixEduSection {
+  constructor({ partnerKey, acquired }) {
+    this.partnerKey = partnerKey;
+    this.acquired = acquired ?? false;
+  }
+
+  get isEvaluated() {
+    return Boolean(this.partnerKey);
+  }
+
+  _isPixEdu2ndDegre() {
+    return pixEdu2ndDegreeBadges.includes(this.partnerKey);
+  }
+
+  _isPixEdu1erDegre() {
+    return pixEdu1stDegreeBadges.includes(this.partnerKey);
+  }
+}
+
+ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels = pixEduCertificationLabels;
+
+module.exports = ComplementaryCertificationCourseResultsForJuryCertificationWithExternal;

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -8,13 +8,6 @@ module.exports = {
           id: juryCertification.certificationCourseId,
           ...juryCertification,
           competencesWithMark: juryCertification.competenceMarks,
-          cleaCertificationStatus: juryCertification.getCleaCertificationStatus(),
-          pixPlusDroitMaitreCertificationStatus: juryCertification.getPixPlusDroitMaitreCertificationStatus(),
-          pixPlusDroitExpertCertificationStatus: juryCertification.getPixPlusDroitExpertCertificationStatus(),
-          pixPlusEduInitieCertificationStatus: juryCertification.getPixPlusEduInitieCertificationStatus(),
-          pixPlusEduConfirmeCertificationStatus: juryCertification.getPixPlusEduConfirmeCertificationStatus(),
-          pixPlusEduAvanceCertificationStatus: juryCertification.getPixPlusEduAvanceCertificationStatus(),
-          pixPlusEduExpertCertificationStatus: juryCertification.getPixPlusEduExpertCertificationStatus(),
         };
       },
       attributes: [
@@ -39,15 +32,19 @@ module.exports = {
         'commentForCandidate',
         'commentForOrganization',
         'commentForJury',
-        'cleaCertificationStatus',
-        'pixPlusDroitMaitreCertificationStatus',
-        'pixPlusDroitExpertCertificationStatus',
-        'pixPlusEduInitieCertificationStatus',
-        'pixPlusEduConfirmeCertificationStatus',
-        'pixPlusEduAvanceCertificationStatus',
-        'pixPlusEduExpertCertificationStatus',
+        'commonComplementaryCertificationCourseResults',
+        'complementaryCertificationCourseResultsWithExternal',
         'certificationIssueReports',
       ],
+
+      commonComplementaryCertificationCourseResults: {
+        ref: 'id',
+        attributes: ['label', 'status'],
+      },
+      complementaryCertificationCourseResultsWithExternal: {
+        ref: 'complementaryCertificationCourseId',
+        attributes: ['complementaryCertificationCourseId', 'pixResult', 'externalResult', 'finalResult'],
+      },
       certificationIssueReports: {
         ref: 'id',
         attributes: [

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -1,18 +1,7 @@
 const { expect, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const juryCertificationRepository = require('../../../../lib/infrastructure/repositories/jury-certification-repository');
-const {
-  PIX_EMPLOI_CLEA_V1,
-  PIX_EMPLOI_CLEA_V2,
-  PIX_EMPLOI_CLEA_V3,
-  PIX_DROIT_MAITRE_CERTIF,
-  PIX_DROIT_EXPERT_CERTIF,
-  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-} = require('../../../../lib/domain/models/Badge').keys;
+const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Integration | Infrastructure | Repository | Jury Certification', function () {
   describe('#get', function () {
@@ -30,10 +19,13 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       expect(error.message).to.equal('Certification course of id 2 does not exist.');
     });
 
-    it('should return get the JuryCertification for given certificationCourseId', async function () {
+    it('should return the JuryCertification for given certificationCourseId', async function () {
       // given
       databaseBuilder.factory.buildUser({ id: 789 });
       databaseBuilder.factory.buildSession({ id: 456 });
+      databaseBuilder.factory.buildBadge({ key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE });
+      databaseBuilder.factory.buildBadge({ key: Badge.keys.PIX_DROIT_EXPERT_CERTIF });
+
       databaseBuilder.factory.buildCertificationCourse({ id: 2, sessionId: 456 });
       databaseBuilder.factory.buildAssessment({ certificationCourseId: 2 });
       databaseBuilder.factory.buildCertificationCourse({
@@ -52,6 +44,38 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         completedAt: new Date('2020-02-01'),
         isPublished: false,
         isCancelled: false,
+      });
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 23,
+        name: 'Pix+ Droit',
+      });
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 24,
+        name: 'Pix+ Édu',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationCourse({
+        id: 123,
+        complementaryCertificationId: 23,
+        certificationCourseId: 1,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationCourse({
+        id: 456,
+        complementaryCertificationId: 24,
+        certificationCourseId: 1,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId: 123,
+        source: 'PIX',
+        partnerKey: Badge.keys.PIX_DROIT_EXPERT_CERTIF,
+        acquired: true,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId: 456,
+        source: 'PIX',
+        partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        acquired: true,
       });
       databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
       databaseBuilder.factory.buildUser({ id: 22 });
@@ -173,50 +197,5 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         expectedCertificationIssueReportA,
       ]);
     });
-
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    [
-      { partnerKey: PIX_EMPLOI_CLEA_V1, method: 'getCleaCertificationStatus' },
-      { partnerKey: PIX_EMPLOI_CLEA_V2, method: 'getCleaCertificationStatus' },
-      { partnerKey: PIX_EMPLOI_CLEA_V3, method: 'getCleaCertificationStatus' },
-      { partnerKey: PIX_DROIT_MAITRE_CERTIF, method: 'getPixPlusDroitMaitreCertificationStatus' },
-      { partnerKey: PIX_DROIT_EXPERT_CERTIF, method: 'getPixPlusDroitExpertCertificationStatus' },
-      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE, method: 'getPixPlusEduInitieCertificationStatus' },
-      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, method: 'getPixPlusEduConfirmeCertificationStatus' },
-      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME, method: 'getPixPlusEduConfirmeCertificationStatus' },
-      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, method: 'getPixPlusEduAvanceCertificationStatus' },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-        method: 'getPixPlusEduExpertCertificationStatus',
-      },
-    ].forEach(function ({ partnerKey, method }) {
-      it(`should have the status acquired when ${partnerKey} certification is acquired`, async function () {
-        // given
-        await _buildJuryCertification(1);
-        databaseBuilder.factory.buildBadge({ key: partnerKey });
-        databaseBuilder.factory.buildComplementaryCertificationCourse({
-          id: 111,
-          certificationCourseId: 1,
-        });
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 111,
-          partnerKey,
-          acquired: true,
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const juryCertification = await juryCertificationRepository.get(1);
-
-        // then
-        expect(juryCertification[method]()).to.equal('acquired');
-      });
-    });
   });
 });
-
-async function _buildJuryCertification(certificationCourseId) {
-  databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
-  databaseBuilder.factory.buildAssessment({ certificationCourseId: 1 });
-  await databaseBuilder.commit();
-}

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -112,7 +112,24 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         commentForJury: 'Un commentaire jury',
         competenceMarks: [expectedCompetenceMark],
         certificationIssueReports: [],
-        complementaryCertificationCourseResults: [],
+        commonComplementaryCertificationCourseResults: [
+          {
+            acquired: true,
+            id: 123,
+            partnerKey: 'PIX_DROIT_EXPERT_CERTIF',
+          },
+        ],
+        complementaryCertificationCourseResultsWithExternal: {
+          complementaryCertificationCourseId: 456,
+          externalSection: {
+            acquired: false,
+            partnerKey: undefined,
+          },
+          pixSection: {
+            acquired: true,
+            partnerKey: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+          },
+        },
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
     });

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification-with-external.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification-with-external.js
@@ -1,0 +1,19 @@
+const ComplementaryCertificationCourseResultsForJuryCertificationWithExternal = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal');
+const { PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT } =
+  require('../../../../lib/domain/models/Badge').keys;
+
+module.exports = function buildPixEduComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+  complementaryCertificationCourseId = 456,
+  pixPartnerKey = PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  pixAcquired = true,
+  externalPartnerKey = PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+  externalAcquired = true,
+} = {}) {
+  return new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+    complementaryCertificationCourseId,
+    pixPartnerKey,
+    pixAcquired,
+    externalPartnerKey,
+    externalAcquired,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification.js
@@ -1,0 +1,14 @@
+const ComplementaryCertificationCourseResultForJuryCertification = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification');
+const { PIX_EMPLOI_CLEA_V2 } = require('../../../../lib/domain/models/Badge').keys;
+
+module.exports = function buildComplementaryCertificationCourseResultForJuryCertification({
+  id = 1234,
+  partnerKey = PIX_EMPLOI_CLEA_V2,
+  acquired = true,
+} = {}) {
+  return new ComplementaryCertificationCourseResultForJuryCertification({
+    id,
+    partnerKey,
+    acquired,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-jury-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-certification.js
@@ -26,7 +26,8 @@ const buildJuryCertification = function ({
   commentForJury = 'comment jury',
   competenceMarks = [buildCompetenceMark()],
   certificationIssueReports = [buildCertificationIssueReport()],
-  complementaryCertificationCourseResults = [],
+  commonComplementaryCertificationCourseResults = [],
+  complementaryCertificationCourseResultsWithExternal = {},
 } = {}) {
   return new JuryCertification({
     certificationCourseId,
@@ -52,7 +53,8 @@ const buildJuryCertification = function ({
     commentForJury,
     competenceMarks,
     certificationIssueReports,
-    complementaryCertificationCourseResults,
+    commonComplementaryCertificationCourseResults,
+    complementaryCertificationCourseResultsWithExternal,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildAccountRecoveryDemand: require('./build-account-recovery-demand'),
+  buildAdminMember: require('./build-admin-member'),
   buildAllowedCertificationCenterAccess: require('./build-allowed-certification-center-access'),
   buildAnswer: require('./build-answer'),
   buildArea: require('./build-area'),
@@ -80,7 +81,8 @@ module.exports = {
   buildOrganizationTag: require('./build-organization-tag'),
   buildParticipationForCampaignManagement: require('./build-participation-for-campaign-management'),
   buildComplementaryCertificationCourseResult: require('./build-complementary-certification-course-result'),
-  buildAdminMember: require('./build-admin-member'),
+  buildComplementaryCertificationCourseResultForJuryCertification: require('./build-complementary-certification-course-result-for-certification'),
+  buildComplementaryCertificationCourseResultForJuryCertificationWithExternal: require('./build-complementary-certification-course-result-for-certification-with-external'),
   buildPixPlusDroitCertificationResult: require('./build-pix-plus-droit-certification-result'),
   buildPixPlusDroitCertificationScoring: require('./build-pix-plus-droit-certification-scoring'),
   buildPixPlusEduCertificationScoring: require('./build-pix-plus-edu-certification-scoring'),

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -133,7 +133,8 @@ describe('Unit | Controller | certification-course-controller', function () {
         commentForJury: 'comment jury',
         competenceMarks: [],
         certificationIssueReports: [],
-        complementaryCertificationCourseResults: [],
+        commonComplementaryCertificationCourseResults: [],
+        complementaryCertificationCourseResultsWithExternal: null,
       });
       sinon.stub(usecases, 'getJuryCertification').withArgs({ certificationCourseId }).resolves(juryCertification);
 
@@ -166,17 +167,16 @@ describe('Unit | Controller | certification-course-controller', function () {
           'comment-for-candidate': 'comment candidate',
           'comment-for-jury': 'comment jury',
           'comment-for-organization': 'comment organization',
-          'clea-certification-status': 'not_taken',
-          'pix-plus-droit-expert-certification-status': 'not_taken',
-          'pix-plus-droit-maitre-certification-status': 'not_taken',
-          'pix-plus-edu-initie-certification-status': 'not_taken',
-          'pix-plus-edu-confirme-certification-status': 'not_taken',
-          'pix-plus-edu-avance-certification-status': 'not_taken',
-          'pix-plus-edu-expert-certification-status': 'not_taken',
         },
         relationships: {
           'certification-issue-reports': {
             data: [],
+          },
+          'common-complementary-certification-course-results': {
+            data: [],
+          },
+          'complementary-certification-course-results-with-external': {
+            data: null,
           },
         },
       });

--- a/api/tests/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/unit/domain/models/JuryCertification_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const JuryCertification = require('../../../../lib/domain/models/JuryCertification');
+const { PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE } = require('../../../../lib/domain/models/Badge').keys;
 const { PIX_EMPLOI_CLEA } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Models | JuryCertification', function () {
@@ -29,17 +30,6 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         commentForCandidate: 'coucou',
         commentForOrganization: 'comment',
         commentForJury: 'ça va',
-        competenceMarks: [
-          {
-            id: 123,
-            score: 10,
-            level: 4,
-            area_code: '2',
-            competence_code: '2.3',
-            assessmentResultId: 753,
-            competenceId: 'recComp23',
-          },
-        ],
       };
     });
 
@@ -51,15 +41,41 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         isCancelled: false,
       };
       const certificationIssueReports = [certificationIssueReport];
-      const complementaryCertificationCourseResults = [
-        domainBuilder.buildComplementaryCertificationCourseResult({ partnerKey: PIX_EMPLOI_CLEA, acquired: true }),
+      const commonComplementaryCertificationCourseResults = [
+        domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
+          partnerKey: PIX_EMPLOI_CLEA,
+          acquired: true,
+        }),
       ];
+
+      const competenceMarkDTOs = [
+        {
+          id: 123,
+          score: 10,
+          level: 4,
+          area_code: '2',
+          competence_code: '2.3',
+          assessmentResultId: 753,
+          competenceId: 'recComp23',
+        },
+      ];
+
+      const complementaryCertificationCourseResultsWithExternal =
+        domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+          complementaryCertificationCourseId: 123,
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          pixAcquired: true,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          externalAcquired: true,
+        });
 
       // when
       const juryCertification = JuryCertification.from({
         juryCertificationDTO,
         certificationIssueReports,
-        complementaryCertificationCourseResults,
+        competenceMarkDTOs,
+        commonComplementaryCertificationCourseResults,
+        complementaryCertificationCourseResultsWithExternal,
       });
 
       // then
@@ -96,7 +112,8 @@ describe('Unit | Domain | Models | JuryCertification', function () {
         commentForJury: 'ça va',
         competenceMarks: [expectedCompetenceMark],
         certificationIssueReports,
-        complementaryCertificationCourseResults,
+        commonComplementaryCertificationCourseResults,
+        complementaryCertificationCourseResultsWithExternal,
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
     });
@@ -115,6 +132,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           juryCertificationDTO,
           certificationIssueReports: [],
           complementaryCertificationCourseResults: [],
+          competenceMarkDTOs: [],
         });
 
         // then
@@ -134,6 +152,7 @@ describe('Unit | Domain | Models | JuryCertification', function () {
           juryCertificationDTO,
           certificationIssueReports: [],
           complementaryCertificationCourseResults: [],
+          competenceMarkDTOs: [],
         });
 
         // then

--- a/api/tests/unit/domain/read-models/CertifiedBadges_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadges_test.js
@@ -291,7 +291,7 @@ describe('Unit | Domain | Read-models | CertifiedBadges', function () {
           expectedLowestBadge: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
         },
       ].forEach(({ sourcePix, sourceExternal, expectedLowestBadge }) => {
-        it(`should return ${expectedLowestBadge} when the 'PIX' source level is ${sourcePix} and the 'ETERNAL' source level is ${sourceExternal}`, function () {
+        it(`should return ${expectedLowestBadge} when the 'PIX' source level is ${sourcePix} and the 'EXTERNAL' source level is ${sourceExternal}`, function () {
           // given
           const complementaryCertificationCourseResults = [
             domainBuilder.buildComplementaryCertificationCourseResult({

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
@@ -289,4 +289,183 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
       );
     });
   });
+
+  describe('#pixResult', function () {
+    context('when pix section is not evaluated', function () {
+      it('should return null', function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+          new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({});
+
+        // when
+        const pixResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.pixResult;
+
+        // then
+        expect(pixResult).to.be.null;
+      });
+    });
+
+    context('when pix section is evaluated', function () {
+      [
+        {
+          partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          acquired: true,
+          expectedResult: 'Pix+ Édu Initié (entrée dans le métier)',
+        },
+        {
+          partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          acquired: true,
+          expectedResult: 'Pix+ Édu Confirmé',
+        },
+        {
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          acquired: true,
+          expectedResult: 'Pix+ Édu Confirmé',
+        },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, acquired: true, expectedResult: 'Pix+ Édu Avancé' },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, acquired: true, expectedResult: 'Pix+ Édu Expert' },
+        {
+          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          acquired: true,
+          expectedResult: 'Pix+ Édu Initié (entrée dans le métier)',
+        },
+        {
+          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          acquired: true,
+          expectedResult: 'Pix+ Édu Confirmé',
+        },
+        {
+          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          acquired: true,
+          expectedResult: 'Pix+ Édu Confirmé',
+        },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE, acquired: true, expectedResult: 'Pix+ Édu Avancé' },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT, acquired: true, expectedResult: 'Pix+ Édu Expert' },
+        { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT, acquired: false, expectedResult: 'Rejetée' },
+      ].forEach(({ partnerKey, acquired, expectedResult }) => {
+        it(`should return ${expectedResult} when pix section partner key is ${partnerKey} and acquired is ${acquired}`, function () {
+          // given
+          const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+            new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+              pixPartnerKey: partnerKey,
+              pixAcquired: acquired,
+            });
+
+          // when
+          const pixResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.pixResult;
+
+          // then
+          expect(pixResult).to.equal(expectedResult);
+        });
+      });
+    });
+  });
+
+  describe('#externalResult', function () {
+    context('when pix section is not acquired', function () {
+      it('should return "-"', function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+          new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            pixAcquired: false,
+          });
+
+        // when
+        const externalResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.externalResult;
+
+        // then
+        expect(externalResult).to.equal('-');
+      });
+    });
+
+    context('when piw section is acquired and external section is not yet evaluated', function () {
+      it('should return "En attente"', function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+          new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            pixAcquired: true,
+          });
+
+        // when
+        const externalResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.externalResult;
+
+        // then
+        expect(externalResult).to.equal('En attente');
+      });
+    });
+
+    context('when pix section is acquired and external section is evaluated', function () {
+      context('when acquired is true', function () {
+        [
+          {
+            partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            expectedResult: 'Pix+ Édu Initié (entrée dans le métier)',
+          },
+          {
+            partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+            expectedResult: 'Pix+ Édu Confirmé',
+          },
+          {
+            partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+            expectedResult: 'Pix+ Édu Confirmé',
+          },
+          { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, expectedResult: 'Pix+ Édu Avancé' },
+          { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, expectedResult: 'Pix+ Édu Expert' },
+          {
+            partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+            expectedResult: 'Pix+ Édu Initié (entrée dans le métier)',
+          },
+          {
+            partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+            expectedResult: 'Pix+ Édu Confirmé',
+          },
+          {
+            partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            expectedResult: 'Pix+ Édu Confirmé',
+          },
+          { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE, expectedResult: 'Pix+ Édu Avancé' },
+          { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT, expectedResult: 'Pix+ Édu Expert' },
+        ].forEach(({ partnerKey, expectedResult }) => {
+          it(`should return ${expectedResult} when external section partner key is ${partnerKey}`, function () {
+            // given
+            const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+              new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+                pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+                pixAcquired: true,
+                externalPartnerKey: partnerKey,
+                externalAcquired: true,
+              });
+
+            // when
+            const externalResult =
+              complementaryCertificationCourseResultsForJuryCertificationWithExternal.externalResult;
+
+            // then
+            expect(externalResult).to.equal(expectedResult);
+          });
+        });
+      });
+
+      context('when acquired is false', function () {
+        it(`should return Rejetée`, function () {
+          // given
+          const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+            new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+              pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+              pixAcquired: true,
+              externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+              externalAcquired: false,
+            });
+
+          // when
+          const externalResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.externalResult;
+
+          // then
+          expect(externalResult).to.equal('Rejetée');
+        });
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
@@ -1,0 +1,292 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable mocha/no-setup-in-describe */
+const ComplementaryCertificationCourseResultsForJuryCertificationWithExternal = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal');
+const { expect, domainBuilder, catchErr } = require('../../../test-helper');
+const {
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../../../../lib/domain/models/Badge').keys;
+
+describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJuryCertificationWithExternal', function () {
+  describe('#finalResult', function () {
+    context('when external section is not scored yet', function () {
+      it('should return "En attente volet jury" ', function () {
+        // given
+        const complementaryCertificationCourseResultForJuryCertificationWithExternal =
+          domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            pixAcquired: true,
+            externalPartnerKey: null,
+          });
+
+        // when
+        const finalResult = complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
+
+        // then
+        expect(finalResult).to.be.equal('En attente volet jury');
+      });
+    });
+
+    it('should return "Rejetée" when pix section is not obtained', function () {
+      // given
+      const complementaryCertificationCourseResultForJuryCertificationWithExternal =
+        domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          pixAcquired: false,
+        });
+
+      // when
+      const finalResult = complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
+
+      // then
+      expect(finalResult).to.equal('Rejetée');
+    });
+
+    context('when both section are scored', function () {
+      it('should return "Rejetée" when external section is not obtained', function () {
+        // given
+        const complementaryCertificationCourseResultForJuryCertificationWithExternal =
+          domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            pixAcquired: true,
+            externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            externalAcquired: false,
+          });
+
+        // when
+        const finalResult = complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
+
+        // then
+        expect(finalResult).to.equal('Rejetée');
+      });
+
+      [
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE
+            ],
+        },
+        {
+          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+          expectedFinalResult:
+            ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.labels[
+              PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT
+            ],
+        },
+      ].forEach(({ pixPartnerKey, externalPartnerKey, expectedFinalResult }) => {
+        it(`should return ${expectedFinalResult} when the 'PIX' source level is ${pixPartnerKey} and the 'EXTERNAL' source level is ${externalPartnerKey}`, function () {
+          // given
+          const complementaryCertificationCourseResultForJuryCertificationWithExternal =
+            domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+              pixPartnerKey,
+              pixAcquired: true,
+              externalPartnerKey,
+              externalAcquired: true,
+            });
+
+          // when
+          const finalResult = complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
+
+          // then
+          expect(finalResult).to.equal(expectedFinalResult);
+        });
+      });
+
+      it('should throw an Error when partner key are not from the same degrees', async function () {
+        // given
+        const complementaryCertificationCourseResultForJuryCertificationWithExternal =
+          domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            pixAcquired: true,
+            externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+            externalAcquired: true,
+          });
+
+        // when
+        const myFunc = () => complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
+        const error = await catchErr(myFunc)();
+
+        // then
+        expect(error.message).to.equal(
+          `Badges edu incoherent !!! ${PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE} et ${PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT}`
+        );
+      });
+    });
+  });
+
+  describe('#from', function () {
+    it('should return a PixEduComplementaryCertificationCourseResultForJuryCertification', function () {
+      // given
+      const complementaryCertificationCourseResultsWithExternal = [
+        domainBuilder.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId: 1234,
+          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          acquired: true,
+          source: 'PIX',
+        }),
+        domainBuilder.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId: 1234,
+          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          acquired: false,
+          source: 'EXTERNAL',
+        }),
+      ];
+
+      // when
+      const result = ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.from(
+        complementaryCertificationCourseResultsWithExternal
+      );
+
+      // then
+      expect(result).to.deepEqualInstance(
+        new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+          pixAcquired: true,
+          externalAcquired: false,
+          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          complementaryCertificationCourseId: 1234,
+        })
+      );
+    });
+  });
+});

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification_test.js
@@ -1,0 +1,90 @@
+const { expect } = require('../../../test-helper');
+const ComplementaryCertificationCourseResultsForJuryCertification = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification');
+const {
+  PIX_EMPLOI_CLEA_V1,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_EMPLOI_CLEA_V3,
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+} = require('../../../../lib/domain/models/Badge').keys;
+
+describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJuryCertification', function () {
+  describe('#label', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      { partnerKey: PIX_EMPLOI_CLEA_V1, expectedLabel: 'CléA Numérique' },
+      { partnerKey: PIX_EMPLOI_CLEA_V2, expectedLabel: 'CléA Numérique' },
+      { partnerKey: PIX_EMPLOI_CLEA_V3, expectedLabel: 'CléA Numérique' },
+      { partnerKey: PIX_DROIT_MAITRE_CERTIF, expectedLabel: 'Pix+ Droit Maître' },
+      { partnerKey: PIX_DROIT_EXPERT_CERTIF, expectedLabel: 'Pix+ Droit Expert' },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        expectedLabel: 'Pix+ Édu Initié (entrée dans le métier)',
+      },
+      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, expectedLabel: 'Pix+ Édu Confirmé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME, expectedLabel: 'Pix+ Édu Confirmé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, expectedLabel: 'Pix+ Édu Avancé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, expectedLabel: 'Pix+ Édu Expert' },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        expectedLabel: 'Pix+ Édu Initié (entrée dans le métier)',
+      },
+      { partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, expectedLabel: 'Pix+ Édu Confirmé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME, expectedLabel: 'Pix+ Édu Confirmé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE, expectedLabel: 'Pix+ Édu Avancé' },
+      { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT, expectedLabel: 'Pix+ Édu Expert' },
+    ].forEach(({ partnerKey, expectedLabel }) => {
+      it(`should return ${expectedLabel} for partner key ${partnerKey}`, function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertification =
+          new ComplementaryCertificationCourseResultsForJuryCertification({ partnerKey });
+
+        // when
+        const label = complementaryCertificationCourseResultsForJuryCertification.label;
+
+        // then
+        expect(label).to.equal(expectedLabel);
+      });
+    });
+  });
+
+  describe('#status', function () {
+    describe('when the complementary certification course result is acquired', function () {
+      it('should return Validée', function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertification =
+          new ComplementaryCertificationCourseResultsForJuryCertification({ acquired: true });
+
+        // when
+        const status = complementaryCertificationCourseResultsForJuryCertification.status;
+
+        // then
+        expect(status).to.equal('Validée');
+      });
+    });
+
+    describe('when the complementary certification course result is not acquired', function () {
+      it('should return Rejetée', function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertification =
+          new ComplementaryCertificationCourseResultsForJuryCertification({ acquired: false });
+
+        // when
+        const status = complementaryCertificationCourseResultsForJuryCertification.status;
+
+        // then
+        expect(status).to.equal('Rejetée');
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -1,11 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-certification-serializer');
-const {
-  PIX_DROIT_MAITRE_CERTIF,
-  PIX_DROIT_EXPERT_CERTIF,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-} = require('../../../../../lib/domain/models/Badge').keys;
+const Badge = require('../../../../../lib/domain/models/Badge');
 
 describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function () {
   describe('#serialize', function () {
@@ -43,24 +38,26 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
         commentForJury: 'ça va',
         competenceMarks,
         certificationIssueReports,
-        complementaryCertificationCourseResults: [
-          domainBuilder.buildComplementaryCertificationCourseResult({
-            partnerKey: PIX_DROIT_MAITRE_CERTIF,
+        commonComplementaryCertificationCourseResults: [
+          domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
+            id: 12,
+            partnerKey: Badge.keys.PIX_DROIT_EXPERT_CERTIF,
             acquired: true,
           }),
-          domainBuilder.buildComplementaryCertificationCourseResult({
-            partnerKey: PIX_DROIT_EXPERT_CERTIF,
-            acquired: false,
-          }),
-          domainBuilder.buildComplementaryCertificationCourseResult({
-            partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+          domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
+            id: 14,
+            partnerKey: Badge.keys.PIX_EMPLOI_CLEA_V3,
             acquired: true,
-          }),
-          domainBuilder.buildComplementaryCertificationCourseResult({
-            partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-            acquired: false,
           }),
         ],
+        complementaryCertificationCourseResultsWithExternal:
+          domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
+            complementaryCertificationCourseId: 1234,
+            pixPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            pixAcquired: true,
+            externalPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            externalAcquired: true,
+          }),
       });
 
       // when
@@ -93,13 +90,6 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             'comment-for-candidate': 'coucou',
             'comment-for-jury': 'ça va',
             'comment-for-organization': 'comment',
-            'clea-certification-status': 'not_taken',
-            'pix-plus-droit-maitre-certification-status': 'acquired',
-            'pix-plus-droit-expert-certification-status': 'rejected',
-            'pix-plus-edu-initie-certification-status': 'not_taken',
-            'pix-plus-edu-confirme-certification-status': 'acquired',
-            'pix-plus-edu-avance-certification-status': 'rejected',
-            'pix-plus-edu-expert-certification-status': 'not_taken',
           },
           relationships: {
             'certification-issue-reports': {
@@ -110,9 +100,53 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
                 },
               ],
             },
+            'common-complementary-certification-course-results': {
+              data: [
+                {
+                  id: '12',
+                  type: 'commonComplementaryCertificationCourseResults',
+                },
+                {
+                  id: '14',
+                  type: 'commonComplementaryCertificationCourseResults',
+                },
+              ],
+            },
+            'complementary-certification-course-results-with-external': {
+              data: {
+                id: '1234',
+                type: 'complementaryCertificationCourseResultsWithExternals',
+              },
+            },
           },
         },
         included: [
+          {
+            type: 'commonComplementaryCertificationCourseResults',
+            id: '12',
+            attributes: {
+              label: 'Pix+ Droit Expert',
+              status: 'Validée',
+            },
+          },
+          {
+            type: 'commonComplementaryCertificationCourseResults',
+            id: '14',
+            attributes: {
+              label: 'CléA Numérique',
+              status: 'Validée',
+            },
+          },
+          {
+            type: 'complementaryCertificationCourseResultsWithExternals',
+            id: '1234',
+            attributes: {
+              'complementary-certification-course-id': 1234,
+              'pix-result': 'Pix+ Édu Avancé',
+              'external-result': 'Pix+ Édu Avancé',
+              'final-result': 'Pix+ Édu Avancé',
+            },
+          },
           {
             type: 'certificationIssueReports',
             id: certificationIssueReport.id.toString(),


### PR DESCRIPTION
## :unicorn: Problème
La certification Pix+ Edu comporte 2 volets, menant à l’obtention d’un niveau final pour cette certif complémentaire : le volet Pix et le volet jury (externe). Il faut donc permettre, pour une certification Pix+ Edu, l’affichage de ces 3 informations depuis Pix Admin.

## :robot: Solution
Afficher le niveau obtenu à chaque étape de la certification Pix+Edu dans Pix Admin > page de détails d’une certification.

![image](https://user-images.githubusercontent.com/37305474/166641448-db21c3fa-104d-4272-8dd7-f722d37847b1.png)


## :100: Pour tester

- Passer avec succès une certification avec ```certifedu.2nd.initiale@example.net```
- Finaliser / Publier la session
- Ajouter en base un badge cléa acquis
- Constater l'affichage suivant 
![image](https://user-images.githubusercontent.com/37305474/166893653-310f07e0-13d7-49ae-84af-41cbbbd71aa0.png)

- Passer le volet jury du badge pix Edu en acquired FALSE
- Constater l'affichage suivant 
![image](https://user-images.githubusercontent.com/37305474/166893879-e6b23cc8-ed87-4a45-9159-62e26c26d672.png)

- Repasser le volet Pix en acquis 
- Ajouter un volet jury acquis du même niveau
- Constater l'affichage suivant
![image](https://user-images.githubusercontent.com/37305474/166894116-5f98728c-b5ed-4178-8022-17f5b894023c.png)

- Modifier le volet jury pour donner un niveau supérieur
- Constater que le niveau final correspond au niveau le plus bas
![image](https://user-images.githubusercontent.com/37305474/166892658-7718de7b-f1d2-47f9-8321-1747c8816376.png)

- Supprimer les deux volets pix Edu
- Constater l'affichage suivant
![image](https://user-images.githubusercontent.com/37305474/166894965-f7f31fcf-ee21-4123-b1dc-c75758e53fe9.png)

- Supprimer le badge clea
- Constater que la partie ```Certifications complémentaires``` ne s'affiche plus
![image](https://user-images.githubusercontent.com/37305474/166895105-cacdd4cd-5453-4d55-ad85-c7012d5d867e.png)

