### PR TITLE
[FEATURE] Récupérer les acquis depuis des sujets (PIX-4762).

### DIFF
--- a/api/lib/application/frameworks/index.js
+++ b/api/lib/application/frameworks/index.js
@@ -52,4 +52,4 @@ exports.register = async function (server) {
   ]);
 };
 
-exports.name = 'tubes-api';
+exports.name = 'frameworks-api';

--- a/api/lib/application/tubes/index.js
+++ b/api/lib/application/tubes/index.js
@@ -1,0 +1,29 @@
+const tubeController = require('./tube-controller');
+const securityPreHandlers = require('../security-pre-handlers');
+const Joi = require('joi');
+const identifiersType = require('../../domain/types/identifiers-type');
+
+exports.register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/tubes/{id}/skills',
+      config: {
+        handler: tubeController.listSkills,
+        pre: [{ method: securityPreHandlers.checkUserHasRoleSuperAdmin }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.tubeId,
+          }),
+        },
+        tags: ['api', 'tubes', 'skills'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
+          "Elle permet de récupérer tous les acquis d'un sujet",
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'tubes-api';

--- a/api/lib/application/tubes/tube-controller.js
+++ b/api/lib/application/tubes/tube-controller.js
@@ -1,0 +1,16 @@
+module.exports = {
+  async listSkills() {
+    return {
+      data: [
+        {
+          id: 'skillId2',
+          type: 'skills',
+        },
+        {
+          id: 'skillId1',
+          type: 'skills',
+        },
+      ],
+    };
+  },
+};

--- a/api/lib/application/tubes/tube-controller.js
+++ b/api/lib/application/tubes/tube-controller.js
@@ -1,16 +1,12 @@
+const usecases = require('../../domain/usecases');
+const skillSerializer = require('../../infrastructure/serializers/jsonapi/skill-serializer');
+
 module.exports = {
-  async listSkills() {
-    return {
-      data: [
-        {
-          id: 'skillId2',
-          type: 'skills',
-        },
-        {
-          id: 'skillId1',
-          type: 'skills',
-        },
-      ],
-    };
+  async listSkills(request) {
+    const tubeId = request.params.id;
+
+    const skills = await usecases.getTubeSkills({ tubeId });
+
+    return skillSerializer.serialize(skills);
   },
 };

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -50,7 +50,7 @@ const typesPositiveInteger32bits = [
 ];
 
 const typesAlphanumeric = ['courseId', 'tutorialId'];
-const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId'];
+const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId'];
 
 _assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInteger32bits);
 _assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);

