### PR TITLE
[FEATURE] Inciter le candidat à contacter le surveillant pour rejoindre une session (PIX-4880).

### DIFF
--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -3,70 +3,72 @@
   <h1 class="certification-joiner__title">{{t "pages.certification-joiner.first-title"}}</h1>
   <form autocomplete="off" {{on "submit" this.attemptNext}}>
     <div class="certification-joiner__row">
-      <label class="certification-joiner__label" for="certificationJoinerSessionId">{{t
-          "pages.certification-joiner.form.fields.session-number"
-        }}</label>
-      <Input
-        id="certificationJoinerSessionId"
+      <PixInput
+        @id="certificationJoinerSessionId"
         class={{if this.sessionIdIsNotANumberError "certification-joiner__input--invalid"}}
         pattern={{this.SESSION_ID_VALIDATION_PATTERN}}
         title={{t "pages.certification-joiner.form.fields-validation.session-number-error"}}
-        @type="text"
+        type="text"
         size="6"
-        @value={{this.sessionId}}
         {{on "input" this.checkSessionIdIsValid}}
+        {{on "change" this.setSessionId}}
         inputmode="decimal"
         required="true"
+        @label={{t "pages.certification-joiner.form.fields.session-number"}}
       />
       <p class="certification-joiner__validation-error">{{this.sessionIdIsNotANumberError}}</p>
     </div>
     <div class="certification-joiner__row">
-      <label class="certification-joiner__label" for="certificationJoinerFirstName">{{t
-          "pages.certification-joiner.form.fields.first-name"
-        }}</label>
-      <Input @type="text" @value={{this.firstName}} id="certificationJoinerFirstName" />
+      <PixInput
+        @id="certificationJoinerFirstName"
+        type="text"
+        {{on "change" this.setFirstName}}
+        @label={{t "pages.certification-joiner.form.fields.first-name"}}
+      />
     </div>
     <div class="certification-joiner__row">
-      <label class="certification-joiner__label" for="certificationJoinerLastName">{{t
-          "pages.certification-joiner.form.fields.birth-name"
-        }}</label>
-      <Input @type="text" @value={{this.lastName}} id="certificationJoinerLastName" />
+      <PixInput
+        type="text"
+        {{on "change" this.setLastName}}
+        @id="certificationJoinerLastName"
+        @label={{t "pages.certification-joiner.form.fields.birth-name"}}
+      />
     </div>
     <div class="certification-joiner__row">
       <label class="certification-joiner__label" for="certificationJoinerDayOfBirth">{{t
           "pages.certification-joiner.form.fields.birth-date"
         }}</label>
       <div class="certification-joiner__birthdate" id="certificationJoinerBirthDate">
-        <Input
+        <PixInput
+          @id="certificationJoinerDayOfBirth"
           min="1"
           max="31"
-          @type="number"
-          @value={{this.dayOfBirth}}
+          type="number"
           placeholder="JJ"
-          id="certificationJoinerDayOfBirth"
+          {{on "change" this.setDayOfBirth}}
           {{on "input" this.handleDayInputChange}}
           {{on "focus-in" this.handleInputFocus}}
           aria-label={{t "pages.certification-joiner.form.fields.birth-day"}}
         />
         <div class="certification-joiner__divider"></div>
-        <Input
-          min="1"
-          @max="12"
-          @type="number"
-          @value={{this.monthOfBirth}}
-          placeholder="MM"
+        <PixInput
           @id="certificationJoinerMonthOfBirth"
+          min="1"
+          max="12"
+          type="number"
+          placeholder="MM"
+          {{on "change" this.setMonthOfBirth}}
           {{on "input" this.handleMonthInputChange}}
           {{on "focus-in" this.handleInputFocus}}
           aria-label={{t "pages.certification-joiner.form.fields.birth-month"}}
         />
         <div class="certification-joiner__divider"></div>
-        <Input
-          @min="1900"
-          @type="number"
-          @value={{this.yearOfBirth}}
-          placeholder="AAAA"
+        <PixInput
           @id="certificationJoinerYearOfBirth"
+          min="1900"
+          type="number"
+          placeholder="AAAA"
+          {{on "change" this.setYearOfBirth}}
           {{on "focus-in" this.handleInputFocus}}
           aria-label={{t "pages.certification-joiner.form.fields.birth-year"}}
         />

