### PR TITLE
[FEATURE] Ajoute un filtre sur le nom et prénom dans l'onglet Activité d'une campagne (PIX-4580)

### DIFF
--- a/api/db/migrations/20220504150638_add-extension-pg-trgm.js
+++ b/api/db/migrations/20220504150638_add-extension-pg-trgm.js
@@ -1,0 +1,7 @@
+exports.up = async function (knex) {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS pg_trgm;');
+};
+
+exports.down = async function (knex) {
+  await knex.raw('DROP EXTENSION IF EXISTS pg_trgm;');
+};

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -201,13 +201,14 @@ module.exports = {
       filters.groups = [filters.groups];
     }
 
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+    const { userId } = request.auth.credentials;
     const paginatedParticipations = await usecases.findPaginatedCampaignParticipantsActivities({
       userId,
       campaignId,
       page,
       filters,
     });
+
     return campaignParticipantsActivitySerializer.serialize(paginatedParticipations);
   },
 

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -331,6 +331,7 @@ exports.register = async function (server) {
               .valid(...campaignParticipationStatuses)
               .empty(''),
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'filter[search]': Joi.string().empty(''),
           }),
         },
         handler: campaignController.findParticipantsActivity,

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1251,6 +1251,21 @@ describe('Acceptance | API | Campaign Controller', function () {
       expect(participation['first-name']).to.equal(participant2.firstName);
     });
 
