### PR TITLE
[TECH] Mettre en cohérence la seed de candidat SCO certifié (PIX-5080).

### DIFF
--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -12,6 +12,9 @@ const {
   COMPLEMENTARY_CERTIFICATIONS_SESSION_ID,
 } = require('./certification-sessions-builder');
 const {
+  SCO_STUDENT_ID: SCO_STUDENT_ORGANIZATION_LEARNER_ID,
+} = require('../organizations-sco-builder');
+const {
   CERTIF_SUCCESS_USER_ID,
   CERTIF_FAILED_USER_ID,
   CERTIF_REGULAR_USER5_ID,
@@ -145,7 +148,11 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
 
   let sessionId;
   const candidateDataSuccessWithUser = { ...CANDIDATE_DATA_SUCCESS, userId: CERTIF_SUCCESS_USER_ID };
-  const candidateDataSuccessWithUserSco = { ...CANDIDATE_SCO_DATA_SUCCESS, userId: CERTIF_SCO_STUDENT_ID };
+  const candidateDataSuccessWithUserSco = {
+    ...CANDIDATE_SCO_DATA_SUCCESS,
+    userId: CERTIF_SCO_STUDENT_ID,
+    organizationLearnerId: SCO_STUDENT_ORGANIZATION_LEARNER_ID,
+  };
   const candidateDataFailureWithUser = { ...CANDIDATE_DATA_FAILURE, userId: CERTIF_FAILED_USER_ID };
   const candidateDataMissingWithUser = { ...CANDIDATE_DATA_MISSING, userId: null };
   const candidateDataStartedWithUser = { ...CANDIDATE_DATA_STARTED, userId: CERTIF_REGULAR_USER5_ID };

--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -70,7 +70,7 @@ const CANDIDATE_DATA_STARTED = {
 };
 const CANDIDATE_SCO_DATA_SUCCESS = {
   firstName: 'Student',
-  lastName: 'Certif',
+  lastName: 'Certified',
   birthdate: '2000-01-01',
   birthCity: 'Ici',
   resultRecipientEmail: null,

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -178,9 +178,9 @@ function _buildMiddleSchools({ databaseBuilder }) {
   // schooling registration associated with email used by certification
   const userCertifWithEmail = databaseBuilder.factory.buildUser.withRawPassword({
     id: SCO_STUDENT_ID,
-    firstName: 'student',
-    lastName: 'certif',
-    email: 'eleve-certif@example.net',
+    firstName: 'Student',
+    lastName: 'Certified',
+    email: 'student.certified@example.net',
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });


### PR DESCRIPTION
## :unicorn: Problème
Le candidat `eleve-certif@example.net` du centre de certification SCO  `isMaganingStudents = TRUE`
- apparait dans les candidats de certification
- n'est pas réconcilié avec le parcours de certification `certification_candidates."organizationLearnerId" IS NULL`, à tord
- mais a passé une certification

En conséquence, il n’apparaît pas dans l’export des résultats dans Pix Orga

## :robot: Solution
Lier le candidat à l'élève

## :rainbow: Remarques
Alignement des noms des candidats, utilisateur et élève

## :100: Pour tester
Se connecter à PixOrga avec l'utilisateur `sco.admin@example.net`
Télécharger les résultats de la classe `5D`
Vérifier que son contenu est 

```
"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Date de passage de la certification"
106763;"Student";"Certified";"01/01/2000";"Paris";"externalId";"Validée";518;5;5;5;5;3;5;4;5;0;5;2;5;0;5;5;4;;10;"31/01/2020"
```