--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -15,6 +15,7 @@
         inputmode="decimal"
         required="true"
         @label={{t "pages.certification-joiner.form.fields.session-number"}}
+        @information={{t "pages.certification-joiner.form.fields.session-number-information"}}
       />
       <p class="certification-joiner__validation-error">{{this.sessionIdIsNotANumberError}}</p>
     </div>

--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -51,7 +51,6 @@
           {{on "focus-in" this.handleInputFocus}}
           aria-label={{t "pages.certification-joiner.form.fields.birth-day"}}
         />
-        <div class="certification-joiner__divider"></div>
         <PixInput
           @id="certificationJoinerMonthOfBirth"
           min="1"
@@ -63,10 +62,10 @@
           {{on "focus-in" this.handleInputFocus}}
           aria-label={{t "pages.certification-joiner.form.fields.birth-month"}}
         />
-        <div class="certification-joiner__divider"></div>
         <PixInput
           @id="certificationJoinerYearOfBirth"
           min="1900"
+          max="2100"
           type="number"
           placeholder="AAAA"
           {{on "change" this.setYearOfBirth}}
@@ -96,6 +95,9 @@
         {{/if}}
       </div>
     {{/if}}
-    <PixButton @type="submit">{{t "pages.certification-joiner.form.actions.submit"}}</PixButton>
+    <PixButton @id="certificationJoinerSubmitButton" @type="submit">{{t
+        "pages.certification-joiner.form.actions.submit"
+      }}
+    </PixButton>
   </form>
 </section>

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -70,6 +70,21 @@ export default class CertificationJoiner extends Component {
   }
 
   @action
+  setSessionId(event) {
+    this.sessionId = event.target.value;
+  }
+
+  @action
+  setFirstName(event) {
+    this.firstName = event.target.value;
+  }
+
+  @action
+  setLastName(event) {
+    this.lastName = event.target.value;
+  }
+
+  @action
   async attemptNext(e) {
     e.preventDefault();
     this._resetErrorMessages();
@@ -115,6 +130,19 @@ export default class CertificationJoiner extends Component {
     if (value.length === 2) {
       document.getElementById('certificationJoinerMonthOfBirth').focus();
     }
+  }
+
+  @action
+  setDayOfBirth(event) {
+    this.dayOfBirth = event.target.value;
+  }
+  @action
+  setMonthOfBirth(event) {
+    this.monthOfBirth = event.target.value;
+  }
+  @action
+  setYearOfBirth(event) {
+    this.yearOfBirth = event.target.value;
   }
 
   @action

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -19,21 +19,6 @@
     margin-bottom: 24px;
   }
 
-  &__birthdate {
-    display: flex;
-    flex-flow: row nowrap;
-    align-items: center;
-
-    input {
-      padding-right: 3px;
-    }
-  }
-
-  &__divider {
-    width: 20px;
-    flex-shrink: 0;
-  }
-
   form {
     width: 280px;
     display: block;
@@ -103,6 +88,21 @@
     font-size: 0.875rem;
     margin-top: 6px;
     margin-bottom: 0;
+  }
+
+  &__birthdate {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: space-between;
+
+    .pix-input {
+      flex: 0.3;
+
+      input {
+        padding-right: 3px;
+      }
+    }
   }
 
   &__label {

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -2,17 +2,8 @@
   margin-top: 32px;
   text-rendering: optimizeLegibility;
 
-  &__label {
-    color: rgb(88, 95, 117);
-    font-family: $font-roboto;
-    font-size: 1rem;
-    font-weight: normal;
-    height: 18px;
-    margin-bottom: 6px;
-  }
-
   &__title {
-    color: $grey-100;
+    color: $grey-90;
     font-family: $font-open-sans;
     font-size: 2rem;
     font-weight: $font-light;
@@ -32,6 +23,10 @@
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
+
+    input {
+      padding-right: 3px;
+    }
   }
 
   &__divider {
@@ -108,5 +103,11 @@
     font-size: 0.875rem;
     margin-top: 6px;
     margin-bottom: 0;
+  }
+
+  &__label {
+    font-size: 0.875rem;
+    color: $grey-70;
+    margin-bottom: 4px;
   }
 }

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -236,6 +236,14 @@ describe('Integration | Component | certification-joiner', function () {
       });
     });
   });
