### PR TITLE
[FEATURE] Permettre de donner l'accès à l'application Pix Admin à un nouvel employé Pix (PIX-4004)

### DIFF
--- a/admin/app/components/team/add-member.hbs
+++ b/admin/app/components/team/add-member.hbs
@@ -1,0 +1,36 @@
+<form class="add-member-to-team-form" onsubmit={{this.inviteMember}}>
+  <h2 class="pix-text--large">Donner accès à un agent Pix</h2>
+
+  <section class="add-member-to-team-form__content">
+    <section class="add-member-to-team-form__input">
+      <PixInput
+        @id="email"
+        @label="Adresse e-mail professionnelle de l'agent Pix à rattacher"
+        @requiredLabel="Champ obligatoire"
+        @errorMessage={{this.inviteErrorRaised}}
+        value={{this.email}}
+        {{on "change" this.emailChanged}}
+      />
+    </section>
+
+    <section class="add-member-to-team-form__select {{if this.inviteErrorRaised "error-padding"}}">
+      <PixSelect
+        @options={{@roles}}
+        @selectedOption={{this.role}}
+        @isSearchable={{false}}
+        @onChange={{this.roleChanged}}
+        aria-label="Choisir le rôle à assigner au nouveau membre"
+      />
+    </section>
+
+    <PixButton
+      @size="small"
+      class={{if this.inviteErrorRaised "error-padding"}}
+      type="submit"
+      aria-label="Donner accès à un agent Pix"
+      @triggerAction={{this.inviteMember}}
+    >
+      Valider
+    </PixButton>
+  </section>
+</form>

--- a/admin/app/components/team/add-member.js
+++ b/admin/app/components/team/add-member.js
@@ -1,0 +1,75 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import isEmailValid from '../../utils/email-validator';
+
+export default class AddMember extends Component {
+  @service notifications;
+  @service store;
+
+  @tracked email = '';
+  @tracked role = 'SUPER_ADMIN';
+  @tracked inviteErrorRaised;
+
+  @action
+  async inviteMember(event) {
+    event.preventDefault();
+
+    if (!this._isEmailValid()) {
+      return;
+    }
+
+    const members = this.store.peekAll('admin-member');
+    if (members.find((member) => member.email === this.email)) {
+      return this.notifications.error('Cet agent a déjà accès');
+    }
+
+    try {
+      const adminMember = this.store.createRecord('admin-member', { email: this.email, role: this.role });
+      await adminMember.save();
+      this.email = '';
+      this.role = 'SUPER_ADMIN';
+      this.notifications.success("L'agent a dorénavant accès");
+    } catch (error) {
+      let errorMessage = "Une erreur s'est produite, veuillez réessayer.";
+
+      if (error?.errors?.length) {
+        const { code, detail } = error.errors[0];
+
+        if (code === 'USER_ACCOUNT_NOT_FOUND') {
+          errorMessage = "Cet utilisateur n'existe pas";
+        } else {
+          errorMessage = detail;
+        }
+      }
+
+      this.notifications.error(errorMessage);
+    }
+  }
+
+  @action
+  emailChanged(event) {
+    this.email = event?.target?.value?.trim() ?? null;
+  }
+
+  @action
+  roleChanged(event) {
+    this.role = event?.target?.value ?? null;
+  }
+
+  _isEmailValid() {
+    if (!this.email) {
+      this.inviteErrorRaised = 'Le champ adresse e-mail est requis.';
+      return false;
+    }
+
+    if (!isEmailValid(this.email)) {
+      this.inviteErrorRaised = "L'adresse e-mail saisie n'est pas valide.";
+      return false;
+    }
+
+    this.inviteErrorRaised = null;
+    return true;
+  }
+}

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -4,7 +4,7 @@
       <tr>
         <th>Prénom</th>
         <th>Nom</th>
-        <th>E-mail</th>
+        <th>Adresse e-mail</th>
         <th>Rôle</th>
         <th>Actions</th>
       </tr>

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -1,5 +1,5 @@
 <div class="content-text content-text--small">
-  <table class="table-admin">
+  <table aria-label="Liste des membres" class="table-admin">
     <thead>
       <tr>
         <th>Prénom</th>
@@ -21,7 +21,7 @@
                 <PixSelect
                   @onChange={{this.setAdminRoleSelection}}
                   @selectedOption={{member.role}}
-                  @options={{this.adminRoles}}
+                  @options={{@roles}}
                   aria-label="Sélectionner un rôle"
                   @isSearchable={{false}}
                   as |role|

