### PR TITLE
[FEATURE] Gérer dynamiquement l'affichage des date de reprise de certification pour le sco dans Pix-certif (PIX-5088)

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -297,6 +297,8 @@ function _buildHighSchools({ databaseBuilder }) {
     provinceCode: '12',
   });
 
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: SCO_HIGH_SCHOOL_ID, tagId: 9 });
+
   databaseBuilder.factory.buildMembership({
     userId: SCO_ADMIN_ID,
     organizationId: SCO_HIGH_SCHOOL_ID,

--- a/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
@@ -75,6 +75,14 @@ class AllowedCertificationCenterAccess {
   isEndTestScreenRemovalEnabled() {
     return this.isSupervisorAccessEnabled;
   }
+
+  get pixCertifScoBlockedAccessDateLycee() {
+    return features.pixCertifScoBlockedAccessDateLycee ?? null;
+  }
+
+  get pixCertifScoBlockedAccessDateCollege() {
+    return features.pixCertifScoBlockedAccessDateCollege ?? null;
+  }
 }
 
 module.exports = AllowedCertificationCenterAccess;

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -26,6 +26,8 @@ module.exports = {
           'relatedOrganizationTags',
           'habilitations',
           'isEndTestScreenRemovalEnabled',
+          'pixCertifScoBlockedAccessDateLycee',
+          'pixCertifScoBlockedAccessDateCollege',
         ],
       },
       typeForAttribute: function (attribute) {
@@ -47,6 +49,8 @@ module.exports = {
               isAccessBlockedAEFE: access.isAccessBlockedAEFE(),
               isAccessBlockedAgri: access.isAccessBlockedAgri(),
               isEndTestScreenRemovalEnabled: access.isEndTestScreenRemovalEnabled(),
+              pixCertifScoBlockedAccessDateCollege: access.pixCertifScoBlockedAccessDateCollege,
+              pixCertifScoBlockedAccessDateLycee: access.pixCertifScoBlockedAccessDateLycee,
             };
           }
         );

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -71,6 +71,8 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
               'is-related-to-managing-students-organization': false,
+              'pix-certif-sco-blocked-access-date-college': null,
+              'pix-certif-sco-blocked-access-date-lycee': null,
               'related-organization-tags': [],
               habilitations: [],
               'is-end-test-screen-removal-enabled': false,

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -718,4 +718,74 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
       expect(result).to.be.false;
     });
   });
