### PR TITLE
[FEATURE] Créer un script qui crée les comptes des participants au concours de la mairie de Paris (PIX-4962).

### DIFF
--- a/api/scripts/create-users-accounts-for-contest.js
+++ b/api/scripts/create-users-accounts-for-contest.js
@@ -1,0 +1,78 @@
+const { parseCsvWithHeader } = require('./helpers/csvHelpers');
+const bluebird = require('bluebird');
+const userToCreateRepository = require('../lib/infrastructure/repositories/user-to-create-repository');
+const authenticationMethodRepository = require('../lib/infrastructure/repositories/authentication-method-repository');
+const userService = require('../lib/domain/services/user-service');
+const encryptionService = require('../lib/domain/services/encryption-service');
+
+function prepareDataForInsert(rawUsers) {
+  return rawUsers.map(({ firstName, lastName, email, password }) => {
+    return {
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+      email: email.trim().toLowerCase(),
+      password: password.trim(),
+    };
+  });
+}
+
+async function createUsers({ usersInRaw }) {
+  const now = new Date();
+  await bluebird.mapSeries(usersInRaw, async (userDTO) => {
+    const userToCreate = {
+      firstName: userDTO.firstName,
+      lastName: userDTO.lastName,
+      email: userDTO.email,
+      createAt: now,
+      updatedAt: now,
+      cgu: true,
+      lang: 'fr',
+    };
+    const hashedPassword = await encryptionService.hashPassword(userDTO.password);
+
+    await userService.createUserWithPassword({
+      user: userToCreate,
+      hashedPassword,
+      userToCreateRepository,
+      authenticationMethodRepository,
+    });
+  });
+}
+
+async function main() {
+  console.log('Starting creating users accounts for contest.');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading and parsing csv data file... ');
+    const csvData = await parseCsvWithHeader(filePath);
+    console.log('ok');
+
+    console.log('Preparing data... ');
+    const usersInRaw = prepareDataForInsert(csvData);
+    console.log('ok');
+
+    console.log('Creating users...');
+    await createUsers({ usersInRaw });
+    console.log('\nDone.');
+  } catch (error) {
+    console.error('\n', error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  prepareDataForInsert,
+  createUsers,
+};

--- a/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
+++ b/api/tests/acceptance/scripts/create-users-accounts-for-contest_test.js
@@ -1,0 +1,117 @@
+const { expect, knex } = require('../../test-helper');
+const { createUsers } = require('../../../scripts/create-users-accounts-for-contest');
+const sinon = require('sinon');
+
+describe('Acceptance | Scripts | create-users-accounts-for-contest', function () {
+  describe('#createUsers', function () {
+    const now = new Date();
+    let clock;
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({
+        now,
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+      await knex('authentication-methods').delete();
+      await knex('users').delete();
+    });
+
+    it('should insert users', async function () {
+      // given
+      const usersInRaw = [
+        {
+          firstName: 'Sandy',
+          lastName: 'Kilo',
+          email: 'sandy-kilo@example.net',
+          password: 'pix123',
+        },
+        {
+          firstName: 'Tom',
+          lastName: 'Desavoie',
+          email: 'tom.desavoie@example.net',
+          password: 'pixou123',
+        },
+      ];
+
+      // when
+      await createUsers({ usersInRaw });
+
+      // then
+      const firstUserFound = await knex('users').where({ lastName: 'Kilo' }).first();
+      expect(firstUserFound).to.contains({
+        firstName: 'Sandy',
+        lastName: 'Kilo',
+        email: 'sandy-kilo@example.net',
+        cgu: true,
+        pixOrgaTermsOfServiceAccepted: false,
+        pixCertifTermsOfServiceAccepted: false,
+        hasSeenAssessmentInstructions: false,
+        username: null,
+        mustValidateTermsOfService: false,
+        lastTermsOfServiceValidatedAt: null,
+        lang: 'fr',
+        hasSeenNewDashboardInfo: false,
+        isAnonymous: false,
+        emailConfirmedAt: null,
+        hasSeenFocusedChallengeTooltip: false,
+        lastLoggedAt: null,
+        hasSeenOtherChallengesTooltip: false,
+        lastPixOrgaTermsOfServiceValidatedAt: null,
+        lastPixCertifTermsOfServiceValidatedAt: null,
+      });
+      expect(firstUserFound.createdAt).to.deep.equal(now);
+      expect(firstUserFound.updatedAt).to.deep.equal(now);
+
+      const secondUserFound = await knex('users').where({ lastName: 'Desavoie' }).first();
+      expect(secondUserFound).to.contains({
+        firstName: 'Tom',
+        lastName: 'Desavoie',
+      });
+    });
+
+    it("should create users's authentication methods", async function () {
+      // given
+      const usersInRaw = [
+        {
+          firstName: 'Sandy',
+          lastName: 'Kilo',
+          email: 'sandy-kilo@example.net',
+          password: 'pix123',
+        },
+        {
+          firstName: 'Tom',
+          lastName: 'Desavoie',
+          email: 'tom.desavoie@example.net',
+          password: 'pixou123',
+        },
+      ];
+
+      // when
+      await createUsers({ usersInRaw });
+
+      // then
+      const usersInDatabases = await knex('authentication-methods');
+      expect(usersInDatabases.length).to.equal(2);
+
+      const firstUserFound = await knex('users').where({ lastName: 'Kilo' }).first();
+      const firstAuthenticationMethodFound = await knex('authentication-methods')
+        .where({ userId: firstUserFound.id })
+        .first();
+      expect(firstAuthenticationMethodFound.identityProvider).to.equal('PIX');
+      expect(firstAuthenticationMethodFound.authenticationComplement.password).to.exist;
+      expect(firstAuthenticationMethodFound.authenticationComplement.shouldChangePassword).to.be.false;
+      expect(firstAuthenticationMethodFound.createdAt).to.be.not.null;
+      expect(firstAuthenticationMethodFound.updatedAt).to.be.not.null;
+
+      const secondUserFound = await knex('users').where({ lastName: 'Desavoie' }).first();
+      const secondAuthenticationMethodFound = await knex('authentication-methods')
+        .where({ userId: secondUserFound.id })
+        .first();
+      expect(secondAuthenticationMethodFound.authenticationComplement.password).to.exist;
+    });
+  });
+});

--- a/api/tests/unit/scripts/create-users-accounts-for-contest_test.js
+++ b/api/tests/unit/scripts/create-users-accounts-for-contest_test.js
@@ -1,0 +1,34 @@
+const { expect } = require('../../test-helper');
+
+const { prepareDataForInsert } = require('../../../scripts/create-users-accounts-for-contest');
+
+describe('Unit | Scripts | create-users-accounts-for-contest.js', function () {
+  describe('#prepareDataForInsert', function () {
+    it('should trim firstName, lastName, email and password', function () {
+      // given
+      const data = [
+        {
+          firstName: '  Salim    ',
+          lastName: ' Bienléongle     ',
+          email: '  salim@example.net  ',
+          password: '     pix123   ',
+        },
+        { firstName: '  Samantha      ', lastName: '  Lo ', email: '  lo@example.net  ', password: '     pixou123   ' },
+      ];
+
+      // when
+      const result = prepareDataForInsert(data);
+
+      // then
+      expect(result).to.deep.equal([
+        {
+          firstName: 'Salim',
+          lastName: 'Bienléongle',
+          email: 'salim@example.net',
+          password: 'pix123',
+        },
+        { firstName: 'Samantha', lastName: 'Lo', email: 'lo@example.net', password: 'pixou123' },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour le concours de la maire de Paris il est nécessaire que les comptes des participants soient créés à l'avance car : 
- il est difficile pour les participants de se créer un compte au début de l'épreuve
- il est essentiel pour les organisateurs de ce concours d'avoir les identités des personnes selon leur base : le nom / prénom et email doit correspondre aux infos qu'ils ont

Il y aura une information préalable pour les candidats au moment de l'invitation qui remplacera l'acceptation des cgu via l'application. 

Les comptes sont destinés à n'être utilisés que dans le cadre de ce concours.

## :robot: Solution
Créer un script qui permet de créer des comptes des candidats en batch selon 4 infos : nom / prénom / email / mot de passe.

## :rainbow: Remarques
Si un email existe déjà le script s'arrête de suite et renvoie une erreur. Cependant les utilisateurs déjà créés ne sont pas rollback.
Étant donné que ce script n'a pas pour objectif d'être joué régulièrement (voir même lancé qu'une seule fois peut être), j'ai pris parti de **faire au plus simple et de ne pas aller loin dans la gestion des erreurs et de la validation des données**. 

Petite commande avant de lancer le script afin de vérifier si les emails sont dispo : 
```sql
SELECT * FROM "users"
WHERE "email" IN('certif-success@example.net','toto@example.net', 'superadmin@example.net');
``` 

## :100: Pour tester
- Créer un fichier `users.csv` contenant quelques utilisateurs en fournissant : nom, prénom, email et password : 
```csv
firstName,lastName,password,email
stephane,dupont,pix123,steph@example.net
fabien,petit,pixou123,fabien.rodrigues@example.net
olivia,dutronc,pixien123,olivia.groppi@example.net
```

- Si nécessaire, ajouter les droits d'exécution au fichier de script : `chmod +x scripts/create-users-accounts-for-concours.js  ` 

- Exécuter le script avec vos données dans le fichier .csv précedemment créé : 
```bash
node create-users-accounts-for-concours.js users.csv   
```

- Lancer l'api et mon-pix et essayer de se connecter avec les utilisateurs précédemment créés. 
Vérifier que vous arrivez à vous connecter et que vous n'avez pas besoin de valider les cgu.  