### PR TITLE
[FEATURE] Afficher la méthode de connexion CNAV sur la page de détail d'un utilisateur sur Pix Admin (PIX-5022).

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -153,6 +153,25 @@
         {{/if}}
       </td>
     </tr>
+
+    <tr>
+      <td class="authentication-method__name-column">CNAV</td>
+      <td>
+        {{#if @user.hasCnavAuthenticationMethod}}
+          <FaIcon
+            @icon="check-circle"
+            aria-label="L'utilisateur a une méthode de connexion CNAV"
+            class="authentication-method__check"
+          />
+        {{else}}
+          <FaIcon
+            @icon="times-circle"
+            aria-label="L'utilisateur n'a pas de méthode de connexion CNAV"
+            class="authentication-method__uncheck"
+          />
+        {{/if}}
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -75,46 +75,6 @@
     </tr>
 
     <tr>
-      <td class="authentication-method__name-column">Pôle emploi</td>
-      <td>
-        {{#if @user.hasPoleEmploiAuthenticationMethod}}
-          <FaIcon
-            @icon="check-circle"
-            aria-label="L'utilisateur a une méthode de connexion Pôle Emploi"
-            class="authentication-method__check"
-          />
-        {{else}}
-          <FaIcon
-            @icon="times-circle"
-            aria-label="L'utilisateur n'a pas de méthode de connexion Pôle Emploi"
-            class="authentication-method__uncheck"
-          />
-        {{/if}}
-      </td>
-      <td>
-        {{#if this.accessControl.hasAccessToUsersActionsScope}}
-          {{#if @user.isAllowedToRemovePoleEmploiAuthenticationMethod}}
-            <PixButton
-              class="user-authentication-method__remove-button"
-              @size="small"
-              @backgroundColor="red"
-              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "POLE_EMPLOI"}}
-            >Supprimer</PixButton>
-          {{/if}}
-        {{/if}}
-      </td>
-      <td>
-        {{#if this.accessControl.hasAccessToUsersActionsScope}}
-          {{#if @user.hasPoleEmploiAuthenticationMethod}}
-            <PixButton @triggerAction={{this.toggleReassignPoleEmploiAuthenticationMethodModal}} @size="small">
-              Déplacer cette méthode de connexion
-            </PixButton>
-          {{/if}}
-        {{/if}}
-      </td>
-    </tr>
-
-    <tr>
       <td class="authentication-method__name-column">Médiacentre</td>
       <td>
         {{#if @user.hasGarAuthenticationMethod}}
@@ -147,6 +107,46 @@
         {{#if this.accessControl.hasAccessToUsersActionsScope}}
           {{#if @user.hasGarAuthenticationMethod}}
             <PixButton @triggerAction={{this.toggleReassignGarAuthenticationMethodModal}} @size="small">
+              Déplacer cette méthode de connexion
+            </PixButton>
+          {{/if}}
+        {{/if}}
+      </td>
+    </tr>
+
+    <tr>
+      <td class="authentication-method__name-column">Pôle emploi</td>
+      <td>
+        {{#if @user.hasPoleEmploiAuthenticationMethod}}
+          <FaIcon
+            @icon="check-circle"
+            aria-label="L'utilisateur a une méthode de connexion Pôle Emploi"
+            class="authentication-method__check"
+          />
+        {{else}}
+          <FaIcon
+            @icon="times-circle"
+            aria-label="L'utilisateur n'a pas de méthode de connexion Pôle Emploi"
+            class="authentication-method__uncheck"
+          />
+        {{/if}}
+      </td>
+      <td>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.isAllowedToRemovePoleEmploiAuthenticationMethod}}
+            <PixButton
+              class="user-authentication-method__remove-button"
+              @size="small"
+              @backgroundColor="red"
+              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "POLE_EMPLOI"}}
+            >Supprimer</PixButton>
+          {{/if}}
+        {{/if}}
+      </td>
+      <td>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.hasPoleEmploiAuthenticationMethod}}
+            <PixButton @triggerAction={{this.toggleReassignPoleEmploiAuthenticationMethodModal}} @size="small">
               Déplacer cette méthode de connexion
             </PixButton>
           {{/if}}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -45,6 +45,10 @@ export default class User extends Model {
     );
   }
 
+  get hasCnavAuthenticationMethod() {
+    return this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'CNAV');
+  }
+
   get hasGarAuthenticationMethod() {
     return this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'GAR');
   }

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -89,19 +89,57 @@ module('Integration | Component | users | user-detail-personal-information/authe
         });
       });
 
-      test('should display user’s Pole Emploi authentication method', async function (assert) {
-        // given
-        this.set('user', { hasPoleEmploiAuthenticationMethod: true });
-        this.owner.register('service:access-control', AccessControlStub);
+      module('pole emploi authentication method', function () {
+        module('when user has pole emploi authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasPoleEmploiAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
 
-        // when
-        const screen = await render(hbs`
+            // when
+            const screen = await render(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
         />`);
 
-        // then
-        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Pôle Emploi")).exists();
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Pôle Emploi")).exists();
+          });
+
+          test('should display reassign authentication method button', async function (assert) {
+            // given
+            this.set('user', {
+              hasPoleEmploiAuthenticationMethod: true,
+            });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+          <Users::UserDetailPersonalInformation::AuthenticationMethod
+            @user={{this.user}}
+          />`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
+          });
+        });
+
+        module('when user does not have pole emploi authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasPoleEmploiAuthenticationMethod: false, hasCnavAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion Pôle Emploi")).exists();
+          });
+        });
       });
 
       test('should display user’s gar authentication method', async function (assert) {
@@ -215,25 +253,6 @@ module('Integration | Component | users | user-detail-personal-information/authe
           // given
           this.set('user', {
             hasGarAuthenticationMethod: true,
-          });
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(hbs`
-          <Users::UserDetailPersonalInformation::AuthenticationMethod
-            @user={{this.user}}
-          />`);
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
-        });
-      });
-
-      module('When user has Pole Emploi authentication method', function () {
-        test('it should display reassign authentication method button', async function (assert) {
-          // given
-          this.set('user', {
-            hasPoleEmploiAuthenticationMethod: true,
           });
           this.owner.register('service:access-control', AccessControlStub);
 

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -73,6 +73,42 @@ module('Integration | Component | users | user-detail-personal-information/authe
         assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Médiacentre")).exists();
       });
 
+      module('cnav authentication method', function () {
+        module('when user has cnav authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasCnavAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion CNAV")).exists();
+          });
+        });
+
+        module('when user does not have cnav authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasUsernameAuthenticationMethod: true, hasCnavAuthenticationMethod: false });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion CNAV")).exists();
+          });
+        });
+      });
+
       module('When user has only one authentication method', function () {
         test('it should not display a remove authentication method link', async function (assert) {
           // given

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -13,19 +13,42 @@ module('Integration | Component | users | user-detail-personal-information/authe
     }
 
     module('When user has authentication methods', function () {
-      test('should display user’s email authentication method', async function (assert) {
-        // given
-        this.set('user', { hasEmailAuthenticationMethod: true });
-        this.owner.register('service:access-control', AccessControlStub);
+      module('email authentication method', function () {
+        module('when user has email authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasEmailAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
 
-        // when
-        const screen = await render(hbs`
+            // when
+            const screen = await render(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
         />`);
 
-        // then
-        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec adresse e-mail")).exists();
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec adresse e-mail")).exists();
+          });
+        });
+
+        module('when user does not have email authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasEmailAuthenticationMethod: false, hasCnavAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+            // then
+            assert
+              .dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec adresse e-mail"))
+              .exists();
+          });
+        });
       });
 
       test('should display user’s username authentication method', async function (assert) {

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -142,19 +142,57 @@ module('Integration | Component | users | user-detail-personal-information/authe
         });
       });
 
-      test('should display user’s gar authentication method', async function (assert) {
-        // given
-        this.set('user', { hasGarAuthenticationMethod: true });
-        this.owner.register('service:access-control', AccessControlStub);
+      module('gar authentication method', function () {
+        module('when user has gar authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasGarAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
 
-        // when
-        const screen = await render(hbs`
+            // when
+            const screen = await render(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
         />`);
 
-        // then
-        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Médiacentre")).exists();
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion Médiacentre")).exists();
+          });
+
+          test('it should display reassign authentication method button', async function (assert) {
+            // given
+            this.set('user', {
+              hasGarAuthenticationMethod: true,
+            });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+          <Users::UserDetailPersonalInformation::AuthenticationMethod
+            @user={{this.user}}
+          />`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
+          });
+        });
+
+        module('when user does not have gar authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasGarAuthenticationMethod: false, hasCnavAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion Médiacentre")).exists();
+          });
+        });
       });
 
       module('cnav authentication method', function () {
@@ -245,25 +283,6 @@ module('Integration | Component | users | user-detail-personal-information/authe
             // then
             assert.dom(screen.queryByRole('button', { name: 'Ajouter une adresse e-mail' })).doesNotExist();
           });
-        });
-      });
-
-      module('When user has gar authentication method', function () {
-        test('it should display reassign authentication method button', async function (assert) {
-          // given
-          this.set('user', {
-            hasGarAuthenticationMethod: true,
-          });
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(hbs`
-          <Users::UserDetailPersonalInformation::AuthenticationMethod
-            @user={{this.user}}
-          />`);
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Déplacer cette méthode de connexion' })).exists();
         });
       });
     });

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -51,19 +51,42 @@ module('Integration | Component | users | user-detail-personal-information/authe
         });
       });
 
