### PR TITLE
[FEATURE] Afficher le nom du créateur de l'organisation dans Pix Admin (PIX-3099)

### DIFF
--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -179,6 +179,7 @@
           <div class="organization-information-section__details">
             <ul>
               <li>Type : {{@organization.type}}</li>
+              <li>Créée par : {{@organization.creatorFullName}} ({{@organization.createdBy}})</li>
               {{#if @organization.externalId}}
                 <li>Identifiant externe : {{@organization.externalId}}</li>
               {{/if}}

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -20,6 +20,7 @@ export default class Organization extends Model {
   @attr('boolean') showSkills;
   @attr() archivistFullName;
   @attr() archivedAt;
+  @attr() creatorFullName;
 
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -25,6 +25,8 @@ module('Integration | Component | organizations/information-section', function (
         credit: 350,
         documentationUrl: 'https://pix.fr',
         showSkills: true,
+        createdBy: 1,
+        creatorFullName: 'Gilles Parbal',
       });
 
       // when
@@ -33,6 +35,7 @@ module('Integration | Component | organizations/information-section', function (
       // then
       assert.dom(screen.getByRole('heading', { name: 'SUPer Orga' })).exists();
       assert.dom(screen.getByText('Type : SUP')).exists();
+      assert.dom(screen.getByText('Créée par : Gilles Parbal (1)')).exists();
       assert.dom(screen.getByText("Affichage des acquis dans l'export de résultats : Oui")).exists();
       assert.dom(screen.getByText('Crédits : 350')).exists();
       assert.dom(screen.getByText('https://pix.fr')).exists();

--- a/api/lib/domain/models/OrganizationForAdmin.js
+++ b/api/lib/domain/models/OrganizationForAdmin.js
@@ -17,6 +17,8 @@ class OrganizationForAdmin {
     archivedAt,
     archivistFirstName,
     archivistLastName,
+    creatorFirstName,
+    creatorLastName,
     tags = [],
   } = {}) {
     this.id = id;
@@ -36,6 +38,8 @@ class OrganizationForAdmin {
     this.archivedAt = archivedAt;
     this.archivistFirstName = archivistFirstName;
     this.archivistLastName = archivistLastName;
+    this.creatorFirstName = creatorFirstName;
+    this.creatorLastName = creatorLastName;
     this.tags = tags;
   }
 
@@ -43,6 +47,10 @@ class OrganizationForAdmin {
     return this.archivistFirstName && this.archivistLastName
       ? `${this.archivistFirstName} ${this.archivistLastName}`
       : null;
+  }
+
+  get creatorFullName() {
+    return this.creatorFirstName && this.creatorLastName ? `${this.creatorFirstName} ${this.creatorLastName}` : null;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/organization-for-admin-repository.js
@@ -23,6 +23,8 @@ function _toDomain(rawOrganization) {
     archivedAt: rawOrganization.archivedAt,
     archivistFirstName: rawOrganization.archivistFirstName,
     archivistLastName: rawOrganization.archivistLastName,
+    creatorFirstName: rawOrganization.creatorFirstName,
+    creatorLastName: rawOrganization.creatorLastName,
   });
 
   organization.tags = rawOrganization.tags || [];
@@ -49,10 +51,13 @@ module.exports = {
         formNPSUrl: 'organizations.formNPSUrl',
         showSkills: 'organizations.showSkills',
         archivedAt: 'organizations.archivedAt',
-        archivistFirstName: 'users.firstName',
-        archivistLastName: 'users.lastName',
+        archivistFirstName: 'archivists.firstName',
+        archivistLastName: 'archivists.lastName',
+        creatorFirstName: 'creators.firstName',
+        creatorLastName: 'creators.lastName',
       })
-      .leftJoin('users', 'users.id', 'organizations.archivedBy')
+      .leftJoin('users AS archivists', 'archivists.id', 'organizations.archivedBy')
+      .leftJoin('users AS creators', 'creators.id', 'organizations.createdBy')
       .where('organizations.id', id)
       .first();
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js
@@ -19,6 +19,7 @@ module.exports = {
         'showSkills',
         'archivedAt',
         'archivistFullName',
+        'creatorFullName',
         'tags',
         'memberships',
         'students',

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
   describe('#get', function () {
     it('should return a organization for admin by provided id', async function () {
       // given
-      const superAdminUserId = databaseBuilder.factory.buildUser().id;
+      const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
 
       const insertedOrganization = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
@@ -20,7 +20,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         isManagingStudents: 'true',
         email: 'sco.generic.account@example.net',
         documentationUrl: 'https://pix.fr/',
-        createdBy: superAdminUserId,
+        createdBy: superAdminUser.id,
         showNPS: true,
         formNPSUrl: 'https://pix.fr/',
         showSkills: false,
@@ -54,6 +54,8 @@ describe('Integration | Repository | Organization-for-admin', function () {
         archivedAt: null,
         archivistFirstName: null,
         archivistLastName: null,
+        creatorFirstName: 'Cécile',
+        creatorLastName: 'Encieux',
       });
       expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
     });
@@ -150,6 +152,8 @@ describe('Integration | Repository | Organization-for-admin', function () {
           archivedAt,
           archivistFirstName: archivist.firstName,
           archivistLastName: archivist.lastName,
+          creatorFirstName: superAdminUser.firstName,
+          creatorLastName: superAdminUser.lastName,
         });
         expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
       });

--- a/api/tests/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/unit/domain/models/OrganizationForAdmin_test.js
@@ -19,4 +19,22 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
       expect(organization.archivistFullName).to.be.null;
     });
   });
+
+  describe('#creatorFullName', function () {
+    it('should return the full name of user who create the organization', function () {
+      // given
+      const organization = new OrganizationForAdmin({ creatorFirstName: 'Sarah', creatorLastName: 'Croche' });
+
+      // when / then
+      expect(organization.creatorFullName).equal('Sarah Croche');
+    });
+
+    it('should return null if organization has no creator', function () {
+      // given
+      const organization = new OrganizationForAdmin({ creatorFirstName: null, creatorLastName: null });
+
+      // when / then
+      expect(organization.creatorFullName).to.be.null;
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -43,6 +43,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'show-skills': organization.showSkills,
             'archived-at': organization.archivedAt,
             'archivist-full-name': organization.archivistFullName,
+            'creator-full-name': organization.creatorFullName,
           },
           relationships: {
             memberships: {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement il n'y a aucune manière de savoir qui a créée telle ou telle orga dans Pix Admin.

## :robot: Solution
Afficher le nom du créateur d'une organisation dans Pix Admin sur la page de détail d'un organisation.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Lancer Pix Admin
- Créer une orga
- Voir qu'il est affiché `Organisation créée par : Super Admin (199)` dans la page d'info de l'orga crée 
