### PR TITLE
[FEATURE] Changer le message d'erreur de connexion en session de certification. (PIX-4878)

### DIFF
--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -74,7 +74,15 @@
     </div>
 
     {{#if this.errorMessage}}
-      <div class="certification-course-page__errors">{{this.errorMessage}}</div>
+      <div class="certification-course-page__errors">{{this.errorMessage}}
+        {{#if this.genericErrorListElements}}
+          <ul class="certification-course-page__errors__list">
+            {{#each this.genericErrorListElements as |genericErrorElement|}}
+              <li>{{genericErrorElement}}</li>
+            {{/each}}
+          </ul>
+        {{/if}}
+      </div>
     {{/if}}
     <PixButton @type="submit">{{t "pages.certification-joiner.form.actions.submit"}}</PixButton>
   </form>

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -25,6 +25,8 @@ export default class CertificationJoiner extends Component {
   SESSION_ID_VALIDATION_PATTERN = '^[0-9]*$';
 
   @tracked errorMessage = null;
+  @tracked genericErrorDisclaimer = null;
+  @tracked genericErrorListElements = [];
   @tracked sessionIdIsNotANumberError = null;
   @tracked validationClassName = '';
   @tracked sessionId = null;
@@ -89,10 +91,16 @@ export default class CertificationJoiner extends Component {
 
       if (_isMatchingReconciledStudentNotFoundError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');
+        this.genericErrorListElements = [];
       } else if (_isSessionNotAccessibleError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.session-not-accessible');
+        this.genericErrorListElements = [];
       } else {
-        this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.generic');
+        this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer');
+        this.genericErrorListElements = [
+          this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'),
+          this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'),
+        ];
       }
     }
   }

--- a/mon-pix/app/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/congratulations-certification-banner.hbs
@@ -11,25 +11,39 @@
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
   </p>
   {{#if @certificationEligibility.cleaCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.clea-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.clea-eligibility"
+      }}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusDroitMaitreCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-maitre-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.pix-plus-droit-maitre-eligibility"
+      }}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusDroitExpertCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"
+      }}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduInitieCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-initie-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.pix-plus-edu-initie-eligibility"
+      }}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduConfirmeCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-confirme-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.pix-plus-edu-confirme-eligibility"
+      }}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduAvanceCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-avance-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.pix-plus-edu-avance-eligibility"
+      }}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduExpertCertificationEligible}}
-    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-expert-eligibility"}}</p>
+    <p class="congratulations-banner__eligibility-message">{{t
+        "pages.certification-joiner.congratulation-banner.pix-plus-edu-expert-eligibility"
+      }}</p>
   {{/if}}
 
   <a

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -149,8 +149,17 @@
 .certification-course-page__errors {
   color: $pure-orange;
   font-size: 0.875rem;
-  text-align: center;
+  text-align: start;
   margin: 5px 5px 5px 5px;
+
+  &__list {
+
+    li {
+      text-align: start;
+      list-style: disc;
+      margin: 8px 0 0 16px;
+    }
+  }
 }
 
 .certification-course-page__field-button {

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -45,6 +45,10 @@
   margin-bottom: 16px;
 }
 
+.congratulations-banner__eligibility-message {
+  text-align: center;
+}
+
 .congratulations-banner__link {
   @include textBannerStyle();
 

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -66,11 +66,15 @@ describe('Acceptance | Certification | Certification Course', function () {
             });
           });
 
-          it('should display an error message', function () {
+          it('Should display an error message', function () {
             // then
-            expect(find('.certification-course-page__errors').textContent.trim()).to.equal(
-              'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.'
-            );
+            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
+            ).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
+            ).to.exist;
           });
         });
 
@@ -90,9 +94,13 @@ describe('Acceptance | Certification | Certification Course', function () {
 
           it('should display an error message', function () {
             // then
-            expect(find('.certification-course-page__errors').textContent.trim()).to.equal(
-              'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.'
-            );
+            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
+            ).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
+            ).to.exist;
           });
         });
 
@@ -112,9 +120,13 @@ describe('Acceptance | Certification | Certification Course', function () {
 
           it('should display an error message', function () {
             // then
-            expect(find('.certification-course-page__errors').textContent.trim()).to.equal(
-              'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.'
-            );
+            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
+            ).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
+            ).to.exist;
           });
         });
 
@@ -134,9 +146,13 @@ describe('Acceptance | Certification | Certification Course', function () {
 
           it('should display an error message', function () {
             // then
-            expect(find('.certification-course-page__errors').textContent.trim()).to.equal(
-              'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.'
-            );
+            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
+            ).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
+            ).to.exist;
           });
         });
 
