### PR TITLE
[TECH] Afficher une page d'erreur lorsque un identity provider externe nous renvoie une erreur (PIX-5017).

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -145,7 +145,8 @@
       "server.js",
       "package.json",
       "db",
-      "translations"
+      "translations",
+      ".env"
     ],
     "ignore": [
       "db/seeds",

--- a/mon-pix/app/components/authentication/terms-of-service-pole-emploi.js
+++ b/mon-pix/app/components/authentication/terms-of-service-pole-emploi.js
@@ -34,7 +34,9 @@ export default class TermsOfServicePoleEmploiComponent extends Component {
           this.isAuthenticationKeyExpired = true;
           this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['expiredAuthenticationKey']);
         } else {
-          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
+          const errorDetail = get(error, 'errors[0].detail');
+          this.errorMessage =
+            this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']) + (errorDetail ? ` (${errorDetail})` : '');
         }
       }
     } else {

--- a/mon-pix/app/controllers/terms-of-service-cnav.js
+++ b/mon-pix/app/controllers/terms-of-service-cnav.js
@@ -39,7 +39,9 @@ export default class TermsOfServiceCnavController extends Controller {
           this.isAuthenticationKeyExpired = true;
           this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['expiredAuthenticationKey']);
         } else {
-          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
+          const errorDetail = get(error, 'errors[0].detail');
+          this.errorMessage =
+            this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']) + (errorDetail ? ` (${errorDetail})` : '');
         }
       }
     } else {

--- a/mon-pix/app/routes/login-cnav.js
+++ b/mon-pix/app/routes/login-cnav.js
@@ -19,7 +19,7 @@ export default class LoginCnavRoute extends Route {
   beforeModel(transition) {
     const queryParams = transition.to.queryParams;
     if (queryParams.error) {
-      return this.replaceWith('login');
+      throw new Error(`${queryParams.error}: ${queryParams.error_description}`);
     }
 
     if (!queryParams.code) {

--- a/mon-pix/app/routes/login-cnav.js
+++ b/mon-pix/app/routes/login-cnav.js
@@ -18,11 +18,11 @@ export default class LoginCnavRoute extends Route {
 
   beforeModel(transition) {
     const queryParams = transition.to.queryParams;
-    if (!queryParams.code && queryParams.error) {
+    if (queryParams.error) {
       return this.replaceWith('login');
     }
 
-    if (!queryParams.code && !queryParams.error) {
+    if (!queryParams.code) {
       return this._handleRedirectRequest();
     }
   }

--- a/mon-pix/app/routes/login-cnav.js
+++ b/mon-pix/app/routes/login-cnav.js
@@ -17,7 +17,7 @@ export default class LoginCnavRoute extends Route {
   }
 
   beforeModel(transition) {
-    const queryParams = transition.to ? transition.to.queryParams : transition.queryParams;
+    const queryParams = transition.to.queryParams;
     if (!queryParams.code && queryParams.error) {
       return this.replaceWith('login');
     }
@@ -28,7 +28,7 @@ export default class LoginCnavRoute extends Route {
   }
 
   async model(_, transition) {
-    const queryParams = transition.to ? transition.to.queryParams : transition.queryParams;
+    const queryParams = transition.to.queryParams;
     if (queryParams.code) {
       return this._handleCallbackRequest(queryParams.code, queryParams.state);
     }

--- a/mon-pix/app/routes/login-pole-emploi.js
+++ b/mon-pix/app/routes/login-pole-emploi.js
@@ -18,11 +18,11 @@ export default class LoginPoleEmploiRoute extends Route {
 
   beforeModel(transition) {
     const queryParams = transition.to.queryParams;
-    if (!queryParams.code && queryParams.error) {
+    if (queryParams.error) {
       return this.replaceWith('login');
     }
 
-    if (!queryParams.code && !queryParams.error) {
+    if (!queryParams.code) {
       return this._handleRedirectRequest();
     }
   }

--- a/mon-pix/app/routes/login-pole-emploi.js
+++ b/mon-pix/app/routes/login-pole-emploi.js
@@ -17,7 +17,7 @@ export default class LoginPoleEmploiRoute extends Route {
   }
 
   beforeModel(transition) {
-    const queryParams = transition.to ? transition.to.queryParams : transition.queryParams;
+    const queryParams = transition.to.queryParams;
     if (!queryParams.code && queryParams.error) {
       return this.replaceWith('login');
     }
@@ -28,7 +28,7 @@ export default class LoginPoleEmploiRoute extends Route {
   }
 
   async model(_, transition) {
-    const queryParams = transition.to ? transition.to.queryParams : transition.queryParams;
+    const queryParams = transition.to.queryParams;
     if (queryParams.code) {
       return this._handleCallbackRequest(queryParams.code, queryParams.state);
     }

--- a/mon-pix/app/routes/login-pole-emploi.js
+++ b/mon-pix/app/routes/login-pole-emploi.js
@@ -19,7 +19,7 @@ export default class LoginPoleEmploiRoute extends Route {
   beforeModel(transition) {
     const queryParams = transition.to.queryParams;
     if (queryParams.error) {
-      return this.replaceWith('login');
+      throw new Error(`${queryParams.error}: ${queryParams.error_description}`);
     }
 
     if (!queryParams.code) {

--- a/mon-pix/tests/unit/components/authentication/terms-of-service-pole-emploi_test.js
+++ b/mon-pix/tests/unit/components/authentication/terms-of-service-pole-emploi_test.js
@@ -61,6 +61,23 @@ describe('Unit | Component | authentication::terms-of-service-pole-emploi', func
       });
     });
 
+    it('it should display detailed error', async function () {
+      // given
+      const component = createGlimmerComponent('component:authentication/terms-of-service-pole-emploi');
+      const createSession = sinon.stub().rejects({ errors: [{ status: '500', detail: 'some detail' }] });
+      component.args.createSession = createSession;
+      component.isTermsOfServiceValidated = true;
+      component.errorMessage = null;
+
+      // when
+      await component.submit();
+
+      // then
+      expect(component.errorMessage).to.equal(
+        'Une erreur est survenue. Veuillez recommencer ou contacter le support. (some detail)'
+      );
+    });
+
     it('it should display generic error', async function () {
       // given
       const component = createGlimmerComponent('component:authentication/terms-of-service-pole-emploi');

--- a/mon-pix/tests/unit/controllers/terms-of-service-cnav_test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-cnav_test.js
@@ -62,6 +62,21 @@ describe('Unit | Controller | terms-of-service-cnav', function () {
       });
     });
 
+    it('it should display detailed error', async function () {
+      // given
+      controller.isTermsOfServiceValidated = true;
+      controller.errorMessage = null;
+      controller.session.authenticate.rejects({ errors: [{ detail: 'some details' }] });
+
+      // when
+      await controller.send('submit');
+
+      // then
+      expect(controller.errorMessage).to.equal(
+        'Une erreur est survenue. Veuillez recommencer ou contacter le support. (some details)'
+      );
+    });
+
     it('it should display generic error', async function () {
       // given
       controller.isTermsOfServiceValidated = true;

--- a/mon-pix/tests/unit/routes/login-cnav_test.js
+++ b/mon-pix/tests/unit/routes/login-cnav_test.js
@@ -1,29 +1,26 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import sinon from 'sinon';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | login-cnav', function () {
   setupTest();
 
   context('when cnav user disallow pix to use data', function () {
-    it('should redirect to login route if there is an error in transition.to', function () {
+    it('should throw an error if there is an error in query parameters', function () {
       // given
       const route = this.owner.lookup('route:login-cnav');
-      const loginTransition = Symbol('login transition');
-      sinon.stub(route, 'replaceWith').withArgs('login').returns(loginTransition);
 
-      // when
-      const transitionResult = route.beforeModel({
-        to: {
-          queryParams: {
-            error: 'access_denied',
+      // when & then
+      expect(() => {
+        route.beforeModel({
+          to: {
+            queryParams: {
+              error: 'access_denied',
+              error_description: 'Access was denied.',
+            },
           },
-        },
-      });
-
-      // then
-      expect(transitionResult).to.equal(loginTransition);
+        });
+      }).to.throw(Error, 'access_denied: Access was denied.');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/login-pole-emploi_test.js
+++ b/mon-pix/tests/unit/routes/login-pole-emploi_test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import sinon from 'sinon';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | login-pole-emploi', function () {
@@ -19,23 +18,6 @@ describe('Unit | Route | login-pole-emploi', function () {
           queryParams: {
             error: 'access_denied',
           },
-        },
-      });
-
-      // then
-      expect(transitionResult).to.equal(loginTransition);
-    });
-
-    it('should redirect to login route if there is an error in transition', function () {
-      // given
-      const route = this.owner.lookup('route:login-pole-emploi');
-      const loginTransition = Symbol('login transition');
-      sinon.stub(route, 'replaceWith').withArgs('login').returns(loginTransition);
-
-      // when
-      const transitionResult = route.beforeModel({
-        queryParams: {
-          error: 'access_denied',
         },
       });
 

--- a/mon-pix/tests/unit/routes/login-pole-emploi_test.js
+++ b/mon-pix/tests/unit/routes/login-pole-emploi_test.js
@@ -6,23 +6,21 @@ describe('Unit | Route | login-pole-emploi', function () {
   setupTest();
 
   context('when pole-emploi user disallow PIX to use data', function () {
-    it('should redirect to login route if there is an error in transition.to', function () {
+    it('should throw an error if there is an error in query parameters', function () {
       // given
       const route = this.owner.lookup('route:login-pole-emploi');
-      const loginTransition = Symbol('login transition');
-      sinon.stub(route, 'replaceWith').withArgs('login').returns(loginTransition);
 
-      // when
-      const transitionResult = route.beforeModel({
-        to: {
-          queryParams: {
-            error: 'access_denied',
+      // when & then
+      expect(() => {
+        route.beforeModel({
+          to: {
+            queryParams: {
+              error: 'access_denied',
+              error_description: 'Access was denied.',
+            },
           },
-        },
-      });
-
-      // then
-      expect(transitionResult).to.equal(loginTransition);
+        });
+      }).to.throw(Error, 'access_denied: Access was denied.');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement lorsqu'un identity provider externe nous renvoie une erreur nous le redirigeons vers la page de login sans explications. Cela peut être difficile par la suite de comprendre quelle est la source du problème.

## :robot: Solution
Lorsque l'idp externe nous renvoie une erreur, afficher une page d'erreur avec le détail de l'erreur à l'utilisateur (plutôt que de rediriger l'utilisateur vers la page de connexion).

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer Pix App
- aller à l'url `connexion-cnav` en passant une erreur en paramètre. Ex: 
`http://localhost:4200/connexion-cnav?error=une%20erreur&error_description=il%20y%20a%20eu%20un%20probl%C3%A8me`
- constatez que vous tombez bien sur la page d'erreur générique "Oups, une erreur est survenue !" et que le détail de votre erreur (passée par le queryparams `error_description`) s'affiche bien à l'écran : 
<img width="1379" alt="image" src="https://user-images.githubusercontent.com/38167520/171826577-10d89fcf-df62-4442-a9b9-a09eeae0dc1b.png">

- faire de même avec pole emploi (ex: `http://localhost:4200/connexion-pole-emploi?error=une%20erreur&error_description=il%20y%20a%20eu%20un%20probl%C3%A8me`)