-      test('should display user’s username authentication method', async function (assert) {
-        // given
-        this.set('user', { hasUsernameAuthenticationMethod: true });
-        this.owner.register('service:access-control', AccessControlStub);
+      module('username authentication method', function () {
+        module('when user has username authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasUsernameAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
 
-        // when
-        const screen = await render(hbs`
+            // when
+            const screen = await render(hbs`
         <Users::UserDetailPersonalInformation::AuthenticationMethod
           @user={{this.user}}
         />`);
 
-        // then
-        assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec identifiant")).exists();
+            // then
+            assert.dom(screen.getByLabelText("L'utilisateur a une méthode de connexion avec identifiant")).exists();
+          });
+        });
+
+        module('when user does not have username authentication method', function () {
+          test('should display information', async function (assert) {
+            // given
+            this.set('user', { hasUsernameAuthenticationMethod: false, hasCnavAuthenticationMethod: true });
+            this.owner.register('service:access-control', AccessControlStub);
+
+            // when
+            const screen = await render(hbs`
+        <Users::UserDetailPersonalInformation::AuthenticationMethod
+          @user={{this.user}}
+        />`);
+
+            // then
+            assert
+              .dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec identifiant"))
+              .exists();
+          });
+        });
       });
 
       test('should display user’s Pole Emploi authentication method', async function (assert) {

--- a/admin/tests/unit/models/user_test.js
+++ b/admin/tests/unit/models/user_test.js
@@ -106,6 +106,17 @@ module('Unit | Model | user', function (hooks) {
     });
   });
 
+  module('#hasCnavAuthenticationMethod', function () {
+    test('it should return true when user has cnav authentication method', function (assert) {
+      // given
+      const authenticationMethod = store.createRecord('authentication-method', { identityProvider: 'CNAV' });
+      const user = store.createRecord('user', { authenticationMethods: [authenticationMethod] });
+
+      // when & then
+      assert.true(user.hasCnavAuthenticationMethod);
+    });
+  });
+
   module('hasOnlyOneAuthenticationMethod', function () {
     test('it should return true when user has only one authentication method', function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Désormais nous permettons la création de compte Pix avec la méthode de connexion CNAV (interconnexion). Mais celle-ci n'apparaît pas dans la page de détails d'un utilisateur sur Pix Admin.

## :robot: Solution
Afficher la méthode connexion CNAV, en dessous de Pôle Emploi

## :rainbow: Remarques
La méthode Médiacentre à été déplacé plus haut, comme demandé dans le ticket JIRA

Des ajouts et une réorganisation des tests d'intégration à été fait dans les 3 derniers commits.

## :100: Pour tester
- Se connecter sur Pix Admin (ex: superadmin@example.net)
- Dans le menu de gauche, aller sur "utilisateurs"
- Entrer "Ivy" en prénom et aller sur la page de détails de l'utilisateur
- Constater que la méthode CNAV apparaît sur cette page 
- L'utilisateur Ivy ne possède pas cette méthode, constater que la pastille est grise.
- Retourner dans la recherche d"utilisateur et taper CnavPix
- Aller dans la page de détails et constater que la pastille CNAV est verte.