### PR TITLE
[FEATURE] Restreindre les actions de la page "Utilisateurs" dans Pix Admin aux rôles "SUPER_ADMIN" et "SUPPORT" (PIX-4191)

### DIFF
--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -1,12 +1,14 @@
 import ApplicationAdapter from './application';
 
 export default class UserAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
   urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/admin/users/${id}`;
+    return `${this.host}/${this.namespace}/users/${id}`;
   }
 
   urlForUpdateRecord(id) {
-    return `${this.host}/${this.namespace}/admin/users/${id}`;
+    return `${this.host}/${this.namespace}/users/${id}`;
   }
 
   updateRecord(store, type, snapshot) {

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -25,16 +25,20 @@
         {{/if}}
       </td>
       <td>
-        {{#if @user.isAllowedToRemoveEmailAuthenticationMethod}}
-          <PixButton
-            class="user-authentication-method__remove-button"
-            @size="small"
-            @backgroundColor="red"
-            @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "EMAIL"}}
-          >Supprimer</PixButton>
-        {{/if}}
-        {{#if @user.isAllowedToAddEmailAuthenticationMethod}}
-          <PixButton @triggerAction={{this.toggleAddAuthenticationMethodModal}} @size="small">Ajouter une adresse e-mail</PixButton>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.isAllowedToRemoveEmailAuthenticationMethod}}
+            <PixButton
+              class="user-authentication-method__remove-button"
+              @size="small"
+              @backgroundColor="red"
+              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "EMAIL"}}
+            >Supprimer</PixButton>
+          {{/if}}
+          {{#if @user.isAllowedToAddEmailAuthenticationMethod}}
+            <PixButton @triggerAction={{this.toggleAddAuthenticationMethodModal}} @size="small">
+              Ajouter une adresse e-mail
+            </PixButton>
+          {{/if}}
         {{/if}}
       </td>
     </tr>
@@ -57,13 +61,15 @@
         {{/if}}
       </td>
       <td>
-        {{#if @user.isAllowedToRemoveUsernameAuthenticationMethod}}
-          <PixButton
-            class="user-authentication-method__remove-button"
-            @size="small"
-            @backgroundColor="red"
-            @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "USERNAME"}}
-          >Supprimer</PixButton>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.isAllowedToRemoveUsernameAuthenticationMethod}}
+            <PixButton
+              class="user-authentication-method__remove-button"
+              @size="small"
+              @backgroundColor="red"
+              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "USERNAME"}}
+            >Supprimer</PixButton>
+          {{/if}}
         {{/if}}
       </td>
     </tr>
@@ -86,20 +92,24 @@
         {{/if}}
       </td>
       <td>
-        {{#if @user.isAllowedToRemovePoleEmploiAuthenticationMethod}}
-          <PixButton
-            class="user-authentication-method__remove-button"
-            @size="small"
-            @backgroundColor="red"
-            @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "POLE_EMPLOI"}}
-          >Supprimer</PixButton>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.isAllowedToRemovePoleEmploiAuthenticationMethod}}
+            <PixButton
+              class="user-authentication-method__remove-button"
+              @size="small"
+              @backgroundColor="red"
+              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "POLE_EMPLOI"}}
+            >Supprimer</PixButton>
+          {{/if}}
         {{/if}}
       </td>
       <td>
-        {{#if @user.hasPoleEmploiAuthenticationMethod}}
-          <PixButton @triggerAction={{this.toggleReassignPoleEmploiAuthenticationMethodModal}} @size="small">
-            Déplacer cette méthode de connexion
-          </PixButton>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.hasPoleEmploiAuthenticationMethod}}
+            <PixButton @triggerAction={{this.toggleReassignPoleEmploiAuthenticationMethodModal}} @size="small">
+              Déplacer cette méthode de connexion
+            </PixButton>
+          {{/if}}
         {{/if}}
       </td>
     </tr>
@@ -122,20 +132,24 @@
         {{/if}}
       </td>
       <td>
-        {{#if @user.isAllowedToRemoveGarAuthenticationMethod}}
-          <PixButton
-            class="user-authentication-method__remove-button"
-            @size="small"
-            @backgroundColor="red"
-            @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "GAR"}}
-          >Supprimer</PixButton>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.isAllowedToRemoveGarAuthenticationMethod}}
+            <PixButton
+              class="user-authentication-method__remove-button"
+              @size="small"
+              @backgroundColor="red"
+              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "GAR"}}
+            >Supprimer</PixButton>
+          {{/if}}
         {{/if}}
       </td>
       <td>
-        {{#if @user.hasGarAuthenticationMethod}}
-          <PixButton @triggerAction={{this.toggleReassignGarAuthenticationMethodModal}} @size="small">
-            Déplacer cette méthode de connexion
-          </PixButton>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.hasGarAuthenticationMethod}}
+            <PixButton @triggerAction={{this.toggleReassignGarAuthenticationMethodModal}} @size="small">
+              Déplacer cette méthode de connexion
+            </PixButton>
+          {{/if}}
         {{/if}}
       </td>
     </tr>

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 
 export default class AuthenticationMethod extends Component {
   @service notifications;
+  @service accessControl;
 
   @tracked showAddAuthenticationMethodModal = false;
   @tracked showReassignGarAuthenticationMethodModal = false;

--- a/admin/app/components/users/user-detail-personal-information/schooling-registration-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information/schooling-registration-information.hbs
@@ -27,10 +27,11 @@
             {{if schoolingRegistration.division schoolingRegistration.division}}
             {{if schoolingRegistration.group schoolingRegistration.group}}
           </td>
-          <td><LinkTo
-              @route="authenticated.organizations.get"
-              @model={{schoolingRegistration.organizationId}}
-            >{{schoolingRegistration.organizationName}}</LinkTo></td>
+          <td>
+            <LinkTo @route="authenticated.organizations.get" @model={{schoolingRegistration.organizationId}}>
+              {{schoolingRegistration.organizationName}}
+            </LinkTo>
+          </td>
           <td>{{format-date schoolingRegistration.createdAt}}</td>
           <td>{{format-date schoolingRegistration.updatedAt}}</td>
           <td class="table-admin-schooling-registrations-status">
@@ -49,14 +50,16 @@
             {{/if}}
           </td>
           <td>
-            {{#if schoolingRegistration.canBeDissociated}}
-              <PixButton
-                @triggerAction={{fn @toggleDisplayDissociateModal schoolingRegistration}}
-                @size="small"
-                @backgroundColor="red"
-              >
-                Dissocier
-              </PixButton>
+            {{#if this.accessControl.hasAccessToUsersActionsScope}}
+              {{#if schoolingRegistration.canBeDissociated}}
+                <PixButton
+                  @triggerAction={{fn @toggleDisplayDissociateModal schoolingRegistration}}
+                  @size="small"
+                  @backgroundColor="red"
+                >
+                  Dissocier
+                </PixButton>
+              {{/if}}
             {{/if}}
           </td>
         </tr>

--- a/admin/app/components/users/user-detail-personal-information/schooling-registration-information.js
+++ b/admin/app/components/users/user-detail-personal-information/schooling-registration-information.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class SchoolingRegistrationInformation extends Component {
+  @service accessControl;
+}

--- a/admin/app/components/users/user-detail-personal-information/user-overview.hbs
+++ b/admin/app/components/users/user-detail-personal-information/user-overview.hbs
@@ -140,17 +140,19 @@
       </div>
     </section>
     <div class="col-md-4 form-actions">
-      <PixButton
-        @size="small"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @triggerAction={{this.changeEditionMode}}
-      >
-        Modifier
-      </PixButton>
-      <PixButton @size="small" @backgroundColor="red" @triggerAction={{@toggleDisplayAnonymizeModal}}>
-        Anonymiser cet utilisateur
-      </PixButton>
+      {{#if this.accessControl.hasAccessToUsersActionsScope}}
+        <PixButton
+          @size="small"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.changeEditionMode}}
+        >
+          Modifier
+        </PixButton>
+        <PixButton @size="small" @backgroundColor="red" @triggerAction={{@toggleDisplayAnonymizeModal}}>
+          Anonymiser cet utilisateur
+        </PixButton>
+      {{/if}}
     </div>
   </form>
 {{/if}}

--- a/admin/app/components/users/user-detail-personal-information/user-overview.js
+++ b/admin/app/components/users/user-detail-personal-information/user-overview.js
@@ -87,6 +87,7 @@ export default class UserOverview extends Component {
   @tracked isEditionMode = false;
 
   @service notifications;
+  @service accessControl;
 
   constructor() {
     super(...arguments);

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -5,6 +5,10 @@ export default class AccessControlService extends Service {
   @service currentUser;
   @service router;
 
+  get hasAccessToUsersActionsScope() {
+    return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isSupport;
+  }
+
   restrictAccessTo(roles, redirectionUrl) {
     const currentUserIsAllowed = roles.some((role) => this.currentUser.adminMember[role]);
     if (!currentUserIsAllowed) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -90,7 +90,7 @@ export default function () {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
 
-  this.get('/users');
+  this.get('/admin/users');
 
   this.get('/certification-centers');
   this.get('/certification-centers/:id');

--- a/admin/tests/acceptance/user-list_test.js
+++ b/admin/tests/acceptance/user-list_test.js
@@ -57,7 +57,7 @@ module('Acceptance | User List', function (hooks) {
         ],
       };
 
-      this.server.get('/users', () => result);
+      this.server.get('/admin/users', () => result);
 
       // when
       const screen = await visit('/users/list?email=example.net');

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -2,71 +2,21 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 
 module('Integration | Component | users | user-detail-personal-information/authentication-method', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('When user has authentication methods', function () {
-    test('should display user’s email authentication method', async function (assert) {
-      // given
-      this.set('user', { hasEmailAuthenticationMethod: true });
+  module('When the admin member has access to users actions scope', function () {
+    class AccessControlStub extends Service {
+      hasAccessToUsersActionsScope = true;
+    }
 
-      // when
-      const screen = await render(hbs`
-        <Users::UserDetailPersonalInformation::AuthenticationMethod
-          @user={{this.user}}
-        />`);
-
-      // then
-      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec adresse e-mail")).exists();
-    });
-
-    test('should display user’s username authentication method', async function (assert) {
-      // given
-      this.set('user', { hasUsernameAuthenticationMethod: true });
-
-      // when
-      const screen = await render(hbs`
-        <Users::UserDetailPersonalInformation::AuthenticationMethod
-          @user={{this.user}}
-        />`);
-
-      // then
-      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec identifiant")).exists();
-    });
-
-    test('should display user’s Pole Emploi authentication method', async function (assert) {
-      // given
-      this.set('user', { hasPoleEmploiAuthenticationMethod: true });
-
-      // when
-      const screen = await render(hbs`
-        <Users::UserDetailPersonalInformation::AuthenticationMethod
-          @user={{this.user}}
-        />`);
-
-      // then
-      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Pôle Emploi")).exists();
-    });
-
-    test('should display user’s gar authentication method', async function (assert) {
-      // given
-      this.set('user', { hasGarAuthenticationMethod: true });
-
-      // when
-      const screen = await render(hbs`
-        <Users::UserDetailPersonalInformation::AuthenticationMethod
-          @user={{this.user}}
-        />`);
-
-      // then
-      assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Médiacentre")).exists();
-    });
-
-    module('When user has only one authentication method', function () {
-      test('it should not display a remove authentication method link', async function (assert) {
+    module('When user has authentication methods', function () {
+      test('should display user’s email authentication method', async function (assert) {
         // given
-        this.set('user', { hasOnlyOneAuthenticationMethod: true });
+        this.set('user', { hasEmailAuthenticationMethod: true });
+        this.owner.register('service:access-control', AccessControlStub);
 
         // when
         const screen = await render(hbs`
