### PR TITLE
[FEATURE] Prévenir l'ajout individuel de candidat une fois la session finalisée (PIX-4959).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -414,6 +414,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }
 
+  if (error instanceof DomainErrors.CertificationCandidateOnFinalizedSessionError) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
+
   if (error instanceof DomainErrors.SchoolingRegistrationCannotBeDissociatedError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -186,6 +186,7 @@ class AuthenticationKeyExpired extends DomainError {
     super(message);
   }
 }
+
 class AccountRecoveryDemandExpired extends DomainError {
   constructor(message = 'This account recovery demand has expired.') {
     super(message);
@@ -338,6 +339,7 @@ class DeprecatedCertificationIssueReportCategoryError extends DomainError {
     super(message);
   }
 }
+
 class DeprecatedCertificationIssueReportSubcategoryError extends DomainError {
   constructor(message = 'La sous-catégorie de signalement choisie est dépréciée.') {
     super(message);
@@ -392,6 +394,12 @@ class SupervisorAccessNotAuthorizedError extends DomainError {
   constructor(
     message = "Cette session est organisée dans un centre de certification pour lequel l'espace surveillant n'a pas été activé par Pix."
   ) {
+    super(message);
+  }
+}
+
+class CertificationCandidateOnFinalizedSessionError extends DomainError {
+  constructor(message = "Cette session a déjà été finalisée, l'ajout de candidat n'est pas autorisé") {
     super(message);
   }
 }
@@ -1119,6 +1127,7 @@ module.exports = {
   CertificateVerificationCodeGenerationTooManyTrials,
   NoCertificationAttestationForDivisionError,
   CertificationBadgeForbiddenDeletionError,
+  CertificationCandidateOnFinalizedSessionError,
   CertificationCandidateAddError,
   CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -90,6 +90,10 @@ class Session {
   isSupervisable(supervisorPassword) {
     return this.supervisorPassword === supervisorPassword;
   }
+
+  canEnrollCandidate() {
+    return _.isNull(this.finalizedAt);
+  }
 }
 
 module.exports = Session;

--- a/api/lib/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/lib/domain/usecases/add-certification-candidate-to-session.js
@@ -2,6 +2,7 @@ const {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CpfBirthInformationValidationError,
   CertificationCandidateAddError,
+  CertificationCandidateOnFinalizedSessionError,
 } = require('../errors');
 
 module.exports = async function addCertificationCandidateToSession({
@@ -15,6 +16,12 @@ module.exports = async function addCertificationCandidateToSession({
   certificationCpfCityRepository,
 }) {
   certificationCandidate.sessionId = sessionId;
+
+  const session = await sessionRepository.get(sessionId);
+  if (!session.canEnrollCandidate()) {
+    throw new CertificationCandidateOnFinalizedSessionError();
+  }
+
   const isSco = await sessionRepository.isSco({ sessionId });
 
   try {

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -30,9 +30,9 @@ module.exports = {
     return Boolean(session);
   },
 
-  async get(idSession) {
+  async get(sessionId) {
     try {
-      const session = await BookshelfSession.where({ id: idSession }).fetch();
+      const session = await BookshelfSession.where({ id: sessionId }).fetch();
       return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, session);
     } catch (err) {
       if (err instanceof BookshelfSession.NotFoundError) {
@@ -42,8 +42,8 @@ module.exports = {
     }
   },
 
-  async getWithCertificationCandidates(idSession) {
-    const session = await knex.from('sessions').where({ 'sessions.id': idSession }).first();
+  async getWithCertificationCandidates(sessionId) {
+    const session = await knex.from('sessions').where({ 'sessions.id': sessionId }).first();
 
     if (!session) {
       throw new NotFoundError("La session n'existe pas ou son accès est restreint");
@@ -68,7 +68,7 @@ module.exports = {
         'complementary-certification-subscriptions.complementaryCertificationId'
       )
       .groupBy('certification-candidates.id')
-      .where({ sessionId: idSession })
+      .where({ sessionId })
       .orderByRaw('LOWER(??) ASC, LOWER(??) ASC', ['lastName', 'firstName']);
 
     return _toDomain({ ...session, certificationCandidates });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -21,6 +21,7 @@ const {
   UncancellableOrganizationInvitationError,
   SchoolingRegistrationCannotBeDissociatedError,
   UserShouldNotBeReconciledOnAnotherAccountError,
+  CertificationCandidateOnFinalizedSessionError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -393,6 +394,19 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate PreconditionFailedError when CertificationCandidateOnFinalizedSessionError', async function () {
+      // given
+      const error = new CertificationCandidateOnFinalizedSessionError();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
     });
   });
 });

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -231,6 +231,30 @@ describe('Unit | Domain | Models | Session', function () {
       expect(isSupervisable).to.be.false;
     });
   });
+
+  context('#canEnrollCandidate', function () {
+    it('should return true when session is not finalized', function () {
+      // given
+      const session = domainBuilder.buildSession.created();
+
+      // when
+      const result = session.canEnrollCandidate();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when session is not finalized', function () {
+      // given
+      const session = domainBuilder.buildSession.finalized();
+
+      // when
+      const result = session.canEnrollCandidate();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
 });
 
 context('#generateSupervisorPassword', function () {


### PR DESCRIPTION
## :unicorn: Problème
Il est possible d’ajouter un candidat manuellement (SCO ou pas) après que la session soit finalisée.
Ce candidat ne pourra pas rejoindre la session : il sera bloqué dans l'écran pour la rejoindre (à vérifier).

Si un appel support nous parvient en disant que ce candidat n’a pas pu rejoindre son parcours, il n’est pas évident de penser à vérifier s’il a été inscrit après finalisation de la session

## :robot: Solution
Empêcher la création en la rejetant côté API

:warning:  @asrodride Je mets la PR en Blocked en attendant ta confirmation

## :rainbow: Remarques
Le cas de l'inscription SCO n'est pas gérée dans cette PR
api/lib/domain/usecases/enroll-students-to-session.js

Le message affiché à l'utilisateur n'est pas explicite

## :100: Pour tester
Inscrire un candidat.

Rejoindre le parcours.

Finaliser la session.

Ajouter un candidat, [par exemple en RA](https://certif-pr4440.review.pix.fr/sessions/20000/candidats)

Constater 
- le message d'erreur côté IHM `Une erreur s'est produite lors de l'ajout du candidat`
- que le candidat n'a pas été ajoutée en BDD

![image](https://user-images.githubusercontent.com/56302715/168566407-296dd170-0eca-4d3e-b095-46197ad2227b.png)

