### PR TITLE
[TECH] Mieux cibler les erreurs lors de la réinitialisation du mot de passe sur Pix App (PIX-5016)

### DIFF
--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const { knex } = require('../../../db/knex-database-connection');
-const logger = require('../../infrastructure/logger');
+
 const DomainTransaction = require('../DomainTransaction');
 const BookshelfUser = require('../orm-models/User');
 const { isUniqConstraintViolated } = require('../utils/knex-utils');
@@ -55,12 +55,6 @@ module.exports = {
       })
       .then((foundUser) => {
         if (foundUser === null) {
-          logger.warn(
-            {
-              username,
-            },
-            'Trying to change his password with incorrect username'
-          );
           return Promise.reject(new UserNotFoundError());
         }
         return _toDomain(foundUser);

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -62,7 +62,7 @@ describe('Unit | UseCase | update-expired-password', function () {
   });
 
   context('When credentials are invalid', function () {
-    it('should throw UserNotFoundError when username is unknow', async function () {
+    it('should throw UserNotFoundError when username is unknown', async function () {
       // given
       pixAuthenticationService.getUserByUsernameAndPassword.rejects(new UserNotFoundError());
 


### PR DESCRIPTION
## :unicorn: Problème
Un ticket précédent (#4458) permet de déclencher une alerte dans datadog lorsque survient une erreur lors de la réinitialisation d’un mot de passe. Mais l’erreur se déclenche trop souvent, notamment dès qu’un utilisateur entre un identifiant invalide (ce qui est très fréquent).

## :robot: Solution
- Supprimer le logger actuel dans la méthode de repository getByUsernameOrEmailWithRolesAndPassword
- Ajouter un logguer dans le usecase updateExpiredPassword lorsqu’on catche l’erreur UserNotFound

## :rainbow: Remarques

Le commit [feat(api): log username on password reset error](https://github.com/1024pix/pix/pull/4471/commits/9bf0dc3d6797bba134b66d095cb9c7934069f647) sera à revert une fois l'investigation terminée

## :100: Pour tester (en local)

### Cas passant

1. Aller sur Pix Orga et se connecter (sco.admin)
2. Dans le menu de gauche, aller sur Élèves
3. Choisir un élève possédant une méthode identifiant et/ou adresse e-mail et cliquer sur le bouton d'action tout à droite "Gérer le compte"
4. Cliquer sur le bouton "Réinitialiser le mot de passe"
5. Récupérer l'identifiant et nouveau mot de passe de l'élève et aller sur Mon Pix
6. Sur la page connexion, renseigner les deux informations
7. Renseigner un nouveau mot de passe
8. Constater qu'on redirigé vers Pix App en étant identifié

### Cas non-passant

1. Répéter les étapes 1 à 6 du cas passant
2. Simuler une erreur 404, par exemple en ajoutant `throw new UserNotFoundError();` ligne 44 dans la méthode `getByUsernameOrEmailWithRolesAndPassword` du user-repository (et ne pas oublier de redémarrer l'API)
3. Constater que l'erreur apparaît avec le username dans les logs de l'API

![Capture d’écran 2022-05-31 à 15 59 01](https://user-images.githubusercontent.com/5627688/171191584-27934d87-5419-4ffd-b7ca-9a770f37d2fd.png)

4. Tenter de se connecter à Pix App avec un username inexistant
5. Constater que l'erreur n'apparaît *pas* dans les logs de l'API
