### PR TITLE
[TECH] Corriger la version de l'API.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "3.215.0",
+      "version": "3.218.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {


### PR DESCRIPTION
## :unicorn: Problème
Suite à un problème non éclairici (mais à priori pendant une release manuelle suite à une erreur de release automatique dans pix-bot), le numéro de version de l'api dans son propre `package-lock.json` (3.215) n'est pas en phase avec celui du `package.json` (3.218) de l'api, ni du repo (3.218).

## :robot: Solution
Utiliser dans le `package-lock.json` la version du repo (3.218)

## :100: Pour tester
Exécuter un `npm install` en local et vérifier avec `git status` que le `package-lock.json` n'est pas modifié
