### PR TITLE
[BUGFIX] Corriger le bouton d'assignation à une session

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -25,7 +25,7 @@ export default class IndexController extends Controller {
   get isCurrentUserAssignedToSession() {
     const currentUserId = this.currentUser.adminMember.get('userId');
     const assignedCertificationOfficerId = this.sessionModel.assignedCertificationOfficer.get('id');
-    return assignedCertificationOfficerId != null && currentUserId === assignedCertificationOfficerId;
+    return assignedCertificationOfficerId != null && currentUserId == assignedCertificationOfficerId;
   }
 
   get isAssigned() {

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -150,19 +150,17 @@
 />
 
 {{#if this.isShowingAssignmentModal}}
-  <ModalDialog @targetAttachment="center" @translucentOverlay={{true}} @onClose={{this.cancelAssignment}}>
-    <div class="ember-modal-dialog--title">
-      <h2>Assignation de la session</h2>
-      <span role="button" {{on "click" this.cancelAssignment}}>×</span>
-    </div>
-    <p>
-      L'utilisateur
-      {{this.sessionModel.assignedCertificationOfficer.fullName}}
-      s'est déjà assigné cette session.
-      <br />
-      Voulez-vous vous quand même vous assigner cette session ?
-    </p>
-    <div class="ember-modal-dialog--actions">
+  <PixModal @title="Assignation de la session" @onCloseButtonClick={{this.cancelAssignment}}>
+    <:content>
+      <p>
+        L'utilisateur
+        {{this.sessionModel.assignedCertificationOfficer.fullName}}
+        s'est déjà assigné cette session.
+        <br />
+        Voulez-vous vous quand même vous assigner cette session ?
+      </p>
+    </:content>
+    <:footer>
       <PixButton
         @backgroundColor="transparent-light"
         @isBorderVisible={{true}}
@@ -174,6 +172,6 @@
       <PixButton @size="small" @triggerAction={{this.confirmAssignment}}>
         Confirmer
       </PixButton>
-    </div>
-  </ModalDialog>
+    </:footer>
+  </PixModal>
 {{/if}}

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Controller | authenticated/sessions/session/informations', function (hooks) {
   setupTest(hooks);
@@ -163,6 +164,25 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       assert.equal(controller.copyButtonText, 'Erreur !');
       assert.ok(controller.isCopyButtonClicked);
       assert.ok(window.setTimeout);
+    });
+  });
+
+  module('#isCurrentUserAssignedToSession', function () {
+    test('it should return true if current user is assigned to session', async function (assert) {
+      // given
+      const getUserIdStub = sinon.stub();
+      class CurrentUserStub extends Service {
+        adminMember = { get: getUserIdStub.withArgs('userId').returns(3) };
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
+
+      const getIdStub = sinon.stub();
+      controller.model = {
+        assignedCertificationOfficer: { get: getIdStub.withArgs('id').returns('3') },
+      };
+
+      // when / then
+      assert.true(controller.isCurrentUserAssignedToSession);
     });
   });
 });

