### PR TITLE
[FEATURE] Mettre à jour le lien de certification (PIX-5033).

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -242,7 +242,7 @@
         "complementary-certification-eligibility": "Vous êtes également éligible à la certification {complementaryCertificationName}.",
         "link": {
           "text": "Comment se certifier ?",
-          "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
+          "url": "https://pix.fr/se-certifier#slice-2"
         },
         "message": "Bravo {fullName},'<br>'votre profil est certifiable."
       },


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, cliquer sur le lien “Comment se certifier ?” depuis la page “Certification” sur [app.pix.fr](http://app.pix.fr/) renvoie sur la page `https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-`

Cette documentation n’explique pas les étapes à suivre pour se certifier et donc n’est pas pertinente. Les utilisateurs continuent donc de contacter le support pour avoir des informations sur les démarches à suivre pour se certifier.

## :robot: Solution
Modifier le lien, à remplacer par https://pix.fr/se-certifier/ : 
- à ouvrir dans un nouvel onglet (c’est déjà le cas pour la page actuelle)
- mettre une ancre pour diriger l’utilisateur directement sur la section “La certification en 3 étapes”

## :rainbow: Remarques
L'ancre n'est pas très parlante `slice-2` et n'existe pas encore coté pix.fr

## :100: Pour tester
Se connecter à Pix App avec l'utilisateur `certif-success@example.net`

Vérifier que le lien renvoie dans un nouvel onglet vers l'URL avec ancre

![image](https://user-images.githubusercontent.com/56302715/171375276-4e8e8c41-9bdf-469b-83e2-5e681947563f.png)

