### PR TITLE
[FEATURE] Création d'un gabarit avec sujets/niveaux lors de celle d'un profil cible (PIX-4927).

### DIFF
--- a/admin/app/controllers/authenticated/target-profiles/new.js
+++ b/admin/app/controllers/authenticated/target-profiles/new.js
@@ -33,10 +33,15 @@ export default class NewController extends Controller {
     try {
       const json = JSON.parse(event.target.result);
       const skillIds = json.flatMap((tube) => tube.skills);
+      const templateTubes = json.map(({ id, level }) => ({
+        id,
+        level,
+      }));
       if (skillIds.length === 0) {
         throw new Error('Ce fichier ne contient aucun acquis !');
       }
       this.isFileInvalid = false;
+      this.model.templateTubes = templateTubes;
       this.model.skillIds = skillIds;
     } catch (e) {
       this.isFileInvalid = true;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -27,6 +27,7 @@ export default class TargetProfile extends Model {
   @attr('string') category;
   @attr('boolean') isSimplifiedAccess;
   @attr('array') skillIds;
+  @attr('array') templateTubes;
 
   @hasMany('badge') badges;
   @hasMany('stage') stages;

--- a/admin/tests/unit/controllers/authenticated/target-profiles/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/new_test.js
@@ -60,13 +60,19 @@ module('Unit | Controller | authenticated/target-profiles/new', function (hooks)
         controller.isFileInvalid = true;
         const event = {
           target: {
-            result: [{ skills: ['skill1'] }, { skills: ['skill2'] }],
+            result: [
+              { id: 'tube-1', level: 7, skills: ['skill1'] },
+              { id: 'tube-2', level: 5, skills: ['skill2'] },
+            ],
           },
         };
-        const skillsList = [{ skills: ['skill1'] }, { skills: ['skill2'] }];
+        const selectionTubeList = [
+          { id: 'tube-1', level: 7, skills: ['skill1'] },
+          { id: 'tube-2', level: 5, skills: ['skill2'] },
+        ];
 
         // when
-        sinon.stub(JSON, 'parse').returns(skillsList);
+        sinon.stub(JSON, 'parse').returns(selectionTubeList);
         controller._onFileLoad(event);
       });
 
@@ -76,6 +82,12 @@ module('Unit | Controller | authenticated/target-profiles/new', function (hooks)
 
       test('it should fill skillIds list', function (assert) {
         assert.deepEqual(controller.model.skillIds, ['skill1', 'skill2']);
+      });
+      test('it should fill templateTubes list', function (assert) {
+        assert.deepEqual(controller.model.templateTubes, [
+          { id: 'tube-1', level: 7 },
+          { id: 'tube-2', level: 5 },
+        ]);
       });
     });
 

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -170,6 +170,7 @@ exports.register = async (server) => {
                 'skill-ids': Joi.array().required(),
                 comment: Joi.string().optional().allow(null).max(500).empty(''),
                 description: Joi.string().optional().allow(null).max(500).empty(''),
+                'template-tubes': Joi.array().required(),
               },
             },
           }),