@@ -156,9 +172,13 @@ describe('Acceptance | Certification | Certification Course', function () {
 
           it('should display an error message', function () {
             // then
-            expect(find('.certification-course-page__errors').textContent.trim()).to.equal(
-              'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.'
-            );
+            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
+            ).to.exist;
+            expect(
+              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
+            ).to.exist;
           });
         });
 

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -50,34 +50,6 @@ describe('Acceptance | Certification | Certification Course', function () {
           return visit('/certifications');
         });
 
-        context('when user forget to fill a field', function () {
-          beforeEach(async function () {
-            await visit('/certifications');
-
-            // when
-            await fillCertificationJoiner({
-              sessionId: '1',
-              firstName: 'Laura',
-              lastName: '',
-              dayOfBirth: '04',
-              monthOfBirth: '01',
-              yearOfBirth: '1990',
-              intl: this.intl,
-            });
-          });
-
-          it('Should display an error message', function () {
-            // then
-            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
-            expect(
-              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
-            ).to.exist;
-            expect(
-              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
-            ).to.exist;
-          });
-        });
-
         context('when no candidate with given info has been registered in the given session', function () {
           beforeEach(async function () {
             // when
@@ -137,32 +109,6 @@ describe('Acceptance | Certification | Certification Course', function () {
               sessionId: '1',
               firstName: 'Laura',
               lastName: 'UtilisateurLiéAutre',
-              dayOfBirth: '04',
-              monthOfBirth: '01',
-              yearOfBirth: '1990',
-              intl: this.intl,
-            });
-          });
-
-          it('should display an error message', function () {
-            // then
-            expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
-            expect(
-              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
-            ).to.exist;
-            expect(
-              contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))
-            ).to.exist;
-          });
-        });
-
-        context('when candidate has already been linked to another user in the session', function () {
-          beforeEach(async function () {
-            // when
-            await fillCertificationJoiner({
-              sessionId: '1',
-              firstName: 'Laura',
-              lastName: 'CandidatLiéAutre',
               dayOfBirth: '04',
               monthOfBirth: '01',
               yearOfBirth: '1990',

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -172,11 +172,9 @@ describe('Integration | Component | certification-joiner', function () {
       await clickByLabel(this.intl.t('pages.certification-joiner.form.actions.submit'));
 
       // then
-      expect(
-        contains(
-          'Oups ! Nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez le surveillant.'
-        )
-      ).to.exist;
+      expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer'))).to.exist;
+      expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))).to.exist;
+      expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))).to.exist;
     });
 
     it('should display an error message on session not accessible', async function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -253,7 +253,11 @@
         "pix-plus-droit-maitre-eligibility": "You are also eligible for the Pix+ Droit Maître certification."
       },
       "error-messages": {
-        "generic": "Oops! We can't find you.\nPlease check your details to continue or call the invigilator.",
+        "generic": {
+          "disclaimer": "The information entered does not match any candidate registered for the session.",
+          "check-session-number": "Check the session number.",
+          "check-personal-info": "Check with the invigilator that your personal information matches the sign-in sheet."
+        },
         "session-not-accessible": "The session you are trying to join is no longer available.",
         "wrong-account": "Oops! It seems that you are using the wrong Pix account to join this certification session.\nTo continue, please login to the correct Pix account or ask the invigilator for help."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -252,7 +252,11 @@
         "pix-plus-droit-maitre-eligibility": "Vous êtes également éligible à la certification Pix+ Droit Maître."
       },
       "error-messages": {
-        "generic": "Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.",
+        "generic": {
+          "disclaimer": "Les informations saisies ne correspondent à aucun candidat inscrit à la session.",
+          "check-session-number": "Vérifiez le numéro de session.",
+          "check-personal-info": "Vérifiez auprès du surveillant la correspondance de vos informations personnelles avec la feuille d'émargement."
+        },
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
         "wrong-account": "Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant."
       },


### PR DESCRIPTION
## :unicorn: Problème
Le pôle support reçoit beaucoup de tickets de candidats qui tentent de rejoindre une session de certification, mais qui n’y parviennent pas car les infos perso et/ou le numéro de session renseignés ne matchent avec aucun candidat inscrit dans cette session. Le message d’erreur affiché dans ce cas n’est a priori pas assez explicite.

## :robot: Solution
Rendre plus explicite le message d’erreur affiché dans ce cas : 

Les informations saisies ne correspondent à aucun candidat inscrit à la session.
- Vérifiez le numéro de session. 
- Vérifiez auprès du surveillant la correspondance de vos informations personnelles avec la feuille d'émargement.

## :100: Pour tester
Essayer de se connecter sur Pix app à une session de certification avec de mauvaises informations pour avoir l'erreur générique. Constater le changement du message d'erreur.