### PR TITLE
[FEATURE] Restreindre l'accès à la page Outils de Pix Admin uniquement aux Super Admin (PIX-4189)

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -71,16 +71,18 @@
         <:tooltip>Équipe</:tooltip>
       </PixTooltip>
     </li>
-    <li class="menu-bar__entry">
-      <PixTooltip @position="right">
-        <:triggerElement>
-          <LinkTo @route="authenticated.tools" class="menu-bar__link">
-            <FaIcon @icon="tools" @title="Outils" />
-          </LinkTo>
-        </:triggerElement>
-        <:tooltip>Outils</:tooltip>
-      </PixTooltip>
-    </li>
+    {{#if this.currentUser.adminMember.isSuperAdmin}}
+      <li class="menu-bar__entry">
+        <PixTooltip @position="right">
+          <:triggerElement>
+            <LinkTo @route="authenticated.tools" class="menu-bar__link">
+              <FaIcon @icon="tools" @title="Outils" />
+            </LinkTo>
+          </:triggerElement>
+          <:tooltip>Outils</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/if}}
     <li class="menu-bar__entry">
       <PixTooltip @position="right" @inline={{true}}>
         <:triggerElement>

--- a/admin/app/components/menu-bar.js
+++ b/admin/app/components/menu-bar.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 
 export default class MenuBar extends Component {
   @service session;
+  @service currentUser;
 
   @action
   logout() {

--- a/admin/app/models/admin-member.js
+++ b/admin/app/models/admin-member.js
@@ -16,8 +16,4 @@ export default class AdminMember extends Model {
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
-
-  hasAccess(rights) {
-    return rights.some((right) => this[right]);
-  }
 }

--- a/admin/app/routes/authenticated/tools.js
+++ b/admin/app/routes/authenticated/tools.js
@@ -2,12 +2,9 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ToolsRoute extends Route {
-  @service router;
-  @service currentUser;
+  @service accessControl;
 
   beforeModel() {
-    if (!this.currentUser.adminMember.hasAccess(['isSuperAdmin'])) {
-      this.router.transitionTo('authenticated');
-    }
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
   }
 }

--- a/admin/app/routes/authenticated/tools.js
+++ b/admin/app/routes/authenticated/tools.js
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class ToolsRoute extends Route {}
+export default class ToolsRoute extends Route {
+  @service router;
+  @service currentUser;
+
+  beforeModel() {
+    if (!this.currentUser.adminMember.hasAccess(['isSuperAdmin'])) {
+      this.router.transitionTo('authenticated');
+    }
+  }
+}

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -1,0 +1,14 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+
+export default class AccessControlService extends Service {
+  @service currentUser;
+  @service router;
+
+  restrictAccessTo(roles, redirectionUrl) {
+    const currentUserIsAllowed = roles.some((role) => this.currentUser.adminMember[role]);
+    if (!currentUserIsAllowed) {
+      this.router.transitionTo(redirectionUrl);
+    }
+  }
+}

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -62,12 +62,34 @@ module('Integration | Component | menu-bar', function (hooks) {
     assert.dom(screen.getByTitle('Profils cibles')).exists();
   });
 
-  test('should contain link to "tools" management page', async function (assert) {
-    // when
-    const screen = await render(hbs`{{menu-bar}}`);
+  module('Tools tab', function () {
+    module('when user is Super Admin', function () {
+      test('should contain link to "tools" management page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSuperAdmin: true };
 
-    // then
-    assert.dom(screen.getByTitle('Outils')).exists();
+        // when
+        const screen = await render(hbs`{{menu-bar}}`);
+
+        // then
+        assert.dom(screen.getByTitle('Outils')).exists();
+      });
+    });
+
+    module('when user is Certif, Metier or Support', function () {
+      test('should not contain link to "tools" management page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSuperAdmin: false };
+
+        // when
+        const screen = await render(hbs`{{menu-bar}}`);
+
+        // then
+        assert.dom(screen.queryByText('Outils')).doesNotExist();
+      });
+    });
   });
 
   test('should contain link to "logout"', async function (assert) {

--- a/admin/tests/unit/models/admin-member_test.js
+++ b/admin/tests/unit/models/admin-member_test.js
@@ -24,41 +24,4 @@ module('Unit | Model | admin-member', function (hooks) {
       assert.strictEqual(fullName, 'Jean-Baptiste Poquelin');
     });
   });
-
-  module('hasAccess', function () {
-    test('it should return true if current user has the given right', function (assert) {
-      // given
-      const adminMember = run(() => {
-        return store.createRecord('adminMember', {
-          firstName: 'Jean-Baptiste',
-          lastName: 'Poquelin',
-          isSuperAdmin: true,
-        });
-      });
-
-      // when
-      const hasAdminMemberAccess = adminMember.hasAccess(['isCertif', 'isSuperAdmin']);
-
-      // then
-      assert.true(hasAdminMemberAccess);
-    });
-
-    test('it should return false if current user does not have the given right', function (assert) {
-      // given
-      const adminMember = run(() => {
-        return store.createRecord('adminMember', {
-          firstName: 'Jean-Baptiste',
-          lastName: 'Poquelin',
-          isSuperAdmin: false,
-          isCertif: false,
-        });
-      });
-
-      // when
-      const hasAdminMemberAccess = adminMember.hasAccess(['isCertif', 'isSuperAdmin']);
-
-      // then
-      assert.false(hasAdminMemberAccess);
-    });
-  });
 });