+    it('should return the campaign participant activity filtered by search as JSONAPI', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/participants-activity?filter[search]=Mary M`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(200);
+      const participation = response.result.data[0].attributes;
+      expect(response.result.data).to.have.lengthOf(1);
+      expect(participation['first-name']).to.equal(participant3.firstName);
+    });
+
     it('should return the campaign participant activity with group L1 as JSONAPI', async function () {
       const options = {
         method: 'GET',

--- a/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
+++ b/api/tests/integration/domain/usecases/find-paginated-campaign-participant-activities_test.js
@@ -48,7 +48,7 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
     });
   });
 
-  context('when there is a filter on division', function () {
+  context('when there are filters', function () {
     beforeEach(async function () {
       databaseBuilder.factory.buildMembership({ organizationId, userId });
 
@@ -72,6 +72,16 @@ describe('Integration | UseCase | find-paginated-campaign-participants-activitie
       });
 
       expect(campaignParticipantsActivities[0].participantExternalId).to.equal('Yubaba');
+    });
+
+    it('returns the campaignParticipantsActivities filtered by the search', async function () {
+      const { campaignParticipantsActivities } = await useCases.findPaginatedCampaignParticipantsActivities({
+        userId,
+        campaignId,
+        filters: { search: 'Tonari N' },
+      });
+
+      expect(campaignParticipantsActivities.length).to.equal(1);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -42,7 +42,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('When there are several participations for the same participant', function () {
       it('Returns one CampaignParticipantActivity with the most recent participation (isImproved = false)', async function () {
-        //Given
+        // given
         const campaign = databaseBuilder.factory.buildCampaign();
         const user = databaseBuilder.factory.buildUser();
 
@@ -77,36 +77,48 @@ describe('Integration | Repository | Campaign Participant activity', function ()
     context('status', function () {
       context('when the participation is shared', function () {
         it('should return status shared', async function () {
+          // given
           campaign = databaseBuilder.factory.buildCampaign();
           databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, status: SHARED });
           await databaseBuilder.commit();
 
+          // when
           const { campaignParticipantsActivities } =
             await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id });
+
+          // then
           expect(campaignParticipantsActivities[0].status).to.equal(SHARED);
         });
       });
 
       context('when the participation is not shared', function () {
         it('should return status to share', async function () {
+          // given
           campaign = databaseBuilder.factory.buildCampaign();
           databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, status: TO_SHARE });
           await databaseBuilder.commit();
 
+          // when
           const { campaignParticipantsActivities } =
             await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id });
+
+          // then
           expect(campaignParticipantsActivities[0].status).to.equal(TO_SHARE);
         });
       });
 
       context('when the participation is started', function () {
         it('should return status started', async function () {
+          // given
           campaign = databaseBuilder.factory.buildCampaign();
           databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, status: STARTED });
           await databaseBuilder.commit();
 
+          // when
           const { campaignParticipantsActivities } =
             await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id });
+
+          // then
           expect(campaignParticipantsActivities[0].status).to.equal(STARTED);
         });
       });
@@ -153,6 +165,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('when there is a filter on division', function () {
       it('returns participants which have the correct division', async function () {
+        // given
         campaign = databaseBuilder.factory.buildCampaign();
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { organizationId: campaign.organizationId, division: 'Good Guys Team' },
@@ -188,6 +201,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
 
     context('when there is a filter on status', function () {
       it('returns participants which have the correct status', async function () {
+        // given
         campaign = databaseBuilder.factory.buildCampaign({});
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -217,8 +231,235 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
     });
 
+    context('when there is a filter on the firstname and lastname', function () {
+      it('returns all participants if the filter is empty', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { pagination } = await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: '' },
+        });
+
+        // then
+        expect(pagination.rowCount).to.equal(2);
+      });
+
+      it('return Choupette participant when we search part its firstname', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: 'Chou' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when we search contains a space before', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: ' Cho' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when we search contains a space after', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: 'Cho ' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when we search part its lastname', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: 'Eura' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].lastName).to.equal('Eurasier');
+      });
+
+      it('return Choupette participant when we search part its fullname', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: 'Choupette E' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant only for the involved campaign when we search part of its full name', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+        const otherCampaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Right' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Choupette', lastName: 'Wrong' },
+          { campaignId: otherCampaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: 'Choupette' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(1);
+        expect(campaignParticipantsActivities[0].lastName).to.equal('Right');
+      });
+
+      it('return all participants when we search similar part of firstname', async function () {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({});
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Saphira', lastName: 'Eurasier' },
+          { campaignId: campaign.id }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          { organizationId: campaign.organizationId, firstName: 'Salto', lastName: 'Irish terrier' },
+          { campaignId: campaign.id }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipantsActivities, pagination } =
+          await campaignParticipantActivityRepository.findPaginatedByCampaignId({
+            campaignId: campaign.id,
+            filters: { search: 'Sa' },
+          });
+
+        // then
+        expect(pagination.rowCount).to.equal(2);
+        expect(campaignParticipantsActivities[0].firstName).to.equal('Saphira');
+        expect(campaignParticipantsActivities[1].firstName).to.equal('Salto');
+      });
+    });
+
     context('when there is a filter on group', function () {
       it('returns participants which have the correct group', async function () {
+        // given
         campaign = databaseBuilder.factory.buildCampaign();
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -266,21 +507,26 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       it('should return paginated campaign participations based on the given size and number', async function () {
+        // given
         const page = { size: 1, number: 1 };
 
+        // when
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id, page });
 
+        // then
         expect(campaignParticipantsActivities).to.have.lengthOf(1);
         expect(pagination).to.deep.equals({ page: 1, pageCount: 2, pageSize: 1, rowCount: 2 });
       });
 
       context('default pagination', function () {
         it('should return a page size of 25', async function () {
+          // when
           const { pagination } = await campaignParticipantActivityRepository.findPaginatedByCampaignId({
             campaignId: campaign.id,
           });
 
+          // then
           expect(pagination.pageSize).to.equals(25);
         });
       });
@@ -293,9 +539,11 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         });
 
         it('should return the first page with 0 elements', async function () {
+          // when
           const { campaignParticipantsActivities, pagination } =
             await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id });
 
+          // then
           expect(campaignParticipantsActivities).to.have.lengthOf(0);
           expect(pagination).to.deep.equals({ page: 1, pageCount: 0, pageSize: 25, rowCount: 0 });
         });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -566,7 +566,7 @@ describe('Unit | Application | Controller | Campaign', function () {
   describe('#findParticipantsActivity', function () {
     let serializedParticipantsActivities;
     let participantsActivities;
-    const filters = { status: 'SHARED', groups: ['L1'] };
+    const filters = { status: 'SHARED', groups: ['L1'], search: 'Choupette' };
 
     const campaignId = 1;
     const userId = 1;
@@ -574,7 +574,7 @@ describe('Unit | Application | Controller | Campaign', function () {
     beforeEach(function () {
       participantsActivities = Symbol('participants activities');
       serializedParticipantsActivities = Symbol('serialized participants activities');
-      sinon.stub(usecases, 'findPaginatedCampaignParticipantsActivities').resolves(participantsActivities);
+      sinon.stub(usecases, 'findPaginatedCampaignParticipantsActivities');
       sinon
         .stub(campaignParticipantsActivitySerializer, 'serialize')
         .withArgs({ participantsActivities })
@@ -584,7 +584,7 @@ describe('Unit | Application | Controller | Campaign', function () {
     it('should return the participants activities properly serialized', async function () {
       // given
       usecases.findPaginatedCampaignParticipantsActivities
-        .withArgs({ campaignId, userId, page: 3, filters })
+        .withArgs({ campaignId, userId, page: { number: 3 }, filters })
         .resolves(participantsActivities);
       campaignParticipantsActivitySerializer.serialize
         .withArgs(participantsActivities)
@@ -596,11 +596,12 @@ describe('Unit | Application | Controller | Campaign', function () {
         auth: {
           credentials: { userId },
         },
+
         query: {
-          filter: {
-            group: ['L1'],
-            status: 'SHARED',
-          },
+          'page[number]': 3,
+          'filter[groups][]': ['L1'],
+          'filter[status]': 'SHARED',
+          'filter[search]': 'Choupette',
         },
       });
 

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -3,6 +3,7 @@
   @selectedDivisions={{@selectedDivisions}}
   @selectedStatus={{@selectedStatus}}
   @selectedGroups={{@selectedGroups}}
+  @searchFilter={{@searchFilter}}
   @rowCount={{@rowCount}}
   @isHiddenStages={{true}}
   @isHiddenBadges={{true}}

--- a/orga/app/components/campaign/activity/participants-list.js
+++ b/orga/app/components/campaign/activity/participants-list.js
@@ -18,7 +18,7 @@ export default class ParticipantsList extends Component {
   }
 
   get canDeleteParticipation() {
-    return this.currentUser.isAdminInOrganization || this.args.campaign.ownerId == this.currentUser.prescriber.id;
+    return this.currentUser.isAdminInOrganization || this.args.campaign.ownerId == this.currentUser.prescriber?.id;
   }
 
   @action

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -34,6 +34,15 @@
         class="participant-filter-banner__multi-select"
       />
     {{/if}}
+    {{#if this.displaySearchFilter}}
+      <Ui::SearchInput
+        @inputName="search"
+        @value={{@searchFilter}}
+        @placeholder={{t "pages.campaign-results.filters.type.search.placeholder"}}
+        @ariaLabel={{t "pages.campaign-results.filters.type.search.title"}}
+        @onSearch={{this.onSearch}}
+      />
+    {{/if}}
     {{#if this.displayStagesFilter}}
       <PixMultiSelect
         @id="stage"

--- a/orga/app/components/campaign/filter/participation-filters.js
+++ b/orga/app/components/campaign/filter/participation-filters.js
@@ -12,7 +12,8 @@ export default class ParticipationFilters extends Component {
       this.displayBadgesFilter ||
       this.displayDivisionFilter ||
       this.displayStatusFilter ||
-      this.displayGroupsFilter
+      this.displayGroupsFilter ||
+      this.displaySearchFilter
     );
   }
 
@@ -36,6 +37,10 @@ export default class ParticipationFilters extends Component {
 
   get displayStatusFilter() {
     return !this.args.isHiddenStatus;
+  }
+
+  get displaySearchFilter() {
+    return !this.args.isHiddenSearch;
   }
 
   get stageOptions() {
@@ -71,6 +76,11 @@ export default class ParticipationFilters extends Component {
   @action
   onSelectStatus(e) {
     this.args.onFilter({ status: e.target.value });
+  }
+
+  @action
+  onSearch(e) {
+    this.args.onFilter({ search: e.target.value });
   }
 
   @action

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -9,6 +9,7 @@
     @selectedStages={{@selectedStages}}
     @rowCount={{@participations.meta.rowCount}}
     @isHiddenStatus={{true}}
+    @isHiddenSearch={{true}}
     @onResetFilter={{@onResetFilter}}
     @onFilter={{@onFilter}}
   />

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -9,6 +9,7 @@
     @onFilter={{@onFilter}}
     @onResetFilter={{@onReset}}
     @isHiddenStatus={{true}}
+    @isHiddenSearch={{true}}
   />
 
   <div class="panel">

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -16,6 +16,7 @@ export default class ActivityController extends Controller {
   @tracked groups = [];
   @tracked campaign;
   @tracked participations;
+  @tracked search = null;
 
   @action
   goToParticipantPage(campaignId, participationId) {
@@ -34,6 +35,9 @@ export default class ActivityController extends Controller {
     if (filters.status !== undefined) {
       this.status = filters.status;
     }
+    if (filters.search !== undefined) {
+      this.search = filters.search;
+    }
   }
 
   @action
@@ -42,6 +46,7 @@ export default class ActivityController extends Controller {
     this.divisions = [];
     this.status = null;
     this.groups = [];
+    this.search = null;
   }
 
   @action

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -19,6 +19,9 @@ export default class ActivityRoute extends Route {
     groups: {
       refreshModel: true,
     },
+    search: {
+      refreshModel: true,
+    },
   };
 
   model(params) {
@@ -40,6 +43,7 @@ export default class ActivityRoute extends Route {
         divisions: params.divisions,
         status: params.status,
         groups: params.groups,
+        search: params.search,
       },
     });
   }
@@ -59,6 +63,7 @@ export default class ActivityRoute extends Route {
       controller.divisions = [];
       controller.status = null;
       controller.groups = [];
+      controller.search = null;
     }
   }
 

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -18,6 +18,7 @@
     @selectedDivisions={{this.divisions}}
     @selectedGroups={{this.groups}}
     @rowCount={{@model.participations.meta.rowCount}}
+    @searchFilter={{this.search}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}
     @deleteCampaignParticipant={{this.deleteCampaignParticipant}}

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { currentURL, click } from '@ember/test-helpers';
-import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createPrescriberByUser, createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import setupIntl from '../helpers/setup-intl';
 

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -118,4 +118,26 @@ module('Acceptance | Campaign Activity', function (hooks) {
       assert.contains('Un problème est survenu lors de la suppression de la participation.');
     });
   });
+
+  module('when prescriber set filters', () => {
+    test('should set status filter', async function (assert) {
+      // when
+      await visit('/campagnes/1');
+
+      await fillByLabel('Statut', 'STARTED');
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/1?status=STARTED');
+    });
+
+    test('should set search filter', async function (assert) {
+      // when
+      await visit('/campagnes/1');
+
+      await fillByLabel('Recherche sur le nom et prénom', 'Choupette');
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/1?search=Choupette');
+    });
+  });
 });

--- a/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
@@ -173,4 +173,24 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       assert.ok(this.onFilter.calledWith({ status: 'SHARED' }));
     });
   });
+
+  module('search filter', function () {
+    test('it should filter participants by names', async function (assert) {
+      this.campaign = { idPixLabel: 'id' };
+      this.participations = [];
+      this.onClickParticipant = sinon.stub();
+      this.onFilter = sinon.stub();
+
+      await render(hbs`<Campaign::Activity::ParticipantsList
+          @campaign={{campaign}}
+          @participations={{participations}}
+          @onClickParticipant={{onClickParticipant}}
+          @onFilter={{onFilter}}
+        />`);
+
+      await fillByLabel('Recherche sur le nom et prénom', 'Jean');
+
+      assert.ok(this.onFilter.calledWith({ search: 'Jean' }));
+    });
+  });
 });

--- a/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-activity-list_test.js
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { find } from '@ember/test-helpers';
-import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import { render, find } from '@ember/test-helpers';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
+import { fillByLabel, clickByText } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -171,6 +171,63 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       await fillByLabel('Statut', 'SHARED');
 
       assert.ok(this.onFilter.calledWith({ status: 'SHARED' }));
+    });
+  });
+
+  module('division filter', function () {
+    class CurrentUserStub extends Service {
+      organization = { isSco: true };
+      isSCOManagingStudents = true;
+    }
+
+    test('it should filter on participation divisions', async function (assert) {
+      // given
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      this.campaign = { idPixLabel: 'id', divisions: [{ name: '3B' }, { name: '3A' }] };
+      this.participations = [];
+      this.onClickParticipant = sinon.stub();
+      this.onFilter = sinon.stub();
+
+      await render(hbs`<Campaign::Activity::ParticipantsList
+          @campaign={{campaign}}
+          @participations={{participations}}
+          @onClickParticipant={{onClickParticipant}}
+          @onFilter={{onFilter}}
+        />`);
+
+      await clickByText('Classes');
+      await clickByText('3A');
+
+      assert.ok(this.onFilter.calledWith({ divisions: ['3A'] }));
+    });
+  });
+
+  module('group filter', function () {
+    class CurrentUserStub extends Service {
+      organization = { isSup: true };
+      isSUPManagingStudents = true;
+    }
+    test('it should filter on participants groups', async function (assert) {
+      // given
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      this.campaign = { idPixLabel: 'id', groups: [{ name: 'M1' }, { name: 'M2' }] };
+      this.participations = [];
+      this.onClickParticipant = sinon.stub();
+      this.onFilter = sinon.stub();
+
+      await render(hbs`<Campaign::Activity::ParticipantsList
+          @campaign={{campaign}}
+          @participations={{participations}}
+          @onClickParticipant={{onClickParticipant}}
+          @onFilter={{onFilter}}
+        />`);
+
+      await clickByText('Groupes');
+      await clickByText('M2');
+
+      assert.ok(this.onFilter.calledWith({ groups: ['M2'] }));
     });
   });
 

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { render, click, fillIn, find } from '@ember/test-helpers';
+import { render, click, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import sinon from 'sinon';
@@ -330,7 +330,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         await render(
           hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @onFilter={{triggerFiltering}}/>`
         );
