### PR TITLE
[FEATURE] Afficher le niveau Pix des certifications complémentaire Pix+ Édu de 1er degré dans l'export csv des résultats (PIX-5043)

### DIFF
--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -119,156 +119,137 @@ class CertificationResult {
   }
 
   hasTakenClea() {
-    return this.complementaryCertificationCourseResults.some(({ partnerKey }) =>
-      [PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3].includes(partnerKey)
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([
+      PIX_EMPLOI_CLEA_V1,
+      PIX_EMPLOI_CLEA_V2,
+      PIX_EMPLOI_CLEA_V3,
+    ]);
+    return Boolean(result);
   }
 
   hasAcquiredClea() {
-    const cleaComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => [PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3].includes(partnerKey)
-    );
-    return Boolean(cleaComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([
+      PIX_EMPLOI_CLEA_V1,
+      PIX_EMPLOI_CLEA_V2,
+      PIX_EMPLOI_CLEA_V3,
+    ]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusDroitMaitre() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_DROIT_MAITRE_CERTIF]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusDroitMaitre() {
-    const pixPlusDroitMaitreComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_DROIT_MAITRE_CERTIF
-    );
-    return Boolean(pixPlusDroitMaitreComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_DROIT_MAITRE_CERTIF]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusDroitExpert() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_DROIT_EXPERT_CERTIF
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_DROIT_EXPERT_CERTIF]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusDroitExpert() {
-    const pixPlusDroitExpertComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_DROIT_EXPERT_CERTIF
-    );
-    return Boolean(pixPlusDroitExpertComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_DROIT_EXPERT_CERTIF]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu2ndDegreInitie() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu2ndDegreInitie() {
-    const pixPlusEduInitieComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
-    );
-    return Boolean(pixPlusEduInitieComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu2ndDegreConfirme() {
-    return this.complementaryCertificationCourseResults.some(({ partnerKey }) =>
-      [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
-        partnerKey
-      )
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+    ]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu2ndDegreConfirme() {
-    const pixPlusEduConfirmeComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) =>
-        [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
-          partnerKey
-        )
-    );
-    return Boolean(pixPlusEduConfirmeComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([
+      PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+    ]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu2ndDegreAvance() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu2ndDegreAvance() {
-    const pixPlusEduAvanceComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
-    );
-    return Boolean(pixPlusEduAvanceComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu2ndDegreExpert() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu2ndDegreExpert() {
-    const pixPlusEduExpertComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
-    );
-    return Boolean(pixPlusEduExpertComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu1erDegreInitie() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu1erDegreInitie() {
-    const pixPlusEduInitieComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE
-    );
-    return Boolean(pixPlusEduInitieComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu1erDegreConfirme() {
-    return this.complementaryCertificationCourseResults.some(({ partnerKey }) =>
-      [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME].includes(
-        partnerKey
-      )
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+    ]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu1erDegreConfirme() {
-    const pixPlusEduConfirmeComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) =>
-        [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME].includes(
-          partnerKey
-        )
-    );
-    return Boolean(pixPlusEduConfirmeComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([
+      PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+      PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+    ]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu1erDegreAvance() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu1erDegreAvance() {
-    const pixPlusEduAvanceComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE
-    );
-    return Boolean(pixPlusEduAvanceComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE]);
+    return Boolean(result?.acquired);
   }
 
   hasTakenPixPlusEdu1erDegreExpert() {
-    return this.complementaryCertificationCourseResults.some(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT
-    );
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT]);
+    return Boolean(result);
   }
 
   hasAcquiredPixPlusEdu1erDegreExpert() {
-    const pixPlusEduExpertComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
-      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT
-    );
-    return Boolean(pixPlusEduExpertComplementaryCertificationCourseResult?.acquired);
+    const result = this._getCertificationCourseResultByPartnerKeys([PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT]);
+    return Boolean(result?.acquired);
+  }
+
+  _getCertificationCourseResultByPartnerKeys(partnerKeys) {
+    return this.complementaryCertificationCourseResults.find(({ partnerKey }) => partnerKeys.includes(partnerKey));
   }
 }
 

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -12,6 +12,11 @@ const {
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
 } = require('./Badge').keys;
 
 const status = {
@@ -205,6 +210,63 @@ class CertificationResult {
   hasAcquiredPixPlusEdu2ndDegreExpert() {
     const pixPlusEduExpertComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
+    );
+    return Boolean(pixPlusEduExpertComplementaryCertificationCourseResult?.acquired);
+  }
+
+  hasTakenPixPlusEdu1erDegreInitie() {
+    return this.complementaryCertificationCourseResults.some(
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE
+    );
+  }
+
+  hasAcquiredPixPlusEdu1erDegreInitie() {
+    const pixPlusEduInitieComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE
+    );
+    return Boolean(pixPlusEduInitieComplementaryCertificationCourseResult?.acquired);
+  }
+
+  hasTakenPixPlusEdu1erDegreConfirme() {
+    return this.complementaryCertificationCourseResults.some(({ partnerKey }) =>
+      [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME].includes(
+        partnerKey
+      )
+    );
+  }
+
+  hasAcquiredPixPlusEdu1erDegreConfirme() {
+    const pixPlusEduConfirmeComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
+      ({ partnerKey }) =>
+        [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME].includes(
+          partnerKey
+        )
+    );
+    return Boolean(pixPlusEduConfirmeComplementaryCertificationCourseResult?.acquired);
+  }
+
+  hasTakenPixPlusEdu1erDegreAvance() {
+    return this.complementaryCertificationCourseResults.some(
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE
+    );
+  }
+
+  hasAcquiredPixPlusEdu1erDegreAvance() {
+    const pixPlusEduAvanceComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE
+    );
+    return Boolean(pixPlusEduAvanceComplementaryCertificationCourseResult?.acquired);
+  }
+
+  hasTakenPixPlusEdu1erDegreExpert() {
+    return this.complementaryCertificationCourseResults.some(
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT
+    );
+  }
+
+  hasAcquiredPixPlusEdu1erDegreExpert() {
+    const pixPlusEduExpertComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
+      ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT
     );
     return Boolean(pixPlusEduExpertComplementaryCertificationCourseResult?.acquired);
   }

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -152,20 +152,20 @@ class CertificationResult {
     return Boolean(pixPlusDroitExpertComplementaryCertificationCourseResult?.acquired);
   }
 