--- a/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
@@ -3,26 +3,23 @@ const createServer = require('../../../../server');
 
 describe('PATCH /api/admin/sessions/:id/certification-officer-assignment', function () {
   let server;
-  const options = { method: 'PATCH' };
-  let certificationOfficerId;
 
   beforeEach(async function () {
     server = await createServer();
   });
 
   context('when user does not have the role Super Admin', function () {
-    beforeEach(function () {
-      certificationOfficerId = databaseBuilder.factory.buildUser().id;
-      return databaseBuilder.commit();
-    });
-
     it('should return a 403 error code', async function () {
       // given
-      options.url = '/api/admin/sessions/12/certification-officer-assignment';
-      options.headers = { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) };
+      const certificationOfficerId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
 
       // when
-      const response = await server.inject(options);
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/admin/sessions/12/certification-officer-assignment',
+        headers: { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) },
+      });
 
       // then
       expect(response.statusCode).to.equal(403);
@@ -30,20 +27,18 @@ describe('PATCH /api/admin/sessions/:id/certification-officer-assignment', funct
   });
 
   context('when user has role Super Admin', function () {
-    beforeEach(function () {
-      // given
-      certificationOfficerId = databaseBuilder.factory.buildUser.withRole().id;
-      options.headers = { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) };
-      return databaseBuilder.commit();
-    });
-
     context('when the session id has an invalid format', function () {
       it('should return a 400 error code', async function () {
         // given
-        options.url = '/api/admin/sessions/test/certification-officer-assignment';
+        const certificationOfficerId = databaseBuilder.factory.buildUser.withRole().id;
+        await databaseBuilder.commit();
 
         // when
-        const response = await server.inject(options);
+        const response = await server.inject({
+          method: 'PATCH',
+          headers: { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) },
+          url: '/api/admin/sessions/test/certification-officer-assignment',
+        });
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -54,10 +49,15 @@ describe('PATCH /api/admin/sessions/:id/certification-officer-assignment', funct
       context('when the session does not exist', function () {
         it('should return a 404 error code', async function () {
           // given
-          options.url = '/api/admin/sessions/1/certification-officer-assignment';
+          const certificationOfficerId = databaseBuilder.factory.buildUser.withRole().id;
+          await databaseBuilder.commit();
 
           // when
-          const response = await server.inject(options);
+          const response = await server.inject({
+            method: 'PATCH',
+            headers: { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) },
+            url: '/api/admin/sessions/1/certification-officer-assignment',
+          });
 
           // then
           expect(response.statusCode).to.equal(404);
@@ -67,16 +67,20 @@ describe('PATCH /api/admin/sessions/:id/certification-officer-assignment', funct
       context('when the session exists', function () {
         it('should return a 200 status code', async function () {
           // given
+          const certificationOfficerId = databaseBuilder.factory.buildUser.withRole().id;
           const sessionId = databaseBuilder.factory.buildSession().id;
           databaseBuilder.factory.buildFinalizedSession({
             sessionId,
             isPublishable: true,
           });
           await databaseBuilder.commit();
-          options.url = `/api/admin/sessions/${sessionId}/certification-officer-assignment`;
 
           // when
-          const response = await server.inject(options);
+          const response = await server.inject({
+            method: 'PATCH',
+            headers: { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) },
+            url: `/api/admin/sessions/${sessionId}/certification-officer-assignment`,
+          });
 
           // then
           expect(response.statusCode).to.equal(200);

--- a/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
@@ -605,17 +605,12 @@ describe('Integration | Repository | JurySession', function () {
   });
 
   describe('#assignCertificationOfficer', function () {
-    let sessionId;
-    let assignedCertificationOfficerId;
-
-    beforeEach(function () {
-      sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: null }).id;
-      assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
-
-      return databaseBuilder.commit();
-    });
-
     it('should return an updated Session domain object', async function () {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: null }).id;
+      const assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
       // when
       const updatedSession = await jurySessionRepository.assignCertificationOfficer({
         id: sessionId,
@@ -632,6 +627,9 @@ describe('Integration | Repository | JurySession', function () {
     context('when assignedCertificationOfficerId provided does not exist', function () {
       it('should return a Not found error', async function () {
         // given
+        const sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: null }).id;
+        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
         const unknownUserId = assignedCertificationOfficerId + 1;
 
         // when
@@ -648,6 +646,9 @@ describe('Integration | Repository | JurySession', function () {
     context('when sessionId does not exist', function () {
       it('should return a Not found error', async function () {
         // given
+        const sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: null }).id;
+        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
         const unknownSessionId = sessionId + 1;
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
1- Le bouton pour s'assigner une session ne change plus d'état lorsqu'on clique dessus (il reste écrit "M'assigner la session" au lieu de "Vous êtes déjà assigné à cette session".

2- De plus l'affichage de la modale de confirmation (quand quelqu'un est déjà assigné à la session) n'est plus du tout centré : 
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/38167520/167653875-500730d4-e467-4c6d-af53-8a046b2395a0.png">


## 👀  Investigation 
1- Ce problème a été introduit avec la PR https://github.com/1024pix/pix/pull/4398 avec le changement de : 
```js
const currentUserId = this.currentUser.user.get('id');
```
en 
```js
const currentUserId = this.currentUser.adminMember.get('userId');
```
Dans le fichier `pix/admin/app/controllers/authenticated/sessions/session/informations.js`. En effet, il semblerait que lorsque Ember retourne un `id` il soit sous format string, et il retourne un number quand c'est un attribut comme `userId`.
Donc au moment de comparer les deux entiers pour s'avoir si la session est assigné à l'utilisateur courant `currentUserId === assignedCertificationOfficerId` renvoyait faux.

## :robot: Solution
1- Convertir les id en entier avant de les comparer.
2- Utiliser la PixModal.

## :rainbow: Remarques
Dans le retour API pour assigner une session à un certification-officer (`PATCH | http://localhost:4202/api/admin/sessions/6/certification-officer-assignment`) : on renvoie directement le "assigned-certification-officer" dans la partie "included" ce qui permet à Ember de réactualiser les valeurs par magie à l'écran sans refresh la page ou bien sans faire de call API supplémentaire. 
<img width="651" alt="image" src="https://user-images.githubusercontent.com/38167520/167649225-adfc39e1-1a8f-4dc1-a763-3a7d7e0515e4.png">

Les infos du "assigned-certification-officer" sont sauvegardées dans le model "users" côté front. Etant donné qu'on a introduit un model récemment pour identifier les utilisateurs pix admin (PixMember) il faudrait peut être mettre tout ça à jour, le soucis c'est que ça tire beaucoup trop de choses côté API. 

## :100: Pour tester
- Lancer Pix Admin
- Aller sur une session (la 6 par exemple)
- Cliquer sur le bouton "m'assigner la session"
- Vérifiez qu'il change bien d'état (disabled + "Vous êtes déjà assigné à cette session")
- Se connecter avec un autre utilisateur Pix Admin
- Retourner sur la même session
- Cliquer sur le bouton "m'assigner la session"
- Vérifier que la modale s'affiche bien : 

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/38167520/167654195-675bb935-cb00-4c94-9d03-f915df66c9bb.png">

