### PR TITLE
[FEATURE] Supprimer les refresh tokens d'un utilisateur quand il est anonymisé (PIX-1990).

### DIFF
--- a/api/lib/domain/services/refresh-token-service.js
+++ b/api/lib/domain/services/refresh-token-service.js
@@ -4,9 +4,13 @@ const { UnauthorizedError } = require('../../application/http-errors');
 const temporaryStorage = require('../../infrastructure/temporary-storage').withPrefix('refresh-tokens:');
 const { v4: uuidv4 } = require('uuid');
 
+function _prefixForUser(userId) {
+  return `${userId}:`;
+}
+
 async function createRefreshTokenFromUserId({ userId, source }) {
   const expirationDelaySeconds = settings.authentication.refreshTokenLifespanMs / 1000;
-  const token = `${userId}:${uuidv4()}`;
+  const token = `${_prefixForUser(userId)}${uuidv4()}`;
   return await temporaryStorage.save({
     key: token,
     value: { type: 'refresh_token', userId, source },
@@ -24,10 +28,15 @@ async function revokeRefreshToken({ refreshToken }) {
   await temporaryStorage.delete(refreshToken);
 }
 
+async function revokeRefreshTokensForUserId({ userId }) {
+  await temporaryStorage.deleteByPrefix(_prefixForUser(userId));
+}
+
 module.exports = {
   createRefreshTokenFromUserId,
   createAccessTokenFromRefreshToken,
   revokeRefreshToken,
+  revokeRefreshTokensForUserId,
 
   temporaryStorageForTests: temporaryStorage,
 };

--- a/api/lib/domain/services/refresh-token-service.js
+++ b/api/lib/domain/services/refresh-token-service.js
@@ -6,7 +6,7 @@ const { v4: uuidv4 } = require('uuid');
 
 async function createRefreshTokenFromUserId({ userId, source }) {
   const expirationDelaySeconds = settings.authentication.refreshTokenLifespanMs / 1000;
-  const token = uuidv4();
+  const token = `${userId}:${uuidv4()}`;
   return await temporaryStorage.save({
     key: token,
     value: { type: 'refresh_token', userId, source },

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -1,4 +1,9 @@
-module.exports = async function anonymizeUser({ userId, userRepository, authenticationMethodRepository }) {
+module.exports = async function anonymizeUser({
+  userId,
+  userRepository,
+  authenticationMethodRepository,
+  refreshTokenService,
+}) {
   const anonymizedUser = {
     firstName: `prenom_${userId}`,
     lastName: `nom_${userId}`,
@@ -7,5 +12,6 @@ module.exports = async function anonymizeUser({ userId, userRepository, authenti
   };
 
   await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
+  await refreshTokenService.revokeRefreshTokensForUserId({ userId });
   return userRepository.updateUserDetailsForAdministration(userId, anonymizedUser);
 };

--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -21,6 +21,12 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
   delete(key) {
     return this._client.del(key);
   }
+
+  deleteByPrefix(prefix) {
+    const keys = this._client.keys();
+    const matchingKeys = keys.filter((key) => key.startsWith(prefix));
+    return this._client.del(matchingKeys);
+  }
 }
 
 module.exports = InMemoryTemporaryStorage;

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -31,6 +31,10 @@ class RedisTemporaryStorage extends TemporaryStorage {
   async delete(key) {
     await this._client.del(key);
   }
+
+  async deleteByPrefix(prefix) {
+    await this._client.deleteByPrefix(prefix);
+  }
 }
 
 module.exports = RedisTemporaryStorage;

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -17,6 +17,10 @@ class TemporaryStorage {
     throw new Error('Method #delete(key) must be overridden');
   }
 
+  async deleteByPrefix(/* prefix */) {
+    throw new Error('Method #deleteByPrefix(prefix) must be overridden');
+  }
+
   withPrefix(prefix) {
     const storage = this;
     return {
@@ -32,6 +36,10 @@ class TemporaryStorage {
 
       delete(key) {
         return storage.delete(prefix + key);
+      },
+
+      deleteByPrefix(searchedPrefix) {
+        return storage.deleteByPrefix(prefix + searchedPrefix);
       },
     };
   }

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -1,4 +1,5 @@
 const redis = require('redis');
+const redisScan = require('node-redis-scan');
 const Redlock = require('redlock');
 const { promisify } = require('util');
 const logger = require('../logger');
@@ -57,5 +58,18 @@ module.exports = class RedisClient {
 
   quit() {
     this._client.quit();
+  }
+
+  async deleteByPrefix(searchedPrefix) {
+    const searchedPrefixWithClientPrefix = `${this._prefix}${searchedPrefix}`;
+    const escapedPrefix = searchedPrefixWithClientPrefix.replace(/[*?[\\\]]/g, '\\$&');
+    const pattern = `${escapedPrefix}*`;
+    const redisWithScan = new redisScan(this._client);
+    const scan = promisify(redisWithScan.scan).bind(redisWithScan);
+    const matchingKeys = await scan(pattern);
+    if (matchingKeys.length > 0) {
+      const del = promisify(this._client.del).bind(this._client);
+      await del(matchingKeys);
+    }
   }
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "3.197.0",
+      "version": "3.215.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -46,6 +46,7 @@
         "moment-timezone": "^0.5.34",
         "ms": "^2.1.3",
         "node-cache": "^5.1.2",
+        "node-redis-scan": "^1.3.5",
         "node-stream-zip": "^1.15.0",
         "papaparse": "^5.3.1",
         "pdf-lib": "^1.16.0",
@@ -6544,6 +6545,14 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-redis-scan": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/node-redis-scan/-/node-redis-scan-1.3.5.tgz",
+      "integrity": "sha512-qQ33kqRj56IgaMZK5Hf+8UTdUG7cwxLEgbGBXjeqjI7KdVHN7HokyQzm4JScNMS6VFEufG92JxE2oXAtfJOuag==",
+      "engines": {
+        "node": ">= 10.12.0"
       }
     },
     "node_modules/node-rsa": {
@@ -14904,6 +14913,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "node-redis-scan": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/node-redis-scan/-/node-redis-scan-1.3.5.tgz",
+      "integrity": "sha512-qQ33kqRj56IgaMZK5Hf+8UTdUG7cwxLEgbGBXjeqjI7KdVHN7HokyQzm4JScNMS6VFEufG92JxE2oXAtfJOuag=="
     },
     "node-rsa": {
       "version": "1.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "moment-timezone": "^0.5.34",
     "ms": "^2.1.3",
     "node-cache": "^5.1.2",
+    "node-redis-scan": "^1.3.5",
     "node-stream-zip": "^1.15.0",
     "papaparse": "^5.3.1",
     "pdf-lib": "^1.16.0",

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -1,0 +1,27 @@
+const RedisTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/RedisTemporaryStorage');
+const { expect } = require('../../../test-helper');
+
+describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorage', function () {
+  // this check is used to prevent failure when redis is not setup
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  if (process.env.REDIS_TEST_URL !== undefined) {
+    describe('#deleteByPrefix', function () {
+      it('should delete all found keys with the given matching prefix', async function () {
+        // given
+        const expirationDelaySeconds = 1000;
+        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        await storage.save({ key: '456:c', value: 'c', expirationDelaySeconds });
+        await storage.save({ key: '123:a', value: 'a', expirationDelaySeconds });
+        await storage.save({ key: '123:b', value: 'b', expirationDelaySeconds });
+
+        // when
+        await storage.deleteByPrefix('123:');
+
+        // then
+        expect(await storage.get('123:a')).to.not.exist;
+        expect(await storage.get('123:b')).to.not.exist;
+        expect(await storage.get('456:c')).to.exist;
+      });
+    });
+  }
+});

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -45,5 +45,55 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
       await redisClient1.del('key');
       await redisClient2.del('key');
     });
+
+    describe('#deleteByPrefix', function () {
+      it('should delete keys with given matching prefix', async function () {
+        // given
+        const value = new Date().toISOString();
+        const redisClient = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
+        await redisClient.set('123:AVRIL', value);
+        await redisClient.set('123:abcde', value);
+        await redisClient.set('456:abcde', value);
+
+        // when
+        await redisClient.deleteByPrefix('123:');
+
+        // then
+        expect(await redisClient.get('123:AVRIL')).to.not.exist;
+        expect(await redisClient.get('123:abcde')).to.not.exist;
+        expect(await redisClient.get('456:abcde')).to.exist;
+      });
+
+      it('should escape special characters', async function () {
+        // given
+        const value = new Date().toISOString();
+        const redisClient = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
+        await redisClient.set('123:AVRIL', value);
+        await redisClient.set('123:abcde', value);
+        await redisClient.set('456:abcde', value);
+        await redisClient.set('*:abcde', value);
+        await redisClient.set('**:abcde', value);
+
+        // when
+        await redisClient.deleteByPrefix('**');
+
+        // then
+        expect(await redisClient.get('**:abcde')).to.not.exist;
+        expect(await redisClient.get('*:abcde')).to.exist;
+      });
+
+      it('should do nothing if there is no matching prefix', async function () {
+        // given
+        const value = new Date().toISOString();
+        const redisClient = new RedisClient(process.env.REDIS_URL, { prefix: 'client-prefix:' });
+        await redisClient.set('789:abcde', value);
+
+        // when
+        await redisClient.deleteByPrefix('333:');
+
+        // then
+        expect(await redisClient.get('789:abcde')).to.exist;
+      });
+    });
   }
 });

--- a/api/tests/unit/domain/services/refresh-token-service_test.js
+++ b/api/tests/unit/domain/services/refresh-token-service_test.js
@@ -86,4 +86,17 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
       expect(temporaryStorage.delete).to.have.been.calledWith(refreshToken);
     });
   });
