### PR TITLE
[FEATURE] Déplacement du bouton de fermeture du menu burger sur mobile/tablette (PIX-4958).

### DIFF
--- a/mon-pix/app/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/components/navbar-burger-menu.hbs
@@ -2,9 +2,18 @@
   <div class="navbar-burger-menu__navigation">
 
     {{#if this.currentUser.user}}
-      <p class="navbar-burger-menu-navigation__name">
-        {{this.currentUser.user.fullName}}
-      </p>
+      <div class="navbar-burger-menu-navigation__header">
+        <p class="navbar-burger-menu-navigation-header__name">
+          {{this.currentUser.user.fullName}}
+        </p>
+        <button
+          {{on "click" @burger.state.actions.toggle}}
+          class="navbar-burger-menu-navigation-header__close"
+          type="button"
+        >
+          <FaIcon @icon="xmark" />
+        </button>
+      </div>
     {{/if}}
     <ul class="navbar-burger-menu-navigation__list">
       <li class="navbar-burger-menu-navigation__item">

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -3,11 +3,11 @@
   <div class="navbar-mobile-header__container">
     {{#if @burger}}
       {{#if this.isUserLogged}}
-        <span class="navbar-mobile-header__burger-icon" {{action @burger.state.actions.toggle}}>
+        <button class="navbar-mobile-header__burger-icon" {{action @burger.state.actions.toggle}} type="button">
           {{#unless @burger.state.open}}
             <FaIcon @icon="bars" />
           {{/unless}}
-        </span>
+        </button>
 
         {{#@burger.menu as |menu|}}
           <NavbarBurgerMenu class="navbar-burger-menu-content" @burger={{@burger}} />

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -1,9 +1,9 @@
-{{! template-lint-disable no-implicit-this no-action no-curly-component-invocation no-invalid-interactive no-unused-block-params }}
+{{! template-lint-disable no-implicit-this no-curly-component-invocation no-invalid-interactive no-unused-block-params }}
 <div class="navbar-mobile-header">
   <div class="navbar-mobile-header__container">
     {{#if @burger}}
       {{#if this.isUserLogged}}
-        <button class="navbar-mobile-header__burger-icon" {{action @burger.state.actions.toggle}} type="button">
+        <button class="navbar-mobile-header__burger-icon" {{on "click" @burger.state.actions.toggle}} type="button">
           {{#unless @burger.state.open}}
             <FaIcon @icon="bars" />
           {{/unless}}

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -4,15 +4,13 @@
     {{#if @burger}}
       {{#if this.isUserLogged}}
         <span class="navbar-mobile-header__burger-icon" {{action @burger.state.actions.toggle}}>
-          {{#if @burger.state.open}}
-            <FaIcon @icon="xmark" />
-          {{else}}
+          {{#unless @burger.state.open}}
             <FaIcon @icon="bars" />
-          {{/if}}
+          {{/unless}}
         </span>
 
         {{#@burger.menu as |menu|}}
-          <NavbarBurgerMenu class="navbar-burger-menu-content" />
+          <NavbarBurgerMenu class="navbar-burger-menu-content" @burger={{@burger}} />
         {{/@burger.menu}}
       {{/if}}
     {{/if}}

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -70,15 +70,11 @@
 
 .navbar-burger-menu-navigation {
 
-  &__name {
-    font-size: 1.25rem;
-    font-weight: $font-semi-bold;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    padding: 6px 32px;
-    color: $grey-70;
-    margin: 0 0 20px 0;
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-right: 32px;
   }
 
   &__list {
@@ -90,6 +86,29 @@
     list-style: none;
     padding: 12px 0;
     margin: 5px 0;
+  }
+}
+
+.navbar-burger-menu-navigation-header {
+
+  &__name {
+    font-size: 1.25rem;
+    font-weight: $font-semi-bold;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    padding: 6px 32px;
+    color: $grey-70;
+    margin: 0 0 20px 0;
+  }
+
+  &__close {
+    margin-bottom: 20px;
+    background: none;
+    cursor: pointer;
+    color: $grey-50;
+    font-size: 1.25rem;
+    border: none;
   }
 }
 

--- a/mon-pix/app/styles/components/_navbar-mobile-header.scss
+++ b/mon-pix/app/styles/components/_navbar-mobile-header.scss
@@ -10,6 +10,8 @@
 
   &__burger-icon {
     padding: 0;
+    background: none;
+    border: none;
     color: $grey-70;
     font-size: 1.625rem;
     display: inline-flex;

--- a/mon-pix/tests/integration/components/navbar-burger-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu_test.js
@@ -26,6 +26,14 @@ describe('Integration | Component | navbar-burger-menu', function () {
     expect(contains('Bobby Carotte')).to.exist;
   });
 
+  it('should display the closing button', async function () {
+    // when
+    await render(hbs`<NavbarBurgerMenu />`);
+
+    // then
+    expect(find('.navbar-burger-menu-navigation-header__close')).to.exist;
+  });
+
   it('should display the navigation menu with "Home", "Skills", "Certification", "My tutorials" and "I have a code" links', async function () {
     // when
     await render(hbs`<NavbarBurgerMenu />`);


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on navigue sur pix-app sur tablette en format mobile/tablette, il est possible de remarquer que le bouton de fermeture du menu burger ne se trouve pas à l'intérieur de celui-ci, ce qui entraine des problèmes d'accessibilité en plus d'être disgracieux.

## :robot: Solution

Nous déplaçons le bouton de fermeture à l'intérieur du composant `navbar-burger-menu`.

## :rainbow: Remarques

⚠️ **Je n'ai pas réussi à tester la fermeture du menu en intégration.**
--> Preneur d'une solution si quelqu'un a une idée.

Nous profitons de cette PR pour rendre le menu burger plus accessible dans un second commit en remplaçant la balise `<span>` par un `button` afin d'améliorer la navigation au clavier.

## :100: Pour tester

Sur pix-app en version mobile:
- ouvrir le menu burger
- vérifier qu'il est possible de le fermer en cliquant sur la croix
- constater l'amélioration globale de la navigation au clavier