+
+  context('#pixCertifScoBlockedAccessDateLycee', function () {
+    describe('when pixCertifScoBlockedAccessDateLycee is defined', function () {
+      it('should return the french formated pixCertifScoBlockedAccessDateLycee', function () {
+        // given
+        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value('2022-02-01');
+
+        const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 1,
+        });
+
+        // when
+        const result = allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateLycee;
+
+        // then
+        expect(result).to.be.equal('2022-02-01');
+      });
+    });
+
+    describe('when pixCertifScoBlockedAccessDateLycee is not defined', function () {
+      it('should return null', function () {
+        // given
+        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value(undefined);
+
+        const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 1,
+        });
+
+        // when
+        const result = allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateLycee;
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
+
+  context('#pixCertifScoBlockedAccessDateCollege', function () {
+    describe('when pixCertifScoBlockedAccessDateCollege is defined', function () {
+      it('should return the french formated pixCertifScoBlockedAccessDateCollege', function () {
+        // given
+        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateCollege').value('2022-02-01');
+        const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 1,
+        });
+
+        // when
+        const result = allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateCollege;
+
+        // then
+        expect(result).to.be.equal('2022-02-01');
+      });
+    });
+
+    describe('when pixCertifScoBlockedAccessDateCollege is not defined', function () {
+      it('should return null', function () {
+        // given
+        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateCollege').value(undefined);
+        const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
+          id: 1,
+        });
+
+        // when
+        const result = allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateCollege;
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -1,10 +1,15 @@
 const { expect, domainBuilder, sinon } = require('../../../../test-helper');
+const settings = require('../../../../../lib/config');
 const certificationPointOfContactSerializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer');
 
 describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serializer', function () {
   describe('#serialize()', function () {
     it('should convert a CertificationPointOfContact model into JSON API data', function () {
       // given
+      sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateCollege').value('2022-06-01');
+      sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value('2022-08-01');
+
+      settings.features.pixCertifScoBlockedAccessDateLycee = '2022-08-01';
       const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 123,
         name: 'Sunnydale Center',
@@ -78,6 +83,8 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-lycee': false,
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
+              'pix-certif-sco-blocked-access-date-college': '2022-06-01',
+              'pix-certif-sco-blocked-access-date-lycee': '2022-08-01',
               'related-organization-tags': [],
               habilitations: [
                 { id: 1, name: 'Certif comp 1' },
@@ -98,6 +105,8 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-lycee': false,
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
+              'pix-certif-sco-blocked-access-date-college': '2022-06-01',
+              'pix-certif-sco-blocked-access-date-lycee': '2022-08-01',
               'related-organization-tags': ['tag1'],
               habilitations: [],
               'is-end-test-screen-removal-enabled': true,

--- a/certif/app/controllers/authenticated/restricted-access.js
+++ b/certif/app/controllers/authenticated/restricted-access.js
@@ -1,15 +1,12 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 
 export default class RestrictedAccessController extends Controller {
-  @service router;
-  @service currentUser;
+  get pixCertifScoBlockedAccessDateLycee() {
+    return this.model.pixCertifScoBlockedAccessDateLycee;
+  }
 
-  @action
-  async changeCurrentCertificationCenterAccess(certificationCenterAccess) {
-    this.currentUser.currentAllowedCertificationCenterAccess = certificationCenterAccess;
-    this.router.replaceWith('authenticated');
+  get pixCertifScoBlockedAccessDateCollege() {
+    return this.model.pixCertifScoBlockedAccessDateCollege;
   }
 
   get calendarScoLink() {

--- a/certif/app/controllers/authenticated/restricted-access.js
+++ b/certif/app/controllers/authenticated/restricted-access.js
@@ -1,12 +1,16 @@
 import Controller from '@ember/controller';
 
 export default class RestrictedAccessController extends Controller {
-  get pixCertifScoBlockedAccessDateLycee() {
-    return this.model.pixCertifScoBlockedAccessDateLycee;
-  }
+  get certificationOpeningDate() {
+    if (this.model.isAccessBlockedCollege) {
+      return this.model.pixCertifScoBlockedAccessDateCollege;
+    }
 
-  get pixCertifScoBlockedAccessDateCollege() {
-    return this.model.pixCertifScoBlockedAccessDateCollege;
+    if (this.model.isAccessBlockedLycee || this.model.isAccessBlockedAEFE || this.model.isAccessBlockedAgri) {
+      return this.model.pixCertifScoBlockedAccessDateLycee;
+    }
+
+    return null;
   }
 
   get calendarScoLink() {

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -12,6 +12,8 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() relatedOrganizationTags;
   @attr() habilitations;
   @attr() isEndTestScreenRemovalEnabled;
+  @attr() pixCertifScoBlockedAccessDateLycee;
+  @attr() pixCertifScoBlockedAccessDateCollege;
 
   get isSco() {
     return this.type === 'SCO';

--- a/certif/app/templates/authenticated/restricted-access.hbs
+++ b/certif/app/templates/authenticated/restricted-access.hbs
@@ -1,8 +1,11 @@
 <div class="page restricted-access-page">
   <img class="restricted-access-content__image" src="/images/calendar_blocked_access_sco.svg" alt="" role="none" />
   <h1 class="restricted-access-content__opening-title">Ouverture de votre espace PixCertif</h1>
-  <p class="restricted-access-content__opening-dates">Le 1er novembre pour les lycées et le 1er février pour les
-    collèges</p>
+  <p class="restricted-access-content__opening-dates">Le
+    {{moment-format this.pixCertifScoBlockedAccessDateLycee "DD/MM/YYYY"}}
+    pour les lycées et le
+    {{moment-format this.pixCertifScoBlockedAccessDateCollege "DD/MM/YYYY"}}
+    pour les collèges</p>
   <p class="restricted-access-content__link-calendar">La création de sessions sera donc possible 1 mois avant les dates
     du
     <a class="sidebar-menu__item" href={{this.calendarScoLink}} target="_blank" rel="noopener noreferrer">

--- a/certif/app/templates/authenticated/restricted-access.hbs
+++ b/certif/app/templates/authenticated/restricted-access.hbs
@@ -6,11 +6,4 @@
     pour les lycées et le
     {{moment-format this.pixCertifScoBlockedAccessDateCollege "DD/MM/YYYY"}}
     pour les collèges</p>
-  <p class="restricted-access-content__link-calendar">La création de sessions sera donc possible 1 mois avant les dates
-    du
-    <a class="sidebar-menu__item" href={{this.calendarScoLink}} target="_blank" rel="noopener noreferrer">
-      Calendrier 2021/2022 eduscol
-      <FaIcon @icon="external-link-alt" @class="sidebar-menu__item-icon" />
-    </a>
-  </p>
 </div>

--- a/certif/app/templates/authenticated/restricted-access.hbs
+++ b/certif/app/templates/authenticated/restricted-access.hbs
@@ -1,9 +1,6 @@
 <div class="page restricted-access-page">
   <img class="restricted-access-content__image" src="/images/calendar_blocked_access_sco.svg" alt="" role="none" />
-  <h1 class="restricted-access-content__opening-title">Ouverture de votre espace PixCertif</h1>
-  <p class="restricted-access-content__opening-dates">Le
-    {{moment-format this.pixCertifScoBlockedAccessDateLycee "DD/MM/YYYY"}}
-    pour les lycées et le
-    {{moment-format this.pixCertifScoBlockedAccessDateCollege "DD/MM/YYYY"}}
-    pour les collèges</p>
+  <h1 class="restricted-access-content__opening-title">Ouverture de votre espace PixCertif le
+    {{moment-format this.certificationOpeningDate "DD/MM/YYYY"}}
+  </h1>
 </div>

--- a/certif/tests/acceptance/restricted-access_test.js
+++ b/certif/tests/acceptance/restricted-access_test.js
@@ -62,7 +62,7 @@ module('Acceptance | Restricted access', function (hooks) {
           isAccessBlockedLycee: false,
           isAccessBlockedAEFE: false,
           isAccessBlockedAgri: false,
-          pixCertifScoBlockedAccessDateLycee: '2022-12-12',
+          pixCertifScoBlockedAccessDateLycee: undefined,
           pixCertifScoBlockedAccessDateCollege: '2022-11-12',
         });
         certificationPointOfContact.update({
@@ -73,8 +73,7 @@ module('Acceptance | Restricted access', function (hooks) {
         const screen = await visitScreen('/espace-ferme');
 
         // then
-        assert.dom(screen.getByText('Ouverture de votre espace PixCertif')).exists();
-        assert.dom(screen.getByText('Le 12/12/2022 pour les lycées et le 12/11/2022 pour les collèges')).exists();
+        assert.dom(screen.getByText('Ouverture de votre espace PixCertif le 12/11/2022')).exists();
       });
     });
   });

--- a/certif/tests/acceptance/restricted-access_test.js
+++ b/certif/tests/acceptance/restricted-access_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Restricted access', function (hooks) {
   setupApplicationTest(hooks);
@@ -11,12 +12,10 @@ module('Acceptance | Restricted access', function (hooks) {
   module('When certificationPointOfContact is not logged in', function () {
     test('it should not be accessible by an unauthenticated certificationPointOfContact', async function (assert) {
       // when
-      await visit('/espace-ferme');
+      await visitScreen('/espace-ferme');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -46,17 +45,16 @@ module('Acceptance | Restricted access', function (hooks) {
         });
 
         // when
-        await visit('/espace-ferme');
+        await visitScreen('/espace-ferme');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/sessions/liste');
+        assert.strictEqual(currentURL(), '/sessions/liste');
       });
     });
 
-    module('when current certification center is blocked', function (hooks) {
-      hooks.beforeEach(() => {
+    module('when current certification center is blocked', function () {
+      test('it should render the espace-ferme page', async function (assert) {
+        // given
         const blockedCertificationCenterAccess = server.create('allowed-certification-center-access', {
           type: 'SCO',
           isRelatedToManagingStudentsOrganization: true,
@@ -70,15 +68,13 @@ module('Acceptance | Restricted access', function (hooks) {
         certificationPointOfContact.update({
           allowedCertificationCenterAccesses: [blockedCertificationCenterAccess],
         });
-      });
 
-      test('it should render the espace-ferme page', async function (assert) {
         // when
-        await visit('/espace-ferme');
+        const screen = await visitScreen('/espace-ferme');
 
         // then
-        assert.contains('Ouverture de votre espace PixCertif');
-        assert.contains('Le 12/12/2022 pour les lycées et le 12/11/2022 pour les collèges');
+        assert.dom(screen.getByText('Ouverture de votre espace PixCertif')).exists();
+        assert.dom(screen.getByText('Le 12/12/2022 pour les lycées et le 12/11/2022 pour les collèges')).exists();
       });
     });
   });

--- a/certif/tests/acceptance/restricted-access_test.js
+++ b/certif/tests/acceptance/restricted-access_test.js
@@ -64,6 +64,8 @@ module('Acceptance | Restricted access', function (hooks) {
           isAccessBlockedLycee: false,
           isAccessBlockedAEFE: false,
           isAccessBlockedAgri: false,
+          pixCertifScoBlockedAccessDateLycee: '2022-12-12',
+          pixCertifScoBlockedAccessDateCollege: '2022-11-12',
         });
         certificationPointOfContact.update({
           allowedCertificationCenterAccesses: [blockedCertificationCenterAccess],
@@ -76,7 +78,7 @@ module('Acceptance | Restricted access', function (hooks) {
 
         // then
         assert.contains('Ouverture de votre espace PixCertif');
-        assert.contains('Le 1er novembre pour les lycées et le 1er février pour les collèges');
+        assert.contains('Le 12/12/2022 pour les lycées et le 12/11/2022 pour les collèges');
       });
     });
   });

--- a/certif/tests/unit/controllers/restricted-access_test.js
+++ b/certif/tests/unit/controllers/restricted-access_test.js
@@ -4,33 +4,68 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | authenticated/restricted-access', function (hooks) {
   setupTest(hooks);
 
-  module('#pixCertifScoBlockedAccessDateCollege', function () {
-    test('should return a the pixCertifScoBlockedAccessDateCollege', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        pixCertifScoBlockedAccessDateCollege: '12/12/2020',
-      });
-      const controller = this.owner.lookup('controller:authenticated/restricted-access');
-      controller.model = currentAllowedCertificationCenterAccess;
+  module('#certificationOpeningDate', function () {
+    module('when isAccessBlockedCollege is true', function () {
+      test('should return a the pixCertifScoBlockedAccessDateCollege', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          isAccessBlockedCollege: true,
+          pixCertifScoBlockedAccessDateCollege: '2020-12-12',
+        });
+        const controller = this.owner.lookup('controller:authenticated/restricted-access');
+        controller.model = currentAllowedCertificationCenterAccess;
 
-      // when then
-      assert.strictEqual(controller.model.pixCertifScoBlockedAccessDateCollege, '12/12/2020');
+        // when then
+        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+      });
     });
-  });
 
-  module('#pixCertifScoBlockedAccessDateLycee', function () {
-    test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        pixCertifScoBlockedAccessDateLycee: '12/12/2020',
+    module('when isAccessBlockedLycee is true', function () {
+      test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          isAccessBlockedLycee: true,
+          pixCertifScoBlockedAccessDateLycee: '2020-12-12',
+        });
+        const controller = this.owner.lookup('controller:authenticated/restricted-access');
+        controller.model = currentAllowedCertificationCenterAccess;
+
+        // when then
+        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
       });
-      const controller = this.owner.lookup('controller:authenticated/restricted-access');
-      controller.model = currentAllowedCertificationCenterAccess;
+    });
 
-      // when then
-      assert.strictEqual(controller.model.pixCertifScoBlockedAccessDateLycee, '12/12/2020');
+    module('when isAccessBlockedAgri is true', function () {
+      test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          isAccessBlockedAgri: true,
+          pixCertifScoBlockedAccessDateLycee: '2020-12-12',
+        });
+        const controller = this.owner.lookup('controller:authenticated/restricted-access');
+        controller.model = currentAllowedCertificationCenterAccess;
+
+        // when then
+        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+      });
+    });
+    module('when isAccessBlockedAEFE is true', function () {
+      test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          isAccessBlockedAEFE: true,
+          pixCertifScoBlockedAccessDateLycee: '2020-12-12',
+        });
+        const controller = this.owner.lookup('controller:authenticated/restricted-access');
+        controller.model = currentAllowedCertificationCenterAccess;
+
+        // when then
+        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+      });
     });
   });
 });

--- a/certif/tests/unit/controllers/restricted-access_test.js
+++ b/certif/tests/unit/controllers/restricted-access_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/restricted-access', function (hooks) {
+  setupTest(hooks);
+
+  module('#pixCertifScoBlockedAccessDateCollege', function () {
+    test('should return a the pixCertifScoBlockedAccessDateCollege', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        pixCertifScoBlockedAccessDateCollege: '12/12/2020',
+      });
+      const controller = this.owner.lookup('controller:authenticated/restricted-access');
+      controller.model = currentAllowedCertificationCenterAccess;
+
+      // when then
+      assert.strictEqual(controller.model.pixCertifScoBlockedAccessDateCollege, '12/12/2020');
+    });
+  });
+
+  module('#pixCertifScoBlockedAccessDateLycee', function () {
+    test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        pixCertifScoBlockedAccessDateLycee: '12/12/2020',
+      });
+      const controller = this.owner.lookup('controller:authenticated/restricted-access');
+      controller.model = currentAllowedCertificationCenterAccess;
+
+      // when then
+      assert.strictEqual(controller.model.pixCertifScoBlockedAccessDateLycee, '12/12/2020');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La page affichée lorsqu’un utilisateur tente de rejoindre un espace fermé fait apparaître les dates de réouvertures, dates renseignées en dur dans le code actuellement.

## :robot: Solution
permettre un affichage dynamique de ces dates en fonction des dates renseignées en paramètre de la variable d’environnement

## :100: Pour tester
- Renseigner une date future dans la vairable suivante: 
      PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE=2022-09-22
      
- Se connecter à Pix-Certif avec ```certifsco```
- Constater l'affichage suivant pour les établiessements Agri, AEFE et lycée

![image](https://user-images.githubusercontent.com/37305474/173605842-a3e7dec4-48f3-49b6-b926-f67abeadd209.png)


