### PR TITLE
[TECH] Ajout d'une route pour récupérer un gabarit de profil cible (PIX-5025).

### DIFF
--- a/api/db/database-builder/factory/build-target-profile-template-tube.js
+++ b/api/db/database-builder/factory/build-target-profile-template-tube.js
@@ -1,0 +1,20 @@
+const buildTargetProfileTemplate = require('./build-target-profile-template');
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildTargetProfileTemplateTube({
+  id = databaseBuffer.getNextId(),
+  targetProfileTemplateId = buildTargetProfileTemplate().id,
+  tubeId = 'tubeId1',
+  level = 8,
+} = {}) {
+  const values = {
+    id,
+    targetProfileTemplateId,
+    tubeId,
+    level,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'target-profile-templates_tubes',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/build-target-profile-template.js
+++ b/api/db/database-builder/factory/build-target-profile-template.js
@@ -1,0 +1,8 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildTargetProfileTemplate({ id = databaseBuffer.getNextId() } = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'target-profile-templates',
+    values: { id },
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -57,6 +57,8 @@ module.exports = {
   buildTargetProfile: require('./build-target-profile'),
   buildTargetProfileSkill: require('./build-target-profile-skill'),
   buildTargetProfileShare: require('./build-target-profile-share'),
+  buildTargetProfileTemplate: require('./build-target-profile-template'),
+  buildTargetProfileTemplateTube: require('./build-target-profile-template-tube'),
   buildTutorialEvaluation: require('./build-tutorial-evaluation'),
   buildUser: require('./build-user'),
   buildUserOrgaSettings: require('./build-user-orga-settings'),

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -425,6 +425,33 @@ exports.register = async (server) => {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/target-profile-templates/{id}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.userHasAtLeastOneAccessOf([securityPreHandlers.checkUserHasRoleSuperAdmin])(
+                request,
+                h
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.targetProfileTemplateId,
+          }),
+        },
+        handler: targetProfileController.getTargetProfileTemplate,
+        tags: ['api', 'target-profiles'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet de récupérer les informations d’un gabarit de profil cible',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 const targetProfileSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-serializer');
+const targetProfileTemplateSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-template-serializer');
 const targetProfileWithLearningContentSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
@@ -105,5 +106,11 @@ module.exports = {
 
     const targetProfile = await usecases.markTargetProfileAsSimplifiedAccess({ id });
     return h.response(targetProfileSerializer.serialize(targetProfile));
+  },
+
+  async getTargetProfileTemplate(request) {
+    const targetProfileTemplateId = request.params.id;
+    const targetProfileTemplate = await usecases.getTargetProfileTemplate({ targetProfileTemplateId });
+    return targetProfileTemplateSerializer.serialize(targetProfileTemplate);
   },
 };

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -46,6 +46,7 @@ const typesPositiveInteger32bits = [
   'stageId',
   'supervisorAccessesId',
   'targetProfileId',
+  'targetProfileTemplateId',
   'userId',
   'userOrgaSettingsId',
 ];

--- a/api/lib/domain/usecases/get-target-profile-template.js
+++ b/api/lib/domain/usecases/get-target-profile-template.js
@@ -1,0 +1,8 @@
+const { NotFoundError } = require('../errors');
+module.exports = async function getTargetProfileTemplate({ targetProfileTemplateId, targetProfileRepository }) {
+  const targetProfileTemplate = await targetProfileRepository.getTargetProfileTemplate({ id: targetProfileTemplateId });
+  if (!targetProfileTemplate) {
+    throw new NotFoundError(`No target profile template for ID ${targetProfileTemplateId}`);
+  }
+  return targetProfileTemplate;
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -333,6 +333,7 @@ module.exports = injectDependencies(
     getStageDetails: require('./get-stage-details'),
     getSupervisorKitSessionInfo: require('./get-supervisor-kit-session-info'),
     getTargetProfileDetails: require('./get-target-profile-details'),
+    getTargetProfileTemplate: require('./get-target-profile-template'),
     getTubeSkills: require('./get-tube-skills'),
     getFrameworks: require('./get-frameworks'),
     getFrameworkAreas: require('./get-framework-areas'),

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -201,6 +201,21 @@ module.exports = {
       throw new TargetProfileCannotBeCreated();
     }
   },
+
+  async getTargetProfileTemplate({ id }) {
+    const targetProfileTemplate = await knex('target-profile-templates').where({ id }).first();
+    if (!targetProfileTemplate) {
+      return null;
+    }
+    const tubes = await knex('target-profile-templates_tubes')
+      .where({ targetProfileTemplateId: id })
+      .orderBy('id', 'asc');
+
+    return new TargetProfileTemplate({
+      id,
+      tubes,
+    });
+  },
 };
 
 async function _getWithLearningContentSkills(targetProfile) {

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-template-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-template-serializer.js
@@ -1,0 +1,13 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(targetProfileTemplate, meta) {
+    return new Serializer('target-profile-template', {
+      attributes: ['tubes'],
+      tubes: {
+        attributes: ['tubeId', 'level'],
+      },
+      meta,
+    }).serialize(targetProfileTemplate);
+  },
+};

--- a/api/tests/integration/application/target-profile/target-profile-controller_test.js
+++ b/api/tests/integration/application/target-profile/target-profile-controller_test.js
@@ -1,0 +1,83 @@
+const { expect, sinon, domainBuilder, HttpTestServer } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const targetProfilesRouter = require('../../../../lib/application/target-profiles');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Application | Route | target-profile-router', function () {
+  describe('GET /api/admin/target-profile-templates/{id}', function () {
+    let httpTestServer, targetProfileTemplateId, targetProfileTemplate;
+    const targetProfileTemplateNotFoundId = 456;
+
+    beforeEach(async function () {
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(targetProfilesRouter);
+      sinon.stub(securityPreHandlers, 'userHasAtLeastOneAccessOf').returns(() => true);
+      targetProfileTemplate = domainBuilder.buildTargetProfileTemplate();
+    });
+
+    describe('When templateId is found', function () {
+      beforeEach(async function () {
+        targetProfileTemplateId = targetProfileTemplate.id;
+        sinon
+          .stub(usecases, 'getTargetProfileTemplate')
+          .withArgs({ targetProfileTemplateId })
+          .resolves(targetProfileTemplate);
+      });
+
+      it('should return status code 200 OK', async function () {
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          `/api/admin/target-profile-templates/${targetProfileTemplateId}`
+        );
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return target profile template data', async function () {
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          `/api/admin/target-profile-templates/${targetProfileTemplateId}`
+        );
+
+        // then
+        expect(response.result).to.deep.equal({
+          data: {
+            type: 'target-profile-templates',
+            id: `${targetProfileTemplateId}`,
+            attributes: {
+              tubes: [{ 'tube-id': 'tubeId1', level: 8 }],
+            },
+          },
+        });
+      });
+    });
+    describe('When templateId is not found', function () {
+      it('should return a 404 error', async function () {
+        // given
+        sinon.stub(usecases, 'getTargetProfileTemplate').rejects(new NotFoundError());
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          `/api/admin/target-profile-templates/${targetProfileTemplateNotFoundId}`
+        );
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+    describe('When provided ID is not a number', function () {
+      it('should return a 400 error', async function () {
+        // when
+        const response = await httpTestServer.request('GET', `/api/admin/target-profile-templates/coucou`);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/get-target-profile-template_test.js
+++ b/api/tests/integration/domain/usecases/get-target-profile-template_test.js
@@ -1,0 +1,59 @@
+const getTargetProfileTemplate = require('../../../../lib/domain/usecases/get-target-profile-template');
+const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
+const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Integration | UseCases | get-target-profile-template', function () {
+  let targetProfileTemplate, tube1, tube2;
+  const ID_NOT_EXIST = '-1';
+
+  beforeEach(async function () {
+    targetProfileTemplate = await databaseBuilder.factory.buildTargetProfileTemplate({
+      id: 1,
+    });
+
+    tube1 = databaseBuilder.factory.buildTargetProfileTemplateTube({
+      id: 2,
+      targetProfileTemplateId: 1,
+      tubeId: 'tubeId1',
+      level: 8,
+    });
+    tube2 = databaseBuilder.factory.buildTargetProfileTemplateTube({
+      id: 3,
+      targetProfileTemplateId: 1,
+      tubeId: 'tubeId2',
+      level: 7,
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async function () {
+    await knex('target-profile-templates_tubes').delete();
+    await knex('target-profile-templates').delete();
+  });
+
+  it('should return a target profile template', async function () {
+    // when
+    const targetProfileTemplateResult = await getTargetProfileTemplate({
+      targetProfileTemplateId: targetProfileTemplate.id,
+      targetProfileRepository,
+    });
+
+    // then
+    expect(targetProfileTemplateResult).to.exist;
+    expect(targetProfileTemplateResult.tubes).to.deepEqualArray([tube1, tube2]);
+  });
+
+  it('should return an exception because the target profile template does not exist', async function () {
+    // when
+    const error = await catchErr(getTargetProfileTemplate)({
+      targetProfileTemplateId: ID_NOT_EXIST,
+      targetProfileRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(NotFoundError);
+    expect(error.message).to.equal('No target profile template for ID -1');
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-template.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-template.js
@@ -1,0 +1,13 @@
+const TargetProfileTemplate = require('../../../../lib/domain/models/TargetProfileTemplate');
+
+module.exports = function buildTargetProfileTemplate({
+  id = 123,
+  targetProfileIds = [],
+  tubes = [{ tubeId: 'tubeId1', level: 8 }],
+} = {}) {
+  return new TargetProfileTemplate({
+    id,
+    targetProfileIds,
+    tubes,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -112,6 +112,7 @@ module.exports = {
   buildTargetedSkill: require('./build-targeted-skill'),
   buildTargetedTube: require('./build-targeted-tube'),
   buildTargetProfile: require('./build-target-profile'),
+  buildTargetProfileTemplate: require('./build-target-profile-template'),
   buildOrganizationsToAttachToTargetProfile: require('./build-organizations-to-attach-to-target-profile'),
   buildTargetProfileWithLearningContent: require('./build-target-profile-with-learning-content'),
   buildThematic: require('./build-thematic'),


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas de route qui permet de récupérer un gabarit de profile cible.

## :robot: Solution
Ajouter un endpoint qui permette de récupérer un gabarit de profile cible grâce à son `ID`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un profile cible depuis pix-admin.
Interroger l'api via la route `curl -H "Authorization: bearer xxx" http://localhost:3000/api/admin/target-profile-templates/{id}`