### PR TITLE
[FEATURE] Ajout d'un bouton pour vider les champs de recherche d'utilisateurs dans Pix Admin (PIX-4862).

### DIFF
--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -55,5 +55,10 @@ export default class ListController extends Controller {
     this.lastName = null;
     this.email = null;
     this.username = null;
+
+    this.firstNameForm = null;
+    this.lastNameForm = null;
+    this.emailForm = null;
+    this.usernameForm = null;
   }
 }

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -48,4 +48,12 @@ export default class ListController extends Controller {
   onChangeUsername(event) {
     this.usernameForm = event.target.value;
   }
+
+  @action
+  clearSearchFields() {
+    this.firstName = null;
+    this.lastName = null;
+    this.email = null;
+    this.username = null;
+  }
 }

--- a/admin/app/styles/authenticated/users/list.scss
+++ b/admin/app/styles/authenticated/users/list.scss
@@ -1,5 +1,15 @@
-.user-list__form {
+.user-list-form {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
+
+  &__input--small {
+    max-width: 190px;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+  }
 }

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -5,12 +5,12 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 20px;
+    padding: 6px 20px;
     border-bottom: 1px solid $grey-20;
     top: 0;
     left: 80px;
     right: 0;
-    height: 60px;
+    min-height: 60px;
     z-index: 4;
     margin: 0;
 

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -4,8 +4,18 @@
   <h1 class="page-title">Rechercher un(des) utilisateur(s)</h1>
   <div class="page-actions">
     <form class="form-inline user-list__form" {{on "submit" this.refreshModel}}>
-      <PixInput @id="firstName" {{on "change" this.onChangeFirstName}} placeholder="Prénom" @ariaLabel="Prénom" />
-      <PixInput @id="lastName" {{on "change" this.onChangeLastName}} placeholder="Nom" @ariaLabel="Nom" />
+      <PixInput
+        @id="firstName"
+        {{on "change" this.onChangeFirstName}}
+        placeholder="Prénom"
+        @ariaLabel="Prénom"
+      />
+      <PixInput
+        @id="lastName"
+        {{on "change" this.onChangeLastName}}
+        placeholder="Nom"
+        @ariaLabel="Nom"
+      />
       <PixInput
         @id="email"
         {{on "change" this.onChangeEmail}}
@@ -20,6 +30,7 @@
       />
       <PixButton @size="small" @type="submit">Charger</PixButton>
       <PixIconButton
+        type="reset"
         @ariaLabel="Vider les champs de recherche"
         @icon="times"
         @withBackground={{true}}

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -19,6 +19,12 @@
         @ariaLabel="Identifiant"
       />
       <PixButton @size="small" @type="submit">Charger</PixButton>
+      <PixIconButton
+        @ariaLabel="Vider les champs de recherche"
+        @icon="times"
+        @withBackground={{true}}
+        @triggerAction={{this.clearSearchFields}}
+      />
     </form>
   </div>
 </header>

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -3,18 +3,20 @@
 <header class="page-header">
   <h1 class="page-title">Rechercher un(des) utilisateur(s)</h1>
   <div class="page-actions">
-    <form class="form-inline user-list__form" {{on "submit" this.refreshModel}}>
+    <form class="user-list-form" {{on "submit" this.refreshModel}}>
       <PixInput
         @id="firstName"
         {{on "change" this.onChangeFirstName}}
         placeholder="Prénom"
         @ariaLabel="Prénom"
+        class="user-list-form__input--small"
       />
       <PixInput
         @id="lastName"
         {{on "change" this.onChangeLastName}}
         placeholder="Nom"
         @ariaLabel="Nom"
+        class="user-list-form__input--small"
       />
       <PixInput
         @id="email"
@@ -27,15 +29,18 @@
         {{on "change" this.onChangeUsername}}
         placeholder="Identifiant"
         @ariaLabel="Identifiant"
+        class="user-list-form__input--small"
       />
-      <PixButton @size="small" @type="submit">Charger</PixButton>
-      <PixIconButton
-        type="reset"
-        @ariaLabel="Vider les champs de recherche"
-        @icon="times"
-        @withBackground={{true}}
-        @triggerAction={{this.clearSearchFields}}
-      />
+      <div class="user-list-form__actions">
+        <PixButton @size="small" @type="submit">Charger</PixButton>
+        <PixIconButton
+          type="reset"
+          @ariaLabel="Vider les champs de recherche"
+          @icon="times"
+          @withBackground={{true}}
+          @triggerAction={{this.clearSearchFields}}
+        />
+      </div>
     </form>
   </div>
 </header>

--- a/admin/tests/acceptance/authenticated/users/list_test.js
+++ b/admin/tests/acceptance/authenticated/users/list_test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+
+module('Acceptance | authenticated/users | list', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('when clicking on "Vider" button', function () {
+    test('should empty url params', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      await visit('/users/list?firstName=emma&lastName=sardine&email=emma@example.net');
+      await clickByName('Vider les champs de recherche');
+
+      // then
+      assert.strictEqual(currentURL(), '/users/list');
+    });
+  });
+});