-  hasTakenPixPlusEduInitie() {
+  hasTakenPixPlusEdu2ndDegreInitie() {
     return this.complementaryCertificationCourseResults.some(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
     );
   }
 
-  hasAcquiredPixPlusEduInitie() {
+  hasAcquiredPixPlusEdu2ndDegreInitie() {
     const pixPlusEduInitieComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE
     );
     return Boolean(pixPlusEduInitieComplementaryCertificationCourseResult?.acquired);
   }
 
-  hasTakenPixPlusEduConfirme() {
+  hasTakenPixPlusEdu2ndDegreConfirme() {
     return this.complementaryCertificationCourseResults.some(({ partnerKey }) =>
       [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
         partnerKey
@@ -173,7 +173,7 @@ class CertificationResult {
     );
   }
 
-  hasAcquiredPixPlusEduConfirme() {
+  hasAcquiredPixPlusEdu2ndDegreConfirme() {
     const pixPlusEduConfirmeComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
       ({ partnerKey }) =>
         [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME].includes(
@@ -183,26 +183,26 @@ class CertificationResult {
     return Boolean(pixPlusEduConfirmeComplementaryCertificationCourseResult?.acquired);
   }
 
-  hasTakenPixPlusEduAvance() {
+  hasTakenPixPlusEdu2ndDegreAvance() {
     return this.complementaryCertificationCourseResults.some(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
     );
   }
 
-  hasAcquiredPixPlusEduAvance() {
+  hasAcquiredPixPlusEdu2ndDegreAvance() {
     const pixPlusEduAvanceComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE
     );
     return Boolean(pixPlusEduAvanceComplementaryCertificationCourseResult?.acquired);
   }
 
-  hasTakenPixPlusEduExpert() {
+  hasTakenPixPlusEdu2ndDegreExpert() {
     return this.complementaryCertificationCourseResults.some(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
     );
   }
 
-  hasAcquiredPixPlusEduExpert() {
+  hasAcquiredPixPlusEdu2ndDegreExpert() {
     const pixPlusEduExpertComplementaryCertificationCourseResult = this.complementaryCertificationCourseResults.find(
       ({ partnerKey }) => partnerKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT
     );

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -77,16 +77,16 @@ function _buildFileHeaders(certificationResults) {
     certificationResult.hasTakenPixPlusDroitExpert()
   );
   const shouldIncludePixPlusEdu2ndDegreInitieHeader = certificationResults.some((certificationResult) =>
-    certificationResult.hasTakenPixPlusEduInitie()
+    certificationResult.hasTakenPixPlusEdu2ndDegreInitie()
   );
   const shouldIncludePixPlusEdu2ndDegreConfirmeHeader = certificationResults.some((certificationResult) =>
-    certificationResult.hasTakenPixPlusEduConfirme()
+    certificationResult.hasTakenPixPlusEdu2ndDegreConfirme()
   );
   const shouldIncludePixPlusEdu2ndDegreAvanceHeader = certificationResults.some((certificationResult) =>
-    certificationResult.hasTakenPixPlusEduAvance()
+    certificationResult.hasTakenPixPlusEdu2ndDegreAvance()
   );
   const shouldIncludePixPlusEdu2ndDegreExpertHeader = certificationResults.some((certificationResult) =>
-    certificationResult.hasTakenPixPlusEduExpert()
+    certificationResult.hasTakenPixPlusEdu2ndDegreExpert()
   );
 
   const cleaHeader = shouldIncludeCleaHeader ? [_headers.CLEA_STATUS] : [];
@@ -179,24 +179,24 @@ function _formatPixPlusDroitExpertCertificationResult(certificationResult) {
 }
 
 function _formatPixPlusEduInitieCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEduInitie()) return 'Non passée';
+  if (!certificationResult.hasTakenPixPlusEdu2ndDegreInitie()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEduInitie() ? 'Validée' : 'Rejetée';
+  return certificationResult.hasAcquiredPixPlusEdu2ndDegreInitie() ? 'Validée' : 'Rejetée';
 }
 function _formatPixPlusEduConfirmeCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEduConfirme()) return 'Non passée';
+  if (!certificationResult.hasTakenPixPlusEdu2ndDegreConfirme()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEduConfirme() ? 'Validée' : 'Rejetée';
+  return certificationResult.hasAcquiredPixPlusEdu2ndDegreConfirme() ? 'Validée' : 'Rejetée';
 }
 function _formatPixPlusEduAvanceCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEduAvance()) return 'Non passée';
+  if (!certificationResult.hasTakenPixPlusEdu2ndDegreAvance()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEduAvance() ? 'Validée' : 'Rejetée';
+  return certificationResult.hasAcquiredPixPlusEdu2ndDegreAvance() ? 'Validée' : 'Rejetée';
 }
 function _formatPixPlusEduExpertCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEduExpert()) return 'Non passée';
+  if (!certificationResult.hasTakenPixPlusEdu2ndDegreExpert()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEduExpert() ? 'Validée' : 'Rejetée';
+  return certificationResult.hasAcquiredPixPlusEdu2ndDegreExpert() ? 'Validée' : 'Rejetée';
 }
 
 function _formatPixScore(certificationResult) {

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -170,53 +170,57 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
     [_headers.BIRTHPLACE]: certificationResult.birthplace,
     [_headers.EXTERNAL_ID]: certificationResult.externalId,
     [_headers.STATUS]: _formatStatus(certificationResult),
-    [_headers.CLEA_STATUS]: _formatComplementaryCertification(certificationResult, 'hasTakenClea', 'hasAcquiredClea'),
-    [_headers.PIX_PLUS_DROIT_MAITRE_STATUS]: _formatComplementaryCertification(
+    [_headers.CLEA_STATUS]: _getComplementaryCertificationStatus(
+      certificationResult,
+      'hasTakenClea',
+      'hasAcquiredClea'
+    ),
+    [_headers.PIX_PLUS_DROIT_MAITRE_STATUS]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusDroitMaitre',
       'hasAcquiredPixPlusDroitMaitre'
     ),
-    [_headers.PIX_PLUS_DROIT_EXPERT_STATUS]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_DROIT_EXPERT_STATUS]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusDroitExpert',
       'hasAcquiredPixPlusDroitExpert'
     ),
-    [_headers.PIX_PLUS_EDU_2ND_DEGRE_INITIE_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_INITIE_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreInitie',
       'hasAcquiredPixPlusEdu2ndDegreInitie'
     ),
-    [_headers.PIX_PLUS_EDU_2ND_DEGRE_CONFIRME_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_CONFIRME_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreConfirme',
       'hasAcquiredPixPlusEdu2ndDegreConfirme'
     ),
-    [_headers.PIX_PLUS_EDU_2ND_DEGRE_AVANCE_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_AVANCE_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreAvance',
       'hasAcquiredPixPlusEdu2ndDegreAvance'
     ),
-    [_headers.PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreExpert',
       'hasAcquiredPixPlusEdu2ndDegreExpert'
     ),
-    [_headers.PIX_PLUS_EDU_1ER_DEGRE_INITIE_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_INITIE_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu1erDegreInitie',
       'hasAcquiredPixPlusEdu1erDegreInitie'
     ),
-    [_headers.PIX_PLUS_EDU_1ER_DEGRE_CONFIRME_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_CONFIRME_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu1erDegreConfirme',
       'hasAcquiredPixPlusEdu1erDegreConfirme'
     ),
-    [_headers.PIX_PLUS_EDU_1ER_DEGRE_AVANCE_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_AVANCE_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu1erDegreAvance',
       'hasAcquiredPixPlusEdu1erDegreAvance'
     ),
-    [_headers.PIX_PLUS_EDU_1ER_DEGRE_EXPERT_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_EXPERT_HEADER]: _getComplementaryCertificationStatus(
       certificationResult,
       'hasTakenPixPlusEdu1erDegreExpert',
       'hasAcquiredPixPlusEdu1erDegreExpert'
@@ -232,7 +236,7 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
   return { ...rowWithoutCompetences, ...competencesCells };
 };
 
-function _formatComplementaryCertification(certificationResult, hasTakenFunction, hasAcquiredFunction) {
+function _getComplementaryCertificationStatus(certificationResult, hasTakenFunction, hasAcquiredFunction) {
   if (!certificationResult[hasTakenFunction]()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
   return certificationResult[hasAcquiredFunction]() ? 'Validée' : 'Rejetée';

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -142,13 +142,37 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
     [_headers.BIRTHPLACE]: certificationResult.birthplace,
     [_headers.EXTERNAL_ID]: certificationResult.externalId,
     [_headers.STATUS]: _formatStatus(certificationResult),
-    [_headers.CLEA_STATUS]: _formatCleaCertificationResult(certificationResult),
-    [_headers.PIX_PLUS_DROIT_MAITRE_STATUS]: _formatPixPlusDroitMaitreCertificationResult(certificationResult),
-    [_headers.PIX_PLUS_DROIT_EXPERT_STATUS]: _formatPixPlusDroitExpertCertificationResult(certificationResult),
-    [_headers.PIX_PLUS_EDU_INITIE_HEADER]: _formatPixPlusEduInitieCertificationResult(certificationResult),
-    [_headers.PIX_PLUS_EDU_CONFIRME_HEADER]: _formatPixPlusEduConfirmeCertificationResult(certificationResult),
-    [_headers.PIX_PLUS_EDU_AVANCE_HEADER]: _formatPixPlusEduAvanceCertificationResult(certificationResult),
-    [_headers.PIX_PLUS_EDU_EXPERT_HEADER]: _formatPixPlusEduExpertCertificationResult(certificationResult),
+    [_headers.CLEA_STATUS]: _formatComplementaryCertification(certificationResult, 'hasTakenClea', 'hasAcquiredClea'),
+    [_headers.PIX_PLUS_DROIT_MAITRE_STATUS]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusDroitMaitre',
+      'hasAcquiredPixPlusDroitMaitre'
+    ),
+    [_headers.PIX_PLUS_DROIT_EXPERT_STATUS]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusDroitExpert',
+      'hasAcquiredPixPlusDroitExpert'
+    ),
+    [_headers.PIX_PLUS_EDU_INITIE_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu2ndDegreInitie',
+      'hasAcquiredPixPlusEdu2ndDegreInitie'
+    ),
+    [_headers.PIX_PLUS_EDU_CONFIRME_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu2ndDegreConfirme',
+      'hasAcquiredPixPlusEdu2ndDegreConfirme'
+    ),
+    [_headers.PIX_PLUS_EDU_AVANCE_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu2ndDegreAvance',
+      'hasAcquiredPixPlusEdu2ndDegreAvance'
+    ),
+    [_headers.PIX_PLUS_EDU_EXPERT_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu2ndDegreExpert',
+      'hasAcquiredPixPlusEdu2ndDegreExpert'
+    ),
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
     [_headers.JURY_COMMENT_FOR_ORGANIZATION]: certificationResult.commentForOrganization,
     [_headers.SESSION_ID]: session.id,
@@ -160,43 +184,10 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
   return { ...rowWithoutCompetences, ...competencesCells };
 };
 
-function _formatCleaCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenClea()) return 'Non passée';
+function _formatComplementaryCertification(certificationResult, hasTakenFunction, hasAcquiredFunction) {
+  if (!certificationResult[hasTakenFunction]()) return 'Non passée';
   if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredClea() ? 'Validée' : 'Rejetée';
-}
-
-function _formatPixPlusDroitMaitreCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusDroitMaitre()) return 'Non passée';
-  if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusDroitMaitre() ? 'Validée' : 'Rejetée';
-}
-
-function _formatPixPlusDroitExpertCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusDroitExpert()) return 'Non passée';
-  if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusDroitExpert() ? 'Validée' : 'Rejetée';
-}
-
-function _formatPixPlusEduInitieCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEdu2ndDegreInitie()) return 'Non passée';
-  if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEdu2ndDegreInitie() ? 'Validée' : 'Rejetée';
-}
-function _formatPixPlusEduConfirmeCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEdu2ndDegreConfirme()) return 'Non passée';
-  if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEdu2ndDegreConfirme() ? 'Validée' : 'Rejetée';
-}
-function _formatPixPlusEduAvanceCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEdu2ndDegreAvance()) return 'Non passée';
-  if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEdu2ndDegreAvance() ? 'Validée' : 'Rejetée';
-}
-function _formatPixPlusEduExpertCertificationResult(certificationResult) {
-  if (!certificationResult.hasTakenPixPlusEdu2ndDegreExpert()) return 'Non passée';
-  if (certificationResult.isCancelled()) return 'Annulée';
-  return certificationResult.hasAcquiredPixPlusEdu2ndDegreExpert() ? 'Validée' : 'Rejetée';
+  return certificationResult[hasAcquiredFunction]() ? 'Validée' : 'Rejetée';
 }
 
 function _formatPixScore(certificationResult) {

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -93,16 +93,16 @@ function _buildFileHeaders(certificationResults) {
   const pixPlusDroitMaitreHeader = shouldIncludePixPlusDroitMaitreHeader ? [_headers.PIX_PLUS_DROIT_MAITRE_STATUS] : [];
   const pixPlusDroitExpertHeader = shouldIncludePixPlusDroitExpertHeader ? [_headers.PIX_PLUS_DROIT_EXPERT_STATUS] : [];
   const pixPlusEdu2ndDegreInitieHeader = shouldIncludePixPlusEdu2ndDegreInitieHeader
-    ? [_headers.PIX_PLUS_EDU_INITIE_HEADER]
+    ? [_headers.PIX_PLUS_EDU_2ND_DEGRE_INITIE_HEADER]
     : [];
   const pixPlusEdu2ndDegreConfirmeHeader = shouldIncludePixPlusEdu2ndDegreConfirmeHeader
-    ? [_headers.PIX_PLUS_EDU_CONFIRME_HEADER]
+    ? [_headers.PIX_PLUS_EDU_2ND_DEGRE_CONFIRME_HEADER]
     : [];
   const pixPlusEdu2ndDegreAvanceHeader = shouldIncludePixPlusEdu2ndDegreAvanceHeader
-    ? [_headers.PIX_PLUS_EDU_AVANCE_HEADER]
+    ? [_headers.PIX_PLUS_EDU_2ND_DEGRE_AVANCE_HEADER]
     : [];
   const pixPlusEdu2ndDegreExpertHeader = shouldIncludePixPlusEdu2ndDegreExpertHeader
-    ? [_headers.PIX_PLUS_EDU_EXPERT_HEADER]
+    ? [_headers.PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER]
     : [];
 
   return _.concat(
@@ -153,22 +153,22 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
       'hasTakenPixPlusDroitExpert',
       'hasAcquiredPixPlusDroitExpert'
     ),
-    [_headers.PIX_PLUS_EDU_INITIE_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_INITIE_HEADER]: _formatComplementaryCertification(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreInitie',
       'hasAcquiredPixPlusEdu2ndDegreInitie'
     ),
-    [_headers.PIX_PLUS_EDU_CONFIRME_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_CONFIRME_HEADER]: _formatComplementaryCertification(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreConfirme',
       'hasAcquiredPixPlusEdu2ndDegreConfirme'
     ),
-    [_headers.PIX_PLUS_EDU_AVANCE_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_AVANCE_HEADER]: _formatComplementaryCertification(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreAvance',
       'hasAcquiredPixPlusEdu2ndDegreAvance'
     ),
-    [_headers.PIX_PLUS_EDU_EXPERT_HEADER]: _formatComplementaryCertification(
+    [_headers.PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER]: _formatComplementaryCertification(
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreExpert',
       'hasAcquiredPixPlusEdu2ndDegreExpert'
@@ -276,10 +276,10 @@ const _headers = {
   CLEA_STATUS: 'Certification CléA numérique',
   PIX_PLUS_DROIT_MAITRE_STATUS: 'Certification Pix+ Droit Maître',
   PIX_PLUS_DROIT_EXPERT_STATUS: 'Certification Pix+ Droit Expert',
-  PIX_PLUS_EDU_INITIE_HEADER: 'Certification Pix+ Édu Initié (entrée dans le métier)',
-  PIX_PLUS_EDU_CONFIRME_HEADER: 'Certification Pix+ Édu Confirmé',
-  PIX_PLUS_EDU_AVANCE_HEADER: 'Certification Pix+ Édu Avancé',
-  PIX_PLUS_EDU_EXPERT_HEADER: 'Certification Pix+ Édu Expert',
+  PIX_PLUS_EDU_2ND_DEGRE_INITIE_HEADER: 'Certification Pix+ Édu 2nd degré Initié (entrée dans le métier)',
+  PIX_PLUS_EDU_2ND_DEGRE_CONFIRME_HEADER: 'Certification Pix+ Édu 2nd degré Confirmé',
+  PIX_PLUS_EDU_2ND_DEGRE_AVANCE_HEADER: 'Certification Pix+ Édu 2nd degré Avancé',
+  PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER: 'Certification Pix+ Édu 2nd degré Expert',
   PIX_SCORE: 'Nombre de Pix',
   SESSION_ID: 'Session',
   CERTIFICATION_CENTER: 'Centre de certification',

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -76,26 +76,34 @@ function _buildFileHeaders(certificationResults) {
   const shouldIncludePixPlusDroitExpertHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusDroitExpert()
   );
-  const shouldIncludePixPlusEduAutonomeHeader = certificationResults.some((certificationResult) =>
+  const shouldIncludePixPlusEdu2ndDegreInitieHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusEduInitie()
   );
-  const shouldIncludePixPlusEduAvanceHeader = certificationResults.some((certificationResult) =>
+  const shouldIncludePixPlusEdu2ndDegreConfirmeHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusEduConfirme()
   );
-  const shouldIncludePixPlusEduExpertHeader = certificationResults.some((certificationResult) =>
+  const shouldIncludePixPlusEdu2ndDegreAvanceHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusEduAvance()
   );
-  const shouldIncludePixPlusEduFormateurHeader = certificationResults.some((certificationResult) =>
+  const shouldIncludePixPlusEdu2ndDegreExpertHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusEduExpert()
   );
 
   const cleaHeader = shouldIncludeCleaHeader ? [_headers.CLEA_STATUS] : [];
   const pixPlusDroitMaitreHeader = shouldIncludePixPlusDroitMaitreHeader ? [_headers.PIX_PLUS_DROIT_MAITRE_STATUS] : [];
   const pixPlusDroitExpertHeader = shouldIncludePixPlusDroitExpertHeader ? [_headers.PIX_PLUS_DROIT_EXPERT_STATUS] : [];
-  const pixPlusEduAutonomeHeader = shouldIncludePixPlusEduAutonomeHeader ? [_headers.PIX_PLUS_EDU_INITIE_HEADER] : [];
-  const pixPlusEduAvanceHeader = shouldIncludePixPlusEduAvanceHeader ? [_headers.PIX_PLUS_EDU_CONFIRME_HEADER] : [];
-  const pixPlusEduExpertHeader = shouldIncludePixPlusEduExpertHeader ? [_headers.PIX_PLUS_EDU_AVANCE_HEADER] : [];
-  const pixPlusEduFormateurHeader = shouldIncludePixPlusEduFormateurHeader ? [_headers.PIX_PLUS_EDU_EXPERT_HEADER] : [];
+  const pixPlusEdu2ndDegreInitieHeader = shouldIncludePixPlusEdu2ndDegreInitieHeader
+    ? [_headers.PIX_PLUS_EDU_INITIE_HEADER]
+    : [];
+  const pixPlusEdu2ndDegreConfirmeHeader = shouldIncludePixPlusEdu2ndDegreConfirmeHeader
+    ? [_headers.PIX_PLUS_EDU_CONFIRME_HEADER]
+    : [];
+  const pixPlusEdu2ndDegreAvanceHeader = shouldIncludePixPlusEdu2ndDegreAvanceHeader
+    ? [_headers.PIX_PLUS_EDU_AVANCE_HEADER]
+    : [];
+  const pixPlusEdu2ndDegreExpertHeader = shouldIncludePixPlusEdu2ndDegreExpertHeader
+    ? [_headers.PIX_PLUS_EDU_EXPERT_HEADER]
+    : [];
 
   return _.concat(
     [
@@ -110,10 +118,10 @@ function _buildFileHeaders(certificationResults) {
     pixPlusDroitMaitreHeader,
     pixPlusDroitExpertHeader,
     cleaHeader,
-    pixPlusEduAutonomeHeader,
-    pixPlusEduAvanceHeader,
-    pixPlusEduExpertHeader,
-    pixPlusEduFormateurHeader,
+    pixPlusEdu2ndDegreInitieHeader,
+    pixPlusEdu2ndDegreConfirmeHeader,
+    pixPlusEdu2ndDegreAvanceHeader,
+    pixPlusEdu2ndDegreExpertHeader,
     [_headers.PIX_SCORE],
     _competenceIndexes,
     [

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -88,6 +88,18 @@ function _buildFileHeaders(certificationResults) {
   const shouldIncludePixPlusEdu2ndDegreExpertHeader = certificationResults.some((certificationResult) =>
     certificationResult.hasTakenPixPlusEdu2ndDegreExpert()
   );
+  const shouldIncludePixPlusEdu1erDegreInitieHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEdu1erDegreInitie()
+  );
+  const shouldIncludePixPlusEdu1erDegreConfirmeHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEdu1erDegreConfirme()
+  );
+  const shouldIncludePixPlusEdu1erDegreAvanceHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEdu1erDegreAvance()
+  );
+  const shouldIncludePixPlusEdu1erDegreExpertHeader = certificationResults.some((certificationResult) =>
+    certificationResult.hasTakenPixPlusEdu1erDegreExpert()
+  );
 
   const cleaHeader = shouldIncludeCleaHeader ? [_headers.CLEA_STATUS] : [];
   const pixPlusDroitMaitreHeader = shouldIncludePixPlusDroitMaitreHeader ? [_headers.PIX_PLUS_DROIT_MAITRE_STATUS] : [];
@@ -103,6 +115,18 @@ function _buildFileHeaders(certificationResults) {
     : [];
   const pixPlusEdu2ndDegreExpertHeader = shouldIncludePixPlusEdu2ndDegreExpertHeader
     ? [_headers.PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER]
+    : [];
+  const pixPlusEdu1erDegreInitieHeader = shouldIncludePixPlusEdu1erDegreInitieHeader
+    ? [_headers.PIX_PLUS_EDU_1ER_DEGRE_INITIE_HEADER]
+    : [];
+  const pixPlusEdu1erDegreConfirmeHeader = shouldIncludePixPlusEdu1erDegreConfirmeHeader
+    ? [_headers.PIX_PLUS_EDU_1ER_DEGRE_CONFIRME_HEADER]
+    : [];
+  const pixPlusEdu1erDegreAvanceHeader = shouldIncludePixPlusEdu1erDegreAvanceHeader
+    ? [_headers.PIX_PLUS_EDU_1ER_DEGRE_AVANCE_HEADER]
+    : [];
+  const pixPlusEdu1erDegreExpertHeader = shouldIncludePixPlusEdu1erDegreExpertHeader
+    ? [_headers.PIX_PLUS_EDU_1ER_DEGRE_EXPERT_HEADER]
     : [];
 
   return _.concat(
@@ -122,6 +146,10 @@ function _buildFileHeaders(certificationResults) {
     pixPlusEdu2ndDegreConfirmeHeader,
     pixPlusEdu2ndDegreAvanceHeader,
     pixPlusEdu2ndDegreExpertHeader,
+    pixPlusEdu1erDegreInitieHeader,
+    pixPlusEdu1erDegreConfirmeHeader,
+    pixPlusEdu1erDegreAvanceHeader,
+    pixPlusEdu1erDegreExpertHeader,
     [_headers.PIX_SCORE],
     _competenceIndexes,
     [
@@ -172,6 +200,26 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
       certificationResult,
       'hasTakenPixPlusEdu2ndDegreExpert',
       'hasAcquiredPixPlusEdu2ndDegreExpert'
+    ),
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_INITIE_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu1erDegreInitie',
+      'hasAcquiredPixPlusEdu1erDegreInitie'
+    ),
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_CONFIRME_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu1erDegreConfirme',
+      'hasAcquiredPixPlusEdu1erDegreConfirme'
+    ),
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_AVANCE_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu1erDegreAvance',
+      'hasAcquiredPixPlusEdu1erDegreAvance'
+    ),
+    [_headers.PIX_PLUS_EDU_1ER_DEGRE_EXPERT_HEADER]: _formatComplementaryCertification(
+      certificationResult,
+      'hasTakenPixPlusEdu1erDegreExpert',
+      'hasAcquiredPixPlusEdu1erDegreExpert'
     ),
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
     [_headers.JURY_COMMENT_FOR_ORGANIZATION]: certificationResult.commentForOrganization,
@@ -280,6 +328,10 @@ const _headers = {
   PIX_PLUS_EDU_2ND_DEGRE_CONFIRME_HEADER: 'Certification Pix+ Édu 2nd degré Confirmé',
   PIX_PLUS_EDU_2ND_DEGRE_AVANCE_HEADER: 'Certification Pix+ Édu 2nd degré Avancé',
   PIX_PLUS_EDU_2ND_DEGRE_EXPERT_HEADER: 'Certification Pix+ Édu 2nd degré Expert',
+  PIX_PLUS_EDU_1ER_DEGRE_INITIE_HEADER: 'Certification Pix+ Édu 1er degré Initié (entrée dans le métier)',
+  PIX_PLUS_EDU_1ER_DEGRE_CONFIRME_HEADER: 'Certification Pix+ Édu 1er degré Confirmé',
+  PIX_PLUS_EDU_1ER_DEGRE_AVANCE_HEADER: 'Certification Pix+ Édu 1er degré Avancé',
+  PIX_PLUS_EDU_1ER_DEGRE_EXPERT_HEADER: 'Certification Pix+ Édu 1er degré Expert',
   PIX_SCORE: 'Nombre de Pix',
   SESSION_ID: 'Session',
   CERTIFICATION_CENTER: 'Centre de certification',

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -151,13 +151,19 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
       { partnerKey: PIX_DROIT_EXPERT_CERTIF, expectedHeader: 'Certification Pix+ Droit Expert' },
       {
         partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-        expectedHeader: 'Certification Pix+ Édu Initié (entrée dans le métier)',
+        expectedHeader: 'Certification Pix+ Édu 2nd degré Initié (entrée dans le métier)',
       },
-      { partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, expectedHeader: 'Certification Pix+ Édu Confirmé' },
-      { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, expectedHeader: 'Certification Pix+ Édu Avancé' },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        expectedHeader: 'Certification Pix+ Édu 2nd degré Confirmé',
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        expectedHeader: 'Certification Pix+ Édu 2nd degré Avancé',
+      },
       {
         partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-        expectedHeader: 'Certification Pix+ Édu Expert',
+        expectedHeader: 'Certification Pix+ Édu 2nd degré Expert',
       },
     ].forEach(({ partnerKey, expectedHeader }) => {
       context(`when at least one candidate has passed ${partnerKey} certification`, function () {
@@ -294,7 +300,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         // then
         const expectedResult =
           '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Certification Pix+ Édu Initié (entrée dans le métier)";"Certification Pix+ Édu Confirmé";"Certification Pix+ Édu Avancé";"Certification Pix+ Édu Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Certification Pix+ Édu 2nd degré Initié (entrée dans le métier)";"Certification Pix+ Édu 2nd degré Confirmé";"Certification Pix+ Édu 2nd degré Avancé";"Certification Pix+ Édu 2nd degré Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
           '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";"Validée";"Validée";"Validée";"Rejetée";"Validée";"Rejetée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -11,6 +11,10 @@ const {
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
 } = require('../../../../../lib/domain/models/Badge').keys;
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', function () {
@@ -165,6 +169,22 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
         expectedHeader: 'Certification Pix+ Édu 2nd degré Expert',
       },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        expectedHeader: 'Certification Pix+ Édu 1er degré Initié (entrée dans le métier)',
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        expectedHeader: 'Certification Pix+ Édu 1er degré Confirmé',
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        expectedHeader: 'Certification Pix+ Édu 1er degré Avancé',
+      },
+      {
+        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        expectedHeader: 'Certification Pix+ Édu 1er degré Expert',
+      },
     ].forEach(({ partnerKey, expectedHeader }) => {
       context(`when at least one candidate has passed ${partnerKey} certification`, function () {
         it(`should return correct csvContent with the ${partnerKey} information`, async function () {
@@ -289,6 +309,22 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
               partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
               acquired: false,
             }),
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+              acquired: true,
+            }),
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+              acquired: false,
+            }),
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+              acquired: true,
+            }),
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+              acquired: false,
+            }),
           ],
         });
 
