### PR TITLE
[BUGFIX] Calculer correctement les Pix quand un acquis a été passé dans 2 compétences différentes (PIX-4938).

### DIFF
--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -119,14 +119,8 @@ module.exports = {
     competenceId,
     domainTransaction = DomainTransaction.emptyTransaction(),
   }) {
-    const query = _findByUserIdAndLimitDateQuery({ userId });
-    const knowledgeElementRows = await query.where({ competenceId }, { transacting: domainTransaction });
-
-    const knowledgeElements = _.map(
-      knowledgeElementRows,
-      (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow)
-    );
-    return _applyFilters(knowledgeElements);
+    const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({ userId, domainTransaction });
+    return knowledgeElements.filter((knowledgeElement) => knowledgeElement.competenceId === competenceId);
   },
 
   async findUniqByUserIdGroupedByCompetenceId({ userId, limitDate }) {

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -253,6 +253,35 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       // then
       expect(actualKnowledgeElements).to.have.deep.members(wantedKnowledgeElements);
     });
+
+    context('when the user has two KE for the same skill but in two different competences', function () {
+      it('should return the most recent KE independent of the competence', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          skillId: '@skill123',
+          competenceId: '@comp1',
+          createdAt: new Date('2022-10-02'),
+        });
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          skillId: '@skill123',
+          competenceId: '@comp256',
+          createdAt: new Date('2022-10-01'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const knowledgeElementFound = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
+          userId,
+          competenceId: '@comp256',
+        });
+
+        // then
+        expect(knowledgeElementFound).to.deep.equal([]);
+      });
+    });
   });
 
   describe('findByCampaignIdForSharedCampaignParticipation', function () {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, pour comptabiliser les Pix, nous prenons tous les KE les plus récents de l'utilisateur pour chaque acquis passé. 

Cependant, certains acquis on pu être déplacé de compétence sans que celui obtienne un nouvel id (via Airtable). Les utilisateurs ont alors pu passer un acquis sur une compétence, puis repasser le même acquis sur une seconde. 

Cependant, lorsque nous remontons les knowledge elements pour calculer le profile de l'utilisateur, cela pose des problèmes, car uniquement le KE le plus récent pour un même `skillId` est gardé. 

Imaginons 2 KE : 

```js
1 : {  userId: 1, skillId: '@skill1', competenceId: '@comp2', createdAt: '2022-05-10' }
2 : {  userId: 1, skillId: '@skill1', competenceId: '@comp1', createdAt: '2022-05-11' }
```

Avec la méthode `findUniqByUserId` qui : 
 - remonte tous les KE d'un utilisateur,
 - puis les tri par date de création décroissante 
 - et retire les doublons grâce au champ `skillId`

Le résultat sera donc uniquement le KE **2**. 
Dans ce cas nous supprimons les KE d'un même acquis présent sur plusieurs compétences. 

Avec la méthode `findUniqByUserIdAndCompetenceId` qui : 
- remonte tous les KE d'un utilisateur pour une compétence donnée 
- puis les tri par date de création décroissante
- et retire les doublons grâce au champ `skillId`

Le résultat comprendra le KE **1**.
Dans ce cas, nous comptabilisons bien le KE présent dans la compétence, car nous n’avons pas la connaissance du KE sur l'autre compétence. 

### Impact utilisateur : 

Lorsque l'utilisateur arrive sur son profil, nous lui affichons son nombre de Pix par compétence. Il peut alors avoir 45 Pix sur la compétence et lorsqu'il clique sur le détail de la compétence avoir 46 Pix, car à ce moment-là on ira chercher les KE uniquement sur cette compétence. 

## :robot: Solution
Dans la méthode `findUniqByUserIdAndCompetenceId` remonter dans un premier tous les KE unique par `skillId` puis ensuite les filtrer par compétence au lieu de remonter uniquement les KE de la compétence puis de les rendre unique par `skillId`.

## :rainbow: Remarques
- Des utilisateurs peuvent perdre des Pix, mais cela représente la réalité de leur profile. 
- 
## :100: Pour tester
- Se connecter à la base de données 
- Copier un KE au statut `validé` et avec la date la plus récente tout en changeant sa `competenceId` et lui mettre une date de création moins récente que l'originale.  
- Se connecter sur Pix App à l'utilisateur possédant ce KE copié. 
- Vérifier sur le profile le nombre de Pix : sur la compétence cible choisie
- Puis cliquer sur le détail de la compétence et vérifier que le nombre de Pix est identique.