--- a/admin/tests/acceptance/authenticated/users/list_test.js
+++ b/admin/tests/acceptance/authenticated/users/list_test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, fillIn, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
-import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | authenticated/users | list', function (hooks) {
   setupApplicationTest(hooks);
@@ -15,11 +15,63 @@ module('Acceptance | authenticated/users | list', function (hooks) {
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
       // when
-      await visit('/users/list?firstName=emma&lastName=sardine&email=emma@example.net');
-      await clickByName('Vider les champs de recherche');
+      const screen = await visit('/users/list?firstName=emma&lastName=sardine&email=emma@example.net');
+      await click(screen.getByRole('button', { name: 'Vider les champs de recherche' }));
 
       // then
       assert.strictEqual(currentURL(), '/users/list');
+    });
+
+    test('should empty all search fields', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      server.create('user', {
+        firstName: 'emma',
+        lastName: 'sardine',
+        email: 'emma@example.net',
+        identifiant: 'emma123',
+      });
+      const screen = await visit('/users/list');
+      await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'sardine');
+      await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'emma@example.net');
+      await fillIn(screen.getByRole('textbox', { name: 'Identifiant' }), 'emma123');
+
+      // when
+      await click(screen.getByRole('button', { name: 'Vider les champs de recherche' }));
+
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Prénom' })).hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom' })).hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Identifiant' })).hasNoValue();
+    });
+
+    test('should let empty fields on search', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      server.create('user', {
+        firstName: 'emma',
+        lastName: 'sardine',
+        email: 'emma@example.net',
+        identifiant: 'emma123',
+      });
+      const screen = await visit('/users/list');
+      await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'sardine');
+      await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'emma@example.net');
+      await fillIn(screen.getByRole('textbox', { name: 'Identifiant' }), 'emma123');
+
+      // when
+      await click(screen.getByRole('button', { name: 'Vider les champs de recherche' }));
+      await click(screen.getByRole('button', { name: 'Charger' }));
+
+      // then
+      assert.strictEqual(currentURL(), '/users/list');
+      assert.dom(screen.getByRole('textbox', { name: 'Prénom' })).hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom' })).hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).hasNoValue();
+      assert.dom(screen.getByRole('textbox', { name: 'Identifiant' })).hasNoValue();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour vider les champs prénom, nom, email et identifiant il faut supprimer à la main toutes les valeurs une par une. C'est long.

## :robot: Solution
Rajouter un bouton qui permet de vider tous les champs d'un coup.

## :rainbow: Remarques
Voilà.

## :100: Pour tester
- Lancer Pix Admin
- Aller sur `users/list`
- Remplir les champs de recherche
- Cliquer sur le bouton en forme de croix
- Constater que les champs de recherche sont vidés
