### PR TITLE
[FEATURE] Préciser le texte de la sous-catégorie de signalement E3 dans la page de finalisation de session (PIX-4907)

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -50,7 +50,8 @@ export const subcategoryToLabel = {
     'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: "L'image ne s'affiche pas",
   [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: "Le simulateur/l'application ne s'affiche pas",
-  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: "Le fichier à télécharger ne s'ouvre pas",
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]:
+    "Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas",
   [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]:
     'Le site à visiter est indisponible/en maintenance/inaccessible',
   [certificationIssueReportSubcategories.WEBSITE_BLOCKED]:

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -6,6 +6,32 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 module('Integration | Component | certifications/issue-report', function (hooks) {
   setupRenderingTest(hooks);
 
+  test('it should display issue details', async function (assert) {
+    // Given
+    const store = this.owner.lookup('service:store');
+    const issueReport = store.createRecord('certification-issue-report', {
+      category: 'TECHNICAL_PROBLEM',
+      subcategory: 'FILE_NOT_OPENING',
+      description: 'this is a report',
+      questionNumber: 2,
+      isImpactful: true,
+      resolvedAt: null,
+    });
+    this.set('issueReport', issueReport);
+
+    // When
+    const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+    // Then
+    assert
+      .dom(
+        screen.getByText(
+          "Problème technique non bloquant : Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas - this is a report - Question 2"
+        )
+      )
+      .exists();
+  });
+
   module('when the issue has not been resolved yet', function () {
     test('it should display resolve button', async function (assert) {
       // Given

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -167,7 +167,9 @@ module.exports = (function () {
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
     },
 
-    featureToggles: {},
+    featureToggles: {
+      isCertificationFreeFieldsDeletionEnabled: isFeatureEnabled(process.env.FT_CERTIFICATION_FREE_FIELDS_DELETION),
+    },
 
     infra: {
       concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -23,6 +23,7 @@ const schema = Joi.object({
   LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
+  FT_CERTIFICATION_FREE_FIELDS_DELETION: Joi.string().optional().valid('true', 'false'),
   LOG_OPS_METRICS: Joi.string().optional().valid('true', 'false'),
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -21,6 +21,9 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
         data: {
           id: '0',
           type: 'feature-toggles',
+          attributes: {
+            'is-certification-free-fields-deletion-enabled': false,
+          },
         },
       };
 

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -51,6 +51,7 @@ export class RadioButtonCategoryWithDescription extends RadioButtonCategory {
 }
 
 export class RadioButtonCategoryWithSubcategory extends RadioButtonCategory {
+  @service featureToggles;
   @tracked subcategory;
 
   constructor({ name, subcategory, isChecked }) {
@@ -60,6 +61,12 @@ export class RadioButtonCategoryWithSubcategory extends RadioButtonCategory {
   }
 
   get subcategoryLabel() {
+    if (
+      this.subcategory === certificationIssueReportSubcategories.FILE_NOT_OPENING &&
+      !this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+    ) {
+      return "Le fichier à télécharger ne s'ouvre pas";
+    }
     return subcategoryToLabel[this.subcategory];
   }
 

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import {
   certificationIssueReportSubcategories,
@@ -7,6 +8,8 @@ import {
 } from 'pix-certif/models/certification-issue-report';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
+  @service featureToggles;
+
   @action
   onChangeSubcategory(event) {
     this.args.inChallengeCategory.subcategory = event.target.value;
@@ -23,9 +26,16 @@ export default class InChallengeCertificationIssueReportFields extends Component
     'UNINTENTIONAL_FOCUS_OUT',
   ].map((subcategoryKey) => {
     const subcategory = certificationIssueReportSubcategories[subcategoryKey];
+    let labelForSubcategory = subcategoryToLabel[subcategory];
+    if (
+      subcategory === certificationIssueReportSubcategories.FILE_NOT_OPENING &&
+      !this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+    ) {
+      labelForSubcategory = "Le fichier à télécharger ne s'ouvre pas";
+    }
     return {
       value: certificationIssueReportSubcategories[subcategory],
-      label: `${subcategoryToCode[subcategory]} ${subcategoryToLabel[subcategory]}`,
+      label: `${subcategoryToCode[subcategory]} ${labelForSubcategory}`,
     };
   });
 }

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
+import { inject as service } from '@ember/service';
 
 export const certificationIssueReportCategories = {
   OTHER: 'OTHER',
@@ -43,7 +44,8 @@ export const subcategoryToLabel = {
     'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: "L'image ne s'affiche pas",
   [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: "Le simulateur/l'application ne s'affiche pas",
-  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: "Le fichier à télécharger ne s'ouvre pas",
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]:
+    "Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas",
   [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]:
     'Le site à visiter est indisponible/en maintenance/inaccessible',
   [certificationIssueReportSubcategories.WEBSITE_BLOCKED]:
@@ -89,6 +91,7 @@ export const subcategoryToTextareaLabel = {
 };
 
 export default class CertificationIssueReport extends Model {
+  @service featureToggles;
   @attr('string') category;
   @attr('string') subcategory;
   @attr('string') description;
@@ -101,6 +104,12 @@ export default class CertificationIssueReport extends Model {
   }
 
   get subcategoryLabel() {
+    if (
+      this.subcategory === certificationIssueReportSubcategories.FILE_NOT_OPENING &&
+      !this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+    ) {
+      return "Le fichier à télécharger ne s'ouvre pas";
+    }
     return this.subcategory ? subcategoryToLabel[this.subcategory] : '';
   }
 

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isCertificationFreeFieldsDeletionEnabled;
+}

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import {
@@ -12,6 +13,15 @@ import {
 
 module('Integration | Component | add-issue-report-modal', function (hooks) {
   setupRenderingTest(hooks);
+
+  const featureToggles = {};
+
+  hooks.beforeEach(function () {
+    class FeatureTogglesStub extends Service {
+      featureToggles = featureToggles;
+    }
+    this.owner.register('service:feature-toggles', FeatureTogglesStub);
+  });
 
   test('it show candidate informations in title', async function (assert) {
     // given

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 
 module('Integration | Component | SessionFinalization::UncompletedReportsInformationStep', function (hooks) {
   setupRenderingTest(hooks);
@@ -15,6 +16,13 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
   let reportB;
   let store;
   let certificationIssueReportA;
+
+  hooks.beforeEach(function () {
+    class FeatureTogglesStub extends Service {
+      featureToggles = {};
+    }
+    this.owner.register('service:feature-toggles', FeatureTogglesStub);
+  });
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');

--- a/certif/tests/unit/models/certification-issue-report_test.js
+++ b/certif/tests/unit/models/certification-issue-report_test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import Service from '@ember/service';
 import map from 'lodash/map';
+import find from 'lodash/find';
 
 import {
   certificationIssueReportCategories,
@@ -14,6 +16,21 @@ import {
 
 module('Unit | Model | certification issue report', function (hooks) {
   setupTest(hooks);
+
+  const featureToggles = {
+    isCertificationFreeFieldsDeletionEnabled: true,
+  };
+
+  hooks.beforeEach(function () {
+    class FeatureTogglesStub extends Service {
+      featureToggles = featureToggles;
+    }
+    this.owner.register('service:feature-toggles', FeatureTogglesStub);
+  });
+
+  hooks.afterEach(function () {
+    featureToggles.isCertificationFreeFieldsDeletionEnabled = true;
+  });
 
   test('it should return the right label for the category', function (assert) {
     assert.expect(7);
@@ -30,7 +47,7 @@ module('Unit | Model | certification issue report', function (hooks) {
     }
   });
 
-  test('it should return the right label for the subcategory', function (assert) {
+  test('it should return the right label for the subcategory when FT enabled', function (assert) {
     const expectedAssertNumber = 12;
     assert.expect(expectedAssertNumber);
     // given
@@ -44,6 +61,20 @@ module('Unit | Model | certification issue report', function (hooks) {
     for (const model of models) {
       assert.strictEqual(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
     }
+  });
+
+  test('it should return the right label for the subcategory FILE_NOT_OPENING when FT disabled', function (assert) {
+    featureToggles.isCertificationFreeFieldsDeletionEnabled = false;
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportSubcategories, (subcategory) => {
+      return run(() => store.createRecord('certification-issue-report', { subcategory }));
+    });
+    const fileNotOpeningModel = find(models, (m) => m.subcategory === 'FILE_NOT_OPENING');
+
+    // when / then
+    assert.strictEqual(fileNotOpeningModel.subcategoryLabel, "Le fichier à télécharger ne s'ouvre pas");
   });
 
   test('it should return the right code for the category', function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Contexte : Epix de suppression des champs libres lors de la finalisation d'une session de certification.
Cette épix contient des changements visuels et fonctionnels importants, de fait on souhaite présenter à l'utilisateur toutes les modifications en même temps (et simultanément diffuser une doc à jour). 

## :robot: Solution
Introduction du feature toggle suivant : `FT_CERTIFICATION_FREE_FIELDS_DELETION`

Modification du texte du signalement E3 soumis à la toggle  `Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas.`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

### PixCertif

[Accéder à la finalisation d'une session](https://certif-pr4404.review.pix.fr/sessions/20001/finalisation)
Sous la catégorie E1/E10, ajouter un signalement E3

Avec le toggle ON, avoir le texte : `Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas.`
Avec le toggle OFF, avoir le texte: `Le fichier à télécharger ne s'ouvre pas.`

Ajoutez ce signalement et finalisez la session.

### PixAdmin
Allez dans la liste des signalements de la certif.

Constater le texte `Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas. `  : (quel que soit l'état du toggle) 
