### PR TITLE
[FEATURE] Restreindre l'accès à la page "Équipe" de Pix Admin uniquement au rôle "SUPER_ADMIN" (PIX-4850)

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -61,16 +61,18 @@
         <:tooltip>Profils cibles</:tooltip>
       </PixTooltip>
     </li>
-    <li class="menu-bar__entry">
-      <PixTooltip @position="right">
-        <:triggerElement>
-          <LinkTo @route="authenticated.team" class="menu-bar__link">
-            <FaIcon @icon="users" @title="Équipe" />
-          </LinkTo>
-        </:triggerElement>
-        <:tooltip>Équipe</:tooltip>
-      </PixTooltip>
-    </li>
+    {{#if this.currentUser.adminMember.isSuperAdmin}}
+      <li class="menu-bar__entry">
+        <PixTooltip @position="right">
+          <:triggerElement>
+            <LinkTo @route="authenticated.team" class="menu-bar__link">
+              <FaIcon @icon="users" @title="Équipe" />
+            </LinkTo>
+          </:triggerElement>
+          <:tooltip>Équipe</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/if}}
     {{#if this.currentUser.adminMember.isSuperAdmin}}
       <li class="menu-bar__entry">
         <PixTooltip @position="right">

--- a/admin/app/routes/authenticated/team/list.js
+++ b/admin/app/routes/authenticated/team/list.js
@@ -1,6 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ListRoute extends Route {
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');
+  }
+
   async model() {
     return this.store.query('admin-member', {});
   }

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -19,12 +19,11 @@ module('Acceptance | Team | List', function (hooks) {
     });
   });
 
