### PR TITLE
[TECH] Corriger le nom de l'index knowledge-elements_assessmentId_idx qui ne respecte pas la convention de nommage knex.

### DIFF
--- a/api/db/migrations/20220510152417_fix-index-knowledge-elements-assessment-id-not-compliant-knex-convention.js
+++ b/api/db/migrations/20220510152417_fix-index-knowledge-elements-assessment-id-not-compliant-knex-convention.js
@@ -1,0 +1,9 @@
+exports.up = (knex) => {
+  return knex.raw(
+    'ALTER INDEX IF EXISTS "knowledge-elements_assessmentId_idx" RENAME TO "knowledge_elements_assessmentid_index"'
+  );
+};
+
+exports.down = function () {
+  // no rollback for this case
+};


### PR DESCRIPTION
## :unicorn: Problème
L'index "knowledge-elements_assessmentId_idx" a été créé manuellement et ne suit pas les conventions Knex.

<img width="736" alt="Capture d’écran 2022-05-10 à 17 34 48" src="https://user-images.githubusercontent.com/10045497/167667360-88dc545f-83ec-4140-870f-c2a361a608f6.png">

## :robot: Solution
Renommer le nom de l'index pour être compliant avec la convention Knex.

## :100: Pour tester
1- Faire un describe de la table en local ou en RA
`- \d knowledge-elements`

2- Vérifier que le nom de l'index est corrigé.

<img width="1156" alt="Capture d’écran 2022-05-10 à 18 18 56" src="https://user-images.githubusercontent.com/10045497/167675743-b6f9d39f-20ed-4783-ad91-250d261c2617.png">
