### PR TITLE
[FEATURE] Afficher les sous catégories E10-E11-E12 dans Pix-Admin (PIX-4914).

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -28,6 +28,9 @@ export const certificationIssueReportSubcategories = {
   OTHER: 'OTHER',
   EXTRA_TIME_EXCEEDED: 'EXTRA_TIME_EXCEEDED',
   SOFTWARE_NOT_WORKING: 'SOFTWARE_NOT_WORKING',
+  UNINTENTIONAL_FOCUS_OUT: 'UNINTENTIONAL_FOCUS_OUT',
+  SKIP_ON_OOPS: 'SKIP_ON_OOPS',
+  ACCESSIBILITY_ISSUE: 'ACCESSIBILITY_ISSUE',
 };
 
 export const categoryToLabel = {
@@ -62,6 +65,12 @@ export const subcategoryToLabel = {
     "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
   [certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]:
     "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+  [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
+    'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
+  [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
+    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+  [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
+    'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };
 
 export const subcategoryToTextareaLabel = {

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { certificationIssueReportSubcategories } from 'pix-admin/models/certification-issue-report';
 
 module('Integration | Component | certifications/issue-report', function (hooks) {
   setupRenderingTest(hooks);
@@ -62,6 +63,86 @@ module('Integration | Component | certifications/issue-report', function (hooks)
 
       // Then
       assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
+    });
+  });
+
+  [
+    {
+      subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+      expectedLabel: 'Modification des prénom/nom/date de naissance',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
+      expectedLabel: 'Ajout/modification du temps majoré',
+    },
+    { subcategory: certificationIssueReportSubcategories.LEFT_EXAM_ROOM, expectedLabel: 'Écran de fin de test non vu' },
+    {
+      subcategory: certificationIssueReportSubcategories.SIGNATURE_ISSUE,
+      expectedLabel: 'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+      expectedLabel: "L'image ne s'affiche pas",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.EMBED_NOT_WORKING,
+      expectedLabel: "Le simulateur/l'application ne s'affiche pas",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.FILE_NOT_OPENING,
+      expectedLabel: "Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
+      expectedLabel: 'Le site à visiter est indisponible/en maintenance/inaccessible',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.WEBSITE_BLOCKED,
+      expectedLabel: "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+    },
+    { subcategory: certificationIssueReportSubcategories.LINK_NOT_WORKING, expectedLabel: 'Le lien ne fonctionne pas' },
+    { subcategory: certificationIssueReportSubcategories.OTHER, expectedLabel: 'Autre incident lié à une question' },
+    {
+      subcategory: certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+      expectedLabel:
+        "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+      expectedLabel: "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+      expectedLabel:
+        'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.SKIP_ON_OOPS,
+      expectedLabel: 'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+    },
+    {
+      subcategory: certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
+      expectedLabel: 'Problème avec l’accessibilité de la question (ex : daltonisme)',
+    },
+  ].forEach(function ({ subcategory, expectedLabel }) {
+    test('should display subcategory', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
+        category: 'TECHNICAL_PROBLEM',
+        subcategory,
+        description: 'this is a report',
+        questionNumber: 2,
+        isImpactful: true,
+        resolvedAt: null,
+      });
+      this.set('issueReport', issueReport);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // then
+      assert.dom(screen.getByText(expectedLabel, { exact: false })).exists();
     });
   });
 });

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -31,7 +31,7 @@ module('Unit | Model | certification issue report', function (hooks) {
   });
 
   test('it should return the right label for the subcategory', function (assert) {
-    assert.expect(13);
+    assert.expect(16);
     // given
     const store = this.owner.lookup('service:store');
 


### PR DESCRIPTION
## :unicorn: Problème
Les sous-catégories E10-E11-E12  ne sont pas affichées

## :robot: Solution
Les afficher

## :rainbow: Remarques
Ajout de tests manquants

## :100: Pour tester
Activer le FT `FT_CERTIFICATION_FREE_FIELDS_DELETION`
Créer des signalements de ce type
Finaliser la session
[Visualiser dans PixAdmin](https://admin-pr4473.review.pix.fr/certifications/18000)


![image](https://user-images.githubusercontent.com/56302715/171213194-ad2974f3-091c-4edf-9e39-280ae3ad339a.png)
