### PR TITLE
[A11Y] Ajouter le rôle img aux boulettes de pertinence dans l'onglet Analyse (PIX-4246)

### DIFF
--- a/orga/app/components/campaign/analysis/recommendation-indicator.hbs
+++ b/orga/app/components/campaign/analysis/recommendation-indicator.hbs
@@ -1,5 +1,5 @@
 <div class="recommendation-indicator">
-  <svg height="10" width={{this.bubbleWidth}} aria-label={{this.label}}>
+  <svg height="10" width={{this.bubbleWidth}} aria-label={{this.label}} role="img">
     {{#each this.bubbles as |bubble index|}}
       <circle cx={{sum (multiply 12 index) 5}} cy="5" r="5" class="recommendation-indicator__bubble"></circle>
     {{/each}}

--- a/orga/app/components/campaign/analysis/recommendations.hbs
+++ b/orga/app/components/campaign/analysis/recommendations.hbs
@@ -13,7 +13,8 @@
         <Table::Header @size="wide">{{t
             "pages.campaign-review.table.analysis.column.subjects"
             count=this.sortedRecommendations.length
-          }}</Table::Header>
+          }}
+        </Table::Header>
         <Table::HeaderSort
           @size="small"
           @align="center"

--- a/orga/app/components/campaign/analysis/recommendations.js
+++ b/orga/app/components/campaign/analysis/recommendations.js
@@ -20,7 +20,7 @@ export default class Recommendations extends Component {
     return htmlSafe(
       this.intl.t('pages.campaign-review.description', {
         bubble:
-          '<svg height="10" width="10"><circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble" /></svg>',
+          '<svg height="10" width="10" role="img"><circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble" /></svg>',
       })
     );
   }


### PR DESCRIPTION
## :unicorn: Problème
Dans la continuité des changements à effectuer pour rendre l'application Pix Orga plus accessible, il a été constaté lors de l'audit que les boulettes de pertinence dans l'onglet Analyse n'avait pas de rôle img ce qui avait pour effet de polluer la lecture des lecteurs d'écran.

## :robot: Solution
Ajouter un rôle =img aux boulettes dans le tableau et dans la phrase d'explication.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga et aller dans une campagne avec des résultats
- Dans l'onglet Analyse, constater la présence du rôle