--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -9,11 +9,6 @@ export default class List extends Component {
   @tracked editionMode = false;
   @tracked newRole;
 
-  get adminRoles() {
-    const allRoles = ['SUPER_ADMIN', 'CERTIF', 'METIER', 'SUPPORT'];
-    return allRoles.map((role) => ({ value: role, label: role }));
-  }
-
   @action
   async toggleEditionModeForThisMember(member) {
     member.isInEditionMode = true;

--- a/admin/app/controllers/authenticated/team/list.js
+++ b/admin/app/controllers/authenticated/team/list.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+
+export default class ListController extends Controller {
+  get roles() {
+    const roles = ['SUPER_ADMIN', 'CERTIF', 'METIER', 'SUPPORT'];
+    return roles.map((role) => ({ value: role, label: role }));
+  }
+}

--- a/admin/app/routes/authenticated/team/list.js
+++ b/admin/app/routes/authenticated/team/list.js
@@ -9,6 +9,12 @@ export default class ListRoute extends Route {
   }
 
   async model() {
-    return this.store.query('admin-member', {});
+    return this.store.findAll('admin-member');
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('inviteErrorRaised', null);
+    }
   }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -76,6 +76,7 @@
 @import 'components/target-profiles/organizations';
 @import 'components/target-profiles/stages';
 @import 'components/target-profiles/stage-form';
+@import 'components/team/add-member';
 @import 'components/badges/badge';
 @import 'components/campaigns/update';
 @import 'components/campaigns/participations-section';

--- a/admin/app/styles/components/team/add-member.scss
+++ b/admin/app/styles/components/team/add-member.scss
@@ -1,0 +1,21 @@
+.add-member-to-team-form {
+
+  &__content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+  }
+
+  &__input {
+    min-width: 280px;
+  }
+
+  &__input,
+  &__select {
+    padding-right: 6px;
+  }
+
+  .error-padding {
+    margin-bottom: 22px;
+  }
+}

--- a/admin/app/templates/authenticated/team/list.hbs
+++ b/admin/app/templates/authenticated/team/list.hbs
@@ -6,6 +6,10 @@
 
 <main class="page-body">
   <section class="page-section">
-    <Team::List @members={{@model}} />
+    <Team::AddMember @roles={{this.roles}} />
+  </section>
+
+  <section class="page-section">
+    <Team::List @members={{@model}} @roles={{this.roles}} />
   </section>
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -25,6 +25,7 @@ import {
   getOrganizationPlaces,
 } from './handlers/organizations';
 import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