+
+  describe('#revokeRefreshTokensForUserId', function () {
+    it('should remove refresh tokens for given userId from temporary storage', async function () {
+      // given
+      sinon.stub(temporaryStorage, 'deleteByPrefix');
+
+      // when
+      await refreshTokenService.revokeRefreshTokensForUserId({ userId: 123 });
+
+      // then
+      expect(temporaryStorage.deleteByPrefix).to.have.been.calledWith('123:');
+    });
+  });
 });

--- a/api/tests/unit/domain/services/refresh-token-service_test.js
+++ b/api/tests/unit/domain/services/refresh-token-service_test.js
@@ -11,7 +11,6 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
       // given
       const userId = 123;
       const source = 'pix';
-      const validRefreshToken = 'valid-refresh-token';
       const value = {
         type: 'refresh_token',
         userId,
@@ -21,14 +20,14 @@ describe('Unit | Domain | Service | Refresh Token Service', function () {
 
       sinon
         .stub(temporaryStorage, 'save')
-        .withArgs(sinon.match({ key: sinon.match(/^[-0-9a-f]+$/), value, expirationDelaySeconds }))
-        .resolves(validRefreshToken);
+        .withArgs(sinon.match({ key: sinon.match(/^123:[-0-9a-f]+$/), value, expirationDelaySeconds }))
+        .resolves('123:aaaabbbb-1111-ffff-8888-7777dddd0000');
 
       // when
       const result = await refreshTokenService.createRefreshTokenFromUserId({ userId, source });
 
       // then
-      expect(result).to.equal(validRefreshToken);
+      expect(result).to.equal('123:aaaabbbb-1111-ffff-8888-7777dddd0000');
     });
   });
 