--- a/admin/tests/unit/routes/authenticated/tools_test.js
+++ b/admin/tests/unit/routes/authenticated/tools_test.js
@@ -1,11 +1,46 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Route | authenticated/tools', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function (assert) {
+  test('it should allow super admin to access page', function (assert) {
+    // given
     const route = this.owner.lookup('route:authenticated/tools');
-    assert.ok(route);
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = sinon.stub();
+
+    class CurrentUserStub extends Service {
+      adminMember = { hasAccess: sinon.stub().returns(true) };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    route.beforeModel();
+
+    // then
+    assert.ok(router.transitionTo.notCalled);
+  });
+
+  test('it should redirect all other pix member (certif, metier, support) into home page', function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/tools');
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = sinon.stub();
+
+    const hasAccessStub = sinon.stub().returns(true);
+    hasAccessStub.withArgs(['isSuperAdmin']).returns(false);
+    class CurrentUserStub extends Service {
+      adminMember = { hasAccess: hasAccessStub };
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    route.beforeModel();
+
+    // then
+    assert.ok(router.transitionTo.called);
   });
 });

--- a/admin/tests/unit/routes/authenticated/tools_test.js
+++ b/admin/tests/unit/routes/authenticated/tools_test.js
@@ -6,41 +6,20 @@ import Service from '@ember/service';
 module('Unit | Route | authenticated/tools', function (hooks) {
   setupTest(hooks);
 
-  test('it should allow super admin to access page', function (assert) {
+  test('it should check if current user is super admin', function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/tools');
-    const router = this.owner.lookup('service:router');
-    router.transitionTo = sinon.stub();
 
-    class CurrentUserStub extends Service {
-      adminMember = { hasAccess: sinon.stub().returns(true) };
+    const restrictAccessToStub = sinon.stub().returns();
+    class AccessControlStub extends Service {
+      restrictAccessTo = restrictAccessToStub;
     }
-    this.owner.register('service:current-user', CurrentUserStub);
+    this.owner.register('service:access-control', AccessControlStub);
 
     // when
     route.beforeModel();
 
     // then
-    assert.ok(router.transitionTo.notCalled);
-  });
-
-  test('it should redirect all other pix member (certif, metier, support) into home page', function (assert) {
-    // given
-    const route = this.owner.lookup('route:authenticated/tools');
-    const router = this.owner.lookup('service:router');
-    router.transitionTo = sinon.stub();
-
-    const hasAccessStub = sinon.stub().returns(true);
-    hasAccessStub.withArgs(['isSuperAdmin']).returns(false);
-    class CurrentUserStub extends Service {
-      adminMember = { hasAccess: hasAccessStub };
-    }
-    this.owner.register('service:current-user', CurrentUserStub);
-
-    // when
-    route.beforeModel();
-
-    // then
-    assert.ok(router.transitionTo.called);
+    assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin'], 'authenticated'));
   });
 });

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | access-control', function (hooks) {
+  setupTest(hooks);
+
+  module('#restrictAccessTo', function () {
+    module('when user does not have the given role', function () {
+      test('it should be redirected to the given redirection url', function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isCertif: true };
+
+        const router = this.owner.lookup('service:router');
+        router.transitionTo = sinon.stub();
+
+        const service = this.owner.lookup('service:access-control');
+
+        // when
+        service.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+
+        // then
+        assert.ok(router.transitionTo.calledWith('authenticated'));
+      });
+    });
+
+    module('when user has the given role', function () {
+      test('it should not be redirected', function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSuperAdmin: true };
+
+        const router = this.owner.lookup('service:router');
+        router.transitionTo = sinon.stub();
+
+        const service = this.owner.lookup('service:access-control');
+
+        // when
+        service.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+
+        // then
+        assert.ok(router.transitionTo.notCalled);
+      });
+    });
+  });
+});