@@ -300,8 +336,8 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         // then
         const expectedResult =
           '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Certification Pix+ Édu 2nd degré Initié (entrée dans le métier)";"Certification Pix+ Édu 2nd degré Confirmé";"Certification Pix+ Édu 2nd degré Avancé";"Certification Pix+ Édu 2nd degré Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";"Validée";"Validée";"Validée";"Rejetée";"Validée";"Rejetée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Certification Pix+ Droit Maître";"Certification Pix+ Droit Expert";"Certification CléA numérique";"Certification Pix+ Édu 2nd degré Initié (entrée dans le métier)";"Certification Pix+ Édu 2nd degré Confirmé";"Certification Pix+ Édu 2nd degré Avancé";"Certification Pix+ Édu 2nd degré Expert";"Certification Pix+ Édu 1er degré Initié (entrée dans le métier)";"Certification Pix+ Édu 1er degré Confirmé";"Certification Pix+ Édu 1er degré Avancé";"Certification Pix+ Édu 1er degré Expert";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          '123;"Lili";"Oxford";"04/01/1990";"Torreilles";"LOLORD";"Validée";"Rejetée";"Validée";"Validée";"Validée";"Rejetée";"Validée";"Rejetée";"Validée";"Rejetée";"Validée";"Rejetée";55;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";3;0;"RAS";777;"CentreCertif";"01/01/2020"';
         expect(result).to.equal(expectedResult);
       });
     });

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -11,6 +11,11 @@ const {
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
 } = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Models | CertificationResult', function () {
