### PR TITLE
[ADMIN] Nettoyer le CSS de la page informations de la session (PIX-5015)

### DIFF
--- a/admin/app/components/campaigns/participations-section.hbs
+++ b/admin/app/components/campaigns/participations-section.hbs
@@ -43,7 +43,7 @@
       </table>
 
       {{#unless @participations}}
-        <div class="table__empty content-text">Aucune participation</div>
+        <div class="table__empty">Aucune participation</div>
       {{/unless}}
     </div>
     {{#if @participations}}

--- a/admin/app/components/certification-centers/list-items.hbs
+++ b/admin/app/components/certification-centers/list-items.hbs
@@ -66,7 +66,7 @@
   </table>
 
   {{#unless @certificationCenters}}
-    <div class="table__empty content-text">Aucun résultat</div>
+    <div class="table__empty">Aucun résultat</div>
   {{/unless}}
 </div>
 

--- a/admin/app/components/certification-centers/memberships-section.hbs
+++ b/admin/app/components/certification-centers/memberships-section.hbs
@@ -54,7 +54,7 @@
       </table>
 
       {{#unless @certificationCenterMemberships}}
-        <div class="table__empty content-text">Aucun résultat</div>
+        <div class="table__empty">Aucun résultat</div>
       {{/unless}}
     </div>
   </div>

--- a/admin/app/components/certifications/certified-profile.hbs
+++ b/admin/app/components/certifications/certified-profile.hbs
@@ -52,6 +52,6 @@
   </section>
 {{else}}
   <section class="page-section mb_10">
-    <div class="table__empty content-text">Profil certifié vide.</div>
+    <div class="table__empty">Profil certifié vide.</div>
   </section>
 {{/each}}

--- a/admin/app/components/organizations/campaigns-section.hbs
+++ b/admin/app/components/organizations/campaigns-section.hbs
@@ -49,7 +49,7 @@
       </table>
 
       {{#unless @campaigns}}
-        <div class="table__empty content-text">Aucune campagne</div>
+        <div class="table__empty">Aucune campagne</div>
       {{/unless}}
     </div>
     {{#if @campaigns}}

--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -67,7 +67,7 @@
     </table>
 
     {{#unless @organizations}}
-      <div class="table__empty content-text">Aucun résultat</div>
+      <div class="table__empty">Aucun résultat</div>
     {{/unless}}
   </div>
 </div>

--- a/admin/app/components/organizations/target-profiles-section.hbs
+++ b/admin/app/components/organizations/target-profiles-section.hbs
@@ -49,7 +49,7 @@
       </table>
 
       {{#unless @organization.targetProfiles}}
-        <div class="table__empty content-text">Aucun résultat</div>
+        <div class="table__empty">Aucun résultat</div>
       {{/unless}}
     </div>
   </div>

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -81,7 +81,7 @@
       </table>
 
       {{#unless @memberships}}
-        <div class="table__empty content-text">Aucun résultat</div>
+        <div class="table__empty">Aucun résultat</div>
       {{/unless}}
     </div>
 

--- a/admin/app/components/sessions/jury-comment.hbs
+++ b/admin/app/components/sessions/jury-comment.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10 session-jury-comment">
+<section class="page-section session-jury-comment">
   <h2 class="jury-comment__title">Commentaire de l'équipe Certification</h2>
   {{#if this.shouldDisplayForm}}
     {{#if this.accessControl.hasAccessToCertificationActionsScope}}

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -106,7 +106,7 @@
   </table>
 
   {{#unless @sessions}}
-    <div class="table__empty content-text">Aucun résultat</div>
+    <div class="table__empty">Aucun résultat</div>
   {{/unless}}
 </div>
 

--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -47,7 +47,7 @@
       </tbody>
     </table>
   {{else}}
-    <div class="table__empty content-text">Aucun résultat thématique associé</div>
+    <div class="table__empty">Aucun résultat thématique associé</div>
   {{/if}}
 </div>
 

--- a/admin/app/components/target-profiles/details.hbs
+++ b/admin/app/components/target-profiles/details.hbs
@@ -46,6 +46,6 @@
   </section>
 {{else}}
   <section class="page-section">
-    <div class="table__empty content-text">Profil cible vide.</div>
+    <div class="table__empty">Profil cible vide.</div>
   </section>
 {{/each}}

--- a/admin/app/components/target-profiles/list-items.hbs
+++ b/admin/app/components/target-profiles/list-items.hbs
@@ -50,7 +50,7 @@
     </table>
 
     {{#unless @targetProfiles}}
-      <div class="table__empty content-text">Aucun résultat</div>
+      <div class="table__empty">Aucun résultat</div>
     {{/unless}}
   </div>
 </div>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -119,7 +119,7 @@
         </table>
       </div>
     {{else}}
-      <div class="table__empty content-text">Aucun palier associé</div>
+      <div class="table__empty">Aucun palier associé</div>
     {{/if}}
 
     <PixButton

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -54,6 +54,6 @@
   </table>
 
   {{#unless @members}}
-    <div class="table__empty content-text">Aucun résultat</div>
+    <div class="table__empty">Aucun résultat</div>
   {{/unless}}
 </div>

--- a/admin/app/components/to-be-published-sessions/list-items.hbs
+++ b/admin/app/components/to-be-published-sessions/list-items.hbs
@@ -43,7 +43,7 @@
   </table>
 
   {{#unless @toBePublishedSessions}}
-    <div class="table__empty content-text">Aucun résultat</div>
+    <div class="table__empty">Aucun résultat</div>
   {{/unless}}
 </div>
 

--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -30,7 +30,7 @@
   </table>
 
   {{#unless @users}}
-    <div class="table__empty content-text">Aucun résultat</div>
+    <div class="table__empty">Aucun résultat</div>
   {{/unless}}
 </div>
 

--- a/admin/app/components/with-required-action-sessions/list-items.hbs
+++ b/admin/app/components/with-required-action-sessions/list-items.hbs
@@ -36,6 +36,6 @@
   </table>
 
   {{#unless @withRequiredActionSessions}}
-    <div class="table__empty content-text">Aucun résultat</div>
+    <div class="table__empty">Aucun résultat</div>
   {{/unless}}
 </div>

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -10,6 +10,20 @@
     margin-right: -20px;
   }
 
+  &__list {
+    list-style: none;
+    margin-bottom: 40px;
+    padding: 0;
+  }
+
+  &__list-item {
+    display: flex;
+
+    span {
+      width: 50%;
+    }
+  }
+
   &__certification-officer-assigned {
     display: flex;
     justify-content: flex-end;
@@ -20,12 +34,9 @@
     }
   }
 
-  &__stats {
-    padding-top: 40px;
-  }
-
   &__actions {
-    padding-top: 32px;
+    display: flex;
+    flex-wrap: wrap;
   }
 
   &__copy-button {
@@ -52,43 +63,6 @@
         bottom: -10px;
         left: calc(50% - 5px);
       }
-    }
-  }
-}
-
-.ember-modal-dialog {
-  padding: 0;
-  margin: 0;
-  min-width: 35vw;
-
-  .ember-modal-dialog--title {
-    border-bottom: 1px solid $grey-20;
-    display: flex;
-    justify-content: space-between;
-    padding: 1rem;
-
-    & > * {
-      font-size: 1.25rem;
-    }
-
-    span { color: $grey-40; }
-
-    span:hover {
-      cursor: pointer;
-      color: $black;
-    }
-  }
-
-  p { padding: 1rem; }
-
-  .ember-modal-dialog--actions {
-    border-top: 1px solid $grey-20;
-    padding: 1rem;
-    display: flex;
-    justify-content: flex-end;
-
-    button {
-      margin: 0 4px;
     }
   }
 }

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -5,139 +5,133 @@
       <span>{{this.sessionModel.assignedCertificationOfficer.fullName}}</span>
     </div>
 
-    <div class="session-info__details">
-      <div class="row">
-        <div class="col">Centre :</div>
-        <div class="col">
+    <ul class="session-info__list">
+      <li class="session-info__list-item">
+        <span>Centre :</span>
+        <span>
           <LinkTo @route="authenticated.certification-centers.get" @model={{this.sessionModel.certificationCenterId}}>
             {{this.sessionModel.certificationCenterName}}
           </LinkTo>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">Adresse :</div>
-        <div class="col">{{this.sessionModel.address}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Pièce :</div>
-        <div class="col">{{this.sessionModel.room}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Surveillant :</div>
-        <div class="col">{{this.sessionModel.examiner}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Date :</div>
-        <div class="col">{{format-date this.sessionModel.date}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Heure :</div>
-        <div class="col">{{this.sessionModel.time}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Description :</div>
-        <div class="col">{{this.sessionModel.description}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Code d'accès :</div>
-        <div class="col">{{this.sessionModel.accessCode}}</div>
-      </div>
-      <div class="row">
-        <div class="col">Statut :</div>
-        <div class="col">{{this.sessionModel.displayStatus}}</div>
-      </div>
+        </span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Adresse :</span>
+        <span>{{this.sessionModel.address}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Pièce :</span>
+        <span>{{this.sessionModel.room}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Surveillant :</span>
+        <span>{{this.sessionModel.examiner}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Date :</span>
+        <span>{{format-date this.sessionModel.date}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Heure :</span>
+        <span>{{this.sessionModel.time}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Description :</span>
+        <span>{{this.sessionModel.description}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Code d'accès :</span>
+        <span>{{this.sessionModel.accessCode}}</span>
+      </li>
+      <li class="session-info__list-item">
+        <span>Statut :</span>
+        <span>{{this.sessionModel.displayStatus}}</span>
+      </li>
 
       {{#if this.sessionModel.finalizedAt}}
-        <div class="row">
-          <div class="col">Date de finalisation :</div>
-          <div class="col">{{format-date this.sessionModel.finalizedAt}}</div>
-        </div>
+        <li class="session-info__list-item">
+          <span>Date de finalisation :</span>
+          <span>{{format-date this.sessionModel.finalizedAt}}</span>
+        </li>
       {{/if}}
       {{#if this.sessionModel.publishedAt}}
-        <div class="row">
-          <div class="col">Date de publication :</div>
-          <div class="col">{{format-date this.sessionModel.publishedAt}}</div>
-        </div>
+        <li class="session-info__list-item">
+          <span>Date de publication :</span>
+          <span>{{format-date this.sessionModel.publishedAt}}</span>
+        </li>
       {{/if}}
       {{#if this.sessionModel.resultsSentToPrescriberAt}}
-        <div class="row">
-          <div class="col">Date d'envoi des résultats au prescripteur :</div>
-          <div class="col">{{format-date this.sessionModel.resultsSentToPrescriberAt}}</div>
-        </div>
+        <li class="session-info__list-item">
+          <span>Date d'envoi des résultats au prescripteur :</span>
+          <span>{{format-date this.sessionModel.resultsSentToPrescriberAt}}</span>
+        </li>
       {{/if}}
-    </div>
+    </ul>
 
     {{#if this.sessionModel.finalizedAt}}
-      <div class="session-info__stats">
-        <div class="row">
-          <div class="col">Nombre de signalements impactants non résolus:</div>
-          <div class="col">{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</div>
-        </div>
-        <div class="row">
-          <div class="col">Nombre de signalements :</div>
-          <div
-            class="col"
+      <ul class="session-info__list">
+        <li class="session-info__list-item">
+          <span>Nombre de signalements impactants non résolus:</span>
+          <span>{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</span>
+        </li>
+        <li class="session-info__list-item">
+          <span>Nombre de signalements :</span>
+          <span
             data-test-id="session-info__number-of-issue-report"
-          >{{this.sessionModel.countCertificationIssueReports}}</div>
-        </div>
+          >{{this.sessionModel.countCertificationIssueReports}}</span>
+        </li>
         {{#unless this.sessionModel.hasSupervisorAccess}}
-          <div class="row">
-            <div class="col">Nombre d'écrans de fin de test non renseignés :</div>
-            <div
-              class="col"
+          <li class="session-info__list-item">
+            <span>Nombre d'écrans de fin de test non renseignés :</span>
+            <span
               data-test-id="session-info__number-of-not-checked-end-screen"
-            >{{this.sessionModel.countNotCheckedEndScreen}}</div>
-          </div>
+            >{{this.sessionModel.countNotCheckedEndScreen}}</span>
+          </li>
         {{/unless}}
-        <div class="row">
-          <div class="col">Certifications non terminées traitées automatiquement :</div>
-          <div class="col">{{this.sessionModel.countCertificationsFlaggedAsAborted}}</div>
-        </div>
-        <div class="row">
-          <div class="col">Nombre de certifications démarrées/en erreur :</div>
-          <div
-            class="col"
+        <li class="session-info__list-item">
+          <span>Certifications non terminées traitées automatiquement :</span>
+          <span>{{this.sessionModel.countCertificationsFlaggedAsAborted}}</span>
+        </li>
+        <li class="session-info__list-item">
+          <span>Nombre de certifications démarrées/en erreur :</span>
+          <span
             data-test-id="session-info__number-of-started-or-error-certifications"
-          >{{this.sessionModel.countStartedAndInErrorCertifications}}</div>
-        </div>
+          >{{this.sessionModel.countStartedAndInErrorCertifications}}</span>
+        </li>
         {{#if this.sessionModel.hasExaminerGlobalComment}}
-          <div class="row">
-            <div class="col">Commentaire global :</div>
-            <div class="col">{{this.sessionModel.examinerGlobalComment}}</div>
-          </div>
+          <li class="session-info__list-item">
+            <span>Commentaire global :</span>
+            <span>{{this.sessionModel.examinerGlobalComment}}</span>
+          </li>
         {{/if}}
-      </div>
+      </ul>
     {{/if}}
 
     {{#if this.accessControl.hasAccessToCertificationActionsScope}}
       <div class="session-info__actions">
-        <div class="row row--btn">
+        {{#if this.sessionModel.finalizedAt}}
+          {{#if this.isCurrentUserAssignedToSession}}
+            <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
+          {{else}}
+            <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
+          {{/if}}
+        {{/if}}
 
-          {{#if this.sessionModel.finalizedAt}}
-            {{#if this.isCurrentUserAssignedToSession}}
-              <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
-            {{else}}
-              <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
-            {{/if}}
+        <div class="session-info__copy-button">
+          {{#if this.isCopyButtonClicked}}
+            <p>{{this.copyButtonText}}</p>
           {{/if}}
 
-          <div class="session-info__copy-button">
-            {{#if this.isCopyButtonClicked}}
-              <p>{{this.copyButtonText}}</p>
-            {{/if}}
-
-            <PixButton size="small" @triggerAction={{this.copyResultsDownloadLink}} @backgroundColor="grey">
-              <FaIcon @icon="copy" @prefix="far" class="fa-inverse" aria-label="Copier" />
-              Lien de téléchargement des résultats
-            </PixButton>
-          </div>
-
-          {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
-            <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
-              Résultats transmis au prescripteur
-            </PixButton>
-          {{/if}}
+          <PixButton size="small" @triggerAction={{this.copyResultsDownloadLink}} @backgroundColor="grey">
+            <FaIcon @icon="copy" @prefix="far" class="fa-inverse" aria-label="Copier" />
+            Lien de téléchargement des résultats
+          </PixButton>
         </div>
+
+        {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
+          <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
+            Résultats transmis au prescripteur
+          </PixButton>
+        {{/if}}
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
## :unicorn: Problème
Trop de page utilise encore Bootstrap dans Pix Admin, nous empechant d'exploiter pleinement pix ui sur cette application

## :robot: Solution
Nettoyer la page informations de sessions

## :rainbow: Remarques

## :100: Pour tester
Vérifier que la page est toujours lisible