### PR TITLE
[BUGFIX] Réparer les filtres sur la page liste des membres d'une organisation(PIX-4849) 

### DIFF
--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -17,7 +17,6 @@
           </tr>
           <tr>
             <td class="table__column"></td>
-            <td class="table__column"></td>
             <td class="table__column table__column--wide">
               <input
                 id="firstName"

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -47,7 +47,7 @@
                 class="table-admin-input form-control"
               />
             </td>
-            <th class="table__column">
+            <td class="table__column">
               <PixSelect
                 id="organizationRole"
                 @options={{this.options}}
@@ -56,7 +56,7 @@
                 @emptyOptionLabel="Tous"
                 aria-label="Rechercher par rôle"
               />
-            </th>
+            </td>
             <td class="table__column"></td>
           </tr>
         </thead>

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -52,7 +52,7 @@
                 id="organizationRole"
                 @options={{this.options}}
                 @selectedOption={{@organizationRole}}
-                @onChange={{this.selectRole}}
+                @onChange={{@selectRoleForSearch}}
                 @emptyOptionLabel="Tous"
                 aria-label="Rechercher par rôle"
               />

--- a/admin/app/components/organizations/team-section.js
+++ b/admin/app/components/organizations/team-section.js
@@ -1,14 +1,8 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 
 export default class OrganizationTeamSection extends Component {
   options = [
     { value: 'ADMIN', label: 'Administrateur' },
     { value: 'MEMBER', label: 'Membre' },
   ];
-
-  @action
-  selectRole(event) {
-    return this.selectRoleForSearch(event.target.value || null);
-  }
 }

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -39,8 +39,8 @@ export default class GetTeamController extends Controller {
   }
 
   @action
-  selectRoleForSearch(selectedRole) {
-    this.organizationRole = selectedRole;
+  selectRoleForSearch(event) {
+    this.organizationRole = event.target.value || null;
   }
 
   async _getUser(email) {

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -13,7 +13,24 @@ function getOrganizationInvitations(schema, request) {
 function findPaginatedOrganizationMemberships(schema, request) {
   const organizationId = request.params.id;
   const queryParams = request.queryParams;
-  const memberships = schema.memberships.where({ organizationId, disabledAt: undefined }).models;
+  const organizationRole = queryParams['filter[organizationRole]'];
+  const withOrganizationRoleFilter = ['ADMIN', 'MEMBER'].some((role) => role === organizationRole);
+
+  let filters = {
+    organizationId,
+    disabledAt: undefined,
+  };
+
+  if (withOrganizationRoleFilter) {
+    filters = {
+      organizationId,
+      disabledAt: undefined,
+      organizationRole,
+    };
+  }
+
+  const memberships = schema.memberships.where(filters).models;
+
   const rowCount = memberships.length;
 
   const pagination = _getPaginationFromQueryParams(queryParams);
@@ -26,6 +43,7 @@ function findPaginatedOrganizationMemberships(schema, request) {
     rowCount,
     pageCount: Math.ceil(rowCount / pagination.pageSize),
   };
+
   return json;
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Les filtres étaient décalés : il manquait le filtre sur le prénom qui était décalé sur la colonne nom et ainsi de suite pour chaque filtre

## :robot: Solution
Il y avait une colonne supplémentaire dans la ligne des filtres  

## :rainbow: Remarques
Les tests vérifient que le filtre est présent et est fonctionnel, pas qu'il se trouve au bon endroit dans le tableau.

## :100: Pour tester
Se rendre sur la page de détail d'une organization  http://localhost:4202/organizations/1/team et vérifier que :
- on peut filtrer par prénom
- on peut filtrer par nom
- on peut filtrer par email
- on peut filtrer par rôle
et que chaque filtre se trouve dans la colonne du paramètre sur lequel il filtre 