### PR TITLE
[BUGFIX] Centrer le niveau sur la notification de changement de niveau (PIX-4783).

### DIFF
--- a/mon-pix/app/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/congratulations-certification-banner.hbs
@@ -5,7 +5,7 @@
     {{on "click" @closeBanner}}
     type="button"
   >
-    <FaIcon @icon="times" />
+    <FaIcon @icon="xmark" />
   </button>
   <p class="congratulations-banner__message">
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}

--- a/mon-pix/app/components/levelup-notif.hbs
+++ b/mon-pix/app/components/levelup-notif.hbs
@@ -16,7 +16,7 @@
         type="button"
       >
         <span id="button-label" hidden>{{t "common.actions.close"}}</span>
-        <FaIcon @icon="times" />
+        <FaIcon @icon="xmark" />
       </button>
     </div>
   {{/unless}}

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -5,7 +5,7 @@
       {{#if this.isUserLogged}}
         <span class="navbar-mobile-header__burger-icon" {{action @burger.state.actions.toggle}}>
           {{#if @burger.state.open}}
-            <FaIcon @icon="times" />
+            <FaIcon @icon="xmark" />
           {{else}}
             <FaIcon @icon="bars" />
           {{/if}}

--- a/mon-pix/app/components/new-information.hbs
+++ b/mon-pix/app/components/new-information.hbs
@@ -36,7 +36,7 @@
 
   {{#if @closeaction}}
     <button class="new-information__close {{@textColorClass}}" {{on "click" @closeaction}} type="button">
-      <FaIcon @icon="times" /><span class="sr-only">{{t "common.actions.close"}}</span>
+      <FaIcon @icon="xmark" /><span class="sr-only">{{t "common.actions.close"}}</span>
     </button>
   {{/if}}
 </div>

--- a/mon-pix/app/styles/components/_levelup-notif.scss
+++ b/mon-pix/app/styles/components/_levelup-notif.scss
@@ -1,5 +1,7 @@
 .levelup {
   display: flex;
+  justify-content: center;
+  align-items: center;
   position: fixed;
   top: 10px;
   right: 10px;
@@ -18,10 +20,14 @@
     width: 362px;
   }
 
+  & > img {
+    height: 100%;
+  }
+
   &__icon-card-level {
     position: absolute;
     top: 31px;
-    left: 40px;
+    left: 45px;
     font-size: 1.5rem;
     font-family: $font-open-sans;
     font-weight: $font-bold;


### PR DESCRIPTION
## :unicorn: Problème

Sur Chrome, le niveau nouvellement atteint lors d'une évaluation de compétences et affiché sur notification n'est pas centré.

## :robot: Solution

Modification du style.

## :rainbow: Remarques

Nous remplaçons également dans cette PR une icône font-awesome qui n'est plus utilisée depuis le changement de version du package `@fortawesome` (voir #4393) 

## :100: Pour tester
Sur Chrome et Firefox : 
- Passer des épreuves dans pix-app de façon à changer de niveau dans une compétence
- Vérifier que le chiffre du niveau acquis est centré sur la carte de la notification
