### PR TITLE
[FEATURE] Afficher un lien pour transmettre le PV de fraude lors de la finalisation de session (PIX-4943)

### DIFF
--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -11,9 +11,20 @@
       >{{@fraudCategory.categoryCode}}&nbsp;</span>{{@fraudCategory.categoryLabel}}</label>
   </div>
   {{#if @fraudCategory.isChecked}}
-    <div class="fraud-certification-issue-report-fields__details">
-      <p>Merci de joindre le procès-verbal de fraude rempli pendant la session de certification en utilisant le
-        formulaire 123formbuilder accessible à l'étape suivante de cette finalisation de session.</p>
-    </div>
+    {{#if this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled}}
+      <div class="fraud-certification-issue-report-fields__details">
+        <p>Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant
+          <span>
+            <a href="https://form-eu.123formbuilder.com/41052/form" target="_blank" rel="noreferrer noopener">
+              ce formulaire</a>
+          </span>
+        </p>
+      </div>
+    {{else}}
+      <div class="fraud-certification-issue-report-fields__details">
+        <p>Merci de joindre le procès-verbal de fraude rempli pendant la session de certification en utilisant le
+          formulaire 123formbuilder accessible à l'étape suivante de cette finalisation de session.</p>
+      </div>
+    {{/if}}
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class FraudCertificationIssueReportFields extends Component {
+  @service featureToggles;
+}


### PR DESCRIPTION
## :unicorn: Problème
L'étape 2 (“Transmettre des documents (facultatif)”) de la page de finalisation de session va être supprimée, dans le but d'éviter l’effet “Voir PV d’incident” et le non report des incidents remontés sur le PV, sur la page de finalisation.
C’est depuis le formulaire accessible à cette étape que les centres peuvent également transmettre un PV de fraude, le cas échéant.

## :robot: Solution
Ajouter un lien vers un formulaire permettant de transmettre uniquement un PV de fraude au niveau de la catégorie spécifique pour la fraude, lorsque l’utilisateur sélectionne cette catégorie

## :rainbow: Remarques
Feature sous toggle (FT_CERTIFICATION_FREE_FIELDS_DELETION)

## :100: Pour tester
- Activer le toggle FT_CERTIFICATION_FREE_FIELDS_DELETION
- Se connecter à Pix certif avec le compte certifsco
- Essayer de finaliser la session 3
- Et constater l'affichage suisvant pour la catégorie C6

<img width="952" alt="Capture d’écran 2022-06-02 à 15 15 15" src="https://user-images.githubusercontent.com/103997660/171638830-9021bcd8-75c0-4cf3-a32f-f148607eb487.png">

