### PR TITLE
[FEATURE] Ajouter un lien vers "Mes certifications" dans la page d'accès à une session de certification (PIX-4881).

### DIFF
--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -11,6 +11,22 @@
   padding: 12px;
 }
 
+.certification-start-page__link-to-user-certifications {
+  background-color: $grey-10;
+  border-radius: 8px;
+  color: $grey-70;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 16px;
+  padding: 16px;
+
+  a, a:visited {
+    color: $grey-70;
+    text-decoration-line: underline;
+  }
+}
+
 .certification-start-page__title {
   color: $grey-100;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable declaration-colon-newline-after */
 /* stylelint-disable function-parentheses-newline-inside */
+/* stylelint-disable no-descending-specificity */
 
 .certification-starter {
   @include device-is('desktop') {
@@ -7,33 +8,59 @@
   }
 }
 
-.certification-start-page__block {
-  padding: 12px;
-}
+.certification-start-page {
 
-.certification-start-page__link-to-user-certifications {
-  background-color: $grey-10;
-  border-radius: 8px;
-  color: $grey-70;
-  display: flex;
-  gap: 8px;
-  justify-content: center;
-  margin-top: 16px;
-  padding: 16px;
-
-  a, a:visited {
-    color: $grey-70;
-    text-decoration-line: underline;
+  &__block {
+    padding: 12px;
   }
-}
 
-.certification-start-page__title {
-  color: $grey-100;
-  font-family: $font-open-sans;
-  font-size: 2.625rem;
-  font-weight: $font-light;
-  text-align: center;
-  margin-bottom: 20px;
+  &__errors {
+    color: $pure-orange;
+    font-size: 0.875rem;
+    text-align: start;
+    margin: 5px 5px 5px 5px;
+
+    &__list {
+
+      li {
+        text-align: start;
+        list-style: disc;
+        margin: 8px 0 0 16px;
+      }
+    }
+
+    a,
+    a:visited {
+      color: $pure-orange;
+      text-decoration: underline;
+    }
+  }
+
+  &__link-to-user-certifications {
+    background-color: $grey-10;
+    border-radius: 8px;
+    color: $grey-70;
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    margin-top: 16px;
+    padding: 16px;
+
+    a,
+    a:visited {
+      color: $grey-70;
+      text-decoration-line: underline;
+    }
+  }
+
+  &__title {
+    color: $grey-100;
+    font-family: $font-open-sans;
+    font-size: 2.625rem;
+    font-weight: $font-light;
+    text-align: center;
+    margin-bottom: 20px;
+  }
 }
 
 .certification-starter-subscriptions {
@@ -159,28 +186,6 @@
   &:focus {
     outline: none;
     color: $grey-70;
-  }
-}
-
-.certification-course-page__errors {
-  color: $pure-orange;
-  font-size: 0.875rem;
-  text-align: start;
-  margin: 5px 5px 5px 5px;
-
-  &__list {
-
-    li {
-      text-align: start;
-      list-style: disc;
-      margin: 8px 0 0 16px;
-    }
-  }
-
-  a,
-  a:visited {
-    color: $pure-orange;
-    text-decoration: underline;
   }
 }
 

--- a/mon-pix/app/templates/certifications/join.hbs
+++ b/mon-pix/app/templates/certifications/join.hbs
@@ -15,6 +15,10 @@
                 @closeBanner={{this.closeBanner}}
               />
             {{/if}}
+            <div class="certification-start-page__link-to-user-certifications">
+              <FaIcon @icon="arrow-right" />
+              <LinkTo @route="user-certifications">{{t "pages.certification-start.link-to-user-certification"}}</LinkTo>
+            </div>
             <CertificationJoiner @onStepChange={{this.changeStep}} />
           </PixBlock>
         {{else}}

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -50,6 +50,11 @@ describe('Acceptance | Certification | Certification Course', function () {
           return visit('/certifications');
         });
 
+        it("should display a link to user's certifications", async function () {
+          // then
+          expect(contains(this.intl.t('pages.certification-start.link-to-user-certification'))).to.exist;
+        });
+
         context('when no candidate with given info has been registered in the given session', function () {
           beforeEach(async function () {
             // when

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -342,7 +342,8 @@
         "candidate-not-authorized-to-start": "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator.",
         "candidate-not-authorized-to-resume": "Please contact your invigilator to resume your certification test."
       },
-      "first-title": "You are about to begin your certification test."
+      "first-title": "You are about to begin your certification test.",
+      "link-to-user-certification": "See my certificates"
     },
     "certifications-list": {
       "title": "My Certifications",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -342,7 +342,8 @@
         "candidate-not-authorized-to-start": "Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.",
         "candidate-not-authorized-to-resume": "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test."
       },
-      "first-title": "Vous allez commencer votre test de certification"
+      "first-title": "Vous allez commencer votre test de certification",
+      "link-to-user-certification": "Voir mes certifications"
     },
     "certifications-list": {
       "title": "Mes Certifications",


### PR DESCRIPTION
## :unicorn: Problème
Le pôle support reçoit beaucoup de tickets de candidats ayant passé un test de certifications, mais qui ne trouvent pas leur résultats sur Pix App. En effet, ces candidats cliquent sur l’onglet “Certification” depuis Pix App, et non dans leur compte > Mes certifications, et s'étonnent de ne pas y trouver leurs résultats.

## :robot: Solution
- Ajouter un lien vers la page "Mes certifications"

## :rainbow: Remarques
La règle de linter `no-descending-specificity` a été ajoutée car ce dernier disait que la règle sur les liens HTML de la class `certification-start-page__link-to-user-certifications` surchargeait ceux de `certification-start-page__errors` or ce n'est pas le cas. Voir https://stylelint.io/user-guide/rules/list/no-descending-specificity/#dom-limitations pour plus d'informations.

## :100: Pour tester
- Se connecter à Pix App avec un compte certifiable.
- Voir qu'un lien "Voir mes certifications" a été ajouté.
- Vérifier que le lien renvoie bien vers la bonne page.
