### PR TITLE
[FEATURE] Améliorer le message de la page j'ai un code (Pix-4976)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -8,8 +8,8 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "NERA" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
-    Lorsque je clique sur "Commencer"
+    Et je saisis "NERA" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Lorsque je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne evaluation" est correctement affichée
     Lorsque je clique sur "Je commence"
@@ -42,8 +42,8 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
-    Et je clique sur "Commencer"
+    Lorsque je saisis "WINTER" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"
     Alors je vois la page d'"eleve" de la campagne
@@ -56,8 +56,8 @@ Fonctionnalité: Campagne d'évaluation
 
   Scénario: Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
-    Et je clique sur "Commencer"
+    Lorsque je saisis "WINTER" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"
     Alors je vois la page de "rejoindre" de la campagne

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -8,8 +8,8 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "LION" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
-    Lorsque je clique sur "Commencer"
+    Et je saisis "LION" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Lorsque je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne collecte profils" est correctement affichée
     Lorsque je clique sur "C'est parti !"
@@ -34,8 +34,8 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
-    Et je clique sur "Commencer"
+    Lorsque je saisis "WOLF" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C'est parti !"
     Alors je vois la page d'"eleve" de la campagne
@@ -50,8 +50,8 @@ Fonctionnalité: Campagne de collecte de profils
 
   Scénario: Je partage mon profil de manière restreinte en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation"
-    Et je clique sur "Commencer"
+    Lorsque je saisis "WOLF" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C'est parti !"
     Alors je vois la page de "rejoindre" de la campagne

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -28,7 +28,15 @@
     text-align: center;
     font-weight: $font-light;
     margin-bottom: 16px;
-    max-width: 390px;
+    max-width: 600px;
+
+    @include device-is('tablet') {
+      width: 75vw;
+    }
+
+    @include device-is('mobile') {
+      width: 75vw;
+    }
   }
 
   &__form-field {
@@ -66,5 +74,21 @@
     font-size: 0.875rem;
     text-align: center;
     margin-top: 40px;
+  }
+
+  &__explanation {
+    text-align: center;
+    padding-top: 25px;
+    margin-top: 25px;
+    border-top: 1px solid $grey-15;
+    max-width: 600px;
+
+    @include device-is('tablet') {
+      width: 75vw;
+    }
+
+    @include device-is('mobile') {
+      width: 75vw;
+    }
   }
 }

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -53,6 +53,16 @@
               </a>
             </div>
           {{/if}}
+          <div class="fill-in-campaign-code__explanation">
+            <a
+              href="https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-"
+              class="link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{t "pages.fill-in-campaign-code.explanation-message"}}
+            </a>
+          </div>
         </PixBlock>
       </PixBackgroundHeader>
     </main>

--- a/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
@@ -1,0 +1,55 @@
+import { visit } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-mocha';
+import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import { authenticateByEmail } from '../helpers/authentication';
+import { contains } from '../helpers/contains';
+import setupIntl from '../helpers/setup-intl';
+import { clickByLabel } from '../helpers/click-by-label';
+
+describe('Acceptance | Fill in campaign code page', function () {
+  setupApplicationTest();
+  setupMirage();
+  setupIntl();
+
+  let user;
+
+  beforeEach(async function () {
+    user = server.create('user', 'withEmail');
+  });
+
+  describe('When connected', function () {
+    it('should disconnect when cliking on the link', async function () {
+      // given
+      await authenticateByEmail(user);
+      await visit('/campagnes');
+
+      // when
+      await clickByLabel(this.intl.t('pages.fill-in-campaign-code.warning-message-logout'));
+
+      // then
+      expect(contains(user.firstName)).to.be.null;
+      expect(contains(this.intl.t('navigation.not-logged.sign-in')));
+    });
+  });
+
+  describe('Explanation link', function () {
+    it('should redirect on the right support page', async function () {
+      // given
+      await authenticateByEmail(user);
+      await visit('/campagnes');
+
+      // when
+      await clickByLabel(this.intl.t('pages.fill-in-campaign-code.explanation-message'));
+
+      // then
+      expect(
+        find(
+          '[href="https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-"]'
+        )
+      ).to.exist;
+      expect(find('[target="_blank"]')).to.exist;
+    });
+  });
+});

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -19,6 +19,7 @@ import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helper
 import { currentSession } from 'ember-simple-auth/test-support';
 import ENV from 'mon-pix/config/environment';
 import setupIntl from '../helpers/setup-intl';
+import { t } from 'ember-intl/test-support';
 
 const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
@@ -61,7 +62,9 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           await visit('/campagnes');
 
           // then
-          expect(find('.fill-in-campaign-code__start-button').textContent).to.contains('Commencer');
+          expect(find('.fill-in-campaign-code__start-button').textContent).to.contains(
+            t('pages.fill-in-campaign-code.start')
+          );
         });
       });
 
@@ -135,7 +138,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await clickByLabel('Commencer');
+              await clickByLabel(t('pages.fill-in-campaign-code.start'));
               await clickByLabel('Je commence');
               await click('#login-button');
               await fillIn('#login', prescritUser.email);
@@ -159,7 +162,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
                 // when
                 await fillIn('#campaign-code', campaign.code);
-                await clickByLabel('Commencer');
+                await clickByLabel(t('pages.fill-in-campaign-code.start'));
                 await clickByLabel('Je commence');
                 await click('#login-button');
                 await fillIn('#login', prescritUser.email);
@@ -178,7 +181,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
               await visit('/campagnes');
               prescritUser.mustValidateTermsOfService = true;
               await fillIn('#campaign-code', campaign.code);
-              await clickByLabel('Commencer');
+              await clickByLabel(t('pages.fill-in-campaign-code.start'));
               await clickByLabel('Je commence');
               await click('#login-button');
               await fillIn('#login', prescritUser.email);
