### PR TITLE
[FEATURE] Récupération du niveau des acquis (PIX-4889)

### DIFF
--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -1,5 +1,5 @@
 class Skill {
-  constructor({ id, name, pixValue, competenceId, tutorialIds = [], tubeId, version } = {}) {
+  constructor({ id, name, pixValue, competenceId, tutorialIds = [], tubeId, version, level } = {}) {
     this.id = id;
     this.name = name;
     this.pixValue = pixValue;
@@ -7,6 +7,7 @@ class Skill {
     this.tutorialIds = tutorialIds;
     this.tubeId = tubeId;
     this.version = version;
+    this.level = level;
   }
 
   get difficulty() {

--- a/api/lib/infrastructure/adapters/skill-adapter.js
+++ b/api/lib/infrastructure/adapters/skill-adapter.js
@@ -10,6 +10,7 @@ module.exports = {
       tutorialIds: datasourceObject.tutorialIds,
       tubeId: datasourceObject.tubeId,
       version: datasourceObject.version,
+      level: datasourceObject.level,
     });
   },
 };

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -11,6 +11,7 @@ function _toDomain(skillData) {
     tutorialIds: skillData.tutorialIds,
     tubeId: skillData.tubeId,
     version: skillData.version,
+    level: skillData.level,
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/skill-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/skill-serializer.js
@@ -4,6 +4,7 @@ module.exports = {
   serialize(skills) {
     return new Serializer('skill', {
       ref: 'id',
+      attributes: ['level'],
     }).serialize(skills);
   },
 };

--- a/api/tests/acceptance/application/tubes/tubes-route_test.js
+++ b/api/tests/acceptance/application/tubes/tubes-route_test.js
@@ -34,26 +34,31 @@ describe('Acceptance | Route | Tubes', function () {
             id: 'skillId1',
             status: 'actif',
             tubeId: 'tubeId1',
+            level: 1,
           },
           {
             id: 'skillId2',
             status: 'actif',
             tubeId: 'tubeId1',
+            level: 2,
           },
           {
             id: 'skillId3',
             status: 'archivé',
             tubeId: 'tubeId1',
+            level: 3,
           },
           {
             id: 'skillId4',
             status: 'supprimé',
             tubeId: 'tubeId1',
+            level: 4,
           },
           {
             id: 'skillId5',
             status: 'actif',
             tubeId: 'tubeId2',
+            level: 5,
           },
         ],
       });
@@ -95,10 +100,16 @@ describe('Acceptance | Route | Tubes', function () {
       expect(response.result.data).to.deep.include({
         id: 'skillId1',
         type: 'skills',
+        attributes: {
+          level: 1,
+        },
       });
       expect(response.result.data).to.deep.include({
         id: 'skillId2',
         type: 'skills',
+        attributes: {
+          level: 2,
+        },
       });
     });
 

--- a/api/tests/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/integration/domain/services/placement-profile-service_test.js
@@ -31,6 +31,7 @@ describe('Integration | Service | Placement Profile Service', function () {
                     pixValue: 1,
                     challenges: ['challengeRecordIdOne', 'challengeRecordIdTwo', 'challengeRecordIdTen'],
                     version: 1,
+                    level: 4,
                   },
                 ],
               },
@@ -51,6 +52,7 @@ describe('Integration | Service | Placement Profile Service', function () {
                     pixValue: 1,
                     challenges: ['challengeRecordIdOne', 'challengeRecordIdFive'],
                     version: 1,
+                    level: 2,
                   },
                   {
                     id: 'recRemplir4',
@@ -58,6 +60,7 @@ describe('Integration | Service | Placement Profile Service', function () {
                     pixValue: 1,
                     challenges: ['challengeRecordIdSix'],
                     version: 1,
+                    level: 4,
                   },
                 ],
               },
@@ -78,6 +81,7 @@ describe('Integration | Service | Placement Profile Service', function () {
                     pixValue: 1,
                     challenges: ['challengeRecordIdNine'],
                     version: 1,
+                    level: 5,
                   },
                 ],
               },
@@ -327,6 +331,7 @@ describe('Integration | Service | Placement Profile Service', function () {
                 tubeId: 'Remplir',
                 tutorialIds: [],
                 version: 1,
+                level: 2,
               },
             ],
           });
@@ -472,6 +477,7 @@ describe('Integration | Service | Placement Profile Service', function () {
                 tubeId: 'Remplir',
                 tutorialIds: [],
                 version: 1,
+                level: 2,
               },
             ],
           });

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -418,6 +418,7 @@ function _buildSkill({ id }) {
     tutorialIds: [],
     version: 1,
     status: 'actif',
+    level: 1,
   };
 }
 

