### PR TITLE
[TECH] Supprimer l'erreur UserAccountNotFoundForPoleEmploiError inutilisée (PIX-4915).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -126,11 +126,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.GeneratePoleEmploiTokensError) {
     return new HttpErrors.InternalServerError(error.message, error.title);
   }
-  if (error instanceof DomainErrors.UserAccountNotFoundForPoleEmploiError) {
-    return new HttpErrors.UnauthorizedError(error.message, error.responseCode, {
-      authenticationKey: error.authenticationKey,
-    });
-  }
   if (error instanceof DomainErrors.UserAlreadyExistsWithAuthenticationMethodError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -909,14 +909,6 @@ class UserNotFoundError extends NotFoundError {
   }
 }
 
-class UserAccountNotFoundForPoleEmploiError extends DomainError {
-  constructor({ message = "L'utilisateur n'a pas de compte Pix", responseCode, authenticationKey }) {
-    super(message);
-    this.responseCode = responseCode;
-    this.authenticationKey = authenticationKey;
-  }
-}
-
 class UnknownCountryForStudentEnrollmentError extends DomainError {
   constructor(
     { firstName, lastName },
@@ -1214,7 +1206,6 @@ module.exports = {
   TooManyRows,
   UnexpectedPoleEmploiStateError,
   UnexpectedUserAccountError,
-  UserAccountNotFoundForPoleEmploiError,
   UnknownCountryForStudentEnrollmentError,
   UserAlreadyExistsWithAuthenticationMethodError,
   UserAlreadyLinkedToCandidateInSessionError,

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -826,15 +826,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('Erreur, vous devez changer votre mot de passe.');
     });
 
-    it('when a UserShouldChangePasswordError error is thrown', async function () {
-      const expectedMessage = "L'utilisateur n'a pas de compte Pix";
-      routeHandler.throws(new DomainErrors.UserAccountNotFoundForPoleEmploiError(expectedMessage));
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
-      expect(responseDetail(response)).to.equal(expectedMessage);
-    });
-
     it('responds Unauthorized when a UserCantBeCreatedError error occurs', async function () {
       routeHandler.throws(new DomainErrors.UserCantBeCreatedError("L'utilisateur ne peut pas être créé"));
       const response = await server.requestObject(request);

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -475,10 +475,6 @@ describe('Unit | Domain | Errors', function () {
     });
   });
 
-  it('should export a UserAccountNotFoundForPoleEmploiError', function () {
-    expect(errors.UserAccountNotFoundForPoleEmploiError).to.exist;
-  });
-
   it('should export a UnknownCountryForStudentEnrollmentError', function () {
     expect(errors.UnknownCountryForStudentEnrollmentError).to.exist;
   });


### PR DESCRIPTION
## :unicorn: Problème
L'erreur, introduite dans la [PR suivante](https://github.com/1024pix/pix/pull/2409/files), n'est désormais plus utilisé suite aux refactos qui ont été fait sur le code de Pôle Emploi.

## :robot: Solution
Supprimer le code lié à l'erreur `UserAccountNotFoundForPoleEmploiError`

## :100: Pour tester
Les tests passent
Vous pouvez faire une passe fonctionnelle sur Pôle Emploi voir si rien n'est impacté. ( mais elle n'est appelé nulle part :D )
