### PR TITLE
[FEATURE] Modification des titres de boutons d'action des cartes tutos (PIX-4921).

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -17,7 +17,7 @@
       {{moment-duration @tutorial.duration}}
     </p>
     <div class="tutorial-card-v2-content__actions">
-      <div class="tutorial-card-v2-content-actions__evaluate" title={{this.evaluateInformation}}>
+      <div title={{this.evaluateInformation}}>
         <button
           class="pix-action-chip {{if this.isTutorialEvaluated "pix-action-chip--selected"}}"
           aria-label={{this.evaluateInformation}}

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -2,7 +2,7 @@
   <div class="user-tutorials-banner-v2">
     <h1 class="user-tutorials-banner-v2__title">{{t "pages.user-tutorials.title"}}</h1>
     <p class="user-tutorials-banner-v2__description">
-      {{t "pages.user-tutorials-v2.description"}}
+      {{t "pages.user-tutorials.description"}}
     </p>
 
     <div class="user-tutorials-banner-v2__filters">

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -1,6 +1,6 @@
 <header class="background-banner-v2">
   <div class="user-tutorials-banner-v2">
-    <h1 class="user-tutorials-banner-v2__title">{{t "pages.user-tutorials-v2.title"}}</h1>
+    <h1 class="user-tutorials-banner-v2__title">{{t "pages.user-tutorials.title"}}</h1>
     <p class="user-tutorials-banner-v2__description">
       {{t "pages.user-tutorials-v2.description"}}
     </p>

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -10,7 +10,7 @@
         {{t "pages.user-tutorials.recommended"}}
       </ChoiceChip>
       <ChoiceChip @route="user-tutorials.saved">
-        {{t "pages.user-tutorials-v2.saved"}}
+        {{t "pages.user-tutorials.saved"}}
       </ChoiceChip>
     </div>
   </div>

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -7,7 +7,7 @@
 
     <div class="user-tutorials-banner-v2__filters">
       <ChoiceChip @route="user-tutorials.recommended">
-        {{t "pages.user-tutorials-v2.recommended"}}
+        {{t "pages.user-tutorials.recommended"}}
       </ChoiceChip>
       <ChoiceChip @route="user-tutorials.saved">
         {{t "pages.user-tutorials-v2.saved"}}

--- a/mon-pix/app/components/tutorials/recommended-empty.hbs
+++ b/mon-pix/app/components/tutorials/recommended-empty.hbs
@@ -1,13 +1,13 @@
 <div class="user-tutorials-content-v2__recommended-empty">
   <div>
     <h2 class="user-tutorials-recommended-empty-v2__title">
-      {{t "pages.user-tutorials-v2.recommended-empty.title" firstName=this.currentUser.user.firstName}}
+      {{t "pages.user-tutorials.recommended-empty.title" firstName=this.currentUser.user.firstName}}
     </h2>
     <p class="user-tutorials-recommended-empty-v2__description">
-      {{t "pages.user-tutorials-v2.recommended-empty.description"}}
+      {{t "pages.user-tutorials.recommended-empty.description"}}
     </p>
     <PixButtonLink @route="profile" class="user-tutorials-recommended-empty-v2__link">
-      {{t "pages.user-tutorials-v2.recommended-empty.link"}}
+      {{t "pages.user-tutorials.recommended-empty.link"}}
     </PixButtonLink>
   </div>
   <img src="/images/illustrations/user-tutorials/recommended-empty.svg" role="presentation" alt="" />

--- a/mon-pix/app/components/tutorials/saved-empty.hbs
+++ b/mon-pix/app/components/tutorials/saved-empty.hbs
@@ -1,10 +1,10 @@
 <div class="user-tutorials-content-v2__saved-empty">
   <div>
     <h2 class="user-tutorials-saved-empty-v2__title">
-      {{t "pages.user-tutorials-v2.saved-empty.title"}}
+      {{t "pages.user-tutorials.saved-empty.title"}}
     </h2>
     <p class="user-tutorials-saved-empty-v2__description">
-      {{t "pages.user-tutorials-v2.saved-empty.description"}}
+      {{t "pages.user-tutorials.saved-empty.description"}}
     </p>
   </div>
   <img src="/images/illustrations/user-tutorials/saved-empty.png" alt="" role="presentation" />

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -54,13 +54,6 @@
   }
 }
 
