### PR TITLE
[FEATURE] Restreindre l'accès des actions liés aux sessions de certification (PIX-4666)

### DIFF
--- a/admin/app/components/sessions/jury-comment.hbs
+++ b/admin/app/components/sessions/jury-comment.hbs
@@ -1,26 +1,28 @@
 <section class="page-section mb_10 session-jury-comment">
   <h2 class="jury-comment__title">Commentaire de l'équipe Certification</h2>
   {{#if this.shouldDisplayForm}}
-    <form onsubmit={{this.submitForm}}>
-      <PixTextarea
-        placeholder="Ajouter un commentaire…"
-        @value={{this.commentBeingEdited}}
-        class="jury-comment__field"
-        @id="jury-comment-field"
-        aria-label="Texte du commentaire"
-        required={{true}}
-      />
-      <div class="jury-comment__actions">
-        {{#if this.commentExists}}
-          <PixButton @triggerAction={{this.exitEditingMode}} @backgroundColor="transparent-light" @size="small">
-            Annuler
+    {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+      <form onsubmit={{this.submitForm}}>
+        <PixTextarea
+          placeholder="Ajouter un commentaire…"
+          @value={{this.commentBeingEdited}}
+          class="jury-comment__field"
+          @id="jury-comment-field"
+          aria-label="Texte du commentaire"
+          required={{true}}
+        />
+        <div class="jury-comment__actions">
+          {{#if this.commentExists}}
+            <PixButton @triggerAction={{this.exitEditingMode}} @backgroundColor="transparent-light" @size="small">
+              Annuler
+            </PixButton>
+          {{/if}}
+          <PixButton @type="submit" @size="small">
+            Enregistrer
           </PixButton>
-        {{/if}}
-        <PixButton @type="submit" @size="small">
-          Enregistrer
-        </PixButton>
-      </div>
-    </form>
+        </div>
+      </form>
+    {{/if}}
   {{else}}
     <div>
       <span class="jury-comment__author">{{@author}}</span>
@@ -28,19 +30,21 @@
       <time class="jury-comment__date">{{moment-format @date "DD/MM/YYYY à HH:mm"}}</time>
     </div>
     <p class="jury-comment__content">{{this.comment}}</p>
-    <div class="jury-comment__actions">
-      <PixButton @triggerAction={{this.enterEditingMode}} @size="small">
-        Modifier
-      </PixButton>
-      <PixButton
-        @triggerAction={{this.openDeletionConfirmationModal}}
-        @size="small"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-      >
-        Supprimer
-      </PixButton>
-    </div>
+    {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+      <div class="jury-comment__actions">
+        <PixButton @triggerAction={{this.enterEditingMode}} @size="small">
+          Modifier
+        </PixButton>
+        <PixButton
+          @triggerAction={{this.openDeletionConfirmationModal}}
+          @size="small"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+        >
+          Supprimer
+        </PixButton>
+      </div>
+    {{/if}}
   {{/if}}
 </section>
 

--- a/admin/app/components/sessions/jury-comment.js
+++ b/admin/app/components/sessions/jury-comment.js
@@ -2,8 +2,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import noop from 'lodash/noop';
+import { inject as service } from '@ember/service';
 
 export default class JuryComment extends Component {
+  @service accessControl;
+
   @tracked editingMode = false;
   @tracked commentBeingEdited;
   @tracked shouldDisplayDeletionConfirmationModal = false;

--- a/admin/app/components/to-be-published-sessions/list-items.hbs
+++ b/admin/app/components/to-be-published-sessions/list-items.hbs
@@ -6,7 +6,9 @@
         <th>Centre de certification</th>
         <th>Date de session</th>
         <th>Date de finalisation</th>
-        <th>Actions</th>
+        {{#if this.isCurrentUserAllowedToPublishSession}}
+          <th>Actions</th>
+        {{/if}}
       </tr>
     </thead>
 
@@ -22,16 +24,18 @@
             <td>{{toBePublishedSession.certificationCenterName}}</td>
             <td>{{toBePublishedSession.printableDateAndTime}}</td>
             <td>{{toBePublishedSession.printableFinalizationDate}}</td>
-            <td>
-              <PixButton
-                @triggerAction={{fn this.showConfirmModal toBePublishedSession}}
-                class="publish-session-button"
-                @size="small"
-                aria-label="Publier la session numéro {{toBePublishedSession.id}}"
-              >
-                <FaIcon @icon="paper-plane" />Publier
-              </PixButton>
-            </td>
+            {{#if this.isCurrentUserAllowedToPublishSession}}
+              <td>
+                <PixButton
+                  @triggerAction={{fn this.showConfirmModal toBePublishedSession}}
+                  class="publish-session-button"
+                  @size="small"
+                  aria-label="Publier la session numéro {{toBePublishedSession.id}}"
+                >
+                  <FaIcon @icon="paper-plane" />Publier
+                </PixButton>
+              </td>
+            {{/if}}
           </tr>
         {{/each}}
       </tbody>

--- a/admin/app/components/to-be-published-sessions/list-items.hbs
+++ b/admin/app/components/to-be-published-sessions/list-items.hbs
@@ -6,7 +6,7 @@
         <th>Centre de certification</th>
         <th>Date de session</th>
         <th>Date de finalisation</th>
-        {{#if this.isCurrentUserAllowedToPublishSession}}
+        {{#if this.accessControl.hasAccessToCertificationActionsScope}}
           <th>Actions</th>
         {{/if}}
       </tr>
@@ -24,7 +24,7 @@
             <td>{{toBePublishedSession.certificationCenterName}}</td>
             <td>{{toBePublishedSession.printableDateAndTime}}</td>
             <td>{{toBePublishedSession.printableFinalizationDate}}</td>
-            {{#if this.isCurrentUserAllowedToPublishSession}}
+            {{#if this.accessControl.hasAccessToCertificationActionsScope}}
               <td>
                 <PixButton
                   @triggerAction={{fn this.showConfirmModal toBePublishedSession}}

--- a/admin/app/components/to-be-published-sessions/list-items.js
+++ b/admin/app/components/to-be-published-sessions/list-items.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class ToBePublishedSessionsList extends Component {
-  @service currentUser;
+  @service accessControl;
 
   @tracked shouldShowModal = false;
   currentSelectedSession;
@@ -12,14 +12,6 @@ export default class ToBePublishedSessionsList extends Component {
   _cancelModalSelection() {
     this.shouldShowModal = false;
     this.currentSelectedSession = null;
-  }
-
-  get isCurrentUserAllowedToPublishSession() {
-    return (
-      this.currentUser.adminMember.isSuperAdmin ||
-      this.currentUser.adminMember.isSupport ||
-      this.currentUser.adminMember.isCertif
-    );
   }
 
   @action

--- a/admin/app/components/to-be-published-sessions/list-items.js
+++ b/admin/app/components/to-be-published-sessions/list-items.js
@@ -1,14 +1,25 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class ToBePublishedSessionsList extends Component {
+  @service currentUser;
+
   @tracked shouldShowModal = false;
   currentSelectedSession;
 
   _cancelModalSelection() {
     this.shouldShowModal = false;
     this.currentSelectedSession = null;
+  }
+
+  get isCurrentUserAllowedToPublishSession() {
+    return (
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isSupport ||
+      this.currentUser.adminMember.isCertif
+    );
   }
 
   @action

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -7,7 +7,16 @@ import get from 'lodash/get';
 export default class SessionToBePublishedController extends Controller {
   @service notifications;
   @service store;
+  @service currentUser;
   @tracked shouldShowModal = false;
+
+  get isCurrentUserAllowedToPublishSession() {
+    return (
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isSupport ||
+      this.currentUser.adminMember.isCertif
+    );
+  }
 
   @action
   async publishSession(toBePublishedSession) {

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -7,16 +7,8 @@ import get from 'lodash/get';
 export default class SessionToBePublishedController extends Controller {
   @service notifications;
   @service store;
-  @service currentUser;
+  @service accessControl;
   @tracked shouldShowModal = false;
-
-  get isCurrentUserAllowedToPublishSession() {
-    return (
-      this.currentUser.adminMember.isSuperAdmin ||
-      this.currentUser.adminMember.isSupport ||
-      this.currentUser.adminMember.isCertif
-    );
-  }
 
   @action
   async publishSession(toBePublishedSession) {

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -9,7 +9,7 @@ import { action, computed } from '@ember/object';
 export default class ListController extends Controller {
   @service notifications;
   @service store;
-  @service currentUser;
+  @service accessControl;
 
   @tracked displayConfirm = false;
   @tracked confirmMessage = null;
@@ -18,14 +18,6 @@ export default class ListController extends Controller {
   get canPublish() {
     return !some(this.model.juryCertificationSummaries.toArray(), (certif) =>
       ['error', 'started'].includes(certif.status)
-    );
-  }
-
-  get isCurrentUserAllowedToPublishSession() {
-    return (
-      this.currentUser.adminMember.isSuperAdmin ||
-      this.currentUser.adminMember.isSupport ||
-      this.currentUser.adminMember.isCertif
     );
   }
 

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -9,6 +9,7 @@ import { action, computed } from '@ember/object';
 export default class ListController extends Controller {
   @service notifications;
   @service store;
+  @service currentUser;
 
   @tracked displayConfirm = false;
   @tracked confirmMessage = null;
@@ -17,6 +18,14 @@ export default class ListController extends Controller {
   get canPublish() {
     return !some(this.model.juryCertificationSummaries.toArray(), (certif) =>
       ['error', 'started'].includes(certif.status)
+    );
+  }
+
+  get isCurrentUserAllowedToPublishSession() {
+    return (
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isSupport ||
+      this.currentUser.adminMember.isCertif
     );
   }
 

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -9,6 +9,7 @@ import { statusToDisplayName } from '../../../../models/session';
 export default class IndexController extends Controller {
   @service notifications;
   @service currentUser;
+  @service accessControl;
   @service session;
 
   @alias('model') sessionModel;

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -19,4 +19,12 @@ export default class AccessControlService extends Service {
       this.currentUser.adminMember.isMetier
     );
   }
+
+  get hasAccessToCertificationActionsScope() {
+    return !!(
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isSupport ||
+      this.currentUser.adminMember.isCertif
+    );
+  }
 }

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
@@ -1,6 +1,6 @@
 {{page-title "Sessions à publier"}}
 {{#if @model.length}}
-  {{#if this.isCurrentUserAllowedToPublishSession}}
+  {{#if this.accessControl.hasAccessToCertificationActionsScope}}
     <div class="session-to-be-publish__publish-all">
       <PixButton @triggerAction={{this.showConfirmModal}}>Publier toutes les sessions</PixButton>
     </div>

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
@@ -1,8 +1,10 @@
 {{page-title "Sessions à publier"}}
 {{#if @model.length}}
-  <div class="session-to-be-publish__publish-all">
-    <PixButton @triggerAction={{this.showConfirmModal}}>Publier toutes les sessions</PixButton>
-  </div>
+  {{#if this.isCurrentUserAllowedToPublishSession}}
+    <div class="session-to-be-publish__publish-all">
+      <PixButton @triggerAction={{this.showConfirmModal}}>Publier toutes les sessions</PixButton>
+    </div>
+  {{/if}}
 {{/if}}
 
 <ToBePublishedSessions::ListItems @toBePublishedSessions={{@model}} @publishSession={{this.publishSession}} />

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -5,7 +5,7 @@
 
     <header class="certification-list-page__header">
       <h2>Certifications</h2>
-      {{#if this.isCurrentUserAllowedToPublishSession}}
+      {{#if this.accessControl.hasAccessToCertificationActionsScope}}
         <div class="btn-group" role="group">
 
           {{#if this.model.isPublished}}

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -5,32 +5,34 @@
 
     <header class="certification-list-page__header">
       <h2>Certifications</h2>
-      <div class="btn-group" role="group">
+      {{#if this.isCurrentUserAllowedToPublishSession}}
+        <div class="btn-group" role="group">
 
-        {{#if this.model.isPublished}}
-          <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Dépublier la session</PixButton>
-        {{else}}
-
-          {{#if this.canPublish}}
-            <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Publier la session</PixButton>
+          {{#if this.model.isPublished}}
+            <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Dépublier la session</PixButton>
           {{else}}
 
-            <PixTooltip @position="left" @isWide={{true}}>
-              <:triggerElement>
-                <PixButton
-                  @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}
-                  @isDisabled={{true}}
-                >
-                  Publier la session
-                </PixButton>
-              </:triggerElement>
-              <:tooltip>Vous ne pouvez pas publier la session tant qu'il reste des certifications en 'error' ou
-                'started'.</:tooltip>
-            </PixTooltip>
-          {{/if}}
+            {{#if this.canPublish}}
+              <PixButton @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}>Publier la session</PixButton>
+            {{else}}
 
-        {{/if}}
-      </div>
+              <PixTooltip @position="left" @isWide={{true}}>
+                <:triggerElement>
+                  <PixButton
+                    @triggerAction={{this.displayCertificationStatusUpdateConfirmationModal}}
+                    @isDisabled={{true}}
+                  >
+                    Publier la session
+                  </PixButton>
+                </:triggerElement>
+                <:tooltip>Vous ne pouvez pas publier la session tant qu'il reste des certifications en 'error' ou
+                  'started'.</:tooltip>
+              </PixTooltip>
+            {{/if}}
+
+          {{/if}}
+        </div>
+      {{/if}}
     </header>
 
     <div>

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -109,35 +109,37 @@
       </div>
     {{/if}}
 
-    <div class="session-info__actions">
-      <div class="row row--btn">
+    {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+      <div class="session-info__actions">
+        <div class="row row--btn">
 
-        {{#if this.sessionModel.finalizedAt}}
-          {{#if this.isCurrentUserAssignedToSession}}
-            <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
-          {{else}}
-            <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
-          {{/if}}
-        {{/if}}
-
-        <div class="session-info__copy-button">
-          {{#if this.isCopyButtonClicked}}
-            <p>{{this.copyButtonText}}</p>
+          {{#if this.sessionModel.finalizedAt}}
+            {{#if this.isCurrentUserAssignedToSession}}
+              <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
+            {{else}}
+              <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
+            {{/if}}
           {{/if}}
 
-          <PixButton size="small" @triggerAction={{this.copyResultsDownloadLink}} @backgroundColor="grey">
-            <FaIcon @icon="copy" @prefix="far" class="fa-inverse" aria-label="Copier" />
-            Lien de téléchargement des résultats
-          </PixButton>
+          <div class="session-info__copy-button">
+            {{#if this.isCopyButtonClicked}}
+              <p>{{this.copyButtonText}}</p>
+            {{/if}}
+
+            <PixButton size="small" @triggerAction={{this.copyResultsDownloadLink}} @backgroundColor="grey">
+              <FaIcon @icon="copy" @prefix="far" class="fa-inverse" aria-label="Copier" />
+              Lien de téléchargement des résultats
+            </PixButton>
+          </div>
+
+          {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
+            <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
+              Résultats transmis au prescripteur
+            </PixButton>
+          {{/if}}
         </div>
-
-        {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
-          <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
-            Résultats transmis au prescripteur
-          </PixButton>
-        {{/if}}
       </div>
-    </div>
+    {{/if}}
   </div>
 </section>
 

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
@@ -22,13 +22,11 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
     });
   });
 
-  module('When user is logged in', function (hooks) {
-    hooks.beforeEach(async function () {
+  module('When user is logged in', function () {
+    test('visiting /sessions/list/to-be-published', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    });
 
-    test('visiting /sessions/list/to-be-published', async function (assert) {
       // when
       await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
 
@@ -39,6 +37,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
     test('it should display sessions to publish informations', async function (assert) {
       assert.expect(7);
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const finalizedAt = new Date('2021-02-01T03:00:00Z');
       server.create('to-be-published-session', {
         id: '1',
@@ -66,6 +65,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
     test('it should publish a session', async function (assert) {
       assert.expect(2);
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const sessionDate = '2021-01-01';
       const sessionTime = '17:00:00';
       const finalizedAt = new Date('2021-02-01T03:00:00Z');
@@ -97,6 +97,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
     test('it should publish a batch of sessions', async function (assert) {
       assert.expect(3);
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const sessionDate = '2021-01-01';
       const sessionTime = '17:00:00';
       const finalizedAt = new Date('2021-02-01T03:00:00Z');

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published_test.js
@@ -94,38 +94,69 @@ module('Acceptance | authenticated/sessions/list/to be published', function (hoo
       _assertSecondSessionIsNotDisplayed(assert, screen);
     });
 
-    test('it should publish a batch of sessions', async function (assert) {
-      assert.expect(3);
-      // given
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      const sessionDate = '2021-01-01';
-      const sessionTime = '17:00:00';
-      const finalizedAt = new Date('2021-02-01T03:00:00Z');
-      server.create('to-be-published-session', {
-        id: '1',
-        certificationCenterName: 'Centre SCO des Anne-Étoiles',
-        finalizedAt,
-        sessionDate,
-        sessionTime,
+    module('publish a batch of sessions button', function () {
+      test('it should be hidden if current user is Metier', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isMetier: true })(server);
+
+        const sessionDate = '2021-01-01';
+        const sessionTime = '17:00:00';
+        const finalizedAt = new Date('2021-02-01T03:00:00Z');
+        server.create('to-be-published-session', {
+          id: '1',
+          certificationCenterName: 'Centre SCO des Anne-Étoiles',
+          finalizedAt,
+          sessionDate,
+          sessionTime,
+        });
+        server.create('to-be-published-session', {
+          id: '2',
+          certificationCenterName: 'Centre SUP et rieur',
+          finalizedAt,
+          sessionDate,
+          sessionTime,
+        });
+
+        // when
+        const screen = await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
+
+        // then
+        assert.dom(screen.queryByText('Publier toutes les sessions')).doesNotExist();
       });
-      server.create('to-be-published-session', {
-        id: '2',
-        certificationCenterName: 'Centre SUP et rieur',
-        finalizedAt,
-        sessionDate,
-        sessionTime,
+
+      test('it should be clickable if current user is Certif', async function (assert) {
+        assert.expect(3);
+        // given
+        await authenticateAdminMemberWithRole({ isCertif: true })(server);
+        const sessionDate = '2021-01-01';
+        const sessionTime = '17:00:00';
+        const finalizedAt = new Date('2021-02-01T03:00:00Z');
+        server.create('to-be-published-session', {
+          id: '1',
+          certificationCenterName: 'Centre SCO des Anne-Étoiles',
+          finalizedAt,
+          sessionDate,
+          sessionTime,
+        });
+        server.create('to-be-published-session', {
+          id: '2',
+          certificationCenterName: 'Centre SUP et rieur',
+          finalizedAt,
+          sessionDate,
+          sessionTime,
+        });
+
+        const screen = await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
+        await clickByName('Publier toutes les sessions');
+
+        // when
+        await clickByName('Confirmer');
+
+        // then
+        _assertPublishAllSessionsButtonHidden(assert, screen);
+        _assertNoSessionInList(assert, screen);
+        _assertConfirmModalIsClosed(assert, screen);
       });
-
-      const screen = await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
-      await clickByName('Publier toutes les sessions');
-
-      // when
-      await clickByName('Confirmer');
-
-      // then
-      _assertPublishAllSessionsButtonHidden(assert, screen);
-      _assertNoSessionInList(assert, screen);
-      _assertConfirmModalIsClosed(assert, screen);
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/sessions/session/certifications_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/certifications_test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
+
+module('Acceptance | authenticated/sessions/session/certifications', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user has role metier', function () {
+    test('it should not show publish button', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isMetier: true })(server);
+      server.create('session', { id: '1' });
+
+      // when
+      const screen = await visit('/sessions/1/certifications');
+
+      // then
+      assert.dom(screen.queryByText('Publier la session')).doesNotExist();
+    });
+  });
+});

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -190,6 +190,40 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         assert.dom(screen.getByText('24/10/2022')).exists();
       });
     });
+
+    module('buttons sections', function () {
+      module('when user does not have the right to make certif actions', function () {
+        test('it does not render the buttons section', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isMetier: true })(server);
+          const session = _buildSessionWithTwoJuryCertificationSummary({}, server);
+
+          // when
+          const screen = await visit(`/sessions/${session.id}`);
+
+          // then
+          assert.dom(screen.queryByText("M'assigner la session")).doesNotExist();
+          assert.dom(screen.queryByText('Lien de téléchargement des résultats')).doesNotExist();
+          assert.dom(screen.queryByText('Résultats transmis au prescripteur')).doesNotExist();
+        });
+      });
+    });
+
+    module('when user has the right to make certif actions', function () {
+      test('it renders the buttons section', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isCertif: true })(server);
+        const session = _buildSessionWithTwoJuryCertificationSummary({}, server);
+
+        // when
+        const screen = await visit(`/sessions/${session.id}`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: "M'assigner la session" })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Lien de téléchargement des résultats' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Résultats transmis au prescripteur' })).exists();
+      });
+    });
   });
 });
 
@@ -208,7 +242,6 @@ function _buildSessionWithTwoJuryCertificationSummary(sessionData, server) {
     status: 'finalized',
     finalizedAt: new Date('2022-01-01'),
     examinerGlobalComment: 'ceci est un commentaire sur les sessions de certification',
-    resultsSentToPrescriberAt: new Date('2020-01-01'),
     juryCertificationSummaries: [juryCertifSummary1, juryCertifSummary2],
     ...sessionData,
   });

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
@@ -3,14 +3,18 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Integration | Component | routes/authenticated/to-be-published-sessions | list-items', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should display to be published sessions list', async function (assert) {
     // given
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.adminMember = { isCertif: true };
+    class SessionStub extends Service {
+      hasAccessToCertificationActionsScope = true;
+    }
+    this.owner.register('service:accessControl', SessionStub);
+
     const firstSession = {
       id: '1',
       certificationCenterName: 'Centre SCO des Anne-Étoiles',
@@ -48,8 +52,11 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
 
   test('it should "Aucun résultat" if there are no sessions to show', async function (assert) {
     // given
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.adminMember = { isCertif: true };
+    class SessionStub extends Service {
+      hasAccessToCertificationActionsScope = true;
+    }
+    this.owner.register('service:accessControl', SessionStub);
+
     this.toBePublishedSessions = [];
 
     // when
@@ -62,10 +69,13 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
   });
 
   module('Publish a session', function () {
-    test('it should not show button if current user is metier', async function (assert) {
+    test('it should not show button if current user does not have the right', async function (assert) {
       // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isMetier: true };
+      class SessionStub extends Service {
+        hasAccessToCertificationActionsScope = false;
+      }
+      this.owner.register('service:accessControl', SessionStub);
+
       const session = {
         id: '1',
         certificationCenterName: 'Centre SCO des Anne-Étoiles',
@@ -86,8 +96,11 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
 
     test('it should show confirmation modal when one clicks on "Publier" button', async function (assert) {
       // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isCertif: true };
+
+      class SessionStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:accessControl', SessionStub);
 
       const session = {
         id: '1',
@@ -110,8 +123,10 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
 
     test('it should call provided publishModel "action" with the right published session as argument', async function (assert) {
       // given
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isCertif: true };
+      class SessionStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:accessControl', SessionStub);
 
       const session = {
         id: '1',

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items_test.js
@@ -9,6 +9,8 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
 
   test('it should display to be published sessions list', async function (assert) {
     // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isCertif: true };
     const firstSession = {
       id: '1',
       certificationCenterName: 'Centre SCO des Anne-Étoiles',
@@ -46,6 +48,8 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
 
   test('it should "Aucun résultat" if there are no sessions to show', async function (assert) {
     // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.adminMember = { isCertif: true };
     this.toBePublishedSessions = [];
 
     // when
@@ -57,48 +61,78 @@ module('Integration | Component | routes/authenticated/to-be-published-sessions 
     assert.dom(screen.getByText('Aucun résultat')).exists();
   });
 
-  test('it should show confirmation modal when one clicks on "Publier" button', async function (assert) {
-    // given
-    const session = {
-      id: '1',
-      certificationCenterName: 'Centre SCO des Anne-Étoiles',
-      sessionDate: '2021-01-01',
-      sessionTime: '11:00:00',
-      finalizedAt: new Date('2021-01-02T03:00:00Z'),
-    };
-    this.toBePublishedSessions = [session];
-    const screen = await render(
-      hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}}/>`
-    );
+  module('Publish a session', function () {
+    test('it should not show button if current user is metier', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isMetier: true };
+      const session = {
+        id: '1',
+        certificationCenterName: 'Centre SCO des Anne-Étoiles',
+        sessionDate: '2021-01-01',
+        sessionTime: '11:00:00',
+        finalizedAt: new Date('2021-01-02T03:00:00Z'),
+      };
+      this.toBePublishedSessions = [session];
 
-    // when
-    await clickByName('Publier la session numéro 1');
+      // when
+      const screen = await render(
+        hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}}/>`
+      );
 
-    // then
-    assert.dom(screen.getByText('Souhaitez-vous publier la session ?')).exists();
-  });
+      // then
+      assert.dom(screen.queryByText('Publier')).doesNotExist();
+    });
 
-  test('it should call provided publishModel "action" with the right published session as argument', async function (assert) {
-    // given
-    const session = {
-      id: '1',
-      certificationCenterName: 'Centre SCO des Anne-Étoiles',
-      sessionDate: '2021-01-01',
-      sessionTime: '11:00:00',
-      finalizedAt: new Date('2021-01-02T03:00:00Z'),
-    };
-    this.toBePublishedSessions = [session];
-    this.publishSession = sinon.stub();
-    await render(
-      hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}} @publishSession={{this.publishSession}}/>`
-    );
-    await clickByName('Publier la session numéro 1');
+    test('it should show confirmation modal when one clicks on "Publier" button', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isCertif: true };
 
-    // when
-    await clickByName('Confirmer');
+      const session = {
+        id: '1',
+        certificationCenterName: 'Centre SCO des Anne-Étoiles',
+        sessionDate: '2021-01-01',
+        sessionTime: '11:00:00',
+        finalizedAt: new Date('2021-01-02T03:00:00Z'),
+      };
+      this.toBePublishedSessions = [session];
+      const screen = await render(
+        hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}}/>`
+      );
 
-    // then
-    sinon.assert.calledWith(this.publishSession, session);
-    assert.ok(true);
+      // when
+      await clickByName('Publier la session numéro 1');
+
+      // then
+      assert.dom(screen.getByText('Souhaitez-vous publier la session ?')).exists();
+    });
+
+    test('it should call provided publishModel "action" with the right published session as argument', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isCertif: true };
+
+      const session = {
+        id: '1',
+        certificationCenterName: 'Centre SCO des Anne-Étoiles',
+        sessionDate: '2021-01-01',
+        sessionTime: '11:00:00',
+        finalizedAt: new Date('2021-01-02T03:00:00Z'),
+      };
+      this.toBePublishedSessions = [session];
+      this.publishSession = sinon.stub();
+      await render(
+        hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}} @publishSession={{this.publishSession}}/>`
+      );
+      await clickByName('Publier la session numéro 1');
+
+      // when
+      await clickByName('Confirmer');
+
+      // then
+      sinon.assert.calledWith(this.publishSession, session);
+      assert.ok(true);
+    });
   });
 });

--- a/admin/tests/integration/components/sessions/jury-comment_test.js
+++ b/admin/tests/integration/components/sessions/jury-comment_test.js
@@ -5,19 +5,26 @@ import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library
 import { hbs } from 'ember-cli-htmlbars';
 import moment from 'moment';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Integration | Component | Sessions::JuryComment', function (hooks) {
   setupRenderingTest(hooks);
 
   module('when there is no comment', function () {
-    test('it renders an empty comment form', async function (assert) {
-      // given
-      this.author = null;
-      this.date = null;
-      this.comment = null;
+    module('when current user is not allowed to comment', function () {
+      test('it should not render the form section', async function (assert) {
+        // given
+        class SessionStub extends Service {
+          hasAccessToCertificationActionsScope = false;
+        }
+        this.owner.register('service:accessControl', SessionStub);
 
-      // when
-      const screen = await render(hbs`
+        this.author = null;
+        this.date = null;
+        this.comment = null;
+
+        // when
+        const screen = await render(hbs`
         <Sessions::JuryComment
           @author={{this.author}}
           @date={{this.date}}
@@ -25,27 +32,59 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
         />
       `);
 
-      // then
-      assert.dom(screen.getByText("Commentaire de l'équipe Certification")).exists();
-      assert.dom(screen.getByRole('textbox', { name: 'Texte du commentaire' })).hasValue('');
-      assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
-      assert.dom(screen.queryByText('Annuler')).doesNotExist();
+        // then
+        assert.dom(screen.queryByRole('textbox', { name: 'Texte du commentaire' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
+      });
     });
 
-    module('when the form is submitted', function () {
-      module('when form submission succeeds', function () {
-        test('it calls onFormSubmit callback and exits edit mode', async function (assert) {
-          // given
-          this.author = null;
-          this.date = null;
-          this.comment = null;
-          this.onFormSubmit = sinon.stub().callsFake((comment) => {
-            this.set('comment', comment);
-            return new Promise((resolve) => resolve());
-          });
+    module('when current user is allowed to comment', function () {
+      test('it renders an empty comment form', async function (assert) {
+        // given
+        class SessionStub extends Service {
+          hasAccessToCertificationActionsScope = true;
+        }
+        this.owner.register('service:accessControl', SessionStub);
 
-          // when
-          const screen = await render(hbs`
+        this.author = null;
+        this.date = null;
+        this.comment = null;
+
+        // when
+        const screen = await render(hbs`
+        <Sessions::JuryComment
+          @author={{this.author}}
+          @date={{this.date}}
+          @comment={{this.comment}}
+        />
+      `);
+
+        // then
+        assert.dom(screen.getByText("Commentaire de l'équipe Certification")).exists();
+        assert.dom(screen.getByRole('textbox', { name: 'Texte du commentaire' })).hasValue('');
+        assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+        assert.dom(screen.queryByText('Annuler')).doesNotExist();
+      });
+
+      module('when the form is submitted', function () {
+        module('when form submission succeeds', function () {
+          test('it calls onFormSubmit callback and exits edit mode', async function (assert) {
+            // given
+            class SessionStub extends Service {
+              hasAccessToCertificationActionsScope = true;
+            }
+            this.owner.register('service:accessControl', SessionStub);
+
+            this.author = null;
+            this.date = null;
+            this.comment = null;
+            this.onFormSubmit = sinon.stub().callsFake((comment) => {
+              this.set('comment', comment);
+              return new Promise((resolve) => resolve());
+            });
+
+            // when
+            const screen = await render(hbs`
           <Sessions::JuryComment
               @author={{this.author}}
               @date={{this.date}}
@@ -53,26 +92,31 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
               @onFormSubmit={{this.onFormSubmit}}
             />
           `);
-          await fillByLabel('Texte du commentaire', 'Un nouveau commentaire');
-          await clickByName('Enregistrer');
+            await fillByLabel('Texte du commentaire', 'Un nouveau commentaire');
+            await clickByName('Enregistrer');
 
-          // then
-          assert.ok(this.onFormSubmit.calledWith('Un nouveau commentaire'));
-          assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
-          assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+            // then
+            assert.ok(this.onFormSubmit.calledWith('Un nouveau commentaire'));
+            assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
+            assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+          });
         });
-      });
 
-      module('when form submission fails', function () {
-        test('it stays in edit mode', async function (assert) {
-          // given
-          this.author = null;
-          this.date = null;
-          this.comment = null;
-          this.onFormSubmit = sinon.stub().rejects();
+        module('when form submission fails', function () {
+          test('it stays in edit mode', async function (assert) {
+            // given
+            class SessionStub extends Service {
+              hasAccessToCertificationActionsScope = true;
+            }
+            this.owner.register('service:accessControl', SessionStub);
 
-          // when
-          const screen = await render(hbs`
+            this.author = null;
+            this.date = null;
+            this.comment = null;
+            this.onFormSubmit = sinon.stub().rejects();
+
+            // when
+            const screen = await render(hbs`
             <Sessions::JuryComment
               @author={{this.author}}
               @date={{this.date}}
@@ -80,12 +124,13 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
               @onFormSubmit={{this.onFormSubmit}}
             />
           `);
-          await fillByLabel('Texte du commentaire', 'Un nouveau commentaire');
-          await clickByName('Enregistrer');
+            await fillByLabel('Texte du commentaire', 'Un nouveau commentaire');
+            await clickByName('Enregistrer');
 
-          // then
-          assert.ok(this.onFormSubmit.calledWith('Un nouveau commentaire'));
-          assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+            // then
+            assert.ok(this.onFormSubmit.calledWith('Un nouveau commentaire'));
+            assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+          });
         });
       });
     });
@@ -94,6 +139,11 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
   module('when there is a comment', function () {
     test('it renders the comment', async function (assert) {
       // given
+      class SessionStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:accessControl', SessionStub);
+
       this.author = 'Vernon Sanders Law';
       this.date = new Date('2021-06-21T14:30:21Z');
       this.comment =
@@ -123,9 +173,14 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
       assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
     });
 
-    module('when the "Modifier" button is clicked', function () {
-      test('it renders a prefilled form', async function (assert) {
+    module('when current user is not allowed to comment', function () {
+      test('it should not render actions buttons section', async function (assert) {
         // given
+        class SessionStub extends Service {
+          hasAccessToCertificationActionsScope = false;
+        }
+        this.owner.register('service:accessControl', SessionStub);
+
         this.author = 'Vernon Sanders Law';
         this.date = new Date('2021-06-21T14:30:21Z');
         this.comment =
@@ -133,109 +188,159 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
 
         // when
         const screen = await render(hbs`
-          <Sessions::JuryComment
-            @author={{this.author}}
-            @date={{this.date}}
-            @comment={{this.comment}}
-          />
-        `);
-        await clickByName('Modifier');
+        <Sessions::JuryComment
+          @author={{this.author}}
+          @date={{this.date}}
+          @comment={{this.comment}}
+        />
+      `);
 
         // then
-        assert
-          .dom(screen.getByLabelText('Texte du commentaire'))
-          .hasValue(
-            "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon."
-          );
-        assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
-        assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+
+        assert.dom(screen.queryByText('button', { name: 'Modifier' })).doesNotExist();
+        assert.dom(screen.queryByText('button', { name: 'Supprimer' })).doesNotExist();
       });
     });
 
-    module('when the "Annuler" button is clicked', function () {
-      test('it exits edit mode and renders the comment', async function (assert) {
-        // given
-        this.author = 'Vernon Sanders Law';
-        this.date = new Date('2021-06-21T14:30:21Z');
-        this.comment =
-          "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon.";
+    module('when current user is allowed to comment', function () {
+      module('when the "Modifier" button is clicked', function () {
+        test('it renders a prefilled form', async function (assert) {
+          // given
+          class SessionStub extends Service {
+            hasAccessToCertificationActionsScope = true;
+          }
+          this.owner.register('service:accessControl', SessionStub);
 
-        // when
-        const screen = await render(hbs`
+          this.author = 'Vernon Sanders Law';
+          this.date = new Date('2021-06-21T14:30:21Z');
+          this.comment =
+            "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon.";
+
+          // when
+          const screen = await render(hbs`
           <Sessions::JuryComment
             @author={{this.author}}
             @date={{this.date}}
             @comment={{this.comment}}
           />
         `);
-        await clickByName('Modifier');
-        await clickByName('Annuler');
+          await clickByName('Modifier');
 
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
-        assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+          // then
+          assert
+            .dom(screen.getByLabelText('Texte du commentaire'))
+            .hasValue(
+              "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon."
+            );
+          assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+          assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+        });
       });
 
-      test('it should keep the comment unchanged', async function (assert) {
-        // given
-        this.author = 'Serge Gainsbourg';
-        this.date = new Date('2021-06-21T14:30:21Z');
-        this.comment = 'Qui promène son chien est au bout de la laisse.';
+      module('when the "Annuler" button is clicked', function () {
+        test('it exits edit mode and renders the comment', async function (assert) {
+          // given
+          class SessionStub extends Service {
+            hasAccessToCertificationActionsScope = true;
+          }
+          this.owner.register('service:accessControl', SessionStub);
 
-        // when
-        const screen = await render(hbs`
+          this.author = 'Vernon Sanders Law';
+          this.date = new Date('2021-06-21T14:30:21Z');
+          this.comment =
+            "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon.";
+
+          // when
+          const screen = await render(hbs`
           <Sessions::JuryComment
             @author={{this.author}}
             @date={{this.date}}
             @comment={{this.comment}}
           />
         `);
-        await clickByName('Modifier');
-        await fillByLabel('Texte du commentaire', 'Qui promène son chat est au bout de la laisse.');
-        await clickByName('Annuler');
+          await clickByName('Modifier');
+          await clickByName('Annuler');
 
-        // then
-        assert.dom(screen.getByText('Qui promène son chien est au bout de la laisse.')).exists();
-      });
-    });
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
+          assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+        });
 
-    module('when the "Supprimer" button is clicked', function () {
-      test('it opens a confirmation modal', async function (assert) {
-        // given
-        this.author = 'Frederic Brown';
-        this.date = new Date('2006-11-21T15:32:12Z');
-        this.comment =
-          'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
+        test('it should keep the comment unchanged', async function (assert) {
+          // given
+          class SessionStub extends Service {
+            hasAccessToCertificationActionsScope = true;
+          }
+          this.owner.register('service:accessControl', SessionStub);
 
-        // when
-        const screen = await render(hbs`
+          this.author = 'Serge Gainsbourg';
+          this.date = new Date('2021-06-21T14:30:21Z');
+          this.comment = 'Qui promène son chien est au bout de la laisse.';
+
+          // when
+          const screen = await render(hbs`
           <Sessions::JuryComment
             @author={{this.author}}
             @date={{this.date}}
             @comment={{this.comment}}
           />
         `);
-        await clickByName('Supprimer');
+          await clickByName('Modifier');
+          await fillByLabel('Texte du commentaire', 'Qui promène son chat est au bout de la laisse.');
+          await clickByName('Annuler');
 
-        // then
-        assert.dom(screen.getByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?')).exists();
+          // then
+          assert.dom(screen.getByText('Qui promène son chien est au bout de la laisse.')).exists();
+        });
       });
 
-      module('when the confirmation modal "Confirmer" button is clicked', function () {
-        module('when the deletion succeeds', function () {
-          test('it calls the onDeleteButtonClicked callback and closes the modal', async function (assert) {
-            // given
-            this.author = 'Frederic Brown';
-            this.date = new Date('2006-11-21T15:32:12Z');
-            this.comment =
-              'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
-            this.onDeleteButtonClicked = sinon.stub().callsFake(() => {
-              this.set('comment', null);
-              return new Promise((resolve) => resolve());
-            });
+      module('when the "Supprimer" button is clicked', function () {
+        test('it opens a confirmation modal', async function (assert) {
+          // given
+          class SessionStub extends Service {
+            hasAccessToCertificationActionsScope = true;
+          }
+          this.owner.register('service:accessControl', SessionStub);
 
-            // when
-            const screen = await render(hbs`
+          this.author = 'Frederic Brown';
+          this.date = new Date('2006-11-21T15:32:12Z');
+          this.comment =
+            'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
+
+          // when
+          const screen = await render(hbs`
+          <Sessions::JuryComment
+            @author={{this.author}}
+            @date={{this.date}}
+            @comment={{this.comment}}
+          />
+        `);
+          await clickByName('Supprimer');
+
+          // then
+          assert.dom(screen.getByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?')).exists();
+        });
+
+        module('when the confirmation modal "Confirmer" button is clicked', function () {
+          module('when the deletion succeeds', function () {
+            test('it calls the onDeleteButtonClicked callback and closes the modal', async function (assert) {
+              // given
+              class SessionStub extends Service {
+                hasAccessToCertificationActionsScope = true;
+              }
+              this.owner.register('service:accessControl', SessionStub);
+
+              this.author = 'Frederic Brown';
+              this.date = new Date('2006-11-21T15:32:12Z');
+              this.comment =
+                'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
+              this.onDeleteButtonClicked = sinon.stub().callsFake(() => {
+                this.set('comment', null);
+                return new Promise((resolve) => resolve());
+              });
+
+              // when
+              const screen = await render(hbs`
               <Sessions::JuryComment
                 @author={{this.author}}
                 @date={{this.date}}
@@ -243,49 +348,100 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
                 @onDeleteButtonClicked={{this.onDeleteButtonClicked}}
               />
             `);
-            await clickByName('Supprimer');
-            await clickByName('Confirmer');
+              await clickByName('Supprimer');
+              await clickByName('Confirmer');
 
-            // then
-            assert.ok(this.onDeleteButtonClicked.calledOnce);
-            assert
-              .dom(screen.queryByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?'))
-              .doesNotExist();
-            assert
-              .dom(
-                screen.queryByText(
-                  'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…'
+              // then
+              assert.ok(this.onDeleteButtonClicked.calledOnce);
+              assert
+                .dom(screen.queryByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?'))
+                .doesNotExist();
+              assert
+                .dom(
+                  screen.queryByText(
+                    'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…'
+                  )
                 )
-              )
-              .doesNotExist();
-            assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+                .doesNotExist();
+              assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+            });
+          });
+
+          module('when the deletion fails', function () {
+            test('it keeps the comment and the modal open', async function (assert) {
+              // given
+              class SessionStub extends Service {
+                hasAccessToCertificationActionsScope = true;
+              }
+              this.owner.register('service:accessControl', SessionStub);
+
+              this.author = 'Frederic Brown';
+              this.date = new Date('2006-11-21T15:32:12Z');
+              this.comment =
+                'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
+              this.onDeleteButtonClicked = sinon.stub().rejects();
+
+              // when
+              const screen = await render(hbs`
+              <Sessions::JuryComment
+                @author={{this.author}}
+                @date={{this.date}}
+                @comment={{this.comment}}
+                @onDeleteButtonClicked={{this.onDeleteButtonClicked}}
+              />
+            `);
+              await clickByName('Supprimer');
+              await clickByName('Confirmer');
+
+              // then
+              assert.ok(this.onDeleteButtonClicked.calledOnce);
+              assert
+                .dom(screen.getByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?'))
+                .exists();
+              assert
+                .dom(
+                  screen.getByText(
+                    'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…'
+                  )
+                )
+                .exists();
+              assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
+              assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+            });
           });
         });
 
-        module('when the deletion fails', function () {
-          test('it keeps the comment and the modal open', async function (assert) {
+        module('when the confirmation modal "Annuler" button is clicked', function () {
+          test('it does not call the onDeleteButtonClicked callback and closes the modal', async function (assert) {
             // given
+            class SessionStub extends Service {
+              hasAccessToCertificationActionsScope = true;
+            }
+            this.owner.register('service:accessControl', SessionStub);
+
             this.author = 'Frederic Brown';
             this.date = new Date('2006-11-21T15:32:12Z');
             this.comment =
               'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
-            this.onDeleteButtonClicked = sinon.stub().rejects();
+            this.onDeleteButtonClicked = sinon.stub();
 
             // when
             const screen = await render(hbs`
-              <Sessions::JuryComment
-                @author={{this.author}}
-                @date={{this.date}}
-                @comment={{this.comment}}
-                @onDeleteButtonClicked={{this.onDeleteButtonClicked}}
-              />
-            `);
+            <Sessions::JuryComment
+              @author={{this.author}}
+              @date={{this.date}}
+              @comment={{this.comment}}
+              @onDeleteButtonClicked={{this.onDeleteButtonClicked}}
+            />
+          `);
             await clickByName('Supprimer');
-            await clickByName('Confirmer');
+            await clickByName('Annuler');
 
             // then
-            assert.ok(this.onDeleteButtonClicked.calledOnce);
-            assert.dom(screen.getByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?')).exists();
+            assert.ok(this.onDeleteButtonClicked.notCalled);
+            assert
+              .dom(screen.queryByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?'))
+              .doesNotExist();
             assert
               .dom(
                 screen.getByText(
@@ -299,72 +455,39 @@ module('Integration | Component | Sessions::JuryComment', function (hooks) {
         });
       });
 
-      module('when the confirmation modal "Annuler" button is clicked', function () {
-        test('it does not call the onDeleteButtonClicked callback and closes the modal', async function (assert) {
+      module("when the component's arguments change", function () {
+        test('it renders the updated comment', async function (assert) {
           // given
-          this.author = 'Frederic Brown';
-          this.date = new Date('2006-11-21T15:32:12Z');
+          class SessionStub extends Service {
+            hasAccessToCertificationActionsScope = true;
+          }
+          this.owner.register('service:accessControl', SessionStub);
+
+          const yesterday = '2021-06-21T14:30:21Z';
+          const today = '2021-07-21T14:30:21Z';
+          this.author = 'Vernon Sanders Law';
+          this.date = new Date(yesterday);
           this.comment =
-            'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…';
-          this.onDeleteButtonClicked = sinon.stub();
+            "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon.";
 
           // when
           const screen = await render(hbs`
-            <Sessions::JuryComment
-              @author={{this.author}}
-              @date={{this.date}}
-              @comment={{this.comment}}
-              @onDeleteButtonClicked={{this.onDeleteButtonClicked}}
-            />
-          `);
-          await clickByName('Supprimer');
-          await clickByName('Annuler');
-
-          // then
-          assert.ok(this.onDeleteButtonClicked.notCalled);
-          assert
-            .dom(screen.queryByText('Voulez-vous vraiment supprimer le commentaire de Frederic Brown ?'))
-            .doesNotExist();
-          assert
-            .dom(
-              screen.getByText(
-                'Le dernier homme sur la Terre était assis tout seul dans une pièce. Il y eut un coup à la porte…'
-              )
-            )
-            .exists();
-          assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
-          assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
-        });
-      });
-    });
-
-    module("when the component's arguments change", function () {
-      test('it renders the updated comment', async function (assert) {
-        // given
-        const yesterday = '2021-06-21T14:30:21Z';
-        const today = '2021-07-21T14:30:21Z';
-        this.author = 'Vernon Sanders Law';
-        this.date = new Date(yesterday);
-        this.comment =
-          "L'expérience est un professeur cruel car elle vous fait passer l'examen, avant de vous expliquer la leçon.";
-
-        // when
-        const screen = await render(hbs`
         <Sessions::JuryComment
           @author={{this.author}}
           @date={{this.date}}
           @comment={{this.comment}}
         />
         `);
-        this.set('author', 'XXXX');
-        this.set('date', new Date(today));
-        this.set('comment', 'Saperlipopette, quelle experience!');
-        await settled();
+          this.set('author', 'XXXX');
+          this.set('date', new Date(today));
+          this.set('comment', 'Saperlipopette, quelle experience!');
+          await settled();
 
-        // then
-        assert.dom(screen.getByText('XXXX')).exists();
-        assert.dom(screen.getByText(_formatDate(today))).exists();
-        assert.dom(screen.getByText('Saperlipopette, quelle experience!')).exists();
+          // then
+          assert.dom(screen.getByText('XXXX')).exists();
+          assert.dom(screen.getByText(_formatDate(today))).exists();
+          assert.dom(screen.getByText('Saperlipopette, quelle experience!')).exists();
+        });
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/certifications_test.js
@@ -67,9 +67,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
         await controller.actions.displayCertificationStatusUpdateConfirmationModal.call(controller);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.confirmMessage, 'Souhaitez-vous publier la session ?');
+        assert.strictEqual(controller.confirmMessage, 'Souhaitez-vous publier la session ?');
         assert.true(controller.displayConfirm);
       });
     });
@@ -84,9 +82,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
         await controller.actions.displayCertificationStatusUpdateConfirmationModal.call(controller);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.confirmMessage, 'Souhaitez-vous dépublier la session ?');
+        assert.strictEqual(controller.confirmMessage, 'Souhaitez-vous dépublier la session ?');
         assert.true(controller.displayConfirm);
       });
     });

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -46,7 +46,7 @@ module('Unit | Service | access-control', function (hooks) {
   });
 
   module('#hasAccessToOrganizationActionsScope', function () {
-    test('should be true if user is Super Admin', function (assert) {
+    test('should be true if current admin member is Super Admin', function (assert) {
       // given
       const currentUser = this.owner.lookup('service:currentUser');
       currentUser.adminMember = { isSuperAdmin: true };
@@ -88,6 +88,52 @@ module('Unit | Service | access-control', function (hooks) {
 
       // when / then
       assert.false(service.hasAccessToOrganizationActionsScope);
+    });
+  });
+
+  module('#hasAccessToCertificationActionsScope', function () {
+    test('should be true if current admin member is Super admin', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+
+      const service = this.owner.lookup('service:access-control');
+
+      // when / then
+      assert.true(service.hasAccessToCertificationActionsScope);
+    });
+
+    test('should be true if user is Support', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSupport: true };
+
+      const service = this.owner.lookup('service:access-control');
+
+      // when / then
+      assert.true(service.hasAccessToCertificationActionsScope);
+    });
+
+    test('should be true if user is Certif', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isCertif: true };
+
+      const service = this.owner.lookup('service:access-control');
+
+      // when / then
+      assert.true(service.hasAccessToCertificationActionsScope);
+    });
+
+    test('should be false if user is Metier', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isMetier: true };
+
+      const service = this.owner.lookup('service:access-control');
+
+      // when / then
+      assert.false(service.hasAccessToCertificationActionsScope);
     });
   });
 });

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -531,7 +531,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -704,7 +704,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -618,7 +618,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -591,7 +591,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -650,7 +650,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -676,7 +676,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -563,7 +563,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -375,7 +375,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/domain/services/session-authorization-service.js
+++ b/api/lib/domain/services/session-authorization-service.js
@@ -9,7 +9,10 @@ module.exports = {
     );
     if (!hasMembershipAccess) {
       const isSuperAdmin = await userRepository.isSuperAdmin(userId);
-      if (!isSuperAdmin) {
+      const isSupport = await userRepository.isSupport(userId);
+      const isCertif = await userRepository.isCertif(userId);
+      const hasRights = isSuperAdmin || isSupport || isCertif;
+      if (!hasRights) {
         return false;
       }
     }

--- a/api/lib/domain/usecases/get-certification-course.js
+++ b/api/lib/domain/usecases/get-certification-course.js
@@ -8,8 +8,12 @@ module.exports = async function getCertificationCourse({
 }) {
   const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
   if (!certificationCourse.doesBelongTo(userId)) {
-    const userIsSuperAdmin = await userRepository.isSuperAdmin(userId);
-    if (!userIsSuperAdmin) {
+    const isSuperAdmin = await userRepository.isSuperAdmin(userId);
+    const isSupport = await userRepository.isSupport(userId);
+    const isCertif = await userRepository.isCertif(userId);
+    const isMetier = await userRepository.isMetier(userId);
+    const hasRights = isSuperAdmin || isSupport || isCertif || isMetier;
+    if (!hasRights) {
       throw new UserNotAuthorizedToGetCertificationCoursesError();
     }
   }

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -340,19 +340,35 @@ describe('Unit | Application | Sessions | Routes', function () {
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
-      const payload = {
-        data: {
-          attributes: {
-            toPublish: true,
-          },
-        },
-      };
-
       // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish', payload);
+      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish');
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
   });
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -875,4 +875,32 @@ describe('Unit | Application | Sessions | Routes', function () {
       expect(response.statusCode).to.equal(404);
     });
   });
+
+  describe('GET /api/admin/sessions/{id}/generate-results-download-link', function () {
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(sessionController, 'generateSessionResultsDownloadLink').returns('ok');
+
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/sessions/1/generate-results-download-link');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(sessionController.generateSessionResultsDownloadLink);
+    });
+  });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -872,6 +872,32 @@ describe('Unit | Application | Sessions | Routes', function () {
       expect(securityPreHandlers.userHasAtLeastOneAccessOf).to.be.calledOnce;
       expect(sessionController.deleteJuryComment).to.be.calledOnce;
     });
+
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
+
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/admin/sessions/1/comment');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(sessionController.deleteJuryComment);
+    });
   });
 
   describe('GET /api/sessions/{id}/supervising', function () {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -32,38 +32,6 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('GET /api/admin/sessions/{id}', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'getJurySession').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/123');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
-  describe('GET /api/admin/sessions', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('POST /api/session', function () {
     it('should exist', async function () {
       // given
@@ -231,22 +199,6 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('GET /api/admin/sessions/{id}/jury-certification-summaries', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'getJuryCertificationSummaries').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/1/jury-certification-summaries');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('POST /api/sessions/{id}/candidate-participation', function () {
     it('should exist', async function () {
       // given
@@ -275,294 +227,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
-    });
-  });
-
-  describe('PATCH /api/admin/sessions/{id}/publish', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(sessionController, 'publish').returns('ok');
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').resolves(true);
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/publish', {
-        data: {
-          attributes: {
-            toPublish: true,
-          },
-        },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(sessionController, 'publish').returns('ok');
-
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/publish', {
-        data: {
-          attributes: {
-            toPublish: true,
-          },
-        },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(sessionController.publish);
-    });
-  });
-
-  describe('PATCH /api/admin/sessions/{id}/unpublish', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'unpublish').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
-    });
-  });
-
-  describe('POST /api/admin/sessions/publish-in-batch', function () {
-    it('is protected by a pre-handler checking authorization to access Pix Admin', async function () {
-      // given
-      sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const payload = {
-        data: {
-          attributes: {
-            ids: [1, 2, 3],
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
-
-      // then
-      expect(response.statusCode).to.equal(403);
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(sessionController, 'publishInBatch').returns('ok');
-
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', {
-        data: {
-          attributes: {
-            ids: [1, 2, 3],
-          },
-        },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(sessionController.publishInBatch);
-    });
-
-    it('should succeed with valid session ids', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'publishInBatch').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const payload = {
-        data: {
-          attributes: {
-            ids: [1, 2, 3],
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('should validate the session ids in payload', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const payload = {
-        data: {
-          attributes: {
-            ids: ['an invalid session id'],
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-
-  describe('PUT /api/admin/sessions/{id}/results-sent-to-prescriber', function () {
-    it('should exist', async function () {
-      // when
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const response = await httpTestServer.request('PUT', '/api/admin/sessions/3/results-sent-to-prescriber');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
-
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/results-sent-to-prescriber');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(sessionController.flagResultsAsSentToPrescriber);
-    });
-  });
-
-  describe('GET /api/admin/sessions/{id}/supervisor-kit', function () {
-    it('should return 200', async function () {
-      // when
-      sinon.stub(sessionController, 'getSupervisorKitPdf').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
-  describe('PATCH /api/admin/sessions/{id}/certification-officer-assignment', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/certification-officer-assignment');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/certification-officer-assignment');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
   });
 
@@ -739,167 +403,6 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('GET /api/admin/sessions/to-publish', function () {
-    it('exists', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-    it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
-      // given
-      sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-    });
-  });
-
-  describe('GET /api/admin/sessions/with-required-action', function () {
-    it('exists', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
-      // given
-      sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-    });
-  });
-
-  describe('PUT /api/admin/sessions/{id}/comment', function () {
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'commentAsJury').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
-      // given
-      sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(sessionController, 'commentAsJury').returns('ok');
-
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(sessionController.commentAsJury);
-    });
-  });
-
-  describe('DELETE /api/admin/sessions/{id}/comment', function () {
-    it('should call appropriate use case and ensure user has access to Pix Admin', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      await httpTestServer.request('DELETE', '/api/admin/sessions/1/comment');
-
-      // then
-      expect(securityPreHandlers.userHasAtLeastOneAccessOf).to.be.calledOnce;
-      expect(sessionController.deleteJuryComment).to.be.calledOnce;
-    });
-
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
-
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('DELETE', '/api/admin/sessions/1/comment');
-
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(sessionController.deleteJuryComment);
-    });
-  });
-
   describe('GET /api/sessions/{id}/supervising', function () {
     it('should return 200 if the user is a supervisor of the session and certification center is in the whitelist', async function () {
       //given
@@ -954,31 +457,535 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
-  describe('GET /api/admin/sessions/{id}/generate-results-download-link', function () {
-    it('return forbidden access if user has METIER role', async function () {
-      // given
-      sinon.stub(sessionController, 'generateSessionResultsDownloadLink').returns('ok');
+  describe('For admin', function () {
+    describe('GET /api/admin/sessions/{id}', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'getJurySession').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/123');
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
 
-      // when
-      const response = await httpTestServer.request('GET', '/api/admin/sessions/1/generate-results-download-link');
+    describe('GET /api/admin/sessions', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(sessionController.generateSessionResultsDownloadLink);
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+    describe('GET /api/admin/sessions/{id}/jury-certification-summaries', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'getJuryCertificationSummaries').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/1/jury-certification-summaries');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('PATCH /api/admin/sessions/{id}/publish', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(sessionController, 'publish').returns('ok');
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').resolves(true);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/publish', {
+          data: {
+            attributes: {
+              toPublish: true,
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(sessionController, 'publish').returns('ok');
+
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/publish', {
+          data: {
+            attributes: {
+              toPublish: true,
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(sessionController.publish);
+      });
+    });
+
+    describe('PATCH /api/admin/sessions/{id}/unpublish', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'unpublish').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/unpublish');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
+      });
+    });
+
+    describe('POST /api/admin/sessions/publish-in-batch', function () {
+      it('is protected by a pre-handler checking authorization to access Pix Admin', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payload = {
+          data: {
+            attributes: {
+              ids: [1, 2, 3],
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(sessionController, 'publishInBatch').returns('ok');
+
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', {
+          data: {
+            attributes: {
+              ids: [1, 2, 3],
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(sessionController.publishInBatch);
+      });
+
+      it('should succeed with valid session ids', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'publishInBatch').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payload = {
+          data: {
+            attributes: {
+              ids: [1, 2, 3],
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should validate the session ids in payload', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payload = {
+          data: {
+            attributes: {
+              ids: ['an invalid session id'],
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    describe('PUT /api/admin/sessions/{id}/results-sent-to-prescriber', function () {
+      it('should exist', async function () {
+        // when
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const response = await httpTestServer.request('PUT', '/api/admin/sessions/3/results-sent-to-prescriber');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
+
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/results-sent-to-prescriber');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(sessionController.flagResultsAsSentToPrescriber);
+      });
+    });
+
+    describe('GET /api/admin/sessions/{id}/supervisor-kit', function () {
+      it('should return 200', async function () {
+        // when
+        sinon.stub(sessionController, 'getSupervisorKitPdf').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('PATCH /api/admin/sessions/{id}/certification-officer-assignment', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'PATCH',
+          '/api/admin/sessions/1/certification-officer-assignment'
+        );
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'PATCH',
+          '/api/admin/sessions/1/certification-officer-assignment'
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
+      });
+    });
+
+    describe('GET /api/admin/sessions/to-publish', function () {
+      it('exists', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+      it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('GET /api/admin/sessions/with-required-action', function () {
+      it('exists', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('PUT /api/admin/sessions/{id}/comment', function () {
+      it('should exist', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'commentAsJury').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(sessionController, 'commentAsJury').returns('ok');
+
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(sessionController.commentAsJury);
+      });
+    });
+
+    describe('DELETE /api/admin/sessions/{id}/comment', function () {
+      it('should call appropriate use case and ensure user has access to Pix Admin', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('DELETE', '/api/admin/sessions/1/comment');
+
+        // then
+        expect(securityPreHandlers.userHasAtLeastOneAccessOf).to.be.calledOnce;
+        expect(sessionController.deleteJuryComment).to.be.calledOnce;
+      });
+
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
+
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('DELETE', '/api/admin/sessions/1/comment');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(sessionController.deleteJuryComment);
+      });
+    });
+
+    describe('GET /api/admin/sessions/{id}/generate-results-download-link', function () {
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon.stub(sessionController, 'generateSessionResultsDownloadLink').returns('ok');
+
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/1/generate-results-download-link');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(sessionController.generateSessionResultsDownloadLink);
+      });
     });
   });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -829,6 +829,32 @@ describe('Unit | Application | Sessions | Routes', function () {
       // then
       expect(response.statusCode).to.equal(403);
     });
+
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(sessionController, 'commentAsJury').returns('ok');
+
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/comment');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(sessionController.commentAsJury);
+    });
   });
 
   describe('DELETE /api/admin/sessions/{id}/comment', function () {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -514,6 +514,30 @@ describe('Unit | Application | Sessions | Routes', function () {
       // then
       expect(response.statusCode).to.equal(200);
     });
+
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/1/certification-officer-assignment');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
+    });
   });
 
   describe('id validation', function () {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -484,6 +484,32 @@ describe('Unit | Application | Sessions | Routes', function () {
       // then
       expect(response.statusCode).to.equal(200);
     });
+
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
+
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PUT', '/api/admin/sessions/1/results-sent-to-prescriber');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(sessionController.flagResultsAsSentToPrescriber);
+    });
   });
 
   describe('GET /api/admin/sessions/{id}/supervisor-kit', function () {

--- a/api/tests/unit/domain/services/session-authorization-service_test.js
+++ b/api/tests/unit/domain/services/session-authorization-service_test.js
@@ -14,6 +14,8 @@ describe('Unit | Service | SessionAuthorizationService', function () {
 
     beforeEach(function () {
       sinon.stub(userRepository, 'isSuperAdmin');
+      sinon.stub(userRepository, 'isSupport');
+      sinon.stub(userRepository, 'isCertif');
       sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession');
     });
 
@@ -50,10 +52,38 @@ describe('Unit | Service | SessionAuthorizationService', function () {
         });
       });
 
-      context('when user is not SuperAdmin', function () {
+      context('when user is Support', function () {
+        it('should return true', async function () {
+          // given
+          userRepository.isSupport.withArgs(userId).resolves(true);
+
+          // when
+          const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
+
+          // then
+          expect(isAuthorized).to.be.true;
+        });
+      });
+
+      context('when user is Certif', function () {
+        it('should return true', async function () {
+          // given
+          userRepository.isCertif.withArgs(userId).resolves(true);
+
+          // when
+          const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
+
+          // then
+          expect(isAuthorized).to.be.true;
+        });
+      });
+
+      context('when user is neither SuperAdmin, nor Support, nor Certif', function () {
         it('should return false', async function () {
           // given
           userRepository.isSuperAdmin.withArgs(userId).resolves(false);
+          userRepository.isCertif.withArgs(userId).resolves(false);
+          userRepository.isSupport.withArgs(userId).resolves(false);
 
           // when
           const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });

--- a/api/tests/unit/domain/usecases/get-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-course_test.js
@@ -17,6 +17,9 @@ describe('Unit | UseCase | get-certification-course', function () {
     };
     userRepository = {
       isSuperAdmin: sinon.stub(),
+      isSupport: sinon.stub(),
+      isCertif: sinon.stub(),
+      isMetier: sinon.stub(),
     };
   });
 
@@ -40,6 +43,57 @@ describe('Unit | UseCase | get-certification-course', function () {
     // given
     certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
     userRepository.isSuperAdmin.withArgs('super_admin_user_id').resolves(true);
+
+    // when
+    const actualCertificationCourse = await getCertificationCourse({
+      certificationCourseId: certificationCourse.getId(),
+      userId: 'super_admin_user_id',
+      certificationCourseRepository,
+      userRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.getId()).to.equal(certificationCourse.getId());
+  });
+
+  it('should get the certificationCourse when the user id does not match the certification course user id but is Support', async function () {
+    // given
+    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+    userRepository.isSupport.withArgs('super_admin_user_id').resolves(true);
+
+    // when
+    const actualCertificationCourse = await getCertificationCourse({
+      certificationCourseId: certificationCourse.getId(),
+      userId: 'super_admin_user_id',
+      certificationCourseRepository,
+      userRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.getId()).to.equal(certificationCourse.getId());
+  });
+
+  it('should get the certificationCourse when the user id does not match the certification course user id but is Certif', async function () {
+    // given
+    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+    userRepository.isCertif.withArgs('super_admin_user_id').resolves(true);
+
+    // when
+    const actualCertificationCourse = await getCertificationCourse({
+      certificationCourseId: certificationCourse.getId(),
+      userId: 'super_admin_user_id',
+      certificationCourseRepository,
+      userRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.getId()).to.equal(certificationCourse.getId());
+  });
+
+  it('should get the certificationCourse when the user id does not match the certification course user id but is Metier', async function () {
+    // given
+    certificationCourseRepository.get.withArgs(certificationCourse.getId()).resolves(certificationCourse);
+    userRepository.isMetier.withArgs('super_admin_user_id').resolves(true);
 
     // when
     const actualCertificationCourse = await getCertificationCourse({


### PR DESCRIPTION
## :unicorn: Problème
Les pages liés aux sessions de certification dans Pix Admin sont actuellement disponible à tous les utilisateurs Pix Admin (indépendamment de leur rôles).
Or ces pages contiennent des actions critiques comme : 
- publier une session
- publier plusieurs session d'un coup (en batch)
- dépublier une session
- m'assigner une session
- lien de téléchargement des résultats d'une session
- tagguer la session comme "résultats transmis au prescripteur"
- modifier le commentaire d'une session
- supprimer le commentaire d'une session

Ces actions ne sont jamais utilisées par les membres Pix Admin ayant le rôle METIER. Elles ne devraient être accessible qu'à un utilisateur SUPER_ADMIN, CERTIF ou SUPPORT.

## :robot: Solution
Faire en sorte que les routes API soient protégée et n'acceptent que les SUPER_ADMIN, CERTIF ou SUPPORT pour effectuer ces actions là.
Faire en sorte de dissimuler côté front les boutons d'actions critiques dans le menu aux personnes ayant le rôle METIER

## :rainbow: Remarques
Les routes API concernées par la protection : 
- `PATCH /api/admin/sessions/{id}/publish`
- `POST /api/admin/sessions/publish-in-batch`
- `PATCH /api/admin/sessions/{id}/unpublish`
- `PATCH /api/admin/sessions/{id}/certification-officer-assignment` 
- `GET /api/admin/sessions/{id}/generate-results-download-link`
- `PUT /api/admin/sessions/{id}/results-sent-to-prescriber`
- `PUT /api/admin/sessions/{id}/comment`
- `DELETE /api/admin/sessions/{id}/comment`

## :100: Pour tester

### Vérifier que les routes API sont bien protégées

1- Drop les commits commençant par  "admin:" 

2- Se connecter à Pix Admin avec "pixmetier@example.net" + ouvrir l'inspecteur web , onglet réseau
3- Vérifier que toutes les actions suivantes renvoie une 403 :
- aller sur `sessions/5` et cliquer sur "M'assigner la session"
- aller sur `sessions/5` et cliquer "Lien de téléchargement des résultats"
- aller sur `sessions/5` et cliquer "Résultats transmis au prescripteur"
- aller sur `sessions/5`, remplir le champ commentaire de l'équipe certif et cliquer "Enregistrer"
- aller sur `sessions/6` et cliquer sur "Modifier"
- aller sur `sessions/6` et cliquer sur "Supprimer"
- aller sur `sessions/5/certifications` et cliquer sur "Publier la session"
- aller sur cliquer sur `sessions/list/to-be-published` et cliquer sur "Publier" 
- aller sur `sessions/list/to-be-published` et cliquer sur "Publier toutes les sessions" 


### Vérifier que l'application Pix Admin ne présente pas les fonctionnalités d'actions liées à la certif au Métier

6- Rétablir les commits
7- Vérifier avec le compte "pixmetier@example.net" : 
- que vous ne voyez plus les boutons d'actions cités plus haut


### Vérifier que l'application Pix Admin présente toujours les fonctionnalités d'actions liées à la certif aux Super Admin, au Support et au membre Certif

8- Vérifier avec les comptes "pixsupport@example.net", "superadmin@example.net" ou "pixcertif@example.net" que les actions cités plus haut fonctionnent (n'oubliez pas de reset vos seeds pour simplifier).