### PR TITLE
[FEATURE] Harmoniser le fonctionnement des champs de recherche dans Pix Orga (PIX-5057).

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -610,6 +610,82 @@ describe('Integration | Repository | Campaign-Report', function () {
         });
       });
 
+      context('when some campaigns owner fullname match the given ownerName searched', function () {
+        it('should return the matching campaigns', async function () {
+          // given
+          const owner1 = databaseBuilder.factory.buildUser({ firstName: 'Robert', lastName: 'Howard' });
+          const owner2 = databaseBuilder.factory.buildUser({ firstName: 'Bernard', lastName: 'Dupuy' });
+          const filter = { ownerName: 'Robert H' };
+          _.each(
+            [
+              { name: 'Maths L1', ownerId: owner1.id },
+              { name: 'Maths L2', ownerId: owner2.id },
+              { name: 'Chimie', ownerId: owner1.id },
+            ],
+            (campaign) => {
+              databaseBuilder.factory.buildCampaign({ ...campaign, organizationId });
+            }
+          );
+
+          await databaseBuilder.commit();
+
+          // when
+          const { models: actualCampaignsWithReports } =
+            await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(_.map(actualCampaignsWithReports, 'name')).to.have.members(['Maths L1', 'Chimie']);
+        });
+
+        it('should handle space before search', async function () {
+          // given
+          const owner1 = databaseBuilder.factory.buildUser({ firstName: 'Robert', lastName: 'Howard' });
+          const filter = { ownerName: ' ro' };
+          _.each(
+            [
+              { name: 'Maths L1', ownerId: owner1.id },
+              { name: 'Chimie', ownerId: owner1.id },
+            ],
+            (campaign) => {
+              databaseBuilder.factory.buildCampaign({ ...campaign, organizationId });
+            }
+          );
+
+          await databaseBuilder.commit();
+
+          // when
+          const { models: actualCampaignsWithReports } =
+            await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(_.map(actualCampaignsWithReports, 'name')).to.have.members(['Maths L1', 'Chimie']);
+        });
+
+        it('should handle space after search', async function () {
+          // given
+          const owner1 = databaseBuilder.factory.buildUser({ firstName: 'Robert', lastName: 'Howard' });
+          const filter = { ownerName: 'ro ' };
+          _.each(
+            [
+              { name: 'Maths L1', ownerId: owner1.id },
+              { name: 'Chimie', ownerId: owner1.id },
+            ],
+            (campaign) => {
+              databaseBuilder.factory.buildCampaign({ ...campaign, organizationId });
+            }
+          );
+
+          await databaseBuilder.commit();
+
+          // when
+          const { models: actualCampaignsWithReports } =
+            await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(_.map(actualCampaignsWithReports, 'name')).to.have.members(['Maths L1', 'Chimie']);
+        });
+      });
+
       context('when some campaigns owner firstName match the given ownerName searched', function () {
         it('should return the matching campaigns', async function () {
           // given


### PR DESCRIPTION
## :unicorn: Problème
Suite à la PR https://github.com/1024pix/pix/pull/4467 qui ajoute une recherche sur l'onglet activité d'une campagne, on souhaite harmoniser la manière dont fonctionne ces deux champs. Notamment le champ de recherche sur le nom d'un propriétaire souffre de la limitation suivante : 

Pour un propriétaire qui a comme prénom Mance et comme nom Rayder les recherches suivantes retourne des campagnes : 
- "mance"
- "man"
- "rayder"
- "ray"

Cependant les recherches suivantes ne retournent pas de campagnes : 
- "Mance Rayder"
- "mance r"
- "m rayder"
- "man ray"

## :robot: Solution
Pour corriger de problème nous avons introduit l'utilisation de pg_trgm qui permet de calculer la distance entre deux chaînes de caractères.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixOrga avec "sco.admin@example.net"
- Aller sur la page http://localhost:4201/campagnes/toutes
- Essayer les différentes recherches lister ci-dessus
