### PR TITLE
[FEATURE] Limiter les requêtes par utilisateur sur /api/token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:5.0.7-alpine
     resource_class: medium+
     parallelism: 5
     working_directory: ~/pix/high-level-tests/e2e
@@ -304,6 +305,7 @@ jobs:
           working_directory: ~/pix/api
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            REDIS_URL: 'redis://localhost:6379'
           background: true
           command: npm start
 

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -1,8 +1,6 @@
 const Joi = require('joi');
 const crypto = require('crypto');
-const {
-  rateLimit: { enabled: rateLimitEnabled },
-} = require('../../config');
+const config = require('../../config');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const AuthenticationController = require('./authentication-controller');
 const responseAuthenticationObjectDoc = require('../../infrastructure/open-api-doc/authentication/response-authentication-doc');
@@ -16,7 +14,7 @@ exports.register = async (server) => {
       config: {
         plugins: {
           rateLimit: {
-            enabled: rateLimitEnabled,
+            enabled: () => config.rateLimit.enabled,
             key: (request) => {
               const baseKey = (() => {
                 if (request.payload.grant_type === 'password') {
@@ -25,7 +23,10 @@ exports.register = async (server) => {
                   return request.payload.refresh_token;
                 }
               })();
-              return crypto.createHash('sha256').update(baseKey).digest('hex');
+              return crypto
+                .createHash('sha256')
+                .update(baseKey || '')
+                .digest('hex');
             },
           },
         },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const crypto = require('crypto');
 const {
   rateLimit: { enabled: rateLimitEnabled },
 } = require('../../config');
@@ -17,11 +18,14 @@ exports.register = async (server) => {
           rateLimit: {
             enabled: rateLimitEnabled,
             key: (request) => {
-              if (request.payload.grant_type === 'password') {
-                return request.payload.username;
-              } else {
-                return request.payload.refresh_token;
-              }
+              const baseKey = (() => {
+                if (request.payload.grant_type === 'password') {
+                  return request.payload.username;
+                } else {
+                  return request.payload.refresh_token;
+                }
+              })();
+              return crypto.createHash('sha256').update(baseKey).digest('hex');
             },
           },
         },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -10,6 +10,14 @@ exports.register = async (server) => {
       method: 'POST',
       path: '/api/token',
       config: {
+        plugins: {
+          rateLimit: {
+            enabled: true,
+            key: (request) => {
+              return request.payload.username;
+            },
+          },
+        },
         auth: false,
         payload: {
           allow: 'application/x-www-form-urlencoded',

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -17,7 +17,11 @@ exports.register = async (server) => {
           rateLimit: {
             enabled: rateLimitEnabled,
             key: (request) => {
-              return request.payload.username;
+              if (request.payload.grant_type === 'password') {
+                return request.payload.username;
+              } else {
+                return request.payload.refresh_token;
+              }
             },
           },
         },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -1,4 +1,7 @@
 const Joi = require('joi');
+const {
+  rateLimit: { enabled: rateLimitEnabled },
+} = require('../../config');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const AuthenticationController = require('./authentication-controller');
 const responseAuthenticationObjectDoc = require('../../infrastructure/open-api-doc/authentication/response-authentication-doc');
@@ -12,7 +15,7 @@ exports.register = async (server) => {
       config: {
         plugins: {
           rateLimit: {
-            enabled: true,
+            enabled: rateLimitEnabled,
             key: (request) => {
               return request.payload.username;
             },

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -135,6 +135,14 @@ class InternalServerError extends BaseHttpError {
   }
 }
 
+class TooManyRequestsError extends BaseHttpError {
+  constructor(message) {
+    super(message);
+    this.title = 'Too many requests';
+    this.status = 429;
+  }
+}
+
 function sendJsonApiError(httpError, h) {
   const jsonApiError = new JSONAPIError({
     status: httpError.status.toString(),
@@ -163,4 +171,5 @@ module.exports = {
   SessionPublicationBatchError,
   UnauthorizedError,
   UnprocessableEntityError,
+  TooManyRequestsError,
 };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -154,6 +154,10 @@ module.exports = (function () {
       numbers: '2346789',
     },
 
+    rateLimit: {
+      redisUrl: process.env.REDIS_URL,
+    },
+
     caching: {
       redisUrl: process.env.REDIS_URL,
       redisCacheKeyLockTTL: parseInt(process.env.REDIS_CACHE_KEY_LOCK_TTL, 10) || 60000,
@@ -359,6 +363,8 @@ module.exports = (function () {
     config.caching.redisUrl = null;
     config.caching.redisCacheKeyLockTTL = 0;
     config.caching.redisCacheLockedWaitBeforeRetry = 0;
+
+    config.rateLimit.redisUrl = null;
 
     config.sentry.enabled = false;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -368,7 +368,7 @@ module.exports = (function () {
     config.caching.redisCacheKeyLockTTL = 0;
     config.caching.redisCacheLockedWaitBeforeRetry = 0;
 
-    config.rateLimit.redisUrl = null;
+    config.rateLimit.redisUrl = process.env.TEST_REDIS_URL;
 
     config.sentry.enabled = false;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -156,6 +156,8 @@ module.exports = (function () {
 
     rateLimit: {
       redisUrl: process.env.REDIS_URL,
+      enabled: isFeatureEnabled(process.env.RATE_LIMIT_ENABLED),
+      logOnly: isFeatureEnabled(process.env.RATE_LIMIT_LOG_ONLY),
     },
 
     caching: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -158,6 +158,8 @@ module.exports = (function () {
       redisUrl: process.env.REDIS_URL,
       enabled: isFeatureEnabled(process.env.RATE_LIMIT_ENABLED),
       logOnly: isFeatureEnabled(process.env.RATE_LIMIT_LOG_ONLY),
+      limit: _getNumber(process.env.RATE_LIMIT_DEFAULT_LIMIT, 10),
+      window: _getNumber(process.env.RATE_LIMIT_DEFAULT_WINDOW, 60),
     },
 
     caching: {

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -30,8 +30,6 @@ module.exports = class RedisClient {
     this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);
     this.ping = promisify(this._client.ping).bind(this._client);
     this.flushall = promisify(this._client.flushall).bind(this._client);
-    this.scriptAsync = promisify(this._client.script).bind(this._client);
-    this.evalshaAsync = promisify(this._client.evalsha).bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
   }
 

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -30,6 +30,8 @@ module.exports = class RedisClient {
     this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);
     this.ping = promisify(this._client.ping).bind(this._client);
     this.flushall = promisify(this._client.flushall).bind(this._client);
+    this.scriptAsync = promisify(this._client.script).bind(this._client);
+    this.evalshaAsync = promisify(this._client.evalsha).bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
   }
 

--- a/api/lib/infrastructure/utils/redis-rate-limit.js
+++ b/api/lib/infrastructure/utils/redis-rate-limit.js
@@ -1,0 +1,11 @@
+const redis = require('redis');
+const { promisify } = require('util');
+const logger = require('../logger');
+
+module.exports = function createRedisRateLimit(redisUrl) {
+  const client = redis.createClient(redisUrl);
+  client.scriptAsync = promisify(client.script).bind(client);
+  client.evalshaAsync = promisify(client.evalsha).bind(client);
+  client.on('error', (err) => logger.warn({ redisClient: 'rate-limit', err }, 'Error encountered'));
+  return client;
+};

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -40,6 +40,10 @@ const schema = Joi.object({
   FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
   TEST_LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
   TEST_REDIS_URL: Joi.string().optional(),
+  RATE_LIMIT_ENABLED: Joi.string().optional().valid('true', 'false'),
+  RATE_LIMIT_LOG_ONLY: Joi.string().optional().valid('true', 'false'),
+  RATE_LIMIT_DEFAULT_LIMIT: Joi.number().optional(),
+  RATE_LIMIT_DEFAULT_WINDOW: Joi.number().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -6,7 +6,7 @@ const Vision = require('@hapi/vision');
 const monitoringTools = require('./infrastructure/monitoring-tools');
 const RedisClient = require('./infrastructure/utils/RedisClient');
 const { TooManyRequestsError } = require('./application/http-errors');
-const { redisUrl } = settings.caching;
+const { redisUrl } = settings.rateLimit;
 
 function logObjectSerializer(req) {
   const enhancedReq = {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -69,7 +69,7 @@ const plugins = [
       },
       redisClient,
       overLimitError: (rate, request, h) => {
-        logger.error({ request_id: request.info.id }, 'Rate limit exceeded');
+        logger.error({ request_id: request.info.id, overLimit: rate.overLimit }, 'Rate limit exceeded');
         if (rateLimit.logOnly) {
           return h.continue;
         } else {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -69,7 +69,7 @@ const plugins = [
       },
       redisClient,
       overLimitError: (rate, request, h) => {
-        logger.error({ request_id: request.info.id, overLimit: rate.overLimit }, 'Rate limit exceeded');
+        logger.error({ request_id: request.headers['x-request-id'], overLimit: rate.overLimit }, 'Rate limit exceeded');
         if (rateLimit.logOnly) {
           return h.continue;
         } else {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -7,7 +7,7 @@ const monitoringTools = require('./infrastructure/monitoring-tools');
 const RedisClient = require('./infrastructure/utils/RedisClient');
 const { TooManyRequestsError } = require('./application/http-errors');
 
-const { redisUrl, logOnly: rateLimitLogOnly } = settings.rateLimit;
+const { rateLimit } = settings;
 
 function logObjectSerializer(req) {
   const enhancedReq = {
@@ -26,11 +26,11 @@ function logObjectSerializer(req) {
   };
 }
 
-const redisClient = redisUrl ? new RedisClient(redisUrl, 'api-rate-limiter') : null;
+const redisClient = rateLimit.redisUrl ? new RedisClient(rateLimit.redisUrl, 'api-rate-limiter') : null;
 
 const defaultRate = {
-  limit: 10,
-  window: 60,
+  limit: rateLimit.limit,
+  window: rateLimit.window,
 };
 
 const plugins = [
@@ -70,7 +70,7 @@ const plugins = [
       redisClient,
       overLimitError: (rate, request, h) => {
         logger.error({ request_id: request.info.id }, 'Rate limit exceeded');
-        if (rateLimitLogOnly) {
+        if (rateLimit.logOnly) {
           return h.continue;
         } else {
           return new TooManyRequestsError(`Rate Limit Exceeded - try again in ${rate.window} seconds`);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13883,6 +13883,11 @@
         }
       }
     },
+    "hapi-rate-limiter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-rate-limiter/-/hapi-rate-limiter-5.0.0.tgz",
+      "integrity": "sha512-65pedAIdk9S9awYmXiVnLcG64+h1RG3LbKh/HH7FJHZJuuqXzF9MG9RR2Y6gMsL5QzzI0G4Dc0DJkDU6Wjeg5A=="
+    },
     "hapi-sentry": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/hapi-sentry/-/hapi-sentry-3.2.0.tgz",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -29,7 +29,7 @@
         "file-type": "^16.5.3",
         "hapi-i18n": "^3.0.1",
         "hapi-pino": "^10.1.0",
-        "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-overlimit-count-on-rate",
+        "hapi-rate-limiter": "1024pix/hapi-rate-limiter#pix",
         "hapi-sentry": "^3.2.0",
         "hapi-swagger": "^14.5.5",
         "hash-int": "^1.0.0",
@@ -4503,7 +4503,7 @@
     },
     "node_modules/hapi-rate-limiter": {
       "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#717161c584a893a6b47427b291169fa214462373",
+      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1c225b11f4b072c40578556537e6b6c850ea4f7b",
       "license": "MIT",
       "peerDependencies": {
         "@hapi/hapi": ">=20",
@@ -13894,8 +13894,8 @@
       }
     },
     "hapi-rate-limiter": {
-      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#717161c584a893a6b47427b291169fa214462373",
-      "from": "hapi-rate-limiter@1024pix/hapi-rate-limiter#add-overlimit-count-on-rate",
+      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1c225b11f4b072c40578556537e6b6c850ea4f7b",
+      "from": "hapi-rate-limiter@1024pix/hapi-rate-limiter#pix",
       "requires": {}
     },
     "hapi-sentry": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -29,6 +29,7 @@
         "file-type": "^16.5.3",
         "hapi-i18n": "^3.0.1",
         "hapi-pino": "^10.1.0",
+        "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-params-to-overlimiterror",
         "hapi-sentry": "^3.2.0",
         "hapi-swagger": "^14.5.5",
         "hash-int": "^1.0.0",
@@ -4498,6 +4499,15 @@
       "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
       "dependencies": {
         "real-require": "^0.1.0"
+      }
+    },
+    "node_modules/hapi-rate-limiter": {
+      "version": "6.0.0",
+      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1191fe1bae1d01d57b88ee088d667061b35cc176",
+      "license": "MIT",
+      "peerDependencies": {
+        "@hapi/hapi": ">=20",
+        "redis": "^3.0.0"
       }
     },
     "node_modules/hapi-sentry": {
@@ -13884,9 +13894,9 @@
       }
     },
     "hapi-rate-limiter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hapi-rate-limiter/-/hapi-rate-limiter-5.0.0.tgz",
-      "integrity": "sha512-65pedAIdk9S9awYmXiVnLcG64+h1RG3LbKh/HH7FJHZJuuqXzF9MG9RR2Y6gMsL5QzzI0G4Dc0DJkDU6Wjeg5A=="
+      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1191fe1bae1d01d57b88ee088d667061b35cc176",
+      "from": "hapi-rate-limiter@1024pix/hapi-rate-limiter#add-params-to-overlimiterror",
+      "requires": {}
     },
     "hapi-sentry": {
       "version": "3.2.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -29,7 +29,7 @@
         "file-type": "^16.5.3",
         "hapi-i18n": "^3.0.1",
         "hapi-pino": "^10.1.0",
-        "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-params-to-overlimiterror",
+        "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-overlimit-count-on-rate",
         "hapi-sentry": "^3.2.0",
         "hapi-swagger": "^14.5.5",
         "hash-int": "^1.0.0",
@@ -4503,7 +4503,7 @@
     },
     "node_modules/hapi-rate-limiter": {
       "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1191fe1bae1d01d57b88ee088d667061b35cc176",
+      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#717161c584a893a6b47427b291169fa214462373",
       "license": "MIT",
       "peerDependencies": {
         "@hapi/hapi": ">=20",
@@ -13894,8 +13894,8 @@
       }
     },
     "hapi-rate-limiter": {
-      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1191fe1bae1d01d57b88ee088d667061b35cc176",
-      "from": "hapi-rate-limiter@1024pix/hapi-rate-limiter#add-params-to-overlimiterror",
+      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#717161c584a893a6b47427b291169fa214462373",
+      "from": "hapi-rate-limiter@1024pix/hapi-rate-limiter#add-overlimit-count-on-rate",
       "requires": {}
     },
     "hapi-sentry": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4503,7 +4503,7 @@
     },
     "node_modules/hapi-rate-limiter": {
       "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1c225b11f4b072c40578556537e6b6c850ea4f7b",
+      "resolved": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1d0a820559de84270368b39c6fb5f67bc4413e2a",
       "license": "MIT",
       "peerDependencies": {
         "@hapi/hapi": ">=20",
@@ -13894,7 +13894,7 @@
       }
     },
     "hapi-rate-limiter": {
-      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1c225b11f4b072c40578556537e6b6c850ea4f7b",
+      "version": "git+ssh://git@github.com/1024pix/hapi-rate-limiter.git#1d0a820559de84270368b39c6fb5f67bc4413e2a",
       "from": "hapi-rate-limiter@1024pix/hapi-rate-limiter#pix",
       "requires": {}
     },

--- a/api/package.json
+++ b/api/package.json
@@ -35,7 +35,7 @@
     "file-type": "^16.5.3",
     "hapi-i18n": "^3.0.1",
     "hapi-pino": "^10.1.0",
-    "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-overlimit-count-on-rate",
+    "hapi-rate-limiter": "1024pix/hapi-rate-limiter#pix",
     "hapi-sentry": "^3.2.0",
     "hapi-swagger": "^14.5.5",
     "hash-int": "^1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -35,7 +35,7 @@
     "file-type": "^16.5.3",
     "hapi-i18n": "^3.0.1",
     "hapi-pino": "^10.1.0",
-    "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-params-to-overlimiterror",
+    "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-overlimit-count-on-rate",
     "hapi-sentry": "^3.2.0",
     "hapi-swagger": "^14.5.5",
     "hash-int": "^1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
     "file-type": "^16.5.3",
     "hapi-i18n": "^3.0.1",
     "hapi-pino": "^10.1.0",
+    "hapi-rate-limiter": "^5.0.0",
     "hapi-sentry": "^3.2.0",
     "hapi-swagger": "^14.5.5",
     "hash-int": "^1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -35,7 +35,7 @@
     "file-type": "^16.5.3",
     "hapi-i18n": "^3.0.1",
     "hapi-pino": "^10.1.0",
-    "hapi-rate-limiter": "^5.0.0",
+    "hapi-rate-limiter": "1024pix/hapi-rate-limiter#add-params-to-overlimiterror",
     "hapi-sentry": "^3.2.0",
     "hapi-swagger": "^14.5.5",
     "hash-int": "^1.0.0",

--- a/api/sample.env
+++ b/api/sample.env
@@ -624,14 +624,27 @@ TEST_REDIS_URL=redis://localhost:6379
 # RATE LIMITING
 # ========
 
-# Enable rate limiting
+# Enable rate limiting, a strategy for limiting network traffic. 
+# It puts a cap on how often someone can repeat an action within a certain time window, preventing malicious activity.
 # presence: optional
 # type: boolean
 # default: false
 RATE_LIMIT_ENABLED=false
 
-# Log over limit error but don't block them
+# Log over-limit events, but don't block them
 # presence: optional
 # type: boolean
 # default: true
 RATE_LIMIT_LOG_ONLY=true
+
+# Default number of request allowed within time window
+# presence: optional
+# type: number
+# default: 10
+RATE_LIMIT_DEFAULT_LIMIT=10
+
+# Default number of seconds before resets
+# presence: optional
+# type: number
+# default: 60
+RATE_LIMIT_DEFAULT_WINDOW=60

--- a/api/sample.env
+++ b/api/sample.env
@@ -600,7 +600,6 @@ POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN=7d
 # default: 7d
 CNAV_ACCESS_TOKEN_LIFESPAN=7d
 
-
 # ========
 # TESTS
 # ========
@@ -620,3 +619,19 @@ TEST_LOG_ENABLED=false
 # type: Url
 # default: none
 TEST_REDIS_URL=redis://localhost:6379
+
+# ========
+# RATE LIMITING
+# ========
+
+# Enable rate limiting
+# presence: optional
+# type: boolean
+# default: false
+RATE_LIMIT_ENABLED=false
+
+# Log over limit error but don't block them
+# presence: optional
+# type: boolean
+# default: true
+RATE_LIMIT_LOG_ONLY=true

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -2,6 +2,7 @@ const querystring = require('querystring');
 const { expect, databaseBuilder, knex } = require('../../test-helper');
 const tokenService = require('../../../lib/domain/services/token-service');
 const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
+const settings = require('../../../lib/config');
 
 const createServer = require('../../../server');
 
@@ -16,7 +17,6 @@ describe('Acceptance | Controller | authentication-controller', function () {
     let userId;
 
     beforeEach(async function () {
-      server = await createServer();
       userId = databaseBuilder.factory.buildUser.withRawPassword({
         email: userEmailAddress,
         rawPassword: userPassword,
@@ -27,141 +27,247 @@ describe('Acceptance | Controller | authentication-controller', function () {
       await databaseBuilder.commit();
     });
 
-    it('should return a 200 with an access token and a refresh token when authentication is ok', async function () {
-      // given / when
-      const response = await server.inject({
-        method: 'POST',
-        url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: querystring.stringify({
-          grant_type: 'password',
-          username: userEmailAddress,
-          password: userPassword,
-          scope: 'pix-orga',
-        }),
-      });
-
-      // then
-      const result = response.result;
-      expect(response.statusCode).to.equal(200);
-      expect(result.token_type).to.equal('bearer');
-      expect(result.access_token).to.exist;
-      expect(result.user_id).to.equal(userId);
-      expect(result.refresh_token).to.exist;
-    });
-
-    it('should return a 400 if grant type is invalid', async function () {
-      // when
-      const errorResponse = await server.inject({
-        method: 'POST',
-        url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: querystring.stringify({
-          grant_type: 'appleSauce',
-        }),
-      });
-
-      // then
-      expect(errorResponse.statusCode).to.equal(400);
-    });
-
-    it('should return http code 401 when user should change password', async function () {
-      // given
-      const username = 'username123';
-      const shouldChangePassword = true;
-
-      databaseBuilder.factory.buildUser.withRawPassword({
-        username,
-        rawPassword: userPassword,
-        cgu: true,
-        shouldChangePassword,
-      });
-
-      const expectedResponseError = {
-        errors: [
-          {
-            code: 'SHOULD_CHANGE_PASSWORD',
-            detail: 'Erreur, vous devez changer votre mot de passe.',
-            status: '401',
-            title: 'PasswordShouldChange',
+    function apiTokenTests() {
+      it('should return a 200 with an access token and a refresh token when authentication is ok', async function () {
+        // given / when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/token',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
           },
-        ],
-      };
+          payload: querystring.stringify({
+            grant_type: 'password',
+            username: userEmailAddress,
+            password: userPassword,
+            scope: 'pix-orga',
+          }),
+        });
 
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject({
-        method: 'POST',
-        url: '/api/token',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: querystring.stringify({
-          grant_type: 'password',
-          username,
-          password: userPassword,
-          scope: 'pix-orga',
-        }),
+        // then
+        const result = response.result;
+        expect(response.statusCode).to.equal(200);
+        expect(result.token_type).to.equal('bearer');
+        expect(result.access_token).to.exist;
+        expect(result.user_id).to.equal(userId);
+        expect(result.refresh_token).to.exist;
       });
 
-      // then
-      expect(response.statusCode).to.equal(401);
-      expect(response.result).to.deep.equal(expectedResponseError);
+      it('should return a 400 if grant type is invalid', async function () {
+        // when
+        const errorResponse = await server.inject({
+          method: 'POST',
+          url: '/api/token',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          payload: querystring.stringify({
+            grant_type: 'appleSauce',
+          }),
+        });
+
+        // then
+        expect(errorResponse.statusCode).to.equal(400);
+      });
+
+      it('should return http code 401 when user should change password', async function () {
+        // given
+        const username = 'username123';
+        const shouldChangePassword = true;
+
+        databaseBuilder.factory.buildUser.withRawPassword({
+          username,
+          rawPassword: userPassword,
+          cgu: true,
+          shouldChangePassword,
+        });
+
+        const expectedResponseError = {
+          errors: [
+            {
+              code: 'SHOULD_CHANGE_PASSWORD',
+              detail: 'Erreur, vous devez changer votre mot de passe.',
+              status: '401',
+              title: 'PasswordShouldChange',
+            },
+          ],
+        };
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/token',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          payload: querystring.stringify({
+            grant_type: 'password',
+            username,
+            password: userPassword,
+            scope: 'pix-orga',
+          }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+        expect(response.result).to.deep.equal(expectedResponseError);
+      });
+
+      context('when scope is pix-certif', function () {
+        context('when certification center has the supervisor access enabled', function () {
+          it('should return http code 200 with accessToken when authentication is ok', async function () {
+            //given
+            databaseBuilder.factory.buildCertificationCenter({ id: 345, isSupervisorAccessEnabled: true });
+            databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
+            databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
+            databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
+            await databaseBuilder.commit();
+
+            const options = _getOptions({ scope: 'pix-certif', username: userEmailAddress, password: userPassword });
+
+            await databaseBuilder.commit();
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+
+            const result = response.result;
+            expect(result.token_type).to.equal('bearer');
+            expect(result.access_token).to.exist;
+            expect(result.user_id).to.equal(userId);
+          });
+        });
+
+        context('when certification center does not have the supervisor access enabled', function () {
+          it('should return http code 403 ', async function () {
+            //given
+            databaseBuilder.factory.buildUser.withRawPassword({
+              email: 'email@without.mb',
+              rawPassword: userPassword,
+              cgu: true,
+            });
+            databaseBuilder.factory.buildCertificationCenter({ id: 345, isSupervisorAccessEnabled: false });
+            databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
+            databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
+            databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
+
+            await databaseBuilder.commit();
+            const options = _getOptions({ scope: 'pix-certif', username: 'email@without.mb', password: userPassword });
+
+            // when
+            const { statusCode } = await server.inject(options);
+
+            // then
+            expect(statusCode).to.equal(403);
+          });
+        });
+      });
+    }
+
+    context('with rate limit disabled', function () {
+      let previousRateLimit;
+      beforeEach(async function () {
+        previousRateLimit = { ...settings.rateLimit };
+        settings.rateLimit.enabled = false;
+        server = await createServer();
+        await server.initialize();
+      });
+      afterEach(function () {
+        settings.rateLimit = previousRateLimit;
+      });
+
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      apiTokenTests();
     });
 
-    context('when scope is pix-certif', function () {
-      context('when certification center has the supervisor access enabled', function () {
-        it('should return http code 200 with accessToken when authentication is ok', async function () {
-          //given
-          databaseBuilder.factory.buildCertificationCenter({ id: 345, isSupervisorAccessEnabled: true });
-          databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
-          databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
-          databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
-          await databaseBuilder.commit();
+    context('with rate limit enabled in logOnlyMode', function () {
+      let previousRateLimit;
 
-          const options = _getOptions({ scope: 'pix-certif', username: userEmailAddress, password: userPassword });
-
-          await databaseBuilder.commit();
-          // when
-          const response = await server.inject(options);
-
-          // then
-          expect(response.statusCode).to.equal(200);
-
-          const result = response.result;
-          expect(result.token_type).to.equal('bearer');
-          expect(result.access_token).to.exist;
-          expect(result.user_id).to.equal(userId);
-        });
+      beforeEach(async function () {
+        previousRateLimit = { ...settings.rateLimit };
+        settings.rateLimit.enabled = true;
+        settings.rateLimit.logOnly = true;
+        server = await createServer();
+        await server.initialize();
+      });
+      afterEach(function () {
+        settings.rateLimit = previousRateLimit;
       });
 
-      context('when certification center does not have the supervisor access enabled', function () {
-        it('should return http code 403 ', async function () {
-          //given
-          databaseBuilder.factory.buildUser.withRawPassword({
-            email: 'email@without.mb',
-            rawPassword: userPassword,
-            cgu: true,
-          });
-          databaseBuilder.factory.buildCertificationCenter({ id: 345, isSupervisorAccessEnabled: false });
-          databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
-          databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
-          databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      apiTokenTests();
 
-          await databaseBuilder.commit();
-          const options = _getOptions({ scope: 'pix-certif', username: 'email@without.mb', password: userPassword });
-
-          // when
-          const { statusCode } = await server.inject(options);
-
-          // then
-          expect(statusCode).to.equal(403);
+      it('should not return 429 errors when the rate limit is reached', async function () {
+        settings.rateLimit.limit = 1;
+        await server.inject({
+          method: 'POST',
+          url: '/api/token',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          payload: querystring.stringify({
+            grant_type: 'password',
+            username: 'test',
+            password: 'test',
+          }),
         });
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/token',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          payload: querystring.stringify({
+            grant_type: 'password',
+            username: 'test',
+            password: 'test2',
+          }),
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    context('when the rate limit is active', function () {
+      let previousRateLimit;
+
+      beforeEach(async function () {
+        previousRateLimit = { ...settings.rateLimit };
+        settings.rateLimit.enabled = true;
+        settings.rateLimit.logOnly = false;
+        server = await createServer();
+        await server.initialize();
+      });
+      afterEach(function () {
+        settings.rateLimit = previousRateLimit;
+      });
+
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      apiTokenTests();
+
+      it('should returns 429 TOO_MANY_REQUESTS when the rate limit is reached', async function () {
+        settings.rateLimit.limit = 1;
+        const options = {
+          method: 'POST',
+          url: '/api/token',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          payload: querystring.stringify({
+            grant_type: 'password',
+            username: 'test',
+            password: 'test',
+          }),
+        };
+        await server.inject(options);
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(429);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
L'API de génération de token est susceptible d'être attaqué avec des attaques par force brutes. 

## :robot: Solution
Pour limiter cette capacité d'attaque, un limiteur de requêtes est implémenté avec une fenêtre glissante de 10 requêtes toutes les minutes. La clef utilisé est le nom d'utilisateur rentré.

## :rainbow: Remarques
Un système de feature flag a été implémenté pour désactiver le limiteur et/ou le passer en mode afficheur de journaux uniquement.

---

package utilisé : https://www.npmjs.com/package/hapi-rate-limiter
## :100: Pour tester
Avec: 
```
RATE_LIMIT_ENABLED=true
RATE_LIMIT_LOG_ONLY=false
```

1. Aller sur la page de connexion
2. Rentrer un username et un mot de passe
3. Cliquer 10 fois sur le bouton connexion
4. Constater que l'API renvoit 10 x **401**
5. Cliquer une nouvelle fois sur le bouton
6. Constater que l'API renvoit une **429**
7. Constater que dans les logs on affiche "Rate limit exceeded" avec la request_id

Avec: 
```
RATE_LIMIT_ENABLED=false
RATE_LIMIT_LOG_ONLY=false
```

1. Aller sur la page de connexion
2. Rentrer un username et un mot de passe
3. Cliquer 10 fois sur le bouton connexion
4. Constater que l'API renvoit 10 x **401**
5. Cliquer une nouvelle fois sur le bouton
6. Constater que l'API renvoit une **401**
8. Constater qu'il n'y a rien dans les logs sur le rate limit


Avec: 
```
RATE_LIMIT_ENABLED=true
RATE_LIMIT_LOG_ONLY=true
```

1. Aller sur la page de connexion
2. Rentrer un username et un mot de passe
3. Cliquer 10 fois sur le bouton connexion
4. Constater que l'API renvoit 10 x **401**
5. Cliquer une nouvelle fois sur le bouton
6. Constater que l'API renvoit une **401**
7. Constater que dans les logs on affiche "Rate limit exceeded" avec la request_id