-.tutorial-card-v2-content-actions {
-
-  &__evaluate {
-    display: inline-block;
-  }
-}
-
 .pix-action-chip {
   $dark-blue: #2044DC;
 

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -31,7 +31,7 @@ describe('Acceptance | Tutorial | Actions', function () {
       // then
       expect(find('.tutorial-card-v2')).to.exist;
       expect(find('[aria-label="Marquer ce tuto comme utile"]')).to.exist;
-      expect(find('[aria-label="Enregistrer"]')).to.exist;
+      expect(find('[aria-label="Enregistrer dans ma liste de tutos"]')).to.exist;
     });
 
     it('should disable evaluate action on click', async function () {
@@ -45,10 +45,10 @@ describe('Acceptance | Tutorial | Actions', function () {
     describe('when save action is clicked', function () {
       it('should display remove action button', async function () {
         // when
-        await click('[aria-label="Enregistrer"]');
+        await click('[aria-label="Enregistrer dans ma liste de tutos"]');
 
         // then
-        expect(find('[aria-label="Retirer"]')).to.exist;
+        expect(find('[aria-label="Retirer de ma liste de tutos"]')).to.exist;
       });
     });
   });

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -36,7 +36,7 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
         await visit('/mes-tutos/enregistres');
 
         // when
-        await click('[aria-label="Retirer"]');
+        await click('[aria-label="Retirer de ma liste de tutos"]');
 
         // then
         expect(findAll('.tutorial-card-v2')).to.be.lengthOf(9);

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -64,7 +64,7 @@ describe('Integration | Component | Tutorial Panel', function () {
           expect(find('.tutorial-card-v2-content__details')).to.exist;
           expect(find('.tutorial-card-v2-content__actions')).to.exist;
           expect(find('[aria-label="Marquer ce tuto comme utile"]')).to.exist;
-          expect(find('[aria-label="Enregistrer"]')).to.exist;
+          expect(find('[aria-label="Enregistrer dans ma liste de tutos"]')).to.exist;
           expect(find('[title="Marquer ce tuto comme utile"]')).to.exist;
         });
       });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -34,7 +34,7 @@ describe('Integration | Component | Tutorials | Card', function () {
       .and.contains('une minute');
     expect(find('.tutorial-card-v2-content__actions')).to.exist;
     expect(find('[aria-label="Ce tuto m\'a été utile"]')).to.exist;
-    expect(find('[aria-label="Retirer"]')).to.exist;
+    expect(find('[aria-label="Retirer de ma liste de tutos"]')).to.exist;
     expect(find('[title="Ce tuto m\'a été utile"]')).to.exist;
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1508,17 +1508,17 @@
         }
       },
       "recommended": "Recommended",
+      "recommended-empty": {
+        "title": "{firstName}, find your favorite tutorials here",
+        "description": "To get tutorials recommendations adapted to your level, you must start a test.",
+        "link": "Let's go"
+      },
       "saved": "Saved"
     },
     "user-tutorials-v2": {
       "saved-empty": {
         "title": "No tutorials saved yet",
         "description": "You need to save a tutorial for it to be displayed here."
-      },
-      "recommended-empty": {
-        "title": "{firstName}, find your favorite tutorials here",
-        "description": "To get tutorials recommendations adapted to your level, you must start a test.",
-        "link": "Let's go"
       }
     }
   }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1509,7 +1509,6 @@
       }
     },
     "user-tutorials-v2": {
-      "description": "Improve with the help of tutorials suggested by the Pix users’ community.",
       "recommended": "Recommended",
       "saved": "Saved",
       "saved-empty": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1513,9 +1513,7 @@
         "description": "To get tutorials recommendations adapted to your level, you must start a test.",
         "link": "Let's go"
       },
-      "saved": "Saved"
-    },
-    "user-tutorials-v2": {
+      "saved": "Saved",
       "saved-empty": {
         "title": "No tutorials saved yet",
         "description": "You need to save a tutorial for it to be displayed here."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1496,15 +1496,15 @@
           "actions": {
             "evaluate": {
               "extra-information": "Mark this tutorial as helpful",
-              "label": "This tutorial was useful to me"
+              "label": "This tutorial was helpful to me"
             },
             "remove": {
-              "extra-information": "Remove from my list of tutorials",
-              "label": "Remove"
+              "extra-information": "Remove from my saved tutorials",
+              "label": "Remove from my saved tutorials"
             },
             "save": {
-              "extra-information": "Save in my list of tutorials",
-              "label": "Save"
+              "extra-information": "Add to my saved tutorials",
+              "label": "Add to my saved tutorials"
             }
           },
           "source": "By"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1507,10 +1507,10 @@
           "source": "By"
         }
       },
-      "recommended": "Recommended"
+      "recommended": "Recommended",
+      "saved": "Saved"
     },
     "user-tutorials-v2": {
-      "saved": "Saved",
       "saved-empty": {
         "title": "No tutorials saved yet",
         "description": "You need to save a tutorial for it to be displayed here."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -137,7 +137,6 @@
         "existing-participation": "You cannot take this customised test.",
         "existing-participation-user-info": "There is already a participation associated with the name ",
         "existing-participation-info": "Please contact your teacher so that they can delete your previous participation in Pix Orga."
-
       }
     },
     "campaign-landing": {
@@ -1499,11 +1498,9 @@
               "label": "This tutorial was helpful to me"
             },
             "remove": {
-              "extra-information": "Remove from my saved tutorials",
               "label": "Remove from my saved tutorials"
             },
             "save": {
-              "extra-information": "Add to my saved tutorials",
               "label": "Add to my saved tutorials"
             }
           },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1506,10 +1506,10 @@
           },
           "source": "By"
         }
