### PR TITLE
[DOCS] Corriger le test de la connexion BDD dans l'installation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -82,8 +82,8 @@ en local. Si besoin, éditer le fichier `.env` généré par le script pour l'ad
 
 Vérifier les connexions à la base de donnée :
 
-- de test manuel (présence de table et de données) `docker exec -it pix_postgres_1 psql -U postgres pix`;
-- de test automatique (présence de tables) `docker exec -it pix_postgres_1 psql -U postgres pix_test`.
+- de test manuel (présence de table et de données) `docker exec -it pix-api-postgres psql -U postgres pix`;
+- de test automatique (présence de tables) `docker exec -it pix-api-postgres psql -U postgres pix_test`.
 
 ### 4. Démarrer les applications.
 


### PR DESCRIPTION
## :unicorn: Problème
Le nom du container contenant postgresql n'est plus à jour dans la doc d'install suie à https://github.com/1024pix/pix/pull/3239
La commande ne fonctionne donc jamais.

## :robot: Solution
Utiliser le nouveau nom

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les nouvelles commandes fonctionnent sur un environnement de dev à jour.