+
+  it('should display hint on session number input', async function () {
+    await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
+    const foo = find(`.pix-input__information`);
+
+    expect(foo.innerText).to.contains(this.intl.t('pages.certification-joiner.form.fields.session-number-information'));
+  });
+
   context('when filling form', function () {
     context('should not allow filling letters in birth date', function () {
       it('day', async function () {

--- a/mon-pix/tests/integration/components/certification-joiner_test.js
+++ b/mon-pix/tests/integration/components/certification-joiner_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import sinon from 'sinon';
-import { render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
@@ -11,14 +11,14 @@ import { clickByLabel } from '../../helpers/click-by-label';
 describe('Integration | Component | certification-joiner', function () {
   setupIntlRenderingTest();
 
-  describe('#submit', function () {
+  context('submit', function () {
     it('should create certificate candidate with trimmed first and last name', async function () {
       // given
       this.set('onStepChange', sinon.stub());
       await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
       await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.session-number'), '123456');
-      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert  ');
-      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), '  de Pix');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.first-name'), 'Robert' + '  ');
+      await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-name'), '  ' + 'de Pix');
       await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), '02');
       await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), '01');
       await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), '2000');
@@ -233,6 +233,48 @@ describe('Integration | Component | certification-joiner', function () {
           contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-session-number'))
         ).to.exist;
         expect(contains(this.intl.t('pages.certification-joiner.error-messages.generic.check-personal-info'))).to.exist;
+      });
+    });
+  });
+  context('when filling form', function () {
+    context('should not allow filling letters in birth date', function () {
+      it('day', async function () {
+        // given
+        this.set('onStepChange', sinon.stub());
+        await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
+
+        // when
+        await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-day'), 'aa');
+
+        // then
+        const foo = find(`input[aria-label="${this.intl.t('pages.certification-joiner.form.fields.birth-day')}"]`);
+        expect(foo.value).not.to.contains('aa');
+      });
+
+      it('month', async function () {
+        // given
+        this.set('onStepChange', sinon.stub());
+        await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
+
+        // when
+        await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-month'), 'aa');
+
+        // then
+        const foo = find(`input[aria-label="${this.intl.t('pages.certification-joiner.form.fields.birth-month')}"]`);
+        expect(foo.value).not.to.contains('aa');
+      });
+
+      it('year', async function () {
+        // given
+        this.set('onStepChange', sinon.stub());
+        await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}}/>`);
+
+        // when
+        await fillInByLabel(this.intl.t('pages.certification-joiner.form.fields.birth-year'), 'aa');
+
+        // then
+        const foo = find(`input[aria-label="${this.intl.t('pages.certification-joiner.form.fields.birth-year')}"]`);
+        expect(foo.value).not.to.contains('aa');
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -274,7 +274,8 @@
           "birth-name": "Last name (given at birth)",
           "birth-year": "Year (YYYY)",
           "first-name": "First name",
-          "session-number": "Session number"
+          "session-number": "Session number",
+          "session-number-information": "Given only by the invigilator at the beginning of the session"
         },
         "fields-validation": {
           "session-number-error": "The session ID must only contain numbers."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -274,7 +274,8 @@
           "birth-name": "Nom de naissance",
           "birth-year": "année de naissance (AAAA)",
           "first-name": "Prénom",
-          "session-number": "Numéro de session"
+          "session-number": "Numéro de session",
+          "session-number-information": "Communiqué uniquement par le surveillant en début de session"
         },
         "fields-validation": {
           "session-number-error": "Le numéro de session est composé uniquement de chiffres."


### PR DESCRIPTION
## :unicorn: Problème
Le pôle support reçoit beaucoup de tickets d’utilisateur pix app qui arrivent sur la page “Certifications”, et qui pensent pouvoir passer leur certification sans inscription préalable. Ils contactent donc le support dans le but d’obtenir un numéro de session et passer leur certification en autonomie. 

## :robot: Solution
Donner plus de contexte sur le champ “Numéro de session” sur la page d’entrée en session

## :rainbow: Remarques
Refacto de Input en PixInput pour gérer le champ information en natif

## :100: Pour tester
Se connecter à Pix app avec le compte `certif-success@example.net` et vérifier l'affichage de "Communiqué uniquement par le surveillant en début de session" au dessus de l'input Numéro de session.
