### PR TITLE
[ADMIN] Supprimer les références à Bootstrap dans la page Informations des certifications (PIX-5070)

### DIFF
--- a/admin/app/components/certifications/competence-list.hbs
+++ b/admin/app/components/certifications/competence-list.hbs
@@ -1,48 +1,32 @@
 {{#if @edition}}
   {{#each this.competenceList as |competenceItem key|}}
-    <div
-      class="row form-group certification-info-field"
-      aria-label="Informations de la compétence {{competenceItem}} éditable"
-    >
-      <label class="col-sm-1 col-form-label" for={{concat "certification-info-score_" key}}>{{competenceItem}}</label>
-      <div class="col-sm-2 certificate">
-        <Input
-          @type="text"
-          id={{concat "certification-info-score_" key}}
-          @value={{get this.indexedValues.scores key}}
-          class="form-control"
-          {{on "change" (fn this.onScoreChange key)}}
-        />
-      </div>
-      <label class="col-sm-1 certificate col-form-label">Pix</label>
-      <label class="col-sm-2 certificate text-right col-form-label" for={{concat "certification-info-level_" key}}>
-        Niveau :
-      </label>
-      <div class="col-sm-2 certificate">
-        <Input
-          @type="text"
-          id={{concat "certification-info-level_" key}}
-          @value={{get this.indexedValues.levels key}}
-          class="form-control"
-          {{on "change" (fn this.onLevelChange key)}}
-        />
-      </div>
+    <div class="competence-list-edited" aria-label="Informations de la compétence {{competenceItem}} éditable">
+      <Certifications::InfoField
+        @fieldId={{concat "certification-info-score_" key}}
+        @value={{get this.indexedValues.scores key}}
+        @edition={{@edition}}
+        @label={{competenceItem}}
+        @suffix="Pix"
+        {{on "change" (fn this.onScoreChange key)}}
+      />
+
+      <Certifications::InfoField
+        @fieldId={{concat "certification-info-level_" key}}
+        @value={{get this.indexedValues.levels key}}
+        @edition={{@edition}}
+        @label="Niveau:"
+        {{on "change" (fn this.onLevelChange key)}}
+      />
     </div>
   {{/each}}
 {{else}}
-  {{#each @competences as |competence|}}
-    <div class="row certification-info-field" aria-label="Informations de la compétence {{competence.index}}">
-      <div class="col-sm-3 certification-info-competence-index">
-        {{competence.index}}
-      </div>
-      <div class="col-sm-2 certification-info-competence-score">
-        {{competence.score}}
-        Pix
-      </div>
-      <div class="col-sm-7 certification-info-competence-level">
-        Niveau :
-        {{competence.level}}
-      </div>
-    </div>
-  {{/each}}
+  <ul class="competence-list-details">
+    {{#each @competences as |competence|}}
+      <li class="competence-list-details__item" aria-label="Informations de la compétence {{competence.index}}">
+        <span aria-hidden="true">{{competence.index}}</span>
+        <span>{{competence.score}} Pix</span>
+        <span>Niveau: {{competence.level}}</span>
+      </li>
+    {{/each}}
+  </ul>
 {{/if}}

--- a/admin/app/components/certifications/info-field.hbs
+++ b/admin/app/components/certifications/info-field.hbs
@@ -1,24 +1,17 @@
-{{#if @edition}}
-  <div class="row form-group certification-info-field edited">
-    <label
-      for={{@fieldId}}
-      class="col-form-label certification-info-field__label--editing
-        {{if @isTextarea "certification-info-field__label--large"}}
-        {{if @suffix "certification-info-field__label--small"}}"
-    >
+<div class="certification-info-field">
+  {{#if @edition}}
+    <label for={{@fieldId}} class="certification-info-field__label">
       {{@label}}
     </label>
     {{#if @isTextarea}}
-      <Textarea id={{@fieldId}} @value={{@value}} class="form-control" />
+      <Textarea id={{@fieldId}} @value={{@value}} class="form-control" ...attributes />
     {{else}}
-      <Input id={{@fieldId}} @type="text" @value={{@value}} class="form-control" />
+      <Input id={{@fieldId}} @type="text" @value={{@value}} class="form-control" ...attributes />
     {{/if}}
     {{#if @suffix}}
       <span class="certification-info-field__suffix">{{@suffix}}</span>
     {{/if}}
-  </div>
-{{else}}
-  <div class="row certification-info-field">
+  {{else}}
     <p>
       {{@label}}
       {{#if @linkRoute}}
@@ -31,5 +24,5 @@
         </span>
       {{/if}}
     </p>
-  </div>
-{{/if}}
+  {{/if}}
+</div>

--- a/admin/app/components/certifications/issue-reports.hbs
+++ b/admin/app/components/certifications/issue-reports.hbs
@@ -1,8 +1,8 @@
 {{#if @hasImpactfulIssueReports}}
-  <h2 class="certification-issue-reports__subtitle certification-issue-reports__subtitle--with-action-required">
+  <h3 class="certification-issue-reports__subtitle certification-issue-reports__subtitle--with-action-required">
     {{@impactfulCertificationIssueReports.length}}
     Signalement(s) impactant(s)
-  </h2>
+  </h3>
   <ul class="certification-issue-reports__list">
     {{#each @impactfulCertificationIssueReports as |issueReport|}}
       <Certifications::IssueReport @issueReport={{issueReport}} @resolveIssueReport={{@resolveIssueReport}} />
@@ -10,10 +10,10 @@
   </ul>
 {{/if}}
 {{#if @hasUnimpactfulIssueReports}}
-  <h2 class="certification-issue-reports__subtitle certification-issue-reports__subtitle--without-action-required">
+  <h3 class="certification-issue-reports__subtitle certification-issue-reports__subtitle--without-action-required">
     {{@unimpactfulCertificationIssueReports.length}}
     Signalement(s) non impactant(s)
-  </h2>
+  </h3>
   <ul class="certification-issue-reports__list certification-issue-reports__list--last">
     {{#each @unimpactfulCertificationIssueReports as |issueReport|}}
       <Certifications::IssueReport @issueReport={{issueReport}} />

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -39,6 +39,7 @@
 @import 'components/card';
 @import 'components/common/tick-or-cross';
 @import 'components/certification/candidate-edit-modal';
+@import 'components/certification/competence-list';
 @import 'components/certification/certification-status-select';
 @import 'components/certification-centers/information';
 @import 'components/certification-center-form';
@@ -47,7 +48,7 @@
 @import 'components/certification-info-field';
 @import 'components/certification-issue-report';
 @import 'components/certification-issue-reports';
-@import 'components/certified-profile.scss';
+@import 'components/certified-profile';
 @import 'components/confirm-popup';
 @import 'components/member-item';
 @import 'components/menu-bar';
@@ -61,7 +62,7 @@
 @import 'components/participation-row';
 @import 'components/publish-session-button';
 @import 'components/sessions/jury-comment';
-@import 'components/sessions/list-items.scss';
+@import 'components/sessions/list-items';
 @import 'components/users/user-detail-personal-information-section';
 @import 'components/users/user-detail-personal-information/authentication-method';
 @import 'components/users/user-detail-personal-information/user-profile';

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -1,10 +1,24 @@
 .certification-informations {
-  padding: 20px;
 
-  .buttons-row {
+  &__actions {
+    display: flex;
+    justify-content: center;
+  }
+
+  &__row {
+    align-items: flex-start;
     display: flex;
     justify-content: space-between;
+    gap: 20px;
     margin-bottom: 20px;
+
+    &--center {
+      justify-content: center;
+    }
+
+    &:last-child {
+      margin: 0;
+    }
 
     a:hover {
       color: $pix-neutral-0;
@@ -12,12 +26,111 @@
     }
   }
 
-  .card {
-    margin-bottom: 20px;
+  &__card {
+    box-shadow: 0 4px 8px rgba($grey-200, 0.08);
+    border: 1px solid $grey-20;
+    border-radius: 8px;
+    background: $white;
+    padding: 1rem;
+    flex-grow: 1;
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &--pix-edu {
+      background-color: $pix-neutral-5;
+      text-align: center;
+      box-shadow: none;
+      border: 2px solid $pix-neutral-20;
+      font-weight: 500;
+      color: $pix-neutral-40;
+    }
+
+    &__title {
+      margin-bottom: 0.75rem;
+      font-size: 1.25rem;
+    }
+
+    &__list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    &__list-item {
+      margin-bottom: 0.25rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    &__list-label {
+      color: $pix-neutral-40;
+      min-width: 180px;
+      display: inline-block;
+    }
+
+    &__score {
+      font-size: 1.125rem;
+      color: $grey-90;
+    }
   }
 
   &__published--float {
     float: right;
+  }
+
+  &__pix-edu {
+
+    &__title {
+      margin-bottom: 16px;
+      font-size: 1.125rem;
+    }
+
+    &__row {
+      margin-top: 16px;
+      display: flex;
+      gap: 16px;
+
+      &__jury-level {
+        display: flex;
+        justify-content: center;
+        align-items: start;
+
+        p {
+          margin-top: 0;
+        }
+
+        .jury-level-edit-icon-button {
+          margin-left: 10px;
+          background: none;
+          border: none;
+          cursor: pointer;
+          font-size: 19px;
+          color: $pix-neutral-60;
+        }
+      }
+
+      &__jury-level-editor {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        max-width: 100%;
+        padding: 0 8px 0 8px;
+
+        section:nth-of-type(2) {
+          margin: 8px 0 8px 0;
+          display: flex;
+          gap: 1rem;
+
+          button:last-child {
+            flex: 2;
+          }
+        }
+      }
+    }
   }
 
   &__complementary-certification {
@@ -25,98 +138,10 @@
     &__title {
       margin-bottom: 24px;
     }
-
-    &__non-pix-edu {
-      margin: 8px 0 8px 0;
-      font-size: 0.875rem;
-
-      span {
-        display: inline-block;
-        color: $pix-neutral-40;
-        min-width: 180px;
-      }
-
-      p {
-        margin: 0;
-      }
-    }
-
-    &__pix-edu {
-      margin-top: 24px;
-
-      &__row {
-        margin-top: 16px;
-        display: flex;
-        gap: 16px;
-
-        &__jury-level {
-          display: flex;
-          justify-content: center;
-          align-items: start;
-
-          p {
-            margin-top: 0;
-          }
-
-          .jury-level-edit-icon-button {
-            margin-left: 10px;
-            background: none;
-            border: none;
-            cursor: pointer;
-            font-size: 19px;
-            color: $pix-neutral-60;
-          }
-        }
-
-        &__jury-level-editor {
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
-          max-width: 100%;
-          padding: 0 8px 0 8px;
-
-          section:nth-of-type(2) {
-            margin: 8px 0 8px 0;
-            display: flex;
-            gap: 1rem;
-
-            button:last-child {
-              flex: 2;
-            }
-          }
-        }
-
-        .card {
-          width: 550px;
-          background-color: $pix-neutral-5;
-          text-align: center;
-          box-shadow: none;
-          border: 2px solid $pix-neutral-20;
-          font-weight: 500;
-
-          p {
-            color: $pix-neutral-40;
-          }
-
-          .card-body-text {
-            font-size: 18px;
-            color: $pix-neutral-90;
-          }
-        }
-      }
-    }
   }
 
   &__certification-issue-reports {
-    padding: 0;
-  }
-
-  .certification-informations {
-
-    &__actions {
-      display: flex;
-      justify-content: center;
-    }
+    flex-direction: column;
   }
 
   .candidate-informations {

--- a/admin/app/styles/components/certification-info-field.scss
+++ b/admin/app/styles/components/certification-info-field.scss
@@ -1,20 +1,12 @@
 .certification-info-field {
-  padding: 0 15px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
 
   &__label {
     margin-right: 5px;
-
-    &--editing {
-      width: 160px;
-    }
-
-    &--large {
-      min-width: 100%;
-    }
-
-    &--small {
-      max-width: 54px;
-    }
   }
 
   p {

--- a/admin/app/styles/components/certification-issue-reports.scss
+++ b/admin/app/styles/components/certification-issue-reports.scss
@@ -25,6 +25,7 @@
 
   &__list {
     padding-left: 0;
+    width: 100%;
 
     button:last-of-type {
       margin-left: auto;

--- a/admin/app/styles/components/certification/competence-list.scss
+++ b/admin/app/styles/components/certification/competence-list.scss
@@ -1,0 +1,15 @@
+.competence-list-details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  &__item {
+    display: flex;
+    gap: 20%;
+  }
+}
+
+.competence-list-edited {
+  display: flex;
+  gap: 150px;
+}

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable no-action }}
 <div class="certification-informations">
-  <div class="buttons-row">
+  <div class="certification-informations__row">
     <PixButton @route="authenticated.users.get" @size="small" @model={{this.certification.userId}}>
       Voir les détails de l'utilisateur
     </PixButton>
@@ -14,322 +14,284 @@
       </PixButton>
     {{/if}}
   </div>
-  <div class="row">
-    <div class="col">
-      <div class="card {{if this.editingCandidateResults "border-primary"}}">
-        <div class="card-body">
-          <h5 class="card-title">
-            <Certifications::InfoPublished @record={{this.certification}} @float={{true}} />État
-          </h5>
-          <div class="card-text">
-            <Certifications::InfoField
-              @value={{this.certification.sessionId}}
-              @edition={{false}}
-              @label="Session :"
-              @linkRoute="authenticated.sessions.session"
-            />
-            <Certifications::StatusSelect
-              @certification={{this.certification}}
-              @edition={{this.editingCandidateResults}}
-            />
-            <Certifications::InfoField
-              @value={{this.certification.creationDate}}
-              @edition={{false}}
-              @label="Créée le :"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.completionDate}}
-              @edition={{false}}
-              @label="Terminée le :"
-            />
-            <Certifications::InfoField
-              @value={{this.certification.publishedText}}
-              @edition={{false}}
-              @label="Publiée :"
-            />
-          </div>
-        </div>
-      </div>
+
+  <div class="certification-informations__row">
+    <div class="certification-informations__card {{if this.editingCandidateResults "border-primary"}}">
+      <h2 class="certification-informations__card__title">
+        <Certifications::InfoPublished @record={{this.certification}} @float={{true}} />État
+      </h2>
+      <Certifications::InfoField
+        @value={{this.certification.sessionId}}
+        @edition={{false}}
+        @label="Session :"
+        @linkRoute="authenticated.sessions.session"
+      />
+      <Certifications::StatusSelect @certification={{this.certification}} @edition={{this.editingCandidateResults}} />
+      <Certifications::InfoField @value={{this.certification.creationDate}} @edition={{false}} @label="Créée le :" />
+      <Certifications::InfoField
+        @value={{this.certification.completionDate}}
+        @edition={{false}}
+        @label="Terminée le :"
+      />
+      <Certifications::InfoField @value={{this.certification.publishedText}} @edition={{false}} @label="Publiée :" />
     </div>
-    <div class="col">
-      <div class="card {{if this.editingCandidateInformations "border-primary"}}">
-        <div class="card-body candidate-informations">
-          <h5 class="card-title">Candidat</h5>
-          <div class="card-text">
-            <div>
-              Prénom :
-              {{this.certification.firstName}}
-            </div>
-            <div>
-              Nom de famille :
-              {{this.certification.lastName}}
-            </div>
-            <div>
-              Date de naissance :
-              {{dayjs-format this.certification.birthdate "DD/MM/YYYY" allow-empty=true}}
-            </div>
-            <div>
-              Sexe :
-              {{this.certification.sex}}
-            </div>
-            <div>
-              Commune de naissance :
-              {{this.certification.birthplace}}
-            </div>
-            <div>
-              Code postal de naissance :
-              {{this.certification.birthPostalCode}}
-            </div>
-            <div>
-              Code INSEE de naissance :
-              {{this.certification.birthInseeCode}}
-            </div>
-            <div>
-              Pays de naissance :
-              {{this.certification.birthCountry}}
-            </div>
-            <div class="candidate-informations__actions">
-              <PixButton
-                @size="small"
-                @triggerAction={{this.openCandidateEditModal}}
-                aria-label="Modifier les informations du candidat"
-                @isDisabled={{this.isModifyButtonDisabled}}
-              >
-                Modifier
-              </PixButton>
-              {{#if this.certification.wasRegisteredBeforeCPF}}
-                <span class="candidate-informations__warning-cpf-message">Voir avec PO/Dev pour modifier les infos
-                  candidat.</span>
-              {{/if}}
-            </div>
-          </div>
-        </div>
+
+    <div class="certification-informations__card {{if this.editingCandidateInformations "border-primary"}}">
+      <h2 class="certification-informations__card__title">Candidat</h2>
+      <div>
+        Prénom :
+        {{this.certification.firstName}}
+      </div>
+      <div>
+        Nom de famille :
+        {{this.certification.lastName}}
+      </div>
+      <div>
+        Date de naissance :
+        {{dayjs-format this.certification.birthdate "DD/MM/YYYY" allow-empty=true}}
+      </div>
+      <div>
+        Sexe :
+        {{this.certification.sex}}
+      </div>
+      <div>
+        Commune de naissance :
+        {{this.certification.birthplace}}
+      </div>
+      <div>
+        Code postal de naissance :
+        {{this.certification.birthPostalCode}}
+      </div>
+      <div>
+        Code INSEE de naissance :
+        {{this.certification.birthInseeCode}}
+      </div>
+      <div>
+        Pays de naissance :
+        {{this.certification.birthCountry}}
+      </div>
+
+      <div class="candidate-informations__actions">
+        <PixButton
+          @size="small"
+          @triggerAction={{this.openCandidateEditModal}}
+          aria-label="Modifier les informations du candidat"
+          @isDisabled={{this.isModifyButtonDisabled}}
+        >
+          Modifier
+        </PixButton>
+        {{#if this.certification.wasRegisteredBeforeCPF}}
+          <span class="candidate-informations__warning-cpf-message">Voir avec PO/Dev pour modifier les infos candidat.</span>
+        {{/if}}
       </div>
     </div>
   </div>
 
   {{#if this.certification.hasComplementaryCertifications}}
-    <section class="card certification-informations__complementary-certification">
-      <div class="card-body">
-        <h5 class="card-title certification-informations__complementary-certification__title">Certifications
-          complémentaires</h5>
-        {{#each
-          this.certification.commonComplementaryCertificationCourseResults
-          as |commonComplementaryCertificationCourseResult|
-        }}
-          <div class="certification-informations__complementary-certification__non-pix-edu">
-            <p>
-              <span>
-                {{commonComplementaryCertificationCourseResult.label}}
-                :
-              </span>
-              {{commonComplementaryCertificationCourseResult.status}}
-            </p>
-          </div>
-        {{/each}}
+    <div class="certification-informations__row">
+      <div class="certification-informations__card">
+        <h2 class="certification-informations__card__title">Certifications complémentaires</h2>
+
+        {{#if this.certification.commonComplementaryCertificationCourseResults}}
+          <ul class="certification-informations__card__list">
+            {{#each
+              this.certification.commonComplementaryCertificationCourseResults
+              as |commonComplementaryCertificationCourseResult|
+            }}
+              <li class="certification-informations__card__list-item">
+                <span class="certification-informations__card__list-label">
+                  {{commonComplementaryCertificationCourseResult.label}}
+                  :
+                </span>
+                {{commonComplementaryCertificationCourseResult.status}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/if}}
+
         {{#if this.certification.complementaryCertificationCourseResultsWithExternal}}
-          <section class="certification-informations__complementary-certification__pix-edu">
-            <h6>Résultats de la certification complémentaire Pix+ Edu :</h6>
-            <div class="certification-informations__complementary-certification__pix-edu__row">
-              <div class="card">
-                <div class="card-body">
-                  <p>VOLET PIX</p>
-                  <p
-                    class="card-body-text"
-                  >{{this.certification.complementaryCertificationCourseResultsWithExternal.pixResult}}</p>
-                </div>
+          <section class="certification-informations__pix-edu">
+            <h2 class="certification-informations__pix-edu__title">Résultats de la certification complémentaire Pix+ Edu
+              :</h2>
+            <div class="certification-informations__row">
+              <div class="certification-informations__card certification-informations__card--pix-edu">
+                <p>VOLET PIX</p>
+                <p class="certification-informations__card__score">
+                  {{this.certification.complementaryCertificationCourseResultsWithExternal.pixResult}}
+                </p>
               </div>
-              <div class="card">
-                <div class="card-body">
-                  <p>VOLET JURY</p>
-                  {{#if this.displayJuryLevelSelect}}
-                    <div
-                      class="certification-informations__complementary-certification__pix-edu__row__jury-level-editor"
-                    >
-                      <section>
-                        <PixSelect
-                          aria-label="Sélectionner un niveau"
-                          @options={{this.juryLevelOptions}}
-                          @selectedOption={{this.selectedJuryLevel}}
-                          @emptyOptionNotSelectable={{true}}
-                          @onChange={{this.selectJuryLevel}}
-                          @emptyOptionLabel="Choisir un niveau"
-                          @size="small"
-                        />
-                      </section>
-                      <section>
-                        <PixButton
-                          @backgroundColor="transparent-light"
-                          @isBorderVisible="true"
-                          @size="small"
-                          @triggerAction={{this.onCancelJuryLevelEditButtonClick}}
-                        >
-                          Annuler
-                        </PixButton>
-                        <PixButton
-                          @size="small"
-                          @triggerAction={{this.onEditJuryLevelSave}}
-                          aria-label="Modifier le niveau du jury"
-                          @isDisabled={{this.isModifyButtonDisabled}}
-                        >
-                          Enregistrer
-                        </PixButton>
-                      </section>
-                    </div>
-                  {{else}}
-                    <div class="certification-informations__complementary-certification__pix-edu__row__jury-level">
-                      <p
-                        class="card-body-text"
-                      >{{this.certification.complementaryCertificationCourseResultsWithExternal.externalResult}}</p>
-                      {{#if this.shouldDisplayJuryLevelEditButton}}
-                        <button
-                          type="button"
-                          class="jury-level-edit-icon-button"
-                          aria-label="Modifier le volet jury"
-                          {{on "click" this.editJury}}
-                        >
-                          <FaIcon @icon="edit" />
-                        </button>
-                      {{/if}}
-                    </div>
-                  {{/if}}
-                </div>
+              <div class="certification-informations__card certification-informations__card--pix-edu">
+                <p>VOLET JURY</p>
+                {{#if this.displayJuryLevelSelect}}
+                  <div class="certification-informations__complementary-certification__pix-edu__row__jury-level-editor">
+                    <section>
+                      <PixSelect
+                        aria-label="Sélectionner un niveau"
+                        @options={{this.juryLevelOptions}}
+                        @selectedOption={{this.selectedJuryLevel}}
+                        @emptyOptionNotSelectable={{true}}
+                        @onChange={{this.selectJuryLevel}}
+                        @emptyOptionLabel="Choisir un niveau"
+                        @size="small"
+                      />
+                    </section>
+                    <section>
+                      <PixButton
+                        @backgroundColor="transparent-light"
+                        @isBorderVisible="true"
+                        @size="small"
+                        @triggerAction={{this.onCancelJuryLevelEditButtonClick}}
+                      >
+                        Annuler
+                      </PixButton>
+                      <PixButton
+                        @size="small"
+                        @triggerAction={{this.onEditJuryLevelSave}}
+                        aria-label="Modifier le niveau du jury"
+                        @isDisabled={{this.isModifyButtonDisabled}}
+                      >
+                        Enregistrer
+                      </PixButton>
+                    </section>
+                  </div>
+                {{else}}
+                  <div class="certification-informations__complementary-certification__pix-edu__row__jury-level">
+                    <p>{{this.certification.complementaryCertificationCourseResultsWithExternal.externalResult}}</p>
+                    {{#if this.shouldDisplayJuryLevelEditButton}}
+                      <button
+                        type="button"
+                        class="jury-level-edit-icon-button"
+                        aria-label="Modifier le volet jury"
+                        {{on "click" this.editJury}}
+                      >
+                        <FaIcon @icon="edit" />
+                      </button>
+                    {{/if}}
+                  </div>
+                {{/if}}
               </div>
-              <div class="card">
-                <div class="card-body">
-                  <p>NIVEAU FINAL</p>
-                  <p
-                    class="card-body-text"
-                  >{{this.certification.complementaryCertificationCourseResultsWithExternal.finalResult}}</p>
-                </div>
+              <div class="certification-informations__card certification-informations__card--pix-edu">
+                <p>NIVEAU FINAL</p>
+                <p
+                  class="certification-informations__card__score"
+                >{{this.certification.complementaryCertificationCourseResultsWithExternal.finalResult}}</p>
               </div>
             </div>
           </section>
         {{/if}}
       </div>
-    </section>
+    </div>
   {{/if}}
 
   {{#if this.hasIssueReports}}
-    <section class="card certification-informations__certification-issue-reports">
-      <div class="card-body">
-        <h1 class="card-title certification-informations__certification-issue-reports__title">Signalements</h1>
-        <Certifications::IssueReports
-          @hasImpactfulIssueReports={{this.hasImpactfulIssueReports}}
-          @hasUnimpactfulIssueReports={{this.hasUnimpactfulIssueReports}}
-          @impactfulCertificationIssueReports={{this.impactfulCertificationIssueReports}}
-          @unimpactfulCertificationIssueReports={{this.unimpactfulCertificationIssueReports}}
-          @resolveIssueReport={{this.resolveIssueReport}}
-        />
-      </div>
+    <section
+      class="certification-informations__row certification-informations__card certification-informations__certification-issue-reports"
+    >
+      <h2 class="card-title certification-informations__certification-issue-reports__title">Signalements</h2>
+      <Certifications::IssueReports
+        @hasImpactfulIssueReports={{this.hasImpactfulIssueReports}}
+        @hasUnimpactfulIssueReports={{this.hasUnimpactfulIssueReports}}
+        @impactfulCertificationIssueReports={{this.impactfulCertificationIssueReports}}
+        @unimpactfulCertificationIssueReports={{this.unimpactfulCertificationIssueReports}}
+        @resolveIssueReport={{this.resolveIssueReport}}
+      />
     </section>
   {{/if}}
 
-  <div class="row">
-    <div class="col">
-      <div class="card {{if this.editingCandidateResults "border-primary"}}">
-        <div class="card-body">
-          <h5 class="card-title">Commentaires jury</h5>
-          <div class="card-text">
-            <Certifications::InfoField
-              @value={{this.certification.commentForCandidate}}
-              @edition={{this.editingCandidateResults}}
-              @label="Pour le candidat :"
-              @fieldId="certification-commentForCandidate"
-              @isTextarea={{true}}
-            />
-            <Certifications::InfoField
-              @value={{this.certification.commentForOrganization}}
-              @edition={{this.editingCandidateResults}}
-              @label="Pour l'organisation :"
-              @fieldId="certification-commentForOrganization"
-              @isTextarea={{true}}
-            />
-            <Certifications::InfoField
-              @value={{this.certification.commentForJury}}
-              @edition={{this.editingCandidateResults}}
-              @label="Pour le jury :"
-              @fieldId="certification-commentForJury"
-              @isTextarea={{true}}
-            />
-            <Certifications::InfoField
-              @value={{this.certification.juryId}}
-              @edition={{false}}
-              @label="Identifiant jury :"
-              @isTextarea={{true}}
-            />
-          </div>
-        </div>
-      </div>
+  <div class="certification-informations__row">
+    <div class="certification-informations__card {{if this.editingCandidateResults "border-primary"}}">
+      <h2 class="certification-informations__card__title">Commentaires jury</h2>
+      <Certifications::InfoField
+        @value={{this.certification.commentForCandidate}}
+        @edition={{this.editingCandidateResults}}
+        @label="Pour le candidat :"
+        @fieldId="certification-commentForCandidate"
+        @isTextarea={{true}}
+      />
+      <Certifications::InfoField
+        @value={{this.certification.commentForOrganization}}
+        @edition={{this.editingCandidateResults}}
+        @label="Pour l'organisation :"
+        @fieldId="certification-commentForOrganization"
+        @isTextarea={{true}}
+      />
+      <Certifications::InfoField
+        @value={{this.certification.commentForJury}}
+        @edition={{this.editingCandidateResults}}
+        @label="Pour le jury :"
+        @fieldId="certification-commentForJury"
+        @isTextarea={{true}}
+      />
+      <Certifications::InfoField
+        @value={{this.certification.juryId}}
+        @edition={{false}}
+        @label="Identifiant jury :"
+        @isTextarea={{true}}
+      />
     </div>
+
   </div>
-  <div class="row">
-    <div class="col">
-      <div class="card {{if this.editingCandidateResults "border-primary"}}">
-        <div class="card-body">
-          <h5 class="card-title">Résultats</h5>
-          <div class="card-text">
-            <Certifications::InfoField
-              @value={{this.certification.pixScore}}
-              @edition={{this.editingCandidateResults}}
-              @label="Score :"
-              @fieldId="certification-pixScore"
-              @suffix=" Pix"
-            />
-            <p></p>
-            <Certifications::CompetenceList
-              @competences={{this.certification.competences}}
-              @edition={{this.editingCandidateResults}}
-              @onUpdateScore={{this.onUpdateScore}}
-              @onUpdateLevel={{this.onUpdateLevel}}
-            />
-          </div>
-        </div>
-      </div>
+  <div class="certification-informations__row">
+    <div class="certification-informations__card {{if this.editingCandidateResults "border-primary"}}">
+      <h2 class="certification-informations__card__title">Résultats</h2>
+      <Certifications::InfoField
+        @value={{this.certification.pixScore}}
+        @edition={{this.editingCandidateResults}}
+        @label="Score :"
+        @fieldId="certification-pixScore"
+        @suffix=" Pix"
+      />
+
+      <Certifications::CompetenceList
+        @competences={{this.certification.competences}}
+        @edition={{this.editingCandidateResults}}
+        @onUpdateScore={{this.onUpdateScore}}
+        @onUpdateLevel={{this.onUpdateLevel}}
+      />
     </div>
   </div>
   {{#if this.isValid}}
-    <div class="row">
-      <div class="col certification-informations__actions form-actions">
-        {{#if this.editingCandidateResults}}
-          <PixButton
-            @size="small"
-            @backgroundColor="transparent-light"
-            @isBorderVisible={{true}}
-            @triggerAction={{this.onCandidateResultsCancel}}
-            aria-label="Annuler la modification des résultats du candidat"
-          >
-            Annuler
-          </PixButton>
-          <PixButton
-            @size="small"
-            @triggerAction={{this.onCandidateResultsSaveConfirm}}
-            @backgroundColor="green"
-            aria-label="Enregistrer les résultats du candidat"
-          >
-            Enregistrer
-          </PixButton>
-        {{else}}
-          <PixButton
-            @size="small"
-            @triggerAction={{this.onCandidateResultsEdit}}
-            aria-label="Modifier les résultats du candidat"
-            @isDisabled={{this.editingCandidateInformations}}
-          >
-            Modifier
-          </PixButton>
-        {{/if}}
-      </div>
+    <div class="certification-informations__row certification-informations__row--center">
+      {{#if this.editingCandidateResults}}
+        <PixButton
+          @size="small"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.onCandidateResultsCancel}}
+          aria-label="Annuler la modification des résultats du candidat"
+        >
+          Annuler
+        </PixButton>
+        <PixButton
+          @size="small"
+          @triggerAction={{this.onCandidateResultsSaveConfirm}}
+          @backgroundColor="green"
+          aria-label="Enregistrer les résultats du candidat"
+        >
+          Enregistrer
+        </PixButton>
+      {{else}}
+        <PixButton
+          @size="small"
+          @triggerAction={{this.onCandidateResultsEdit}}
+          aria-label="Modifier les résultats du candidat"
+          @isDisabled={{this.editingCandidateInformations}}
+        >
+          Modifier
+        </PixButton>
+      {{/if}}
     </div>
   {{/if}}
-  <ConfirmPopup
-    @message={{this.confirmMessage}}
-    @error={{this.confirmErrorMessage}}
-    @confirm={{action this.confirmAction}}
-    @cancel={{action this.onCandidateResultsCancelConfirm}}
-    @show={{this.displayConfirm}}
-  />
 </div>
+
+<ConfirmPopup
+  @message={{this.confirmMessage}}
+  @error={{this.confirmErrorMessage}}
+  @confirm={{action this.confirmAction}}
+  @cancel={{action this.onCandidateResultsCancelConfirm}}
+  @show={{this.displayConfirm}}
+/>
+
 <Certifications::CandidateEditModal
   @isDisplayed={{this.isCandidateEditModalOpen}}
   @onCancelButtonsClicked={{this.closeCandidateEditModal}}

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, currentURL } from '@ember/test-helpers';
-import { fillByLabel, clickByName, visit, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, visit, selectByLabelAndOption, within } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
 
@@ -333,14 +333,11 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           await selectByLabelAndOption('Sélectionner un niveau', 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME');
           await click(screen.getByRole('button', { name: 'Modifier le niveau du jury' }));
 
+          const finalResult = within(screen.getByText('NIVEAU FINAL').parentElement);
           // then
-          assert
-            .dom('.certification-informations__complementary-certification__pix-edu__row__jury-level > p')
-            .containsText('Pix+ Édu Initiale 1er degré Confirmé');
+          assert.dom(screen.getByText('Pix+ Édu Initiale 1er degré Confirmé')).exists();
 
-          assert
-            .dom('.certification-informations__complementary-certification__pix-edu__row > div:nth-child(3)')
-            .containsText('Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)');
+          assert.dom(finalResult.getByText('Pix+ Édu Initiale 1er degré Initié (entrée dans le métier)')).exists();
         });
       });
 

--- a/admin/tests/integration/components/certifications/info-competences_test.js
+++ b/admin/tests/integration/components/certifications/info-competences_test.js
@@ -32,7 +32,7 @@ module('Integration | Component | certifications/competence-list', function (hoo
 
     // then
     assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).containsText('30 Pix');
-    assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).containsText('Niveau : 3');
+    assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).containsText('Niveau: 3');
   });
 
   test('it should display 16 entries in edition mode', async function (assert) {
@@ -70,7 +70,7 @@ module('Integration | Component | certifications/competence-list', function (hoo
     assert.dom(screen.getByRole('textbox', { name: '2.1' })).hasValue('16');
     assert.dom(screen.getByRole('textbox', { name: '2.2' })).hasValue('42');
 
-    const certificationInfoLevelInputs = screen.getAllByRole('textbox', { name: 'Niveau :' });
+    const certificationInfoLevelInputs = screen.getAllByRole('textbox', { name: 'Niveau:' });
     assert.dom(certificationInfoLevelInputs[0]).hasValue('3');
     assert.dom(certificationInfoLevelInputs[3]).hasValue('2');
     assert.dom(certificationInfoLevelInputs[4]).hasValue('5');


### PR DESCRIPTION
## :unicorn: Problème
l'utilisation de bootstrap dans Pix Admin génère trop de CSS custom afin de correspondre à notre design.

## :robot: Solution

Supprimer les class bootstrap utiliser dans Pix Admin afin de pouvoir supprimer cette dépendance.

## :rainbow: Remarques

## :100: Pour tester
Allez sur PIx Admin, vérifier que l'affichage de la page d'informations des certifications ne sont pas cassé