-        await fillIn('[aria-label="Statut"]', 'STARTED');
+        await fillByLabel(t('pages.campaign-results.filters.type.status.title'), 'STARTED');
 
         // then
         assert.ok(triggerFiltering.calledWith({ status: 'STARTED' }));

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -4,7 +4,8 @@ import { render, click, fillIn, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import sinon from 'sinon';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 
 module('Integration | Component | Campaign::Filter::ParticipationFilters', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -22,7 +23,9 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @isHiddenStatus={{true}} />`);
+        await render(
+          hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @isHiddenStatus={{true}} @isHiddenSearch={{true}}/>`
+        );
 
         // then
         assert.notContains('Filtres');
@@ -307,6 +310,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         });
       });
     });
+
     module('status', function () {
       test('it triggers the filter when a status is selected', async function (assert) {
         // given
@@ -403,6 +407,32 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         // then
         const values = Array.from(find('[aria-label="Statut"]').options).map((option) => option.value);
         assert.deepEqual(values, ['', 'TO_SHARE', 'SHARED']);
+      });
+    });
+
+    module('search', function () {
+      test('it triggers the filter when a text is searched', async function (assert) {
+        // given
+        const campaign = store.createRecord('campaign', {
+          id: campaignId,
+          name: 'campagne 1',
+          type: 'ASSESSMENT',
+          targetProfileHasStage: false,
+          stages: [],
+        });
+
+        const triggerFiltering = sinon.stub();
+        this.set('campaign', campaign);
+        this.set('triggerFiltering', triggerFiltering);
+
+        // when
+        await render(
+          hbs`<Campaign::Filter::ParticipationFilters @campaign={{campaign}} @onFilter={{triggerFiltering}}/>`
+        );
+        await fillByLabel(t('pages.campaign-results.filters.type.search.title'), 'Sal');
+
+        // then
+        assert.ok(triggerFiltering.calledWith({ search: 'Sal' }));
       });
     });
   });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/activity_test.js