+import { createAdminMember } from './handlers/admin-members';
 
 export default function () {
   this.logging = true;
@@ -42,6 +43,8 @@ export default function () {
   this.get('/admin/admin-members', (schema) => {
     return schema.adminMembers.all();
   });
+
+  this.post('/admin/admin-members', createAdminMember);
 
   this.get('/admin/admin-members/me', (schema, request) => {
     const userToken = request.requestHeaders.Authorization.replace('Bearer ', '');

--- a/admin/mirage/handlers/admin-members.js
+++ b/admin/mirage/handlers/admin-members.js
@@ -1,0 +1,13 @@
+export function createAdminMember(schema, request) {
+  const payload = JSON.parse(request.requestBody);
+  const { email, role } = payload.data.attributes;
+  const user = schema.users.findBy({ email });
+
+  return schema.create('admin-member', {
+    userId: user.id,
+    role,
+    email,
+    firstName: user.firstName,
+    lastName: user.lastName,
+  });
+}

--- a/admin/tests/acceptance/authenticated/team/add-member_test.js
+++ b/admin/tests/acceptance/authenticated/team/add-member_test.js
@@ -1,0 +1,101 @@
+import { module, test } from 'qunit';
+import { click, fillIn } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit } from '@1024pix/ember-testing-library';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { Response } from 'ember-cli-mirage';
+
+module('Acceptance | Team | Add member', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('when admin member is super admin', function () {
+    test('it should allow to assign a role to a Pix agent and display it in the list', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(this.server);
+      this.server.create('user', {
+        email: 'chris@to.phe',
+        firstName: 'christophe',
+        lastName: 'leclerc',
+      });
+
+      // when
+      const screen = await visit('/equipe');
+      await fillIn(
+        screen.getByRole('textbox', { name: "Adresse e-mail professionnelle de l'agent Pix à rattacher" }),
+        'chris@to.phe'
+      );
+      await click(screen.getByRole('button', { name: 'Donner accès à un agent Pix' }));
+
+      // then
+      assert.dom(screen.getByText('chris@to.phe')).exists();
+      assert.dom(screen.getByText("L'agent a dorénavant accès")).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: "Adresse e-mail professionnelle de l'agent Pix à rattacher" }))
+        .hasNoValue();
+      assert.dom(screen.getByRole('table', { name: 'Liste des membres' })).containsText('christophe leclerc');
+    });
+
+    test('it should not allow to add a member that already exists', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(this.server);
+      this.server.create('user', {
+        firstName: 'Marie',
+        lastName: 'Tim',
+        email: 'marie.tim@example.net',
+      });
+      this.server.create('admin-member', {
+        firstName: 'Marie',
+        lastName: 'Tim',
+        email: 'marie.tim@example.net',
+        role: 'SUPER_ADMIN',
+        isSuperAdmin: true,
+      });
+
+      // when
+      const screen = await visit('/equipe');
+      await fillIn(
+        screen.getByRole('textbox', { name: "Adresse e-mail professionnelle de l'agent Pix à rattacher" }),
+        'marie.tim@example.net'
+      );
+      await click(screen.getByRole('button', { name: 'Donner accès à un agent Pix' }));
+
+      // then
+      assert.dom(screen.getByText('Cet agent a déjà accès')).exists();
+    });
+
+    test('it should not allow to add a user that does not exist', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(this.server);
+
+      this.server.post(
+        '/admin/admin-members',
+        () =>
+          new Response(
+            404,
+            {},
+            {
+              errors: [
+                {
+                  status: '404',
+                  code: 'USER_ACCOUNT_NOT_FOUND',
+                },
+              ],
+            }
+          )
+      );
+
+      // when
+      const screen = await visit('/equipe');
+      await fillIn(
+        screen.getByRole('textbox', { name: "Adresse e-mail professionnelle de l'agent Pix à rattacher" }),
+        'marie.tim@example.net'
+      );
+      await click(screen.getByRole('button', { name: 'Donner accès à un agent Pix' }));
+
+      // then
+      assert.dom(screen.getByText("Cet utilisateur n'existe pas")).exists();
+    });
+  });
+});

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -108,7 +108,7 @@ module('Acceptance | Team | List', function (hooks) {
 
       // then
       assert.dom(screen.getByText('Erreur lors de la mise à jour du rôle du membre Pix Admin.')).exists();
-      assert.dom(screen.getByText('SUPPORT')).exists();
+      assert.dom(screen.getByRole('row', { name: 'Anne Estésie' })).includesText('SUPPORT');
       assert.dom(screen.queryByRole('button', { name: 'Valider' })).doesNotExist();
     });
   });

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -182,7 +182,7 @@ buildUser.withRole = function buildUserWithRole({
   hasSeenAssessmentInstructions = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-
+  disabledAt,
   rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
 } = {}) {
@@ -217,7 +217,7 @@ buildUser.withRole = function buildUserWithRole({
     updatedAt,
   });
 
-  buildPixAdminRole({ userId: user.id, role });
+  buildPixAdminRole({ userId: user.id, role, disabledAt });
 
   return user;
 };

--- a/api/lib/application/admin-members/admin-member-controller.js
+++ b/api/lib/application/admin-members/admin-member-controller.js
@@ -15,8 +15,14 @@ module.exports = {
 
   async updateAdminMember(request) {
     const id = request.params.id;
-    const role = request.payload.data.attributes.role;
+    const { role } = await adminMemberSerializer.deserialize(request.payload);
     const updatedAdminMember = await usecases.updateAdminMember({ id, role });
     return adminMemberSerializer.serialize(updatedAdminMember);
+  },
+
+  async saveAdminMember(request, h) {
+    const attributes = await adminMemberSerializer.deserialize(request.payload);
+    const savedAdminMember = await usecases.saveAdminMember(attributes);
+    return h.response(adminMemberSerializer.serialize(savedAdminMember)).created();
   },
 };

--- a/api/lib/application/admin-members/index.js
+++ b/api/lib/application/admin-members/index.js
@@ -35,6 +35,35 @@ exports.register = async function (server) {
         tags: ['api', 'admin-members', 'current-member'],
       },
     },
+
+    {
+      method: 'POST',
+      path: '/api/admin/admin-members',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasRoleSuperAdmin }],
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                email: Joi.string().email().required(),
+                role: Joi.string().valid('SUPER_ADMIN', 'SUPPORT', 'METIER', 'CERTIF').required(),
+              }),
+            }),
+          }),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: adminMemberController.saveAdminMember,
+        notes: [
+          "- Cette route est restreinte aux utilisateurs ayant les droits d'accès\n" +
+            '- Elle permet de donner un accès à Pix Admin à un nouveau membre\n' +
+            'ou à réactiver un membre désactivé',
+        ],
+        tags: ['api', 'admin', 'admin-members'],
+      },
+    },
+
     {
       method: 'PATCH',
       path: '/api/admin/admin-members/{id}',

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -406,6 +406,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 
+  if (error instanceof DomainErrors.AlreadyExistingAdminMemberError) {
+    return new HttpErrors.UnprocessableEntityError(error.message);
+  }
+
   if (error instanceof DomainErrors.CandidateNotAuthorizedToJoinSessionError) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -6,6 +6,12 @@ class DomainError extends Error {
   }
 }
 
