### PR TITLE
[BUGFIX] Remettre le style du message d'erreur de connexion en session de certification. (PIX-4984)

### DIFF
--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -47,9 +47,9 @@
       {{/if}}
     </div>
   {{/if}}
-  <p class="certification-start-page__order">
+  <label for="certificationStarterSessionCode" class="certification-start-page__order">
     {{t "pages.certification-start.access-code"}}
-  </p>
+  </label>
   <form autocomplete="off">
     <div class="certification-start-page__session-code-input">
       <Input

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -47,11 +47,11 @@
       {{/if}}
     </div>
   {{/if}}
-  <p class="certification-course-page__order">
+  <p class="certification-start-page__order">
     {{t "pages.certification-start.access-code"}}
   </p>
   <form autocomplete="off">
-    <div class="certification-course-page__session-code-input">
+    <div class="certification-start-page__session-code-input">
       <Input
         required={{true}}
         id="certificationStarterSessionCode"
@@ -61,11 +61,11 @@
         spellcheck={{false}}
       />
       {{#if this.errorMessage}}
-        <div class="certification-course-page__errors">{{this.errorMessage}}</div>
+        <div class="certification-start-page__errors">{{this.errorMessage}}</div>
       {{/if}}
     </div>
 
-    <div class="certification-course-page__field-button">
+    <div class="certification-start-page__field-button">
 
       <PixButton @type="submit" @triggerAction={{this.submit}}>
         {{t "pages.certification-start.actions.submit"}}
@@ -73,7 +73,7 @@
     </div>
   </form>
 
-  <div class="certification-course-page__cgu">
+  <div class="certification-start-page__cgu">
     <p>
       {{t "pages.certification-start.cgu.info"}}
     </p>

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -110,4 +110,29 @@
     color: $grey-70;
     margin-bottom: 4px;
   }
+
+  .certification-course-page {
+
+    &__errors {
+      color: $pure-orange;
+      font-size: 0.875rem;
+      text-align: start;
+      margin: 5px 5px 5px 5px;
+
+      &__list {
+
+        li {
+          text-align: start;
+          list-style: disc;
+          margin: 8px 0 0 16px;
+        }
+      }
+
+      a,
+      a:visited {
+        color: $pure-orange;
+        text-decoration: underline;
+      }
+    }
+  }
 }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -111,7 +111,7 @@
   }
 }
 
-.certification-course-page__order {
+.certification-start-page__order {
   color: $grey-80;
   font-family: $font-open-sans;
   font-weight: $font-light;
@@ -122,7 +122,7 @@
   margin-bottom: 5px;
 }
 
-.certification-course-page__cgu {
+.certification-start-page__cgu {
   color: $grey-80;
   font-size: 0.75rem;
   line-height: 18px;
@@ -130,7 +130,7 @@
   margin: 5px 30px 5px 30px;
 }
 
-.certification-course-page__session-code-input {
+.certification-start-page__session-code-input {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -189,14 +189,14 @@
   }
 }
 
-.certification-course-page__field-button {
+.certification-start-page__field-button {
   display: flex;
   justify-content: center;
   margin-bottom: 25px;
   margin-top: 25px;
 }
 
-.certification-course-page__submit_button {
+.certification-start-page__submit_button {
   white-space: nowrap;
   width: content-box;
   min-width: 150px;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -113,6 +113,7 @@
 
 .certification-start-page__order {
   color: $grey-80;
+  display: block;
   font-family: $font-open-sans;
   font-weight: $font-light;
   font-size: 1.25rem;

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.212.0",
+      "version": "3.216.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^13.5.0",
+        "@1024pix/pix-ui": "^14.3.1",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -206,7 +206,7 @@
     "node_modules/@1024pix/ember-testing-library/node_modules/broccoli-persistent-filter/node_modules/promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
-      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "integrity": "sha512-wx9Chrutvqu1N/NHzTayZjE1BgIwt6SJykQoCOic4IZ9yUDjKyVYrpLa/4YCNsV61eRENfs29hrEquVuB13Zlw==",
       "dev": true,
       "dependencies": {
         "rsvp": "^3.0.14"
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.5.0.tgz",
-      "integrity": "sha512-HXevWYFqcOdCl9QfblYUONsjK/zfpyf+TF6A4pI8P72UOnYeA36ehV9sXrLsqrAniz0GgI+ktOMJmXq8IaxFRw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.3.1.tgz",
+      "integrity": "sha512-uF0ubb2tlUWCupuN4KP/l40mmrGI4IVgfCxOer3mIm1TQcN3lIfb6GAKsE5gEga0c3KoL/xfAUIxqMU4YMc8CA==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -31670,7 +31670,7 @@
     "node_modules/lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
@@ -39500,7 +39500,7 @@
             "promise-map-series": {
               "version": "0.2.3",
               "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
-              "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+              "integrity": "sha512-wx9Chrutvqu1N/NHzTayZjE1BgIwt6SJykQoCOic4IZ9yUDjKyVYrpLa/4YCNsV61eRENfs29hrEquVuB13Zlw==",
               "dev": true,
               "requires": {
                 "rsvp": "^3.0.14"
@@ -39693,9 +39693,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-13.5.0.tgz",
-      "integrity": "sha512-HXevWYFqcOdCl9QfblYUONsjK/zfpyf+TF6A4pI8P72UOnYeA36ehV9sXrLsqrAniz0GgI+ktOMJmXq8IaxFRw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.3.1.tgz",
+      "integrity": "sha512-uF0ubb2tlUWCupuN4KP/l40mmrGI4IVgfCxOer3mIm1TQcN3lIfb6GAKsE5gEga0c3KoL/xfAUIxqMU4YMc8CA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -64720,7 +64720,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true
     },
     "magic-string": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^13.5.0",
+    "@1024pix/pix-ui": "^14.3.1",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { contains } from '../../../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
@@ -84,11 +85,12 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         this.set('campaignParticipationOverview', campaignParticipationOverview);
 
         // when
-        await render(hbs`<CampaignParticipationOverview::Card::Disabled @model={{campaignParticipationOverview}} />`);
+        const screen = await renderScreen(
+          hbs`<CampaignParticipationOverview::Card::Disabled @model={{campaignParticipationOverview}} />`
+        );
 
         // then
-
-        expect(contains('1 étoile sur 3')).to.exist;
+        expect(screen.getByLabelText('1 étoile sur 3')).to.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ended_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ended_test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { contains } from '../../../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
@@ -75,10 +76,12 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Ended
         this.set('campaignParticipationOverview', campaignParticipationOverview);
 
         // when
-        await render(hbs`<CampaignParticipationOverview::Card::Ended @model={{this.campaignParticipationOverview}} />`);
+        const screen = await renderScreen(
+          hbs`<CampaignParticipationOverview::Card::Ended @model={{this.campaignParticipationOverview}} />`
+        );
 
         // then
-        expect(contains('4 étoiles sur 6')).to.exist;
+        expect(screen.getByLabelText('4 étoiles sur 6')).to.exist;
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On a constaté l'absence de style sur les messages d'erreur lors de l'accès à une session de certification.

## :robot: Solution
Le style précédent avait fonctionné mais semblait avoir été ajouté sur le mauvais fichier CSS. Rajouter le style nécessaire dans le bon fichier CSS. 

## :100: Pour tester
- Lancer Pix App avec un profil certifiable
- Faire apparaitre un message d'erreur sur le formulaire d'accès à une session de certification.
- Constater la présence du style sur le message d'erreur qui s'affiche