### PR TITLE
[TECH] Empêcher la création automatique d'une traduction vide (PIX-4956).

### DIFF
--- a/api/tests/tooling/i18n/i18n.js
+++ b/api/tests/tooling/i18n/i18n.js
@@ -8,6 +8,7 @@ function getI18n() {
     defaultLocale: 'fr',
     directory,
     objectNotation: true,
+    updateFiles: false,
   });
   return i18n;
 }


### PR DESCRIPTION
## :unicorn: Problème
Quand on utilise un clé de traduction qui n'existe pas i18n rajoute la traduction dans le fichier associer à la locale utilisée.

## :robot: Solution
Désactivé la mise à jour des fichiers.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