+class AlreadyExistingAdminMemberError extends DomainError {
+  constructor(message = 'Cet agent a déjà accès') {
+    super(message);
+  }
+}
+
 class AccountRecoveryDemandNotCreatedError extends DomainError {
   constructor(message = "La demande de récupération de compte n'a pas pu être générée.") {
     super(message);
@@ -1104,6 +1110,7 @@ module.exports = {
   AcquiredBadgeForbiddenDeletionError,
   AdminMemberRoleUpdateError,
   AlreadyAcceptedOrCancelledOrganizationInvitationError,
+  AlreadyExistingAdminMemberError,
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
   AlreadyExistingMembershipError,

--- a/api/lib/domain/usecases/get-admin-member-details.js
+++ b/api/lib/domain/usecases/get-admin-member-details.js
@@ -1,3 +1,11 @@
+const { NotFoundError } = require('../errors');
+
 module.exports = async function getAdminMemberDetails({ adminMemberRepository, userId }) {
-  return await adminMemberRepository.get({ userId });
+  const adminMemberDetail = await adminMemberRepository.get({ userId });
+
+  if (!adminMemberDetail) {
+    throw new NotFoundError();
+  }
+
+  return adminMemberDetail;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -369,6 +369,7 @@ module.exports = injectDependencies(
     resetScorecard: require('./reset-scorecard'),
     retrieveLastOrCreateCertificationCourse: require('./retrieve-last-or-create-certification-course'),
     revokeRefreshToken: require('./revoke-refresh-token'),
+    saveAdminMember: require('./save-admin-member'),
     saveCertificationIssueReport: require('./save-certification-issue-report'),
     saveJuryComplementaryCertificationCourseResult: require('./save-jury-complementary-certification-course-result'),
     sendEmailForAccountRecovery: require('./account-recovery/send-email-for-account-recovery'),

--- a/api/lib/domain/usecases/save-admin-member.js
+++ b/api/lib/domain/usecases/save-admin-member.js
@@ -1,0 +1,23 @@
+const { AlreadyExistingAdminMemberError } = require('../errors');
+const AdminMember = require('../models/AdminMember');
+
+module.exports = async function saveAdminMember({ email, role, userRepository, adminMemberRepository }) {
+  const { id: userId, firstName, lastName } = await userRepository.getByEmail(email);
+
+  const adminMember = await adminMemberRepository.get({ userId });
+
+  if (!adminMember) {
+    const savedAdminMember = await adminMemberRepository.save({ userId, role });
+    return new AdminMember({ ...savedAdminMember, email, firstName, lastName });
+  }
+
+  if (adminMember.disabledAt) {
+    const updatedAdminMember = await adminMemberRepository.update({
+      id: adminMember.id,
+      attributesToUpdate: { role, disabledAt: null },
+    });
+    return new AdminMember({ ...updatedAdminMember, email, firstName, lastName });
+  }
+
+  throw new AlreadyExistingAdminMemberError();
+};

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -16,7 +16,7 @@ module.exports = {
 
   get: async function ({ userId }) {
     const member = await knex
-      .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
+      .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role', 'disabledAt')
       .from(TABLE_NAME)
       .where({ userId })
       .join('users', 'users.id', `${TABLE_NAME}.userId`)
@@ -37,10 +37,7 @@ module.exports = {
       throw new AdminMemberRoleUpdateError();
     }
 
-    return new AdminMember({
-      id: updatedAdminMember.id,
-      role: updatedAdminMember.role,
-    });
+    return new AdminMember(updatedAdminMember);
   },
 
   async save(pixAdminRole) {

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -9,6 +9,7 @@ module.exports = {
     const members = await knex
       .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
       .from(TABLE_NAME)
+      .where({ disabledAt: null })
       .join('users', 'users.id', `${TABLE_NAME}.userId`)
       .orderBy(['firstName', 'lastName']);
     return members.map((member) => new AdminMember(member));

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -1,6 +1,5 @@
 const { knex } = require('../bookshelf');
 const AdminMember = require('../../domain/models/AdminMember');
-const { NotFoundError } = require('../../domain/errors');
 const { AdminMemberRoleUpdateError } = require('../../domain/errors');
 
 const TABLE_NAME = 'pix-admin-roles';
@@ -23,11 +22,7 @@ module.exports = {
       .join('users', 'users.id', `${TABLE_NAME}.userId`)
       .first();
 
-    if (!member) {
-      throw new NotFoundError();
-    }
-
-    return new AdminMember(member);
+    return member ? new AdminMember(member) : undefined;
   },
 
   async update({ id, attributesToUpdate }) {

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -3,22 +3,24 @@ const AdminMember = require('../../domain/models/AdminMember');
 const { NotFoundError } = require('../../domain/errors');
 const { AdminMemberRoleUpdateError } = require('../../domain/errors');
 
+const TABLE_NAME = 'pix-admin-roles';
+
 module.exports = {
   findAll: async function () {
     const members = await knex
-      .select('pix-admin-roles.id', 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
-      .from('pix-admin-roles')
-      .join('users', 'users.id', 'pix-admin-roles.userId')
+      .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
+      .from(TABLE_NAME)
+      .join('users', 'users.id', `${TABLE_NAME}.userId`)
       .orderBy(['firstName', 'lastName']);
     return members.map((member) => new AdminMember(member));
   },
 
   get: async function ({ userId }) {
     const member = await knex
-      .select('pix-admin-roles.id', 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
-      .from('pix-admin-roles')
+      .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role')
+      .from(TABLE_NAME)
       .where({ userId })
-      .join('users', 'users.id', 'pix-admin-roles.userId')
+      .join('users', 'users.id', `${TABLE_NAME}.userId`)
       .first();
 
     if (!member) {
@@ -31,7 +33,7 @@ module.exports = {
   async update({ id, attributesToUpdate }) {
     const now = new Date();
     const [updatedAdminMember] = await knex
-      .from('pix-admin-roles')
+      .from(TABLE_NAME)
       .where({ id })
       .update({ ...attributesToUpdate, updatedAt: now })
       .returning('*');
@@ -44,5 +46,10 @@ module.exports = {
       id: updatedAdminMember.id,
       role: updatedAdminMember.role,
     });
+  },
+
+  async save(pixAdminRole) {
+    const [savedAdminMember] = await knex(TABLE_NAME).insert(pixAdminRole).returning('*');
+    return new AdminMember(savedAdminMember);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/admin-member-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/admin-member-serializer.js
@@ -1,4 +1,4 @@
-const { Serializer } = require('jsonapi-serializer');
+const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
   serialize(adminMembers, meta) {
@@ -16,5 +16,10 @@ module.exports = {
       ],
       meta,
     }).serialize(adminMembers);
+  },
+
+  async deserialize(jsonApiData) {
+    const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
+    return await deserializer.deserialize(jsonApiData);
   },
 };

--- a/api/tests/acceptance/application/admin-members/index_test.js
+++ b/api/tests/acceptance/application/admin-members/index_test.js
@@ -1,0 +1,51 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
+
+describe('Acceptance | Application | Admin-members | Routes', function () {
+  describe('POST /api/admin/admin-members', function () {
+    context('when admin member has role "SUPER_ADMIN"', function () {
+      it('should return a response with an HTTP status code 201', async function () {
+        // given
+        const adminMemberWithRoleSuperAdmin = databaseBuilder.factory.buildUser.withRole({
+          firstName: 'jaune',
+          lastName: 'attends',
+          email: 'jaune.attends@example.net',
+          password: 'j@Un3@Tt3nds',
+          role: ROLES.SUPER_ADMIN,
+        });
+        const user = databaseBuilder.factory.buildUser({
+          id: 1101,
+          firstName: '11',
+          lastName: '01',
+          email: '11.01@example.net',
+        });
+        await databaseBuilder.commit();
+        const server = await createServer();
+
+        // when
+        const { statusCode, result } = await server.inject({
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(adminMemberWithRoleSuperAdmin.id),
+          },
+          method: 'POST',
+          url: '/api/admin/admin-members',
+          payload: {
+            data: {
+              attributes: {
+                email: user.email,
+                role: ROLES.CERTIF,
+              },
+            },
+          },
+        });
+
+        // then
+        expect(statusCode).to.equal(201);
+        expect(result.data.attributes['user-id']).to.equal(1101);
+        expect(result.data.attributes.role).to.equal('CERTIF');
+        expect(result.data.attributes.email).to.equal('11.01@example.net');
+      });
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/save-admin-member_test.js
+++ b/api/tests/integration/domain/usecases/save-admin-member_test.js
@@ -1,0 +1,37 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const saveAdminMember = require('../../../../lib/domain/usecases/save-admin-member');
+const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
+const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+describe('Integration | UseCases | save-admin-member', function () {
+  context('when admin member exists and is disabled', function () {
+    it('should reactivate admin member, update role if necessary, and return user details', async function () {
+      // given
+      const email = 'ice.bot@example.net';
+      databaseBuilder.factory.buildUser.withRole({
+        firstName: 'Sarah',
+        lastName: 'Croche',
+        email,
+        disabledAt: new Date(),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const reactivatedAdminMember = await saveAdminMember({
+        email,
+        role: ROLES.SUPPORT,
+        adminMemberRepository,
+        userRepository,
+      });
+
+      // then
+      expect(reactivatedAdminMember).to.contain({
+        disabledAt: null,
+        role: ROLES.SUPPORT,
+        firstName: 'Sarah',
+        lastName: 'Croche',
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -7,10 +7,15 @@ const { AdminMemberRoleUpdateError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Infrastructure | Repository | adminMemberRepository', function () {
   describe('#findAll', function () {
-    it('should return all users with a pix admin role', async function () {
+    it('should return all users with a pix admin role that are not disabled', async function () {
       // given
       const userWithPixAdminRole = _buildUserWithPixAdminRole({ firstName: 'Marie', lastName: 'Tim' });
       const otherUserWithPixAdminRole = _buildUserWithPixAdminRole({ firstName: 'Alain', lastName: 'Verse' });
+      _buildUserWithPixAdminRole({
+        firstName: 'Nordine',
+        lastName: 'Ateur',
+        disabledAt: new Date(),
+      });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -94,6 +94,16 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
         })
       );
     });
+
+    context('when does not exist', function () {
+      it('should return undefined', async function () {
+        // given & when
+        const member = await adminMemberRepository.get({ userId: 1 });
+
+        // then
+        expect(member).to.be.undefined;
+      });
+    });
   });
 
   describe('#update', function () {

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -91,6 +91,7 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
           lastName: userWithPixAdminRole.lastName,
           email: userWithPixAdminRole.email,
           role: 'SUPER_ADMIN',
+          disabledAt: null,
         })
       );
     });

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -157,6 +157,28 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
       expect(error).to.be.instanceOf(AdminMemberRoleUpdateError);
     });
   });
+
+  describe('#save', function () {
+    afterEach(async function () {
+      await knex('pix-admin-roles').delete();
+    });
+
+    it('should persist admin member role', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+      const pixAdminRole = {
+        userId: user.id,
+        role: ROLES.SUPER_ADMIN,
+      };
+
+      // when
+      const result = await adminMemberRepository.save(pixAdminRole);
+
+      // then
+      expect(result).to.be.instanceOf(AdminMember);
+    });
+  });
 });
 
 function _buildUserWithPixAdminRole({ firstName, lastName, disabledAt, role } = {}) {

--- a/api/tests/unit/application/admin-members/index_test.js
+++ b/api/tests/unit/application/admin-members/index_test.js
@@ -40,6 +40,142 @@ describe('Unit | Application | Router | admin-members-router', function () {
     });
   });
 
+  describe('POST /api/admin/admin-members', function () {
+    context('when user has role "SUPER_ADMIN"', function () {
+      it('should return a response with an HTTP status code 201', async function () {
+        // given
+        const adminMember = domainBuilder.buildAdminMember();
+        sinon
+          .stub(adminMemberController, 'saveAdminMember')
+          .callsFake((request, h) => h.response(adminMember).created());
+        sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(adminMembersRouter);
+
+        // when
+        const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+          data: { type: 'admin-members', attributes: { role: ROLES.SUPER_ADMIN, email: 'fire.bot@example.net' } },
+        });
+
+        // then
+        expect(statusCode).to.equal(201);
+      });
+
+      context('when role attribute is missing', function () {
+        it('should return a response with an HTTP status code 400', async function () {
+          // given
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(adminMembersRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+            data: { type: 'admin-members', attributes: { email: 'fire.bot@example.net' } },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('when role attribute is not valid', function () {
+        it('should return a response with an HTTP status code 400', async function () {
+          // given
+          const adminMember = domainBuilder.buildAdminMember();
+          sinon.stub(adminMemberController, 'saveAdminMember').returns(adminMember);
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(adminMembersRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+            data: { type: 'admin-members', attributes: { role: 'My-Role', email: 'fire.bot@example.net' } },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('when email attribute is missing', function () {
+        it('should return a response with an HTTP status code 400', async function () {
+          // given
+          const adminMember = domainBuilder.buildAdminMember();
+          sinon.stub(adminMemberController, 'saveAdminMember').returns(adminMember);
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(adminMembersRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+            data: { type: 'admin-members', attributes: { role: ROLES.SUPER_ADMIN } },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('when email attribute is not valid', function () {
+        it('should return a response with an HTTP status code 400', async function () {
+          // given
+          const adminMember = domainBuilder.buildAdminMember();
+          sinon.stub(adminMemberController, 'saveAdminMember').returns(adminMember);
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(adminMembersRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+            data: { type: 'admin-members', attributes: { role: ROLES.SUPER_ADMIN, email: 'my-invalid-email' } },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('when all attributes are missing', function () {
+        it('should return a response with an HTTP status code 400', async function () {
+          // given
+          const adminMember = domainBuilder.buildAdminMember();
+          sinon.stub(adminMemberController, 'saveAdminMember').returns(adminMember);
+          sinon.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin').returns(true);
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(adminMembersRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+            data: { type: 'admin-members', attributes: {} },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+    });
+
+    context('when user does not have role "SUPER_ADMIN"', function () {
+      it('should return a response with an HTTP status code 403', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response().code(403).takeover());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(adminMembersRouter);
+
+        // when
+        const { statusCode } = await httpTestServer.request('POST', '/api/admin/admin-members', {
+          data: { type: 'admin-members', attributes: { role: ROLES.SUPER_ADMIN, email: 'aqua.bot@example.net' } },
+        });
+
+        // then
+        expect(statusCode).to.equal(403);
+        expect(securityPreHandlers.checkUserHasRoleSuperAdmin).to.have.be.called;
+      });
+    });
+  });
+
   describe('PATCH /api/admin/admin-members/{id}', function () {
     it('should return a response with an HTTP status code 200 when user has role "SUPER_ADMIN"', async function () {
       // given

--- a/api/tests/unit/domain/usecases/get-admin-member-details_test.js
+++ b/api/tests/unit/domain/usecases/get-admin-member-details_test.js
@@ -1,19 +1,39 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 const getAdminMemberDetails = require('../../../../lib/domain/usecases/get-admin-member-details');
 
 describe('Unit | UseCase | get-admin-member-details', function () {
-  it('should return an admin member details', async function () {
-    // given
-    const adminMemberRepository = {
-      get: sinon.stub(),
-    };
-    const adminMember = domainBuilder.buildAdminMember();
-    adminMemberRepository.get.withArgs({ userId: adminMember.id }).resolves(adminMember);
+  context('when it exists', function () {
+    it('should return an admin member details', async function () {
+      // given
+      const adminMemberRepository = {
+        get: sinon.stub(),
+      };
+      const adminMember = domainBuilder.buildAdminMember();
+      adminMemberRepository.get.withArgs({ userId: adminMember.id }).resolves(adminMember);
 
-    // when
-    const adminMembers = await getAdminMemberDetails({ adminMemberRepository, userId: adminMember.id });
+      // when
+      const adminMemberDetails = await getAdminMemberDetails({ adminMemberRepository, userId: adminMember.id });
 
-    // then
-    expect(adminMembers).to.deep.equal(adminMember);
+      // then
+      expect(adminMemberDetails).to.deep.equal(adminMember);
+    });
+  });
+
+  context('when it does not exist', function () {
+    it('should thrown a NotFound error', async function () {
+      // given
+      const adminMemberRepository = {
+        get: sinon.stub(),
+      };
+      const adminMember = domainBuilder.buildAdminMember();
+      adminMemberRepository.get.withArgs({ userId: adminMember.id }).resolves(undefined);
+
+      // when
+      const error = await catchErr(getAdminMemberDetails)({ adminMemberRepository, userId: adminMember.id });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/save-admin-member_test.js
+++ b/api/tests/unit/domain/usecases/save-admin-member_test.js
@@ -1,0 +1,72 @@
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const saveAdminMember = require('../../../../lib/domain/usecases/save-admin-member');
+const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
+const { AlreadyExistingAdminMemberError, UserNotFoundError } = require('../../../../lib/domain/errors');
+const AdminMember = require('../../../../lib/domain/models/AdminMember');
+
+describe('Unit | UseCase | save-admin-member', function () {
+  context('when admin member email is not found', function () {
+    it('should throw a UserNotFound error', async function () {
+      // given
+      const attributes = { email: 'ice.bot@example.net', role: ROLES.SUPER_ADMIN };
+      const adminMemberRepository = {};
+      const userRepository = { getByEmail: sinon.stub().withArgs(attributes.email).rejects(new UserNotFoundError()) };
+
+      // when
+      const error = await catchErr(saveAdminMember)({ ...attributes, adminMemberRepository, userRepository });
+
+      // then
+      expect(error).to.be.an.instanceOf(UserNotFoundError);
+    });
+  });
+
+  context('when admin member does not exist', function () {
+    it('should create an admin member', async function () {
+      // given
+      const attributes = { email: 'ice.bot@example.net', role: ROLES.SUPER_ADMIN };
+      const user = domainBuilder.buildUser({ email: attributes.email });
+      const savedAdminMember = domainBuilder.buildAdminMember({
+        userId: user.id,
+        firstName: undefined,
+        lastName: undefined,
+        email: undefined,
+        role: ROLES.SUPER_ADMIN,
+        createdAt: new Date(),
+      });
+      const userRepository = { getByEmail: sinon.stub().withArgs(attributes.email).resolves(user) };
+      const adminMemberRepository = {
+        get: sinon.stub().withArgs({ userId: user.id }).resolves(undefined),
+        save: sinon.stub().withArgs({ userId: user.id, role: ROLES.SUPER_ADMIN }).resolves(savedAdminMember),
+      };
+
+      // when
+      const result = await saveAdminMember({ ...attributes, adminMemberRepository, userRepository });
+
+      // then
+      expect(result).to.be.an.instanceOf(AdminMember);
+    });
+  });
+
+  context('when admin member exists and is active', function () {
+    it('should throw an AlreadyExistingAdminMember error', async function () {
+      // given
+      const attributes = { email: 'ice.bot@example.net', role: ROLES.SUPER_ADMIN };
+      const user = domainBuilder.buildUser({ email: attributes.email });
+      const adminMember = domainBuilder.buildAdminMember({
+        userId: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        role: ROLES.SUPER_ADMIN,
+      });
+      const userRepository = { getByEmail: sinon.stub().withArgs(attributes.email).resolves(user) };
+      const adminMemberRepository = { get: sinon.stub().withArgs({ userId: user.id }).resolves(adminMember) };
+
+      // when
+      const error = await catchErr(saveAdminMember)({ ...attributes, adminMemberRepository, userRepository });
+
+      // then
+      expect(error).to.be.an.instanceOf(AlreadyExistingAdminMemberError);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/admin-member-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/admin-member-serializer_test.js
@@ -37,4 +37,17 @@ describe('Unit | Serializer | JSONAPI | admin-member-serializer', function () {
       });
     });
   });
+
+  describe('#deserialize', function () {
+    it('should extract attributes from JSON API data', async function () {
+      // given
+      const jsonApiData = { data: { attributes: { key: 'value' } } };
+
+      // when
+      const attributes = await serializer.deserialize(jsonApiData);
+
+      // then
+      expect(attributes).to.deep.equal({ key: 'value' });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pour le moment pas possible de donner l'accès à l'application Pix Admin à un nouvel agent Pix sans passer par une requête en base de données.

![Screenshot 2022-06-13 at 15 04 06](https://user-images.githubusercontent.com/6919604/173361388-7a827dab-3dd6-418a-884a-18e6100badbd.png)

## :robot: Solution

Ajouter un nouveau bloc au niveau de la page `Équipe` permettant d'assigner un rôle à un agent Pix existant en base de données et n'ayant pas encore de rôle assigné.

![Screenshot 2022-06-13 at 15 01 31](https://user-images.githubusercontent.com/6919604/173359725-36aa835c-2bf1-4262-b77d-145485eecf6e.png)

## :rainbow: Remarques

⚠️ Il n'y a pas de vérification sur le domaine de l'adresse e-mail fournie.

## :100: Pour tester

1. Se connecter sur Pix Admin avec `superadmin@example.net`
2. Cliquez sur l'onglet `Équipe`
3. Constatez l'affichage du nouveau composant pour assigner un rôle à un agent Pix

#### Aucune adresse e-mail

- Sélectionnez un rôle
- Cliquez sur le bouton `Valider`
- Constatez l'affichage d'un message d'erreur

#### Adresse e-mail n'existant pas en base de données

- Entrez une adresse e-mail qui n'existe pas en base de données
- Sélectionnez un rôle
- Cliquez sur le bouton `Valider`
- Constatez l'affichage d'un message d'erreur

#### Adresse e-mail existante mais déjà lié à un rôle actif

- Entrez `pixcertif@example.net` comme adresse e-mail
- Sélectionnez un rôle
- Cliquez sur le bouton `Valider`
- Constatez l'affichage d'un message d'erreur

#### Adresse e-mail existante mais déjà lié à un rôle non-actif

- Ajoutez une date dans `disabledAt` en base de données au user ayant le role `CERTIF` 
- Vérifiez que le user Pix Certif n'apparait plus dans la liste des membres
- Entrez `pixcertif@example.net` comme adresse e-mail
- Sélectionnez `CERTIF` comme rôle
- Cliquez sur le bouton `Valider`
- Constatez que le user Pix Certif est de nouveau dans la liste des membres

#### Adresse e-mail existante sans aucun rôle assigné

- Entrez une adresse e-mail existante en base de données n'ayant aucun rôle
- Sélectionnez un rôle
- Cliquez sur le bouton `Valider`
- Constatez l'ajout du nouvel agent dans le tableau listant les membres ayant un rôle assigné

