### PR TITLE
[FEATURE] Contrôler le type d'identifiant de session pour la supervision (PIX-4904).

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -439,7 +439,7 @@ exports.register = async (server) => {
               type: 'supervisor-authentications',
               attributes: {
                 'supervisor-password': Joi.string().required(),
-                'session-id': Joi.number().required(),
+                'session-id': identifiersType.sessionId,
               },
             },
           }),

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -435,7 +435,7 @@ exports.register = async (server) => {
         validate: {
           payload: Joi.object({
             data: {
-              id: Joi.string().required(),
+              id: identifiersType.supervisorAccessesId,
               type: 'supervisor-authentications',
               attributes: {
                 'supervisor-password': Joi.string().required(),

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -44,6 +44,7 @@ const typesPositiveInteger32bits = [
   'schoolingRegistrationId',
   'sessionId',
   'stageId',
+  'supervisorAccessesId',
   'targetProfileId',
   'userId',
   'userOrgaSettingsId',


### PR DESCRIPTION
## :unicorn: Problème
La route POST `/api/sessions/supervise` ne contrôle pas le type de l'identifiant de session.
Cela laisse la possibilité d'une erreur de BDD `UTC ERROR:  value "157115718878" is out of range for type integer , `

## :robot: Solution
Vérifier le type avec le type JOI générique

## :100: Pour tester
Appeler avec curl `POST /api/sessions/supervise "session-id": 157115718878`
Vérifier la non-régression avec un parcours sur l'espace surveillant