@@ -38,6 +38,31 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
     });
   });
 
+  module('#action resetFiltering', function (hooks) {
+    hooks.beforeEach(function () {
+      controller.model = { campaign: { isTypeAssessment: false } };
+    });
+
+    test('it reset all filters', function (assert) {
+      // given
+      controller.pageNumber = 5;
+      controller.divisions = ['A2'];
+      controller.status = 'SHARED';
+      controller.groups = ['L3'];
+      controller.search = 'Jean';
+
+      // when
+      controller.send('resetFiltering');
+
+      // then
+      assert.strictEqual(controller.pageNumber, null);
+      assert.deepEqual(controller.divisions, []);
+      assert.strictEqual(controller.status, null);
+      assert.deepEqual(controller.groups, []);
+      assert.strictEqual(controller.search, null);
+    });
+  });
+
   module('#action triggerFiltering', function (hooks) {
     hooks.beforeEach(function () {
       controller.model = { campaign: { isTypeAssessment: false } };
@@ -49,15 +74,17 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
       controller.divisions = ['A2'];
       controller.status = 'SHARED';
       controller.groups = ['L3'];
+      controller.search = 'Jean';
 
       // when
-      controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED', groups: ['L3'] });
+      controller.send('triggerFiltering', { divisions: ['A1'], status: 'STARTED', groups: ['L3'], search: 'Jean' });
 
       // then
       assert.strictEqual(controller.pageNumber, null);
       assert.deepEqual(controller.divisions, ['A1']);
       assert.strictEqual(controller.status, 'STARTED');
       assert.deepEqual(controller.groups, ['L3']);
+      assert.strictEqual(controller.search, 'Jean');
     });
 
     module('when division filter does not change', function () {
@@ -66,6 +93,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.pageNumber = 5;
         controller.divisions = ['A2'];
         controller.status = 'SHARED';
+        controller.search = 'Jean';
 
         // when
         controller.send('triggerFiltering', { status: 'COMPLETED' });
@@ -74,6 +102,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         assert.strictEqual(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A2']);
         assert.strictEqual(controller.status, 'COMPLETED');
+        assert.strictEqual(controller.search, 'Jean');
       });
     });
 
@@ -83,6 +112,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.pageNumber = 5;
         controller.groups = ['A2'];
         controller.status = 'SHARED';
+        controller.search = 'Jean';
 
         // when
         controller.send('triggerFiltering', { status: 'COMPLETED' });
@@ -91,6 +121,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         assert.strictEqual(controller.pageNumber, null);
         assert.deepEqual(controller.groups, ['A2']);
         assert.strictEqual(controller.status, 'COMPLETED');
+        assert.strictEqual(controller.search, 'Jean');
       });
     });
 
