### PR TITLE
[FEATURE] Enlever les espaces en début et fin de classe et groupe lors des import de fichier prescrits (Pix-4629).

### DIFF
--- a/api/lib/domain/models/HigherSchoolingRegistrationSet.js
+++ b/api/lib/domain/models/HigherSchoolingRegistrationSet.js
@@ -44,7 +44,8 @@ class HigherSchoolingRegistrationSet {
     const registration = new HigherSchoolingRegistration(registrationAttributes);
     this._checkStudyScheme(registration);
     this._checkDiploma(registration);
-    this.registrations.push(registration);
+    const transformedRegistration = this._transform(registration);
+    this.registrations.push(transformedRegistration);
 
     checkValidation(this);
   }
@@ -74,6 +75,13 @@ class HigherSchoolingRegistrationSet {
       const input = valueToCheck.toLowerCase();
       return areTwoStringsCloseEnough(input, reference, RATIO);
     });
+  }
+
+  _transform(registration) {
+    return {
+      ...registration,
+      group: registration.group?.trim().replace(/\s+/g, ' '),
+    };
   }
 }
 

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -32,7 +32,7 @@ class SchoolingRegistrationSet {
 
   _transform(registrationAttributes) {
     let sex;
-    const { birthCountryCode, nationalIdentifier } = registrationAttributes;
+    const { birthCountryCode, nationalIdentifier, division } = registrationAttributes;
 
     if (registrationAttributes.sex) {
       sex = _convertSexCodeToLabel(registrationAttributes.sex);
@@ -44,6 +44,7 @@ class SchoolingRegistrationSet {
       ...registrationAttributes,
       birthCountryCode: birthCountryCode.slice(-3),
       nationalStudentId: nationalIdentifier,
+      division: division?.trim().replace(/\s+/g, ' '),
       sex,
     };
   }

--- a/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
+++ b/api/tests/unit/domain/models/HigherSchoolingRegistrationSet_test.js
@@ -217,5 +217,45 @@ describe('Unit | Domain | Models | HigherSchoolingRegistrationSet', function () 
         expect(warnings).to.have.lengthOf(0);
       });
     });
+
+    context('When group has spaces', function () {
+      it('should trim group', async function () {
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
+        const registration = {
+          firstName: 'Beatrix',
+          lastName: 'Kiddo',
+          birthdate: '1990-04-01',
+          studentNumber: '123ABC',
+          organizationId: 123,
+          diploma: 'BAD',
+          studyScheme: 'Autre',
+          group: ' some group ',
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+        const { registrations } = higherSchoolingRegistrationSet;
+
+        expect(registrations[0].group).to.equal('some group');
+      });
+
+      it('should remove extra space on group', function () {
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet(i18n);
+        const registration = {
+          firstName: 'Beatrix',
+          lastName: 'Kiddo',
+          birthdate: '1990-04-01',
+          studentNumber: '123ABC',
+          organizationId: 123,
+          diploma: 'BAD',
+          studyScheme: 'Autre',
+          group: 'some        group',
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+        const { registrations } = higherSchoolingRegistrationSet;
+
+        expect(registrations[0].group).to.equal('some group');
+      });
+    });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -213,6 +213,22 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', function () {
             expect(registrations[0].division).to.equal('Division 1');
           });
         });
+
+        context('When the organization is Agriculture and file contain status AP', function () {
+          it('should return schooling registration with nationalStudentId', function () {
+            const input = `${schoolingRegistrationCsvColumns}
+            0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+            `;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
+
+            const { registrations } = parser.parse();
+            expect(registrations[0]).to.includes({
+              nationalStudentId: '0123456789F',
+              status: 'AP',
+            });
+          });
+        });
       });
 
       context('when the data are not correct', function () {
@@ -247,22 +263,6 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', function () {
           expect(error).to.be.an.instanceOf(CsvImportError);
           expect(error.code).to.equal('INSEE_CODE_INVALID');
           expect(error.meta).to.deep.equal({ line: 2, field: 'Code commune naissance**' });
-        });
-
-        context('When the organization is Agriculture and file contain status AP', function () {
-          it('should return schooling registration with nationalStudentId', function () {
-            const input = `${schoolingRegistrationCsvColumns}
-            0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
-            `;
-            const encodedInput = iconv.encode(input, 'utf8');
-            const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
-
-            const { registrations } = parser.parse();
-            expect(registrations[0]).to.includes({
-              nationalStudentId: '0123456789F',
-              status: 'AP',
-            });
-          });
         });
 
         context('When csv has duplicates on national identifier', function () {

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -189,6 +189,30 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', function () {
             });
           });
         });
+
+        context('when division has spaces', function () {
+          it('should trim division', function () {
+            const input = `${schoolingRegistrationCsvColumns}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;200;99100;ST;MEF1;  Division 1 ;
+            `;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, 456, i18n);
+
+            const { registrations } = parser.parse();
+            expect(registrations[0].division).to.equal('Division 1');
+          });
+
+          it('should remove extra space on division', function () {
+            const input = `${schoolingRegistrationCsvColumns}
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;1;01/01/1970;97422;;200;99100;ST;MEF1;Division     1;
+            `;
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, 456, i18n);
+
+            const { registrations } = parser.parse();
+            expect(registrations[0].division).to.equal('Division 1');
+          });
+        });
       });
 
       context('when the data are not correct', function () {

--- a/api/tests/unit/scripts/create-pro-organizations-with-tags_test.js
+++ b/api/tests/unit/scripts/create-pro-organizations-with-tags_test.js
@@ -9,6 +9,10 @@ const organizationInvitationService = require('../../../lib/domain/services/orga
 const { FileValidationError } = require('../../../lib/domain/errors');
 
 describe('Unit | Scripts | create-pro-organization-with-tags.js', function () {
+  beforeEach(function () {
+    sinon.stub(console, 'log');
+  });
+
   context('When organization file is empty', function () {
     it('should throw an error', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Les espaces au début et à la fin des classes et groupes posent des problèmes après lors des filtres etc.

## :robot: Solution
Enlever ces espaces.

## :rainbow: Remarques
SR sur un test qui n'était pas à sa place.
SR pour cacher un console.log dans les tests.

## :100: Pour tester
Importer un fichier siecle XML avec des espaces en tant que sco.admin@example.net dans Pix Orga et vérifier que les classes sont sans espaces. Idem pour le fichier CSV AGRI et pour le fichier CSV du SUP.