@@ -75,17 +25,116 @@ module('Integration | Component | users | user-detail-personal-information/authe
         />`);
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
+        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec adresse e-mail")).exists();
       });
 
-      module('When user does not have pix authentication method', function () {
-        test('it should display add authentication method button', async function (assert) {
+      test('should display user’s username authentication method', async function (assert) {
+        // given
+        this.set('user', { hasUsernameAuthenticationMethod: true });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+        // then
+        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec identifiant")).exists();
+      });
+
+      test('should display user’s Pole Emploi authentication method', async function (assert) {
+        // given
+        this.set('user', { hasPoleEmploiAuthenticationMethod: true });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+        // then
+        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Pôle Emploi")).exists();
+      });
+
+      test('should display user’s gar authentication method', async function (assert) {
+        // given
+        this.set('user', { hasGarAuthenticationMethod: true });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+        // then
+        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Médiacentre")).exists();
+      });
+
+      module('When user has only one authentication method', function () {
+        test('it should not display a remove authentication method link', async function (assert) {
+          // given
+          this.set('user', { hasOnlyOneAuthenticationMethod: true });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
+        });
+
+        module('When user does not have pix authentication method', function () {
+          test('it should display add authentication method button', async function (assert) {
+            // given
+            this.set('user', {
+              isAllowedToAddEmailAuthenticationMethod: true,
+              hasOnlyOneAuthenticationMethod: true,
+              hasPixAuthenticationMethod: false,
+            });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+          <Users::UserDetailPersonalInformation::AuthenticationMethod
+            @user={{this.user}}
+          />`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Ajouter une adresse e-mail' })).exists();
+          });
+        });
+
+        module('When user has a pix authentication method', function () {
+          test('it should not display add authentication method button', async function (assert) {
+            // given
+            this.set('user', { hasOnlyOneAuthenticationMethod: true, hasPixAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+          <Users::UserDetailPersonalInformation::AuthenticationMethod
+            @user={{this.user}}
+          />`);
+
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Ajouter une adresse e-mail' })).doesNotExist();
+          });
+        });
+      });
+
+      module('When user has gar authentication method', function () {
+        test('it should display reassign authentication method button', async function (assert) {
           // given
           this.set('user', {
-            isAllowedToAddEmailAuthenticationMethod: true,
-            hasOnlyOneAuthenticationMethod: true,
-            hasPixAuthenticationMethod: false,
+            hasGarAuthenticationMethod: true,
           });
+          this.owner.register('service:access-control', AccessControlStub);
 
           // when
           const screen = await render(hbs`
@@ -94,14 +143,17 @@ module('Integration | Component | users | user-detail-personal-information/authe
           />`);
 
           // then
-          assert.dom(screen.getByRole('button', { name: 'Ajouter une adresse e-mail' })).exists();
+          assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
         });
       });
 
-      module('When user has a pix authentication method', function () {
-        test('it should not display add authentication method button', async function (assert) {
+      module('When user has Pole Emploi authentication method', function () {
+        test('it should display reassign authentication method button', async function (assert) {
           // given
-          this.set('user', { hasOnlyOneAuthenticationMethod: true, hasPixAuthenticationMethod: true });
+          this.set('user', {
+            hasPoleEmploiAuthenticationMethod: true,
+          });
+          this.owner.register('service:access-control', AccessControlStub);
 
           // when
           const screen = await render(hbs`
@@ -110,45 +162,32 @@ module('Integration | Component | users | user-detail-personal-information/authe
           />`);
 
           // then
-          assert.dom(screen.queryByRole('button', { name: 'Ajouter une adresse e-mail' })).doesNotExist();
+          assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
         });
       });
     });
+  });
 
-    module('When user has gar authentication method', function () {
-      test('it should display reassign authentication method button', async function (assert) {
-        // given
-        this.set('user', {
-          hasGarAuthenticationMethod: true,
-        });
-
-        // when
-        const screen = await render(hbs`
-          <Users::UserDetailPersonalInformation::AuthenticationMethod
-            @user={{this.user}}
-          />`);
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
+  module('When the admin member does not have access to users actions scope', function () {
+    test('it should not be able to see action buttons "Supprimer" and "Déplacer cette méthode de connexion"', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToUsersActionsScope = false;
+      }
+      this.set('user', {
+        isAllowedToRemoveGarAuthenticationMethod: true,
+        hasGarAuthenticationMethod: true,
       });
-    });
+      this.owner.register('service:access-control', AccessControlStub);
 
-    module('When user has Pole Emploi authentication method', function () {
-      test('it should display reassign authentication method button', async function (assert) {
-        // given
-        this.set('user', {
-          hasPoleEmploiAuthenticationMethod: true,
-        });
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}}/>`
+      );
 
-        // when
-        const screen = await render(hbs`
-          <Users::UserDetailPersonalInformation::AuthenticationMethod
-            @user={{this.user}}
-          />`);
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
-      });
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Déplacer cette méthode de connexion' })).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/users/user-detail-personal-information/schooling-registration-information_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/schooling-registration-information_test.js
@@ -3,162 +3,199 @@ import { setupRenderingTest } from 'ember-qunit';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module(
   'Integration | Component | users | user-detail-personal-information/schooling-registration-information',
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test('should display schooling registration’s info', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ firstName: 'John', lastName: 'Doe', birthdate: new Date('2020-10-02') }],
+    module('When the admin member has access to users actions scope', function () {
+      class AccessControlStub extends Service {
+        hasAccessToUsersActionsScope = true;
+      }
+
+      test('should display schooling registration’s info', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ firstName: 'John', lastName: 'Doe', birthdate: new Date('2020-10-02') }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByText('John')).exists();
+        assert.dom(screen.getByText('Doe')).exists();
+        assert.dom(screen.getByText('02/10/2020')).exists();
       });
 
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
+      test('should display schooling registration’s division', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ division: '3A' }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
 
-      // then
-      assert.dom(screen.getByText('John')).exists();
-      assert.dom(screen.getByText('Doe')).exists();
-      assert.dom(screen.getByText('02/10/2020')).exists();
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByText('3A')).exists();
+      });
+
+      test('should display schooling registration’s group', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ division: 'groupe 2' }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByText('groupe 2')).exists();
+      });
+
+      test('should display schooling registration’s organization info', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ organizationId: 42, organizationName: 'Dragon & Co' }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByText('Dragon & Co')).exists();
+        assert.dom('[href="/organizations/42"]').exists();
+      });
+
+      test('should display schooling registration’s import date and re-import date', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ createdAt: new Date('2020-01-01'), updatedAt: new Date('2020-01-02') }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByText('01/01/2020')).exists();
+        assert.dom(screen.getByText('02/01/2020')).exists();
+      });
+
+      test('should display schooling registration as active', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ isDisabled: false }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByLabelText('Inscription activée')).exists();
+      });
+
+      test('should display schooling registration as inactive', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', {
+          schoolingRegistrations: [{ isDisabled: true }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.getByLabelText('Inscription désactivée')).exists();
+      });
+
+      test('should be able to dissociate user if it is enabled', async function (assert) {
+        // given
+        const toggleDisplayDissociateModal = sinon.stub();
+        this.set('toggleDisplayDissociateModal', toggleDisplayDissociateModal);
+        this.set('user', {
+          schoolingRegistrations: [{ firstName: 'some name', canBeDissociated: true }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+        await clickByName('Dissocier');
+
+        // then
+        sinon.assert.called(this.toggleDisplayDissociateModal);
+        assert.ok(true);
+      });
+
+      test('should not be able to dissociate user if it is disabled', async function (assert) {
+        // given
+        const toggleDisplayDissociateModal = sinon.stub();
+        this.set('toggleDisplayDissociateModal', toggleDisplayDissociateModal);
+        this.set('user', {
+          schoolingRegistrations: [{ firstName: 'some name', canBeDissociated: false }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
+        );
+
+        // then
+        assert.dom(screen.queryByText('Dissocier')).doesNotExist();
+      });
     });
 
-    test('should display schooling registration’s division', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ division: '3A' }],
+    module('When the admin member does not have access to users actions scope', function () {
+      test('it should not be able to see action button "Dissocier"', async function (assert) {
+        // Given
+        class AccessControlStub extends Service {
+          hasAccessToUsersActionsScope = false;
+        }
+        this.set('user', {
+          schoolingRegistrations: [{ firstName: 'some name', canBeDissociated: true }],
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // When
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}}/>`
+        );
+
+        // Then
+        assert.dom(screen.queryByRole('button', { name: 'Dissocier' })).doesNotExist();
       });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.getByText('3A')).exists();
-    });
-
-    test('should display schooling registration’s group', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ division: 'groupe 2' }],
-      });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.getByText('groupe 2')).exists();
-    });
-
-    test('should display schooling registration’s organization info', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ organizationId: 42, organizationName: 'Dragon & Co' }],
-      });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.getByText('Dragon & Co')).exists();
-      assert.dom('[href="/organizations/42"]').exists();
-    });
-
-    test('should display schooling registration’s import date and re-import date', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ createdAt: new Date('2020-01-01'), updatedAt: new Date('2020-01-02') }],
-      });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.getByText('01/01/2020')).exists();
-      assert.dom(screen.getByText('02/01/2020')).exists();
-    });
-
-    test('should display schooling registration as active', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ isDisabled: false }],
-      });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.getByLabelText('Inscription activée')).exists();
-    });
-
-    test('should display schooling registration as inactive', async function (assert) {
-      // given
-      this.toggleDisplayDissociateModal = sinon.spy();
-      this.set('user', {
-        schoolingRegistrations: [{ isDisabled: true }],
-      });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.getByLabelText('Inscription désactivée')).exists();
-    });
-
-    test('should be able to dissociate user if it is enabled', async function (assert) {
-      // given
-      const toggleDisplayDissociateModal = sinon.stub();
-      this.set('toggleDisplayDissociateModal', toggleDisplayDissociateModal);
-      this.set('user', {
-        schoolingRegistrations: [{ firstName: 'some name', canBeDissociated: true }],
-      });
-
-      // when
-      await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-      await clickByName('Dissocier');
-
-      // then
-      sinon.assert.called(this.toggleDisplayDissociateModal);
-      assert.ok(true);
-    });
-
-    test('should not be able to dissociate user if it is disabled', async function (assert) {
-      // given
-      const toggleDisplayDissociateModal = sinon.stub();
-      this.set('toggleDisplayDissociateModal', toggleDisplayDissociateModal);
-      this.set('user', {
-        schoolingRegistrations: [{ firstName: 'some name', canBeDissociated: false }],
-      });
-
-      // when
-      const screen = await render(
-        hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}} />`
-      );
-
-      // then
-      assert.dom(screen.queryByText('Dissocier')).doesNotExist();
     });
   }
 );

--- a/admin/tests/integration/components/users/user-detail-personal-information/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/user-overview_test.js
@@ -3,282 +3,331 @@ import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 
 module('Integration | Component | users | user-detail-personal-information/user-overview', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('When the administrator click on user details', function () {
-    module('update button', function () {
-      test('should display the update button', async function (assert) {
+  module('When the admin member has access to users actions scope', function () {
+    class AccessControlStub extends Service {
+      hasAccessToUsersActionsScope = true;
+    }
+
+    module('When the admin member click on user details', function () {
+      module('update button', function () {
+        test('should display the update button', async function (assert) {
+          // given
+          this.set('user', {
+            firstName: 'John',
+            lastName: 'Harry',
+            email: 'john.harry@example.net',
+            username: 'john.harry0102',
+          });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
+        });
+      });
+
+      module('user authentication', function () {
+        test('should display user’s first name', async function (assert) {
+          // given
+          this.set('user', { firstName: 'John' });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText(this.user.firstName)).exists();
+        });
+
+        test('should display user’s last name', async function (assert) {
+          // given
+          this.set('user', { lastName: 'Snow' });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText(this.user.lastName)).exists();
+        });
+
+        test('should display user’s email', async function (assert) {
+          // given
+          this.set('user', { email: 'john.snow@winterfell.got' });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText(this.user.email)).exists();
+        });
+
+        test('should display user’s username', async function (assert) {
+          // given
+          this.set('user', { username: 'kingofthenorth' });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText(this.user.username)).exists();
+        });
+      });
+
+      module('terms of service', function () {
+        test('should display "OUI" when user accepted Pix App terms of service', async function (assert) {
+          // given
+          this.set('user', { cgu: true });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText('OUI')).exists();
+        });
+
+        test('should display "NON" when user not accepted Pix App terms of service', async function (assert) {
+          // given
+          this.set('user', { pixCertifTermsOfServiceAccepted: true, pixOrgaTermsOfServiceAccepted: true, cgu: false });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText('NON')).exists();
+        });
+
+        test('should display "OUI" when user accepted Pix Orga terms of service', async function (assert) {
+          // given
+          this.set('user', { pixOrgaTermsOfServiceAccepted: true });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText('OUI')).exists();
+        });
+
+        test('should display "NON" when user not accepted Pix Orga terms of service', async function (assert) {
+          // given
+          this.set('user', { pixCertifTermsOfServiceAccepted: true, pixOrgaTermsOfServiceAccepted: false, cgu: true });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText('NON')).exists();
+        });
+
+        test('should display "OUI" when user accepted Pix Certif terms of service', async function (assert) {
+          // given
+          this.set('user', { pixCertifTermsOfServiceAccepted: true });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText('OUI')).exists();
+        });
+
+        test('should display "NON" when user not accepted Pix Certif terms of service', async function (assert) {
+          // given
+          this.set('user', { pixCertifTermsOfServiceAccepted: false, pixOrgaTermsOfServiceAccepted: true, cgu: true });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+
+          // then
+          assert.dom(screen.getByText('NON')).exists();
+        });
+      });
+    });
+
+    module('When the admin member click to update user details', function (hooks) {
+      let user = null;
+
+      hooks.beforeEach(function () {
+        user = EmberObject.create({
+          lastName: 'Harry',
+          firstName: 'John',
+          email: 'john.harry@gmail.com',
+          username: null,
+        });
+      });
+
+      test('should display the edit and cancel buttons', async function (assert) {
         // given
         this.set('user', {
           firstName: 'John',
           lastName: 'Harry',
           email: 'john.harry@example.net',
-          username: 'john.harry0102',
+          username: null,
+        });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
+        await clickByName('Modifier');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Editer' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      });
+
+      test('should display user’s first name and last name in edit mode', async function (assert) {
+        // given
+        this.set('user', user);
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+        await clickByName('Modifier');
+
+        // then
+        assert.dom(screen.getByRole('textbox', { name: 'Prénom :' })).hasValue(this.user.firstName);
+        assert.dom(screen.getByRole('textbox', { name: 'Nom :' })).hasValue(this.user.lastName);
+      });
+
+      module('when user has an email only', function () {
+        test('should display user’s email in edit mode', async function (assert) {
+          // given
+          this.set('user', user);
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+          await clickByName('Modifier');
+
+          // then
+          assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).hasValue(this.user.email);
         });
 
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+        test('should not display username in edit mode', async function (assert) {
+          // given
+          this.set('user', user);
+          this.owner.register('service:access-control', AccessControlStub);
 
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
-      });
-    });
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+          await clickByName('Modifier');
 
-    module('user authentication', function () {
-      test('should display user’s first name', async function (assert) {
-        // given
-        this.set('user', { firstName: 'John' });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText(this.user.firstName)).exists();
+          // then
+          assert.dom(screen.queryByRole('textbox', { name: 'Identifiant :' })).doesNotExist();
+        });
       });
 
-      test('should display user’s last name', async function (assert) {
-        // given
-        this.set('user', { lastName: 'Snow' });
+      module('when user has a username only', function () {
+        test('should display user’s username in edit mode', async function (assert) {
+          // given
+          const user = EmberObject.create({
+            lastName: 'Harry',
+            firstName: 'John',
+            email: null,
+            username: 'user.name1212',
+          });
+          this.set('user', user);
+          this.owner.register('service:access-control', AccessControlStub);
 
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
+          await clickByName('Modifier');
 
-        // then
-        assert.dom(screen.getByText(this.user.lastName)).exists();
+          // then
+          assert.dom(screen.getByRole('textbox', { name: 'Identifiant :' })).hasValue(this.user.username);
+        });
+
+        test('should display email', async function (assert) {
+          // given
+          const user = EmberObject.create({
+            lastName: 'Harry',
+            firstName: 'John',
+            email: null,
+            username: 'user.name1212',
+          });
+          this.set('user', user);
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
+          await clickByName('Modifier');
+
+          // then
+          assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).exists();
+        });
       });
 
-      test('should display user’s email', async function (assert) {
-        // given
-        this.set('user', { email: 'john.snow@winterfell.got' });
+      module('when user has no username and no email', function () {
+        test('should not display email', async function (assert) {
+          // given
+          const user = EmberObject.create({
+            lastName: 'Harry',
+            firstName: 'John',
+            email: null,
+            username: undefined,
+          });
+          this.set('user', user);
+          this.owner.register('service:access-control', AccessControlStub);
 
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+          // when
+          const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
+          await clickByName('Modifier');
 
-        // then
-        assert.dom(screen.getByText(this.user.email)).exists();
+          // then
+          assert.dom(screen.queryByRole('textbox', { name: 'Adresse e-mail :' })).doesNotExist();
+        });
       });
 
-      test('should display user’s username', async function (assert) {
+      test('should not display user’s terms of service', async function (assert) {
         // given
-        this.set('user', { username: 'kingofthenorth' });
+        this.set('user', user);
+        this.owner.register('service:access-control', AccessControlStub);
 
         // when
         const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
+        await clickByName('Modifier');
 
         // then
-        assert.dom(screen.getByText(this.user.username)).exists();
-      });
-    });
-
-    module('terms of service', function () {
-      test('should display "OUI" when user accepted Pix App terms of service', async function (assert) {
-        // given
-        this.set('user', { cgu: true });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('OUI')).exists();
-      });
-
-      test('should display "NON" when user not accepted Pix App terms of service', async function (assert) {
-        // given
-        this.set('user', { pixCertifTermsOfServiceAccepted: true, pixOrgaTermsOfServiceAccepted: true, cgu: false });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('NON')).exists();
-      });
-
-      test('should display "OUI" when user accepted Pix Orga terms of service', async function (assert) {
-        // given
-        this.set('user', { pixOrgaTermsOfServiceAccepted: true });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('OUI')).exists();
-      });
-
-      test('should display "NON" when user not accepted Pix Orga terms of service', async function (assert) {
-        // given
-        this.set('user', { pixCertifTermsOfServiceAccepted: true, pixOrgaTermsOfServiceAccepted: false, cgu: true });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('NON')).exists();
-      });
-
-      test('should display "OUI" when user accepted Pix Certif terms of service', async function (assert) {
-        // given
-        this.set('user', { pixCertifTermsOfServiceAccepted: true });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('OUI')).exists();
-      });
-
-      test('should display "NON" when user not accepted Pix Certif terms of service', async function (assert) {
-        // given
-        this.set('user', { pixCertifTermsOfServiceAccepted: false, pixOrgaTermsOfServiceAccepted: true, cgu: true });
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('NON')).exists();
+        assert.dom(screen.queryByText('CGU Pix Orga validé :')).doesNotExist();
+        assert.dom(screen.queryByText('CGU Pix Certif validé :')).doesNotExist();
       });
     });
   });
 
