### PR TITLE
[FEATURE] Restreindre l'accès aux actions liées aux certifications (PIX-4667)

### DIFF
--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -29,16 +29,18 @@
       </div>
     {{/if}}
   </div>
-  {{#if @issueReport.canBeResolved}}
-    <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Résoudre le
-      signalement</PixButton>
-  {{/if}}
-  {{#if this.showResolveModal}}
-    <Certifications::IssueReports::ResolveIssueReportModal
-      @toggleResolveModal={{this.toggleResolveModal}}
-      @issueReport={{@issueReport}}
-      @resolveIssueReport={{@resolveIssueReport}}
-      @closeResolveModal={{this.closeResolveModal}}
-    />
+  {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+    {{#if @issueReport.canBeResolved}}
+      <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Résoudre le
+        signalement</PixButton>
+    {{/if}}
+    {{#if this.showResolveModal}}
+      <Certifications::IssueReports::ResolveIssueReportModal
+        @toggleResolveModal={{this.toggleResolveModal}}
+        @issueReport={{@issueReport}}
+        @resolveIssueReport={{@resolveIssueReport}}
+        @closeResolveModal={{this.closeResolveModal}}
+      />
+    {{/if}}
   {{/if}}
 </li>

--- a/admin/app/components/certifications/issue-report.js
+++ b/admin/app/components/certifications/issue-report.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 
 export default class CertificationIssueReport extends Component {
   @service notifications;
+  @service accessControl;
 
   @tracked showResolveModal = false;
 

--- a/admin/app/controllers/authenticated/certifications/certification/details.js
+++ b/admin/app/controllers/authenticated/certifications/certification/details.js
@@ -12,6 +12,7 @@ export default class CertificationDetailsController extends Controller {
   requestedId = '';
 
   @service('mark-store') _markStore;
+  @service accessControl;
 
   @alias('details.percentageCorrectAnswers') rate;
   @alias('details.totalScore') score;

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -25,6 +25,8 @@ export default class CertificationInformationsController extends Controller {
   @tracked editingCandidateResults = false;
   @service notifications;
   @service featureToggles;
+  @service accessControl;
+
   @tracked displayConfirm = false;
   @tracked confirmMessage = '';
   @tracked confirmErrorMessage = '';

--- a/admin/app/controllers/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/controllers/authenticated/certifications/certification/neutralization.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 export default class NeutralizationController extends Controller {
   @alias('model') certificationDetails;
   @service notifications;
+  @service accessControl;
 
   @action
   async neutralize(challengeRecId, questionIndex) {

--- a/admin/app/templates/authenticated/certifications/certification/details.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/details.hbs
@@ -50,7 +50,9 @@
   </div>
   <div class="row">
     <div class="col certification-details__actions">
-      <PixButton @type="submit" @size="small" @triggerAction={{this.onStoreMarks}}>Enregistrer</PixButton>
+      {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+        <PixButton @type="submit" @size="small" @triggerAction={{this.onStoreMarks}}>Enregistrer</PixButton>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -90,20 +90,22 @@
               Pays de naissance :
               {{this.certification.birthCountry}}
             </div>
-            <div class="candidate-informations__actions">
-              <PixButton
-                @size="small"
-                @triggerAction={{this.openCandidateEditModal}}
-                aria-label="Modifier les informations du candidat"
-                @isDisabled={{this.isModifyButtonDisabled}}
-              >
-                Modifier
-              </PixButton>
-              {{#if this.certification.wasRegisteredBeforeCPF}}
-                <span class="candidate-informations__warning-cpf-message">Voir avec PO/Dev pour modifier les infos
-                  candidat.</span>
-              {{/if}}
-            </div>
+            {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+              <div class="candidate-informations__actions">
+                <PixButton
+                  @size="small"
+                  @triggerAction={{this.openCandidateEditModal}}
+                  aria-label="Modifier les informations du candidat"
+                  @isDisabled={{this.isModifyButtonDisabled}}
+                >
+                  Modifier
+                </PixButton>
+                {{#if this.certification.wasRegisteredBeforeCPF}}
+                  <span class="candidate-informations__warning-cpf-message">Voir avec PO/Dev pour modifier les infos
+                    candidat.</span>
+                {{/if}}
+              </div>
+            {{/if}}
           </div>
         </div>
       </div>

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -4,14 +4,16 @@
     <PixButton @route="authenticated.users.get" @size="small" @model={{this.certification.userId}}>
       Voir les détails de l'utilisateur
     </PixButton>
-    {{#if this.isCertificationCancelled}}
-      <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onUncancelCertificationButtonClick}}>
-        Désannuler la certification
-      </PixButton>
-    {{else}}
-      <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onCancelCertificationButtonClick}}>
-        Annuler la certification
-      </PixButton>
+    {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+      {{#if this.isCertificationCancelled}}
+        <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onUncancelCertificationButtonClick}}>
+          Désannuler la certification
+        </PixButton>
+      {{else}}
+        <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onCancelCertificationButtonClick}}>
+          Annuler la certification
+        </PixButton>
+      {{/if}}
     {{/if}}
   </div>
   <div class="row">

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -292,39 +292,41 @@
       </div>
     </div>
   </div>
-  {{#if this.isValid}}
-    <div class="row">
-      <div class="col certification-informations__actions form-actions">
-        {{#if this.editingCandidateResults}}
-          <PixButton
-            @size="small"
-            @backgroundColor="transparent-light"
-            @isBorderVisible={{true}}
-            @triggerAction={{this.onCandidateResultsCancel}}
-            aria-label="Annuler la modification des résultats du candidat"
-          >
-            Annuler
-          </PixButton>
-          <PixButton
-            @size="small"
-            @triggerAction={{this.onCandidateResultsSaveConfirm}}
-            @backgroundColor="green"
-            aria-label="Enregistrer les résultats du candidat"
-          >
-            Enregistrer
-          </PixButton>
-        {{else}}
-          <PixButton
-            @size="small"
-            @triggerAction={{this.onCandidateResultsEdit}}
-            aria-label="Modifier les résultats du candidat"
-            @isDisabled={{this.editingCandidateInformations}}
-          >
-            Modifier
-          </PixButton>
-        {{/if}}
+  {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+    {{#if this.isValid}}
+      <div class="row">
+        <div class="col certification-informations__actions form-actions">
+          {{#if this.editingCandidateResults}}
+            <PixButton
+              @size="small"
+              @backgroundColor="transparent-light"
+              @isBorderVisible={{true}}
+              @triggerAction={{this.onCandidateResultsCancel}}
+              aria-label="Annuler la modification des résultats du candidat"
+            >
+              Annuler
+            </PixButton>
+            <PixButton
+              @size="small"
+              @triggerAction={{this.onCandidateResultsSaveConfirm}}
+              @backgroundColor="green"
+              aria-label="Enregistrer les résultats du candidat"
+            >
+              Enregistrer
+            </PixButton>
+          {{else}}
+            <PixButton
+              @size="small"
+              @triggerAction={{this.onCandidateResultsEdit}}
+              aria-label="Modifier les résultats du candidat"
+              @isDisabled={{this.editingCandidateInformations}}
+            >
+              Modifier
+            </PixButton>
+          {{/if}}
+        </div>
       </div>
-    </div>
+    {{/if}}
   {{/if}}
   <ConfirmPopup
     @message={{this.confirmMessage}}

--- a/admin/app/templates/authenticated/certifications/certification/neutralization.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/neutralization.hbs
@@ -9,9 +9,11 @@
         <th>
           RecId de l'épreuve
         </th>
-        <th>
-          Action
-        </th>
+        {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+          <th>
+            Action
+          </th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
@@ -23,27 +25,29 @@
           <td>
             {{answer.challengeId}}
           </td>
-          <td>
-            {{#if answer.isNeutralized}}
-              <PixButton
-                @triggerAction={{fn this.deneutralize answer.challengeId answer.order}}
-                @backgroundColor="transparent"
-                @loading-color="grey"
-                @size="small"
-              >
-                Dé-neutraliser
-              </PixButton>
-            {{else}}
-              <PixButton
-                @triggerAction={{fn this.neutralize answer.challengeId answer.order}}
-                @backgroundColor="blue"
-                @loading-color="white"
-                @size="small"
-              >
-                Neutraliser
-              </PixButton>
-            {{/if}}
-          </td>
+          {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+            <td>
+              {{#if answer.isNeutralized}}
+                <PixButton
+                  @triggerAction={{fn this.deneutralize answer.challengeId answer.order}}
+                  @backgroundColor="transparent"
+                  @loading-color="grey"
+                  @size="small"
+                >
+                  Dé-neutraliser
+                </PixButton>
+              {{else}}
+                <PixButton
+                  @triggerAction={{fn this.neutralize answer.challengeId answer.order}}
+                  @backgroundColor="blue"
+                  @loading-color="white"
+                  @size="small"
+                >
+                  Neutraliser
+                </PixButton>
+              {{/if}}
+            </td>
+          {{/if}}
         </tr>
       {{/each}}
     </tbody>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -46,7 +46,7 @@ export default function () {
   this.get('/admin/admin-members/me', (schema, request) => {
     const userToken = request.requestHeaders.Authorization.replace('Bearer ', '');
     const userId = JSON.parse(atob(userToken.split('.')[1])).user_id;
-    return schema.adminMembers.find(userId);
+    return schema.adminMembers.findBy({ userId });
   });
 
   this.patch('/admin/admin-members/:id', (schema, request) => {

--- a/admin/tests/acceptance/authenticated/certifications/certification/details_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/details_test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
+
+module('Acceptance | authenticated/certifications/certification/details', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('when user does not have access to certification action scope', function () {
+    test('it does not render save button', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isMetier: true })(server);
+      const listChallengesAndAnswers = [
+        {
+          result: 'ok',
+          value: 'Dummy value',
+          challengeId: 'recCGEqqWBQnzD3NZ',
+          competence: '1.1',
+          skill: '',
+          isNeutralized: false,
+        },
+      ];
+      const certificationId = this.server.create('certification').id;
+      this.server.create('certification-detail', {
+        id: certificationId,
+        competencesWithMark: [],
+        status: 'started',
+        listChallengesAndAnswers,
+      });
+
+      // when
+      const screen = await visit(`/certifications/${certificationId}/details`);
+
+      // then
+      assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
+    });
+  });
+});

--- a/admin/tests/acceptance/authenticated/certifications/certification/details_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/details_test.js
@@ -10,7 +10,7 @@ module('Acceptance | authenticated/certifications/certification/details', functi
   setupMirage(hooks);
 
   module('when user does not have access to certification action scope', function () {
-    test('it does not render save button', async function (assert) {
+    test('it should not render save button', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isMetier: true })(server);
       const listChallengesAndAnswers = [

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -12,7 +12,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
   let certification;
 
   hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     this.server.create('user', { id: 888 });
 
     this.server.create('country', {
@@ -44,6 +43,9 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
   module('certification information read', function () {
     test('it displays candidate information', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
       // when
       const screen = await visit(`/certifications/${certification.id}`);
 
@@ -61,6 +63,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     module('Certification issue reports section', function () {
       test('should not render the "Signalements" section when certification has no issue reports', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         certification.update({ certificationIssueReports: [] });
 
         // when
@@ -72,6 +75,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('should render the "Signalements" section when certification has issue reports', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationIssueReport = this.server.create('certification-issue-report', {
           category: 'OTHER',
           description: 'Un signalement impactant',
@@ -88,6 +92,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('should display the issue reports, impactful and non impactful', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationIssueReportNonImpactful = this.server.create('certification-issue-report', {
           category: 'CANDIDATE_INFORMATIONS_CHANGES',
           subcategory: 'EXTRA_TIME_PERCENTAGE',
@@ -127,6 +132,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('should hide "Signalement(s) non impactant(s)" sub-section when no not impactful issue reports exist', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
           category: 'OTHER',
           description: 'Un signalement super impactant',
@@ -151,6 +157,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('should hide "Signalement(s) impactant(s)" sub-section when no impactful issue reports exist', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationIssueReportNonImpactful = this.server.create('certification-issue-report', {
           category: 'CANDIDATE_INFORMATIONS_CHANGES',
           subcategory: 'EXTRA_TIME_PERCENTAGE',
@@ -176,6 +183,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('should display a resolved issue report when resolved', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
           category: 'OTHER',
           description: 'Un signalement super impactant',
@@ -194,6 +202,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('should display a non-resolved issue report when not resolved', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
           category: 'OTHER',
           description: 'Un signalement super impactant',
@@ -213,6 +222,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       module('IN_CHALLENGE issue report', function () {
         test('should display a "in challenge" issue report with its challenge number', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const certificationIssueReport = this.server.create('certification-issue-report', {
             category: 'IN_CHALLENGE',
             subcategory: 'IMAGE_NOT_DISPLAYING',
@@ -240,6 +250,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     module('when go to user detail button is clicked', function () {
       test('it should redirect to user detail page', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         await visit(`/certifications/${certification.id}`);
 
         // when
@@ -256,6 +267,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       module('when candidate certification was enrolled before the CPF feature was enabled', function () {
         test('should prevent user from editing candidate information', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           this.server.create('certification', {
             id: 456,
             firstName: 'Bora Horza',
@@ -284,6 +296,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       module('when there is a complementary certification course result with external', function () {
         test('should be possible to update jury level', async function (assert) {
           //given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const complementaryCertificationCourseResultsWithExternal = server.create(
             'complementary-certification-course-results-with-external',
             {
@@ -332,7 +345,8 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       });
 
       test('it displays common complementary certifications result', async function (assert) {
-        //given
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const commonComplementaryCertificationCourseResults = [
           server.create('common-complementary-certification-course-result', {
             label: 'CléA Numérique',
@@ -366,7 +380,8 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       });
 
       test('it displays external complementary certifications', async function (assert) {
-        //given
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const complementaryCertificationCourseResultsWithExternal = server.create(
           'complementary-certification-course-results-with-external',
           {
@@ -396,6 +411,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         module('when editing candidate information succeeds', function () {
           test('should save the candidate information data when modifying them', async function (assert) {
             // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             const screen = await visit('/certifications/123');
             await clickByName('Modifier les informations du candidat');
 
@@ -417,6 +433,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           test('should display a success notification', async function (assert) {
             // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             const screen = await visit('/certifications/123');
             await clickByName('Modifier les informations du candidat');
 
@@ -431,6 +448,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           test('should close the modal', async function (assert) {
             // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             const screen = await visit('/certifications/123');
             await clickByName('Modifier les informations du candidat');
 
@@ -447,6 +465,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         module('when editing candidate information fails', function () {
           test('should display an error notification', async function (assert) {
             // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             this.server.patch(
               '/certification-courses/:id',
               () => ({
@@ -467,6 +486,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           test('should leave the modal opened', async function (assert) {
             // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             this.server.patch(
               '/certification-courses/:id',
               () => ({
@@ -487,6 +507,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           test('should leave candidate information untouched when aborting the edition', async function (assert) {
             // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             this.server.patch(
               '/certification-courses/:id',
               () => ({
@@ -519,6 +540,9 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     module('Certification results edition', function () {
       module('when candidate results edit button is clicked', function () {
         test('it disables candidate informations edit button', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
           // when
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Modifier les résultats du candidat');
@@ -530,6 +554,9 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       module('when candidate results form cancel button is clicked', function () {
         test('it re-enables candidate informations edit button', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
           // when
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Modifier les résultats du candidat');
@@ -542,6 +569,9 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       module('when candidate results form is submitted', function () {
         test('it also re-enables candidate informations edit button', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
           // when
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Modifier les résultats du candidat');
@@ -561,6 +591,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             module('when a label is keyed', function () {
               test('it should set issue as resolved with label', async function (assert) {
                 // given
+                await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
                 const certificationIssueReport = this.server.create('certification-issue-report', {
                   category: 'OTHER',
                   description: 'Un signalement impactant',
@@ -596,6 +627,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           module('when the api returns an error', function () {
             test('it should display an error notification', async function (assert) {
               // given
+              await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
               const certificationIssueReport = this.server.create('certification-issue-report', {
                 category: 'OTHER',
                 description: 'Un signalement impactant',
@@ -634,6 +666,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
         test('should display confirmation popup for cancellation when certification is not yet cancelled and cancellation button is clicked', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const screen = await visit(`/certifications/${certification.id}`);
 
           // when
@@ -651,6 +684,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
         test('should not cancel the certification when aborting action in the confirmation popup', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Annuler la certification');
 
@@ -664,6 +698,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
         test('should cancel the certification when confirming action in the confirmation popup', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Annuler la certification');
 
@@ -683,6 +718,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
         test('should display confirmation popup for uncancellation when certification is cancelled and uncancellation button is clicked', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const screen = await visit(`/certifications/${certification.id}`);
 
           // when
@@ -700,6 +736,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
         test('should not uncancel the certification when aborting action in the confirmation popup', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Désannuler la certification');
 
@@ -713,6 +750,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
         test('should uncancel the certification when confirming action in the confirmation popup', async function (assert) {
           // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
           const screen = await visit(`/certifications/${certification.id}`);
           await clickByName('Désannuler la certification');
 

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -42,437 +42,138 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
   });
 
-  test('it displays candidate information', async function (assert) {
-    // when
-    const screen = await visit(`/certifications/${certification.id}`);
+  module('certification information read', function () {
+    test('it displays candidate information', async function (assert) {
+      // when
+      const screen = await visit(`/certifications/${certification.id}`);
 
-    // then
-    assert.dom(screen.getByText('Prénom : Bora Horza')).exists();
-    assert.dom(screen.getByText('Nom de famille : Gobuchul')).exists();
-    assert.dom(screen.getByText('Date de naissance : 24/07/1987')).exists();
-    assert.dom(screen.getByText('Sexe : M')).exists();
-    assert.dom(screen.getByText('Commune de naissance : Sorpen')).exists();
-    assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
-    assert.dom(screen.getByText('Code postal de naissance :')).exists();
-    assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
-  });
+      // then
+      assert.dom(screen.getByText('Prénom : Bora Horza')).exists();
+      assert.dom(screen.getByText('Nom de famille : Gobuchul')).exists();
+      assert.dom(screen.getByText('Date de naissance : 24/07/1987')).exists();
+      assert.dom(screen.getByText('Sexe : M')).exists();
+      assert.dom(screen.getByText('Commune de naissance : Sorpen')).exists();
+      assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
+      assert.dom(screen.getByText('Code postal de naissance :')).exists();
+      assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
+    });
 
-  module('Candidate information edition', function () {
-    module('when candidate certification was enrolled before the CPF feature was enabled', function () {
-      test('should prevent user from editing candidate information', async function (assert) {
+    module('Certification issue reports section', function () {
+      test('should not render the "Signalements" section when certification has no issue reports', async function (assert) {
         // given
-        this.server.create('certification', {
-          id: 456,
-          firstName: 'Bora Horza',
-          lastName: 'Gobuchul',
-          birthdate: '1987-07-24',
-          birthplace: 'Sorpen',
-          userId: 888,
-          sex: null,
-          birthCountry: null,
-          birthInseeCode: null,
-          birthPostalCode: null,
-          competencesWithMark: [],
-          listChallengesAndAnswers: [],
-          createdAt: new Date('2020-01-01'),
-        });
+        certification.update({ certificationIssueReports: [] });
 
         // when
-        const screen = await visit('/certifications/456');
+        const screen = await visit('/certifications/123');
 
         // then
-        assert.dom(screen.getByText('Voir avec PO/Dev pour modifier les infos candidat.')).exists();
-        assert.dom(screen.queryByLabelText('Modifier les informations du candidat')).isDisabled();
-      });
-    });
-
-    test('it displays common complementary certifications result', async function (assert) {
-      //given
-      const commonComplementaryCertificationCourseResults = [
-        server.create('common-complementary-certification-course-result', {
-          label: 'CléA Numérique',
-          status: 'Validée',
-        }),
-        server.create('common-complementary-certification-course-result', {
-          label: 'Pix+ Droit Maître',
-          status: 'Validée',
-        }),
-        server.create('common-complementary-certification-course-result', {
-          label: 'Pix+ Droit Expert',
-          status: 'Rejetée',
-        }),
-      ];
-
-      certification.update({
-        commonComplementaryCertificationCourseResults,
+        assert.dom(screen.queryByText('Signalements')).doesNotExist();
       });
 
-      // when
-      const screen = await visit(`/certifications/${certification.id}`);
+      test('should render the "Signalements" section when certification has issue reports', async function (assert) {
+        // given
+        const certificationIssueReport = this.server.create('certification-issue-report', {
+          category: 'OTHER',
+          description: 'Un signalement impactant',
+          isImpactful: true,
+        });
+        certification.update({ certificationIssueReports: [certificationIssueReport] });
 
-      // then
-      assert.dom(screen.getByText('Certifications complémentaires')).exists();
-      assert.dom(screen.queryByText('Résultats de la certification complémentaire Pix+ Edu :')).doesNotExist();
-      assert.dom(screen.getByText('CléA Numérique :')).exists();
-      assert.dom(screen.getByText('Pix+ Droit Maître :')).exists();
-      assert.dom(screen.getByText('Pix+ Droit Expert :')).exists();
-      assert.strictEqual(screen.getAllByText('Validée').length, 2);
-      assert.strictEqual(screen.getAllByText('Rejetée').length, 1);
-    });
+        // when
+        const screen = await visit('/certifications/123');
 
-    test('it displays external complementary certifications', async function (assert) {
-      //given
-      const complementaryCertificationCourseResultsWithExternal = server.create(
-        'complementary-certification-course-results-with-external',
-        {
-          complementaryCertificationCourseId: 1234,
-          pixResult: 'Pix+ Édu Initié (entrée dans le métier)',
-          externalResult: 'Pix+ Édu Avancé',
-          finalResult: 'Pix+ Édu Initié (entrée dans le métier)',
-        }
-      );
-      certification.update({
-        complementaryCertificationCourseResultsWithExternal,
+        // then
+        assert.dom(screen.getByText('Signalements')).exists();
       });
 
-      // when
-      const screen = await visit(`/certifications/${certification.id}`);
-
-      // then
-      assert.dom(screen.getByText('Résultats de la certification complémentaire Pix+ Edu :')).exists();
-      assert.dom(screen.getByText('VOLET PIX')).exists();
-      assert.dom(screen.getByText('VOLET JURY')).exists();
-      assert.dom(screen.getByText('NIVEAU FINAL')).exists();
-      assert.strictEqual(screen.getAllByText('Pix+ Édu Initié (entrée dans le métier)').length, 2);
-      assert.strictEqual(screen.getAllByText('Pix+ Édu Avancé').length, 1);
-    });
-
-    module('when candidate certification was enrolled with CPF data', function () {
-      module('when editing candidate information succeeds', function () {
-        test('should save the candidate information data when modifying them', async function (assert) {
-          // given
-          const screen = await visit('/certifications/123');
-          await clickByName('Modifier les informations du candidat');
-
-          // when
-          await fillByLabel('* Nom de famille', 'Summers');
-          await fillByLabel('* Commune de naissance', 'Sunnydale');
-          await clickByName('Enregistrer');
-
-          // then
-          assert.dom(screen.getByText('Prénom : Bora Horza')).exists();
-          assert.dom(screen.getByText('Nom de famille : Summers')).exists();
-          assert.dom(screen.getByText('Date de naissance : 24/07/1987')).exists();
-          assert.dom(screen.getByText('Sexe : M')).exists();
-          assert.dom(screen.getByText('Commune de naissance : Sunnydale')).exists();
-          assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
-          assert.dom(screen.getByText('Code postal de naissance :')).exists();
-          assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
+      test('should display the issue reports, impactful and non impactful', async function (assert) {
+        // given
+        const certificationIssueReportNonImpactful = this.server.create('certification-issue-report', {
+          category: 'CANDIDATE_INFORMATIONS_CHANGES',
+          subcategory: 'EXTRA_TIME_PERCENTAGE',
+          description: 'Un signalement pas du tout impactant',
+          isImpactful: false,
         });
-
-        test('should display a success notification', async function (assert) {
-          // given
-          const screen = await visit('/certifications/123');
-          await clickByName('Modifier les informations du candidat');
-
-          // when
-          await fillByLabel('* Nom de famille', 'Summers');
-          await fillByLabel('* Commune de naissance', 'Sunnydale');
-          await clickByName('Enregistrer');
-
-          // then
-          assert.dom(screen.getByText('Les informations du candidat ont bien été enregistrées.')).exists();
+        const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
+          category: 'OTHER',
+          description: 'Un signalement super impactant',
+          isImpactful: true,
         });
-
-        test('should close the modal', async function (assert) {
-          // given
-          const screen = await visit('/certifications/123');
-          await clickByName('Modifier les informations du candidat');
-
-          // when
-          await fillByLabel('* Nom de famille', 'Summers');
-          await fillByLabel('* Commune de naissance', 'Sunnydale');
-          await clickByName('Enregistrer');
-
-          // then
-          assert.dom(screen.queryByText('Editer les informations du candidat')).doesNotExist();
-        });
-      });
-
-      module('when editing candidate information fails', function () {
-        test('should display an error notification', async function (assert) {
-          // given
-          this.server.patch(
-            '/certification-courses/:id',
-            () => ({
-              errors: [{ detail: "Candidate's first name must not be blank or empty" }],
-            }),
-            422
-          );
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Modifier les informations du candidat');
-          await fillByLabel('* Nom de famille', 'Summers');
-
-          // when
-          await clickByName('Enregistrer');
-
-          // then
-          assert.dom(screen.getByText("Candidate's first name must not be blank or empty")).exists();
-        });
-
-        test('should leave the modal opened', async function (assert) {
-          // given
-          this.server.patch(
-            '/certification-courses/:id',
-            () => ({
-              errors: [{ detail: "Candidate's first name must not be blank or empty" }],
-            }),
-            422
-          );
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Modifier les informations du candidat');
-          await fillByLabel('* Nom de famille', 'Summers');
-
-          // when
-          await clickByName('Enregistrer');
-
-          // then
-          assert.dom(screen.getByText('Editer les informations du candidat')).exists();
-        });
-
-        test('should leave candidate information untouched when aborting the edition', async function (assert) {
-          // given
-          this.server.patch(
-            '/certification-courses/:id',
-            () => ({
-              errors: [{ detail: "Candidate's first name must not be blank or empty" }],
-            }),
-            422
-          );
-          const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Modifier les informations du candidat');
-          await fillByLabel('* Nom de famille', 'Summers');
-          await clickByName('Enregistrer');
-
-          // when
-          await clickByName('Fermer');
-
-          // then
-          assert.dom(screen.getByText('Prénom : Bora Horza')).exists();
-          assert.dom(screen.getByText('Nom de famille : Gobuchul')).exists();
-          assert.dom(screen.getByText('Date de naissance : 24/07/1987')).exists();
-          assert.dom(screen.getByText('Sexe : M')).exists();
-          assert.dom(screen.getByText('Commune de naissance : Sorpen')).exists();
-          assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
-          assert.dom(screen.getByText('Code postal de naissance :')).exists();
-          assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
-        });
-      });
-    });
-
-    module('when there is a complementary certification course result with external', function () {
-      test('should be possible to update jury level', async function (assert) {
-        //given
-        const complementaryCertificationCourseResultsWithExternal = server.create(
-          'complementary-certification-course-results-with-external',
-          {
-            complementaryCertificationCourseId: 1234,
-            pixResult: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
-            externalResult: 'En attente',
-            finalResult: 'En attente',
-            allowedExternalLevels: [
-              { value: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME', label: 'Pix+ Édu Initiale 1er degré Confirmé' },
-            ],
-          }
-        );
         certification.update({
-          complementaryCertificationCourseResultsWithExternal,
+          certificationIssueReports: [certificationIssueReportImpactful, certificationIssueReportNonImpactful],
         });
 
-        this.server.post('/admin/complementary-certification-course-results', (schema) => {
-          const complementaryCertificationCourseResultsWithExternal =
-            schema.complementaryCertificationCourseResultsWithExternals.first();
+        // when
+        const screen = await visit('/certifications/123');
 
-          complementaryCertificationCourseResultsWithExternal.update({
-            externalResult: 'Pix+ Édu Initiale 1er degré Confirmé',
-            finalResult: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
-          });
+        // then
+        assert.dom(screen.getByText('1 Signalement(s) impactant(s)')).exists();
+        assert
+          .dom(
+            screen.getByText(
+              'Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement super impactant'
+            )
+          )
+          .exists();
+        assert.dom(screen.getByText('1 Signalement(s) non impactant(s)')).exists();
+        assert
+          .dom(
+            screen.getByText(
+              'Modification infos candidat : Ajout/modification du temps majoré - Un signalement pas du tout impactant'
+            )
+          )
+          .exists();
+      });
+
+      test('should hide "Signalement(s) non impactant(s)" sub-section when no not impactful issue reports exist', async function (assert) {
+        // given
+        const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
+          category: 'OTHER',
+          description: 'Un signalement super impactant',
+          isImpactful: true,
         });
-
-        const screen = await visit(`/certifications/${certification.id}`);
+        certification.update({ certificationIssueReports: [certificationIssueReportImpactful] });
 
         // when
-        await click(screen.getByRole('button', { name: 'Modifier le volet jury' }));
-        await selectByLabelAndOption('Sélectionner un niveau', 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME');
-        await click(screen.getByRole('button', { name: 'Modifier le niveau du jury' }));
+        const screen = await visit('/certifications/123');
 
         // then
+        assert.dom(screen.getByText('1 Signalement(s) impactant(s)')).exists();
         assert
-          .dom('.certification-informations__complementary-certification__pix-edu__row__jury-level > p')
-          .containsText('Pix+ Édu Initiale 1er degré Confirmé');
+          .dom(
+            screen.getByText(
+              'Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement super impactant'
+            )
+          )
+          .exists();
+        assert.dom(screen.queryByText('Signalement(s) non impactant(s)')).doesNotExist();
+      });
 
+      test('should hide "Signalement(s) impactant(s)" sub-section when no impactful issue reports exist', async function (assert) {
+        // given
+        const certificationIssueReportNonImpactful = this.server.create('certification-issue-report', {
+          category: 'CANDIDATE_INFORMATIONS_CHANGES',
+          subcategory: 'EXTRA_TIME_PERCENTAGE',
+          description: 'Un signalement pas du tout impactant',
+          isImpactful: false,
+        });
+        certification.update({ certificationIssueReports: [certificationIssueReportNonImpactful] });
+
+        // when
+        const screen = await visit('/certifications/123');
+
+        // then
+        assert.dom(screen.getByText('1 Signalement(s) non impactant(s)')).exists();
         assert
-          .dom('.certification-informations__complementary-certification__pix-edu__row > div:nth-child(3)')
-          .containsText('Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)');
-      });
-    });
-  });
-
-  module('Certification results edition', function () {
-    module('when candidate results edit button is clicked', function () {
-      test('it disables candidate informations edit button', async function (assert) {
-        // when
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Modifier les résultats du candidat');
-
-        // then
-        assert.dom(screen.getByLabelText('Modifier les informations du candidat')).isDisabled();
-      });
-    });
-
-    module('when candidate results form cancel button is clicked', function () {
-      test('it re-enables candidate informations edit button', async function (assert) {
-        // when
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Modifier les résultats du candidat');
-        await clickByName('Annuler la modification des résultats du candidat');
-
-        // then
-        assert.dom(screen.getByLabelText('Modifier les informations du candidat')).exists().isEnabled();
-      });
-    });
-
-    module('when candidate results form is submitted', function () {
-      test('it also re-enables candidate informations edit button', async function (assert) {
-        // when
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Modifier les résultats du candidat');
-        await clickByName('Enregistrer les résultats du candidat');
-        await clickByName('Confirmer');
-
-        // then
-        assert.dom(screen.getByLabelText('Modifier les informations du candidat')).exists().isEnabled();
-      });
-    });
-  });
-
-  module('Certification issue reports section', function () {
-    test('should not render the "Signalements" section when certification has no issue reports', async function (assert) {
-      // given
-      certification.update({ certificationIssueReports: [] });
-
-      // when
-      const screen = await visit('/certifications/123');
-
-      // then
-      assert.dom(screen.queryByText('Signalements')).doesNotExist();
-    });
-
-    test('should render the "Signalements" section when certification has issue reports', async function (assert) {
-      // given
-      const certificationIssueReport = this.server.create('certification-issue-report', {
-        category: 'OTHER',
-        description: 'Un signalement impactant',
-        isImpactful: true,
-      });
-      certification.update({ certificationIssueReports: [certificationIssueReport] });
-
-      // when
-      const screen = await visit('/certifications/123');
-
-      // then
-      assert.dom(screen.getByText('Signalements')).exists();
-    });
-
-    test('should display the issue reports, impactful and non impactful', async function (assert) {
-      // given
-      const certificationIssueReportNonImpactful = this.server.create('certification-issue-report', {
-        category: 'CANDIDATE_INFORMATIONS_CHANGES',
-        subcategory: 'EXTRA_TIME_PERCENTAGE',
-        description: 'Un signalement pas du tout impactant',
-        isImpactful: false,
-      });
-      const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
-        category: 'OTHER',
-        description: 'Un signalement super impactant',
-        isImpactful: true,
-      });
-      certification.update({
-        certificationIssueReports: [certificationIssueReportImpactful, certificationIssueReportNonImpactful],
-      });
-
-      // when
-      const screen = await visit('/certifications/123');
-
-      // then
-      assert.dom(screen.getByText('1 Signalement(s) impactant(s)')).exists();
-      assert
-        .dom(
-          screen.getByText(
-            'Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement super impactant'
+          .dom(
+            screen.getByText(
+              'Modification infos candidat : Ajout/modification du temps majoré - Un signalement pas du tout impactant'
+            )
           )
-        )
-        .exists();
-      assert.dom(screen.getByText('1 Signalement(s) non impactant(s)')).exists();
-      assert
-        .dom(
-          screen.getByText(
-            'Modification infos candidat : Ajout/modification du temps majoré - Un signalement pas du tout impactant'
-          )
-        )
-        .exists();
-    });
-
-    test('should hide "Signalement(s) non impactant(s)" sub-section when no not impactful issue reports exist', async function (assert) {
-      // given
-      const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
-        category: 'OTHER',
-        description: 'Un signalement super impactant',
-        isImpactful: true,
+          .exists();
+        assert.dom(screen.queryByText('Signalement(s) impactant(s)')).doesNotExist();
       });
-      certification.update({ certificationIssueReports: [certificationIssueReportImpactful] });
 
-      // when
-      const screen = await visit('/certifications/123');
-
-      // then
-      assert.dom(screen.getByText('1 Signalement(s) impactant(s)')).exists();
-      assert
-        .dom(
-          screen.getByText(
-            'Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement super impactant'
-          )
-        )
-        .exists();
-      assert.dom(screen.queryByText('Signalement(s) non impactant(s)')).doesNotExist();
-    });
-
-    test('should hide "Signalement(s) impactant(s)" sub-section when no impactful issue reports exist', async function (assert) {
-      // given
-      const certificationIssueReportNonImpactful = this.server.create('certification-issue-report', {
-        category: 'CANDIDATE_INFORMATIONS_CHANGES',
-        subcategory: 'EXTRA_TIME_PERCENTAGE',
-        description: 'Un signalement pas du tout impactant',
-        isImpactful: false,
-      });
-      certification.update({ certificationIssueReports: [certificationIssueReportNonImpactful] });
-
-      // when
-      const screen = await visit('/certifications/123');
-
-      // then
-      assert.dom(screen.getByText('1 Signalement(s) non impactant(s)')).exists();
-      assert
-        .dom(
-          screen.getByText(
-            'Modification infos candidat : Ajout/modification du temps majoré - Un signalement pas du tout impactant'
-          )
-        )
-        .exists();
-      assert.dom(screen.queryByText('Signalement(s) impactant(s)')).doesNotExist();
-    });
-
-    module('Impactful issue reports resolution', function () {
       test('should display a resolved issue report when resolved', async function (assert) {
         // given
         const certificationIssueReportImpactful = this.server.create('certification-issue-report', {
@@ -509,8 +210,353 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         assert.dom(screen.queryByLabelText('Signalement résolu')).doesNotExist();
       });
 
-      module('when Resolve button is clicked on issue report', function () {
-        module('when Resolve button is clicked', function () {
+      module('IN_CHALLENGE issue report', function () {
+        test('should display a "in challenge" issue report with its challenge number', async function (assert) {
+          // given
+          const certificationIssueReport = this.server.create('certification-issue-report', {
+            category: 'IN_CHALLENGE',
+            subcategory: 'IMAGE_NOT_DISPLAYING',
+            description: 'image disparue',
+            questionNumber: 666,
+            isImpactful: true,
+          });
+          certification.update({ certificationIssueReports: [certificationIssueReport] });
+
+          // when
+          const screen = await visit('/certifications/123');
+
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                "Problème technique sur une question : L'image ne s'affiche pas - image disparue - Question 666"
+              )
+            )
+            .exists();
+        });
+      });
+    });
+
+    module('when go to user detail button is clicked', function () {
+      test('it should redirect to user detail page', async function (assert) {
+        // given
+        await visit(`/certifications/${certification.id}`);
+
+        // when
+        await clickByName("Voir les détails de l'utilisateur");
+
+        // then
+        assert.strictEqual(currentURL(), '/users/888');
+      });
+    });
+  });
+
+  module('certification edition actions', function () {
+    module('Candidate information edition', function () {
+      module('when candidate certification was enrolled before the CPF feature was enabled', function () {
+        test('should prevent user from editing candidate information', async function (assert) {
+          // given
+          this.server.create('certification', {
+            id: 456,
+            firstName: 'Bora Horza',
+            lastName: 'Gobuchul',
+            birthdate: '1987-07-24',
+            birthplace: 'Sorpen',
+            userId: 888,
+            sex: null,
+            birthCountry: null,
+            birthInseeCode: null,
+            birthPostalCode: null,
+            competencesWithMark: [],
+            listChallengesAndAnswers: [],
+            createdAt: new Date('2020-01-01'),
+          });
+
+          // when
+          const screen = await visit('/certifications/456');
+
+          // then
+          assert.dom(screen.getByText('Voir avec PO/Dev pour modifier les infos candidat.')).exists();
+          assert.dom(screen.queryByLabelText('Modifier les informations du candidat')).isDisabled();
+        });
+      });
+
+      module('when there is a complementary certification course result with external', function () {
+        test('should be possible to update jury level', async function (assert) {
+          //given
+          const complementaryCertificationCourseResultsWithExternal = server.create(
+            'complementary-certification-course-results-with-external',
+            {
+              complementaryCertificationCourseId: 1234,
+              pixResult: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
+              externalResult: 'En attente',
+              finalResult: 'En attente',
+              allowedExternalLevels: [
+                {
+                  value: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME',
+                  label: 'Pix+ Édu Initiale 1er degré Confirmé',
+                },
+              ],
+            }
+          );
+          certification.update({
+            complementaryCertificationCourseResultsWithExternal,
+          });
+
+          this.server.post('/admin/complementary-certification-course-results', (schema) => {
+            const complementaryCertificationCourseResultsWithExternal =
+              schema.complementaryCertificationCourseResultsWithExternals.first();
+
+            complementaryCertificationCourseResultsWithExternal.update({
+              externalResult: 'Pix+ Édu Initiale 1er degré Confirmé',
+              finalResult: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
+            });
+          });
+
+          const screen = await visit(`/certifications/${certification.id}`);
+
+          // when
+          await click(screen.getByRole('button', { name: 'Modifier le volet jury' }));
+          await selectByLabelAndOption('Sélectionner un niveau', 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME');
+          await click(screen.getByRole('button', { name: 'Modifier le niveau du jury' }));
+
+          // then
+          assert
+            .dom('.certification-informations__complementary-certification__pix-edu__row__jury-level > p')
+            .containsText('Pix+ Édu Initiale 1er degré Confirmé');
+
+          assert
+            .dom('.certification-informations__complementary-certification__pix-edu__row > div:nth-child(3)')
+            .containsText('Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)');
+        });
+      });
+
+      test('it displays common complementary certifications result', async function (assert) {
+        //given
+        const commonComplementaryCertificationCourseResults = [
+          server.create('common-complementary-certification-course-result', {
+            label: 'CléA Numérique',
+            status: 'Validée',
+          }),
+          server.create('common-complementary-certification-course-result', {
+            label: 'Pix+ Droit Maître',
+            status: 'Validée',
+          }),
+          server.create('common-complementary-certification-course-result', {
+            label: 'Pix+ Droit Expert',
+            status: 'Rejetée',
+          }),
+        ];
+
+        certification.update({
+          commonComplementaryCertificationCourseResults,
+        });
+
+        // when
+        const screen = await visit(`/certifications/${certification.id}`);
+
+        // then
+        assert.dom(screen.getByText('Certifications complémentaires')).exists();
+        assert.dom(screen.queryByText('Résultats de la certification complémentaire Pix+ Edu :')).doesNotExist();
+        assert.dom(screen.getByText('CléA Numérique :')).exists();
+        assert.dom(screen.getByText('Pix+ Droit Maître :')).exists();
+        assert.dom(screen.getByText('Pix+ Droit Expert :')).exists();
+        assert.strictEqual(screen.getAllByText('Validée').length, 2);
+        assert.strictEqual(screen.getAllByText('Rejetée').length, 1);
+      });
+
+      test('it displays external complementary certifications', async function (assert) {
+        //given
+        const complementaryCertificationCourseResultsWithExternal = server.create(
+          'complementary-certification-course-results-with-external',
+          {
+            complementaryCertificationCourseId: 1234,
+            pixResult: 'Pix+ Édu Initié (entrée dans le métier)',
+            externalResult: 'Pix+ Édu Avancé',
+            finalResult: 'Pix+ Édu Initié (entrée dans le métier)',
+          }
+        );
+        certification.update({
+          complementaryCertificationCourseResultsWithExternal,
+        });
+
+        // when
+        const screen = await visit(`/certifications/${certification.id}`);
+
+        // then
+        assert.dom(screen.getByText('Résultats de la certification complémentaire Pix+ Edu :')).exists();
+        assert.dom(screen.getByText('VOLET PIX')).exists();
+        assert.dom(screen.getByText('VOLET JURY')).exists();
+        assert.dom(screen.getByText('NIVEAU FINAL')).exists();
+        assert.strictEqual(screen.getAllByText('Pix+ Édu Initié (entrée dans le métier)').length, 2);
+        assert.strictEqual(screen.getAllByText('Pix+ Édu Avancé').length, 1);
+      });
+
+      module('when candidate certification was enrolled with CPF data', function () {
+        module('when editing candidate information succeeds', function () {
+          test('should save the candidate information data when modifying them', async function (assert) {
+            // given
+            const screen = await visit('/certifications/123');
+            await clickByName('Modifier les informations du candidat');
+
+            // when
+            await fillByLabel('* Nom de famille', 'Summers');
+            await fillByLabel('* Commune de naissance', 'Sunnydale');
+            await clickByName('Enregistrer');
+
+            // then
+            assert.dom(screen.getByText('Prénom : Bora Horza')).exists();
+            assert.dom(screen.getByText('Nom de famille : Summers')).exists();
+            assert.dom(screen.getByText('Date de naissance : 24/07/1987')).exists();
+            assert.dom(screen.getByText('Sexe : M')).exists();
+            assert.dom(screen.getByText('Commune de naissance : Sunnydale')).exists();
+            assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
+            assert.dom(screen.getByText('Code postal de naissance :')).exists();
+            assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
+          });
+
+          test('should display a success notification', async function (assert) {
+            // given
+            const screen = await visit('/certifications/123');
+            await clickByName('Modifier les informations du candidat');
+
+            // when
+            await fillByLabel('* Nom de famille', 'Summers');
+            await fillByLabel('* Commune de naissance', 'Sunnydale');
+            await clickByName('Enregistrer');
+
+            // then
+            assert.dom(screen.getByText('Les informations du candidat ont bien été enregistrées.')).exists();
+          });
+
+          test('should close the modal', async function (assert) {
+            // given
+            const screen = await visit('/certifications/123');
+            await clickByName('Modifier les informations du candidat');
+
+            // when
+            await fillByLabel('* Nom de famille', 'Summers');
+            await fillByLabel('* Commune de naissance', 'Sunnydale');
+            await clickByName('Enregistrer');
+
+            // then
+            assert.dom(screen.queryByText('Editer les informations du candidat')).doesNotExist();
+          });
+        });
+
+        module('when editing candidate information fails', function () {
+          test('should display an error notification', async function (assert) {
+            // given
+            this.server.patch(
+              '/certification-courses/:id',
+              () => ({
+                errors: [{ detail: "Candidate's first name must not be blank or empty" }],
+              }),
+              422
+            );
+            const screen = await visit(`/certifications/${certification.id}`);
+            await clickByName('Modifier les informations du candidat');
+            await fillByLabel('* Nom de famille', 'Summers');
+
+            // when
+            await clickByName('Enregistrer');
+
+            // then
+            assert.dom(screen.getByText("Candidate's first name must not be blank or empty")).exists();
+          });
+
+          test('should leave the modal opened', async function (assert) {
+            // given
+            this.server.patch(
+              '/certification-courses/:id',
+              () => ({
+                errors: [{ detail: "Candidate's first name must not be blank or empty" }],
+              }),
+              422
+            );
+            const screen = await visit(`/certifications/${certification.id}`);
+            await clickByName('Modifier les informations du candidat');
+            await fillByLabel('* Nom de famille', 'Summers');
+
+            // when
+            await clickByName('Enregistrer');
+
+            // then
+            assert.dom(screen.getByText('Editer les informations du candidat')).exists();
+          });
+
+          test('should leave candidate information untouched when aborting the edition', async function (assert) {
+            // given
+            this.server.patch(
+              '/certification-courses/:id',
+              () => ({
+                errors: [{ detail: "Candidate's first name must not be blank or empty" }],
+              }),
+              422
+            );
+            const screen = await visit(`/certifications/${certification.id}`);
+            await clickByName('Modifier les informations du candidat');
+            await fillByLabel('* Nom de famille', 'Summers');
+            await clickByName('Enregistrer');
+
+            // when
+            await clickByName('Fermer');
+
+            // then
+            assert.dom(screen.getByText('Prénom : Bora Horza')).exists();
+            assert.dom(screen.getByText('Nom de famille : Gobuchul')).exists();
+            assert.dom(screen.getByText('Date de naissance : 24/07/1987')).exists();
+            assert.dom(screen.getByText('Sexe : M')).exists();
+            assert.dom(screen.getByText('Commune de naissance : Sorpen')).exists();
+            assert.dom(screen.getByText('Code INSEE de naissance : 99217')).exists();
+            assert.dom(screen.getByText('Code postal de naissance :')).exists();
+            assert.dom(screen.getByText('Pays de naissance : JAPON')).exists();
+          });
+        });
+      });
+    });
+
+    module('Certification results edition', function () {
+      module('when candidate results edit button is clicked', function () {
+        test('it disables candidate informations edit button', async function (assert) {
+          // when
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Modifier les résultats du candidat');
+
+          // then
+          assert.dom(screen.getByLabelText('Modifier les informations du candidat')).isDisabled();
+        });
+      });
+
+      module('when candidate results form cancel button is clicked', function () {
+        test('it re-enables candidate informations edit button', async function (assert) {
+          // when
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Modifier les résultats du candidat');
+          await clickByName('Annuler la modification des résultats du candidat');
+
+          // then
+          assert.dom(screen.getByLabelText('Modifier les informations du candidat')).exists().isEnabled();
+        });
+      });
+
+      module('when candidate results form is submitted', function () {
+        test('it also re-enables candidate informations edit button', async function (assert) {
+          // when
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Modifier les résultats du candidat');
+          await clickByName('Enregistrer les résultats du candidat');
+          await clickByName('Confirmer');
+
+          // then
+          assert.dom(screen.getByLabelText('Modifier les informations du candidat')).exists().isEnabled();
+        });
+      });
+    });
+
+    module('Certification issue reports section', function () {
+      module('Impactful issue reports resolution', function () {
+        module('when Resolve button is clicked on issue report', function () {
           module('when the api returns ok', function () {
             module('when a label is keyed', function () {
               test('it should set issue as resolved with label', async function (assert) {
@@ -580,142 +626,103 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       });
     });
 
-    module('IN_CHALLENGE issue report', function () {
-      test('should display a "in challenge" issue report with its challenge number', async function (assert) {
-        // given
-        const certificationIssueReport = this.server.create('certification-issue-report', {
-          category: 'IN_CHALLENGE',
-          subcategory: 'IMAGE_NOT_DISPLAYING',
-          description: 'image disparue',
-          questionNumber: 666,
-          isImpactful: true,
+    module('Certification cancellation', function () {
+      module('Cancel', function (hooks) {
+        hooks.beforeEach(async function () {
+          certification.update({ status: 'validated' });
         });
-        certification.update({ certificationIssueReports: [certificationIssueReport] });
 
-        // when
-        const screen = await visit('/certifications/123');
+        test('should display confirmation popup for cancellation when certification is not yet cancelled and cancellation button is clicked', async function (assert) {
+          // given
+          const screen = await visit(`/certifications/${certification.id}`);
 
-        // then
-        assert
-          .dom(
-            screen.getByText(
-              "Problème technique sur une question : L'image ne s'affiche pas - image disparue - Question 666"
+          // when
+          await clickByName('Annuler la certification');
+
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.'
+              )
             )
-          )
-          .exists();
+            .exists();
+        });
+
+        test('should not cancel the certification when aborting action in the confirmation popup', async function (assert) {
+          // given
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Annuler la certification');
+
+          // when
+          await clickByName('Fermer');
+
+          // then
+          assert.dom(screen.getByText('Validée')).exists();
+          assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
+        });
+
+        test('should cancel the certification when confirming action in the confirmation popup', async function (assert) {
+          // given
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Annuler la certification');
+
+          // when
+          await clickByName('Confirmer');
+
+          // then
+          assert.dom(screen.getByText('Annulée')).exists();
+          assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
+        });
       });
-    });
-  });
 
-  module('when go to user detail button is clicked', function () {
-    test('it should redirect to user detail page', async function (assert) {
-      // given
-      await visit(`/certifications/${certification.id}`);
+      module('Uncancel', function (hooks) {
+        hooks.beforeEach(async function () {
+          certification.update({ status: 'cancelled' });
+        });
 
-      // when
-      await clickByName("Voir les détails de l'utilisateur");
+        test('should display confirmation popup for uncancellation when certification is cancelled and uncancellation button is clicked', async function (assert) {
+          // given
+          const screen = await visit(`/certifications/${certification.id}`);
 
-      // then
-      assert.strictEqual(currentURL(), '/users/888');
-    });
-  });
+          // when
+          await clickByName('Désannuler la certification');
 
-  module('Certification cancellation', function () {
-    module('Cancel', function (hooks) {
-      hooks.beforeEach(async function () {
-        certification.update({ status: 'validated' });
-      });
-
-      test('should display confirmation popup for cancellation when certification is not yet cancelled and cancellation button is clicked', async function (assert) {
-        // given
-        const screen = await visit(`/certifications/${certification.id}`);
-
-        // when
-        await clickByName('Annuler la certification');
-
-        // then
-        assert
-          .dom(
-            screen.getByText(
-              'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.'
+          // then
+          assert
+            .dom(
+              screen.getByText(
+                'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.'
+              )
             )
-          )
-          .exists();
-      });
+            .exists();
+        });
 
-      test('should not cancel the certification when aborting action in the confirmation popup', async function (assert) {
-        // given
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Annuler la certification');
+        test('should not uncancel the certification when aborting action in the confirmation popup', async function (assert) {
+          // given
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Désannuler la certification');
 
-        // when
-        await clickByName('Fermer');
+          // when
+          await clickByName('Fermer');
 
-        // then
-        assert.dom(screen.getByText('Validée')).exists();
-        assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
-      });
+          // then
+          assert.dom(screen.getByText('Annulée')).exists();
+          assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
+        });
 
-      test('should cancel the certification when confirming action in the confirmation popup', async function (assert) {
-        // given
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Annuler la certification');
+        test('should uncancel the certification when confirming action in the confirmation popup', async function (assert) {
+          // given
+          const screen = await visit(`/certifications/${certification.id}`);
+          await clickByName('Désannuler la certification');
 
-        // when
-        await clickByName('Confirmer');
+          // when
+          await clickByName('Confirmer');
 
-        // then
-        assert.dom(screen.getByText('Annulée')).exists();
-        assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
-      });
-    });
-
-    module('Uncancel', function (hooks) {
-      hooks.beforeEach(async function () {
-        certification.update({ status: 'cancelled' });
-      });
-
-      test('should display confirmation popup for uncancellation when certification is cancelled and uncancellation button is clicked', async function (assert) {
-        // given
-        const screen = await visit(`/certifications/${certification.id}`);
-
-        // when
-        await clickByName('Désannuler la certification');
-
-        // then
-        assert
-          .dom(
-            screen.getByText(
-              'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.'
-            )
-          )
-          .exists();
-      });
-
-      test('should not uncancel the certification when aborting action in the confirmation popup', async function (assert) {
-        // given
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Désannuler la certification');
-
-        // when
-        await clickByName('Fermer');
-
-        // then
-        assert.dom(screen.getByText('Annulée')).exists();
-        assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
-      });
-
-      test('should uncancel the certification when confirming action in the confirmation popup', async function (assert) {
-        // given
-        const screen = await visit(`/certifications/${certification.id}`);
-        await clickByName('Désannuler la certification');
-
-        // when
-        await clickByName('Confirmer');
-
-        // then
-        assert.dom(screen.getByText('Validée')).exists();
-        assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
+          // then
+          assert.dom(screen.getByText('Validée')).exists();
+          assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
+        });
       });
     });
   });

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -549,6 +549,17 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
 
     module('Certification results edition', function () {
+      test('should not show certification modify button when user does not have access to certification actions scope', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isMetier: true })(server);
+
+        // when
+        const screen = await visit(`/certifications/${certification.id}`);
+
+        // then
+        assert.dom(screen.queryByLabelText('Modifier les résultats du candidat')).doesNotExist();
+      });
+
       module('when candidate results edit button is clicked', function () {
         test('it disables candidate informations edit button', async function (assert) {
           // given

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -664,6 +664,17 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           certification.update({ status: 'validated' });
         });
 
+        test('should not show cancellation button when user does not have access to certification actions scope', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isMetier: true })(server);
+
+          // when
+          const screen = await visit(`/certifications/${certification.id}`);
+
+          // then
+          assert.dom(screen.queryByText('Annuler la certification')).doesNotExist();
+        });
+
         test('should display confirmation popup for cancellation when certification is not yet cancelled and cancellation button is clicked', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -264,6 +264,17 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
   module('certification edition actions', function () {
     module('Candidate information edition', function () {
+      test('should not show candidate modify button when user does not have access to certification actions scope', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isMetier: true })(server);
+
+        // when
+        const screen = await visit(`/certifications/${certification.id}`);
+
+        // then
+        assert.dom(screen.queryByLabelText('Modifier les informations du candidat')).doesNotExist();
+      });
+
       module('when candidate certification was enrolled before the CPF feature was enabled', function () {
         test('should prevent user from editing candidate information', async function (assert) {
           // given

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
@@ -107,122 +107,130 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       });
 
       module('when user has access to certification action scope', function () {
-        test('it renders a "Neutraliser" button when challenge is not neutralized', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const listChallengesAndAnswers = [
-            {
-              result: 'ok',
-              value: 'Dummy value',
-              challengeId: 'recCGEqqWBQnzD3NZ',
-              competence: '1.1',
-              skill: '',
-              isNeutralized: false,
-            },
-          ];
+        module('when challenge is not neutralized', function () {
+          test('it renders a "Neutraliser" button', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            const listChallengesAndAnswers = [
+              {
+                result: 'ok',
+                value: 'Dummy value',
+                challengeId: 'recCGEqqWBQnzD3NZ',
+                competence: '1.1',
+                skill: '',
+                isNeutralized: false,
+              },
+            ];
 
-          const certificationId = this.server.create('certification').id;
-          this.server.create('certification-detail', {
-            id: certificationId,
-            competencesWithMark: [],
-            status: 'started',
-            listChallengesAndAnswers,
+            const certificationId = this.server.create('certification').id;
+            this.server.create('certification-detail', {
+              id: certificationId,
+              competencesWithMark: [],
+              status: 'started',
+              listChallengesAndAnswers,
+            });
+
+            // when
+            const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
           });
-
-          // when
-          const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
         });
 
-        test('it renders a "Dé-neutraliser" button when challenge is neutralized', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const listChallengesAndAnswers = [
-            {
-              result: 'ok',
-              value: 'Dummy value',
-              challengeId: 'recCGEqqWBQnzD3NZ',
-              competence: '1.1',
-              skill: '',
-              isNeutralized: true,
-            },
-          ];
+        module('when challenge is neutralized', function () {
+          test('it renders a "Dé-neutraliser" button', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            const listChallengesAndAnswers = [
+              {
+                result: 'ok',
+                value: 'Dummy value',
+                challengeId: 'recCGEqqWBQnzD3NZ',
+                competence: '1.1',
+                skill: '',
+                isNeutralized: true,
+              },
+            ];
 
-          const certificationId = this.server.create('certification').id;
-          this.server.create('certification-detail', {
-            id: certificationId,
-            competencesWithMark: [],
-            status: 'started',
-            listChallengesAndAnswers,
+            const certificationId = this.server.create('certification').id;
+            this.server.create('certification-detail', {
+              id: certificationId,
+              competencesWithMark: [],
+              status: 'started',
+              listChallengesAndAnswers,
+            });
+
+            // when
+            const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
           });
-
-          // when
-          const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
         });
 
-        test('it toggles the "Dé-neutraliser" button into a "Neutraliser" button when deneutralizing a neutralized challenge', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const listChallengesAndAnswers = [
-            {
-              result: 'ok',
-              value: 'Dummy value',
-              challengeId: 'recCGEqqWBQnzD3NZ',
-              competence: '1.1',
-              skill: '',
-              isNeutralized: true,
-            },
-          ];
+        module('when deneutralizing a neutralized challenge', function () {
+          test('it toggles the "Dé-neutraliser" button into a "Neutraliser" button', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            const listChallengesAndAnswers = [
+              {
+                result: 'ok',
+                value: 'Dummy value',
+                challengeId: 'recCGEqqWBQnzD3NZ',
+                competence: '1.1',
+                skill: '',
+                isNeutralized: true,
+              },
+            ];
 
-          const certificationId = this.server.create('certification').id;
-          this.server.create('certification-detail', {
-            id: certificationId,
-            competencesWithMark: [],
-            status: 'started',
-            listChallengesAndAnswers,
+            const certificationId = this.server.create('certification').id;
+            this.server.create('certification-detail', {
+              id: certificationId,
+              competencesWithMark: [],
+              status: 'started',
+              listChallengesAndAnswers,
+            });
+            const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+            // when
+            await clickByName('Dé-neutraliser');
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
           });
-          const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-          // when
-          await clickByName('Dé-neutraliser');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
         });
 
-        test('it toggles the "Neutraliser" button into a "Dé-neutraliser" button when neutralizing a deneutralized challenge', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-          const listChallengesAndAnswers = [
-            {
-              result: 'ok',
-              value: 'Dummy value',
-              challengeId: 'recCGEqqWBQnzD3NZ',
-              competence: '1.1',
-              skill: '',
-              isNeutralized: false,
-            },
-          ];
+        module('when neutralizing a deneutralized challenge', function () {
+          test('it toggles the "Neutraliser" button into a "Dé-neutraliser" button', async function (assert) {
+            // given
+            await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+            const listChallengesAndAnswers = [
+              {
+                result: 'ok',
+                value: 'Dummy value',
+                challengeId: 'recCGEqqWBQnzD3NZ',
+                competence: '1.1',
+                skill: '',
+                isNeutralized: false,
+              },
+            ];
 
-          const certificationId = this.server.create('certification').id;
-          this.server.create('certification-detail', {
-            id: certificationId,
-            competencesWithMark: [],
-            status: 'started',
-            listChallengesAndAnswers,
+            const certificationId = this.server.create('certification').id;
+            this.server.create('certification-detail', {
+              id: certificationId,
+              competencesWithMark: [],
+              status: 'started',
+              listChallengesAndAnswers,
+            });
+            const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+            // when
+            await clickByName('Neutraliser');
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
           });
-          const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-          // when
-          await clickByName('Neutraliser');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
         });
       });
 

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
@@ -8,13 +8,10 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function () {
-    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-  });
-
   module('when there is no challenge for this certification', function () {
     test('it renders "Aucune épreuve posée"', async function (assert) {
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationId = this.server.create('certification').id;
       this.server.create('certification-detail', {
         id: certificationId,
@@ -35,6 +32,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     module('it renders a challenge list', function () {
       test('it renders as many rows as there are challenges', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const listChallengesAndAnswers = [
           {
             result: 'ok',
@@ -81,6 +79,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('it renders the challenge info', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const listChallengesAndAnswers = [
           {
             result: 'ok',
@@ -109,6 +108,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('it renders a "Neutraliser" button when challenge is not neutralized', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const listChallengesAndAnswers = [
           {
             result: 'ok',
@@ -137,6 +137,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('it renders a "Dé-neutraliser" button when challenge is neutralized', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const listChallengesAndAnswers = [
           {
             result: 'ok',
@@ -165,6 +166,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('it toggles the "Dé-neutraliser" button into a "Neutraliser" button when deneutralizing a neutralized challenge', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const listChallengesAndAnswers = [
           {
             result: 'ok',
@@ -194,6 +196,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
       test('it toggles the "Neutraliser" button into a "Dé-neutraliser" button when neutralizing a deneutralized challenge', async function (assert) {
         // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
         const listChallengesAndAnswers = [
           {
             result: 'ok',
@@ -224,6 +227,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
     test('it sort challenges by order property', async function (assert) {
       // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const listChallengesAndAnswers = [
         {
           result: 'ok',

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization_test.js
@@ -106,122 +106,156 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         assert.dom(screen.getByText('recCGEqqWBQnzD3NZ')).exists();
       });
 
-      test('it renders a "Neutraliser" button when challenge is not neutralized', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        const listChallengesAndAnswers = [
-          {
-            result: 'ok',
-            value: 'Dummy value',
-            challengeId: 'recCGEqqWBQnzD3NZ',
-            competence: '1.1',
-            skill: '',
-            isNeutralized: false,
-          },
-        ];
+      module('when user has access to certification action scope', function () {
+        test('it renders a "Neutraliser" button when challenge is not neutralized', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          const listChallengesAndAnswers = [
+            {
+              result: 'ok',
+              value: 'Dummy value',
+              challengeId: 'recCGEqqWBQnzD3NZ',
+              competence: '1.1',
+              skill: '',
+              isNeutralized: false,
+            },
+          ];
 
-        const certificationId = this.server.create('certification').id;
-        this.server.create('certification-detail', {
-          id: certificationId,
-          competencesWithMark: [],
-          status: 'started',
-          listChallengesAndAnswers,
+          const certificationId = this.server.create('certification').id;
+          this.server.create('certification-detail', {
+            id: certificationId,
+            competencesWithMark: [],
+            status: 'started',
+            listChallengesAndAnswers,
+          });
+
+          // when
+          const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
         });
 
-        // when
-        const screen = await visit(`/certifications/${certificationId}/neutralization`);
+        test('it renders a "Dé-neutraliser" button when challenge is neutralized', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          const listChallengesAndAnswers = [
+            {
+              result: 'ok',
+              value: 'Dummy value',
+              challengeId: 'recCGEqqWBQnzD3NZ',
+              competence: '1.1',
+              skill: '',
+              isNeutralized: true,
+            },
+          ];
 
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
+          const certificationId = this.server.create('certification').id;
+          this.server.create('certification-detail', {
+            id: certificationId,
+            competencesWithMark: [],
+            status: 'started',
+            listChallengesAndAnswers,
+          });
+
+          // when
+          const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
+        });
+
+        test('it toggles the "Dé-neutraliser" button into a "Neutraliser" button when deneutralizing a neutralized challenge', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          const listChallengesAndAnswers = [
+            {
+              result: 'ok',
+              value: 'Dummy value',
+              challengeId: 'recCGEqqWBQnzD3NZ',
+              competence: '1.1',
+              skill: '',
+              isNeutralized: true,
+            },
+          ];
+
+          const certificationId = this.server.create('certification').id;
+          this.server.create('certification-detail', {
+            id: certificationId,
+            competencesWithMark: [],
+            status: 'started',
+            listChallengesAndAnswers,
+          });
+          const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+          // when
+          await clickByName('Dé-neutraliser');
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
+        });
+
+        test('it toggles the "Neutraliser" button into a "Dé-neutraliser" button when neutralizing a deneutralized challenge', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          const listChallengesAndAnswers = [
+            {
+              result: 'ok',
+              value: 'Dummy value',
+              challengeId: 'recCGEqqWBQnzD3NZ',
+              competence: '1.1',
+              skill: '',
+              isNeutralized: false,
+            },
+          ];
+
+          const certificationId = this.server.create('certification').id;
+          this.server.create('certification-detail', {
+            id: certificationId,
+            competencesWithMark: [],
+            status: 'started',
+            listChallengesAndAnswers,
+          });
+          const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+          // when
+          await clickByName('Neutraliser');
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
+        });
       });
 
-      test('it renders a "Dé-neutraliser" button when challenge is neutralized', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        const listChallengesAndAnswers = [
-          {
-            result: 'ok',
-            value: 'Dummy value',
-            challengeId: 'recCGEqqWBQnzD3NZ',
-            competence: '1.1',
-            skill: '',
-            isNeutralized: true,
-          },
-        ];
+      module('when user does not have access to certification action scope', function () {
+        test('it does not render action column', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isMetier: true })(server);
+          const listChallengesAndAnswers = [
+            {
+              result: 'ok',
+              value: 'Dummy value',
+              challengeId: 'recCGEqqWBQnzD3NZ',
+              competence: '1.1',
+              skill: '',
+              isNeutralized: false,
+            },
+          ];
 
-        const certificationId = this.server.create('certification').id;
-        this.server.create('certification-detail', {
-          id: certificationId,
-          competencesWithMark: [],
-          status: 'started',
-          listChallengesAndAnswers,
+          const certificationId = this.server.create('certification').id;
+          this.server.create('certification-detail', {
+            id: certificationId,
+            competencesWithMark: [],
+            status: 'started',
+            listChallengesAndAnswers,
+          });
+
+          // when
+          const screen = await visit(`/certifications/${certificationId}/neutralization`);
+
+          // then
+          assert.dom(screen.queryByText('Action')).doesNotExist();
+          assert.dom(screen.queryByText('Neutraliser')).doesNotExist();
         });
-
-        // when
-        const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
-      });
-
-      test('it toggles the "Dé-neutraliser" button into a "Neutraliser" button when deneutralizing a neutralized challenge', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        const listChallengesAndAnswers = [
-          {
-            result: 'ok',
-            value: 'Dummy value',
-            challengeId: 'recCGEqqWBQnzD3NZ',
-            competence: '1.1',
-            skill: '',
-            isNeutralized: true,
-          },
-        ];
-
-        const certificationId = this.server.create('certification').id;
-        this.server.create('certification-detail', {
-          id: certificationId,
-          competencesWithMark: [],
-          status: 'started',
-          listChallengesAndAnswers,
-        });
-        const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-        // when
-        await clickByName('Dé-neutraliser');
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Neutraliser' })).exists();
-      });
-
-      test('it toggles the "Neutraliser" button into a "Dé-neutraliser" button when neutralizing a deneutralized challenge', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        const listChallengesAndAnswers = [
-          {
-            result: 'ok',
-            value: 'Dummy value',
-            challengeId: 'recCGEqqWBQnzD3NZ',
-            competence: '1.1',
-            skill: '',
-            isNeutralized: false,
-          },
-        ];
-
-        const certificationId = this.server.create('certification').id;
-        this.server.create('certification-detail', {
-          id: certificationId,
-          competencesWithMark: [],
-          status: 'started',
-          listChallengesAndAnswers,
-        });
-        const screen = await visit(`/certifications/${certificationId}/neutralization`);
-
-        // when
-        await clickByName('Neutraliser');
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Dé-neutraliser' })).exists();
       });
     });
 

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -39,39 +39,43 @@ module('Integration | Component | certifications/issue-report', function (hooks)
   });
 
   module('when the issue has not been resolved yet', function () {
-    test('it should display resolve button if current user has access to certification actions scope', async function (assert) {
-      // Given
-      const store = this.owner.lookup('service:store');
-      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
-      this.set('issueReport', issueReport);
-      class AccessControlStub extends Service {
-        hasAccessToCertificationActionsScope = true;
-      }
-      this.owner.register('service:access-control', AccessControlStub);
+    module('when current user has access to certification actions scope', function () {
+      test('it should display resolve button', async function (assert) {
+        // Given
+        const store = this.owner.lookup('service:store');
+        const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+        this.set('issueReport', issueReport);
+        class AccessControlStub extends Service {
+          hasAccessToCertificationActionsScope = true;
+        }
+        this.owner.register('service:access-control', AccessControlStub);
 
-      // When
-      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+        // When
+        const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
-      // Then
-      assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
+        // Then
+        assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
+      });
     });
 
-    test('it should not display resolve button if current user does not have access to certification actions scope', async function (assert) {
-      // Given
-      const store = this.owner.lookup('service:store');
-      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
-      this.set('issueReport', issueReport);
+    module('when current user does not have access to certification actions scope', function () {
+      test('it should not display resolve button', async function (assert) {
+        // Given
+        const store = this.owner.lookup('service:store');
+        const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+        this.set('issueReport', issueReport);
 
-      class AccessControlStub extends Service {
-        hasAccessToCertificationActionsScope = false;
-      }
-      this.owner.register('service:access-control', AccessControlStub);
+        class AccessControlStub extends Service {
+          hasAccessToCertificationActionsScope = false;
+        }
+        this.owner.register('service:access-control', AccessControlStub);
 
-      // When
-      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+        // When
+        const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
-      // Then
-      assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
+        // Then
+        assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
+      });
     });
   });
 

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { certificationIssueReportSubcategories } from 'pix-admin/models/certification-issue-report';
+import Service from '@ember/service';
 
 module('Integration | Component | certifications/issue-report', function (hooks) {
   setupRenderingTest(hooks);
@@ -19,6 +20,10 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       resolvedAt: null,
     });
     this.set('issueReport', issueReport);
+    class AccessControlStub extends Service {
+      hasAccessToCertificationActionsScope = true;
+    }
+    this.owner.register('service:access-control', AccessControlStub);
 
     // When
     const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
@@ -34,17 +39,39 @@ module('Integration | Component | certifications/issue-report', function (hooks)
   });
 
   module('when the issue has not been resolved yet', function () {
-    test('it should display resolve button', async function (assert) {
+    test('it should display resolve button if current user has access to certification actions scope', async function (assert) {
       // Given
       const store = this.owner.lookup('service:store');
       const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
       this.set('issueReport', issueReport);
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
 
       // When
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
       // Then
       assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
+    });
+
+    test('it should not display resolve button if current user does not have access to certification actions scope', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+      this.set('issueReport', issueReport);
+
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // Then
+      assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
     });
   });
 
@@ -57,6 +84,10 @@ module('Integration | Component | certifications/issue-report', function (hooks)
         resolvedAt: new Date('2020-01-01'),
       });
       this.set('issueReport', issueReport);
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
 
       // When
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
@@ -126,7 +157,11 @@ module('Integration | Component | certifications/issue-report', function (hooks)
     },
   ].forEach(function ({ subcategory, expectedLabel }) {
     test('should display subcategory', async function (assert) {
-      // Given
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
       const store = this.owner.lookup('service:store');
       const issueReport = store.createRecord('certification-issue-report', {
         category: 'TECHNICAL_PROBLEM',
@@ -138,7 +173,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       });
       this.set('issueReport', issueReport);
 
-      // When
+      // when
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
       // then

--- a/api/lib/application/assessment-results/index.js
+++ b/api/lib/application/assessment-results/index.js
@@ -14,7 +14,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -110,7 +110,6 @@ exports.register = async function (server) {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -171,7 +171,6 @@ exports.register = async function (server) {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -195,7 +195,6 @@ exports.register = async function (server) {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -57,7 +57,6 @@ exports.register = async (server) => {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -118,7 +118,6 @@ exports.register = async function (server) {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -89,7 +89,6 @@ exports.register = async function (server) {
                 securityPreHandlers.checkUserHasRoleSuperAdmin,
                 securityPreHandlers.checkUserHasRoleCertif,
                 securityPreHandlers.checkUserHasRoleSupport,
-                securityPreHandlers.checkUserHasRoleMetier,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },

--- a/api/tests/unit/application/assessment-results/index_test.js
+++ b/api/tests/unit/application/assessment-results/index_test.js
@@ -1,0 +1,32 @@
+const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const moduleUnderTest = require('../../../../lib/application/assessment-results');
+
+describe('Unit | Application | Assessmnet results | Route', function () {
+  describe('POST /api/admin/assessment-results', function () {
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/assessment-results');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
+    });
+  });
+});

--- a/api/tests/unit/application/assessment-results/index_test.js
+++ b/api/tests/unit/application/assessment-results/index_test.js
@@ -26,7 +26,6 @@ describe('Unit | Application | Assessmnet results | Route', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
   });
 });

--- a/api/tests/unit/application/assessment-results/index_test.js
+++ b/api/tests/unit/application/assessment-results/index_test.js
@@ -7,17 +7,20 @@ describe('Unit | Application | Assessmnet results | Route', function () {
   describe('POST /api/admin/assessment-results', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -134,7 +134,6 @@ describe('Unit | Application | Certifications Course | Route', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
   });
 
@@ -191,7 +190,6 @@ describe('Unit | Application | Certifications Course | Route', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
 
     it('should call handler when user is ', async function () {
@@ -231,8 +229,8 @@ describe('Unit | Application | Certifications Course | Route', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
+
     it('should call handler when user is ', async function () {
       // given
       sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -113,19 +113,23 @@ describe('Unit | Application | Certifications Course | Route', function () {
       expect(response.statusCode).to.equal(200);
     });
 
-    it('return forbidden access if user has METIER role', async function () {
+    it('should return a forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserOwnsCertificationCourse,
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -171,17 +175,20 @@ describe('Unit | Application | Certifications Course | Route', function () {
   describe('POST /api/admin/certification-courses/{id}/cancel', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -210,16 +217,20 @@ describe('Unit | Application | Certifications Course | Route', function () {
   describe('POST /api/admin/certification-courses/{id}/uncancel', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
 
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -97,7 +97,6 @@ describe('Unit | Application | Certifications Course | Route', function () {
       expect(response.statusCode).to.equal(400);
     });
   });
-  //});
 
   describe('PATCH /api/certification-courses/id', function () {
     it('should exist', async function () {
@@ -171,21 +170,28 @@ describe('Unit | Application | Certifications Course | Route', function () {
   });
 
   describe('POST /api/admin/certification-courses/{id}/cancel', function () {
-    it('should reject with 403 code when user is not Super Admin', async function () {
+    it('return forbidden access if user has METIER role', async function () {
       // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
-      sinon.stub(certificationCoursesController, 'cancel').throws(new Error('I should not be here'));
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const result = await httpTestServer.request('POST', '/api/admin/certification-courses/1/cancel');
+      const response = await httpTestServer.request('POST', '/api/admin/certification-courses/1/cancel');
 
       // then
-      expect(result.statusCode).to.equal(403);
-      expect(certificationCoursesController.cancel).to.not.have.been.called;
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
 
     it('should call handler when user is ', async function () {

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -113,6 +113,30 @@ describe('Unit | Application | Certifications Course | Route', function () {
       // then
       expect(response.statusCode).to.equal(200);
     });
+
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/certification-courses/1234');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
+    });
   });
 
   describe('POST /api/certification-courses', function () {

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -71,7 +71,6 @@ describe('Unit | Application | Certifications Issue Report | Route', function ()
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
   });
 });

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -48,16 +48,20 @@ describe('Unit | Application | Certifications Issue Report | Route', function ()
 
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
 
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -6,28 +6,35 @@ const moduleUnderTest = require('../../../../lib/application/certifications');
 
 describe('Unit | Application | Certification | Routes', function () {
   context('POST /api/admin/certification/neutralize-challenge', function () {
-    it('rejects access if the logged user is not a Super Admin', async function () {
+    it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(certificationController, 'neutralizeChallenge').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
-      const payload = {
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/certification/neutralize-challenge', {
         data: {
           attributes: {
             certificationCourseId: 1,
             challengeRecId: 'rec43mpMIR5dUzdjh',
           },
         },
-      };
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/certification/neutralize-challenge', payload);
+      });
 
       // then
       expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
 
     it('checks that a valid certification-course id is given', async function () {

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -83,28 +83,35 @@ describe('Unit | Application | Certification | Routes', function () {
   });
 
   context('POST /api/admin/certification/deneutralize-challenge', function () {
-    it('rejects access if the logged user is not a Super Admin', async function () {
+    it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
-        .returns((request, h) => h.response().code(403).takeover());
+        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
-      const payload = {
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/certification/deneutralize-challenge', {
         data: {
           attributes: {
             certificationCourseId: 1,
             challengeRecId: 'rec43mpMIR5dUzdjh',
           },
         },
-      };
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/certification/deneutralize-challenge', payload);
+      });
 
       // then
       expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
 
     it('checks that a valid certification-course id is given', async function () {

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -34,7 +34,6 @@ describe('Unit | Application | Certification | Routes', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
 
     it('checks that a valid certification-course id is given', async function () {
@@ -111,7 +110,6 @@ describe('Unit | Application | Certification | Routes', function () {
 
       // then
       expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
     });
 
     it('checks that a valid certification-course id is given', async function () {

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -8,16 +8,20 @@ describe('Unit | Application | Certification | Routes', function () {
   context('POST /api/admin/certification/neutralize-challenge', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
 
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -84,16 +88,20 @@ describe('Unit | Application | Certification | Routes', function () {
   context('POST /api/admin/certification/deneutralize-challenge', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
       sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
 
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -528,18 +528,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(sessionController, 'publish').returns('ok');
-
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
 
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -555,7 +557,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(sessionController.publish);
       });
     });
 
@@ -576,17 +577,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -624,19 +628,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(sessionController, 'publishInBatch').returns('ok');
-
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -651,7 +656,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(sessionController.publishInBatch);
       });
 
       it('should succeed with valid session ids', async function () {
@@ -713,19 +717,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
-
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -734,7 +739,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(sessionController.flagResultsAsSentToPrescriber);
       });
     });
 
@@ -772,17 +776,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -890,19 +897,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(sessionController, 'commentAsJury').returns('ok');
-
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -911,7 +919,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(sessionController.commentAsJury);
       });
     });
 
@@ -933,19 +940,20 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
-
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -954,24 +962,26 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(sessionController.deleteJuryComment);
       });
     });
 
     describe('GET /api/admin/sessions/{id}/generate-results-download-link', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkUserHasRoleCertif')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-
+          .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkUserHasRoleSuperAdmin,
+            securityPreHandlers.checkUserHasRoleCertif,
+            securityPreHandlers.checkUserHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -963,8 +963,6 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('GET /api/admin/sessions/{id}/generate-results-download-link', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
-        sinon.stub(sessionController, 'generateSessionResultsDownloadLink').returns('ok');
-
         sinon.stub(securityPreHandlers, 'checkUserHasRoleMetier').callsFake((request, h) => h.response(true));
         sinon
           .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
@@ -984,7 +982,7 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(sessionController.generateSessionResultsDownloadLink);
+        sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
       });
     });
   });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -595,7 +595,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
       });
     });
 
@@ -795,7 +794,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
       });
     });
 
@@ -982,7 +980,6 @@ describe('Unit | Application | Sessions | Routes', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        sinon.assert.notCalled(securityPreHandlers.checkUserHasRoleMetier);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Les pages liés aux certifications dans Pix Admin sont actuellement disponibles à tous les utilisateurs Pix Admin (indépendamment de leur rôles).
Or ces pages contiennent des actions critiques comme : 
- Annuler / désannuler une certification
- Modifier un candidat
- Résoudre un signalement
- Modifier le statut de la certif, les commentaires Jury et les résultats
- Neutraliser / Déneutraliser une question
- Ajouter/modifier le niveau obtenu au volet jury d'une certif Pix+ Edu (voir avec team-certif)

Ces actions ne sont jamais utilisées par les membres Pix Admin ayant le rôle `METIER`. 

Elles ne devraient être accessible qu'aux rôles:
- SUPER_ADMIN;
- CERTIF;
- SUPPORT.

## :robot: Solution

### API
Rejeter les requêtes si le rôle de l'utilisateur (identifié par token) n'est pas: 
- SUPER_ADMIN;
- CERTIF;
- SUPPORT.

Routes API concernées: 
- `POST /api/admin/certification-courses/id/cancel` (Annuler une certification)
- `POST /api/admin/certification-courses/id/uncancel`(Désannuler une certification)
- `PATCH /api/certification-courses/id` (Modifier un candidat)
- `PATCH /api/certification-issue-reports/id` (Résoudre un signalement)
- `POST /api/admin/assessment-results/` (Modifier le statut de la certif, les commentaires Jury et les résultats)
- `POST /api/admin/certification/neutralize-challenge`(Neutraliser une question)
- `POST /api/admin/certification/deneutralize-challenge` (Déneutraliser une question)

### Front
Afficher les contrôles uniquement si le rôle le permet.


## :rainbow: Remarques



## :100: Pour tester

### API
Vérifier que les routes API sont bien protégées

1- Drop les commits commençant par  "admin:" 

2- Se connecter à Pix Admin avec "pixmetier@example.net" + ouvrir l'inspecteur web , onglet réseau
3- Vérifier que toutes les actions suivantes renvoie une 403 :
- aller sur `sessions/5` et cliquer sur "M'assigner la session"
- todo

Ou 
Se connecter à pix admin en tant que pixmetier@example.net.

Dans l'inspecteur ember, Data, admin-member, passer :
- `is super admin` de `false` à `true`
- `is metier` de `true` à `false`

### Pix Admin

#### Evolution
Vérifier que l'application Pix Admin ne présente pas les fonctionnalités d'actions liées à la certif au Métier

6- Rétablir les commits
7- Vérifier avec le compte "pixmetier@example.net" : 
- que vous ne voyez plus les boutons d'actions cités plus haut


#### Non-régression

Vérifier que l'application Pix Admin présente toujours les fonctionnalités d'actions liées à la certif aux Super Admin, au Support et au membre Certif

8- Vérifier avec les comptes "pixsupport@example.net", "superadmin@example.net" ou "pixcertif@example.net" que les actions cités plus haut fonctionnent (n'oubliez pas de reset vos seeds pour simplifier).