--- a/api/tests/tooling/domain-builder/factory/build-skill-learning-content-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-skill-learning-content-data-object.js
@@ -6,7 +6,8 @@ const DEFAULT_ID = 'recSK0X22abcdefgh',
   DEFAULT_COMPETENCE_ID = 'recCT0X22abcdefgh',
   DEFAULT_PIX_VALUE = 2.4,
   DEFAULT_TUBE_ID = 'recTU0X22abcdefgh',
-  DEFAULT_VERSION = 1;
+  DEFAULT_VERSION = 1,
+  DEFAULT_LEVEL = 1;
 
 module.exports = function ({
   id = DEFAULT_ID,
@@ -18,6 +19,7 @@ module.exports = function ({
   pixValue = DEFAULT_PIX_VALUE,
   tubeId = DEFAULT_TUBE_ID,
   version = DEFAULT_VERSION,
+  level = DEFAULT_LEVEL,
 } = {}) {
   return {
     id,
@@ -29,5 +31,6 @@ module.exports = function ({
     competenceId,
     tubeId,
     version,
+    level,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-skill.js
+++ b/api/tests/tooling/domain-builder/factory/build-skill.js
@@ -8,6 +8,7 @@ const buildSkill = function buildSkill({
   tutorialIds = [],
   tubeId = 'recTUB123',
   version = 1,
+  level = 1,
 } = {}) {
   return new Skill({
     id,
@@ -17,6 +18,7 @@ const buildSkill = function buildSkill({
     tutorialIds,
     tubeId,
     version,
+    level,
   });
 };
 

--- a/api/tests/tooling/learning-content-builder/build-learning-content.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content.js
@@ -58,6 +58,7 @@ const buildLearningContent = function (learningContent) {
               pixValue: skill.pixValue,
               tutorialIds: skill.tutorials && _.map(skill.tutorials, 'id'),
               version: skill.version,
+              level: skill.level,
             };
           });
           allSkills.push(skills);

--- a/api/tests/unit/infrastructure/adapters/skill-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/skill-adapter_test.js
@@ -15,6 +15,7 @@ describe('Unit | Infrastructure | Adapter | skillAdapter', function () {
         tutorialIds: ['recCO0X22abcdefgh'],
         tubeId: skillDataObject.tubeId,
         version: skillDataObject.version,
+        level: skillDataObject.level,
       });
 
       // when

--- a/api/tests/unit/infrastructure/adapters/target-profile-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/target-profile-adapter_test.js
@@ -4,7 +4,7 @@ const BookshelfTargetProfileShare = require('../../../../lib/infrastructure/orm-
 const TargetProfile = require('../../../../lib/domain/models/TargetProfile');
 const targetProfileAdapter = require('../../../../lib/infrastructure/adapters/target-profile-adapter');
 
-describe('Unit | Infrastructure | Adapter | targetSkillAdapter', function () {
+describe('Unit | Infrastructure | Adapter | targetProfileAdapter', function () {
   it('should adapt TargetProfile object to domain', function () {
     // given
     const bookshelfTargetProfile = new BookshelfTargetProfile(databaseBuilder.factory.buildTargetProfile());

--- a/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
@@ -9,10 +9,12 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', function () {
         {
           id: 'skillId1',
           name: 'skill1',
+          level: 1,
         },
         {
           id: 'skillId2',
           name: 'skill1',
+          level: 2,
         },
       ];
 
@@ -21,10 +23,16 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', function () {
           {
             type: 'skills',
             id: 'skillId1',
+            attributes: {
+              level: 1,
+            },
           },
           {
             type: 'skills',
             id: 'skillId2',
+            attributes: {
+              level: 2,
+            },
           },
         ],
       };


### PR DESCRIPTION
## :unicorn: Problème
Le endpoint `/api/tubes/{id}/skills` ne renvoie que l'identifiant des acquis mais par leur niveau.

## :robot: Solution
Ajouter le niveau des acquis dans la réponse du endpoint.

## :rainbow: Remarques
ils ont été ajoutés dans la release https://github.com/1024pix/pix-editor/pull/52

## :100: Pour tester
Ce sera user testable dans la PR front.

Sinon avec un token superadmin :

```sh
curl -H "Authorization: Bearer XXX" https://admin-pr4401.review.pix.fr/api/tubes/recs1vdbHxX8X55G9/skills
```

et vérifier que le niveau des acquis est présent dans la payload de réponse.