### PR TITLE
[FEATURE] Mettre à jour le design de la pop-up de confirmation de finalisation de session (PIX-5042)

### DIFF
--- a/certif/app/components/session-finalization/finalization-confirmation-modal.hbs
+++ b/certif/app/components/session-finalization/finalization-confirmation-modal.hbs
@@ -1,0 +1,31 @@
+<PixModal
+  @title="Finalisation de la session"
+  @onCloseButtonClick={{@closeModal}}
+  class="finalization-confirmation-modal"
+>
+  <:content>
+    {{#if (and @hasUncheckedHasSeenEndTestScreen @shouldDisplayHasSeenEndTestScreenCheckbox)}}
+      <p class="app-modal-body__contextual finalization-confirmation-modal__unchecked-has-seen-end-test-screen">La case
+        "Écran de fin du test vu" n'est pas cochée pour
+        {{@uncheckedHasSeenEndTestScreenCount}}
+        candidat(s)</p>
+    {{/if}}
+    <p><span class="finalization-confirmation-modal__warning">Attention :</span>
+      il ne vous sera plus possible de modifier ces informations par la suite.</p>
+    <p>Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement
+      pouvant varier d'une session à l'autre).</p>
+  </:content>
+  <:footer>
+    <PixButton
+      @triggerAction={{@closeModal}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible="true"
+      @size="small"
+    >
+      Annuler
+    </PixButton>
+    <PixButton data-test-id="finalize-session-modal__confirm-button" @triggerAction={{@finalizeSession}} @size="small">
+      Confirmer la finalisation
+    </PixButton>
+  </:footer>
+</PixModal>

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -39,6 +39,7 @@
 @import "components/login-session-supervisor-form.scss";
 @import "components/finalize";
 @import "components/new-certification-candidate-modal";
+@import "components/finalization-confirmation-modal";
 @import "components/session-finalization-step-container";
 @import "components/session-finalization/reports-information-step";
 @import "components/session-finalization/formbuilder-link-step";

--- a/certif/app/styles/components/finalization-confirmation-modal.scss
+++ b/certif/app/styles/components/finalization-confirmation-modal.scss
@@ -1,0 +1,15 @@
+/* stylelint-disable no-descending-specificity */
+
+.finalization-confirmation-modal {
+  min-width: 578px;
+  max-width: 578px;
+  margin: 315px auto;
+
+  &__unchecked-has-seen-end-test-screen {
+    text-align: center;
+  }
+
+  &__warning {
+    font-weight: 500;
+  }
+}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -67,41 +67,11 @@
 </div>
 
 {{#if this.showConfirmModal}}
-  <AppModal @containerClass="pix-modal-dialog--wide" @onClose={{this.closeModal}}>
-
-    <div class="pix-modal__close-button">
-      <button type="button" data-test-id="finalize-session-modal__close-cross" {{on "click" this.closeModal}}>Fermer
-        <img src="/icons/icon-close-modal.svg" alt="Fermer la fenêtre de confirmation" width="24" height="24" />
-      </button>
-    </div>
-
-    <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
-      <div class="pix-modal-body pix-modal-body--with-padding">
-        <div class="app-modal-body__attention">Vous êtes sur le point de finaliser cette session.</div>
-        <div class="app-modal-body__warning">
-          {{#if (and this.hasUncheckedHasSeenEndTestScreen this.shouldDisplayHasSeenEndTestScreenCheckbox)}}
-            <p class="app-modal-body__contextual">La case "Écran de fin du test vu" n'est pas cochée pour
-              {{this.uncheckedHasSeenEndTestScreenCount}}
-              candidat(s)</p>
-          {{/if}}
-          <p>Attention : il ne vous sera plus possible de modifier ces informations par la suite.</p>
-          <p>Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de
-            traitement pouvant varier d'une session à l'autre).</p>
-        </div>
-      </div>
-
-      <div class="pix-modal-footer">
-        <PixButton
-          data-test-id="finalize-session-modal__cancel-button"
-          @triggerAction={{this.closeModal}}
-          @backgroundColor="transparent-light"
-        >
-          Annuler
-        </PixButton>
-        <PixButton data-test-id="finalize-session-modal__confirm-button" @triggerAction={{this.finalizeSession}}>
-          Confirmer
-        </PixButton>
-      </div>
-    </div>
-  </AppModal>
+  <SessionFinalization::FinalizationConfirmationModal
+    @closeModal={{this.closeModal}}
+    @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+    @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+    @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+    @finalizeSession={{this.finalizeSession}}
+  />
 {{/if}}

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -7,7 +7,7 @@ import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-const CONFIRMATION_TEXT = 'Vous êtes sur le point de finaliser cette session.';
+const MODAL_TITLE = 'Finalisation de la session';
 
 module('Acceptance | Session Finalization', function (hooks) {
   setupApplicationTest(hooks);
@@ -204,7 +204,7 @@ module('Acceptance | Session Finalization', function (hooks) {
             await clickByLabel('Finaliser');
 
             // then
-            assert.contains(CONFIRMATION_TEXT);
+            assert.contains(MODAL_TITLE);
             assert.notContains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
           });
         });
@@ -225,7 +225,7 @@ module('Acceptance | Session Finalization', function (hooks) {
             await clickByLabel('Finaliser');
 
             // then
-            assert.contains(CONFIRMATION_TEXT);
+            assert.contains(MODAL_TITLE);
             assert.contains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
           });
         });
@@ -262,7 +262,7 @@ module('Acceptance | Session Finalization', function (hooks) {
               await clickByLabel('Finaliser');
 
               // then
-              assert.contains(CONFIRMATION_TEXT);
+              assert.contains(MODAL_TITLE);
               assert.notContains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
             });
           });
@@ -281,7 +281,7 @@ module('Acceptance | Session Finalization', function (hooks) {
               await clickByLabel('Finaliser');
 
               // then
-              assert.contains(CONFIRMATION_TEXT);
+              assert.contains(MODAL_TITLE);
               assert.contains('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
             });
           });