-  module('When the administrator click to update user details', function (hooks) {
-    let user = null;
-
-    hooks.beforeEach(function () {
-      user = EmberObject.create({
-        lastName: 'Harry',
-        firstName: 'John',
-        email: 'john.harry@gmail.com',
-        username: null,
-      });
-    });
-
-    test('should display the edit and cancel buttons', async function (assert) {
+  module('When the admin member does not have access to users actions scope', function () {
+    test('it should not be able to see action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
       // given
+      class AccessControlStub extends Service {
+        hasAccessToUsersActionsScope = false;
+      }
       this.set('user', {
         firstName: 'John',
         lastName: 'Harry',
         email: 'john.harry@example.net',
-        username: null,
+        username: 'john.harry0102',
       });
-
-      // when
-      const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
-      await clickByName('Modifier');
-
-      // then
-      assert.dom(screen.getByRole('button', { name: 'Editer' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-    });
-
-    test('should display user’s first name and last name in edit mode', async function (assert) {
-      // given
-      this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
 
       // when
       const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-      await clickByName('Modifier');
 
       // then
-      assert.dom(screen.getByRole('textbox', { name: 'Prénom :' })).hasValue(this.user.firstName);
-      assert.dom(screen.getByRole('textbox', { name: 'Nom :' })).hasValue(this.user.lastName);
-    });
-
-    module('when user has an email only', function () {
-      test('should display user’s email in edit mode', async function (assert) {
-        // given
-        this.set('user', user);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-        await clickByName('Modifier');
-
-        // then
-        assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).hasValue(this.user.email);
-      });
-
-      test('should not display username in edit mode', async function (assert) {
-        // given
-        this.set('user', user);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-        await clickByName('Modifier');
-
-        // then
-        assert.dom(screen.queryByRole('textbox', { name: 'Identifiant :' })).doesNotExist();
-      });
-    });
-
-    module('when user has a username only', function () {
-      test('should display user’s username in edit mode', async function (assert) {
-        // given
-        const user = EmberObject.create({
-          lastName: 'Harry',
-          firstName: 'John',
-          email: null,
-          username: 'user.name1212',
-        });
-        this.set('user', user);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
-        await clickByName('Modifier');
-
-        // then
-        assert.dom(screen.getByRole('textbox', { name: 'Identifiant :' })).hasValue(this.user.username);
-      });
-
-      test('should display email', async function (assert) {
-        // given
-        const user = EmberObject.create({
-          lastName: 'Harry',
-          firstName: 'John',
-          email: null,
-          username: 'user.name1212',
-        });
-        this.set('user', user);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
-        await clickByName('Modifier');
-
-        // then
-        assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).exists();
-      });
-    });
-
-    module('when user has no username and no email', function () {
-      test('should not display email', async function (assert) {
-        // given
-        const user = EmberObject.create({
-          lastName: 'Harry',
-          firstName: 'John',
-          email: null,
-          username: undefined,
-        });
-        this.set('user', user);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}} />`);
-        await clickByName('Modifier');
-
-        // then
-        assert.dom(screen.queryByRole('textbox', { name: 'Adresse e-mail :' })).doesNotExist();
-      });
-    });
-
-    test('should not display user’s terms of service', async function (assert) {
-      // given
-      this.set('user', user);
-
-      // when
-      const screen = await render(hbs`<Users::UserDetailPersonalInformation::UserOverview @user={{this.user}}/>`);
-      await clickByName('Modifier');
-
-      // then
-      assert.dom(screen.queryByText('CGU Pix Orga validé :')).doesNotExist();
-      assert.dom(screen.queryByText('CGU Pix Certif validé :')).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Modifier' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Anonymiser cet utilisateur' })).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information_test.js
@@ -9,11 +9,16 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 module('Integration | Component | users | user-detail-personal-information', function (hooks) {
   setupRenderingTest(hooks);
 
+  class AccessControlStub extends Service {
+    hasAccessToUsersActionsScope = true;
+  }
+
   module('schooling registrations', function () {
     module('When user has no schoolingRegistrations', function () {
       test('should display no result in schooling registrations table', async function (assert) {
         // given
         this.set('user', { schoolingRegistrations: [] });
+        this.owner.register('service:access-control', AccessControlStub);
 
         // when
         const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -27,6 +32,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
       test('should display schooling registrations in table', async function (assert) {
         // given
         this.set('user', { schoolingRegistrations: [{ id: 1 }, { id: 2 }] });
+        this.owner.register('service:access-control', AccessControlStub);
 
         // when
         const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -39,6 +45,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
         test('Should display a green tick mark on the table when "isDisabled = false"', async function (assert) {
           // given
           this.set('user', { schoolingRegistrations: [{ id: 1, isDisabled: false }] });
+          this.owner.register('service:access-control', AccessControlStub);
 
           // when
           const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -50,6 +57,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
         test('Should display a red cross on the table when "isDisabled= true"', async function (assert) {
           // given
           this.set('user', { schoolingRegistrations: [{ id: 1, isDisabled: true }] });
+          this.owner.register('service:access-control', AccessControlStub);
 
           // when
           const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -61,7 +69,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
     });
   });
 
-  module('when the administrator click on anonymize button', function (hooks) {
+  module('when the admin member click on anonymize button', function (hooks) {
     let user = null;
 
     hooks.beforeEach(function () {
@@ -76,6 +84,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
     test('should show modal', async function (assert) {
       // given
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
       const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
 
       // when
@@ -93,6 +102,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
     test('should close the modal to cancel action', async function (assert) {
       // given
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
       const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
       await clickByName('Anonymiser cet utilisateur');
 
@@ -106,7 +116,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
     });
   });
 
-  module('when the administrator click on dissociate button', function () {
+  module('when the admin member click on dissociate button', function () {
     test('should display dissociate confirm modal', async function (assert) {
       // given
       const destroyRecordStub = sinon.stub();
@@ -125,6 +135,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
         schoolingRegistrations: [schoolingRegistration],
       });
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
 
       const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}} />`);
 
@@ -153,6 +164,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
         schoolingRegistrations: [schoolingRegistration],
       });
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
 
       const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
       await clickByName('Dissocier');
@@ -183,6 +195,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
         schoolingRegistrations: [schoolingRegistration],
       });
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
 
       await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}} />`);
       await clickByName('Dissocier');
@@ -195,7 +208,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
     });
   });
 
-  module('when the administrator click on remove authentication method button', function () {
+  module('when the admin member click on remove authentication method button', function () {
     test('should display remove authentication methode confirm modal', async function (assert) {
       // given
       const user = EmberObject.create({
@@ -209,6 +222,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
       });
 
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
       const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
 
       // when
@@ -231,6 +245,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
       });
 
       this.set('user', user);
+      this.owner.register('service:access-control', AccessControlStub);
       const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
       await clickByName('Supprimer');
 
@@ -243,7 +258,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
       assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
     });
 
-    module('when the administrator confirm the removal', function () {
+    module('when the admin member confirm the removal', function () {
       test('should call removeAuthenticationMethod parameter', async function (assert) {
         // given
         const user = EmberObject.create({
@@ -256,6 +271,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
           isAllowedToRemoveEmailAuthenticationMethod: true,
         });
         this.set('user', user);
+        this.owner.register('service:access-control', AccessControlStub);
         const removeAuthenticationMethodStub = sinon.stub();
         this.set('removeAuthenticationMethod', removeAuthenticationMethodStub);
 
@@ -274,7 +290,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
         assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
       });
 
-      test('should display an error message when the administrator try to remove the last authentication method', async function (assert) {
+      test('should display an error message when the admin member try to remove the last authentication method', async function (assert) {
         // given
         const user = EmberObject.create({
           lastName: 'Harry',
@@ -285,6 +301,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
           isAllowedToRemoveEmailAuthenticationMethod: true,
         });
         this.set('user', user);
+        this.owner.register('service:access-control', AccessControlStub);
         const removeAuthenticationMethodStub = sinon.stub();
         this.set('removeAuthenticationMethod', removeAuthenticationMethodStub);
 

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -45,6 +45,38 @@ module('Unit | Service | access-control', function (hooks) {
     });
   });
 
+  module('#hasAccessToUsersActionsScope', function () {
+    test('should be true if admin member has role "SUPER_ADMIN"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToUsersActionsScope);
+    });
+
+    test('should be true if admin member has role "SUPPORT"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSupport: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToUsersActionsScope);
+    });
+
+    test('should be false if admin member has role "CERTIF" or "METIER"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSuperAdmin: false, isSupport: false };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.false(service.hasAccessToUsersActionsScope);
+    });
+  });
+
   module('#hasAccessToOrganizationActionsScope', function () {
     test('should be true if current admin member is Super Admin', function (assert) {
       // given

--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -6,7 +6,38 @@ const schoolingRegistrationUserAssociationController = require('./schooling-regi
 const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function (server) {
+  const adminRoutes = [
+    {
+      method: 'DELETE',
+      path: '/api/admin/schooling-registration-user-associations/{id}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.userHasAtLeastOneAccessOf([
+                securityPreHandlers.checkUserHasRoleSuperAdmin,
+                securityPreHandlers.checkUserHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: schoolingRegistrationUserAssociationController.dissociate,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.schoolingRegistrationId,
+          }),
+        },
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle dissocie un utilisateur d’une inscription d’élève',
+        ],
+        tags: ['api', 'admin', 'schoolingRegistrationUserAssociation'],
+      },
+    },
+  ];
+
   server.route([
+    ...adminRoutes,
     {
       method: 'POST',
       path: '/api/schooling-registration-user-associations',
@@ -210,7 +241,7 @@ exports.register = async function (server) {
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             '- Elle dissocie un utilisateur d’une inscription d’élève',
         ],
-        tags: ['api', 'schoolingRegistrationUserAssociation'],
+        tags: ['api', 'admin', 'schoolingRegistrationUserAssociation'],
       },
     },
   ]);

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -259,31 +259,6 @@ exports.register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/users',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.userHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserHasRoleSuperAdmin,
-                securityPreHandlers.checkUserHasRoleCertif,
-                securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        handler: userController.findPaginatedFilteredUsers,
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de récupérer & chercher une liste d’utilisateurs\n' +
-            '- Cette liste est paginée et filtrée selon un **firstName**, un **lastName** et/ou un **email** donnés',
-        ],
-        tags: ['api', 'user'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/users/me',
       config: {
         handler: userController.getCurrentUser,

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -1321,7 +1321,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
   });
 
   describe('DELETE /api/schooling-registration-user-associations', function () {
-    context('When user has therole SUPER_ADMIN and schooling registration can be dissociated', function () {
+    context('When user has the role SUPER_ADMIN and schooling registration can be dissociated', function () {
       it('should return an 204 status after having successfully dissociated user from schoolingRegistration', async function () {
         const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true }).id;
         const superAdmin = await insertUserWithRoleSuperAdmin();
@@ -1333,6 +1333,31 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', f
         const options = {
           method: 'DELETE',
           url: `/api/schooling-registration-user-associations/${organizationLearner.id}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+          },
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+  });
+
+  describe('DELETE /api/admin/schooling-registration-user-associations', function () {
+    context('When user has the role SUPER_ADMIN and schooling registration can be dissociated', function () {
+      it('should return an 204 status after having successfully dissociated user from schoolingRegistration', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true }).id;
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'DELETE',
+          url: `/api/admin/schooling-registration-user-associations/${organizationLearner.id}`,
           headers: {
             authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
           },

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | users-controller-find-users', function () {
 
     options = {
       method: 'GET',
-      url: '/api/users',
+      url: '/api/admin/users',
       headers: { authorization: generateValidRequestAuthorizationHeader(userSuperAdminId) },
     };
 
@@ -83,7 +83,7 @@ describe('Acceptance | users-controller-find-users', function () {
 
       it('should return a 200 status code with paginated and filtered data', async function () {
         // given
-        options.url = '/api/users?filter[firstName]=jean&page[number]=2&page[size]=1';
+        options.url = '/api/admin/users?filter[firstName]=jean&page[number]=2&page[size]=1';
         const expectedMetaData = { page: 2, pageSize: 1, rowCount: 2, pageCount: 2 };
 
         // when
@@ -98,7 +98,7 @@ describe('Acceptance | users-controller-find-users', function () {
 
       it('should return a 200 status code with empty result', async function () {
         // given
-        options.url = '/api/users?filter[firstName]=jean&filter[lastName]=jean&page[number]=1&page[size]=1';
+        options.url = '/api/admin/users?filter[firstName]=jean&filter[lastName]=jean&page[number]=1&page[size]=1';
         const expectedMetaData = { page: 1, pageSize: 1, rowCount: 0, pageCount: 0 };
 
         // when

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -6,26 +6,6 @@ const userController = require('../../../../lib/application/users/user-controlle
 const moduleUnderTest = require('../../../../lib/application/users');
 
 describe('Unit | Router | user-router', function () {
-  describe('GET /api/users', function () {
-    const method = 'GET';
-
-    it('should exist', async function () {
-      // given
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const url = '/api/users?firstName=Bruce&lastName=Wayne&email=batman@gotham.city&page=3&pageSize=25';
-
-      // when
-      const response = await httpTestServer.request(method, url);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
   describe('POST /api/users', function () {
     const method = 'POST';
     const url = '/api/users';
@@ -370,166 +350,6 @@ describe('Unit | Router | user-router', function () {
     });
   });
 
-  describe('PATCH /api/admin/users/{id}', function () {
-    const method = 'PATCH';
-
-    it('should verify user identity and return success update', async function () {
-      // given
-      sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const userId = '12344';
-      const url = `/api/admin/users/${userId}`;
-      const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
-      const payload = { data: { attributes: payloadAttributes } };
-
-      // when
-      const result = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(result.statusCode).to.equal(200);
-      sinon.assert.calledOnce(securityPreHandlers.userHasAtLeastOneAccessOf);
-    });
-
-    describe('Payload and path param schema validation', function () {
-      const method = 'PATCH';
-      const url = '/api/admin/users/not_number';
-
-      it('should return bad request when param id is not numeric', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(moduleUnderTest);
-
-        const payload = { data: { attributes: { email: 'partial@update.net' } } };
-
-        // when
-        const result = await httpTestServer.request(method, url, payload);
-
-        // then
-        expect(result.statusCode).to.equal(400);
-      });
-
-      it('should return bad request when payload is not found', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const result = await httpTestServer.request(method, url);
-
-        // then
-        expect(result.statusCode).to.equal(400);
-      });
-    });
-  });
-
-  describe('POST /api/admin/users/{id}/anonymize', function () {
-    const method = 'POST';
-
-    it('should exist', async function () {
-      // given
-      sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(204));
-      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const url = '/api/admin/users/1/anonymize';
-
-      // when
-      const result = await httpTestServer.request(method, url);
-
-      // then
-      expect(result.statusCode).to.equal(204);
-    });
-
-    it('should return 400 when id is not a number', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const url = '/api/admin/users/wrongId/anonymize';
-
-      // when
-      const result = await httpTestServer.request(method, url);
-
-      // then
-      expect(result.statusCode).to.equal(400);
-      expect(JSON.parse(result.payload).errors[0].detail).to.equal('"id" must be a number');
-    });
-  });
-
-  describe('POST /api/admin/users/{id}/remove-authentication', function () {
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    ['GAR', 'EMAIL', 'USERNAME', 'POLE_EMPLOI'].forEach((type) => {
-      it(`should return 200 when type is ${type}`, async function () {
-        // given
-        sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
-        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(moduleUnderTest);
-
-        const url = '/api/admin/users/1/remove-authentication';
-        const payload = {
-          data: {
-            attributes: {
-              type,
-            },
-          },
-        };
-
-        // when
-        const result = await httpTestServer.request('POST', url, payload);
-
-        // then
-        expect(result.statusCode).to.equal(200);
-      });
-    });
-
-    it('should return 400 when id is not a number', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const url = '/api/admin/users/wrongId/remove-authentication';
-      const payload = {
-        data: {
-          attributes: {
-            type: 'EMAIL',
-          },
-        },
-      };
-
-      // when
-      const result = await httpTestServer.request('POST', url, payload);
-
-      // then
-      expect(result.statusCode).to.equal(400);
-    });
-
-    it('should return 400 when type is not GAR or EMAIL or USERNAME or POLE_EMPLOI', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const url = '/api/admin/users/1/remove-authentication';
-      const payload = {
-        data: {
-          attributes: {
-            type: 'INVALID',
-          },
-        },
-      };
-
-      // when
-      const result = await httpTestServer.request('POST', url, payload);
-
-      // then
-      expect(result.statusCode).to.equal(400);
-    });
-  });
-
   describe('PUT /api/users/{id}/email/verification-code', function () {
     it('should return HTTP code 204', async function () {
       // given
@@ -707,6 +527,652 @@ describe('Unit | Router | user-router', function () {
       expect(result.result.errors[0].detail).to.equal(
         '"data.attributes.code" with value "9" fails to match the required pattern: /^[1-9]{6}$/'
       );
+    });
+  });
+
+  context('Routes /admin', function () {
+    describe('GET /api/admin/users', function () {
+      it('should return an HTTP status code 200', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/users?firstName=Bruce&lastName=Wayne&email=batman@gotham.city&page=3&pageSize=25'
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.userHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(userController.findPaginatedFilteredUsers);
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return an HTTP status code 403', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns((request, h) =>
+          h
+            .response({ errors: new Error('') })
+            .code(403)
+            .takeover()
+        );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/users?firstName=Bruce&lastName=Wayne&email=batman@gotham.city&page=3&pageSize=25'
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.userHasAtLeastOneAccessOf);
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('GET /api/admin/users/{id}', function () {
+      it('should return an HTTP status code 200', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(userController, 'getUserDetailsForAdmin').resolves('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/users/8?include=schoolingRegistrations%2CauthenticationMethods'
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.userHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(userController.getUserDetailsForAdmin);
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return an HTTP status code 403', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns((request, h) =>
+          h
+            .response({ errors: new Error('') })
+            .code(403)
+            .takeover()
+        );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/users/8?include=schoolingRegistrations%2CauthenticationMethods'
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.userHasAtLeastOneAccessOf);
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('PATCH /api/admin/users/{id}', function () {
+      it('should verify user identity and return success update when user role is "SUPER_ADMIN"', async function () {
+        // given
+        sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
+        const payload = { data: { attributes: payloadAttributes } };
+
+        // when
+        const result = await httpTestServer.request('PATCH', '/api/admin/users/12344', payload);
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.calledOnce(userController.updateUserDetailsForAdministration);
+        expect(result.statusCode).to.equal(200);
+      });
+
+      it('should verify user identity and return success update when role is "SUPPORT"', async function () {
+        // given
+        sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSupport').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
+        const payload = { data: { attributes: payloadAttributes } };
+
+        // when
+        const result = await httpTestServer.request('PATCH', '/api/admin/users/12344', payload);
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.calledOnce(userController.updateUserDetailsForAdministration);
+        expect(result.statusCode).to.equal(200);
+      });
+
+      it('should return bad request when param id is not numeric', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payload = { data: { attributes: { email: 'partial@update.net' } } };
+
+        // when
+        const result = await httpTestServer.request('PATCH', '/api/admin/users/not_number', payload);
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should return bad request when payload is not found', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const result = await httpTestServer.request('PATCH', '/api/admin/users/12344');
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it(`should return 403 when user don't have access (CERTIF | METIER)`, async function () {
+        // given
+        sinon.stub(userController, 'updateUserDetailsForAdministration').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
+        const payload = { data: { attributes: payloadAttributes } };
+
+        // when
+        const result = await httpTestServer.request('PATCH', '/api/admin/users/12344', payload);
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.notCalled(userController.updateUserDetailsForAdministration);
+        expect(result.statusCode).to.equal(403);
+      });
+    });
+
+    describe('POST /api/admin/users/{id}/anonymize', function () {
+      it('should return 200 when user role is "SUPER_ADMIN"', async function () {
+        // given
+        sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(200));
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode } = await httpTestServer.request('POST', '/api/admin/users/1/anonymize');
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.calledOnce(userController.anonymizeUser);
+        expect(statusCode).to.equal(200);
+      });
+
+      it('should return 200 when user role is "SUPPORT"', async function () {
+        // given
+        sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(200));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSupport').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode } = await httpTestServer.request('POST', '/api/admin/users/1/anonymize');
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.calledOnce(userController.anonymizeUser);
+        expect(statusCode).to.equal(200);
+      });
+
+      it('should return 400 when id is not a number', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode, payload } = await httpTestServer.request('POST', '/api/admin/users/wrongId/anonymize');
+
+        // then
+        expect(statusCode).to.equal(400);
+        expect(JSON.parse(payload).errors[0].detail).to.equal('"id" must be a number');
+      });
+
+      it(`should return 403 when user don't have access (CERTIF | METIER)`, async function () {
+        // given
+        sinon.stub(userController, 'anonymizeUser').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payloadAttributes = { 'first-name': 'firstname', 'last-name': 'lastname', email: 'partial@update.com' };
+        const payload = { data: { attributes: payloadAttributes } };
+
+        // when
+        const result = await httpTestServer.request('POST', '/api/admin/users/1/anonymize', payload);
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.notCalled(userController.anonymizeUser);
+        expect(result.statusCode).to.equal(403);
+      });
+    });
+
+    describe('POST /api/admin/users/{id}/add-pix-authentication-method', function () {
+      it('should return 200 when user role is "SUPER_ADMIN"', async function () {
+        // given
+        sinon
+          .stub(userController, 'addPixAuthenticationMethodByEmail')
+          .callsFake((request, h) => h.response({}).code(201));
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = { data: { attributes: { email: 'user@rexample.net' } } };
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/1/add-pix-authentication-method',
+          payload
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.calledOnce(userController.addPixAuthenticationMethodByEmail);
+        expect(statusCode).to.equal(201);
+      });
+
+      it('should return 200 when user role is "SUPPORT"', async function () {
+        // given
+        sinon
+          .stub(userController, 'addPixAuthenticationMethodByEmail')
+          .callsFake((request, h) => h.response({}).code(201));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSupport').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = { data: { attributes: { email: 'user@rexample.net' } } };
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/1/add-pix-authentication-method',
+          payload
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.calledOnce(userController.addPixAuthenticationMethodByEmail);
+        expect(statusCode).to.equal(201);
+      });
+
+      it('should return 400 when id is not a number', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode, payload } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/invalid-id/add-pix-authentication-method'
+        );
+
+        // then
+        expect(statusCode).to.equal(400);
+        expect(JSON.parse(payload).errors[0].detail).to.equal('"id" must be a number');
+      });
+
+      it(`should return 403 when user don't have access (CERTIF | METIER)`, async function () {
+        // given
+        sinon.stub(userController, 'addPixAuthenticationMethodByEmail').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = { data: { attributes: { email: 'user@rexample.net' } } };
+
+        // when
+        const result = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/1/add-pix-authentication-method',
+          payload
+        );
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.notCalled(userController.addPixAuthenticationMethodByEmail);
+        expect(result.statusCode).to.equal(403);
+      });
+    });
+
+    describe('POST /api/admin/users/{id}/remove-authentication', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      ['GAR', 'EMAIL', 'USERNAME', 'POLE_EMPLOI'].forEach((type) => {
+        it(`should return 200 when user is "SUPER_ADMIN" and type is ${type}`, async function () {
+          // given
+          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+          sinon
+            .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+            data: {
+              attributes: {
+                type,
+              },
+            },
+          });
+
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+          sinon.assert.calledOnce(userController.removeAuthenticationMethod);
+          expect(result.statusCode).to.equal(200);
+        });
+
+        it(`should return 200 when user is "SUPPORT" and type is ${type}`, async function () {
+          // given
+          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSupport').callsFake((request, h) => h.response(true));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+            data: {
+              attributes: {
+                type,
+              },
+            },
+          });
+
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+          sinon.assert.calledOnce(userController.removeAuthenticationMethod);
+          expect(result.statusCode).to.equal(200);
+        });
+      });
+
+      it('should return 400 when id is not a number', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const result = await httpTestServer.request('POST', '/api/admin/users/invalid-id/remove-authentication', {
+          data: {
+            attributes: {
+              type: 'EMAIL',
+            },
+          },
+        });
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should return 400 when type is not GAR or EMAIL or USERNAME or POLE_EMPLOI', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+          data: {
+            attributes: {
+              type: 'INVALID',
+            },
+          },
+        });
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it(`should return 403 when user don't have access (CERTIF | METIER)`, async function () {
+        // given
+        sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+          data: {
+            attributes: {
+              type: 'POLE_EMPLOI',
+            },
+          },
+        });
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.notCalled(userController.removeAuthenticationMethod);
+        expect(result.statusCode).to.equal(403);
+      });
+    });
+
+    describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      ['GAR', 'POLE_EMPLOI'].forEach((identityProvider) => {
+        it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
+          // given
+          sinon
+            .stub(userController, 'reassignAuthenticationMethods')
+            .callsFake((request, h) => h.response({}).code(204));
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+          sinon
+            .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+          const payload = {
+            data: {
+              attributes: {
+                'user-id': 2,
+                'identity-provider': identityProvider,
+              },
+            },
+          };
+
+          // when
+          const { statusCode } = await httpTestServer.request(
+            'POST',
+            '/api/admin/users/1/authentication-methods/1',
+            payload
+          );
+
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+          expect(statusCode).to.equal(204);
+        });
+
+        it(`should return 200 when user role is "SUPPORT" and identity provider is "${identityProvider}"`, async function () {
+          // given
+          sinon
+            .stub(userController, 'reassignAuthenticationMethods')
+            .callsFake((request, h) => h.response({}).code(204));
+          sinon
+            .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSupport').callsFake((request, h) => h.response(true));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+          const payload = {
+            data: {
+              attributes: {
+                'user-id': 3,
+                'identity-provider': identityProvider,
+              },
+            },
+          };
+
+          // when
+          const { statusCode } = await httpTestServer.request(
+            'POST',
+            '/api/admin/users/1/authentication-methods/1',
+            payload
+          );
+
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+          sinon.assert.calledOnce(userController.reassignAuthenticationMethods);
+          expect(statusCode).to.equal(204);
+        });
+      });
+
+      it('should return 400 when "userId" is not a number', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode, payload } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/invalid-id/authentication-methods/1'
+        );
+
+        // then
+        expect(statusCode).to.equal(400);
+        expect(JSON.parse(payload).errors[0].detail).to.equal('"userId" must be a number');
+      });
+
+      it('should return 400 when "authenticationMethodId" is not a number', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode, payload } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/1/authentication-methods/invalid-id'
+        );
+
+        // then
+        expect(statusCode).to.equal(400);
+        expect(JSON.parse(payload).errors[0].detail).to.equal('"authenticationMethodId" must be a number');
+      });
+
+      it('should return 400 when the payload is invalid', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = {
+          data: {
+            attributes: {
+              'user-id': 'invalid-user-id',
+              'identity-provider': 'invalid-identity-provider',
+            },
+          },
+        };
+
+        // when
+        const { statusCode } = await httpTestServer.request(
+          'POST',
+          '/api/admin/users/1/authentication-methods/1',
+          payload
+        );
+
+        // then
+        expect(statusCode).to.equal(400);
+      });
+
+      it(`should return 403 when user don't have access (CERTIF | METIER)`, async function () {
+        // given
+        sinon.stub(userController, 'reassignAuthenticationMethods').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payload = {
+          data: {
+            attributes: {
+              'user-id': 2,
+              'identity-provider': 'GAR',
+            },
+          },
+        };
+
+        // when
+        const result = await httpTestServer.request('POST', '/api/admin/users/1/authentication-methods/1', payload);
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkUserHasRoleSupport);
+        sinon.assert.notCalled(userController.reassignAuthenticationMethods);
+        expect(result.statusCode).to.equal(403);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, quelque soit le rôle de l'administrateur, ce dernier pourra effectuer des actions lié à un utilisateur comme :

- Modifier les informations
- Anonymiser l'utilisateur
- Ajouter une méthode de connexion
- Supprimer une méthode de connexion
- Dissocier le lien entre un utilisateur et une organisation

Seul certains rôles devraient avoir la possibilité d'exécuter ces actions.

## :robot: Solution

1. Restreindre l'accès aux différents endpoints de l'API associés aux actions
2. Restreindre l'affiche des boutons d'action

## :rainbow: Remarques

Toutes les routes liées au namespace `/admin` ont été regroupé.

## :100: Pour tester

#### Se connecter avec un compte ayant le rôle SUPER_ADMIN ou SUPPORT

1. Se connecter avec `superadmin@example.net` ou `pixsupport@example.net`
2. L'onglet `Utilisateurs` doit être visible sur le menu de gauche
3. Cliquer sur l'onglet `Utilisateurs`
4. Faire une recherche sur le prénom `user` et nom `gar`
5. Une liste d'utilisateurs doit être visible _(1 utilisateur)_
6. Cliquer sur l'ID pour afficher les détails de cet utilisateur
7. Constater que des boutons sont affichés
8. Tenter d'effectuer une action
9. Une notification doit s'afficher pour confirmer l'exécution de l'action

Les étapes 3 à 9 peuvent être répétées pour les utilisateurs suivants (format prénom / nom) :

- Pix / Aile
- Lance / Low

#### Se connecter avec un compte ayant le rôle CERTIF ou METIER

1. Se connecter avec `pixcertif@example.net` ou `pixmetier@example.net`
2. L'onglet `Utilisateurs` doit être visible sur le menu de gauche
3. Cliquer sur l'onglet `Utilisateurs`
4. Faire une recherche sur le prénom `user` et nom `gar`
5. Une liste d'utilisateurs doit être visible _(1 utilisateur)_
6. Cliquer sur l'ID pour afficher les détails de cet utilisateur
7. Constater que la majorité des boutons ne sont plus affichés sauf `Tableau de bord`

Les étapes 3 à 7 peuvent être répétées pour les utilisateurs suivants (format prénom / nom) :

- Pix / Aile
- Lance / Low