### PR TITLE
[FEATURE] Ajouter un message d'information pour le champ "Email du destinataire" dans la modale d'ajout d'un candidat (PIX-4910).

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -212,10 +212,7 @@
         />
       </div>
 
-      <div
-        id="recipient-email-container"
-        class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-      >
+      <div id="recipient-email-container" class="new-certification-candidate-modal__form__field">
         <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur,
           enseignant...)</label>
         <Input
@@ -225,12 +222,14 @@
           @value={{@candidateData.resultRecipientEmail}}
           {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
         />
+        <div class="new-certification-candidate-modal__form__field__info-panel">
+          <FaIcon @icon="info-circle" />
+          <span>Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats
+            concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.</span>
+        </div>
       </div>
 
-      <div
-        id="email-container"
-        class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-      >
+      <div id="email-container" class="new-certification-candidate-modal__form__field">
         <label for="email" class="label">E-mail de convocation</label>
         <Input
           id="email"

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -83,6 +83,17 @@
         }
       }
 
+      &__info-panel {
+        align-items: center;
+        background-color: $blue-alert-light;
+        border-radius: 4px;
+        color: $blue-alert-dark;
+        display: flex;
+        gap: 16px;
+        margin-top: 8px;
+        padding: 12px 16px;
+      }
+
       .complementary-certifications-checkbox-list {
         display: flex;
 
@@ -104,10 +115,6 @@
         }
       }
     }
-  }
-
-  #email-container {
-    padding-top: 18px;
   }
 
   &__actions {

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -71,6 +71,14 @@ module('Integration | Component | new-certification-candidate-modal', function (
     assert.dom(screen.getByLabelText('Identifiant externe')).exists();
     assert.dom(screen.getByLabelText('Temps majoré (%)')).exists();
     assert.dom(screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)')).exists();
+    assert
+      .dom(
+        screen.getByText(
+          'Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.Le candidat verra ses résultats affichés directement sur son compte Pix.',
+          { exact: false }
+        )
+      )
+      .exists();
     assert.dom(screen.getByLabelText('E-mail de convocation')).exists();
     assert.dom(screen.getByLabelText('Certif complémentaire 1')).exists();
     assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
@@ -133,6 +141,14 @@ module('Integration | Component | new-certification-candidate-modal', function (
       assert.dom(screen.getByLabelText('Identifiant externe')).exists();
       assert.dom(screen.getByLabelText('Temps majoré (%)')).exists();
       assert.dom(screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)')).exists();
+      assert
+        .dom(
+          screen.getByText(
+            'Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.Le candidat verra ses résultats affichés directement sur son compte Pix.',
+            { exact: false }
+          )
+        )
+        .exists();
       assert.dom(screen.getByLabelText('E-mail de convocation')).exists();
       assert.dom(screen.getByLabelText('Certif complémentaire 1')).exists();
       assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();


### PR DESCRIPTION
## :unicorn: Problème
Le champ “E-mail du destinataire des résultats” permet à un prescripteur de certif de recevoir le fichier csv de ses candidats. Néanmoins, ce champ n’est pas obligatoire, car certains prescripteurs ne souhaitent PAS recevoir les résultats de leur public, dans quel cas ils peuvent laisser ce champ vide. Parfois, ce champ n’est pas rempli alors que le prescripteur souhaitait recevoir les résultats des candidats. Donc il contacte a posteriori le support en demandant les résultats, ce qui créé une charge de travail supplémentaire pour les pôles support/certif, qui aurait pu être évité si ce champ avait correctement été rempli.

## :robot: Solution
Ajouter un message d'information en dessous du champ "Email du destinataire".

## :100: Pour tester
- Dans Pix Certif, créer une session de certification.
- Ouvrir la modale d'ajout d'un candidat.
- Vérifier la présence du message d'information.