### PR TITLE
[DOC] Correction du format de la variable d'environnement ADDITIONAL_NGINX_LOGS dans la documentation

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -15,7 +15,7 @@ log_format keyvalue
     you want to add to nginx logging.
     For the logs to be correctly parsed, use the nginx_logger_version parameter.
     For example:
-    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
   %><%
     require 'json';
     JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -15,7 +15,7 @@ log_format keyvalue
     you want to add to nginx logging.
     For the logs to be correctly parsed, use the nginx_logger_version parameter.
     For example:
-    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
   %><%
     require 'json';
     JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -15,7 +15,7 @@ log_format keyvalue
     you want to add to nginx logging.
     For the logs to be correctly parsed, use the nginx_logger_version parameter.
     For example:
-    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
   %><%
     require 'json';
     JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -15,7 +15,7 @@ log_format keyvalue
     you want to add to nginx logging.
     For the logs to be correctly parsed, use the nginx_logger_version parameter.
     For example:
-    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version"="0", "my_custom_header"="$http_my_custom_header"}'
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
   %><%
     require 'json';
     JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>


### PR DESCRIPTION
## :unicorn: Problème
La documentation du format à utiliser pour la variable n'est pas bonne

## :robot: Solution
Corriger le format selon celui qui est rééllement utilisé

## :100: Pour tester

Vérifier que la documentation suit bien le même format que la variable en prod : 
`scalingo --region osc-secnum-fr1 --app pix-app-production env |grep ADDITIONAL`
