### PR TITLE
[FEATURE] Filtrer les certifications sélectionnable pour le volet jury coté admin (PIX-4978)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -13,25 +13,6 @@ import ENV from 'pix-admin/config/environment';
 import { tracked } from '@glimmer/tracking';
 
 const PIX_COUNT_BY_LEVEL = 8;
-const options = [
-  {
-    value: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE',
-    label: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
-  },
-  { value: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME', label: 'Pix+ Édu Initiale 1er degré Confirmé' },
-  { value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME', label: 'Pix+ Édu Continue 1er degré Confirmé' },
-  { value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE', label: 'Pix+ Édu Continue 1er degré Avancé' },
-  { value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT', label: 'Pix+ Édu Continue 1er degré Expert' },
-  {
-    value: 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
-    label: 'Pix+ Édu Initiale 2nd degré Initié (entrée dans le métier)',
-  },
-  { value: 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME', label: 'Pix+ Édu Initiale 2nd degré Confirmé' },
-  { value: 'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME', label: 'Pix+ Édu Continue 2nd degré Confirmé' },
-  { value: 'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE', label: 'Pix+ Édu Continue 2nd degré Avancé' },
-  { value: 'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT', label: 'Pix+ Édu Continue 2nd degré Expert' },
-  { value: 'REJECTED', label: 'Rejetée' },
-];
 
 export default class CertificationInformationsController extends Controller {
   // Domain constants
@@ -50,7 +31,10 @@ export default class CertificationInformationsController extends Controller {
   @tracked confirmAction = 'onCandidateResultsSave';
   @tracked isCandidateEditModalOpen = false;
   @tracked displayJuryLevelSelect = false;
-  @tracked juryLevelOptions = options;
+  @tracked juryLevelOptions = [
+    ...this.certification.complementaryCertificationCourseResultsWithExternal.get('allowedExternalLevels'),
+    { value: 'REJECTED', label: 'Rejetée' },
+  ];
   @tracked selectedJuryLevel = null;
 
   // private properties

--- a/admin/app/models/complementary-certification-course-results-with-external.js
+++ b/admin/app/models/complementary-certification-course-results-with-external.js
@@ -5,6 +5,7 @@ export default class ComplementaryCertificationCourseResultsWithExternal extends
   @attr('string') pixResult;
   @attr('string') externalResult;
   @attr('string') finalResult;
+  @attr() allowedExternalLevels;
 
   get isExternalResultEditable() {
     return this.pixResult !== 'Rejetée';

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -280,6 +280,9 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             pixResult: 'Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)',
             externalResult: 'En attente',
             finalResult: 'En attente',
+            allowedExternalLevels: [
+              { value: 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME', label: 'Pix+ Édu Initiale 1er degré Confirmé' },
+            ],
           }
         );
         certification.update({

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
@@ -87,6 +87,47 @@ class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
     throw new Error(`Badges edu incoherent !!! ${this.pixSection.partnerKey} et ${this.externalSection.partnerKey}`);
   }
 
+  get allowedExternalLevels() {
+    const partnerKey = this.pixSection.partnerKey;
+    let filteredBadges;
+    if (this._isInitial1stDegree(partnerKey)) {
+      filteredBadges = pixEdu1stDegreeBadges.filter(this._isInitial1stDegree);
+    }
+    if (this._isContinue1stDegree(partnerKey)) {
+      filteredBadges = pixEdu1stDegreeBadges.filter(this._isContinue1stDegree);
+    }
+    if (this._isInitial2ndDegree(partnerKey)) {
+      filteredBadges = pixEdu2ndDegreeBadges.filter(this._isInitial2ndDegree);
+    }
+    if (this._isContinue2ndDegree(partnerKey)) {
+      filteredBadges = pixEdu2ndDegreeBadges.filter(this._isContinue2ndDegree);
+    }
+
+    if (!filteredBadges.length) {
+      throw new Error('Unknown pix level');
+    }
+
+    return filteredBadges.map((badge) => {
+      return {
+        label: getLabelByBadgeKey(badge),
+        value: badge,
+      };
+    });
+  }
+
+  _isInitial1stDegree(partnerKey) {
+    return partnerKey.startsWith('PIX_EDU_FORMATION_INITIALE_1ER_DEGRE');
+  }
+  _isContinue1stDegree(partnerKey) {
+    return partnerKey.startsWith('PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE');
+  }
+  _isInitial2ndDegree(partnerKey) {
+    return partnerKey.startsWith('PIX_EDU_FORMATION_INITIALE_2ND_DEGRE');
+  }
+  _isContinue2ndDegree(partnerKey) {
+    return partnerKey.startsWith('PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE');
+  }
+
   _getLowestPartnerKeyLabelForPixEdu2ndDegreBadge() {
     const firstIndexOf = pixEdu2ndDegreeBadges.indexOf(this.pixSection.partnerKey);
     const secondIndexOf = pixEdu2ndDegreeBadges.indexOf(this.externalSection.partnerKey);

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -43,7 +43,13 @@ module.exports = {
       },
       complementaryCertificationCourseResultsWithExternal: {
         ref: 'complementaryCertificationCourseId',
-        attributes: ['complementaryCertificationCourseId', 'pixResult', 'externalResult', 'finalResult'],
+        attributes: [
+          'complementaryCertificationCourseId',
+          'pixResult',
+          'externalResult',
+          'finalResult',
+          'allowedExternalLevels',
+        ],
       },
       certificationIssueReports: {
         ref: 'id',

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -327,6 +327,20 @@ describe('Acceptance | API | Certification Course', function () {
           id: '654',
           type: 'complementaryCertificationCourseResultsWithExternals',
           attributes: {
+            'allowed-external-levels': [
+              {
+                label: 'Pix+ Édu 1er degré Confirmé',
+                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+              },
+              {
+                label: 'Pix+ Édu 1er degré Avancé',
+                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+              },
+              {
+                label: 'Pix+ Édu 1er degré Expert',
+                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+              },
+            ],
             'complementary-certification-course-id': 654,
             'external-result': 'Rejetée',
             'final-result': 'Rejetée',

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
@@ -342,7 +342,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
       });
     });
 
-    context('when piw section is acquired and external section is not yet evaluated', function () {
+    context('when pix section is acquired and external section is not yet evaluated', function () {
       it('should return "En attente"', function () {
         // given
         const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
@@ -430,5 +430,176 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         });
       });
     });
+  });
+
+  describe('#allowedExternalLevels', function () {
+    [
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE),
+          },
+          {
+            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE),
+          },
+          {
+            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE),
+          },
+          {
+            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE),
+          },
+          {
+            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT),
+          },
+        ],
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+        expectedLevels: [
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE),
+          },
+          {
+            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT),
+          },
+        ],
+      },
+    ].forEach(({ partnerKey, expectedLevels }) =>
+      context(`when partner key is ${partnerKey}`, function () {
+        it(`should return an array of allowed labels and statuses`, function () {
+          // when
+          const allowedExternalLevels = new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+            pixPartnerKey: partnerKey,
+          }).allowedExternalLevels;
+
+          // then
+          expect(allowedExternalLevels).to.deep.equal(expectedLevels);
+        });
+      })
+    );
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -141,6 +141,20 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             type: 'complementaryCertificationCourseResultsWithExternals',
             id: '1234',
             attributes: {
+              'allowed-external-levels': [
+                {
+                  label: 'Pix+ Édu 1er degré Confirmé',
+                  value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+                },
+                {
+                  label: 'Pix+ Édu 1er degré Avancé',
+                  value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+                },
+                {
+                  label: 'Pix+ Édu 1er degré Expert',
+                  value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+                },
+              ],
               'complementary-certification-course-id': 1234,
               'pix-result': 'Pix+ Édu 1er degré Avancé',
               'external-result': 'Pix+ Édu 1er degré Avancé',


### PR DESCRIPTION
## :unicorn: Problème
La selection propose toutes les certifications complementaires pix edu, si on selectionne un volet jury non compatible, la partie finale ne peut pas etre calculé (page KO)

## :robot: Solution
Filtrer en fonction du volet PIX

## :100: Pour tester
Passer une certification complementaire Edu (ou acceder directement à la certif 505)
Modifier le volet jury
S'assurer que la liste des niveaux selectionnables correspondent à la catégorie du volet Pix.