@@ -181,7 +182,7 @@ exports.register = async (server) => {
         tags: ['api', 'target-profiles', 'create'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de créer un profil cible avec ses acquis',
+            "- Elle permet de créer un profil cible avec ses acquis ainsi qu'un gabarit de ce profil cible",
         ],
       },
     },

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -74,10 +74,13 @@ module.exports = {
   },
 
   async createTargetProfile(request) {
-    const targetProfileData = targetProfileSerializer.deserialize(request.payload);
+    const { targetProfileData, targetProfileTemplateData } = targetProfileSerializer.deserialize(request.payload);
 
-    const targetProfile = await usecases.createTargetProfile({ targetProfileData });
-
+    const targetProfileTemplate = await usecases.createTemplateTargetProfile({
+      targetProfileData,
+      targetProfileTemplateData,
+    });
+    const targetProfile = targetProfileTemplate.targetProfiles[0];
     return targetProfileWithLearningContentSerializer.serialize(targetProfile);
   },
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -215,6 +215,7 @@ module.exports = injectDependencies(
     createStage: require('./create-stage'),
     createTag: require('./create-tag'),
     createTargetProfile: require('./create-target-profile'),
+    createTemplateTargetProfile: require('./create-template-target-profile-and-target-profile'),
     createUser: require('./create-user'),
     createUserAndReconcileToOrganizationLearnerFromExternalUser: require('./create-user-and-reconcile-to-organization-learner-from-external-user'),
     createUserFromCnav: require('./authentication/create-user-from-cnav'),

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -10,14 +10,17 @@ module.exports = {
 
   deserialize(json) {
     return {
-      name: json.data.attributes['name'],
-      ownerOrganizationId: json.data.attributes['owner-organization-id'],
-      isPublic: json.data.attributes['is-public'],
-      imageUrl: json.data.attributes['image-url'],
-      skillIds: json.data.attributes['skill-ids'],
-      comment: json.data.attributes['comment'],
-      description: json.data.attributes['description'],
-      category: json.data.attributes['category'],
+      targetProfileData: {
+        name: json.data.attributes['name'],
+        ownerOrganizationId: json.data.attributes['owner-organization-id'],
+        isPublic: json.data.attributes['is-public'],
+        imageUrl: json.data.attributes['image-url'],
+        skillIds: json.data.attributes['skill-ids'],
+        comment: json.data.attributes['comment'],
+        description: json.data.attributes['description'],
+        category: json.data.attributes['category'],
+      },
+      targetProfileTemplateData: { tubes: json.data.attributes['template-tubes'] },
     };
   },
 };

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -83,6 +83,10 @@ describe('Acceptance | Controller | target-profile-controller', function () {
               'owner-organization-id': null,
               'skill-ids': [skillId],
               comment: 'comment',
+              'template-tubes': [
+                { id: 'tubeId1', level: 5 },
+                { id: 'tubeId2', level: 7 },
+              ],
             },
           },
         },

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -4,7 +4,7 @@ const securityPreHandlers = require('../../../../lib/application/security-pre-ha
 const targetProfileController = require('../../../../lib/application/target-profiles/target-profile-controller');
 const moduleUnderTest = require('../../../../lib/application/target-profiles');
 
-describe('Integration | Application | Target Profiles | Routes', function () {
+describe('Unit | Application | Target Profiles | Routes', function () {
   describe('POST /api/target-profiles', function () {
     it('should resolve with owner organization id to null', async function () {
       // given
@@ -24,6 +24,12 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             'is-public': false,
             'skill-ids': ['skill1', 'skill2'],
             comment: 'comment',
+            'template-tubes': [
+              {
+                id: 'tube1',
+                level: 7,
+              },
+            ],
           },
         },
       };
@@ -53,6 +59,12 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             'is-public': false,
             'skill-ids': ['skill1', 'skill2'],
             comment: 'comment',
+            'template-tubes': [
+              {
+                id: 'tube1',
+                level: 7,
+              },
+            ],
           },
         },
       };
@@ -79,6 +91,12 @@ describe('Integration | Application | Target Profiles | Routes', function () {
             'is-public': false,
             'skill-ids': ['skill1', 'skill2'],
             comment: 'comment',
+            'template-tubes': [
+              {
+                id: 'tube1',
+                level: 7,
+              },
+            ],
           },
         },
       };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -47,13 +47,17 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       const json = {
         data: {
           id: '12',
-          type: 'target-profiles',
+          type: 'target-profile-templates',
           attributes: {
             name: 'Les compétences de BRO 2.0',
             'is-public': false,
             'owner-organization-id': 12,
             'skill-ids': ['skillId1', 'skillIds2'],
             'image-url': 'superImage.png',
+            'template-tubes': [
+              { id: 'tubeId1', level: 5 },
+              { id: 'tubeId2', level: 7 },
+            ],
             comment: 'Interesting comment',
             description: 'Amazing description',
             category: 'OTHER',
@@ -62,21 +66,29 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       };
 
       const expectTargetProfileObject = {
-        ownerOrganizationId: 12,
-        name: 'Les compétences de BRO 2.0',
-        isPublic: false,
-        imageUrl: 'superImage.png',
-        skillIds: ['skillId1', 'skillIds2'],
-        comment: 'Interesting comment',
-        description: 'Amazing description',
-        category: 'OTHER',
+        targetProfileData: {
+          ownerOrganizationId: 12,
+          name: 'Les compétences de BRO 2.0',
+          isPublic: false,
+          imageUrl: 'superImage.png',
+          skillIds: ['skillId1', 'skillIds2'],
+          comment: 'Interesting comment',
+          description: 'Amazing description',
+          category: 'OTHER',
+        },
+        targetProfileTemplateData: {
+          tubes: [
+            { id: 'tubeId1', level: 5 },
+            { id: 'tubeId2', level: 7 },
+          ],
+        },
       };
 
       // when
       const deserializedTargetProfile = serializer.deserialize(json);
 
       // then
-      return expect(deserializedTargetProfile).to.deep.equal(expectTargetProfileObject);
+      expect(deserializedTargetProfile).to.deep.equal(expectTargetProfileObject);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La création d'un profil cible n'entraîne pas la création du gabarit associé avec ses sujets et niveaux.

## :robot: Solution
Envoyer les informations de sujets/niveaux à l'API et utiliser le nouveau usecase de création de profil cible avec gabarit.

## :rainbow: Remarques
N/A

## :100: Pour tester
Créer un profil cible, et vérifier que :
 - la colonne `targetProfileTemplateId` de la table `target-profiles` a bien été valorisée
 - qu'une ligne correspondante a été créée dans `target-profile-templates`
 - que les lignes correspondants aux sujets et leurs niveaux ont été créées dans `target-profile-templates_tubes`