-      }
+      },
+      "recommended": "Recommended"
     },
     "user-tutorials-v2": {
-      "recommended": "Recommended",
       "saved": "Saved",
       "saved-empty": {
         "title": "No tutorials saved yet",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1509,7 +1509,6 @@
       }
     },
     "user-tutorials-v2": {
-      "title": "My tutorials",
       "description": "Improve with the help of tutorials suggested by the Pix users’ community.",
       "recommended": "Recommended",
       "saved": "Saved",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1513,9 +1513,7 @@
         "description": "Afin de vous recommander des tutos adaptés à votre niveau, vous devez commencer un test de compétence.",
         "link": "Je commence"
       },
-      "saved": "Enregistrés"
-    },
-    "user-tutorials-v2": {
+      "saved": "Enregistrés",
       "saved-empty": {
         "title": "Vous n'avez pas encore de tutos enregistrés",
         "description": "Vouz devez enregistrer un tuto recommandé pour qu'il s'affiche ici."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1509,7 +1509,6 @@
       }
     },
     "user-tutorials-v2": {
-      "title": "Mes tutos",
       "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",
       "recommended": "Recommandés",
       "saved": "Enregistrés",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1507,10 +1507,10 @@
           "source": "Par"
         }
       },
-      "recommended": "Recommandés"
+      "recommended": "Recommandés",
+      "saved": "Enregistrés"
     },
     "user-tutorials-v2": {
-      "saved": "Enregistrés",
       "saved-empty": {
         "title": "Vous n'avez pas encore de tutos enregistrés",
         "description": "Vouz devez enregistrer un tuto recommandé pour qu'il s'affiche ici."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1509,7 +1509,6 @@
       }
     },
     "user-tutorials-v2": {
-      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",
       "recommended": "Recommandés",
       "saved": "Enregistrés",
       "saved-empty": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1498,12 +1498,10 @@
               "label": "Ce tuto m'a été utile"
             },
             "remove": {
-              "extra-information": "Retirer de ma liste de tutos",
-              "label": "Retirer"
+              "label": "Retirer de ma liste de tutos"
             },
             "save": {
-              "extra-information": "Enregistrer dans ma liste de tutos",
-              "label": "Enregistrer"
+              "label": "Enregistrer dans ma liste de tutos"
             }
           },
           "source": "Par"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1508,17 +1508,17 @@
         }
       },
       "recommended": "Recommandés",
+      "recommended-empty": {
+        "title": "{firstName}, retrouvez ici vos tutos favoris",
+        "description": "Afin de vous recommander des tutos adaptés à votre niveau, vous devez commencer un test de compétence.",
+        "link": "Je commence"
+      },
       "saved": "Enregistrés"
     },
     "user-tutorials-v2": {
       "saved-empty": {
         "title": "Vous n'avez pas encore de tutos enregistrés",
         "description": "Vouz devez enregistrer un tuto recommandé pour qu'il s'affiche ici."
-      },
-      "recommended-empty": {
-        "title": "{firstName}, retrouvez ici vos tutos favoris",
-        "description": "Afin de vous recommander des tutos adaptés à votre niveau, vous devez commencer un test de compétence.",
-        "link": "Je commence"
       }
     }
   }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1506,10 +1506,10 @@
           },
           "source": "Par"
         }
-      }
+      },
+      "recommended": "Recommandés"
     },
     "user-tutorials-v2": {
-      "recommended": "Recommandés",
       "saved": "Enregistrés",
       "saved-empty": {
         "title": "Vous n'avez pas encore de tutos enregistrés",


### PR DESCRIPTION
## :unicorn: Problème

Les traductions anglaises des attributs `title` des boutons d'action des nouvelles cartes de tutos ne donnent pas assez d'informations.

## :robot: Solution

Modification des traductions des traductions en question.

## :rainbow: Remarques

Dans cette PR, nous : 
- égalisons aussi les valeurs entre `title` et `aria-label`
- supprimons et/ou déplaçons les clés de traductions `user-tutorials-v2` vers `user-tutorials` par souci d'uniformisation.

## :100: Pour tester

- Aller sur sur la page `mes-tutos` sur Pix-app
- Vérifier que les valeurs des attributs `title` des boutons d'action aient les nouvelles valeurs (Inspecteur et tooltip native HTML au survol du bouton)
- Vérifier que les tests passent et qu'il n'y ait pas de régression.

