### PR TITLE
[FEATURE] Permettre de rechercher par identifiant dans la liste des utilisateurs sur Pix Admin (PIX-396).

### DIFF
--- a/admin/app/components/campaigns/participation-row.hbs
+++ b/admin/app/components/campaigns/participation-row.hbs
@@ -10,7 +10,7 @@
       <PixInput
         id="participantExternalId"
         type="text"
-        aria-label="Modifier l'identifiant externe du participant"
+        @ariaLabel="Modifier l'identifiant externe du participant"
         value={{@participation.participantExternalId}}
         onchange={{this.handleChange}}
         class="table-admin-input form-control"

--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -5,7 +5,7 @@
         <th class="table__column table__column--id">ID</th>
         <th>Prénom</th>
         <th>Nom</th>
-        <th>Adresse électronique</th>
+        <th>Adresse e-mail</th>
       </tr>
     </thead>
 

--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -6,6 +6,7 @@
         <th>Prénom</th>
         <th>Nom</th>
         <th>Adresse e-mail</th>
+        <th>Identifiant</th>
       </tr>
     </thead>
 
@@ -13,12 +14,15 @@
       <tbody>
         {{#each @users as |user|}}
           <tr aria-label="Informations de l'utilisateur {{user.firstName}} {{user.lastName}}">
-            <td class="table__column table__column--id"><LinkTo @route="authenticated.users.get" @model={{user.id}}>
+            <td class="table__column table__column--id">
+              <LinkTo @route="authenticated.users.get" @model={{user.id}}>
                 {{user.id}}
-              </LinkTo></td>
+              </LinkTo>
+            </td>
             <td>{{user.firstName}}</td>
             <td>{{user.lastName}}</td>
             <td>{{user.email}}</td>
+            <td>{{user.username}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -5,17 +5,19 @@ import { action } from '@ember/object';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'firstName', 'lastName', 'email'];
+  queryParams = ['pageNumber', 'pageSize', 'firstName', 'lastName', 'email', 'username'];
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked firstName = null;
   @tracked lastName = null;
   @tracked email = null;
+  @tracked username = null;
 
   @tracked firstNameForm = null;
   @tracked lastNameForm = null;
   @tracked emailForm = null;
+  @tracked usernameForm = null;
 
   @action
   async refreshModel(event) {
@@ -23,6 +25,7 @@ export default class ListController extends Controller {
     this.firstName = this.firstNameForm;
     this.lastName = this.lastNameForm;
     this.email = this.emailForm;
+    this.username = this.usernameForm;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }
 
@@ -39,5 +42,10 @@ export default class ListController extends Controller {
   @action
   onChangeEmail(event) {
     this.emailForm = event.target.value;
+  }
+
+  @action
+  onChangeUsername(event) {
+    this.usernameForm = event.target.value;
   }
 }

--- a/admin/app/routes/authenticated/users/list.js
+++ b/admin/app/routes/authenticated/users/list.js
@@ -10,16 +10,18 @@ export default class ListRoute extends Route {
     firstName: { refreshModel: true },
     lastName: { refreshModel: true },
     email: { refreshModel: true },
+    username: { refreshModel: true },
   };
 
   async model(params) {
-    if (!params.firstName && !params.lastName && !params.email) return [];
+    if (!params.firstName && !params.lastName && !params.email && !params.username) return [];
 
     return this.store.query('user', {
       filter: {
         firstName: params.firstName ? params.firstName.trim() : '',
         lastName: params.lastName ? params.lastName.trim() : '',
         email: params.email ? params.email.trim() : '',
+        username: params.username ? params.username.trim() : '',
       },
       page: {
         number: params.pageNumber,
@@ -35,6 +37,7 @@ export default class ListRoute extends Route {
       controller.firstName = null;
       controller.lastName = null;
       controller.email = null;
+      controller.username = null;
     }
   }
 }

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -12,6 +12,12 @@
         placeholder="Adresse e-mail"
         @ariaLabel="Adresse e-mail"
       />
+      <PixInput
+        @id="username"
+        {{on "change" this.onChangeUsername}}
+        placeholder="Identifiant"
+        @ariaLabel="Identifiant"
+      />
       <PixButton @size="small" @type="submit">Charger</PixButton>
     </form>
   </div>
@@ -24,6 +30,7 @@
       @firstName={{this.firstName}}
       @lastName={{this.lastName}}
       @email={{this.email}}
+      @username={{this.username}}
     />
   </section>
 </main>

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -4,9 +4,14 @@
   <h1 class="page-title">Rechercher un(des) utilisateur(s)</h1>
   <div class="page-actions">
     <form class="form-inline user-list__form" {{on "submit" this.refreshModel}}>
-      <PixInput @id="firstName" {{on "change" this.onChangeFirstName}} placeholder="Prénom" />
-      <PixInput @id="lastName" {{on "change" this.onChangeLastName}} placeholder="Nom" />
-      <PixInput @id="email" {{on "change" this.onChangeEmail}} placeholder="Adresse e-mail" />
+      <PixInput @id="firstName" {{on "change" this.onChangeFirstName}} placeholder="Prénom" @ariaLabel="Prénom" />
+      <PixInput @id="lastName" {{on "change" this.onChangeLastName}} placeholder="Nom" @ariaLabel="Nom" />
+      <PixInput
+        @id="email"
+        {{on "change" this.onChangeEmail}}
+        placeholder="Adresse e-mail"
+        @ariaLabel="Adresse e-mail"
+      />
       <PixButton @size="small" @type="submit">Charger</PixButton>
     </form>
   </div>

--- a/admin/package.json
+++ b/admin/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^13.3.4",
+    "@1024pix/pix-ui": "^14.0.0",
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
@@ -8,18 +9,20 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  let currentUser;
+  test('should access on user details page by URL /users/:id', async function (assert) {
+    // given
+    const currentUser = await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
-  hooks.beforeEach(async function () {
-    currentUser = await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-  });
-
-  test('User detail page can be accessed by URL /users/:id', async function (assert) {
+    // when
     await visit(`/users/${currentUser.id}`);
+
+    // then
     assert.strictEqual(currentURL(), `/users/${currentUser.id}`);
   });
 
-  test('User detail page can be accessed from user list page', async function (assert) {
+  test('should access on user details page by user search form', async function (assert) {
+    // given
+    const currentUser = await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     const usersListAfterFilteredSearch = {
       data: [
         {
@@ -37,15 +40,22 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     this.server.get('/users', () => usersListAfterFilteredSearch);
 
     // when
-    await visit('/users/list?email=userpix1example.net');
-    await click('tbody > tr:nth-child(1) > td:nth-child(1) > a');
+    const screen = await visit('/users/list?email=userpix1example.net');
+    await click(screen.getByRole('link', { name: '1' }));
+
+    // then
     assert.strictEqual(currentURL(), `/users/${currentUser.id}`);
   });
 
-  test('Should redirect to list users page when click page title', async function (assert) {
+  test('should redirect to list users page when click page title', async function (assert) {
+    // given
+    const currentUser = await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     await visit(`/users/${currentUser.id}`);
-    assert.strictEqual(currentURL(), `/users/${currentUser.id}`);
+
+    // when
     await click('#link-to-users-page');
+
+    // then
     assert.strictEqual(currentURL(), '/users/list');
   });
 });

--- a/admin/tests/acceptance/user-list_test.js
+++ b/admin/tests/acceptance/user-list_test.js
@@ -41,30 +41,65 @@ module('Acceptance | User List', function (hooks) {
       assert.dom(screen.getByText('Aucun résultat')).exists();
     });
 
-    test('it should display the current filter when users are filtered', async function (assert) {
-      // given
-      const result = {
-        data: [
-          {
-            type: 'users',
-            id: '1',
-            attributes: {
-              'first-name': 'Pix',
-              'last-name': 'Aile',
-              email: 'userpix1@example.net',
-            },
-          },
-        ],
-      };
+    module('when users are filtered', function () {
+      module('when user has only username or email', function () {
+        test('it should display the current user', async function (assert) {
+          // given
+          const result = {
+            data: [
+              {
+                type: 'users',
+                id: '1',
+                attributes: {
+                  'first-name': 'Alex',
+                  'last-name': 'Ception',
+                  username: 'alex.pix1030',
+                },
+              },
+            ],
+          };
 
-      this.server.get('/admin/users', () => result);
+          this.server.get('/admin/users', () => result);
 
-      // when
-      const screen = await visit('/users/list?email=example.net');
+          // when
+          const screen = await visit('/users/list?username=alex.pix1030');
 
-      // then
-      assert.dom(screen.getByLabelText("Informations de l'utilisateur Pix Aile")).containsText('userpix1@example.net');
-      assert.strictEqual(screen.queryAllByLabelText("Informations de l'utilisateur", { exact: false }).length, 1);
+          // then
+          assert
+            .dom(screen.getByLabelText("Informations de l'utilisateur Alex Ception"))
+            .hasText('1 Alex Ception alex.pix1030');
+          assert.strictEqual(screen.queryAllByLabelText("Informations de l'utilisateur", { exact: false }).length, 1);
+        });
+      });
+      module('when user has username and email', function () {
+        test('it should display the current user', async function (assert) {
+          // given
+          const result = {
+            data: [
+              {
+                type: 'users',
+                id: '1',
+                attributes: {
+                  'first-name': 'Alex',
+                  'last-name': 'Ception',
+                  email: 'alex.ception@example.net',
+                  username: 'alex.pix1030',
+                },
+              },
+            ],
+          };
+
+          this.server.get('/admin/users', () => result);
+
+          // when
+          const screen = await visit('/users/list?username=alex.pix1030');
+
+          // then
+          assert
+            .dom(screen.getByLabelText("Informations de l'utilisateur Alex Ception"))
+            .hasText('1 Alex Ception alex.ception@example.net alex.pix1030');
+        });
+      });
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/users/list_test.js
+++ b/admin/tests/unit/routes/authenticated/users/list_test.js
@@ -15,6 +15,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
     const expectedQueryArgs = {};
 
     hooks.beforeEach(function () {
+      // given
       route.store.query = sinon.stub().resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
@@ -69,6 +70,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
     let controller;
 
     hooks.beforeEach(function () {
+      // given
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -85,21 +87,11 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.firstName, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.lastName, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.email, null);
+        assert.deepEqual(controller.pageNumber, 1);
+        assert.deepEqual(controller.pageSize, 10);
+        assert.deepEqual(controller.firstName, null);
+        assert.deepEqual(controller.lastName, null);
+        assert.deepEqual(controller.email, null);
         assert.deepEqual(controller.username, null);
       });
     });
@@ -110,21 +102,11 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 'somePageNumber');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 'somePageSize');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.firstName, 'someFirstName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.lastName, 'someLastName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.email, 'someEmail');
+        assert.deepEqual(controller.pageNumber, 'somePageNumber');
+        assert.deepEqual(controller.pageSize, 'somePageSize');
+        assert.deepEqual(controller.firstName, 'someFirstName');
+        assert.deepEqual(controller.lastName, 'someLastName');
+        assert.deepEqual(controller.email, 'someEmail');
         assert.deepEqual(controller.username, 'someUsername');
       });
     });

--- a/admin/tests/unit/routes/authenticated/users/list_test.js
+++ b/admin/tests/unit/routes/authenticated/users/list_test.js
@@ -32,6 +32,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
           firstName: '',
           lastName: '',
           email: '',
+          username: '',
         };
 
         // then
@@ -40,16 +41,18 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
       });
     });
 
-    module('when queryParams filters are  truthy', function () {
+    module('when queryParams filters are truthy', function () {
       test('it should call store.query with filters containing trimmed values', async function (assert) {
         // given
         params.firstName = ' someFirstName';
         params.lastName = 'someLastName ';
         params.email = 'someEmail';
+        params.username = 'someUsername';
         expectedQueryArgs.filter = {
           firstName: 'someFirstName',
           lastName: 'someLastName',
           email: 'someEmail',
+          username: 'someUsername',
         };
 
         // when
@@ -72,6 +75,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         firstName: 'someFirstName',
         lastName: 'someLastName',
         email: 'someEmail',
+        username: 'someUsername',
       };
     });
 
@@ -96,6 +100,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         // TODO: Fix this the next time the file is edited.
         // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.email, null);
+        assert.deepEqual(controller.username, null);
       });
     });
 
@@ -120,6 +125,7 @@ module('Unit | Route | authenticated/users/list', function (hooks) {
         // TODO: Fix this the next time the file is edited.
         // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(controller.email, 'someEmail');
+        assert.deepEqual(controller.username, 'someUsername');
       });
     });
   });

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -29,7 +29,7 @@ exports.register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             '- Elle permet de récupérer & chercher une liste d’utilisateurs\n' +
-            '- Cette liste est paginée et filtrée selon un **firstName**, un **lastName** et/ou un **email** donnés',
+            '- Cette liste est paginée et filtrée selon un **firstName**, un **lastName**, un **email** et **identifiant** donnés',
         ],
         tags: ['api', 'admin', 'user'],
       },

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -566,7 +566,7 @@ function _toDomain(userBookshelf) {
 }
 
 function _setSearchFiltersForQueryBuilder(filter, qb) {
-  const { firstName, lastName, email } = filter;
+  const { firstName, lastName, email, username } = filter;
 
   if (firstName) {
     qb.whereRaw('LOWER("firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
@@ -576,5 +576,8 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
   }
   if (email) {
     qb.whereRaw('email LIKE ?', `%${email.toLowerCase()}%`);
+  }
+  if (username) {
+    qb.whereRaw('LOWER("username") LIKE ?', `%${username.toLowerCase()}%`);
   }
 }

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1016,7 +1016,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
 
   describe('#findPaginatedFiltered', function () {
     context('when there are users in the database', function () {
-      it('should return an Array of Users', async function () {
+      it('should return an array of users', async function () {
         // given
         const filter = {};
         const page = { number: 1, size: 10 };
@@ -1144,6 +1144,37 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       });
     });
 
+    context('when there are multiple users matching the same "username" search pattern', function () {
+      it('should return only users matching "username" if given in filter', async function () {
+        // given
+        each(
+          [
+            { username: 'alex.ception1011' },
+            { username: 'alex.terieur1011' },
+            { username: 'ella.danloss0101' },
+            { username: 'ella.bienhu1011' },
+            { username: 'ella.bienhu2312' },
+          ],
+          (user) => {
+            databaseBuilder.factory.buildUser(user);
+          }
+        );
+        await databaseBuilder.commit();
+        const filter = { username: '1011' };
+        const page = { number: 1, size: 10 };
+
+        // when
+        const { models: matchingUsers } = await userRepository.findPaginatedFiltered({ filter, page });
+
+        // then
+        expect(map(matchingUsers, 'username')).to.have.members([
+          'alex.ception1011',
+          'alex.terieur1011',
+          'ella.bienhu1011',
+        ]);
+      });
+    });
+
     context(
       'when there are multiple users matching the fields "first name", "last name" and "email" search pattern',
       function () {
@@ -1151,14 +1182,14 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           each(
             [
               // Matching users
-              { firstName: 'fn_ok_1', lastName: 'ln_ok_1', email: 'email_ok_1@mail.com' },
-              { firstName: 'fn_ok_2', lastName: 'ln_ok_2', email: 'email_ok_2@mail.com' },
-              { firstName: 'fn_ok_3', lastName: 'ln_ok_3', email: 'email_ok_3@mail.com' },
+              { firstName: 'fn_ok_1', lastName: 'ln_ok_1', email: 'email_ok_1@mail.com', username: 'username_ok0210' },
+              { firstName: 'fn_ok_2', lastName: 'ln_ok_2', email: 'email_ok_2@mail.com', username: 'username_ok1214' },
+              { firstName: 'fn_ok_3', lastName: 'ln_ok_3', email: 'email_ok_3@mail.com', username: 'username_ok1010' },
 
               // Unmatching users
-              { firstName: 'fn_ko_4', lastName: 'ln_ok_4', email: 'email_ok_4@mail.com' },
-              { firstName: 'fn_ok_5', lastName: 'ln_ko_5', email: 'email_ok_5@mail.com' },
-              { firstName: 'fn_ok_6', lastName: 'ln_ok_6', email: 'email_ko_6@mail.com' },
+              { firstName: 'fn_ko_4', lastName: 'ln_ok_4', email: 'email_ok_4@mail.com', username: 'username_ko1309' },
+              { firstName: 'fn_ok_5', lastName: 'ln_ko_5', email: 'email_ok_5@mail.com', username: 'username_ok1911' },
+              { firstName: 'fn_ok_6', lastName: 'ln_ok_6', email: 'email_ko_6@mail.com', username: 'username_ok2010' },
             ],
             (user) => {
               databaseBuilder.factory.buildUser(user);
@@ -1168,9 +1199,9 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           await databaseBuilder.commit();
         });
 
-        it('should return only users matching "first name" AND "last name" AND "email" if given in filter', async function () {
+        it('should return only users matching "first name" AND "last name" AND "email" AND "username" if given in filter', async function () {
           // given
-          const filter = { firstName: 'fn_ok', lastName: 'ln_ok', email: 'email_ok' };
+          const filter = { firstName: 'fn_ok', lastName: 'ln_ok', email: 'email_ok', username: 'username_ok' };
           const page = { number: 1, size: 10 };
           const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
 
@@ -1184,6 +1215,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
             'email_ok_1@mail.com',
             'email_ok_2@mail.com',
             'email_ok_3@mail.com',
+          ]);
+          expect(map(matchingUsers, 'username')).to.have.members([
+            'username_ok0210',
+            'username_ok1214',
+            'username_ok1010',
           ]);
           expect(pagination).to.deep.equal(expectedPagination);
         });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans Pix Admin, dans la parties Utilisateurs, il n'est pas possible de rechercher un utilisateur via son identifiant.

## :robot: Solution
Permettre de rechercher l'utilisateur par son identifiant, par l'ajout d'un nouveau champ de recherche.
Création, dans le tableau des résultats, de la colonne "Identifiant"

## :rainbow: Remarques
- Renommage de la colonne "Adresse éléctronique" en "Adresse e-mail"
- Mise à jour de Pix UI pour ajouter les aria-labels dans les champs qui ne disposent pas de label. ( 1 Breaking-change)
## :100: Pour tester
- Se connecter sur Pix Admin (superadmin@example.net)
- dans le menu de gauche, aller sur Utilisateurs
- Renseigner uniquement un identifiant existant (exemple: blueivy.carter0701)
- Constater que l'utilisateur à bien été trouvé :  ID : 9912 / Blue Ivy Carter
- Recommencer avec l'identifiant tronqué (exemple: blueivy)
- Constater que l'utilisateur à bien été trouvé :  ID : 9912 / Blue Ivy Carter
- Recommencer avec un identifiant tronqué, commun à plusieurs utilisateurs (exemple: Billy)
- Constater que plusieurs utilisateurs s'affichent avec ce mot en commun