@@ -331,7 +334,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -385,7 +388,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -473,7 +476,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
           // when
           await fillIn('#campaign-code', campaignCode);
-          await clickByLabel('Commencer');
+          await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           // then
           expect(currentURL()).to.equal('/campagnes');
@@ -489,7 +492,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           await visit('/campagnes');
 
           // when
-          await clickByLabel('Commencer');
+          await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           // then
           expect(currentURL()).to.equal('/campagnes');
@@ -578,7 +581,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
             //when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -680,7 +683,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
           //when
           await fillIn('#campaign-code', campaign.code);
-          await clickByLabel('Commencer');
+          await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           //then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -742,7 +745,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -752,7 +755,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
             // given
             await visit('/campagnes');
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // when
             await clickByLabel('Je commence');
@@ -769,7 +772,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -930,7 +933,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
         // when
         await visit('/campagnes');
         await fillIn('#campaign-code', campaign.code);
-        await clickByLabel('Commencer');
+        await clickByLabel(t('pages.fill-in-campaign-code.start'));
         await click('button[type="submit"]');
 
         const currentUserId = session.data.authenticated['user_id'];
@@ -961,7 +964,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           it('should redirect to landing page', async function () {
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -970,7 +973,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           it('should redirect to reconciliation form when landing page has been seen', async function () {
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             // then
@@ -980,7 +983,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           it('should set by default firstName and lastName', async function () {
             // when
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             //then
@@ -991,7 +994,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           it('should begin campaign participation when reconciliation is done', async function () {
             // given
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             // when
@@ -1037,7 +1040,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await clickByLabel('Commencer');
+              await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
               // then
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -1085,7 +1088,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
               campaignCode: campaign.code,
             });
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
@@ -1119,7 +1122,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
             server.post('/token-from-external-user', () => errorsApi);
 
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
@@ -1159,7 +1162,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
             server.post('/token-from-external-user', () => errorsApi);
 
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
@@ -1187,7 +1190,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
             server.post('/token-from-external-user', () => new Response(500));
 
             await fillIn('#campaign-code', campaign.code);
-            await clickByLabel('Commencer');
+            await clickByLabel(t('pages.fill-in-campaign-code.start'));
             await clickByLabel('Je commence');
 
             await fillIn('#dayOfBirth', '10');
@@ -1239,7 +1242,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await clickByLabel('Commencer');
+              await clickByLabel(t('pages.fill-in-campaign-code.start'));
               await clickByLabel('Je commence');
 
               await fillIn('#dayOfBirth', '10');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -749,7 +749,7 @@
     },
     "fill-in-campaign-code": {
       "title": "I have a code",
-      "description": "This code can be used to start a customised test or to submit your profile to an organisation",
+      "description": "This code is given by your school/organisation and can be used to start a customised test or to submit your profile",
       "errors": {
         "forbidden": "Oops! We can’t find you. Check your details to continue or contact the organiser.",
         "missing-code": "Please enter a code.",
@@ -757,7 +757,7 @@
       },
       "first-title-connected": "{ firstName }, enter your code",
       "first-title-not-connected": "Enter your code",
-      "start": "Start",
+      "start": "Start the customised test",
       "warning-message": "If you are not { firstName } { lastName },",
       "warning-message-logout": "please log out"
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -755,6 +755,7 @@
         "missing-code": "Please enter a code.",
         "not-found": "Your code is incorrect. Please check it or contact the organiser."
       },
+      "explanation-message": "Qu’est-ce qu’un code parcours et comment l’utiliser ?",
       "first-title-connected": "{ firstName }, enter your code",
       "first-title-not-connected": "Enter your code",
       "start": "Start the customised test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -755,6 +755,7 @@
         "missing-code": "Veuillez saisir un code.",
         "not-found": "Votre code est erroné, veuillez vérifier ou contacter l’organisateur."
       },
+      "explanation-message": "Qu’est-ce qu’un code parcours et comment l’utiliser ?",
       "first-title-connected": "{ firstName }, saisissez votre code",
       "first-title-not-connected": "Saisissez votre code",
       "start": "Accéder au parcours",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -749,7 +749,7 @@
     },
     "fill-in-campaign-code": {
       "title": "J'ai un code",
-      "description": "Ce code permet de démarrer un parcours ou d’envoyer votre profil à une organisation",
+      "description": "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil.",
       "errors": {
         "forbidden": "Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.",
         "missing-code": "Veuillez saisir un code.",
@@ -757,7 +757,7 @@
       },
       "first-title-connected": "{ firstName }, saisissez votre code",
       "first-title-not-connected": "Saisissez votre code",
-      "start": "Commencer",
+      "start": "Accéder au parcours",
       "warning-message": "Vous n'êtes pas { firstName } { lastName } ?",
       "warning-message-logout": "Se déconnecter"
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans la page de saisie de code (dans le cas ou on est connecté à un compte ou pas connecté voir les deux captures d'écran), on voudrait améliorer le wording.

## :robot: Solution
Texte : ”Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil.”

Bouton “Accéder au parcours”

Lien “Qu’est-ce qu’un code parcours et comment l’utiliser ?”
Lien : https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser- 

Demande de traduction : 
https://trello.com/c/kye1kT6T

”This code is given by your school/organisation and can be used to start a customised test or to submit your profile
Start the customised test
What is a customised test code and how do I use it?”

Bien penser à le faire sur les deux écrans “connecté” et “non connecté”.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Aller sur mon-pix
2. Se connecter
3. Cliquer sur "J'ai un code" 
4. Vérifier les changements
5. Se déconnecter
6. Aller sur /campagnes
7. Vérifier les changements
8. Tada !