--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -120,4 +120,24 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
       expect(savedKey).to.be.undefined;
     });
   });
+
+  describe('#deleteByPrefix', function () {
+    it('should delete all found keys with the given matching prefix', async function () {
+      // given
+      const expirationDelaySeconds = 1000;
+
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+      await inMemoryTemporaryStorage.save({ key: '456:c', value: {}, expirationDelaySeconds });
+      await inMemoryTemporaryStorage.save({ key: '123:a', value: {}, expirationDelaySeconds });
+      await inMemoryTemporaryStorage.save({ key: '123:b', value: {}, expirationDelaySeconds });
+
+      // when
+      await inMemoryTemporaryStorage.deleteByPrefix('123:');
+
+      // then
+      expect(await inMemoryTemporaryStorage.get('123:a')).to.be.undefined;
+      expect(await inMemoryTemporaryStorage.get('123:b')).to.be.undefined;
+      expect(await inMemoryTemporaryStorage.get('456:c')).to.exist;
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -90,7 +90,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
   });
 
   describe('#get', function () {
-    it('should call client set and retrieve value', async function () {
+    it('should call client set to retrieve value', async function () {
       // given
       const key = 'valueKey';
       const value = { name: 'name' };
@@ -107,7 +107,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
   });
 
   describe('#delete', function () {
-    it('should call client set and delete value', async function () {
+    it('should call client del to delete value', async function () {
       // given
       const key = 'valueKey';
       clientStub.del.withArgs(key).resolves();

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -41,6 +41,19 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
     });
   });
 
+  describe('#deleteByPrefix', function () {
+    it('should reject an error (because this class actually mocks an interface)', function () {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.deleteByPrefix('123:');
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
+
   describe('#generateKey', function () {
     it('should return a key from static method', function () {
       // when
@@ -65,6 +78,13 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
         async delete(key) {
           delete store[key];
         }
+        async deleteByPrefix(prefix) {
+          for (const key in store) {
+            if (key.startsWith(prefix)) {
+              delete store[key];
+            }
+          }
+        }
       }
       const storage = new TestStorage().withPrefix('a-prefix:');
 
@@ -80,6 +100,10 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
       expect(randomKey).to.exist;
       expect(store['a-prefix:' + randomKey]).to.exist;
       expect(await storage.get(randomKey)).to.equal('random-key-value');
+
+      await storage.save({ key: '123:a-key', value: 'a-value' });
+      await storage.deleteByPrefix('123:');
+      expect(await storage.get('123:a-key')).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Un utilisateur qui demande la suppression de ses données peut rester connecté pendant 7jours. En effet, au moment de l'anonymisation de cet utilisateur nous ne faisons rien pour fermer ses sessions ouvertes.

## :robot: Solution
Supprimer le/les refresh token de l'utilisateur qu'on anonymise.

## :rainbow: Remarques
Une fois anonymisé l'utilisateur a encore accès à sa session le temps de la durée de l'access token (actuellement 4h)

Actuellement redis est en version 3.1.2 sur notre API. Or dans cette version là il n'existe pas de fonction pour scanner tous le contenu de redis en cherchant un match avec une regex. La montée de version qui ajoute cette fonctionnalité là est une montée de version majeure, et par conséquent il n'est pas simple de la mettre en place. https://redis.io/commands/scan/

Cependant il existe une librairie externe nous permettant d'ajouter la fonctionnalité de scan avec notre version de redis : 
https://www.npmjs.com/package/node-redis-scan. Nous avons donc décidé d'installer cette librairie en attendant d'effectuer la montée de version majeur de notre redis (cette montée de version rendra donc obsolète notre utilisation de node-redis-scan car nous pourrons alors faire le scan natif de redis).


## :100: Pour tester
Mettre un accessToken assez court dans les variables d'env. Ex: `ACCESS_TOKEN_LIFESPAN=20s`.

- Lancer PixAdmin & MonPix
Sur MonPix : 
- Se connecter avec un utilisateur
Sur PixAdmin : 
- Anonymiser cet utilisateur
- Constater que l'anonymisation se déroule bien (notif verte)
Sur MonPix : 
- Constatez qu'on est déconnecté au bout du temps de l'access token (20sec environ) => on est redirigé automatiquement sur une page d'erreur
