### PR TITLE
[FEATURE] Ajouter un bouton d'export JSON sur la page de détail d'un PC (PIX-5082)

### DIFF
--- a/admin/app/adapters/target-profile-template.js
+++ b/admin/app/adapters/target-profile-template.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class TargetProfileTemplateAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/target-profiles/download-modal.hbs
+++ b/admin/app/components/target-profiles/download-modal.hbs
@@ -1,4 +1,4 @@
-<PixModal @title="Télécharger la sélection des sujets" @onCloseButtonClick={{@close}}>
+<PixModal @title={{@title}} @onCloseButtonClick={{@close}}>
   <:content>
     <PixInput
       @id="fileName"

--- a/admin/app/components/target-profiles/download-modal.js
+++ b/admin/app/components/target-profiles/download-modal.js
@@ -2,12 +2,16 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';
+import kebabCase from 'lodash/kebabCase';
 
 export default class DownloadModal extends Component {
   @tracked
   fileName = 'profil-cible';
 
   get fileNameSuffix() {
+    if (this.args.fileNameSuffix) {
+      return `_${kebabCase(this.args.fileNameSuffix)}.json`;
+    }
     const date = dayjs().format('DD-MM-YYYY_HH-mm-ss');
     return `_${date}.json`;
   }

--- a/admin/app/components/target-profiles/download-modal.js
+++ b/admin/app/components/target-profiles/download-modal.js
@@ -17,7 +17,7 @@ export default class DownloadModal extends Component {
   }
 
   get downloadContent() {
-    const json = JSON.stringify(this.args.tubesWithLevelAndSkills);
+    const json = JSON.stringify(this.args.content);
     return new Blob([json], { type: 'application/json' });
   }
 

--- a/admin/app/components/target-profiles/tubes-selection/form.hbs
+++ b/admin/app/components/target-profiles/tubes-selection/form.hbs
@@ -57,8 +57,9 @@
   </section>
 
   {{#if this.isDownloadModalOpened}}
-    <TargetProfiles::TubesSelection::DownloadModal
-      @tubesWithLevelAndSkills={{this.tubesWithLevelAndSkills}}
+    <TargetProfiles::DownloadModal
+      @title="Télécharger la sélection des sujets"
+      @content={{this.tubesWithLevelAndSkills}}
       @close={{this.closeDownloadModal}}
     />
   {{/if}}

--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -8,6 +8,7 @@ export default class TargetProfileController extends Controller {
   @tracked isEditMode = false;
   @tracked displayConfirm = false;
   @tracked displaySimplifiedAccessPopupConfirm = false;
+  @tracked isDownloadModalOpened = false;
 
   get isPublic() {
     return this.model.isPublic ? 'Oui' : 'Non';
@@ -19,6 +20,10 @@ export default class TargetProfileController extends Controller {
 
   get isSimplifiedAccess() {
     return this.model.isSimplifiedAccess ? 'Oui' : 'Non';
+  }
+
+  get tubesWithLevelAndSkills() {
+    return [];
   }
 
   @action
@@ -59,6 +64,16 @@ export default class TargetProfileController extends Controller {
     } catch (responseError) {
       this.notifications.error('Une erreur est survenue.');
     }
+  }
+
+  @action
+  openDownloadModal() {
+    this.isDownloadModalOpened = true;
+  }
+
+  @action
+  closeDownloadModal() {
+    this.isDownloadModalOpened = false;
   }
 
   _handleResponseError({ errors }) {

--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -9,6 +9,7 @@ export default class TargetProfileController extends Controller {
   @tracked displayConfirm = false;
   @tracked displaySimplifiedAccessPopupConfirm = false;
   @tracked isDownloadModalOpened = false;
+  @tracked targetProfileContent;
 
   get isPublic() {
     return this.model.isPublic ? 'Oui' : 'Non';
@@ -20,10 +21,6 @@ export default class TargetProfileController extends Controller {
 
   get isSimplifiedAccess() {
     return this.model.isSimplifiedAccess ? 'Oui' : 'Non';
-  }
-
-  get tubesWithLevelAndSkills() {
-    return [];
   }
 
   @action
@@ -67,8 +64,18 @@ export default class TargetProfileController extends Controller {
   }
 
   @action
-  openDownloadModal() {
+  async openDownloadModal() {
+    this.targetProfileContent = await this.getTargetProfileContent();
     this.isDownloadModalOpened = true;
+  }
+
+  async getTargetProfileContent() {
+    const template = await this.model.template;
+    return template.tubes.map((tube) => ({
+      id: tube['tube-id'],
+      level: tube.level,
+      skills: this.model.skills.filter((skill) => skill.tubeId === tube['tube-id']).map((skill) => skill.id),
+    }));
   }
 
   @action

--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -72,9 +72,9 @@ export default class TargetProfileController extends Controller {
   async getTargetProfileContent() {
     const template = await this.model.template;
     return template.tubes.map((tube) => ({
-      id: tube['tube-id'],
+      id: tube.id,
       level: tube.level,
-      skills: this.model.skills.filter((skill) => skill.tubeId === tube['tube-id']).map((skill) => skill.id),
+      skills: this.model.skills.filter((skill) => skill.tubeId === tube.id).map((skill) => skill.id),
     }));
   }
 

--- a/admin/app/models/target-profile-template.js
+++ b/admin/app/models/target-profile-template.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class TargetProfileTemplate extends Model {}
+export default class TargetProfileTemplate extends Model {
+  @attr('array') tubes;
+}

--- a/admin/app/models/target-profile-template.js
+++ b/admin/app/models/target-profile-template.js
@@ -1,0 +1,3 @@
+import Model from '@ember-data/model';
+
+export default class TargetProfileTemplate extends Model {}

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -1,5 +1,5 @@
 import { memberAction } from 'ember-api-actions';
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import map from 'lodash/map';
 
 export const categories = {
@@ -35,6 +35,7 @@ export default class TargetProfile extends Model {
   @hasMany('tube') tubes;
   @hasMany('competence') competences;
   @hasMany('area') areas;
+  @belongsTo('target-profile-template') template;
 
   attachOrganizations = memberAction({
     path: 'attach-organizations',

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -137,7 +137,7 @@
   {{#if this.isDownloadModalOpened}}
     <TargetProfiles::DownloadModal
       @title="Télécharger le profil cible"
-      @content={{this.tubesWithLevelAndSkills}}
+      @content={{this.targetProfileContent}}
       @close={{this.closeDownloadModal}}
     />
   {{/if}}

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -68,7 +68,7 @@
           </PixButton>
         {{/unless}}
         {{#if @model.template}}
-          <PixButton @size="small" @backgroundColor="green">
+          <PixButton @size="small" @backgroundColor="green" @triggerAction={{this.openDownloadModal}}>
             Télécharger le profil cible (JSON)
           </PixButton>
         {{/if}}
@@ -132,5 +132,13 @@
         </PixButton>
       </:footer>
     </PixModal>
+  {{/if}}
+
+  {{#if this.isDownloadModalOpened}}
+    <TargetProfiles::DownloadModal
+      @title="Télécharger le profil cible"
+      @content={{this.tubesWithLevelAndSkills}}
+      @close={{this.closeDownloadModal}}
+    />
   {{/if}}
 </main>

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -139,6 +139,7 @@
       @title="Télécharger le profil cible"
       @content={{this.targetProfileContent}}
       @close={{this.closeDownloadModal}}
+      @fileNameSuffix={{@model.name}}
     />
   {{/if}}
 </main>

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -54,8 +54,9 @@
           @triggerAction={{this.toggleEditMode}}
         >Editer</PixButton>
         {{#unless @model.outdated}}
-          <PixButton @size="small" @backgroundColor="red" @triggerAction={{this.toggleDisplayConfirm}}>Marquer comme
-            obsolète</PixButton>
+          <PixButton @size="small" @backgroundColor="red" @triggerAction={{this.toggleDisplayConfirm}}>
+            Marquer comme obsolète
+          </PixButton>
         {{/unless}}
         {{#unless @model.isSimplifiedAccess}}
           <PixButton
@@ -66,6 +67,11 @@
             Marquer comme accès simplifié
           </PixButton>
         {{/unless}}
+        {{#if @model.template}}
+          <PixButton @size="small" @backgroundColor="green">
+            Télécharger le profil cible (JSON)
+          </PixButton>
+        {{/if}}
       </div>
     </section>
 

--- a/admin/mirage/serializers/target-profile.js
+++ b/admin/mirage/serializers/target-profile.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const _includes = ['areas', 'competences', 'tubes', 'skills'];
+const _includes = ['areas', 'competences', 'tubes', 'skills', 'template'];
 
 export default ApplicationSerializer.extend({
   include: _includes,

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -257,6 +257,41 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
           assert.dom(screen.queryByLabelText('Marquer comme accès simplifié')).doesNotExist();
         });
       });
+
+      module('when target profile is attached to a template', function () {
+        test('it should display download target profile JSON button', async function (assert) {
+          const template = server.create('target-profile-template', { id: 456 });
+          server.create('target-profile', {
+            id: 1,
+            name: 'Profil Cible avec Gabarit',
+            ownerOrganizationId: 123,
+            template,
+          });
+
+          // when
+          const screen = await visit('/target-profiles/1');
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Télécharger le profil cible (JSON)' })).exists();
+        });
+      });
+
+      module('when target profile is not attached to a template', function () {
+        test('it should not display target profile download button', async function (assert) {
+          server.create('target-profile', {
+            id: 1,
+            name: 'Profil Cible sans Gabarit',
+            ownerOrganizationId: 123,
+            template: null,
+          });
+
+          // when
+          const screen = await visit('/target-profiles/1');
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Télécharger le profil cible (JSON)' })).doesNotExist();
+        });
+      });
     });
 
     module('when admin member has role "CERTIF"', function () {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -1,5 +1,5 @@
 import { click, currentURL } from '@ember/test-helpers';
-import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, visit, within } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -259,8 +259,8 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
       });
 
       module('when target profile is attached to a template', function () {
-        test('it should display download target profile JSON button', async function (assert) {
-          const template = server.create('target-profile-template', { id: 456 });
+        test('it should display target profile download modal', async function (assert) {
+          const template = server.create('target-profile-template', { id: 456, tubes: [] });
           server.create('target-profile', {
             id: 1,
             name: 'Profil Cible avec Gabarit',
@@ -270,9 +270,14 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
           // when
           const screen = await visit('/target-profiles/1');
+          await clickByName('Télécharger le profil cible (JSON)');
 
           // then
-          assert.dom(screen.getByRole('button', { name: 'Télécharger le profil cible (JSON)' })).exists();
+          const dialog = screen.getByRole('dialog', { name: 'Télécharger le profil cible' });
+          assert.dom(dialog).exists();
+          assert.dom(within(dialog).getByRole('textbox', { name: 'Nom du fichier' })).exists();
+          assert.dom(within(dialog).getByRole('button', { name: 'Annuler' })).exists();
+          assert.dom(within(dialog).getByRole('link', { name: /Télécharger \(JSON .+ Ko\)/ })).exists();
         });
       });
 

--- a/admin/tests/unit/controllers/authenticated/target-profiles/target-profile_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/target-profile_test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/target-profiles/target-profile', function (hooks) {
+  setupTest(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/target-profiles/target-profile');
+  });
+
+  module('#getTargetProfileContent', function () {
+    test('should build target profile content for download', async function (assert) {
+      const store = this.owner.lookup('service:store');
+      controller.model = store.createRecord('target-profile', {
+        template: store.createRecord('target-profile-template', {
+          tubes: [
+            { id: 'tubeId1', level: 5 },
+            { id: 'tubeId2', level: 8 },
+            { id: 'tubeId3', level: 7 },
+          ],
+        }),
+        skills: [
+          store.createRecord('skill', { id: 'skillId1', tubeId: 'tubeId1' }),
+          store.createRecord('skill', { id: 'skillId2', tubeId: 'tubeId1' }),
+          store.createRecord('skill', { id: 'skillId3', tubeId: 'tubeId2' }),
+        ],
+      });
+
+      const result = await controller.getTargetProfileContent();
+
+      assert.deepEqual(result, [
+        { id: 'tubeId1', level: 5, skills: ['skillId1', 'skillId2'] },
+        { id: 'tubeId2', level: 8, skills: ['skillId3'] },
+        { id: 'tubeId3', level: 7, skills: [] },
+      ]);
+    });
+  });
+});

--- a/api/lib/domain/models/TargetProfileTemplateTube.js
+++ b/api/lib/domain/models/TargetProfileTemplateTube.js
@@ -1,0 +1,8 @@
+class TargetProfileTemplateTube {
+  constructor({ id, level } = {}) {
+    this.id = id;
+    this.level = level;
+  }
+}
+
+module.exports = TargetProfileTemplateTube;

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -16,6 +16,7 @@ const {
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 const TargetProfile = require('../../domain/models/TargetProfile');
 const TargetProfileTemplate = require('../../domain/models/TargetProfileTemplate');
+const TargetProfileTemplateTube = require('../../domain/models/TargetProfileTemplateTube');
 const { PGSQL_FOREIGN_KEY_VIOLATION_ERROR } = require('../../../db/pgsql-errors');
 
 module.exports = {
@@ -191,10 +192,13 @@ module.exports = {
         return new TargetProfileTemplate({
           id: targetProfileTemplateId,
           targetProfileIds: [savedTargetProfileId],
-          tubes: savedTubes.map((tube) => ({
-            id: tube.tubeId,
-            level: tube.level,
-          })),
+          tubes: savedTubes.map(
+            (tube) =>
+              new TargetProfileTemplateTube({
+                id: tube.tubeId,
+                level: tube.level,
+              })
+          ),
         });
       });
     } catch (e) {
@@ -213,7 +217,13 @@ module.exports = {
 
     return new TargetProfileTemplate({
       id,
-      tubes,
+      tubes: tubes.map(
+        (tube) =>
+          new TargetProfileTemplateTube({
+            id: tube.tubeId,
+            level: tube.level,
+          })
+      ),
     });
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-template-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-template-serializer.js
@@ -5,7 +5,7 @@ module.exports = {
     return new Serializer('target-profile-template', {
       attributes: ['tubes'],
       tubes: {
-        attributes: ['tubeId', 'level'],
+        attributes: ['id', 'level'],
       },
       meta,
     }).serialize(targetProfileTemplate);

--- a/api/tests/integration/application/target-profile/index_test.js
+++ b/api/tests/integration/application/target-profile/index_test.js
@@ -53,7 +53,7 @@ describe('Integration | Application | Route | target-profile-router', function (
             type: 'target-profile-templates',
             id: `${targetProfileTemplateId}`,
             attributes: {
-              tubes: [{ 'tube-id': 'tubeId1', level: 8 }],
+              tubes: [{ id: 'tubeId1', level: 8 }],
             },
           },
         });

--- a/api/tests/integration/domain/usecases/get-target-profile-template_test.js
+++ b/api/tests/integration/domain/usecases/get-target-profile-template_test.js
@@ -2,13 +2,14 @@ const getTargetProfileTemplate = require('../../../../lib/domain/usecases/get-ta
 const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
 const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const TargetProfileTemplateTube = require('../../../../lib/domain/models/TargetProfileTemplateTube');
 
 describe('Integration | UseCases | get-target-profile-template', function () {
   let targetProfileTemplate, tube1, tube2;
   const ID_NOT_EXIST = '-1';
 
   beforeEach(async function () {
-    targetProfileTemplate = await databaseBuilder.factory.buildTargetProfileTemplate({
+    targetProfileTemplate = databaseBuilder.factory.buildTargetProfileTemplate({
       id: 1,
     });
 
@@ -34,6 +35,16 @@ describe('Integration | UseCases | get-target-profile-template', function () {
   });
 
   it('should return a target profile template', async function () {
+    // given
+    const tube1Expected = new TargetProfileTemplateTube({
+      id: tube1.tubeId,
+      level: tube1.level,
+    });
+    const tube2Expected = new TargetProfileTemplateTube({
+      id: tube2.tubeId,
+      level: tube2.level,
+    });
+
     // when
     const targetProfileTemplateResult = await getTargetProfileTemplate({
       targetProfileTemplateId: targetProfileTemplate.id,
@@ -42,7 +53,7 @@ describe('Integration | UseCases | get-target-profile-template', function () {
 
     // then
     expect(targetProfileTemplateResult).to.exist;
-    expect(targetProfileTemplateResult.tubes).to.deepEqualArray([tube1, tube2]);
+    expect(targetProfileTemplateResult.tubes).to.deepEqualArray([tube1Expected, tube2Expected]);
   });
 
   it('should return an exception because the target profile template does not exist', async function () {

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-template.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-template.js
@@ -1,9 +1,10 @@
 const TargetProfileTemplate = require('../../../../lib/domain/models/TargetProfileTemplate');
+const TargetProfileTemplateTube = require('../../../../lib/domain/models/TargetProfileTemplateTube');
 
 module.exports = function buildTargetProfileTemplate({
   id = 123,
   targetProfileIds = [],
-  tubes = [{ tubeId: 'tubeId1', level: 8 }],
+  tubes = [new TargetProfileTemplateTube({ id: 'tubeId1', level: 8 })],
 } = {}) {
   return new TargetProfileTemplate({
     id,


### PR DESCRIPTION
## :unicorn: Problème

À l'heure actuelle pour la création des résultats thématiques et des paliers, il est nécessaire de disposer du JSON du profil cible pour pouvoir l'importer dans pix-editor.
On souhaite garder la retro compatibilité avec cette manière de faire tout en permettant la création d'un profil cible sans passer par un JSON.

## :robot: Solution

Permettre l'export du JSON d'un profil cible depuis la page de détail de celui-ci.

## :rainbow: Remarques

Petit refactoring côté back : le model du gabarit a été complété avec `TargetProfileTemplateTube`.

## :100: Pour tester

Créer un nouveau profil cible.
Exporter le JSON correspondant.