### PR TITLE
[A11Y] Rendre la boulette de pertinence de la phrase explicative non lisible pour les lecteurs d'écran(PIX-4247)

### DIFF
--- a/orga/app/components/campaign/analysis/recommendations.js
+++ b/orga/app/components/campaign/analysis/recommendations.js
@@ -6,8 +6,7 @@ import { htmlSafe } from '@ember/string';
 
 export default class Recommendations extends Component {
   @service intl;
-  @tracked
-  sortedRecommendations;
+  @tracked sortedRecommendations;
 
   constructor() {
     super(...arguments);
@@ -20,7 +19,7 @@ export default class Recommendations extends Component {
     return htmlSafe(
       this.intl.t('pages.campaign-review.description', {
         bubble:
-          '<svg height="10" width="10" role="img"><circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble" /></svg>',
+          '<span aria-hidden="true" focusable="false">(<svg height="10" width="10" role="img"><circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble" /></svg>)</span>',
       })
     );
   }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -477,7 +477,7 @@
     },
     "campaign-review": {
       "title": "Review",
-      "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following topics, sorted by relevance ({bubble}).",
+      "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following topics, sorted by relevance {bubble}.",
       "sub-table": {
         "title": "{count, plural, =1 {1 tutorial} other{{count} tutorials}} recommended by the Pix community",
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -476,7 +476,7 @@
     },
     "campaign-review": {
       "title": "Analyse",
-      "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence ({bubble}).",
+      "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence {bubble}.",
       "sub-table": {
         "title": "{count, plural, =1 {1 tuto recommandé} other{{count} tutos recommandés}} par la communauté Pix",
         "column": {


### PR DESCRIPTION
## :unicorn: Problème
Dans la continuité des changements à effectuer pour rendre l'application Pix Orga plus accessible, il a été constaté lors de l'audit que la boulette de pertinence dans la phrase explicative dans  l'onglet Analyse était lisible par les écrans. Or c'est une image qui apporte une information seulement pour utilisateurs voyants.

## :robot: Solution
Rendre cette image non lisible pour les lecteurs d'écrans.

## :rainbow: Remarques
Ajout de l'attribut `focusable="false"` car sous Internet Explorer les éléments svg sont "par défaut" atteignables au clavier (qu'ils soient interactifs ou pas). Ajouter un attribut focusable="false" sur un élément svg permet d'indiquer à IE que cet élément ne doit pas être atteignable au clavier. Note : cet attribut n'est supporté que par IE.

## :100: Pour tester
- Se connecter à Pix Orga et aller dans une campagne avec des résultats
- Dans l'onglet Analyse, constater la présence du `span aria-hidden=true`
