### PR TITLE
[FEATURE] Empêcher les utilisateurs ayant le rôle métier d'accéder aux pages certifications sur Pix Admin (PIX-5062).

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -41,16 +41,18 @@
         <:tooltip>Sessions de certifications</:tooltip>
       </PixTooltip>
     </li>
-    <li class="menu-bar__entry">
-      <PixTooltip @position="right" @inline={{true}}>
-        <:triggerElement>
-          <LinkTo @route="authenticated.certifications" class="menu-bar__link">
-            <FaIcon @icon="graduation-cap" @title="Certifications" />
-          </LinkTo>
-        </:triggerElement>
-        <:tooltip>Certifications</:tooltip>
-      </PixTooltip>
-    </li>
+    {{#if this.accessControl.hasAccessToCertificationActionsScope}}
+      <li class="menu-bar__entry">
+        <PixTooltip @position="right" @inline={{true}}>
+          <:triggerElement>
+            <LinkTo @route="authenticated.certifications" class="menu-bar__link">
+              <FaIcon @icon="graduation-cap" @title="Certifications" />
+            </LinkTo>
+          </:triggerElement>
+          <:tooltip>Certifications</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/if}}
     {{#if this.accessControl.hasAccessToTargetProfilesActionsScope}}
       <li class="menu-bar__entry">
         <PixTooltip @position="right" @inline={{true}}>

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -25,7 +25,6 @@ export default class CertificationInformationsController extends Controller {
   @tracked editingCandidateResults = false;
   @service notifications;
   @service featureToggles;
-  @service accessControl;
 
   @tracked displayConfirm = false;
   @tracked confirmMessage = '';

--- a/admin/app/routes/authenticated/certifications.js
+++ b/admin/app/routes/authenticated/certifications.js
@@ -1,3 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class CertificationsRoute extends Route {}
+export default class CertificationsRoute extends Route {
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isCertif', 'isSupport'], 'authenticated');
+  }
+}

--- a/admin/app/routes/authenticated/certifications/certification.js
+++ b/admin/app/routes/authenticated/certifications/certification.js
@@ -4,6 +4,11 @@ import { inject as service } from '@ember/service';
 
 export default class CertificationRoute extends Route {
   @service errorNotifier;
+  @service accessControl;
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isCertif', 'isSupport'], 'authenticated');
+  }
 
   setupController(controller, model) {
     super.setupController(controller, model);

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -4,16 +4,14 @@
     <PixButton @route="authenticated.users.get" @size="small" @model={{this.certification.userId}}>
       Voir les détails de l'utilisateur
     </PixButton>
-    {{#if this.accessControl.hasAccessToCertificationActionsScope}}
-      {{#if this.isCertificationCancelled}}
-        <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onUncancelCertificationButtonClick}}>
-          Désannuler la certification
-        </PixButton>
-      {{else}}
-        <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onCancelCertificationButtonClick}}>
-          Annuler la certification
-        </PixButton>
-      {{/if}}
+    {{#if this.isCertificationCancelled}}
+      <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onUncancelCertificationButtonClick}}>
+        Désannuler la certification
+      </PixButton>
+    {{else}}
+      <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onCancelCertificationButtonClick}}>
+        Annuler la certification
+      </PixButton>
     {{/if}}
   </div>
   <div class="row">
@@ -90,22 +88,20 @@
               Pays de naissance :
               {{this.certification.birthCountry}}
             </div>
-            {{#if this.accessControl.hasAccessToCertificationActionsScope}}
-              <div class="candidate-informations__actions">
-                <PixButton
-                  @size="small"
-                  @triggerAction={{this.openCandidateEditModal}}
-                  aria-label="Modifier les informations du candidat"
-                  @isDisabled={{this.isModifyButtonDisabled}}
-                >
-                  Modifier
-                </PixButton>
-                {{#if this.certification.wasRegisteredBeforeCPF}}
-                  <span class="candidate-informations__warning-cpf-message">Voir avec PO/Dev pour modifier les infos
-                    candidat.</span>
-                {{/if}}
-              </div>
-            {{/if}}
+            <div class="candidate-informations__actions">
+              <PixButton
+                @size="small"
+                @triggerAction={{this.openCandidateEditModal}}
+                aria-label="Modifier les informations du candidat"
+                @isDisabled={{this.isModifyButtonDisabled}}
+              >
+                Modifier
+              </PixButton>
+              {{#if this.certification.wasRegisteredBeforeCPF}}
+                <span class="candidate-informations__warning-cpf-message">Voir avec PO/Dev pour modifier les infos
+                  candidat.</span>
+              {{/if}}
+            </div>
           </div>
         </div>
       </div>
@@ -292,41 +288,39 @@
       </div>
     </div>
   </div>
-  {{#if this.accessControl.hasAccessToCertificationActionsScope}}
-    {{#if this.isValid}}
-      <div class="row">
-        <div class="col certification-informations__actions form-actions">
-          {{#if this.editingCandidateResults}}
-            <PixButton
-              @size="small"
-              @backgroundColor="transparent-light"
-              @isBorderVisible={{true}}
-              @triggerAction={{this.onCandidateResultsCancel}}
-              aria-label="Annuler la modification des résultats du candidat"
-            >
-              Annuler
-            </PixButton>
-            <PixButton
-              @size="small"
-              @triggerAction={{this.onCandidateResultsSaveConfirm}}
-              @backgroundColor="green"
-              aria-label="Enregistrer les résultats du candidat"
-            >
-              Enregistrer
-            </PixButton>
-          {{else}}
-            <PixButton
-              @size="small"
-              @triggerAction={{this.onCandidateResultsEdit}}
-              aria-label="Modifier les résultats du candidat"
-              @isDisabled={{this.editingCandidateInformations}}
-            >
-              Modifier
-            </PixButton>
-          {{/if}}
-        </div>
+  {{#if this.isValid}}
+    <div class="row">
+      <div class="col certification-informations__actions form-actions">
+        {{#if this.editingCandidateResults}}
+          <PixButton
+            @size="small"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @triggerAction={{this.onCandidateResultsCancel}}
+            aria-label="Annuler la modification des résultats du candidat"
+          >
+            Annuler
+          </PixButton>
+          <PixButton
+            @size="small"
+            @triggerAction={{this.onCandidateResultsSaveConfirm}}
+            @backgroundColor="green"
+            aria-label="Enregistrer les résultats du candidat"
+          >
+            Enregistrer
+          </PixButton>
+        {{else}}
+          <PixButton
+            @size="small"
+            @triggerAction={{this.onCandidateResultsEdit}}
+            aria-label="Modifier les résultats du candidat"
+            @isDisabled={{this.editingCandidateInformations}}
+          >
+            Modifier
+          </PixButton>
+        {{/if}}
       </div>
-    {{/if}}
+    </div>
   {{/if}}
   <ConfirmPopup
     @message={{this.confirmMessage}}

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -264,17 +264,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
   module('certification edition actions', function () {
     module('Candidate information edition', function () {
-      test('should not show candidate modify button when user does not have access to certification actions scope', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isMetier: true })(server);
-
-        // when
-        const screen = await visit(`/certifications/${certification.id}`);
-
-        // then
-        assert.dom(screen.queryByLabelText('Modifier les informations du candidat')).doesNotExist();
-      });
-
       module('when candidate certification was enrolled before the CPF feature was enabled', function () {
         test('should prevent user from editing candidate information', async function (assert) {
           // given
@@ -549,17 +538,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
 
     module('Certification results edition', function () {
-      test('should not show certification modify button when user does not have access to certification actions scope', async function (assert) {
-        // given
-        await authenticateAdminMemberWithRole({ isMetier: true })(server);
-
-        // when
-        const screen = await visit(`/certifications/${certification.id}`);
-
-        // then
-        assert.dom(screen.queryByLabelText('Modifier les résultats du candidat')).doesNotExist();
-      });
-
       module('when candidate results edit button is clicked', function () {
         test('it disables candidate informations edit button', async function (assert) {
           // given
@@ -684,17 +662,6 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       module('Cancel', function (hooks) {
         hooks.beforeEach(async function () {
           certification.update({ status: 'validated' });
-        });
-
-        test('should not show cancellation button when user does not have access to certification actions scope', async function (assert) {
-          // given
-          await authenticateAdminMemberWithRole({ isMetier: true })(server);
-
-          // when
-          const screen = await visit(`/certifications/${certification.id}`);
-
-          // then
-          assert.dom(screen.queryByText('Annuler la certification')).doesNotExist();
         });
 
         test('should display confirmation popup for cancellation when certification is not yet cancelled and cancellation button is clicked', async function (assert) {

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 
 module('Integration | Component | menu-bar', function (hooks) {
   setupRenderingTest(hooks);
@@ -98,16 +99,34 @@ module('Integration | Component | menu-bar', function (hooks) {
     assert.dom(screen.getByTitle('Sessions de certifications')).exists();
   });
 
-  test('should contain link to "certifications" management page', async function (assert) {
-    // given
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.adminMember = { isSuperAdmin: true };
+  module('Certifications tab', function () {
+    test('should contain link to "certifications" management page when admin member have access to certification actions scope', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+      this.owner.register('service:accessControl', AccessControlStub);
 
-    // when
-    const screen = await render(hbs`{{menu-bar}}`);
+      // when
+      const screen = await render(hbs`{{menu-bar}}`);
 
-    // then
-    assert.dom(screen.getByTitle('Certifications')).exists();
+      // then
+      assert.dom(screen.getByTitle('Certifications')).exists();
+    });
+
+    test('should not contain link to "certifications" management page when admin member does not have access to certification actions scope', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = false;
+      }
+      this.owner.register('service:accessControl', AccessControlStub);
+
+      // when
+      const screen = await render(hbs`{{menu-bar}}`);
+
+      // then
+      assert.dom(screen.queryByText('Certifications')).doesNotExist();
+    });
   });
 
   test('should contain link to "certification centers" management page', async function (assert) {

--- a/admin/tests/unit/routes/authenticated/certifications/certification/certification_test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification/certification_test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/certifications/certification', function (hooks) {
+  setupTest(hooks);
+
+  test('#setupController', function (assert) {
+    // given
+    const certifications = { inputId: 5 };
+    const id = Symbol('id');
+    const route = this.owner.lookup('route:authenticated/certifications/certification');
+
+    // when
+    route.setupController(certifications, { id });
+
+    // then
+    assert.strictEqual(certifications.inputId, id);
+  });
+
+  module('#beforeModel', function () {
+    test('it should check if current user is super admin, certif, or support', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/certifications/certification');
+
+      const restrictAccessToStub = sinon.stub().returns();
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isCertif', 'isSupport'], 'authenticated'));
+    });
+  });
+
+  test('#error', function (assert) {
+    // given
+    const route = this.owner.lookup('route:authenticated/certifications/certification');
+    const errorNotifierStub = {
+      notify: sinon.stub().resolves(),
+    };
+    route.errorNotifier = errorNotifierStub;
+    route.transitionTo = () => {};
+
+    // when
+    route.send('error');
+
+    // then
+    sinon.assert.called(errorNotifierStub.notify);
+    assert.ok(route);
+  });
+});

--- a/admin/tests/unit/routes/authenticated/certifications/certification_test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification_test.js
@@ -3,28 +3,13 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Unit | Route | authenticated/certifications/certification', function (hooks) {
+module('Unit | Route | authenticated/certifications', function (hooks) {
   setupTest(hooks);
-
-  test('#setupController', function (assert) {
-    // given
-    const certifications = { inputId: 5 };
-    const id = Symbol('id');
-    const route = this.owner.lookup('route:authenticated/certifications/certification');
-
-    // when
-    route.setupController(certifications, { id });
-
-    // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(certifications.inputId, id);
-  });
 
   module('#beforeModel', function () {
     test('it should check if current user is super admin, certif, or support', function (assert) {
       // given
-      const route = this.owner.lookup('route:authenticated/certifications/certification');
+      const route = this.owner.lookup('route:authenticated/certifications');
 
       const restrictAccessToStub = sinon.stub().returns();
       class AccessControlStub extends Service {
@@ -38,22 +23,5 @@ module('Unit | Route | authenticated/certifications/certification', function (ho
       // then
       assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isCertif', 'isSupport'], 'authenticated'));
     });
-  });
-
-  test('#error', function (assert) {
-    // given
-    const route = this.owner.lookup('route:authenticated/certifications/certification');
-    const errorNotifierStub = {
-      notify: sinon.stub().resolves(),
-    };
-    route.errorNotifier = errorNotifierStub;
-    route.transitionTo = () => {};
-
-    // when
-    route.send('error');
-
-    // then
-    sinon.assert.called(errorNotifierStub.notify);
-    assert.ok(route);
   });
 });

--- a/admin/tests/unit/routes/authenticated/certifications/certification_test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Route | authenticated/certifications/certification', function (hooks) {
   setupTest(hooks);
@@ -18,6 +19,25 @@ module('Unit | Route | authenticated/certifications/certification', function (ho
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(certifications.inputId, id);
+  });
+
+  module('#beforeModel', function () {
+    test('it should check if current user is super admin, certif, or support', function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/certifications/certification');
+
+      const restrictAccessToStub = sinon.stub().returns();
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isCertif', 'isSupport'], 'authenticated'));
+    });
   });
 
   test('#error', function (assert) {

--- a/api/lib/application/complementary-certification-course-results/index.js
+++ b/api/lib/application/complementary-certification-course-results/index.js
@@ -36,14 +36,19 @@ exports.register = async function (server) {
         },
         pre: [
           {
-            method: securityPreHandlers.checkUserHasRoleSuperAdmin,
-            assign: 'hasRoleSuperAdmin',
+            method: (request, h) =>
+              securityPreHandlers.userHasAtLeastOneAccessOf([
+                securityPreHandlers.checkUserHasRoleSuperAdmin,
+                securityPreHandlers.checkUserHasRoleCertif,
+                securityPreHandlers.checkUserHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
         handler: complementaryCertificationCourseResultsController.saveJuryComplementaryCertificationCourseResult,
         notes: [
-          '- **Cette route est restreinte aux utilisateurs Super Admin authentifiés**\n',
-          "- Elle permet de sauvergarder le volet jury d'une certification complémentaire Pix+ Edu",
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n",
+          "- Elle permet de sauvegarder le volet jury d'une certification complémentaire Pix+ Edu",
         ],
         tags: ['api', 'admin', 'complementary-certification-course-results', 'Pix+ Édu'],
       },

--- a/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -11,6 +11,8 @@ describe('Integration | Application | complementary-certification-course-results
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'saveJuryComplementaryCertificationCourseResult');
     sandbox.stub(securityPreHandlers, 'checkUserHasRoleSuperAdmin');
+    sandbox.stub(securityPreHandlers, 'checkUserHasRoleCertif');
+    sandbox.stub(securityPreHandlers, 'checkUserHasRoleSupport');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
   });
@@ -99,9 +101,15 @@ describe('Integration | Application | complementary-certification-course-results
               },
             },
           };
-          securityPreHandlers.checkUserHasRoleSuperAdmin.callsFake((request, h) => {
-            return Promise.resolve(h.response().code(403).takeover());
-          });
+          securityPreHandlers.checkUserHasRoleSuperAdmin.callsFake((request, h) =>
+            h.response({ errors: new Error('forbidden') }).code(403)
+          );
+          securityPreHandlers.checkUserHasRoleSupport.callsFake((request, h) =>
+            h.response({ errors: new Error('forbidden') }).code(403)
+          );
+          securityPreHandlers.checkUserHasRoleCertif.callsFake((request, h) =>
+            h.response({ errors: new Error('forbidden') }).code(403)
+          );
 
           // when
           const response = await httpTestServer.request(

--- a/api/tests/unit/application/complementary-certification-course-results/index_test.js
+++ b/api/tests/unit/application/complementary-certification-course-results/index_test.js
@@ -1,0 +1,41 @@
+const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const Badge = require('../../../../lib/domain/models/Badge');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const moduleUnderTest = require('../../../../lib/application/complementary-certification-course-results');
+
+describe('Unit | Application | Complementary Certification Course Results | Route', function () {
+  describe('POST /api/admin/complementary-certification-course-results', function () {
+    it('return forbidden access if user has METIER role', async function () {
+      // given
+      sinon
+        .stub(securityPreHandlers, 'userHasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkUserHasRoleSuperAdmin,
+          securityPreHandlers.checkUserHasRoleCertif,
+          securityPreHandlers.checkUserHasRoleSupport,
+        ])
+        .callsFake(
+          () => (request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover()
+        );
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/complementary-certification-course-results', {
+        data: {
+          attributes: {
+            juryLevel: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            complementaryCertificationCourseId: 1234,
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite du ticket https://github.com/1024pix/pix/pull/4432.
On veut aussi restreindre les accès à la page en elle-même

## :robot: Solution
Empêcher les membres admin ayant le rôle Métier d'accéder aux pages certifications

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à Pix Admin avec `pixmetier@example.net`.
- Vérifier que dans le menu il n'y a plus "Certifications"
- Vérifier qu'en allant sur `/certifications/106910` (par exemple) , vous êtes redirigé vers la liste des orgas. 

- Se connecter à Pix Admin avec `pixcertif@example.net`
- Vérifier que vous voyez toujours "Certifications" dans le menu
- Vérifier que vous pouvez accéder à la page `/certifications/106910`