-  module('When user is logged in', function (hooks) {
-    hooks.beforeEach(async () => {
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    });
-
+  module('When user is logged in', function () {
     test('it should be accessible for an authenticated user', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
       // when
       await visit('/equipe');
 
@@ -34,6 +33,7 @@ module('Acceptance | Team | List', function (hooks) {
 
     test('it should list all team members', async function (assert) {
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       server.create('admin-member', { id: 1, firstName: 'Marie', lastName: 'Tim' });
       server.create('admin-member', { id: 2, firstName: 'Alain', lastName: 'Térieur' });
 
@@ -47,6 +47,7 @@ module('Acceptance | Team | List', function (hooks) {
 
     test('it should be possible to change the role of a member', async function (assert) {
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       server.create('admin-member', {
         id: 5,
         firstName: 'Elise',
@@ -75,6 +76,7 @@ module('Acceptance | Team | List', function (hooks) {
 
     test('it should show an error when modification is not successful and not modify user role', async function (assert) {
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       server.create('admin-member', {
         id: 5,
         firstName: 'Elise',

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -14,12 +14,30 @@ module('Integration | Component | menu-bar', function (hooks) {
     assert.dom(screen.getByTitle('Organisations')).exists();
   });
 
-  test('should contain link to "team" management page', async function (assert) {
-    // when
-    const screen = await render(hbs`{{menu-bar}}`);
+  module('Team tab', function () {
+    test('should contain link to "team" management page when admin member have "SUPER_ADMIN" as role', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
 
-    // then
-    assert.dom(screen.getByTitle('Équipe')).exists();
+      // when
+      const screen = await render(hbs`{{menu-bar}}`);
+
+      // then
+      assert.dom(screen.getByTitle('Équipe')).exists();
+    });
+
+    test('should not contain link to "team" management page when admin member have "SUPPORT", "CERTIF" or "METIER" as role', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: false };
+
+      // when
+      const screen = await render(hbs`{{menu-bar}}`);
+
+      // then
+      assert.throws(() => screen.getByTitle('Équipe'), 'HTMLElement not found');
+    });
   });
 
   test('should contain link to "users" management page', async function (assert) {

--- a/admin/tests/unit/routes/authenticated/team/list_test.js
+++ b/admin/tests/unit/routes/authenticated/team/list_test.js
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/team/list', function (hooks) {
+  setupTest(hooks);
+
+  test('it should allow super admin to access page', function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/team/list');
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = sinon.stub();
+
+    class CurrentUserStub extends Service {
+      adminMember = { isSuperAdmin: true };
+    }
+
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    route.beforeModel();
+
+    // then
+    assert.ok(router.transitionTo.notCalled);
+  });
+
+  test('it should redirect all other pix member (certif, metier, support) to home page', function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/team/list');
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = sinon.stub();
+
+    class CurrentUserStub extends Service {
+      adminMember = { isSuperAdmin: false };
+    }
+
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    route.beforeModel();
+
+    // then
+    assert.ok(router.transitionTo.called);
+  });
+});

--- a/api/lib/application/admin-members/index.js
+++ b/api/lib/application/admin-members/index.js
@@ -41,13 +41,7 @@ exports.register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.userHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserHasRoleSuperAdmin,
-                securityPreHandlers.checkUserHasRoleCertif,
-                securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
-              ])(request, h),
+            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],

--- a/api/lib/application/admin-members/index.js
+++ b/api/lib/application/admin-members/index.js
@@ -12,13 +12,7 @@ exports.register = async function (server) {
         handler: adminMemberController.findAll,
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.userHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserHasRoleSuperAdmin,
-                securityPreHandlers.checkUserHasRoleCertif,
-                securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
-              ])(request, h),
+            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],

--- a/api/tests/acceptance/application/admin-members/admin-members-route-get_test.js
+++ b/api/tests/acceptance/application/admin-members/admin-members-route-get_test.js
@@ -1,19 +1,20 @@
-const {
-  expect,
-  databaseBuilder,
-  generateValidRequestAuthorizationHeader,
-  insertUserWithRoleSuperAdmin,
-} = require('../../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
 
 describe('Acceptance | Application | Admin-members | Routes', function () {
   describe('GET /api/admin/admin-members', function () {
-    it('should return 200 http status code', async function () {
+    it('should return 200 http status code when user has role "SUPER_ADMIN"', async function () {
       // given
-      const user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildPixAdminRole({ userId: user.id, role: 'SUPER_ADMIN' });
-      const admin = await insertUserWithRoleSuperAdmin();
+      const admin = databaseBuilder.factory.buildUser.withRole({
+        id: 1234,
+        firstName: 'Super',
+        lastName: 'Papa',
+        email: 'super.papa@example.net',
+        password: 'Password123',
+        role: ROLES.SUPER_ADMIN,
+      });
+
       await databaseBuilder.commit();
       const server = await createServer();
 

--- a/api/tests/acceptance/application/admin-members/admin-members-route-get_test.js
+++ b/api/tests/acceptance/application/admin-members/admin-members-route-get_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
   });
 
   describe('PATCH /api/admin/admin-members/{id}', function () {
-    it('should return 200 http status code', async function () {
+    it('should return 200 http status code if use has role "SUPER_ADMIN"', async function () {
       // given
       const superAdmin = databaseBuilder.factory.buildUser.withRole();
       const pixAdminUserToUpdate = databaseBuilder.factory.buildUser.withRole();
@@ -88,6 +88,37 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
+    });
+
+    it('should return 400 if the payload is invalid', async function () {
+      // given
+      const superAdmin = databaseBuilder.factory.buildUser.withRole();
+      const pixAdminUserToUpdate = databaseBuilder.factory.buildUser.withRole();
+      const pixAdminRole = databaseBuilder.factory.buildPixAdminRole({
+        userId: pixAdminUserToUpdate.id,
+        role: ROLES.SUPPORT,
+      });
+      await databaseBuilder.commit();
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+        },
+        method: 'PATCH',
+        url: `/api/admin/admin-members/${pixAdminRole.id}`,
+        payload: {
+          data: {
+            attributes: {
+              role: 'INVALID_ROLE',
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 });

--- a/api/tests/unit/application/admin-members/index_test.js
+++ b/api/tests/unit/application/admin-members/index_test.js
@@ -1,0 +1,41 @@
+const { domainBuilder, expect, sinon, HttpTestServer } = require('../../../test-helper');
+const adminMemberController = require('../../../../lib/application/admin-members/admin-member-controller');
+const adminMembersRouter = require('../../../../lib/application/admin-members');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+describe('Unit | Application | Router | admin-members-router', function () {
+  describe('GET /api/admin/admin-members', function () {
+    it('should return a response with an HTTP status code 200 when user has role "SUPER_ADMIN"', async function () {
+      // given
+      const adminMembers = [domainBuilder.buildAdminMember()];
+      sinon.stub(adminMemberController, 'findAll').returns(adminMembers);
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(adminMembersRouter);
+
+      // when
+      const { statusCode } = await httpTestServer.request('GET', '/api/admin/admin-members');
+
+      // then
+      expect(statusCode).to.equal(200);
+      sinon.assert.calledOnce(adminMemberController.findAll);
+    });
+
+    it('should return a response with an HTTP status code 403 if user does not have the rights', async function () {
+      // given
+      const adminMembers = [domainBuilder.buildAdminMember()];
+      sinon.stub(adminMemberController, 'findAll').returns(adminMembers);
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(adminMembersRouter);
+
+      // when
+      const { statusCode } = await httpTestServer.request('GET', '/api/admin/admin-members');
+
+      // then
+      expect(statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/unit/application/admin-members/index_test.js
+++ b/api/tests/unit/application/admin-members/index_test.js
@@ -1,4 +1,5 @@
 const { domainBuilder, expect, sinon, HttpTestServer } = require('../../../test-helper');
+const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
 const adminMemberController = require('../../../../lib/application/admin-members/admin-member-controller');
 const adminMembersRouter = require('../../../../lib/application/admin-members');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
@@ -36,6 +37,45 @@ describe('Unit | Application | Router | admin-members-router', function () {
 
       // then
       expect(statusCode).to.equal(403);
+    });
+  });
+
+  describe('PATCH /api/admin/admin-members/{id}', function () {
+    it('should return a response with an HTTP status code 200 when user has role "SUPER_ADMIN"', async function () {
+      // given
+      const updatedAdminMember = domainBuilder.buildAdminMember();
+      sinon.stub(adminMemberController, 'updateAdminMember').returns(updatedAdminMember);
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(adminMembersRouter);
+
+      // when
+      const { statusCode } = await httpTestServer.request('PATCH', '/api/admin/admin-members/1', {
+        data: { type: 'admin-members', attributes: { role: ROLES.SUPER_ADMIN } },
+      });
+
+      // then
+      expect(statusCode).to.equal(200);
+      sinon.assert.calledOnce(adminMemberController.updateAdminMember);
+    });
+
+    it('should return a response with an HTTP status code 403 if user does not have the rights', async function () {
+      // given
+      sinon.stub(adminMemberController, 'updateAdminMember').returns('ok');
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(adminMembersRouter);
+
+      // when
+      const { statusCode } = await httpTestServer.request('PATCH', '/api/admin/admin-members/1', {
+        data: { type: 'admin-members', attributes: { role: ROLES.SUPER_ADMIN } },
+      });
+
+      // then
+      expect(statusCode).to.equal(403);
+      sinon.assert.notCalled(adminMemberController.updateAdminMember);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La page `Équipe` dans l'application `Pix Admin` est visible à tous les utilisateurs de l'application indépendamment de leur rôles. Seul des utilisateurs ayant le rôle `SUPER_ADMIN` devrait avoir accès à cette page.

![Screenshot 2022-05-06 at 12 39 24](https://user-images.githubusercontent.com/6919604/167116574-7d151b85-beca-41e9-b725-89997efe44fb.png)

## :robot: Solution

1. (API) Mettre à jour la liste des pre-handlers pour n'accepter que les requêtes faites par un utilisateur ayant le rôle `SUPER_ADMIN`.
2. (PIX ADMIN) Ne pas afficher l'onglet `Équipe` pour tous les utilisateurs n'ayant pas le rôle `SUPER_ADMIN`.
3. (PIX-ADMIN) Rediriger l'utilisateur n'ayant pas le rôle `SUPER_ADMIN` à la racine de l'application si ce dernier tente de rentrer le chemin vers la page `/equipe` directement dans l'URL.

## :rainbow: Remarques

Les routes concernées

- API
  - `GET /api/admin/admin-members`
  - `PATCH /api/admin/admin-members/{id}`
- PIX ADMIN
  - `/equipe`

## :100: Pour tester

#### Avec un utilisateur ayant le rôle `SUPER_ADMIN`

- Se connecter avec `superadmin@example.net` / `pix123`
- Voir au niveau du menu à gauche que l'onglet `Équipe` est présent
- Remplacer le chemin `/organizations/list` dans la barre de navigation du navigateur par `/equipe`
- Constater que l'on arrive sur la page `Équipe`
- Modifier le rôle d'un utilisateur **différent** du votre
- Constater dans la liste que le nouveau rôle a été pris en compte

#### Avec un utilisateur ayant le rôle `SUPPORT`

- Se connecter avec `pixsupport@example.net` / `pix123`
- Voir au niveau du menu à gauche que l'onglet `Équipe` n'est pas présent
- Remplacer le chemin `/organizations/list` dans la barre de navigation du navigateur par `/equipe`
- Constater que l'on arrive sur la page `Organisations`

#### Avec un utilisateur ayant le rôle `CERTIF`

- Se connecter avec `pixcertif@example.net` / `pix123`
- Voir au niveau du menu à gauche que l'onglet `Équipe` n'est pas présent
- Remplacer le chemin `/organizations/list` dans la barre de navigation du navigateur par `/equipe`
- Constater que l'on arrive sur la page `Organisations`

#### Avec un utilisateur ayant le rôle `METIER`

- Se connecter avec `pixmetier@example.net` / `pix123`
- Voir au niveau du menu à gauche que l'onglet `Équipe` n'est pas présent
- Remplacer le chemin `/organizations/list` dans la barre de navigation du navigateur par `/equipe`
- Constater que l'on arrive sur la page `Organisations`