@@ -327,7 +327,7 @@ module('Acceptance | Session Finalization', function (hooks) {
             await clickByLabel('Finaliser');
 
             // then
-            assert.notContains(CONFIRMATION_TEXT);
+            assert.notContains(MODAL_TITLE);
           });
         });
 
@@ -346,7 +346,7 @@ module('Acceptance | Session Finalization', function (hooks) {
             await clickByLabel('Finaliser');
 
             // then
-            assert.contains(CONFIRMATION_TEXT);
+            assert.contains(MODAL_TITLE);
           });
         });
       });

--- a/certif/tests/integration/components/session-finalization/finalization-confirmation-modal_test.js
+++ b/certif/tests/integration/components/session-finalization/finalization-confirmation-modal_test.js
@@ -1,0 +1,150 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | finalization-confirmation-modal', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shows the finalization confirmation modal', async function (assert) {
+    // given
+    this.set('closeModal', sinon.stub());
+    this.set('hasUncheckedHasSeenEndTestScreen', false);
+    this.set('uncheckedHasSeenEndTestScreenCount', 0);
+    this.set('shouldDisplayHasSeenEndTestScreenCheckbox', false);
+    this.set('finalizeSession', sinon.stub());
+
+    // when
+    const screen = await renderScreen(hbs`
+    <SessionFinalization::FinalizationConfirmationModal
+      @closeModal={{this.closeModal}}
+      @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+      @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+      @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+      @finalizeSession={{this.finalizeSession}}
+    />
+    `);
+
+    // then
+    assert.dom(screen.getByText('Finalisation de la session')).exists();
+    assert
+      .dom(
+        screen.getByText(
+          "Un délai de traitement est nécessaire avant la mise à disposition des résultats par Pix (ce délai de traitement pouvant varier d'une session à l'autre)."
+        )
+      )
+      .exists();
+  });
+
+  module('when hasUncheckedHasSeenEndTestScreen and shouldDisplayHasSeenEndTestScreenCheckbox are true', function () {
+    test('it shows unchecked end test screen count', async function (assert) {
+      // given
+      this.set('closeModal', sinon.stub());
+      this.set('hasUncheckedHasSeenEndTestScreen', true);
+      this.set('uncheckedHasSeenEndTestScreenCount', 2);
+      this.set('shouldDisplayHasSeenEndTestScreenCheckbox', true);
+      this.set('finalizeSession', sinon.stub());
+
+      // when
+      const screen = await renderScreen(hbs`
+      <SessionFinalization::FinalizationConfirmationModal
+        @closeModal={{this.closeModal}}
+        @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+        @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+        @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+        @finalizeSession={{this.finalizeSession}}
+      />
+      `);
+
+      // then
+      assert.dom(screen.getByText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidat(s)')).exists();
+    });
+  });
+
+  module('when close button cross icon is clicked', () => {
+    test('it closes candidate details modal', async function (assert) {
+      // given
+      const closeModalStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('hasUncheckedHasSeenEndTestScreen', false);
+      this.set('uncheckedHasSeenEndTestScreenCount', 0);
+      this.set('shouldDisplayHasSeenEndTestScreenCheckbox', false);
+      this.set('finalizeSession', sinon.stub());
+
+      // when
+      await renderScreen(hbs`
+      <SessionFinalization::FinalizationConfirmationModal
+        @closeModal={{this.closeModal}}
+        @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+        @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+        @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+        @finalizeSession={{this.finalizeSession}}
+      />
+      `);
+
+      await clickByName('Fermer');
+
+      // then
+      sinon.assert.calledOnce(closeModalStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when cancel bottom button is clicked', () => {
+    test('it closes candidate details modal ', async function (assert) {
+      // given
+      const closeModalStub = sinon.stub();
+      this.set('closeModal', closeModalStub);
+      this.set('hasUncheckedHasSeenEndTestScreen', false);
+      this.set('uncheckedHasSeenEndTestScreenCount', 0);
+      this.set('shouldDisplayHasSeenEndTestScreenCheckbox', false);
+      this.set('finalizeSession', sinon.stub());
+
+      // when
+      await renderScreen(hbs`
+      <SessionFinalization::FinalizationConfirmationModal
+        @closeModal={{this.closeModal}}
+        @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+        @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+        @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+        @finalizeSession={{this.finalizeSession}}
+      />
+      `);
+
+      await clickByName('Annuler');
+
+      // then
+      sinon.assert.calledOnce(closeModalStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when the finalization is confirmed', () => {
+    test('it should finalize de session', async function (assert) {
+      // given
+      const finalizeSessionStub = sinon.stub();
+      this.set('closeModal', sinon.stub());
+      this.set('hasUncheckedHasSeenEndTestScreen', false);
+      this.set('uncheckedHasSeenEndTestScreenCount', 0);
+      this.set('shouldDisplayHasSeenEndTestScreenCheckbox', false);
+      this.set('finalizeSession', finalizeSessionStub);
+
+      // when
+      await renderScreen(hbs`
+    <SessionFinalization::FinalizationConfirmationModal
+      @closeModal={{this.closeModal}}
+      @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+      @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+      @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+      @finalizeSession={{this.finalizeSession}}
+    />
+    `);
+
+      await clickByName('Confirmer la finalisation');
+
+      sinon.assert.calledOnce(finalizeSessionStub);
+      assert.ok(true);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui : le design de la pop-up de confirmation de finalisation de session n’est pas iso avec les autres pop-up 

![image](https://user-images.githubusercontent.com/37305474/172820459-bdec69b6-1f3f-4da6-96e0-9872331e4720.png)


## :robot: Solution
modifier le design de cette pop-up pour la rendre iso avec les autres

![image](https://user-images.githubusercontent.com/37305474/172820495-f23572ce-ceeb-458f-b622-9c8a6412fb6f.png)


## :100: Pour tester
- Finaliser une session et constater le design suivant

![image](https://user-images.githubusercontent.com/37305474/172857661-d9e7b518-9dbf-4357-825f-f49cd35d787a.png)
