### PR TITLE
[BUGFIX] Corriger l'acronyme CNAV en majuscules sur Pix App (PIX-5023).

### DIFF
--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -8,7 +8,8 @@ import {
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { triggerEvent, visit } from '@ember/test-helpers';
+import { triggerEvent } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { contains } from '../../helpers/contains';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
@@ -76,11 +77,15 @@ describe('Acceptance | user-account | connection-methods', function () {
       await authenticateByCnav(garUser);
 
       // when
-      await visit('/mon-compte/methodes-de-connexion');
+      const screen = await visit('/mon-compte/methodes-de-connexion');
 
       // then
-      expect(contains(this.intl.t('pages.user-account.connexion-methods.authentication-methods.label'))).to.exist;
-      expect(contains(this.intl.t('pages.user-account.connexion-methods.authentication-methods.cnav'))).to.exist;
+      expect(
+        screen.getByText(this.intl.t('pages.user-account.connexion-methods.authentication-methods.label'))
+      ).to.exist;
+      expect(
+        screen.getByText(this.intl.t('pages.user-account.connexion-methods.authentication-methods.cnav'))
+      ).to.exist;
     });
   });
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1445,7 +1445,7 @@
           "label": "Connexion externe",
           "gar": "via ENT/Mediacentre",
           "pole-emploi": "via Pôle Emploi",
-          "cnav": "via Cnav"
+          "cnav": "via CNAV"
         }
       },
       "email-verification": {


### PR DESCRIPTION
## :unicorn: Problème
L'acronyme CNAV était écrit en minuscule dans les méthodes de connexion de "Mon Compte" sur Pix App

## :robot: Solution
Corriger en le passant en majuscules.

## :rainbow: Remarques
On utilise Testing Library dès qu'on peut 😎

## :100: Pour tester
Aller sur Pix App et entrer /connexion-cnav dans l'url
Remplir les info dans la page de login
Valider les cgu
Dans la page d'accueil, aller dans "Mon Compte" (menu en haut à droite)
Aller dans méthodes de connexion
Constater que l'acronyme est en majuscules