--- a/api/lib/domain/usecases/get-tube-skills.js
+++ b/api/lib/domain/usecases/get-tube-skills.js
@@ -1,0 +1,3 @@
+module.exports = async function getTubeSkills({ skillRepository, tubeId }) {
+  return skillRepository.findActiveByTubeId(tubeId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -324,6 +324,7 @@ module.exports = injectDependencies(
     getStageDetails: require('./get-stage-details'),
     getSupervisorKitSessionInfo: require('./get-supervisor-kit-session-info'),
     getTargetProfileDetails: require('./get-target-profile-details'),
+    getTubeSkills: require('./get-tube-skills'),
     getFrameworks: require('./get-frameworks'),
     getFrameworkAreas: require('./get-framework-areas'),
     getAccountRecoveryDetails: require('./account-recovery/get-account-recovery-details'),

--- a/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
@@ -19,7 +19,14 @@ module.exports = {
           tubes: {
             include: true,
             ref: 'id',
-            attributes: ['practicalTitle', 'practicalDescription', 'mobile', 'tablet'],
+            attributes: ['practicalTitle', 'practicalDescription', 'mobile', 'tablet', 'skills'],
+            skills: {
+              ref: true,
+              ignoreRelationshipData: true,
+              relationshipLinks: {
+                related: (_area, _skills, tube) => `/api/tubes/${tube.id}/skills`,
+              },
+            },
           },
         },
       },

--- a/api/lib/infrastructure/serializers/jsonapi/skill-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/skill-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(skills) {
+    return new Serializer('skill', {
+      ref: 'id',
+    }).serialize(skills);
+  },
+};

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -44,6 +44,7 @@ module.exports = [
   require('./application/stages'),
   require('./application/tags'),
   require('./application/target-profiles'),
+  require('./application/tubes'),
   require('./application/frameworks'),
   require('./application/tutorial-evaluations'),
   require('./application/user-orga-settings'),

--- a/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
+++ b/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
@@ -131,6 +131,13 @@ describe('Acceptance | Controller | frameworks-controller', function () {
                 mobile: false,
                 tablet: false,
               },
+              relationships: {
+                skills: {
+                  links: {
+                    related: '/api/tubes/tubeId/skills',
+                  },
+                },
+              },
             },
 
             {

--- a/api/tests/acceptance/application/tubes/tubes-route_test.js
+++ b/api/tests/acceptance/application/tubes/tubes-route_test.js
@@ -1,0 +1,126 @@
+const {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Route | Tubes', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET api/tubes/{id}/skills', function () {
+    let userId;
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser.withRoleSuperAdmin().id;
+
+      await databaseBuilder.commit();
+      mockLearningContent({
+        tubes: [
+          {
+            id: 'tubeId1',
+          },
+          {
+            id: 'tubeId2',
+          },
+        ],
+        skills: [
+          {
+            id: 'skillId1',
+            status: 'actif',
+            tubeId: 'tubeId1',
+          },
+          {
+            id: 'skillId2',
+            status: 'actif',
+            tubeId: 'tubeId1',
+          },
+          {
+            id: 'skillId3',
+            status: 'archivé',
+            tubeId: 'tubeId1',
+          },
+          {
+            id: 'skillId4',
+            status: 'supprimé',
+            tubeId: 'tubeId1',
+          },
+          {
+            id: 'skillId5',
+            status: 'actif',
+            tubeId: 'tubeId2',
+          },
+        ],
+      });
+    });
+
+    it('should return response code 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/tubes/tubeId1/skills`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it("should return list of tube's skills", async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/tubes/tubeId1/skills`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.have.lengthOf(2);
+      expect(response.result.data).to.deep.include({
+        id: 'skillId1',
+        type: 'skills',
+      });
+      expect(response.result.data).to.deep.include({
+        id: 'skillId2',
+        type: 'skills',
+      });
+    });
+
+    describe('if user is not super admin', function () {
+      it('should return response code 403', async function () {
+        // given
+        userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+        const options = {
+          method: 'GET',
+          url: `/api/tubes/123/skills`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/tubes/tubes-controller_test.js
+++ b/api/tests/unit/application/tubes/tubes-controller_test.js
@@ -1,0 +1,36 @@
+const { expect, sinon } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const tubeController = require('../../../../lib/application/tubes/tube-controller');
+const skillSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/skill-serializer');
+
+describe('Unit | Controller | tubes-controller', function () {
+  let skills;
+  let serializedSkills;
+
+  beforeEach(function () {
+    skills = Symbol('skills');
+    serializedSkills = Symbol('serializedSkills');
+
+    sinon.stub(usecases, 'getTubeSkills').returns(skills);
+    sinon.stub(skillSerializer, 'serialize').returns(serializedSkills);
+  });
+
+  describe('#listSkills', function () {
+    it('should return a list of skills', async function () {
+      // given
+      const request = {
+        params: {
+          id: 'tubeId',
+        },
+      };
+
+      // when
+      const result = await tubeController.listSkills(request);
+
+      // then
+      expect(result).to.equal(serializedSkills);
+      expect(usecases.getTubeSkills).to.have.been.calledWith({ tubeId: 'tubeId' });
+      expect(skillSerializer.serialize).to.have.been.calledWith(skills);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-tube-skills_test.js
+++ b/api/tests/unit/domain/usecases/get-tube-skills_test.js
@@ -1,0 +1,29 @@
+const { expect, sinon } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | UseCase | get-tube-skills', function () {
+  let skillRepository, expectedSkillsResult;
+
+  beforeEach(function () {
+    expectedSkillsResult = [{ id: 'skillId1' }, { id: 'skillId2' }];
+
+    skillRepository = {
+      findActiveByTubeId: sinon.stub().resolves(expectedSkillsResult),
+    };
+  });
+
+  it('should get skills by tube', async function () {
+    // given
+    const tubeId = 'tubeId';
+
+    // when
+    const response = await usecases.getTubeSkills({
+      skillRepository,
+      tubeId,
+    });
+
+    // then
+    expect(skillRepository.findActiveByTubeId).to.have.been.calledWith(tubeId);
+    expect(response).to.deep.equal(expectedSkillsResult);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
@@ -5,15 +5,13 @@ describe('Unit | Serializer | JSONAPI | pix-framework-serializer', function () {
   describe('#serialize', function () {
     it('should return a serialized JSON data object', function () {
       // given
-      const tubeId = '456';
-
       const tube = domainBuilder.buildTube({
-        id: tubeId,
+        id: 'tubeId',
       });
 
       const thematicWithTube = domainBuilder.buildThematic({
         id: 'recThem1',
-        tubeIds: [tubeId],
+        tubeIds: ['tubeId'],
       });
 
       const thematicWithoutTube = domainBuilder.buildThematic({
@@ -50,10 +48,17 @@ describe('Unit | Serializer | JSONAPI | pix-framework-serializer', function () {
         included: [
           {
             type: 'tubes',
-            id: tubeId,
+            id: 'tubeId',
             attributes: {
               'practical-title': 'titre pratique',
               'practical-description': 'description pratique',
+            },
+            relationships: {
+              skills: {
+                links: {
+                  related: '/api/tubes/tubeId/skills',
+                },
+              },
             },
           },
           {
@@ -67,7 +72,7 @@ describe('Unit | Serializer | JSONAPI | pix-framework-serializer', function () {
               tubes: {
                 data: [
                   {
-                    id: tubeId,
+                    id: 'tubeId',
                     type: 'tubes',
                   },
                 ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
@@ -1,0 +1,39 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/skill-serializer');
+
+describe('Unit | Serializer | JSONAPI | skill-serializer', function () {
+  describe('#serialize', function () {
+    it('should return a serialized JSON data object', function () {
+      // given
+      const skills = [
+        {
+          id: 'skillId1',
+          name: 'skill1',
+        },
+        {
+          id: 'skillId2',
+          name: 'skill1',
+        },
+      ];
+
+      const expectedSerializedResult = {
+        data: [
+          {
+            type: 'skills',
+            id: 'skillId1',
+          },
+          {
+            type: 'skills',
+            id: 'skillId2',
+          },
+        ],
+      };
+
+      // when
+      const result = serializer.serialize(skills);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedResult);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de récupérer la liste des acquis d'un sujet.

## :robot: Solution
 - Ajouter la relation sur les sujets dans le endpoint `/api/frameworks/{id}/areas`
 - Créer le endpoint `/api/tubes/{id}/skills`

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Les tests passent.
Vérifier qu'il n'y ait pas de régression sur la page de sélection de sujets : https://admin-pr4392.review.pix.fr/target-profiles/new-tube-based
