### PR TITLE
[BUGFIX] Il n'y a plus d'image par défaut pour les profils cible (PIX-4940).

### DIFF
--- a/api/lib/domain/models/TargetProfileForCreation.js
+++ b/api/lib/domain/models/TargetProfileForCreation.js
@@ -10,7 +10,7 @@ class TargetProfileForCreation {
     description,
     comment,
     isPublic,
-    imageUrl = DEFAULT_IMAGE_URL,
+    imageUrl,
     ownerOrganizationId,
   }) {
     this.name = name;
@@ -19,7 +19,7 @@ class TargetProfileForCreation {
     this.description = description;
     this.comment = comment;
     this.isPublic = isPublic;
-    this.imageUrl = imageUrl;
+    this.imageUrl = imageUrl || DEFAULT_IMAGE_URL;
     this.ownerOrganizationId = ownerOrganizationId;
     validate(this);
   }

--- a/api/tests/unit/domain/models/TargetProfileForCreation_test.js
+++ b/api/tests/unit/domain/models/TargetProfileForCreation_test.js
@@ -45,6 +45,23 @@ describe('Unit | Domain | Models | TargetProfileForUpdate', function () {
       });
     });
 
+    context('when the image url is null', function () {
+      it('set a value by default', function () {
+        const targetProfile = new TargetProfileForCreation({
+          name: 'name',
+          category: TargetProfile.categories.OTHER,
+          skillIds: [1],
+          description: 'description',
+          comment: 'comment',
+          isPublic: true,
+          imageUrl: null,
+          ownerOrganizationId: 1,
+        });
+
+        expect(targetProfile.imageUrl).to.eq('https://images.pix.fr/profil-cible/Illu_GEN.svg');
+      });
+    });
+
     context('when the category is not given', function () {
       it('set a value by default', function () {
         const targetProfile = new TargetProfileForCreation({


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a plus de valeur par défaut pour l'image d'un profil cible

## :robot: Solution
Utiliser une valeur par défaut quand imageUrl est null

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Créer un profil cible sans image. Après la création le profil cible doit avoir une image par defaut.
