### PR TITLE
[TECH] Préparer Pix Admin à la restriction des accès pour certains rôles à certaines pages (PIX-4885)

### DIFF
--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { roles } from 'pix-admin/models/admin-member';
 
 export default class List extends Component {
   @service notifications;
@@ -11,7 +10,8 @@ export default class List extends Component {
   @tracked newRole;
 
   get adminRoles() {
-    return Object.values(roles).map((role) => ({ value: role, label: role }));
+    const allRoles = ['SUPER_ADMIN', 'CERTIF', 'METIER', 'SUPPORT'];
+    return allRoles.map((role) => ({ value: role, label: role }));
   }
 
   @action

--- a/admin/app/models/admin-member.js
+++ b/admin/app/models/admin-member.js
@@ -8,10 +8,18 @@ export default class AdminMember extends Model {
   @attr('string') firstName;
   @attr('string') email;
   @attr('string') role;
+  @attr() isSuperAdmin;
+  @attr() isCertif;
+  @attr() isSupport;
+  @attr() isMetier;
 
   @attr('boolean') isInEditionMode;
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
+  }
+
+  hasAccess(rights) {
+    return rights.some((right) => this[right]);
   }
 }

--- a/admin/app/models/admin-member.js
+++ b/admin/app/models/admin-member.js
@@ -1,7 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
-export const roles = { SUPER_ADMIN: 'SUPER_ADMIN', SUPPORT: 'SUPPORT', METIER: 'METIER', CERTIF: 'CERTIF' };
-
 export default class AdminMember extends Model {
   @attr() userId;
   @attr('string') lastName;

--- a/admin/tests/acceptance/authenticated/badges/badges_test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges_test.js
@@ -10,7 +10,7 @@ module('Acceptance | authenticated/badges/badge', function (hooks) {
 
   test('should display the badge', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
     const tube = this.server.create('tube', { practicalTitle: 'Practical title of tube' });
     const skill = this.server.create('skill', { name: '@skill2', difficulty: 2, tube });

--- a/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
+++ b/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
@@ -23,7 +23,7 @@ module('Acceptance | Campaign Page', function (hooks) {
   module('When user is logged in', function () {
     test('it should display the default page', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       server.create('campaign', { id: 1, name: 'Campaign name' });
 
       // when

--- a/admin/tests/acceptance/authenticated/campaigns/campaign-participations_test.js
+++ b/admin/tests/acceptance/authenticated/campaigns/campaign-participations_test.js
@@ -23,7 +23,7 @@ module('Acceptance | Campaign Participations', function (hooks) {
   module('When user is logged in', function () {
     test('it should display campaign participations', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       server.create('campaign', { id: 1, name: 'Campaign name' });
       server.create('campaign-participation', { firstName: 'Georgette', lastName: 'Frimousse' });
 

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -16,7 +16,7 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     const { id: userId } = server.create('user');
     server.create('admin-member', {
       userId,
-      role: 'SUPER_ADMIN',
+      isSuperAdmin: true,
     });
     await createAuthenticateSession({ userId });
 

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -11,7 +11,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
   test('should access Certification center page by URL /certification-centers/:id', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
@@ -28,7 +28,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
   test('should display Certification center detail', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
@@ -47,7 +47,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
   test('should display Certification center habilitations', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const habilitation1 = server.create('habilitation', { name: 'Pix+Edu' });
     const habilitation2 = server.create('habilitation', { name: 'Pix+Surf' });
     const certificationCenter = server.create('certification-center', {
@@ -67,7 +67,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
   test('should highlight the habilitations of the current certification center', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const habilitation1 = server.create('habilitation', { name: 'Pix+Edu' });
     const habilitation2 = server.create('habilitation', { name: 'Pix+Surf' });
     const certificationCenter = server.create('certification-center', {
@@ -90,7 +90,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
   test('should display Certification center memberships', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
       externalId: 'ABCDEF',
@@ -115,7 +115,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
   test('should be possible to desactive a certification center membership', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const user = server.create('user', { firstName: 'Lili' });
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
@@ -139,7 +139,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   module('To add certification center membership', function () {
     test('should display elements to add certification center membership', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -157,7 +157,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should disable button if email is empty or contains spaces', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -177,7 +177,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should display error message and disable button if email is invalid', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -197,7 +197,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should enable button and not display error message if email is valid', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -217,7 +217,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should display new certification-center-membership', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -241,7 +241,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   module('Update certification center', function () {
     test('should display a form after clicking on "Editer"', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -259,7 +259,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should send edited certification center to the API', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -287,7 +287,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should display a success notification when the certification has been successfully updated', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',
@@ -315,7 +315,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     test('should display an error notification when the certification has not been updated in API', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
         name: 'Center 1',
         externalId: 'ABCDEF',

--- a/admin/tests/acceptance/authenticated/certification-centers/list_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/list_test.js
@@ -23,7 +23,7 @@ module('Acceptance | Certification Centers | List', function (hooks) {
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -12,7 +12,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
   let certification;
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     this.server.create('user', { id: 888 });
 
     this.server.create('country', {

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
@@ -9,7 +9,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   module('when there is no challenge for this certification', function () {

--- a/admin/tests/acceptance/authenticated/certifications/certification/profile_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/profile_test.js
@@ -25,7 +25,7 @@ module('Acceptance | authenticated/certifications/certification/profile', functi
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should display certification id', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -11,7 +11,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   module('editing organization', function () {

--- a/admin/tests/acceptance/authenticated/organizations/list_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/list_test.js
@@ -22,7 +22,7 @@ module('Acceptance | Organizations | List', function (hooks) {
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -12,7 +12,7 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
   let organization;
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     organization = this.server.create('organization');
   });
 

--- a/admin/tests/acceptance/authenticated/organizations/target-profiles-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/target-profiles-management_test.js
@@ -9,7 +9,7 @@ module('Acceptance | Organizations | Target profiles management', function (hook
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   test('should display organization target profiles', async function (assert) {

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
@@ -25,7 +25,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async function () {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('visiting /sessions/list/to-be-published', async function (assert) {

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action_test.js
@@ -33,7 +33,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
         userId,
         firstName,
         lastName,
-        role: 'SUPER_ADMIN',
+        isSuperAdmin: true,
       });
       await createAuthenticateSession({ userId });
     });

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -23,7 +23,7 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async function () {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       server.create('session', { id: '1' });
     });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -24,7 +24,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -13,7 +13,7 @@ module('Acceptance | Target Profiles | Target Profile | Insights', function (hoo
 
   hooks.beforeEach(async function () {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
     targetProfile = this.server.create('target-profile', { name: 'Profil cible du ghetto' });
     this.server.create('badge', { id: 100, title: 'My badge', imageUrl: 'http://images.pix.fr/badges/ag2r.svg' });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
@@ -11,7 +11,7 @@ module('Acceptance | Target Profiles | Target Profile | Organizations', function
   let targetProfile;
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     targetProfile = this.server.create('target-profile', { name: 'Profil cible du ghetto' });
   });
 

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -3,7 +3,6 @@ import { currentURL } from '@ember/test-helpers';
 import { visit, clickByName, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { roles } from 'pix-admin/models/admin-member';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 
 module('Acceptance | Team | List', function (hooks) {
@@ -22,7 +21,7 @@ module('Acceptance | Team | List', function (hooks) {
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {
@@ -48,13 +47,25 @@ module('Acceptance | Team | List', function (hooks) {
 
     test('it should be possible to change the role of a member', async function (assert) {
       // given
-      server.create('admin-member', { id: 5, firstName: 'Elise', lastName: 'Emoi', role: roles.SUPER_ADMIN });
-      server.create('admin-member', { id: 3, firstName: 'Anne', lastName: 'Estésie', role: roles.SUPPORT });
+      server.create('admin-member', {
+        id: 5,
+        firstName: 'Elise',
+        lastName: 'Emoi',
+        role: 'SUPER_ADMIN',
+        isSuperAdmin: true,
+      });
+      server.create('admin-member', {
+        id: 3,
+        firstName: 'Anne',
+        lastName: 'Estésie',
+        role: 'SUPPORT',
+        isSupport: true,
+      });
 
       // when
       const screen = await visit('/equipe');
       await clickByName('Modifier le rôle de Anne Estésie');
-      await selectByLabelAndOption('Sélectionner un rôle', roles.CERTIF);
+      await selectByLabelAndOption('Sélectionner un rôle', 'CERTIF');
       await clickByName('Valider la modification de rôle');
 
       // then
@@ -64,8 +75,20 @@ module('Acceptance | Team | List', function (hooks) {
 
     test('it should show an error when modification is not successful and not modify user role', async function (assert) {
       // given
-      server.create('admin-member', { id: 5, firstName: 'Elise', lastName: 'Emoi', role: roles.SUPER_ADMIN });
-      server.create('admin-member', { id: 377, firstName: 'Anne', lastName: 'Estésie', role: roles.SUPPORT });
+      server.create('admin-member', {
+        id: 5,
+        firstName: 'Elise',
+        lastName: 'Emoi',
+        role: 'SUPER_ADMIN',
+        isSuperAdmin: true,
+      });
+      server.create('admin-member', {
+        id: 377,
+        firstName: 'Anne',
+        lastName: 'Estésie',
+        role: 'SUPPORT',
+        isSupport: true,
+      });
 
       this.server.patch(
         '/admin/admin-members/:id',
@@ -78,7 +101,7 @@ module('Acceptance | Team | List', function (hooks) {
       // when
       const screen = await visit('/equipe');
       await clickByName('Modifier le rôle de Anne Estésie');
-      await selectByLabelAndOption('Sélectionner un rôle', roles.CERTIF);
+      await selectByLabelAndOption('Sélectionner un rôle', 'CERTIF');
       await clickByName('Valider la modification de rôle');
 
       // then

--- a/admin/tests/acceptance/authenticated/users/authentication-method_test.js
+++ b/admin/tests/acceptance/authenticated/users/authentication-method_test.js
@@ -11,7 +11,7 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
   module('when adding Pix authentication method', function () {
     test("should display Pix authentication method with email's information", async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       const firstName = 'Alice';
       const lastName = 'Merveille';
@@ -38,7 +38,7 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
 
     test('should stay on modal if email already existing for an other user', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       const firstName = 'Alice';
       const lastName = 'Merveille';
@@ -65,7 +65,7 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
   module('when reassign Gar authentication method', function () {
     test('should remove Gar authentication method information', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       const firstName = 'Alice';
       const lastName = 'Merveille';
@@ -93,7 +93,7 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
   module('when reassign Pole Emploi authentication method', function () {
     test('should remove Pole Emploi authentication method information', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       const firstName = 'Alice';
       const lastName = 'Merveille';

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -11,7 +11,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   let currentUser;
 
   hooks.beforeEach(async function () {
-    currentUser = await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    currentUser = await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   test('User detail page can be accessed by URL /users/:id', async function (assert) {

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor_test.js
@@ -12,7 +12,7 @@ module('Acceptance | Session page', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   module('Access', function () {

--- a/admin/tests/acceptance/organization-invitations-management_test.js
+++ b/admin/tests/acceptance/organization-invitations-management_test.js
@@ -22,7 +22,7 @@ module('Acceptance | organization invitations management', function (hooks) {
 
   test('should display invitations tab', async function (assert) {
     // given
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const organization = this.server.create('organization');
 
     // when
@@ -35,7 +35,7 @@ module('Acceptance | organization invitations management', function (hooks) {
   module('inviting a member', function () {
     test('should create an organization-invitation', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const organization = this.server.create('organization');
 
       // when
@@ -52,7 +52,7 @@ module('Acceptance | organization invitations management', function (hooks) {
 
     test('should display an error if the creation has failed', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const organization = this.server.create('organization');
 
       this.server.post(

--- a/admin/tests/acceptance/routes-protection_test.js
+++ b/admin/tests/acceptance/routes-protection_test.js
@@ -19,7 +19,7 @@ module('Acceptance | routes protection', function (hooks) {
 
     test('authenticated users can visit /organizations/new', async function (assert) {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       // when
       await visit('/organizations/new');

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -26,7 +26,7 @@ module('Acceptance | Session pages', function (hooks) {
 
     hooks.beforeEach(async () => {
       // given
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       session = server.create('session', {
         id: 1,

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -22,7 +22,7 @@ module('Acceptance | Session List', function (hooks) {
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/acceptance/tools_test.js
+++ b/admin/tests/acceptance/tools_test.js
@@ -10,7 +10,7 @@ module('Acceptance | tools', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   module('Access', function () {

--- a/admin/tests/acceptance/user-details-personal-information_test.js
+++ b/admin/tests/acceptance/user-details-personal-information_test.js
@@ -25,7 +25,7 @@ module('Acceptance | User details personal information', function (hooks) {
     user.save();
     server.create('admin-member', {
       userId: user.id,
-      role: 'SUPER_ADMIN',
+      isSuperAdmin: true,
     });
     await createAuthenticateSession({ userId: user.id });
 

--- a/admin/tests/acceptance/user-list_test.js
+++ b/admin/tests/acceptance/user-list_test.js
@@ -22,7 +22,7 @@ module('Acceptance | User List', function (hooks) {
 
   module('When user is logged in', function (hooks) {
     hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
     test('it should be accessible for an authenticated user', async function (assert) {

--- a/admin/tests/helpers/test-init.js
+++ b/admin/tests/helpers/test-init.js
@@ -9,10 +9,10 @@ export async function createAuthenticateSession({ userId }) {
   });
 }
 
-export function authenticateAdminMemberWithRole({ role }) {
+export function authenticateAdminMemberWithRole({ isSuperAdmin, isCertif, isSupport, isMetier } = {}) {
   return async (server) => {
     const user = server.create('user');
-    server.create('admin-member', { role, userId: user.id });
+    server.create('admin-member', { isSuperAdmin, isCertif, isSupport, isMetier, userId: user.id });
     await createAuthenticateSession({ userId: user.id });
     return user;
   };

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -14,7 +14,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
   let session;
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ role: 'SUPER_ADMIN' })(server);
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
   module('regardless of session status', function () {

--- a/admin/tests/integration/components/team/list_test.js
+++ b/admin/tests/integration/components/team/list_test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
-import { roles } from 'pix-admin/models/admin-member';
 
 module('Integration | Component | team | list', function (hooks) {
   setupRenderingTest(hooks);
@@ -14,7 +13,8 @@ module('Integration | Component | team | list', function (hooks) {
         firstName: 'Marie',
         lastName: 'Tim',
         email: 'marie.tim@example.net',
-        role: roles.SUPER_ADMIN,
+        role: 'SUPER_ADMIN',
+        isSuperAdmin: true,
       },
     ]);
 

--- a/admin/tests/unit/models/admin-member_test.js
+++ b/admin/tests/unit/models/admin-member_test.js
@@ -24,4 +24,41 @@ module('Unit | Model | admin-member', function (hooks) {
       assert.strictEqual(fullName, 'Jean-Baptiste Poquelin');
     });
   });
+
+  module('hasAccess', function () {
+    test('it should return true if current user has the given right', function (assert) {
+      // given
+      const adminMember = run(() => {
+        return store.createRecord('adminMember', {
+          firstName: 'Jean-Baptiste',
+          lastName: 'Poquelin',
+          isSuperAdmin: true,
+        });
+      });
+
+      // when
+      const hasAdminMemberAccess = adminMember.hasAccess(['isCertif', 'isSuperAdmin']);
+
+      // then
+      assert.true(hasAdminMemberAccess);
+    });
+
+    test('it should return false if current user does not have the given right', function (assert) {
+      // given
+      const adminMember = run(() => {
+        return store.createRecord('adminMember', {
+          firstName: 'Jean-Baptiste',
+          lastName: 'Poquelin',
+          isSuperAdmin: false,
+          isCertif: false,
+        });
+      });
+
+      // when
+      const hasAdminMemberAccess = adminMember.hasAccess(['isCertif', 'isSuperAdmin']);
+
+      // then
+      assert.false(hasAdminMemberAccess);
+    });
+  });
 });

--- a/api/lib/domain/models/AdminMember.js
+++ b/api/lib/domain/models/AdminMember.js
@@ -33,4 +33,20 @@ module.exports = class AdminMember {
   get hasAccessToAdminScope() {
     return this.role in ROLES;
   }
+
+  get isSuperAdmin() {
+    return this.role === ROLES.SUPER_ADMIN;
+  }
+
+  get isCertif() {
+    return this.role === ROLES.CERTIF;
+  }
+
+  get isMetier() {
+    return this.role === ROLES.METIER;
+  }
+
+  get isSupport() {
+    return this.role === ROLES.SUPPORT;
+  }
 };

--- a/api/lib/infrastructure/serializers/jsonapi/admin-member-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/admin-member-serializer.js
@@ -3,7 +3,17 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(adminMembers, meta) {
     return new Serializer('admin-member', {
-      attributes: ['firstName', 'lastName', 'email', 'role', 'userId'],
+      attributes: [
+        'firstName',
+        'lastName',
+        'email',
+        'role',
+        'userId',
+        'isSuperAdmin',
+        'isCertif',
+        'isMetier',
+        'isSupport',
+      ],
       meta,
     }).serialize(adminMembers);
   },

--- a/api/tests/unit/domain/models/AdminMember_test.js
+++ b/api/tests/unit/domain/models/AdminMember_test.js
@@ -87,7 +87,7 @@ describe('Unit | Domain | Models | AdminMember', function () {
     });
   });
 
-  describe('the attribute "hasAccessToAdminScope"', function () {
+  describe('#hasAccessToAdminScope', function () {
     it('should be true if user has a non-disabled allowed role', function () {
       // given
       const adminMemberRawDetails = {
@@ -106,6 +106,78 @@ describe('Unit | Domain | Models | AdminMember', function () {
 
       // then
       expect(hasAccess).to.be.true;
+    });
+  });
+
+  describe('#isSuperAdmin', function () {
+    it('should be true if user has Super Admin role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.SUPER_ADMIN });
+
+      // when / then
+      expect(user.isSuperAdmin).to.be.true;
+    });
+
+    it('should be false if user has not Super Admin role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.CERTIF });
+
+      // when / then
+      expect(user.isSuperAdmin).to.be.false;
+    });
+  });
+
+  describe('#isCertif', function () {
+    it('should be true if user has Certif role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.CERTIF });
+
+      // when / then
+      expect(user.isCertif).to.be.true;
+    });
+
+    it('should be false if user has not Certif role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.METIER });
+
+      // when / then
+      expect(user.isCertif).to.be.false;
+    });
+  });
+
+  describe('#isMetier', function () {
+    it('should be true if user has Metier role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.METIER });
+
+      // when / then
+      expect(user.isMetier).to.be.true;
+    });
+
+    it('should be false if user has not Metier role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.SUPER_ADMIN });
+
+      // when / then
+      expect(user.isMetier).to.be.false;
+    });
+  });
+
+  describe('#isSupport', function () {
+    it('should be true if user has Support role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.SUPPORT });
+
+      // when / then
+      expect(user.isSupport).to.be.true;
+    });
+
+    it('should be false if user has not Support role', function () {
+      // given
+      const user = new AdminMember({ id: 7, role: ROLES.METIER });
+
+      // when / then
+      expect(user.isSupport).to.be.false;
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/admin-member-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/admin-member-serializer_test.js
@@ -28,6 +28,10 @@ describe('Unit | Serializer | JSONAPI | admin-member-serializer', function () {
             'user-id': 7,
             email: 'ivan.iakovlievitch@pix.fr',
             role: 'SUPER_ADMIN',
+            'is-certif': false,
+            'is-metier': false,
+            'is-super-admin': true,
+            'is-support': false,
           },
         },
       });


### PR DESCRIPTION
## :unicorn: Problème
Pour pouvoir paralléliser les prochaines tâches (sur la restriction des accès selon les rôles dans Pix Admin), il était nécessaire de mettre en place des helpers / propriétés en commun que nous pourrons utiliser dans les fichiers routes et templates.

## :robot: Solution
Rajouter les briques nécessaires pour simplifier la parallélisation de la restriction des rôles à certaines pages de Pix Admin.

## :rainbow: Remarques
Par exemple, il est possible maintenant de restreindre l'accès de la liste des sessions aux utilisateurs de Pix Admin ayant le rôle Super Admin OU Certif avec : 
```
import Route from '@ember/routing/route';
import { inject as service } from '@ember/service';

export default class AuthenticatedSessionsWithRequiredActionListRoute extends Route {
  @service router;
  @service currentUser;

  beforeModel() {
    if (!this.currentUser.adminMember.hasAccess(['isSuperAdmin', 'isCertif'])) {
      this.router.transitionTo('/');
    }
  }

  model() {
    return this.modelFor('authenticated.sessions.list');
  }
}
```
Ou encore côté hbs : 
```
{{#if this.currentUser.adminMember.isSuperAdmin}}
     // html à n'afficher qu'aux super admin
{{/if}
```

## :100: Pour tester
Vérifier que les tests passent.
Pour les plus téméraires rajouter le code du dessus (avec le beforeModel) dans la route `admin/app/routes/authenticated/sessions/list/with-required-action.js` puis : 
- se connecter avec `superadmin@example.net` et constater que vous avez accès la liste des sessions 
- se connecter avec `pixcertif@example.net` et constater que vous avez accès la liste des sessions 
- se connecter avec `pixmetier@example.net` et constater que vous n'avez PAS accès la liste des sessions 
- se connecter avec `pixsupport@example.net` et constater que vous n'avez PAS accès la liste des sessions 
