### PR TITLE
[BUGFIX] Corriger l'export des résultats de certification pour les noms de classe ayant des caractères spéciaux (PIX-5079).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -168,7 +168,7 @@ module.exports = {
     return h
       .response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
-      .header('Content-Disposition', `attachment; filename=${fileName}`);
+      .header('Content-Disposition', `attachment; filename="${fileName}"`);
   },
 
   async findTargetProfiles(request) {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -993,7 +993,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(response.source).to.equal('csv-string');
       expect(response.headers['Content-Type']).to.equal('text/csv;charset=utf-8');
-      expect(response.headers['Content-Disposition']).to.equal('attachment; filename=20210101_resultats_3èmeA.csv');
+      expect(response.headers['Content-Disposition']).to.equal('attachment; filename="20210101_resultats_3èmeA.csv"');
     });
   });
 

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -33,7 +33,9 @@ export default class AuthenticatedCertificationsController extends Controller {
       }
 
       const organizationId = this.currentUser.organization.id;
-      const url = `/api/organizations/${organizationId}/certification-results?division=${this.selectedDivision}`;
+      const url = `/api/organizations/${organizationId}/certification-results?division=${encodeURIComponent(
+        this.selectedDivision
+      )}`;
 
       let token = '';
 

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -36,7 +36,7 @@ function _fetchData({ url, token }) {
 function _getFileNameFromHeader(headers) {
   if (headers && headers.get('Content-Disposition')) {
     const contentDispositionHeader = headers.get('Content-Disposition');
-    const [, fileName] = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDispositionHeader);
+    const [, fileName] = /filename\*?=['"]?([^;\r\n"']*)['"]?/.exec(contentDispositionHeader);
     return fileName;
   }
 }

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -110,7 +110,9 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
       assert.ok(
         controller.fileSaver.save.calledWith({
           token,
-          url: `/api/organizations/${organizationId}/certification-results?division=${selectedDivision}`,
+          url: `/api/organizations/${organizationId}/certification-results?division=${encodeURIComponent(
+            selectedDivision
+          )}`,
         })
       );
     });


### PR DESCRIPTION
## :unicorn: Problème
Il existe actuellement en production des classes avec des "+" dans le nom. Cependant, ce caractère n'est pas échappé lorsqu'il est passé en query param.

## :robot: Solution
- Échapper les caractères spéciaux dans le nom de la classe.
- Permettre de renvoyer un fichier de résultat dont le nom contient des caractères spéciaux.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