--- a/api/lib/application/tags/index.js
+++ b/api/lib/application/tags/index.js
@@ -10,14 +10,8 @@ exports.register = async (server) => {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.userHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserHasRoleSuperAdmin,
-                securityPreHandlers.checkUserHasRoleCertif,
-                securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
+            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
           },
         ],
         validate: {
@@ -36,7 +30,7 @@ exports.register = async (server) => {
         handler: tagController.create,
         tags: ['api', 'tags'],
         notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+          '- **Cette route est restreinte aux utilisateurs authentifiés ayant le role Super Admin**\n' +
             '- Elle permet de créer un tag',
         ],
       },

--- a/api/tests/acceptance/application/cache-controller_test.js
+++ b/api/tests/acceptance/application/cache-controller_test.js
@@ -26,7 +26,7 @@ describe('Acceptance | Controller | cache-controller', function () {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
+      it('should respond with a 403 - forbidden access - if user is not a Super Admin', async function () {
         // given
         const nonSuperAdminUserId = 9999;
 
@@ -61,7 +61,7 @@ describe('Acceptance | Controller | cache-controller', function () {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
+      it('should respond with a 403 - forbidden access - if user is not a Super Admin', async function () {
         // given
         const nonSuperAdminUserId = 9999;
 

--- a/api/tests/acceptance/application/cache-controller_test.js
+++ b/api/tests/acceptance/application/cache-controller_test.js
@@ -9,27 +9,18 @@ describe('Acceptance | Controller | cache-controller', function () {
   });
 
   describe('PATCH /api/cache/{model}/{id}', function () {
-    let options;
-
-    beforeEach(function () {
-      options = {
-        method: 'PATCH',
-        url: '/api/cache/challenges/recChallengeId',
-        headers: {},
-        payload: {
-          id: 'recChallengeId',
-          param: 'updatedModelParam',
-        },
-      };
-    });
-
     describe('Resource access management', function () {
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
-        // given
-        options.headers.authorization = 'invalid.access.token';
-
-        // when
-        const response = await server.inject(options);
+        // given & when
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/cache/challenges/recChallengeId',
+          headers: { authorization: 'invalid.access.token' },
+          payload: {
+            id: 'recChallengeId',
+            param: 'updatedModelParam',
+          },
+        });
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -38,10 +29,17 @@ describe('Acceptance | Controller | cache-controller', function () {
       it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
         // given
         const nonSuperAdminUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonSuperAdminUserId);
 
         // when
-        const response = await server.inject(options);
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/cache/challenges/recChallengeId',
+          headers: { authorization: generateValidRequestAuthorizationHeader(nonSuperAdminUserId) },
+          payload: {
+            id: 'recChallengeId',
+            param: 'updatedModelParam',
+          },
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -50,23 +48,14 @@ describe('Acceptance | Controller | cache-controller', function () {
   });
 
   describe('PATCH /api/cache', function () {
-    let options;
-
-    beforeEach(function () {
-      options = {
-        method: 'PATCH',
-        url: '/api/cache',
-        headers: {},
-      };
-    });
-
     describe('Resource access management', function () {
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
-        // given
-        options.headers.authorization = 'invalid.access.token';
-
-        // when
-        const response = await server.inject(options);
+        // given & when
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/cache',
+          headers: { authorization: 'invalid.access.token' },
+        });
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -75,10 +64,13 @@ describe('Acceptance | Controller | cache-controller', function () {
       it('should respond with a 403 - forbidden access - if user has not role Super Admin', async function () {
         // given
         const nonSuperAdminUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonSuperAdminUserId);
 
         // when
-        const response = await server.inject(options);
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/cache',
+          headers: { authorization: generateValidRequestAuthorizationHeader(nonSuperAdminUserId) },
+        });
 
         // then
         expect(response.statusCode).to.equal(403);

--- a/api/tests/unit/application/tags/index_test.js
+++ b/api/tests/unit/application/tags/index_test.js
@@ -5,27 +5,57 @@ const securityPreHandlers = require('../../../../lib/application/security-pre-ha
 const tagController = require('../../../../lib/application/tags/tag-controller');
 
 describe('Unit | Application | Router | tag-router', function () {
-  it('return a response with an http status code OK', async function () {
-    // given
-    const tags = [
-      domainBuilder.buildTag({ name: 'TAG1' }),
-      domainBuilder.buildTag({ name: 'TAG2' }),
-      domainBuilder.buildTag({ name: 'TAG3' }),
-    ];
+  describe('GET /api/admin/tags', function () {
+    it('return a response with an http status code OK', async function () {
+      // given
+      const tags = [
+        domainBuilder.buildTag({ name: 'TAG1' }),
+        domainBuilder.buildTag({ name: 'TAG2' }),
+        domainBuilder.buildTag({ name: 'TAG3' }),
+      ];
 
-    const method = 'GET';
-    const url = '/api/admin/tags';
+      sinon.stub(tagController, 'findAllTags').returns(tags);
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').resolves(true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
-    sinon.stub(tagController, 'findAllTags').returns(tags);
-    sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-    const httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/tags');
 
-    // when
-    const response = await httpTestServer.request(method, url);
+      // then
+      expect(response.statusCode).to.equal(200);
+      sinon.assert.calledOnce(tagController.findAllTags);
+    });
+  });
 
-    // then
-    expect(response.statusCode).to.equal(200);
-    sinon.assert.calledOnce(tagController.findAllTags);
+  describe('POST /api/admin/tags', function () {
+    it('return forbiden access if user has CERTIF or SUPPORT or METIER role', async function () {
+      // given
+      sinon.stub(tagController, 'create').resolves('ok');
+
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleCertif').resolves(true);
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleSupport').resolves(true);
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').resolves(true);
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/tags', {
+        data: {
+          type: 'tags',
+          attributes: {
+            name: 'Super Tag',
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(tagController.create);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La page Outils dans Pix Admin est actuellement disponible à tous les utilisateurs Pix Admin (indépendamment de leur rôles).
Or cette page contient des actions critiques et très occasionnelles comme : 
- recharger le cache
- créer une nouvelle version du référentiel et recharger le cache 
- créer un nouveau tag

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/38167520/167089781-63805205-b391-4567-8c67-7752db326107.png">

Ces actions ne sont jamais utilisées par les membres Pix Admin ayant les rôles SUPPORT, METIER et CERTIF. Elles ne devraient être accessible qu'à un utilisateur SUPER_ADMIN.

## :robot: Solution
Faire en sorte que les routes API soient protégée et n'acceptent que les SUPER_ADMIN pour effectuer ces actions là.
Faire en sorte de dissimuler côté front l'onglet "outils" dans le menu aux personnes qui ne sont pas SUPER_ADMIN.
Faire en sorte de ne pas pouvoir accéder à la page outil (directement via l'url) aux personnes qui ne sont pas SUPER_ADMIN.

## :rainbow: Remarques
Les routes API concernées par la protection : 
- `PATCH /api/cache`
- `POST /api/lcms/releases`
- `POST /api/admin/tags`

## :100: Pour tester

### Vérifier que les routes API sont bien protégée

1- Drop les commits commençant par  "admin:" 

2- Se connecter à Pix Admin avec "pixcertif@example.net" + ouvrir l'inspecteur web , onglet réseau
3- Vérifier que toutes les actions suivantes renvoie une 403 : 
- cliquer sur "Recharger le cache" 
- cliquer sur "Créer une nouvelle version du référentiel et recharger le cache" 
- remplir le champ "nom du tag" et cliquer sur "Créer le tag"

4- Répéter l'opération 3 avec les comptes "pixsupport@example.net" et "pixmetier@example.net"

### Vérifier que l'application Pix Admin ne présente pas les fonctionnalités Outils aux Métier, Support ou Certif

5- Rétablir les commits
6- Vérifier avec les comptes "pixcertif@example.net" , "pixsupport@example.net" et "pixmetier@example.net" : 
- que vous ne voyez plus l'onglet "Outils" dans le menu de navigation à gauche
- que vous n'arrivez pas à accéder à la route `/tools` directement via l'url (vous êtes redirigé vers la page d'accueil des orga)


### Vérifier que l'application Pix Admin présente toujours les fonctionnalités Outils aux Super Admin

7- Se connecter à Pix Admin avec "superadmin@example.net" 

8- Vérifier : 
- que vous voyez toujours l'onglet "Outils" dans le menu de navigation à gauche
- que vous arrivez à accéder à la route `/tools` directement via l'url 

9- Vérifier que vous arrivez à effectuer les actions suivantes sans aucune erreur :
- cliquer sur "Recharger le cache" 
- cliquer sur "Créer une nouvelle version du référentiel et recharger le cache" 
- remplir le champ "nom du tag" et cliquer sur "Créer le tag" 
