### PR TITLE
[TECH] Suppression de l'attribut `campaignParticipation` dans le modèle `Assessment` (PIX-4898).

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -50,7 +50,6 @@ class Assessment {
     lastChallengeId,
     lastQuestionState,
     answers = [],
-    campaignParticipation,
     course,
     targetProfile,
     lastQuestionDate,
@@ -72,7 +71,6 @@ class Assessment {
     this.lastChallengeId = lastChallengeId;
     this.lastQuestionState = lastQuestionState;
     this.answers = answers.map((answer) => new Answer(answer));
-    this.campaignParticipation = campaignParticipation;
     this.course = course;
     this.targetProfile = targetProfile;
     this.lastQuestionDate = lastQuestionDate;

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -60,6 +60,7 @@ class Assessment {
     competenceId,
     campaignParticipationId,
     method,
+    campaignCode,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -81,6 +82,7 @@ class Assessment {
     this.competenceId = competenceId;
     this.campaignParticipationId = campaignParticipationId;
     this.method = method || Assessment.computeMethodFromType(this.type);
+    this.campaignCode = campaignCode;
   }
 
   isCompleted() {

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -1,5 +1,6 @@
 const hashInt = require('hash-int');
 const { ObjectValidationError } = require('../errors');
+const Answer = require('./Answer');
 
 const courseIdMessage = {
   COMPETENCE_EVALUATION: '[NOT USED] CompetenceId is in Competence Evaluation.',
@@ -69,7 +70,7 @@ class Assessment {
     this.isImproving = isImproving;
     this.lastChallengeId = lastChallengeId;
     this.lastQuestionState = lastQuestionState;
-    this.answers = answers;
+    this.answers = answers.map((answer) => new Answer(answer));
     this.campaignParticipation = campaignParticipation;
     this.course = course;
     this.targetProfile = targetProfile;
@@ -104,9 +105,8 @@ class Assessment {
 
   validate() {
     if (TYPES_OF_ASSESSMENT_NEEDING_USER.includes(this.type) && !this.userId) {
-      return Promise.reject(new ObjectValidationError(`Assessment ${this.type} needs an User Id`));
+      return new ObjectValidationError(`Assessment ${this.type} needs an User Id`);
     }
-    return Promise.resolve();
   }
 
   isPreview() {

--- a/api/lib/domain/usecases/get-assessment.js
+++ b/api/lib/domain/usecases/get-assessment.js
@@ -7,8 +7,9 @@ module.exports = async function getAssessment({
   assessmentRepository,
   competenceRepository,
   courseRepository,
+  campaignRepository,
 }) {
-  const assessment = await assessmentRepository.getWithAnswersAndCampaignParticipation(assessmentId);
+  const assessment = await assessmentRepository.getWithAnswers(assessmentId);
   if (!assessment) {
     throw new NotFoundError(`Assessment not found for ID ${assessmentId}`);
   }
@@ -18,29 +19,30 @@ module.exports = async function getAssessment({
     locale,
     competenceRepository,
     courseRepository,
+    campaignRepository,
   });
 
   return assessment;
 };
 
-async function _fetchAssessmentTitle({ assessment, locale, competenceRepository, courseRepository }) {
+function _fetchAssessmentTitle({ assessment, locale, competenceRepository, courseRepository, campaignRepository }) {
   switch (assessment.type) {
     case Assessment.types.CERTIFICATION: {
       return assessment.certificationCourseId;
     }
 
     case Assessment.types.COMPETENCE_EVALUATION: {
-      return await competenceRepository.getCompetenceName({ id: assessment.competenceId, locale });
+      return competenceRepository.getCompetenceName({ id: assessment.competenceId, locale });
     }
 
     case Assessment.types.DEMO: {
-      return await courseRepository.getCourseName(assessment.courseId);
+      return courseRepository.getCourseName(assessment.courseId);
     }
     case Assessment.types.PREVIEW: {
       return 'Preview';
     }
     case Assessment.types.CAMPAIGN: {
-      return assessment.campaignParticipation.campaign.title;
+      return campaignRepository.getCampaignTitleByCampaignParticipationId(assessment.campaignParticipationId);
     }
 
     default:

--- a/api/lib/domain/usecases/get-assessment.js
+++ b/api/lib/domain/usecases/get-assessment.js
@@ -11,7 +11,7 @@ module.exports = async function getAssessment({
 }) {
   const assessment = await assessmentRepository.getWithAnswers(assessmentId);
   if (!assessment) {
-    throw new NotFoundError(`Assessment not found for ID ${assessmentId}`);
+    throw new NotFoundError(`Assessment not found for ID ${assessmentId}`); // move
   }
 
   assessment.title = await _fetchAssessmentTitle({
@@ -22,6 +22,11 @@ module.exports = async function getAssessment({
     campaignRepository,
   });
 
+  if (assessment.type === Assessment.types.CAMPAIGN) {
+    assessment.campaignCode = await campaignRepository.getCampaignCodeByCampaignParticipationId(
+      assessment.campaignParticipationId
+    );
+  }
   return assessment;
 };
 

--- a/api/lib/domain/usecases/get-assessment.js
+++ b/api/lib/domain/usecases/get-assessment.js
@@ -1,4 +1,3 @@
-const { NotFoundError } = require('../errors');
 const Assessment = require('../models/Assessment');
 
 module.exports = async function getAssessment({
@@ -10,9 +9,6 @@ module.exports = async function getAssessment({
   campaignRepository,
 }) {
   const assessment = await assessmentRepository.getWithAnswers(assessmentId);
-  if (!assessment) {
-    throw new NotFoundError(`Assessment not found for ID ${assessmentId}`); // move
-  }
 
   assessment.title = await _fetchAssessmentTitle({
     assessment,

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -185,5 +185,6 @@ function _adaptModelToDb(assessment) {
     'campaign',
     'campaignParticipation',
     'title',
+    'campaignCode',
   ]);
 }

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -9,7 +9,9 @@ const { knex } = require('../bookshelf');
 module.exports = {
   async getWithAnswers(id) {
     const [assessment] = await knex('assessments').where('assessments.id', id);
-    if (!assessment) return null;
+    if (!assessment) {
+      throw new NotFoundError(`Assessment not found for ID ${id}`);
+    }
 
     const answers = await knex('answers')
       .select('id', 'challengeId', 'value')

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -7,7 +7,7 @@ const { NotFoundError } = require('../../domain/errors');
 const { knex } = require('../bookshelf');
 
 module.exports = {
-  async getWithAnswersAndCampaignParticipation(id) {
+  async getWithAnswers(id) {
     const bookshelfAssessment = await BookshelfAssessment.where('id', id).fetch({
       require: false,
       withRelated: [
@@ -16,8 +16,6 @@ module.exports = {
             query.orderBy('createdAt', 'ASC');
           },
         },
-        'campaignParticipation',
-        'campaignParticipation.campaign',
       ],
     });
 

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -94,4 +94,15 @@ module.exports = {
     if (!campaign) return null;
     return campaign.title;
   },
+
+  async getCampaignCodeByCampaignParticipationId(campaignParticipationId) {
+    const campaign = await knex('campaigns')
+      .select('code')
+      .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+      .where({ 'campaign-participations.id': campaignParticipationId })
+      .first();
+
+    if (!campaign) return null;
+    return campaign.code;
+  },
 };

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const BookshelfCampaign = require('../orm-models/Campaign');
 const { NotFoundError } = require('../../domain/errors');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const { knex } = require('../../../db/knex-database-connection');
 
 module.exports = {
   isCodeAvailable(code) {
@@ -81,5 +82,16 @@ module.exports = {
 
     const campaign = bookshelfToDomainConverter.buildDomainObject(BookshelfCampaign, bookshelfCampaign);
     return campaign.isArchived();
+  },
+
+  async getCampaignTitleByCampaignParticipationId(campaignParticipationId) {
+    const campaign = await knex('campaigns')
+      .select('title')
+      .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+      .where({ 'campaign-participations.id': campaignParticipationId })
+      .first();
+
+    if (!campaign) return null;
+    return campaign.title;
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -31,8 +31,6 @@ module.exports = {
           assessment.course = { id: currentAssessment.courseId };
         }
 
-        assessment.title = currentAssessment.title;
-
         return assessment;
       },
       attributes: [

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -23,8 +23,8 @@ module.exports = {
           };
         }
 
-        if (currentAssessment.campaignParticipation && currentAssessment.campaignParticipation.campaign) {
-          assessment.codeCampaign = currentAssessment.campaignParticipation.campaign.code;
+        if (currentAssessment.type === Assessment.types.CAMPAIGN) {
+          assessment.codeCampaign = currentAssessment.campaignCode;
         }
 
         if (!currentAssessment.course) {

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -15,7 +15,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     return knex('assessments').delete();
   });
 
-  describe('#getWithAnswersAndCampaignParticipation', function () {
+  describe('#getWithAnswers', function () {
     let assessmentId;
 
     context('when the assessment exists', function () {
@@ -49,7 +49,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
       it('should return the assessment with the answers sorted by creation date ', async function () {
         // when
-        const assessment = await assessmentRepository.getWithAnswersAndCampaignParticipation(assessmentId);
+        const assessment = await assessmentRepository.getWithAnswers(assessmentId);
 
         // then
         expect(assessment).to.be.an.instanceOf(Assessment);
@@ -68,7 +68,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     context('when the assessment does not exist', function () {
       it('should return null', async function () {
         // when
-        const assessment = await assessmentRepository.getWithAnswersAndCampaignParticipation(245);
+        const assessment = await assessmentRepository.getWithAnswers(245);
 
         // then
         expect(assessment).to.equal(null);

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -78,10 +78,10 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     context('when the assessment does not exist', function () {
       it('should return null', async function () {
         // when
-        const assessment = await assessmentRepository.getWithAnswers(245);
+        const error = await catchErr(assessmentRepository.getWithAnswers)(245);
 
         // then
-        expect(assessment).to.equal(null);
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -20,16 +20,21 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
     context('when the assessment exists', function () {
       beforeEach(async function () {
+        assessmentId = databaseBuilder.factory.buildAssessment({
+          courseId: 'course_A',
+          state: 'completed',
+        }).id;
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return the assessment with the answers sorted by creation date', async function () {
+        //given
         const dateOfFirstAnswer = moment.utc().subtract(3, 'minute').toDate();
         const dateOfSecondAnswer = moment.utc().subtract(2, 'minute').toDate();
         const dateOfThirdAnswer = moment.utc().subtract(1, 'minute').toDate();
         moment.utc().toDate();
         const dateOfFourthAnswer = moment.utc().toDate();
-
-        assessmentId = databaseBuilder.factory.buildAssessment({
-          courseId: 'course_A',
-          state: 'completed',
-        }).id;
 
         _.each(
           [
@@ -43,11 +48,8 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
             databaseBuilder.factory.buildAnswer(answer);
           }
         );
-
         await databaseBuilder.commit();
-      });
 
-      it('should return the assessment with the answers sorted by creation date ', async function () {
         // when
         const assessment = await assessmentRepository.getWithAnswers(assessmentId);
 
@@ -62,6 +64,14 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         expect(assessment.answers[1].challengeId).to.equal('challenge_1_4');
         expect(assessment.answers[2].challengeId).to.equal('challenge_2_8');
         expect(assessment.answers[2].value).to.equal('2,8');
+      });
+
+      it('should return the assessment with no answers', async function () {
+        // when
+        const assessment = await assessmentRepository.getWithAnswers(assessmentId);
+
+        // then
+        expect(assessment.answers).to.have.lengthOf(0);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -340,4 +340,58 @@ describe('Integration | Repository | Campaign', function () {
       expect(campaignIsArchived).to.be.false;
     });
   });
+
+  describe('#getCampaignTitleByCampaignParticipationId', function () {
+    it('should return campaign title when campaign has one', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ title: 'Parcours trop bien' }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const title = await campaignRepository.getCampaignTitleByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(title).to.equal('Parcours trop bien');
+    });
+
+    it('should return null when campaign has no title', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ title: null }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const title = await campaignRepository.getCampaignTitleByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(title).to.be.null;
+    });
+
+    it('should return null when campaignParticipationId does not exist', async function () {
+      // when
+      const title = await campaignRepository.getCampaignTitleByCampaignParticipationId(123);
+
+      // then
+      expect(title).to.be.null;
+    });
+
+    it('should return the title from the given campaignParticipationId', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ title: 'Parcours trop bien' }).id;
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+      const otherCampaignId = databaseBuilder.factory.buildCampaign({ title: 'Autre' }).id;
+      const otherCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const title = await campaignRepository.getCampaignTitleByCampaignParticipationId(otherCampaignParticipationId);
+
+      // then
+      expect(title).to.equal('Autre');
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -394,4 +394,45 @@ describe('Integration | Repository | Campaign', function () {
       expect(title).to.equal('Autre');
     });
   });
+
+  describe('#getCampaignCodeByCampaignParticipationId', function () {
+    it('should return campaign code when campaign has one', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ code: 'CAMPAIGN1' }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const code = await campaignRepository.getCampaignCodeByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(code).to.equal('CAMPAIGN1');
+    });
+
+    it('should return null when campaignParticipationId does not exist', async function () {
+      // when
+      const code = await campaignRepository.getCampaignCodeByCampaignParticipationId(123);
+
+      // then
+      expect(code).to.be.null;
+    });
+
+    it('should return the code from the given campaignParticipationId', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ code: 'CAMPAIGN1' }).id;
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+
+      const otherCampaignId = databaseBuilder.factory.buildCampaign({ code: 'CAMPAIGN2' }).id;
+      const otherCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const code = await campaignRepository.getCampaignCodeByCampaignParticipationId(otherCampaignParticipationId);
+
+      // then
+      expect(code).to.equal('CAMPAIGN2');
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment.js
@@ -26,9 +26,9 @@ function buildAssessment({
   lastChallengeId = null,
   lastQuestionState = Assessment.statesOfLastQuestion.ASKED,
   method,
+  campaignCode,
 } = {}) {
   return new Assessment({
-    // attributes
     id,
     courseId,
     certificationCourseId,
@@ -43,11 +43,11 @@ function buildAssessment({
     lastQuestionDate,
     lastChallengeId,
     lastQuestionState,
-    // relationships
     answers,
     course,
     campaignParticipation,
     method,
+    campaignCode,
   });
 }
 
@@ -70,6 +70,7 @@ buildAssessment.ofTypeCampaign = function ({
   campaignParticipationId = null,
   title = 'campaignTitle',
   method,
+  campaignCode,
 } = {}) {
   if (!_.isNil(campaignParticipation) && _.isNil(campaignParticipationId)) {
     campaignParticipationId = campaignParticipation.id;
@@ -83,7 +84,6 @@ buildAssessment.ofTypeCampaign = function ({
   }
 
   return new Assessment({
-    // attributes
     id,
     courseId,
     createdAt,
@@ -98,12 +98,12 @@ buildAssessment.ofTypeCampaign = function ({
     lastQuestionDate,
     lastChallengeId,
     lastQuestionState,
-    // relationships
     answers,
     course,
     targetProfile,
     campaignParticipation,
     method,
+    campaignCode,
   });
 };
 
@@ -128,7 +128,6 @@ buildAssessment.ofTypeCompetenceEvaluation = function ({
   competenceId = 789,
 } = {}) {
   return new Assessment({
-    // attributes
     id,
     courseId,
     certificationCourseId: null,
@@ -144,12 +143,12 @@ buildAssessment.ofTypeCompetenceEvaluation = function ({
     lastQuestionDate,
     lastChallengeId,
     lastQuestionState,
-    // relationships
     answers,
     course,
     targetProfile,
     knowledgeElements,
     campaignParticipation,
+    campaignCode: null,
   });
 };
 

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -83,43 +83,48 @@ describe('Unit | Domain | Models | Assessment', function () {
       assessment = new Assessment({ type: 'DEMO' });
 
       // when
-      const promise = assessment.validate();
+      const call = () => {
+        assessment.validate();
+      };
 
       // then
-      return expect(promise).to.be.fulfilled;
+      expect(call).to.not.throw();
     });
 
-    it('should return rejected promise when Certification assessment has no userId', function () {
+    it('should throw an error when Certification assessment has no userId', function () {
       //given
       assessment = new Assessment({ type: 'CERTIFICATION' });
 
       // when
-      const promise = assessment.validate();
-
-      // then
-      return expect(promise).to.be.rejected;
+      try {
+        assessment.validate();
+      } catch (e) {
+        expect.fail('ObjectValidationError');
+      }
     });
 
-    it('should return rejected promise when Competence evaluation assessment has no userId', function () {
+    it('should throw an error when Competence evaluation assessment has no userId', function () {
       //given
       assessment = new Assessment({ type: 'COMPETENCE_EVALUATION' });
 
       // when
-      const promise = assessment.validate();
-
-      // then
-      return expect(promise).to.be.rejected;
+      try {
+        assessment.validate();
+      } catch (e) {
+        expect.fail('ObjectValidationError');
+      }
     });
 
-    it('should return rejected promise when Campaign assessment has no userId', function () {
+    it('should throw an error when Campaign assessment has no userId', function () {
       //given
       assessment = new Assessment({ type: 'CAMPAIGN' });
 
       // when
-      const promise = assessment.validate();
-
-      // then
-      return expect(promise).to.be.rejected;
+      try {
+        assessment.validate();
+      } catch (e) {
+        expect.fail('ObjectValidationError');
+      }
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -16,12 +16,12 @@ describe('Unit | UseCase | get-assessment', function () {
   let course;
   const certificationCourseId = 1;
 
-  const expectedCampaignName = 'Campagne Il';
+  const expectedCampaignTitle = 'Campagne Il';
   const expectedCourseName = 'Course Àpieds';
   const expectedAssessmentTitle = 'Traiter des données';
 
   beforeEach(function () {
-    campaign = domainBuilder.buildCampaign.ofTypeAssessment({ title: expectedCampaignName });
+    campaign = domainBuilder.buildCampaign.ofTypeAssessment({ title: expectedCampaignTitle });
     campaignParticipation = domainBuilder.buildCampaignParticipation({ campaign });
     competence = domainBuilder.buildCompetence({ id: 'recsvLz0W2ShyfD63', name: expectedAssessmentTitle });
     course = domainBuilder.buildCourse({ id: 'ABC123', name: expectedCourseName });
@@ -33,15 +33,15 @@ describe('Unit | UseCase | get-assessment', function () {
       certificationCourseId,
     });
 
-    sinon.stub(assessmentRepository, 'getWithAnswersAndCampaignParticipation');
-    sinon.stub(campaignRepository, 'get');
+    sinon.stub(assessmentRepository, 'getWithAnswers');
+    sinon.stub(campaignRepository, 'getCampaignTitleByCampaignParticipationId');
     sinon.stub(competenceRepository, 'getCompetenceName');
     sinon.stub(courseRepository, 'getCourseName');
   });
 
   it('should resolve the Assessment domain object matching the given assessment ID', async function () {
     // given
-    assessmentRepository.getWithAnswersAndCampaignParticipation.resolves(assessment);
+    assessmentRepository.getWithAnswers.resolves(assessment);
 
     // when
     const result = await getAssessment({ assessmentRepository, assessmentId: assessment.id });
@@ -55,7 +55,7 @@ describe('Unit | UseCase | get-assessment', function () {
     // given
     const locale = 'fr';
     assessment.type = Assessment.types.COMPETENCE_EVALUATION;
-    assessmentRepository.getWithAnswersAndCampaignParticipation.withArgs(assessment.id).resolves(assessment);
+    assessmentRepository.getWithAnswers.withArgs(assessment.id).resolves(assessment);
     competenceRepository.getCompetenceName.withArgs({ id: assessment.competenceId, locale }).resolves(competence.name);
 
     // when
@@ -75,7 +75,7 @@ describe('Unit | UseCase | get-assessment', function () {
   it('should resolve the Assessment domain object with CERTIFICATION title matching the given assessment ID', async function () {
     // given
     assessment.type = Assessment.types.CERTIFICATION;
-    assessmentRepository.getWithAnswersAndCampaignParticipation.resolves(assessment);
+    assessmentRepository.getWithAnswers.resolves(assessment);
 
     // when
     const result = await getAssessment({
@@ -93,7 +93,7 @@ describe('Unit | UseCase | get-assessment', function () {
   it('should resolve the Assessment domain object with DEMO title matching the given assessment ID', async function () {
     // given
     assessment.type = Assessment.types.DEMO;
-    assessmentRepository.getWithAnswersAndCampaignParticipation.withArgs(assessment.id).resolves(assessment);
+    assessmentRepository.getWithAnswers.withArgs(assessment.id).resolves(assessment);
     courseRepository.getCourseName.withArgs(assessment.courseId).resolves(course.name);
 
     // when
@@ -112,7 +112,10 @@ describe('Unit | UseCase | get-assessment', function () {
   it('should resolve the Assessment domain object with CAMPAIGN title matching the given assessment ID', async function () {
     // given
     assessment.type = Assessment.types.CAMPAIGN;
-    assessmentRepository.getWithAnswersAndCampaignParticipation.withArgs(assessment.id).resolves(assessment);
+    assessmentRepository.getWithAnswers.withArgs(assessment.id).resolves(assessment);
+    campaignRepository.getCampaignTitleByCampaignParticipationId
+      .withArgs(assessment.campaignParticipationId)
+      .resolves(expectedCampaignTitle);
 
     // when
     const result = await getAssessment({
@@ -124,13 +127,13 @@ describe('Unit | UseCase | get-assessment', function () {
     // then
     expect(result).to.be.an.instanceOf(Assessment);
     expect(result.id).to.equal(assessment.id);
-    expect(result.title).to.equal(expectedCampaignName);
+    expect(result.title).to.equal(expectedCampaignTitle);
   });
 
   it('should resolve the Assessment domain object without title matching the given assessment ID', async function () {
     // given
     assessment.type = 'NO TYPE';
-    assessmentRepository.getWithAnswersAndCampaignParticipation.withArgs(assessment.id).resolves(assessment);
+    assessmentRepository.getWithAnswers.withArgs(assessment.id).resolves(assessment);
     competenceRepository.getCompetenceName.resolves(competence);
 
     // when
@@ -151,7 +154,7 @@ describe('Unit | UseCase | get-assessment', function () {
   it('should resolve the Assessment domain object with Preview title matching the given assessment ID', async function () {
     // given
     assessment.type = Assessment.types.PREVIEW;
-    assessmentRepository.getWithAnswersAndCampaignParticipation.withArgs(assessment.id).resolves(assessment);
+    assessmentRepository.getWithAnswers.withArgs(assessment.id).resolves(assessment);
 
     // when
     const result = await getAssessment({
@@ -168,7 +171,7 @@ describe('Unit | UseCase | get-assessment', function () {
 
   it('should reject a domain NotFoundError when there is no assessment for given ID', function () {
     // given
-    assessmentRepository.getWithAnswersAndCampaignParticipation.resolves(null);
+    assessmentRepository.getWithAnswers.resolves(null);
 
     // when
     const promise = getAssessment({ assessmentRepository, assessmentId: assessment.id });

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -6,7 +6,6 @@ const competenceRepository = require('../../../../lib/infrastructure/repositorie
 const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-assessment', function () {
   let assessment;
@@ -176,16 +175,5 @@ describe('Unit | UseCase | get-assessment', function () {
     expect(result).to.be.an.instanceOf(Assessment);
     expect(result.id).to.equal(assessment.id);
     expect(result.title).to.equal('Preview');
-  });
-
-  it('should reject a domain NotFoundError when there is no assessment for given ID', function () {
-    // given
-    assessmentRepository.getWithAnswers.resolves(null);
-
-    // when
-    const promise = getAssessment({ assessmentRepository, assessmentId: assessment.id });
-
-    // then
-    return expect(promise).to.have.been.rejectedWith(NotFoundError, `Assessment not found for ID ${assessment.id}`);
   });
 });

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -17,11 +17,15 @@ describe('Unit | UseCase | get-assessment', function () {
   const certificationCourseId = 1;
 
   const expectedCampaignTitle = 'Campagne Il';
+  const expectedCampaignCode = 'CAMPAIGN1';
   const expectedCourseName = 'Course Àpieds';
   const expectedAssessmentTitle = 'Traiter des données';
 
   beforeEach(function () {
-    campaign = domainBuilder.buildCampaign.ofTypeAssessment({ title: expectedCampaignTitle });
+    campaign = domainBuilder.buildCampaign.ofTypeAssessment({
+      title: expectedCampaignTitle,
+      code: expectedCampaignCode,
+    });
     campaignParticipation = domainBuilder.buildCampaignParticipation({ campaign });
     competence = domainBuilder.buildCompetence({ id: 'recsvLz0W2ShyfD63', name: expectedAssessmentTitle });
     course = domainBuilder.buildCourse({ id: 'ABC123', name: expectedCourseName });
@@ -35,6 +39,7 @@ describe('Unit | UseCase | get-assessment', function () {
 
     sinon.stub(assessmentRepository, 'getWithAnswers');
     sinon.stub(campaignRepository, 'getCampaignTitleByCampaignParticipationId');
+    sinon.stub(campaignRepository, 'getCampaignCodeByCampaignParticipationId');
     sinon.stub(competenceRepository, 'getCompetenceName');
     sinon.stub(courseRepository, 'getCourseName');
   });
@@ -116,6 +121,9 @@ describe('Unit | UseCase | get-assessment', function () {
     campaignRepository.getCampaignTitleByCampaignParticipationId
       .withArgs(assessment.campaignParticipationId)
       .resolves(expectedCampaignTitle);
+    campaignRepository.getCampaignCodeByCampaignParticipationId
+      .withArgs(assessment.campaignParticipationId)
+      .resolves(expectedCampaignCode);
 
     // when
     const result = await getAssessment({
@@ -128,6 +136,7 @@ describe('Unit | UseCase | get-assessment', function () {
     expect(result).to.be.an.instanceOf(Assessment);
     expect(result.id).to.equal(assessment.id);
     expect(result.title).to.equal(expectedCampaignTitle);
+    expect(result.campaignCode).to.equal(expectedCampaignCode);
   });
 
   it('should resolve the Assessment domain object without title matching the given assessment ID', async function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -98,6 +98,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
         type: Assessment.types.CAMPAIGN,
         campaignParticipation: { campaign: { code: 'Konami' } },
         title: 'Parcours',
+        campaignCode: 'CAMPAGNE1',
       });
       const expectedProgressionJson = {
         data: {
@@ -115,7 +116,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       // then
       expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
       expect(json.data.attributes['certification-number']).to.be.null;
-      expect(json.data.attributes['code-campaign']).to.equal('Konami');
+      expect(json.data.attributes['code-campaign']).to.equal('CAMPAGNE1');
       expect(json.data.attributes['title']).to.equal('Parcours');
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -70,9 +70,8 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       //given
       const assessment = domainBuilder.buildAssessment({
         type: Assessment.types.COMPETENCE_EVALUATION,
+        title: 'Traiter des données',
       });
-
-      assessment.title = 'Traiter des données';
 
       const expectedProgressionJson = {
         data: {
@@ -98,6 +97,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       const assessment = domainBuilder.buildAssessment({
         type: Assessment.types.CAMPAIGN,
         campaignParticipation: { campaign: { code: 'Konami' } },
+        title: 'Parcours',
       });
       const expectedProgressionJson = {
         data: {
@@ -116,13 +116,13 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
       expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
       expect(json.data.attributes['certification-number']).to.be.null;
       expect(json.data.attributes['code-campaign']).to.equal('Konami');
+      expect(json.data.attributes['title']).to.equal('Parcours');
     });
 
     it('should convert an Assessment model object with type CAMPAIGN and method FLASH into JSON API data', function () {
       //given
       const assessment = domainBuilder.buildAssessment.ofTypeCampaign({
         method: Assessment.methods.FLASH,
-        campaignParticipation: { campaign: { code: 'Konami' } },
       });
       const expectedProgressionJson = {
         data: {
@@ -139,8 +139,6 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function () {
 
       // then
       expect(json.data.relationships['progression']).to.deep.equal(expectedProgressionJson);
-      expect(json.data.attributes['certification-number']).to.be.null;
-      expect(json.data.attributes['code-campaign']).to.equal('Konami');
       expect(json.data.attributes['method']).to.equal(Assessment.methods.FLASH);
     });
 

--- a/mon-pix/app/routes/assessments/checkpoint.js
+++ b/mon-pix/app/routes/assessments/checkpoint.js
@@ -9,9 +9,5 @@ export default class CheckpointRoute extends Route {
     if (assessment.isCompetenceEvaluation || assessment.isForCampaign) {
       await assessment.belongsTo('progression').reload();
     }
-
-    if (assessment.isForCampaign) {
-      assessment.campaign = await this.store.queryRecord('campaign', { filter: { code: assessment.codeCampaign } });
-    }
   }
 }

--- a/mon-pix/tests/unit/routes/assessments/checkpoint_test.js
+++ b/mon-pix/tests/unit/routes/assessments/checkpoint_test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
@@ -43,29 +42,6 @@ describe('Unit | Route | Assessments | Checkpoint', function () {
       // then
       sinon.assert.calledWith(assessment.belongsTo, 'progression');
       sinon.assert.calledOnce(reloadStub);
-    });
-
-    it('should set campaign attribute in assessment with the right campaign when assessment is for campaign', async function () {
-      // given
-      const code = 'somecampaigncode';
-      const campaign = Symbol('Campaign');
-      const route = this.owner.lookup('route:assessments/checkpoint');
-      const reloadStub = sinon.stub();
-      const storeStub = {
-        queryRecord: sinon.stub().withArgs('campaign', { filter: { code } }).resolves(campaign),
-      };
-      route.set('store', storeStub);
-      const assessment = {
-        code,
-        isForCampaign: true,
-        belongsTo: sinon.stub().returns({ reload: reloadStub }),
-      };
-
-      // when
-      await route.afterModel(assessment);
-
-      // then
-      expect(assessment.campaign).to.deep.equal(campaign);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le modèle `Assessment`, on a à la fois `campaignParticipation` et `campaignParticipationId`.

## :robot: Solution
Dans un premier temps, nous avons regardé s'il allait falloir plutôt garder l'un ou l'autre. Il est apparu que l'on récupérait la `campaignParticipation` uniquement pour avoir accès au code campagne et au titre de la campagne. Nous avons donc décidé de supprimer le `campaignParticipationId`.

Pour attaquer le problème, nous avons décidé de suivre la Méthode Mikado : on enlève quelque chose (A), on regarde ce qui casse, on note ce qu'il faudrait faire avant de faire ça (B), et on rollback nos changements. On réitère le processus avec B, jusqu'à ce qu'on ai quelque chose ok.

Après avoir fait cet exercice, on a alors un arbre :
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/23451175/166706108-b6e058fc-68e1-4308-9c8d-c7670d985e71.png">

L'idée est donc de commencer par les feuilles de cet arbre, d'en faire des commits séparés, et donc où tous les tests sont verts ; avant de supprimer la branche principale (dernier commit), ce qui devient très facile.

## :rainbow: Remarques
Petits SR bonus

## :100: Pour tester
Non régression :
- Lancer une campagne, aller jusqu'à la fin, partager ses résultats, repasser
- Commencer un test de compétence
- Passer une certif
