### PR TITLE
[TECH] Supprimer la méthode non utilisée `getPixScoreByCompetence`. 

### DIFF
--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -4,8 +4,6 @@ const Area = require('../../domain/models/Area');
 const areaDatasource = require('../datasources/learning-content/area-datasource');
 const Competence = require('../../domain/models/Competence');
 const competenceDatasource = require('../datasources/learning-content/competence-datasource');
-const knowledgeElementRepository = require('./knowledge-element-repository');
-const scoringService = require('../../domain/services/scoring/scoring-service');
 const { NotFoundError } = require('../../domain/errors');
 const { FRENCH_FRANCE } = require('../../domain/constants').LOCALE;
 const { PIX_ORIGIN } = require('../../domain/constants');
@@ -78,19 +76,6 @@ module.exports = {
       }
       throw err;
     }
-  },
-
-  async getPixScoreByCompetence({ userId, limitDate }) {
-    const knowledgeElementsGroupedByCompetenceId =
-      await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
-        userId,
-        limitDate,
-      });
-
-    return _.mapValues(knowledgeElementsGroupedByCompetenceId, (knowledgeElements) => {
-      const { pixScoreForCompetence } = scoringService.calculateScoringInformationForCompetence({ knowledgeElements });
-      return pixScoreForCompetence;
-    });
   },
 };
 

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { expect, mockLearningContent, domainBuilder, databaseBuilder } = require('../../../test-helper');
+const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
 const Area = require('../../../../lib/domain/models/Area');
 const Competence = require('../../../../lib/domain/models/Competence');
 const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
@@ -103,35 +103,6 @@ describe('Integration | Repository | competence-repository', function () {
 
       // then
       expect(competenceName).to.equal(expectedCompetence.name);
-    });
-  });
-
-  describe('#getPixScoreByCompetence', function () {
-    it('should return the user pixScore by competence within date', async function () {
-      // given
-      const competenceId1 = 'recCompetenceId1';
-      const competenceId2 = 'recCompetenceId2';
-      const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildKnowledgeElement({
-        competenceId: competenceId1,
-        earnedPix: 1,
-        userId,
-        skillId: 'recS1',
-      });
-      databaseBuilder.factory.buildKnowledgeElement({
-        competenceId: competenceId2,
-        earnedPix: 10,
-        userId,
-        skillId: 'recS2',
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const pixScoreByCompetence = await competenceRepository.getPixScoreByCompetence({ userId });
-
-      // then
-      expect(pixScoreByCompetence[competenceId1]).to.equal(1);
-      expect(pixScoreByCompetence[competenceId2]).to.equal(10);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans l'API, la méthode `getPixScoreByCompetence` de `competence-repository` n'est pas utilisée et pollue donc la lisibilité du code.

## :robot: Solution
- Supprimer la méthode

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Constater que les tests passent toujours
