### PR TITLE
[BUGFIX] Rajout du nom complet de la compétence sur la bannière de l'assessment (PIX-5027).

### DIFF
--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -26,7 +26,6 @@
 
     &__title {
       display: block;
-      overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
       width: 250px;


### PR DESCRIPTION
## :unicorn: Problème

La PR #3888 a introduit un `overflow: hidden` sur les noms de compétences présents dans les titres des bannières de certification et de d'évaluation.

Nous souhaitons pouvoir voir le nom entier de la compétence au format Desktop.

## :robot: Solution

Annulation du `overflow: hidden` pour le format `Desktop`

## :rainbow: Remarques
N/A

## :100: Pour tester

Lors du passage d'une compétence, vérifier que le titre : 

- Ne s'affiche pas en format mobile
- S'affiche avec un overflow en format tablette
- S'affiche en intégralité sur format Desktop
