### PR TITLE
[A11Y] Ajouter un alt au résultat par palier(Pix-4846)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-stage.hbs
+++ b/orga/app/components/campaign/charts/participants-by-stage.hbs
@@ -9,8 +9,8 @@
             @count={{stage.index}}
             @total={{this.totalStage}}
             @color="blue"
+            @alt={{t "charts.participants-by-stage.label-a11y" stage=stage.index totalStage=this.totalStage}}
             class="participants-by-stage__stars"
-            aria-hidden="true"
           />
           <div class="participants-by-stage__values">
             {{t "charts.participants-by-stage.participants" count=stage.value}}

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^14.1.1",
+    "@1024pix/pix-ui": "^14.3.1",
     "@ember/optional-features": "^2.0.0",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",
     "@formatjs/intl-locale": "^2.4.14",

--- a/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
@@ -1,13 +1,14 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Campaign::Charts::ParticipantsByStage', function (hooks) {
   setupIntlRenderingTest(hooks);
   const campaignId = 1;
-  let onSelectStage, dataFetcher;
+  let onSelectStage, dataFetcher, screen;
 
   hooks.beforeEach(async function () {
     // given
@@ -31,7 +32,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
     });
 
     // when
-    await render(
+    screen = await render(
       hbs`<Campaign::Charts::ParticipantsByStage @campaignId={{campaignId}} @onSelectStage={{onSelectStage}} />`
     );
   });
@@ -51,6 +52,12 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
     // then
     assert.contains('0 %');
     assert.contains('100 %');
+  });
+
+  test('should render a screen reader message', async function (assert) {
+    // then
+    assert.dom(screen.getByRole('img', { name: '0 étoile sur 1' })).exists();
+    assert.dom(screen.getByRole('img', { name: '1 étoile sur 1' })).exists();
   });
 
   test('it should not display empty tooltip', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -90,7 +90,8 @@
       "loader": "Loading and sorting the participants grouped by success rates",
       "participants": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}}",
       "percentage": "{percentage} %",
-      "title": "Distribution of participants grouped by success rate"
+      "title": "Distribution of participants grouped by success rate",
+      "label-a11y": "{stage} out of {totalStage} stars"
     },
     "participants-by-status": {
       "labels-tooltip": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -90,7 +90,8 @@
       "loader": "Chargement de la répartition des participants par paliers",
       "participants": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}}",
       "percentage": "{percentage} %",
-      "title": "Répartition des participants par paliers"
+      "title": "Répartition des participants par paliers",
+      "label-a11y": "{stage, plural, =0 {0 étoile} =1 {1 étoile} other {{stage, number} étoiles}} sur {totalStage}"
     },
     "participants-by-status": {
       "labels-tooltip": {


### PR DESCRIPTION
## :unicorn: Problème
Suite à un audit accessibilité réalisé sur Pix Orga, on nous a remonté que dans l'onglet "Résultat", les groupes d'étoile qui indiquent le palier atteint, ne sont pas lisibles par les lecteurs d'écran.

## :robot: Solution
Ajouter un alt qui contient la description du palier atteint.

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à Pix Orga et sélectionner une campagne avec paliers.
- Aller dans l'onglet "Résultat" et constater la présence de alt qui indique le palier atteint.
