### PR TITLE
[FEATURE] Empêcher un candidat de continuer sa certification si la session est finalisée (PIX-4815)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -422,6 +422,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
 
+  if (error instanceof DomainErrors.CertificationEndedByFinalizationError) {
+    return new HttpErrors.ConflictError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -390,6 +390,12 @@ class CertificationEndedBySupervisorError extends DomainError {
   }
 }
 
+class CertificationEndedByFinalizationError extends DomainError {
+  constructor(message = 'La session a été finalisée par votre centre de certification.') {
+    super(message);
+  }
+}
+
 class SupervisorAccessNotAuthorizedError extends DomainError {
   constructor(
     message = "Cette session est organisée dans un centre de certification pour lequel l'espace surveillant n'a pas été activé par Pix."
@@ -1145,6 +1151,7 @@ module.exports = {
   CertificationCourseNotPublishableError,
   CertificationCourseUpdateError,
   CertificationEndedBySupervisorError,
+  CertificationEndedByFinalizationError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
   ChallengeToBeNeutralizedNotFoundError,

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -89,7 +89,7 @@ async function _autoCompleteUnfinishedTest({
     certificationAssessment.neutralizeUnansweredChallenges();
   }
 
-  certificationAssessment.endByFinalization();
+  certificationAssessment.endDueToFinalization();
 
   await certificationAssessmentRepository.save(certificationAssessment);
 

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -89,6 +89,8 @@ async function _autoCompleteUnfinishedTest({
     certificationAssessment.neutralizeUnansweredChallenges();
   }
 
+  certificationAssessment.endByFinalization();
+
   await certificationAssessmentRepository.save(certificationAssessment);
 
   return true;

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -12,7 +12,7 @@ const states = {
   STARTED: 'started',
   ABORTED: 'aborted',
   ENDED_BY_SUPERVISOR: 'endedBySupervisor',
-  ENDED_BY_FINALIZATION: 'endedByFinalization',
+  ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 
 const types = {
@@ -96,8 +96,8 @@ class Assessment {
     return this.state === Assessment.states.ENDED_BY_SUPERVISOR;
   }
 
-  isEndedByFinalization() {
-    return this.state === Assessment.states.ENDED_BY_FINALIZATION;
+  hasBeenEndedDueToFinalization() {
+    return this.state === Assessment.states.ENDED_DUE_TO_FINALIZATION;
   }
 
   setCompleted() {

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -12,6 +12,7 @@ const states = {
   STARTED: 'started',
   ABORTED: 'aborted',
   ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_BY_FINALIZATION: 'endedByFinalization',
 };
 
 const types = {
@@ -93,6 +94,10 @@ class Assessment {
 
   isEndedBySupervisor() {
     return this.state === Assessment.states.ENDED_BY_SUPERVISOR;
+  }
+
+  isEndedByFinalization() {
+    return this.state === Assessment.states.ENDED_BY_FINALIZATION;
   }
 
   setCompleted() {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -10,7 +10,7 @@ const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ENDED_BY_SUPERVISOR: 'endedBySupervisor',
-  ENDED_BY_FINALIZATION: 'endedByFinalization',
+  ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 
 const certificationAssessmentSchema = Joi.object({
@@ -20,7 +20,7 @@ const certificationAssessmentSchema = Joi.object({
   createdAt: Joi.date().required(),
   completedAt: Joi.date().allow(null),
   state: Joi.string()
-    .valid(states.COMPLETED, states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_BY_FINALIZATION)
+    .valid(states.COMPLETED, states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_DUE_TO_FINALIZATION)
     .required(),
   isV2Certification: Joi.boolean().required(),
   certificationChallenges: Joi.array().min(1).required(),
@@ -69,8 +69,8 @@ class CertificationAssessment {
     }
   }
 
-  endByFinalization() {
-    this.state = states.ENDED_BY_FINALIZATION;
+  endDueToFinalization() {
+    this.state = states.ENDED_DUE_TO_FINALIZATION;
   }
 
   neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber) {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -10,6 +10,7 @@ const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_BY_FINALIZATION: 'endedByFinalization',
 };
 
 const certificationAssessmentSchema = Joi.object({
@@ -18,7 +19,9 @@ const certificationAssessmentSchema = Joi.object({
   certificationCourseId: Joi.number().integer().required(),
   createdAt: Joi.date().required(),
   completedAt: Joi.date().allow(null),
-  state: Joi.string().valid(states.COMPLETED, states.STARTED, states.ENDED_BY_SUPERVISOR).required(),
+  state: Joi.string()
+    .valid(states.COMPLETED, states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_BY_FINALIZATION)
+    .required(),
   isV2Certification: Joi.boolean().required(),
   certificationChallenges: Joi.array().min(1).required(),
   certificationAnswersByDate: Joi.array().min(0).required(),
@@ -64,6 +67,10 @@ class CertificationAssessment {
     } else {
       throw new ChallengeToBeNeutralizedNotFoundError();
     }
+  }
+
+  endByFinalization() {
+    this.state = states.ENDED_BY_FINALIZATION;
   }
 
   neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber) {

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -33,7 +33,7 @@ module.exports = async function correctAnswerThenUpdateAssessment({
   if (assessment.isEndedBySupervisor()) {
     throw new CertificationEndedBySupervisorError();
   }
-  if (assessment.isEndedByFinalization()) {
+  if (assessment.hasBeenEndedDueToFinalization()) {
     throw new CertificationEndedByFinalizationError();
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId != answer.challengeId) {

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,4 +1,9 @@
-const { ForbiddenAccess, ChallengeNotAskedError, CertificationEndedBySupervisorError } = require('../errors');
+const {
+  ForbiddenAccess,
+  ChallengeNotAskedError,
+  CertificationEndedBySupervisorError,
+  CertificationEndedByFinalizationError,
+} = require('../errors');
 const Examiner = require('../models/Examiner');
 const KnowledgeElement = require('../models/KnowledgeElement');
 const logger = require('../../infrastructure/logger');
@@ -27,6 +32,9 @@ module.exports = async function correctAnswerThenUpdateAssessment({
   }
   if (assessment.isEndedBySupervisor()) {
     throw new CertificationEndedBySupervisorError();
+  }
+  if (assessment.isEndedByFinalization()) {
+    throw new CertificationEndedByFinalizationError();
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId != answer.challengeId) {
     throw new ChallengeNotAskedError();

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -115,5 +115,9 @@ module.exports = {
         .where({ id: answer.id })
         .update({ result: answerStatusDatabaseAdapter.toSQLString(answer.result) });
     }
+
+    await knex('assessments')
+      .where({ certificationCourseId: certificationAssessment.certificationCourseId })
+      .update({ state: certificationAssessment.state });
   },
 };

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -412,7 +412,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
       await databaseBuilder.commit();
       const certificationAssessmentToBeSaved = await certificationAssessmentRepository.get(certificationAssessmentId);
-      certificationAssessmentToBeSaved.state = CertificationAssessment.states.ENDED_BY_FINALIZATION;
+      certificationAssessmentToBeSaved.state = CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION;
 
       // when
       await certificationAssessmentRepository.save(certificationAssessmentToBeSaved);
@@ -420,7 +420,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       // then
       const persistedCertificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
       expect(persistedCertificationAssessment.state).to.deep.equal(
-        CertificationAssessment.states.ENDED_BY_FINALIZATION
+        CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION
       );
     });
   });

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -391,5 +391,37 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
       expect(persistedCertificationAssessment.certificationAnswersByDate[0].result).to.deep.equal(AnswerStatus.OK);
       expect(persistedCertificationAssessment.certificationAnswersByDate[1].result).to.deep.equal(AnswerStatus.SKIPPED);
     });
+
+    it('persists the mutation of assessment state', async function () {
+      // given
+      const dbf = databaseBuilder.factory;
+      const userId = dbf.buildUser().id;
+      const certificationCourseId = dbf.buildCertificationCourse({ userId }).id;
+      const certificationAssessmentId = dbf.buildAssessment({
+        userId,
+        certificationCourseId,
+        state: 'started',
+      }).id;
+
+      const certificationChallengeRecId = 'rec567';
+
+      dbf.buildCertificationChallenge({
+        challengeId: certificationChallengeRecId,
+        courseId: certificationCourseId,
+      });
+
+      await databaseBuilder.commit();
+      const certificationAssessmentToBeSaved = await certificationAssessmentRepository.get(certificationAssessmentId);
+      certificationAssessmentToBeSaved.state = CertificationAssessment.states.ENDED_BY_FINALIZATION;
+
+      // when
+      await certificationAssessmentRepository.save(certificationAssessmentToBeSaved);
+
+      // then
+      const persistedCertificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
+      expect(persistedCertificationAssessment.state).to.deep.equal(
+        CertificationAssessment.states.ENDED_BY_FINALIZATION
+      );
+    });
   });
 });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -22,6 +22,7 @@ const {
   OrganizationLearnerCannotBeDissociatedError,
   UserShouldNotBeReconciledOnAnotherAccountError,
   CertificationCandidateOnFinalizedSessionError,
+  CertificationEndedByFinalizationError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -407,6 +408,19 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate ConflictError when CertificationEndedByFinalizationError', async function () {
+      // given
+      const error = new CertificationEndedByFinalizationError();
+      sinon.stub(HttpErrors, 'ConflictError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
     });
   });
 });

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -451,7 +451,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01T00:00:00Z'),
         completedAt: new Date('2020-01-01T00:00:00Z'),
-        state: 'started',
+        state: 'endedBecauseSessionFinalized',
         isV2Certification: true,
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -451,7 +451,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01T00:00:00Z'),
         completedAt: new Date('2020-01-01T00:00:00Z'),
-        state: 'endedBecauseSessionFinalized',
+        state: 'endedByFinalization',
         isV2Certification: true,
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -451,7 +451,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         certificationCourseId: 123,
         createdAt: new Date('2020-01-01T00:00:00Z'),
         completedAt: new Date('2020-01-01T00:00:00Z'),
-        state: 'endedByFinalization',
+        state: 'endedDueToFinalization',
         isV2Certification: true,
         certificationChallenges: [
           domainBuilder.buildCertificationChallengeWithType({

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -43,10 +43,10 @@ describe('Unit | Domain | Models | Assessment', function () {
       const assessment = new Assessment({ state: 'endedBySupervisor' });
 
       // when
-      const isCompleted = assessment.isEndedBySupervisor();
+      const isEndedBySupervisor = assessment.isEndedBySupervisor();
 
       // then
-      expect(isCompleted).to.be.true;
+      expect(isEndedBySupervisor).to.be.true;
     });
 
     it('should return false when its state is not endedBySupervisor', function () {
@@ -54,10 +54,10 @@ describe('Unit | Domain | Models | Assessment', function () {
       const assessment = new Assessment({ state: '' });
 
       // when
-      const isCompleted = assessment.isEndedBySupervisor();
+      const isEndedBySupervisor = assessment.isEndedBySupervisor();
 
       // then
-      expect(isCompleted).to.be.false;
+      expect(isEndedBySupervisor).to.be.false;
     });
   });
 

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -61,6 +61,30 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
+  describe('#isEndedByFinalization', function () {
+    it('should return true when its state is endedByFinalization', function () {
+      // given
+      const assessment = new Assessment({ state: 'endedByFinalization' });
+
+      // when
+      const isEndedByFinalization = assessment.isEndedByFinalization();
+
+      // then
+      expect(isEndedByFinalization).to.be.true;
+    });
+
+    it('should return false when its state is not endedByFinalization', function () {
+      // given
+      const assessment = new Assessment({ state: '' });
+
+      // when
+      const isEndedByFinalization = assessment.isEndedByFinalization();
+
+      // then
+      expect(isEndedByFinalization).to.be.false;
+    });
+  });
+
   describe('#setCompleted', function () {
     it('should return the same object with state completed', function () {
       // given

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -61,27 +61,27 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
-  describe('#isEndedByFinalization', function () {
-    it('should return true when its state is endedByFinalization', function () {
+  describe('#hasBeenEndedDueToFinalization', function () {
+    it('should return true when its state is endedDueToFinalization', function () {
       // given
-      const assessment = new Assessment({ state: 'endedByFinalization' });
+      const assessment = new Assessment({ state: 'endedDueToFinalization' });
 
       // when
-      const isEndedByFinalization = assessment.isEndedByFinalization();
+      const hasBeenEndedDueToFinalization = assessment.hasBeenEndedDueToFinalization();
 
       // then
-      expect(isEndedByFinalization).to.be.true;
+      expect(hasBeenEndedDueToFinalization).to.be.true;
     });
 
-    it('should return false when its state is not endedByFinalization', function () {
+    it('should return false when its state is not endedDueToFinalization', function () {
       // given
       const assessment = new Assessment({ state: '' });
 
       // when
-      const isEndedByFinalization = assessment.isEndedByFinalization();
+      const hasBeenEndedDueToFinalization = assessment.hasBeenEndedDueToFinalization();
 
       // then
-      expect(isEndedByFinalization).to.be.false;
+      expect(hasBeenEndedDueToFinalization).to.be.false;
     });
   });
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -439,18 +439,18 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     });
   });
 
-  describe('#endByFinalization', function () {
-    it('should change the assessment state to "endedByFinalization"', function () {
+  describe('#endDueToFinalization', function () {
+    it('should change the assessment state to "endedDueToFinalization"', function () {
       // given
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         state: CertificationAssessment.states.STARTED,
       });
 
       // when
-      certificationAssessment.endByFinalization();
+      certificationAssessment.endDueToFinalization();
 
       // when then
-      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_FINALIZATION);
+      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION);
     });
   });
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -439,6 +439,21 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     });
   });
 
+  describe('#endByFinalization', function () {
+    it('should change the assessment state to "endedByFinalization"', function () {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        state: CertificationAssessment.states.STARTED,
+      });
+
+      // when
+      certificationAssessment.endByFinalization();
+
+      // when then
+      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_FINALIZATION);
+    });
+  });
+
   describe('#listCertifiableBadgeKeysTaken', function () {
     it('returns the certifiable badge keys of those taken during this certification', function () {
       // given

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -10,6 +10,7 @@ const {
   NotFoundError,
   ForbiddenAccess,
   CertificationEndedBySupervisorError,
+  CertificationEndedByFinalizationError,
 } = require('../../../../lib/domain/errors');
 const dateUtils = require('../../../../lib/infrastructure/utils/date-utils');
 
@@ -126,6 +127,29 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
       // then
       return expect(error).to.be.an.instanceOf(CertificationEndedBySupervisorError);
+    });
+  });
+
+  context('when the assessment has been ended because session was finalized', function () {
+    it('should throw a CertificationEndedByFinalizationError error', async function () {
+      // given
+      const assessment = domainBuilder.buildAssessment({
+        userId,
+        lastQuestionDate: nowDate,
+        state: Assessment.states.ENDED_BY_FINALIZATION,
+      });
+      assessmentRepository.get.resolves(assessment);
+
+      // when
+      const error = await catchErr(correctAnswerThenUpdateAssessment)({
+        answer,
+        userId,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(CertificationEndedByFinalizationError);
+      expect(error.message).to.equal('La session a été finalisée par votre centre de certification.');
     });
   });
 

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -136,7 +136,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       const assessment = domainBuilder.buildAssessment({
         userId,
         lastQuestionDate: nowDate,
-        state: Assessment.states.ENDED_BY_FINALIZATION,
+        state: Assessment.states.ENDED_DUE_TO_FINALIZATION,
       });
       assessmentRepository.get.resolves(assessment);
 

--- a/mon-pix/app/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/components/certifications/certification-ender.hbs
@@ -20,7 +20,7 @@
           {{t "pages.certification-ender.candidate.ended-by-supervisor"}}
         </div>
       {{/if}}
-      {{#if @isEndedByFinalization}}
+      {{#if @hasBeenEndedDueToFinalization}}
         <div class="certification-ender__candidate-message">
           {{t "pages.certification-ender.candidate.ended-due-to-finalization"}}
         </div>

--- a/mon-pix/app/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/components/certifications/certification-ender.hbs
@@ -20,6 +20,11 @@
           {{t "pages.certification-ender.candidate.ended-by-supervisor"}}
         </div>
       {{/if}}
+      {{#if @isEndedByFinalization}}
+        <div class="certification-ender__candidate-message">
+          {{t "pages.certification-ender.candidate.ended-due-to-finalization"}}
+        </div>
+      {{/if}}
       <PixButtonLink @route="logout" @backgroundColor="blue" class="certification-ender__candidate-action-disconnect">
         {{t "pages.certification-ender.candidate.disconnect"}}
       </PixButtonLink>

--- a/mon-pix/app/controllers/certifications/results.js
+++ b/mon-pix/app/controllers/certifications/results.js
@@ -1,7 +1,12 @@
 import Controller from '@ember/controller';
+import { assessmentStates } from 'mon-pix/models/assessment';
 
 export default class CertificationResultsController extends Controller {
   get isEndedBySupervisor() {
-    return this.model.assessment.get('state') === 'endedBySupervisor';
+    return this.model.assessment.get('state') === assessmentStates.ENDED_BY_SUPERVISOR;
+  }
+
+  get isEndedByFinalization() {
+    return this.model.assessment.get('state') === assessmentStates.ENDED_BY_FINALIZATION;
   }
 }

--- a/mon-pix/app/controllers/certifications/results.js
+++ b/mon-pix/app/controllers/certifications/results.js
@@ -6,7 +6,7 @@ export default class CertificationResultsController extends Controller {
     return this.model.assessment.get('state') === assessmentStates.ENDED_BY_SUPERVISOR;
   }
 
-  get isEndedByFinalization() {
-    return this.model.assessment.get('state') === assessmentStates.ENDED_BY_FINALIZATION;
+  get hasBeenEndedDueToFinalization() {
+    return this.model.assessment.get('state') === assessmentStates.ENDED_DUE_TO_FINALIZATION;
   }
 }

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -3,6 +3,14 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { equal, or, not, and } from '@ember/object/computed';
 import ENV from 'mon-pix/config/environment';
+
+export const assessmentStates = {
+  COMPLETED: 'completed',
+  STARTED: 'started',
+  ABORTED: 'aborted',
+  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_BY_FINALIZATION: 'endedByFinalization',
+};
 export default class Assessment extends Model {
   // attributes
   @attr('string') certificationNumber;

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -9,7 +9,7 @@ export const assessmentStates = {
   STARTED: 'started',
   ABORTED: 'aborted',
   ENDED_BY_SUPERVISOR: 'endedBySupervisor',
-  ENDED_BY_FINALIZATION: 'endedByFinalization',
+  ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 export default class Assessment extends Model {
   // attributes

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -100,7 +100,7 @@ export default class ChallengeRoute extends Route {
     } catch (error) {
       answer.rollbackAttributes();
 
-      if (error?.errors?.[0]?.detail === 'Le surveillant a mis fin à votre test de certification.') {
+      if (this._isAssessmentEndedBySupervisorOrByFinalization(error)) {
         return this.transitionTo('certifications.results', assessment.certificationCourse.get('id'));
       }
 
@@ -122,5 +122,12 @@ export default class ChallengeRoute extends Route {
     if (isExiting) {
       controller.set('hasFocusedOutOfChallenge', false);
     }
+  }
+
+  _isAssessmentEndedBySupervisorOrByFinalization(error) {
+    return (
+      error?.errors?.[0]?.detail === 'Le surveillant a mis fin à votre test de certification.' ||
+      error?.errors?.[0]?.detail === 'La session a été finalisée par votre centre de certification.'
+    );
   }
 }

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,9 +1,10 @@
 {{page-title (t "pages.certification-results.title")}}
 
-{{#if @model.isEndTestScreenRemovalEnabled}}
+{{#if (or @model.isEndTestScreenRemovalEnabled this.isEndedByFinalization)}}
   <Certifications::CertificationEnder
     @certificationNumber={{@model.id}}
     @isEndedBySupervisor={{this.isEndedBySupervisor}}
+    @isEndedByFinalization={{this.isEndedByFinalization}}
   />
 {{else}}
   <CertificationResultsPage @certificationNumber={{@model.id}} />

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,10 +1,10 @@
 {{page-title (t "pages.certification-results.title")}}
 
-{{#if (or @model.isEndTestScreenRemovalEnabled this.isEndedByFinalization)}}
+{{#if (or @model.isEndTestScreenRemovalEnabled this.hasBeenEndedDueToFinalization)}}
   <Certifications::CertificationEnder
     @certificationNumber={{@model.id}}
     @isEndedBySupervisor={{this.isEndedBySupervisor}}
-    @isEndedByFinalization={{this.isEndedByFinalization}}
+    @hasBeenEndedDueToFinalization={{this.hasBeenEndedDueToFinalization}}
   />
 {{else}}
   <CertificationResultsPage @certificationNumber={{@model.id}} />

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -380,7 +380,7 @@ describe('Acceptance | Certification | Certification Course', function () {
           });
           this.server.create('assessment', {
             certificationCourseId: certificationCourse.id,
-            state: assessmentStates.ENDED_BY_FINALIZATION,
+            state: assessmentStates.ENDED_DUE_TO_FINALIZATION,
           });
 
           // when

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -7,6 +7,7 @@ import { authenticateByEmail } from '../helpers/authentication';
 import { fillCertificationJoiner, fillCertificationStarter } from '../helpers/certification';
 import setupIntl from '../helpers/setup-intl';
 import { contains } from '../helpers/contains';
+import { assessmentStates } from 'mon-pix/models/assessment';
 
 describe('Acceptance | Certification | Certification Course', function () {
   setupApplicationTest();
@@ -354,7 +355,7 @@ describe('Acceptance | Certification | Certification Course', function () {
           });
           this.server.create('assessment', {
             certificationCourseId: certificationCourse.id,
-            state: 'endedBySupervisor',
+            state: assessmentStates.ENDED_BY_SUPERVISOR,
           });
 
           // when
@@ -365,6 +366,31 @@ describe('Acceptance | Certification | Certification Course', function () {
           expect(
             contains(
               'Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.'
+            )
+          ).to.exist;
+        });
+      });
+
+      context('when test was ended by finalization', function () {
+        it('should display "La session a été finalisée par votre centre de certification..."', async function () {
+          // given
+          const user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
+          const certificationCourse = this.server.create('certification-course', {
+            isEndTestScreenRemovalEnabled: false,
+          });
+          this.server.create('assessment', {
+            certificationCourseId: certificationCourse.id,
+            state: assessmentStates.ENDED_BY_FINALIZATION,
+          });
+
+          // when
+          await authenticateByEmail(user);
+          await visit(`/certifications/${certificationCourse.id}/results`);
+
+          // then
+          expect(
+            contains(
+              'La session a été finalisée par votre centre de certification. Vous ne pouvez plus continuer de répondre aux questions.'
             )
           ).to.exist;
         });

--- a/mon-pix/tests/integration/components/certifications/certification-ender_test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender_test.js
@@ -102,7 +102,7 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
 
       // when
       await render(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedByFinalization={{true}} />
+      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @hasBeenEndedDueToFinalization={{true}} />
     `);
 
       // then

--- a/mon-pix/tests/integration/components/certifications/certification-ender_test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender_test.js
@@ -89,4 +89,24 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
       expect(contains(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).to.exist;
     });
   });
+
+  context('when the assessment status is ended by finalization', function () {
+    it('should display the ended by finalization text', async function () {
+      // given
+      class currentUser extends Service {
+        user = {
+          fullName: 'Jim Halpert',
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+
+      // when
+      await render(hbs`
+      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedByFinalization={{true}} />
+    `);
+
+      // then
+      expect(contains(this.intl.t('pages.certification-ender.candidate.ended-due-to-finalization'))).to.exist;
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -306,7 +306,8 @@
         "title": "Your test is finished!",
         "ended-by-supervisor": "Your invigilator has marked your certification test as completed. You cannot continue to answer questions.",
         "disconnect": "Log out of my account",
-        "disconnect-tip": "If this is not your computer, please remember to log out."
+        "disconnect-tip": "If this is not your computer, please remember to log out.",
+        "ended-due-to-finalization": "Your certification centre has ended the session. You can no longer answer questions."
       },
       "results": {
         "disclaimer": "Your results, pending validation by the Pix team, will soon be available on your Pix account",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -306,7 +306,8 @@
         "title": "Test terminé !",
         "ended-by-supervisor": "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.",
         "disconnect": "Déconnecter mon compte",
-        "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter."
+        "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.",
+        "ended-due-to-finalization": "La session a été finalisée par votre centre de certification. Vous ne pouvez plus continuer de répondre aux questions."
       },
       "results": {
         "disclaimer": "Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles depuis votre compte Pix",


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, rien n'empêche un candidat de poursuivre son test de certification après finalisation.

## :robot: Solution
Empecher le candidat de poursuivre son test en
- le redirigeant sur la page de fin de test 
- afficher un message d'information

## :100: Pour tester
- Commencer un test de certification sans aller au bout
- Finaliser la session
- Essayer de continuer à repondre au test
- Constater l'impossiblité de répondre et l'affichage d'une page d'erreur précisant: “La session a été finalisée par votre centre de certification. Vous ne pouvez plus continuer de répondre aux questions.”

![image](https://user-images.githubusercontent.com/37305474/171139827-abfba097-803b-4367-88b9-22b558ee9d37.png)

Vérifier que l'état de l'assessment en BDD est ``

```sql
SELECT
    'center=>',
    crt.name "centerName",
    'session=>',
    s.id     "sessionId",
    s."publishedAt" ,
    'course=>',
    cc.id    "certificationCourseId",
    cc."firstName",
    cc."lastName",
    cc."userId",
    u.email,
    cc."lastName",
    cc.birthdate,
    'assessments=>',
    ass.id,
    ass.type,
    ass.state
FROM sessions s
         INNER JOIN "certification-centers" crt ON crt.id = s."certificationCenterId"
         INNER JOIN "certification-courses" cc ON cc."sessionId" = s.id
         INNER JOIN users u ON u.id = cc."userId"
         INNER JOIN assessments ass ON ass."certificationCourseId" = cc.id
WHERE 1 = 1
  AND s.id = 20006;
```