### PR TITLE
[BUGFIX] Rendre les signalements E11 et E12 impactant (PIX-5054).

### DIFF
--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -116,6 +116,8 @@ const subcategoryCodeImpactful = [
   CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
   CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
   CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+  CertificationIssueReportSubcategories.SKIP_ON_OOPS,
+  CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
 ];
 
 const deprecatedSubcategories = [

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -430,6 +430,18 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
             questionNumber: 42,
           },
           { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
+          {
+            certificationCourseId: 42,
+            category: 'IN_CHALLENGE',
+            subcategory: 'SKIP_ON_OOPS',
+            questionNumber: 42,
+          },
+          {
+            certificationCourseId: 42,
+            category: 'IN_CHALLENGE',
+            subcategory: 'ACCESSIBILITY_ISSUE',
+            questionNumber: 42,
+          },
         ].forEach((certificationIssueReportDTO) => {
           it(`for ${certificationIssueReportDTO.category} ${
             certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les signalements E11 et E12 ne sont pas considérés comme impactant. Cela entraîne un mauvais affichage das Pix Admin et ne permet pas de voir la résolution du signalement.

## :robot: Solution
Rendre le signalements E11 et E12 impactant.

## :100: Pour tester
Aller sur https://admin-pr4491.review.pix.fr/certifications/18000 et vérifier que les signalements E11 et E12 sont bien dans la catégorie des signalements impactant.