### PR TITLE
[FEATURE] Supprimer l'étape 2 lors de finalisation d'une session (PIX-4953)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -10,7 +10,7 @@ import trim from 'lodash/trim';
 
 export default class SessionsFinalizeController extends Controller {
   @service currentUser;
-
+  @service featureToggles;
   @service notifications;
 
   @alias('model') session;
@@ -35,6 +35,10 @@ export default class SessionsFinalizeController extends Controller {
 
   get hasUncheckedHasSeenEndTestScreen() {
     return this.uncheckedHasSeenEndTestScreenCount > 0;
+  }
+
+  get shouldDisplayFormStep() {
+    return !this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled;
   }
 
   showErrorNotification(message, options = {}) {

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -37,14 +37,16 @@
     {{/if}}
   </SessionFinalizationStepContainer>
 
-  <SessionFinalizationStepContainer
-    @number="2"
-    @title="Transmettre des documents (facultatif)"
-    @icon="/icons/session-finalization-send.svg"
-    @iconAlt=""
-  >
-    <SessionFinalization::FormbuilderLinkStep />
-  </SessionFinalizationStepContainer>
+  {{#if this.shouldDisplayFormStep}}
+    <SessionFinalizationStepContainer
+      @number="2"
+      @title="Transmettre des documents (facultatif)"
+      @icon="/icons/session-finalization-send.svg"
+      @iconAlt=""
+    >
+      <SessionFinalization::FormbuilderLinkStep />
+    </SessionFinalizationStepContainer>
+  {{/if}}
 
   <SessionFinalizationStepContainer
     @number="3"

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -350,6 +350,38 @@ module('Acceptance | Session Finalization', function (hooks) {
           });
         });
       });
+
+      module('when the feature toggle isCertificationFreeFieldsDeletionEnabled is enabled', function () {
+        test('it should not display the step two block', async function (assert) {
+          // given
+          server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: true });
+
+          const certificationReport = server.create('certification-report');
+          session.update({ certificationReports: [certificationReport] });
+
+          // when
+          await visit(`/sessions/${session.id}/finalisation`);
+
+          // then
+          assert.notContains('Étape 2 : Transmettre des documents (facultatif)');
+        });
+      });
+
+      module('when the feature toggle isCertificationFreeFieldsDeletionEnabled is not enabled', function () {
+        test('it should display the form step block', async function (assert) {
+          // given
+          server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: false });
+
+          const certificationReport = server.create('certification-report');
+          session.update({ certificationReports: [certificationReport] });
+
+          // when
+          await visit(`/sessions/${session.id}/finalisation`);
+
+          // then
+          assert.contains('Étape 2 : Transmettre des documents (facultatif)');
+        });
+      });
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
 import sinon from 'sinon';
 
 const FINALIZE_PATH = 'authenticated/sessions/finalize';
@@ -127,6 +128,44 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
 
       // when
       const result = controller.shouldDisplayHasSeenEndTestScreenCheckbox;
+
+      // then
+      assert.true(result);
+    });
+  });
+
+  module('#computed shouldDisplayStepTwo', function () {
+    test('it should return false if the feature toggle isCertificationFreeFieldsDeletionEnabled is enabled', function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isCertificationFreeFieldsDeletionEnabled: true,
+        };
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+
+      // when
+      const result = controller.shouldDisplayFormStep;
+
+      // then
+      assert.false(result);
+    });
+
+    test('it should return true if the feature toggle isCertificationFreeFieldsDeletionEnabled is not enabled', function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = {
+          isCertificationFreeFieldsDeletionEnabled: false,
+        };
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+
+      // when
+      const result = controller.shouldDisplayFormStep;
 
       // then
       assert.true(result);


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, certains utilisateurs transmettent le PV d’incident depuis l'étape 2 de la page de finalisation de session, et précisent en commentaire global “Voir PV d’incident partagé”. Ils ne reportent donc pas les signalements la page de finalisation, ce qui force le pôle certif à traiter manuellement une session qui aurait potentiellement pu être traitée automatiquement. Aussi, le pôle certif ne fait rien des PV d’incident, feuille d'émargement et autre documents partagés depuis cette étape, en dehors d’une suspicion de fraude.

## :robot: Solution
- Ne pas afficher l'étape 2 lorsque le feature toggle `FT_CERTIFICATION_FREE_FIELDS_DELETION`

## :100: Pour tester
- Avec le FT `FT_CERTIFICATION_FREE_FIELDS_DELETION` à `true`
- Se connecter à Pix Certif avec le compte `certifsco@example.net`
- Aller sur la page de finalisation de la session 3.
- Vérifier que le l'encart "Étape 2 : Transmettre des documents (facultatif)" n'apparaît pas.
- Passer le FT `FT_CERTIFICATION_FREE_FIELDS_DELETION` à `false`
- Recharger la page et vérifier que l'encart apparaît
