### PR TITLE
[BUGFIX] Afficher correctement les acquis dans les résultats thématiques (PIX-4932).

### DIFF
--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -39,14 +39,20 @@ export default class Badge extends Component {
   get badgeCriteria() {
     this.args.badge.badgeCriteria.forEach((badgeCriterion) => {
       badgeCriterion.skillSets.forEach((skillSet) => {
+        const skills = skillSet.skills;
         const tubes = uniqBy(
-          skillSet.skills.map((skill) => skill.tube),
+          skills.map((skill) => skill.tube),
           (tube) => tube.get('id')
         );
+
         tubes.forEach((tube) => {
           tube.skillsWithAllLevels = new Array(ENV.APP.MAX_LEVEL)
             .fill(undefined)
-            .map((_, index) => tube.get('skills').find((skill) => skill.difficulty === index + 1));
+            .map((_, index) =>
+              skills
+                .filter((skill) => skill.tube.get('id') === tube.get('id'))
+                .find((skill) => skill.difficulty === index + 1)
+            );
         });
         skillSet.tubes = tubes;
       });

--- a/admin/tests/acceptance/authenticated/badges/badges_test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges_test.js
@@ -4,7 +4,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 
-module('Acceptance | authenticated/badges/badge', function (hooks) {
+module('Acceptance | Badge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -55,5 +55,71 @@ module('Acceptance | authenticated/badges/badge', function (hooks) {
     assert.dom(screen.getByText('Certifiable')).exists();
     assert.dom(screen.getByText('Lacunes')).exists();
     assert.dom(screen.getByText('Practical title of tube')).exists();
+  });
+
+  test('should display only skills from skill-set', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+    const tube = this.server.create('tube', { practicalTitle: 'Practical title of tube' });
+    const skill = this.server.create('skill', { name: '@skill2', difficulty: 2, tube });
+    const skillSet = this.server.create('skill-set', {
+      id: 1,
+      name: 'Internet for dummies',
+      color: 'red',
+      skills: [skill],
+    });
+
+    const criterionCampaignParticipation = this.server.create('badge-criterion', {
+      id: 1,
+      scope: 'CampaignParticipation',
+      threshold: 20,
+    });
+    const criterionEverySkillSet = this.server.create('badge-criterion', {
+      id: 2,
+      scope: 'SkillSet',
+      threshold: 40,
+      skillSets: [skillSet],
+    });
+
+    const badge = this.server.create('badge', {
+      id: 1,
+      title: 'My badge',
+      imageUrl: 'https://images.pix/fr/badges/AG2R.svg',
+      isCertifiable: true,
+      isAlwaysVisible: true,
+      badgeCriteria: [criterionCampaignParticipation, criterionEverySkillSet],
+      skillSets: [skillSet],
+    });
+
+    const skill2 = this.server.create('skill', { name: '@skill3', difficulty: 3, tube });
+    const skillSet2 = this.server.create('skill-set', {
+      id: 2,
+      name: 'Internet for dummies',
+      color: 'red',
+      skills: [skill2],
+    });
+    const criterionEverySkillSet2 = this.server.create('badge-criterion', {
+      id: 3,
+      scope: 'SkillSet',
+      threshold: 40,
+      skillSets: [skillSet2],
+    });
+    const badge2 = this.server.create('badge', {
+      id: 2,
+      title: 'My badge 2',
+      imageUrl: 'https://images.pix/fr/badges/AG2R.svg',
+      isCertifiable: true,
+      isAlwaysVisible: true,
+      badgeCriteria: [criterionEverySkillSet2],
+      skillSets: [skillSet2],
+    });
+    await visit(`/badges/${badge2.id}`);
+
+    // when
+    const screen = await visit(`/badges/${badge.id}`);
+
+    // then
+    assert.dom(screen.queryByLabelText('@skill3')).doesNotExist();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix Admin, lorsqu'on charge des acquis d'un tube dans un premier Résultat Thématique et qu'on se rend dans un second RT qui a le même tube, alors les acquis du premier RT peuvent être affiché. 

![avant-en-utilisant-les-skills-du-tube](https://user-images.githubusercontent.com/26384707/167678295-be6a9037-c165-4118-8c73-9bfb2ef95ff8.gif)

![après-en-utilisant-les-skills-du-skill-set](https://user-images.githubusercontent.com/26384707/167678306-273aa0cc-68cf-4358-809d-a90c6b29fa24.gif)

## :robot: Solution
Nous utilisions les acquis du tubes pour afficher les acquis, seulement nous souhaitons à ce moment uniquement les acquis du `skill-sets`. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Admin 
- Se rendre sur : https://admin-pr4421.review.pix.fr/target-profiles/10/insights
- Aller sur le premier RT, puis sur le second
- Revenir sur le premier RT constater que la liste d'acquis est correctement affiché
