### PR TITLE
[BUGFIX] Corriger un problème d'arrondi lors de l'affichage des paliers (PIX-4861)

### DIFF
--- a/orga/app/components/campaign/cards/stage-average.js
+++ b/orga/app/components/campaign/cards/stage-average.js
@@ -2,6 +2,6 @@ import Component from '@glimmer/component';
 
 export default class StageAverage extends Component {
   get valuePercentage() {
-    return this.args.value * 100;
+    return Math.round(this.args.value * 100);
   }
 }

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -30,7 +30,7 @@
         <tr>
           <Table::Header>{{t "pages.campaign-results.table.column.last-name"}}</Table::Header>
           <Table::Header>{{t "pages.campaign-results.table.column.first-name"}}</Table::Header>
-          {{#if @campaign.idPixLabel}}
+          {{#if @campaign.hasExternalId}}
             <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
           <Table::Header>{{t "pages.campaign-results.table.column.results.label"}}</Table::Header>
@@ -43,44 +43,15 @@
       {{#if @participations}}
         <tbody>
           {{#each @participations as |participation|}}
-            <tr
-              aria-label={{t "pages.campaign-results.table.row-title"}}
-              role="button"
-              {{on "click" (fn @onClickParticipant @campaign.id participation.id)}}
-              class="tr--clickable"
-            >
-              <td>
-                <LinkTo
-                  @route={{"authenticated.campaigns.participant-assessment"}}
-                  @models={{array @campaign.id participation.id}}
-                >
-                  {{participation.lastName}}
-                </LinkTo>
-              </td>
-              <td>{{participation.firstName}}</td>
-              {{#if @campaign.idPixLabel}}
-                <td>{{participation.participantExternalId}}</td>
-              {{/if}}
-              {{#if @campaign.hasStages}}
-                <td>
-                  <Campaign::StageStars
-                    @result={{multiply participation.masteryRate 100}}
-                    @stages={{@campaign.stages}}
-                    @withTooltip={{true}}
-                    @tooltipPosition="bottom-left"
-                  />
-                </td>
-              {{else}}
-                <td class="participant-list__mastery-percentage">
-                  {{t "pages.campaign-results.table.column.results.value" percentage=participation.masteryRate}}
-                </td>
-              {{/if}}
-              {{#if @campaign.hasBadges}}
-                <td class="participant-list__badges">
-                  <Campaign::Badges @badges={{participation.badges}} />
-                </td>
-              {{/if}}
-            </tr>
+            <Campaign::Results::AssessmentRow
+              @hasStages={{@campaign.hasStages}}
+              @hasBadges={{@campaign.hasBadges}}
+              @hasExternalId={{@campaign.hasExternalId}}
+              @participation={{participation}}
+              @campaignId={{@campaign.id}}
+              @stages={{@campaign.stages}}
+              @onClickParticipant={{@onClickParticipant}}
+            />
           {{/each}}
         </tbody>
       {{/if}}

--- a/orga/app/components/campaign/results/assessment-row.hbs
+++ b/orga/app/components/campaign/results/assessment-row.hbs
@@ -1,0 +1,35 @@
+<tr
+  aria-label={{t "pages.campaign-results.table.row-title"}}
+  role="button"
+  {{on "click" (fn @onClickParticipant @campaignId @participation.id)}}
+  class="tr--clickable"
+>
+  <td>
+    <LinkTo @route={{"authenticated.campaigns.participant-assessment"}} @models={{array @campaignId @participation.id}}>
+      {{@participation.lastName}}
+    </LinkTo>
+  </td>
+  <td>{{@participation.firstName}}</td>
+  {{#if @hasExternalId}}
+    <td>{{@participation.participantExternalId}}</td>
+  {{/if}}
+  {{#if @hasStages}}
+    <td>
+      <Campaign::StageStars
+        @result={{this.valuePercentage}}
+        @stages={{@stages}}
+        @withTooltip={{true}}
+        @tooltipPosition="bottom-left"
+      />
+    </td>
+  {{else}}
+    <td class="participant-list__mastery-percentage">
+      {{t "pages.campaign-results.table.column.results.value" percentage=@participation.masteryRate}}
+    </td>
+  {{/if}}
+  {{#if @hasBadges}}
+    <td class="participant-list__badges">
+      <Campaign::Badges @badges={{@participation.badges}} />
+    </td>
+  {{/if}}
+</tr>

--- a/orga/app/components/campaign/results/assessment-row.js
+++ b/orga/app/components/campaign/results/assessment-row.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class AssessmentRow extends Component {
+  get valuePercentage() {
+    return Math.round(this.args.participation.masteryRate * 100);
+  }
+}

--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -68,7 +68,7 @@
             class="panel-header-data__content panel-header-data-content__stages"
           >
             <Campaign::StageStars
-              @result={{multiply @participation.masteryRate 100}}
+              @result={{this.valuePercentage}}
               @stages={{@campaign.stages}}
               @withTooltip={{true}}
               @tooltipPosition="bottom-left"

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -5,4 +5,8 @@ export default class Header extends Component {
     const { campaign, participation } = this.args;
     return campaign.hasBadges && participation.badges.length > 0;
   }
+
+  get valuePercentage() {
+    return Math.round(this.args.participation.masteryRate * 100);
+  }
 }

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -42,6 +42,10 @@ export default class Campaign extends Model {
     return this.targetProfileThematicResultCount > 0;
   }
 
+  get hasExternalId() {
+    return Boolean(this.idPixLabel);
+  }
+
   get hasStages() {
     return this.targetProfileHasStage;
   }

--- a/orga/tests/unit/models/campaign_test.js
+++ b/orga/tests/unit/models/campaign_test.js
@@ -99,6 +99,35 @@ module('Unit | Model | campaign', function (hooks) {
     });
   });
 
+  module('#hasExternalId', function () {
+    test('returns false while campaign does not contain IdPixLabel', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        idPixLabel: null,
+      });
+
+      assert.false(model.hasExternalId);
+    });
+
+    test('returns false while idPixLabel is empty', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        idPixLabel: '',
+      });
+
+      assert.false(model.hasExternalId);
+    });
+
+    test('returns true while campaign contain idPixLabel', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        idPixLabel: 'krakow',
+      });
+
+      assert.true(model.hasExternalId);
+    });
+  });
+
   module('#hasBadges', function () {
     test('returns true while campaign contains badges', function (assert) {
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :unicorn: Problème
Nous avons eu le retours que certains prescrit n'avait pas le bon affichage de palier sur certaine campagne du a un souci d'arrondi lors d'une multiplication 0,29 * 100 => 28.9999999993, alors que l'on s'attend à avoir 29. 

## :robot: Solution
Rajouter un `Math.round` là ou nous faisions une simple multiplication afin ISO à la réalité du résultat du prescrit

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que l'affichage des paliers est toujours OK.