### PR TITLE
[BUGFIX] Recharger l'utilisateur après le partage d'une campagne afin de ne plus garder dans les données de la dernière campagne non partagé  (PIX-4923)

### DIFF
--- a/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class SendProfileController extends Controller {
   @service intl;
+  @service currentUser;
 
   @tracked errorMessage = null;
 
@@ -21,6 +22,7 @@ export default class SendProfileController extends Controller {
 
     try {
       await campaignParticipation.save();
+      await this.currentUser.load();
     } catch (errorResponse) {
       campaignParticipation.rollbackAttributes();
       this._handleCampaignParticipationSaveErrors(errorResponse.errors);

--- a/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
@@ -24,11 +24,16 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
     campaignParticipation,
   };
   let controller;
+  let currentUserStub;
 
   beforeEach(function () {
     controller = this.owner.lookup('controller:campaigns.profiles-collection.send-profile');
+    currentUserStub = { load: sinon.stub() };
+
     controller.model = model;
+    controller.set('currentUser', currentUserStub);
     campaignParticipation.save.resolves(campaignParticipationShared);
+    currentUserStub.load.resolves();
   });
 
   describe('#isDisabled', function () {
@@ -65,6 +70,14 @@ describe('Unit | Controller | campaigns/profiles-collection/send-profile', funct
 
       // then
       expect(controller.model.campaignParticipation.isShared).to.equal(true);
+    });
+
+    it('should call load from currentUser', async function () {
+      // when
+      await controller.actions.sendProfile.call(controller);
+
+      // then
+      sinon.assert.called(currentUserStub.load);
     });
 
     it('should not be loading nor in error', async function () {


### PR DESCRIPTION
## :unicorn: Problème
la donnée utilisé pour savoir si nous avons une campagne non partagé et récupéré directement dans le get/user, ce qui ne permet pas de cacher le bandeau un fois la campagne partagé à moins de recharger l'application

## :robot: Solution
Après avoir partagé, faire un load du user afin d'avoir le model à jour

## :rainbow: Remarques
Il serait peut être judicieux de sortir des données qui sont potentiellement "volatile" afin de ne pas avoir a refaire un appel API. 

## :100: Pour tester
Se connecter avec `jaune.attend@example.net`, vérifier que le bandeau n'est pas présent. Commencez une campagne de collecte juste avant de la partager. Retourner sur la page d'accueil vérifier que le bandeau est présent. 

Partagé la campagne vérifier que le bandeau a bien disparu