### PR TITLE
[FEATURE] Modifier le message d'erreur affiché lorsqu'un élève tente de rentrer en session avec le mauvais compte (PIX-4879).

### DIFF
--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -75,10 +75,10 @@
 
     {{#if this.errorMessage}}
       <div class="certification-course-page__errors">{{this.errorMessage}}
-        {{#if this.genericErrorListElements}}
+        {{#if this.errorDetailList}}
           <ul class="certification-course-page__errors__list">
-            {{#each this.genericErrorListElements as |genericErrorElement|}}
-              <li>{{genericErrorElement}}</li>
+            {{#each this.errorDetailList as |errorDetailElement|}}
+              <li>{{errorDetailElement}}</li>
             {{/each}}
           </ul>
         {{/if}}

--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -82,6 +82,15 @@
             {{/each}}
           </ul>
         {{/if}}
+        {{#if this.errorMessageLink}}
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href={{this.errorMessageLink.url}}
+          >{{this.errorMessageLink.label}}
+          </a>
+          <FaIcon @icon="up-right-from-square" />
+        {{/if}}
       </div>
     {{/if}}
     <PixButton @type="submit">{{t "pages.certification-joiner.form.actions.submit"}}</PixButton>

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -25,7 +25,7 @@ export default class CertificationJoiner extends Component {
   SESSION_ID_VALIDATION_PATTERN = '^[0-9]*$';
 
   @tracked errorMessage = null;
-  @tracked genericErrorListElements = [];
+  @tracked errorDetailList = [];
   @tracked errorMessageLink = null;
   @tracked sessionIdIsNotANumberError = null;
   @tracked validationClassName = '';
@@ -100,7 +100,7 @@ export default class CertificationJoiner extends Component {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.session-not-accessible');
       } else {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer');
-        this.genericErrorListElements = [
+        this.errorDetailList = [
           this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'),
           this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'),
         ];
@@ -133,7 +133,7 @@ export default class CertificationJoiner extends Component {
 
   _resetErrorMessages() {
     this.errorMessage = null;
-    this.genericErrorListElements = [];
+    this.errorDetailList = [];
     this.errorMessageLink = null;
   }
 }

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -25,8 +25,8 @@ export default class CertificationJoiner extends Component {
   SESSION_ID_VALIDATION_PATTERN = '^[0-9]*$';
 
   @tracked errorMessage = null;
-  @tracked genericErrorDisclaimer = null;
   @tracked genericErrorListElements = [];
+  @tracked errorMessageLink = null;
   @tracked sessionIdIsNotANumberError = null;
   @tracked validationClassName = '';
   @tracked sessionId = null;
@@ -72,6 +72,7 @@ export default class CertificationJoiner extends Component {
   @action
   async attemptNext(e) {
     e.preventDefault();
+    this._resetErrorMessages();
     let currentCertificationCandidate = null;
     if (this.sessionId && !this._isANumber(this.sessionId)) {
       this.sessionIdIsNotANumberError = this.intl.t(
@@ -91,10 +92,12 @@ export default class CertificationJoiner extends Component {
 
       if (_isMatchingReconciledStudentNotFoundError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');
-        this.genericErrorListElements = [];
+        this.errorMessageLink = {
+          label: this.intl.t('pages.certification-joiner.error-messages.wrong-account-link'),
+          url: 'https://support.pix.org/fr/support/solutions/articles/15000047880',
+        };
       } else if (_isSessionNotAccessibleError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.session-not-accessible');
-        this.genericErrorListElements = [];
       } else {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.generic.disclaimer');
         this.genericErrorListElements = [
@@ -126,5 +129,11 @@ export default class CertificationJoiner extends Component {
   @action
   handleInputFocus(value, event) {
     event.target.select();
+  }
+
+  _resetErrorMessages() {
+    this.errorMessage = null;
+    this.genericErrorListElements = [];
+    this.errorMessageLink = null;
   }
 }

--- a/mon-pix/app/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/congratulations-certification-banner.hbs
@@ -11,39 +11,25 @@
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
   </p>
   {{#if @certificationEligibility.cleaCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.clea-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.clea-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusDroitMaitreCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-droit-maitre-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-maitre-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusDroitExpertCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-droit-expert-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduInitieCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-edu-initie-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-initie-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduConfirmeCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-edu-confirme-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-confirme-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduAvanceCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-edu-avance-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-avance-eligibility"}}</p>
   {{/if}}
   {{#if @certificationEligibility.pixPlusEduExpertCertificationEligible}}
-    <p class="congratulations-banner__eligibility-message">{{t
-        "pages.certification-joiner.congratulation-banner.pix-plus-edu-expert-eligibility"
-      }}</p>
+    <p>{{t "pages.certification-joiner.congratulation-banner.pix-plus-edu-expert-eligibility"}}</p>
   {{/if}}
 
   <a

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -160,6 +160,12 @@
       margin: 8px 0 0 16px;
     }
   }
+
+  a,
+  a:visited {
+    color: $pure-orange;
+    text-decoration: underline;
+  }
 }
 
 .certification-course-page__field-button {

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -12,6 +12,10 @@
   justify-content: center;
 }
 
+.congratulations-banner p {
+  text-align: center;
+}
+
 .congratulations-banner__icon {
   color: $white;
   position: absolute;
@@ -43,10 +47,6 @@
 
   font-size: 1.5rem;
   margin-bottom: 16px;
-}
-
-.congratulations-banner__eligibility-message {
-  text-align: center;
 }
 
 .congratulations-banner__link {

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -144,9 +144,10 @@ describe('Integration | Component | certification-joiner', function () {
       // then
       expect(
         contains(
-          'Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification. Pour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.'
+          "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement. Connectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant."
         )
       ).to.exist;
+      expect(contains("Comment trouver le compte lié à l'établissement ?")).to.exist;
     });
 
     it('should display an error message on candidate not found', async function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -259,7 +259,8 @@
           "check-personal-info": "Check with the invigilator that your personal information matches the sign-in sheet."
         },
         "session-not-accessible": "The session you are trying to join is no longer available.",
-        "wrong-account": "Oops! It seems that you are using the wrong Pix account to join this certification session.\nTo continue, please login to the correct Pix account or ask the invigilator for help."
+        "wrong-account": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",
+        "wrong-account-link": "How to find the account linked to the school/organisation ?"
       },
       "first-title": "Join a session",
       "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -258,7 +258,8 @@
           "check-personal-info": "Vérifiez auprès du surveillant la correspondance de vos informations personnelles avec la feuille d'émargement."
         },
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
-        "wrong-account": "Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant."
+        "wrong-account": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",
+        "wrong-account-link": "Comment trouver le compte lié à l'établissement ?"
       },
       "first-title": "Rejoindre une session",
       "form": {


### PR DESCRIPTION
## :unicorn: Problème
Le pôle support reçoit beaucoup de tickets d'élèves qui tentent de rejoindre une session de certification, mais qui n’y parviennent pas car utilisent un compte qui n’est pas celui avec lequel ils sont liés à leur établissement. Le message d’erreur affiché dans ce cas n’est a priori pas assez explicite.

## :robot: Solution
Mettre à jour le message d'erreur et ajouter un lien vers de la documentation

## :rainbow: Remarques
Cette PR se base sur la PR https://github.com/1024pix/pix/pull/4396

## :100: Pour tester
- Se connecter à Pix App avec le compte `certif-success@example.net`
- Rejoindre une session de certification avec les informations suivantes:
    - Numéro de session: **20000**
    - Prénom: **George**
    - Nom: **De Cambridge**
    - Date de naissance:  **22/07/2013** 
- Vérifier que le bon message d'erreur s'affiche. 
