### PR TITLE
[FEATURE] Modifier le design du bouton d'ajout d'un signalement (PIX-4911).

### DIFF
--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -48,7 +48,8 @@
                   class="button--showed-as-link add-button"
                   {{on "click" (fn this.openIssueReportsModal report)}}
                 >
-                  Ajouter / modifier
+                  <FaIcon @icon="plus-circle" />
+                  Ajouter / supprimer
                 </button>
                 <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}">
                   {{#if (gt report.certificationIssueReports.length 1)}}
@@ -64,7 +65,8 @@
                   class="button--showed-as-link add-button"
                   {{on "click" (fn this.openAddIssueReportModal report)}}
                 >
-                  Ajouter ?
+                  <FaIcon @icon="plus-circle" />
+                  Ajouter
                 </button>
               {{/if}}
             </div>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -62,7 +62,8 @@
                   class="button--showed-as-link add-button"
                   {{on "click" (fn this.openIssueReportsModal report)}}
                 >
-                  Ajouter / modifier
+                  <FaIcon @icon="plus-circle" />
+                  Ajouter / supprimer
                 </button>
                 <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}">
                   {{#if (gt report.certificationIssueReports.length 1)}}
@@ -78,7 +79,8 @@
                   class="button--showed-as-link add-button"
                   {{on "click" (fn this.openAddIssueReportModal report)}}
                 >
-                  Ajouter ?
+                  <FaIcon @icon="plus-circle" />
+                  Ajouter
                 </button>
               {{/if}}
             </div>

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -58,7 +58,19 @@
     display: flex;
 
     .add-button {
-      font-size: 13px;
+      color: $grey-70;
+      display: flex;
+      gap: 4px;
+      align-items: center;
+
+      svg {
+        font-size: 1.125rem;
+      }
+    }
+
+    p {
+      color: $grey-70;
+      font-weight: 700;
     }
   }
 

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -101,9 +101,9 @@ module('Acceptance | Session Finalization', function (hooks) {
 
     module('When certificationPointOfContact click on "Finaliser" button', function () {
       module('when there is no certification issue reports', function () {
-        test('it should show "Ajouter ?" button', async function (assert) {
+        test('it should show "Ajouter" button', async function (assert) {
           // given
-          const expectedText = 'Ajouter ?';
+          const expectedText = 'Ajouter';
           const certificationReportsWithoutIssueReport = server.create('certification-report', {
             certificationCourseId: 1,
           });
@@ -121,10 +121,10 @@ module('Acceptance | Session Finalization', function (hooks) {
       });
 
       module('when we add a certification issue report', function () {
-        test('it should show "Ajouter / modifier" button', async function (assert) {
+        test('it should show "Ajouter / supprimer" button', async function (assert) {
           // given
-          const expectedTextWithIssueReport = 'Ajouter / modifier';
-          const expectedTextWithoutIssueReport = 'Ajouter ?';
+          const expectedTextWithIssueReport = 'Ajouter / supprimer';
+          const expectedTextWithoutIssueReport = 'Ajouter';
           const BTN_ADD_ISSUE_REPORT_FOR_CERTIFICATION_COURSE_1 =
             '[data-test-id="finalization-report-certification-issue-reports_1"] .button--showed-as-link';
           const BTN_ADD_ISSUE_REPORT_FOR_CERTIFICATION_COURSE_2 =

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -200,7 +200,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
           @onChangeAbortReason = {{this.abort}}
         />
       `);
-    await clickByLabel('Ajouter / modifier');
+    await clickByLabel('Ajouter / supprimer');
 
     // then
     assert.contains('Mes signalements (1)');
@@ -232,7 +232,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
         />
       `);
 
-    await clickByLabel('Ajouter ?');
+    await clickByLabel('Ajouter');
 
     // then
     assert.contains('Retard, absence ou départ');


### PR DESCRIPTION
## :unicorn: Problème
Certains signalements remontés sur le PV d’incident, puis sur la page de finalisation de session, ne sont pas pertinents, notamment car certains utilisateurs n’utilisent pas la bonne catégorie de signalement.

## :robot: Solution
Mettre plus en valeur le bouton d’ajout d’un signalement individuel, pour inciter au maximum les utilisateurs à utiliser cette fonctionnalité plutôt que d’être tenté d’utiliser un champ texte libre.

## :100: Pour tester
- Dans Pix Certif, créer une session.
- Ajouter deux candidats.
- Passer une certification complète pour l'un des candidats et une certification incomplète pour l'autre candidat.
- Aller sur la page de finalisation de la session.
- Vérifier l'affichage du bouton "Ajouter" quand il n'y a pas de signalement et le bouton "Ajouter / supprimer" quand il y a un ou plusieurs signalements.