### PR TITLE
[BUGFIX] Corriger l'affichage de la réponse à une épreuve dans la page de détail d'une certification dans Pix Admin (PIX-4897)

### DIFF
--- a/admin/app/components/certifications/details-answer.hbs
+++ b/admin/app/components/certifications/details-answer.hbs
@@ -27,6 +27,9 @@
     <PixSelect
       @onChange={{this.selectOption}}
       @options={{this.resultOptions}}
+      @selectedOption={{this.selectedOption}}
+      @emptyOptionLabel=""
+      @emptyOptionNotSelectable="true"
       aria-label="Sélectionner un résultat"
       @isSearchable={{false}}
       class={{this.resultClass}}

--- a/admin/app/components/certifications/details-answer.js
+++ b/admin/app/components/certifications/details-answer.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import find from 'lodash/find';
 
 const options = [
   { value: 'ok', label: 'Succès' },
@@ -24,10 +23,6 @@ export default class CertificationDetailsAnswer extends Component {
     this.selectedOption = this._answerResultValue();
   }
 
-  getOption(resultValue) {
-    return find(options, { value: resultValue });
-  }
-
   get resultClass() {
     return this.hasJuryResult ? 'jury' : null;
   }
@@ -44,8 +39,8 @@ export default class CertificationDetailsAnswer extends Component {
   selectOption(event) {
     const answer = this.args.answer;
     const answerResult = this._answerResultValue();
-    const newResult = this.getOption(event.target.value);
-    answer.jury = answerResult.value !== newResult.value ? newResult.value : null;
+    const newResult = event.target.value;
+    answer.jury = answerResult !== newResult ? newResult : null;
     this.selectedOption = newResult ?? answerResult;
     this.hasJuryResult = !!newResult;
     this.args.onUpdateRate();
@@ -53,11 +48,11 @@ export default class CertificationDetailsAnswer extends Component {
 
   _answerResultValue() {
     if (this.args.answer.isNeutralized) {
-      return this.getOption('skip');
+      return 'skip';
     }
     if (this.args.answer.hasBeenSkippedAutomatically) {
-      return this.getOption('skippedAutomatically');
+      return 'skippedAutomatically';
     }
-    return this.getOption(this.args.answer.result);
+    return this.args.answer.result;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la liste déroulante permettant de modifier le statut d'une réponse à une épreuve de certification n'affiche pas le statut actuel de la réponse mais "Succès" dans tous les cas.

## :robot: Solution
- Utiliser le paramètre `@selectedOption` de PixSelect

## :rainbow: Remarques
Pour obtenir le comportement d'avant (rien d'affiché s'il n'y a pas encore de réponse), les paramètres `emptyOptionLabel` et `emptyOptionNotSelectable` ont aussi été ajoutés.  

## :100: Pour tester
- Créer une session et inscrire un candidat.
- Commencer un test de certification et vérifier en même temps que l'affichage est bon dans Pix Admin (question ok, ko, passée...)
