### PR TITLE
[FEATURE] Neutraliser automatiquement les signalements des sous-catégories E11 et E12 (PIX-4913)

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -28,6 +28,9 @@ export const certificationIssueReportSubcategories = {
   OTHER: 'OTHER',
   EXTRA_TIME_EXCEEDED: 'EXTRA_TIME_EXCEEDED',
   SOFTWARE_NOT_WORKING: 'SOFTWARE_NOT_WORKING',
+  UNINTENTIONAL_FOCUS_OUT: 'UNINTENTIONAL_FOCUS_OUT',
+  SKIP_ON_OOPS: 'SKIP_ON_OOPS',
+  ACCESSIBILITY_ISSUE: 'ACCESSIBILITY_ISSUE',
 };
 
 export const categoryToLabel = {
@@ -62,6 +65,12 @@ export const subcategoryToLabel = {
     "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
   [certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]:
     "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+  [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
+    'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
+  [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
+    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+  [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
+    'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };
 
 export const subcategoryToTextareaLabel = {

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { certificationIssueReportSubcategories } from 'pix-admin/models/certification-issue-report';
 
 module('Integration | Component | certifications/issue-report', function (hooks) {
   setupRenderingTest(hooks);
@@ -62,6 +63,86 @@ module('Integration | Component | certifications/issue-report', function (hooks)
 
       // Then
       assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
+    });
+  });
+
+  [
+    {
+      subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+      expectedLabel: 'Modification des prénom/nom/date de naissance',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
+      expectedLabel: 'Ajout/modification du temps majoré',
+    },
+    { subcategory: certificationIssueReportSubcategories.LEFT_EXAM_ROOM, expectedLabel: 'Écran de fin de test non vu' },
+    {
+      subcategory: certificationIssueReportSubcategories.SIGNATURE_ISSUE,
+      expectedLabel: 'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+      expectedLabel: "L'image ne s'affiche pas",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.EMBED_NOT_WORKING,
+      expectedLabel: "Le simulateur/l'application ne s'affiche pas",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.FILE_NOT_OPENING,
+      expectedLabel: "Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
+      expectedLabel: 'Le site à visiter est indisponible/en maintenance/inaccessible',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.WEBSITE_BLOCKED,
+      expectedLabel: "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+    },
+    { subcategory: certificationIssueReportSubcategories.LINK_NOT_WORKING, expectedLabel: 'Le lien ne fonctionne pas' },
+    { subcategory: certificationIssueReportSubcategories.OTHER, expectedLabel: 'Autre incident lié à une question' },
+    {
+      subcategory: certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+      expectedLabel:
+        "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+      expectedLabel: "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+      expectedLabel:
+        'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.SKIP_ON_OOPS,
+      expectedLabel: 'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
+      expectedLabel: 'Problème avec l’accessibilité de la question (ex : daltonisme)',
+    },
+  ].forEach(function ({ subcategory, expectedLabel }) {
+    test('should display subcategory', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
+        category: 'TECHNICAL_PROBLEM',
+        subcategory,
+        description: 'this is a report',
+        questionNumber: 2,
+        isImpactful: true,
+        resolvedAt: null,
+      });
+      this.set('issueReport', issueReport);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // then
+      assert.dom(screen.getByText(expectedLabel, { exact: false })).exists();
     });
   });
 });

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -31,7 +31,7 @@ module('Unit | Model | certification issue report', function (hooks) {
   });
 
   test('it should return the right label for the subcategory', function (assert) {
-    assert.expect(13);
+    assert.expect(16);
     // given
     const store = this.owner.lookup('service:store');
 

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -169,6 +169,8 @@ class CertificationIssueReportResolutionStrategies {
       case CertificationIssueReportSubcategories.WEBSITE_BLOCKED:
       case CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE:
       case CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING:
+      case CertificationIssueReportSubcategories.SKIP_ON_OOPS:
+      case CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE:
         return await this._neutralizeWithoutChecking(strategyParameters);
       case CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING:
         return await this._neutralizeIfImage(strategyParameters);

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -1693,6 +1693,16 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         subCategoryToBeResolved: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
         strategyToBeApplied: 'neutralizeOrValidateIfFocusedChallenge',
       },
+      {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        subCategoryToBeResolved: CertificationIssueReportSubcategories.SKIP_ON_OOPS,
+        strategyToBeApplied: 'neutralizeWithoutChecking',
+      },
+      {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        subCategoryToBeResolved: CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
+        strategyToBeApplied: 'neutralizeWithoutChecking',
+      },
     ].forEach(({ subCategoryToBeResolved, strategyToBeApplied }) => {
       it(`apply strategy "${strategyToBeApplied}" when resolving issue report of subcategory "${subCategoryToBeResolved}"`, async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
2 nouvelles sous-catégories de signalement vont être ajoutées pour la catégorie “Problème technique sur une question”. Comme toutes les sous-catégories de cette section, un traitement automatique peut être mis en place pour faciliter le traitement des sessions pour le pôle certif

## :robot: Solution
Neutraliser automatiquement une question pour laquelle les sous-catégories E11 ou E12 auraient été sélectionnées, uniquement si le statut de la réponse est différent de OK (si OK, ne PAS neutraliser)

## :100: Pour tester
- Activer le toggle FT_CERTIFICATION_FREE_FIELDS_DELETION
- Passer une certification avec quelques questions ko et passées
- Finaliser la session en remplissant des reports E11 et E12 pour l'une des questions passée/ko
- Constater que ces questions ont été neutralisées automatiquement lors de l'auto jury
