### PR TITLE
[FEATURE] Mettre à jour le wording du texte explicatif lorsque le signalement C1 est sélectionné (PIX-4946).

### DIFF
--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -94,7 +94,7 @@ export const subcategoryToCode = {
 export const subcategoryToTextareaLabel = {
   [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Précisez et indiquez l’heure de sortie',
   [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Précisez',
-  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Précisez les informations à modifier',
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Renseignez les informations correctes',
   [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Précisez le temps majoré',
 };
 

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
@@ -53,7 +53,7 @@ module('Integration | Component | candidate-information-change-certification-iss
     assert.dom(TEXTAREA_SELECTOR).exists();
   });
 
-  test('it should show "Précisez les informations à modifier" if subcategory NAME_OR_BIRTHDATE is selected', async function (assert) {
+  test('it should show "Renseignez les informations correctes" if subcategory NAME_OR_BIRTHDATE is selected', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
     const candidateInformationChangeCategory = {
@@ -75,7 +75,7 @@ module('Integration | Component | candidate-information-change-certification-iss
     // then
     assert.dom(SUBCATEGORY_SELECTOR).exists();
     assert.dom(TEXTAREA_SELECTOR).exists();
-    assert.contains('Précisez les informations à modifier');
+    assert.contains('Renseignez les informations correctes');
   });
 
   test('it should show "Précisez le temps majoré" if subcategory EXTRA_TIME_PERCENTAGE is selected', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la catégorie C1 - Modification des prénoms/nom/date de naissance est sélectionnée, un texte s’affiche pour guider l’utilisateur dans ce qu’il doit renseigner dans le champ qui s’affiche. Certains utilisateurs se contentent d’indiquer “Merci de modifier le nom de famille” sans préciser par quelle information remplacer l’info erronée.

## :robot: Solution
Remplacer "Précisez les informations à modifier" par "Renseignez les informations correctes"

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certifsco@example.net`
- Aller sur la page de finalisation de la session 3
- Sélectionner un signalement C1 et vérifier que le libellé du champ texte est bien "Renseignez les informations correctes" 