@@ -368,6 +373,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     },
     { method: 'hasTakenPixPlusEdu2ndDegreAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE] },
     { method: 'hasTakenPixPlusEdu2ndDegreExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
+    { method: 'hasTakenPixPlusEdu1erDegreInitie', partnerKeys: [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE] },
+    {
+      method: 'hasTakenPixPlusEdu1erDegreConfirme',
+      partnerKeys: [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME],
+    },
+    { method: 'hasTakenPixPlusEdu1erDegreAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE] },
+    { method: 'hasTakenPixPlusEdu1erDegreExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT] },
   ].forEach(({ method, partnerKeys }) => {
     context(`#${method}`, function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
@@ -415,6 +427,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     },
     { method: 'hasAcquiredPixPlusEdu2ndDegreAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE] },
     { method: 'hasAcquiredPixPlusEdu2ndDegreExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
+    { method: 'hasAcquiredPixPlusEdu1erDegreInitie', partnerKeys: [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE] },
+    {
+      method: 'hasAcquiredPixPlusEdu1erDegreConfirme',
+      partnerKeys: [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME],
+    },
+    { method: 'hasAcquiredPixPlusEdu1erDegreAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE] },
+    { method: 'hasAcquiredPixPlusEdu1erDegreExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT] },
   ].forEach(({ method, partnerKeys }) => {
     context(`#${method}`, function () {
       // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/unit/domain/models/CertificationResult_test.js
@@ -361,13 +361,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     { method: 'hasTakenClea', partnerKeys: [PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3] },
     { method: 'hasTakenPixPlusDroitMaitre', partnerKeys: [PIX_DROIT_MAITRE_CERTIF] },
     { method: 'hasTakenPixPlusDroitExpert', partnerKeys: [PIX_DROIT_EXPERT_CERTIF] },
-    { method: 'hasTakenPixPlusEduInitie', partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE] },
+    { method: 'hasTakenPixPlusEdu2ndDegreInitie', partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE] },
     {
-      method: 'hasTakenPixPlusEduConfirme',
+      method: 'hasTakenPixPlusEdu2ndDegreConfirme',
       partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME],
     },
-    { method: 'hasTakenPixPlusEduAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE] },
-    { method: 'hasTakenPixPlusEduExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
+    { method: 'hasTakenPixPlusEdu2ndDegreAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE] },
+    { method: 'hasTakenPixPlusEdu2ndDegreExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
   ].forEach(({ method, partnerKeys }) => {
     context(`#${method}`, function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
@@ -408,13 +408,13 @@ describe('Unit | Domain | Models | CertificationResult', function () {
     { method: 'hasAcquiredClea', partnerKeys: [PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3] },
     { method: 'hasAcquiredPixPlusDroitMaitre', partnerKeys: [PIX_DROIT_MAITRE_CERTIF] },
     { method: 'hasAcquiredPixPlusDroitExpert', partnerKeys: [PIX_DROIT_EXPERT_CERTIF] },
-    { method: 'hasAcquiredPixPlusEduInitie', partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE] },
+    { method: 'hasAcquiredPixPlusEdu2ndDegreInitie', partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE] },
     {
-      method: 'hasAcquiredPixPlusEduConfirme',
+      method: 'hasAcquiredPixPlusEdu2ndDegreConfirme',
       partnerKeys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME, PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME],
     },
-    { method: 'hasAcquiredPixPlusEduAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE] },
-    { method: 'hasAcquiredPixPlusEduExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
+    { method: 'hasAcquiredPixPlusEdu2ndDegreAvance', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE] },
+    { method: 'hasAcquiredPixPlusEdu2ndDegreExpert', partnerKeys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT] },
   ].forEach(({ method, partnerKeys }) => {
     context(`#${method}`, function () {
       // eslint-disable-next-line mocha/no-setup-in-describe


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'export csv des résultats d'une certification ne prend pas en compte les certifications complémentaires Pix+ Édu de 1er degré.

## :robot: Solution
Ajouter les certifications Pix+ du de 1er degré dans l'export des résultats.

## :rainbow: Remarques
Un refacto du repository a été effectué afin de séparer la requête principale de celle récupérant les certifications complémentaires (les certifications complémentaires remontaient plusieurs fois à cause de deux `json_agg`)

## :100: Pour tester
- Se connecter à Pix Admin et aller sur la session 20000.
- Télécharger les résultats (bouton "Lien de téléchargement des résultats).
- Vérifier que les résultats des certifs complémentaires correspond bien à ceux affichés dans le détail d'une certification dans Pix Admin.