### PR TITLE
[TECH] Obtenir des détails sur l'erreur lors de la réinitialisation du mot de passe sur Pix App (PIX-4957).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -118,7 +118,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.NotFoundError(error.message);
   }
   if (error instanceof DomainErrors.NotFoundError) {
-    return new HttpErrors.NotFoundError(error.message);
+    return new HttpErrors.NotFoundError(error.message, error.code);
   }
   if (error instanceof DomainErrors.CampaignCodeError) {
     return new HttpErrors.NotFoundError(error.message);

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -48,10 +48,11 @@ class MissingQueryParamError extends BaseHttpError {
 }
 
 class NotFoundError extends BaseHttpError {
-  constructor(message, title) {
+  constructor(message, code, title) {
     super(message);
     this.title = title || 'Not Found';
     this.status = 404;
+    this.code = code;
   }
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -684,8 +684,9 @@ class NotEligibleCandidateError extends DomainError {
 }
 
 class NotFoundError extends DomainError {
-  constructor(message = 'Erreur, ressource introuvable.') {
+  constructor(message = 'Erreur, ressource introuvable.', code) {
     super(message);
+    this.code = code;
   }
 }
 
@@ -896,8 +897,8 @@ class UserCantBeCreatedError extends DomainError {
 }
 
 class UserNotFoundError extends NotFoundError {
-  constructor(message = 'Ce compte est introuvable.') {
-    super(message);
+  constructor(message = 'Ce compte est introuvable.', code = 'USER_ACCOUNT_NOT_FOUND') {
+    super(message, code);
   }
 
   getErrorMessage() {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const { knex } = require('../../../db/knex-database-connection');
-
+const logger = require('../../infrastructure/logger');
 const DomainTransaction = require('../DomainTransaction');
 const BookshelfUser = require('../orm-models/User');
 const { isUniqConstraintViolated } = require('../utils/knex-utils');
@@ -55,6 +55,12 @@ module.exports = {
       })
       .then((foundUser) => {
         if (foundUser === null) {
+          logger.warn(
+            {
+              username,
+            },
+            'Trying to change his password with incorrect username'
+          );
           return Promise.reject(new UserNotFoundError());
         }
         return _toDomain(foundUser);

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -196,6 +196,7 @@ describe('Acceptance | Controller | password-controller', function () {
 
           // then
           expect(response.statusCode).to.equal(404);
+          expect(response.result.errors[0].code).to.equal('USER_ACCOUNT_NOT_FOUND');
         });
       });
 
@@ -212,7 +213,7 @@ describe('Acceptance | Controller | password-controller', function () {
         });
       });
 
-      context('when shoulChangePassword is false', function () {
+      context('when shouldChangePassword is false', function () {
         it('should respond 403 HTTP status code', async function () {
           // given
           const username = 'jean.oubliejamais0105';

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -103,8 +103,11 @@ export default class UpdateExpiredPasswordForm extends Component {
 
   _manageErrorsApi(error) {
     const statusCode = get(error, 'status');
+    const code = get(error, 'code');
     if (statusCode === '400') {
       this.validation = VALIDATION_MAP.error;
+    } else if (statusCode === '404' && code === 'USER_ACCOUNT_NOT_FOUND') {
+      this.errorMessage = this.intl.t('common.error');
     } else {
       this.errorMessage = this._showErrorMessages(statusCode);
     }

--- a/mon-pix/tests/acceptance/update-expired-password_test.js
+++ b/mon-pix/tests/acceptance/update-expired-password_test.js
@@ -80,6 +80,27 @@ describe('Acceptance | Update Expired Password', function () {
     expect(contains(expectedErrorMessage)).to.exist;
   });
 
+  it('should display error message when update password fails with http 404 error', async function () {
+    // given
+    this.server.post('/expired-password-updates', () => {
+      return new Response(
+        401,
+        {},
+        {
+          errors: [{ status: '404', code: 'USER_ACCOUNT_NOT_FOUND' }],
+        }
+      );
+    });
+
+    await fillIn('#password', 'newPass12345!');
+
+    // when
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
+
+    // then
+    expect(this.intl.t('common.error')).to.exist;
+  });
+
   it('should display error message when update password fails', async function () {
     // given
     const expectedErrorMessage = this.intl.t('api-error-messages.internal-server-error');


### PR DESCRIPTION
## :unicorn: Problème
Des utilisateurs nous ont remonté des soucis sur le scénario de réinitialisation de mot de passe temporaire.

Ce problème avait déjà été remonté mais nous ne parvenons pas à reproduire. Au départ, nous étions parties sur un problème d'environnement de l'outil de l'utilisateur, avec des extensions qui bloquent le bon déroulement de notre appli. 
Mais en investiguant il y a quelques jours, nous avons observé de nombreux 404 sur Datadog.

Seulement les erreurs 404 remontées ne fournissent pas de complément d'information. On ne peut savoir de quel 404 il s'agit.

Tout le détail ici : https://1024pix.atlassian.net/browse/PIX-4882

## :robot: Solution
Pour poursuivre cette investigation des erreurs 404, nous allons log les détails sur Datadog avec un warn. (voir remarques)
De plus coté front, nous ajoutons un nouveau message d'erreur pour les futurs utilisateurs qui passeront dans ce scénario. 

## :rainbow: Remarques
La seule erreur 404 retrouvée pour l'instant vient du repository, qui la retourne lorsqu'il ne trouve pas le compte utilisateur. Or dans le scénario fonctionnel, l'utilisateur à déjà attesté dans un précédent appel qu'il a bien un compte.

Pour le choix du warn, vu avec Mickael pour permettre de log les infos sur Datadog. On utilise le username de l'utilisateur pour pouvoir le comparer avec la base de données. Cela permettra de confirmer ou infirmer cette piste d'un compte inexistant. **Ceci n'est que temporaire le temps de l'investigation**.
A cette étape, l'utilisateur n'est pas connecté, nous n'avons donc aucun userId à utiliser.

## :100: Pour tester
Pour tester le scénario de la réinitialisation, avec le nouveau message d'erreur (en local)
- Aller sur Pix Orga et se connecter (sco.admin)
- Dans le menu de gauche, aller sur Élèves
- Choisir un élève possédant une méthode identifiant et/ou adresse e-mail et cliquer sur le bouton d'action tout à droite "Gérer le compte"
- Cliquer sur le bouton "Réinitialiser le mot de passe"
- récupérer l'identifiant et nouveau mot de passe de l'élève et aller sur Mon Pix
- Sur la page connexion, renseigner les deux informations
- Renseigner un nouveau mot de passe
- Pour reproduire le 404, on peut bidouiller de pleins de façons. Par exemple aller sur la méthode `getByUsernameOrEmailWithRolesAndPassword` et retirer la condition ligne 57 pour obliger le return sur l'erreur `UserNotFoundError()`
<img width="406" alt="Capture d’écran 2022-05-20 à 11 37 22" src="https://user-images.githubusercontent.com/58915422/169500495-3ec031d8-def0-423c-be08-e69cc4f75f5e.png">

- Constater le message d'erreur suivant (vu avec Emmy): Une erreur est survenue. Veuillez recommencer ou contacter le support.