@@ -100,6 +131,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         controller.pageNumber = 5;
         controller.divisions = ['A2'];
         controller.status = 'SHARED';
+        controller.search = 'Jean';
 
         // when
         controller.send('triggerFiltering', { divisions: ['A1'] });
@@ -108,6 +140,26 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
         assert.strictEqual(controller.pageNumber, null);
         assert.deepEqual(controller.divisions, ['A1']);
         assert.strictEqual(controller.status, 'SHARED');
+        assert.strictEqual(controller.search, 'Jean');
+      });
+    });
+
+    module('when search filter does not change', function () {
+      test('it does not update search', function (assert) {
+        // given
+        controller.pageNumber = 5;
+        controller.divisions = ['A2'];
+        controller.status = 'SHARED';
+        controller.search = 'Jean';
+
+        // when
+        controller.send('triggerFiltering', { divisions: ['A1'] });
+
+        // then
+        assert.strictEqual(controller.pageNumber, null);
+        assert.deepEqual(controller.divisions, ['A1']);
+        assert.strictEqual(controller.status, 'SHARED');
+        assert.strictEqual(controller.search, 'Jean');
       });
     });
 
@@ -122,6 +174,20 @@ module('Unit | Controller | authenticated/campaigns/campaign/activity', function
 
         // then
         assert.strictEqual(controller.status, '');
+      });
+    });
+
+    module('when search filter is changed', function () {
+      test('it updates search', function (assert) {
+        // given
+        controller.pageNumber = 5;
+        controller.search = 'Jean';
+
+        // when
+        controller.send('triggerFiltering', { search: 'Paul' });
+
+        // then
+        assert.strictEqual(controller.search, 'Paul');
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -173,10 +173,10 @@
     },
     "percentage": "{value, number, ::percent}",
     "target-profile-details": {
-      "subjects" : "Topics: {value, number}",
-      "results" : {
+      "subjects": "Topics: {value, number}",
+      "results": {
         "common": "Success rate in ",
-        "star" :"stars",
+        "star": "stars",
         "percent": "percentage"
       },
       "thematic-results": "Thematic results: {value, number}"
@@ -439,12 +439,16 @@
           "divisions": {
             "placeholder": "Classes"
           },
+          "search": {
+            "title": "Search by lastname and firstname",
+            "placeholder": "Lastname, firstname"
+          },
           "status": {
             "title": "Status",
             "empty": "All statuses"
           },
           "stages": "Success rate",
-          "groups":  {
+          "groups": {
             "title": "Groups",
             "empty": "No group"
           }
@@ -518,7 +522,7 @@
       }
     },
     "campaigns-list": {
-      "title":  "Campaigns",
+      "title": "Campaigns",
       "navigation": "Navigation in the Campaign section",
       "tabs": {
         "all-campaigns": "All the campaigns",
@@ -646,7 +650,7 @@
       "title": "Topic selection",
       "table": {
         "caption": "Topic selection",
-        "column" : {
+        "column": {
           "action": "Select",
           "theme-name": "Theme name",
           "name": "Topic name",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -173,12 +173,12 @@
     },
     "percentage": "{value, number, ::percent}",
     "target-profile-details": {
-      "results" : {
+      "results": {
         "common": "Résultats affichés en ",
-        "star" : "étoile",
+        "star": "étoile",
         "percent": "pourcentage"
       },
-      "subjects" : "Sujets : {value, number}",
+      "subjects": "Sujets : {value, number}",
       "thematic-results": "Résultats thématiques : {value, number}"
     }
   },
@@ -438,6 +438,10 @@
           "divisions": {
             "placeholder": "Classes"
           },
+          "search": {
+            "title": "Recherche sur le nom et prénom",
+            "placeholder": "Nom, prénom"
+          },
           "status": {
             "title": "Statut",
             "empty": "Tous les statuts"
@@ -517,7 +521,7 @@
       }
     },
     "campaigns-list": {
-      "title":  "Campagnes",
+      "title": "Campagnes",
       "navigation": "Navigation de la section Campagnes",
       "tabs": {
         "all-campaigns": "Toutes les campagnes",


### PR DESCRIPTION
## :unicorn: Problème
Dans nos travaux de refonte du prescrit, une fois que nous avions harmoniser la gestion des prescrits dans les orgas PRO/SUP/SCO, import pas import, nous avons compris qu’il était essentiel de pouvoir supprimer une participation (entre autre afin de gérer certains cas contraignants de dissociation). 
C’est pourquoi nous allons dans cette épix mettre en place ce nouvel mécanisme de suppression.
Maintenant que nous avons rajouté les champs et réalisé les modifications dans Pix APP, nous passons maintenant à Pix ORGA !

## :robot: Solution 

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/19487141/171219449-f7b9723a-8cc0-4177-9db9-fd0dccf180e8.png">

### Solution au problème de la recherche “Lise Q" :

 1. Il faut d’abord runner dans la console PG :

`CREATE EXTENSION pg_trgm;`

2. Ensuite faire évoluer la requête qui filtre les résultats pour intégré la requête qui suit :

```
WITH fullnames AS (
 SELECT CONCAT(users."firstName", ' ', users."lastName") AS fullname, id FROM users
)
SELECT f.fullname, f.fullname <-> 'De Tar' AS distance 
FROM users u
LEFT JOIN fullnames f on u.id=f.id
ORDER BY distance ASC
```

3. Pour finir ajouter un `WHERE` sur la distance (après quelques essais > 0.9 semble pas mal)


Placeholder : “Nom, prénom”

trad + aria label + trad de l'aria label

## :rainbow: Remarques
Le `WHERE` sur la distance est pratique mais pas suffisant. Le fait est que cela appliquait la recherche uniquement si nous cherchions un nom (ou une partie de ce dernier) ET un prénom (ou une partie de ce dernier).
Ce pourquoi nous avons complété avec :  `ORWHERE` une recherche strictement sur le nom ou sur le prénom

## :100: Pour tester
1. Se connecter à Pix Orga en tant que SCO (et recommencer par la suite en tant que SUP)
2. Se rendre sur la page des campagnes
3. Sélectionner une campagne
4. Scroller jusqu'à la liste des participations
5. Tester (si dessous des exemples)
> - Essayer de chercher un nom avec le filtre contenant le placeholder "Nom, prénom"
> -  Essayer de chercher un prénom avec le filtre contenant le placeholder "Nom, prénom"
> - Essayer de chercher une partie d'un nom espace une partie d'un prénom avec le filtre contenant le placeholder "Nom, prénom"
> - Essayer de chercher quelqu'un n'ayant pas participé à cette campagne (devrait ne renvoyer aucune participation)

6. Tadaaaaa 🎉 

