### PR TITLE
[FEATURE] MAJ des certificat et certificat partagé suite au renouvellement France Compétences (PIX-5091)

### DIFF
--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -24,6 +24,9 @@ const { CERTIFICATION_CHALLENGES_DATA } = require('./certification-data');
 const {
   CertificationIssueReportCategories,
 } = require('./../../../../lib/domain/models/CertificationIssueReportCategory');
+const {
+  generateCertificateVerificationCode,
+} = require('../../../../lib/domain/services/verify-certificate-code-service');
 
 const ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID = 100;
 const ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID = 101;
@@ -40,142 +43,121 @@ const CERTIFICATION_COURSE_SUCCESS_ID = 200;
 const CERTIFICATION_COURSE_FAILURE_ID = 403;
 const CERTIFICATION_COURSE_EDU_ID = 505;
 
-function certificationCoursesBuilder({ databaseBuilder }) {
+async function certificationCoursesBuilder({ databaseBuilder }) {
   // Each certification tests present the same questions
-  _.each(
-    [
-      {
-        userId: CERTIF_SUCCESS_USER_ID,
-        sessionId: TO_FINALIZE_SESSION_ID,
-        assessmentId: ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID,
-        candidateData: CANDIDATE_DATA_SUCCESS,
-        examinerComment: null,
-        hasSeenEndTestScreen: false,
-        isPublished: false,
-        verificationCode: 'ABC123',
-      },
-      {
-        userId: CERTIF_FAILURE_USER_ID,
-        sessionId: TO_FINALIZE_SESSION_ID,
-        assessmentId: ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID,
-        candidateData: CANDIDATE_DATA_FAILURE,
-        examinerComment: null,
-        hasSeenEndTestScreen: false,
-        isPublished: false,
-        verificationCode: 'DEF456',
-      },
-      {
-        userId: CERTIF_SCO_STUDENT_ID,
-        sessionId: PUBLISHED_SCO_SESSION_ID,
-        assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID,
-        candidateData: CANDIDATE_SCO_DATA_SUCCESS,
-        examinerComment: null,
-        hasSeenEndTestScreen: true,
-        isPublished: true,
-        verificationCode: 'GHI789',
-      },
-      {
-        userId: CERTIF_SUCCESS_USER_ID,
-        sessionId: NO_PROBLEM_FINALIZED_SESSION_ID,
-        assessmentId: ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_SUCCESS,
-        examinerComment: null,
-        hasSeenEndTestScreen: true,
-        isPublished: false,
-        verificationCode: 'JKL159',
-      },
-      {
-        userId: CERTIF_FAILURE_USER_ID,
-        sessionId: NO_PROBLEM_FINALIZED_SESSION_ID,
-        assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_FAILURE,
-        examinerComment: null,
-        hasSeenEndTestScreen: true,
-        isPublished: false,
-        verificationCode: 'MNO753',
-      },
-      {
-        userId: CERTIF_SUCCESS_USER_ID,
-        sessionId: PROBLEMS_FINALIZED_SESSION_ID,
-        assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_SUCCESS,
-        examinerComment: 'A regardé son téléphone pendant le test',
-        hasSeenEndTestScreen: true,
-        isPublished: false,
-        verificationCode: 'PQR741',
-      },
-      {
-        userId: CERTIF_FAILURE_USER_ID,
-        sessionId: PROBLEMS_FINALIZED_SESSION_ID,
-        assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_FAILURE,
-        examinerComment: 'Son ordinateur a explosé',
-        hasSeenEndTestScreen: false,
-        isPublished: false,
-        verificationCode: 'STU852',
-      },
-      {
-        userId: CERTIF_REGULAR_USER5_ID,
-        sessionId: PROBLEMS_FINALIZED_SESSION_ID,
-        assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_STARTED,
-        examinerComment: 'Elle a pas fini sa certif',
-        hasSeenEndTestScreen: false,
-        isPublished: false,
-        verificationCode: 'VWX963',
-      },
-      {
-        id: CERTIFICATION_COURSE_SUCCESS_ID,
-        userId: CERTIF_SUCCESS_USER_ID,
-        sessionId: PUBLISHED_SESSION_ID,
-        assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_SUCCESS,
-        hasSeenEndTestScreen: true,
-        isPublished: true,
-        verificationCode: 'YZA147',
-      },
-      {
-        id: CERTIFICATION_COURSE_FAILURE_ID,
-        userId: CERTIF_FAILURE_USER_ID,
-        sessionId: PUBLISHED_SESSION_ID,
-        assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_FAILURE,
-        hasSeenEndTestScreen: true,
-        isPublished: true,
-        verificationCode: 'BCD258',
-      },
-      {
-        id: CERTIFICATION_COURSE_EDU_ID,
-        userId: CERTIF_EDU_FORMATION_INITIALE_1ER_DEGRE_USER_ID,
-        sessionId: PUBLISHED_SESSION_ID,
-        assessmentId: ASSESSMENT_EDU_PUBLISHED_SESSION_ID,
-        candidateData: CANDIDATE_DATA_EDU,
-        hasSeenEndTestScreen: true,
-        isPublished: true,
-        verificationCode: 'BCD259',
-      },
-    ],
-    (certificationCourseData) => {
-      _buildCertificationCourse(databaseBuilder, certificationCourseData);
+  const certificationInformations = [
+    {
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: TO_FINALIZE_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      examinerComment: null,
+      hasSeenEndTestScreen: false,
+      isPublished: false,
     },
-  );
+    {
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: TO_FINALIZE_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      examinerComment: null,
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+    },
+    {
+      userId: CERTIF_SCO_STUDENT_ID,
+      sessionId: PUBLISHED_SCO_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_SCO_ID,
+      candidateData: CANDIDATE_SCO_DATA_SUCCESS,
+      examinerComment: null,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+    },
+    {
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: NO_PROBLEM_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      examinerComment: null,
+      hasSeenEndTestScreen: true,
+      isPublished: false,
+    },
+    {
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: NO_PROBLEM_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      examinerComment: null,
+      hasSeenEndTestScreen: true,
+      isPublished: false,
+    },
+    {
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: PROBLEMS_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      examinerComment: 'A regardé son téléphone pendant le test',
+      hasSeenEndTestScreen: true,
+      isPublished: false,
+    },
+    {
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: PROBLEMS_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      examinerComment: 'Son ordinateur a explosé',
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+    },
+    {
+      userId: CERTIF_REGULAR_USER5_ID,
+      sessionId: PROBLEMS_FINALIZED_SESSION_ID,
+      assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_STARTED,
+      examinerComment: 'Elle a pas fini sa certif',
+      hasSeenEndTestScreen: false,
+      isPublished: false,
+    },
+    {
+      id: CERTIFICATION_COURSE_SUCCESS_ID,
+      userId: CERTIF_SUCCESS_USER_ID,
+      sessionId: PUBLISHED_SESSION_ID,
+      assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_SUCCESS,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+    },
+    {
+      id: CERTIFICATION_COURSE_FAILURE_ID,
+      userId: CERTIF_FAILURE_USER_ID,
+      sessionId: PUBLISHED_SESSION_ID,
+      assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_FAILURE,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+    },
+    {
+      id: CERTIFICATION_COURSE_EDU_ID,
+      userId: CERTIF_EDU_FORMATION_INITIALE_1ER_DEGRE_USER_ID,
+      sessionId: PUBLISHED_SESSION_ID,
+      assessmentId: ASSESSMENT_EDU_PUBLISHED_SESSION_ID,
+      candidateData: CANDIDATE_DATA_EDU,
+      hasSeenEndTestScreen: true,
+      isPublished: true,
+    },
+  ];
+
+  for (const certificationInformation of certificationInformations) {
+    await _buildCertificationCourse(databaseBuilder, certificationInformation);
+  }
 }
 
-function _buildCertificationCourse(
+async function _buildCertificationCourse(
   databaseBuilder,
-  {
-    id,
-    assessmentId,
-    userId,
-    sessionId,
-    candidateData,
-    examinerComment,
-    hasSeenEndTestScreen,
-    isPublished,
-    verificationCode,
-  },
+  { id, assessmentId, userId, sessionId, candidateData, examinerComment, hasSeenEndTestScreen, isPublished },
 ) {
   const createdAt = new Date('2020-01-31T00:00:00Z');
+  const verificationCode = await generateCertificateVerificationCode();
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     ...candidateData,
     id,

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -70,7 +70,7 @@ exports.seed = async (knex) => {
   await certificationUserProfilesBuilder({ databaseBuilder });
   certificationSessionsBuilder({ databaseBuilder });
   certificationCandidatesBuilder({ databaseBuilder });
-  certificationCoursesBuilder({ databaseBuilder });
+  await certificationCoursesBuilder({ databaseBuilder });
   certificationScoresBuilder({ databaseBuilder });
   badgeAcquisitionBuilder({ databaseBuilder });
   complementaryCertificationCourseResultsBuilder({ databaseBuilder });

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -29,6 +29,11 @@
 
       <p>{{t "pages.certificate.exam-date"}} {{moment-format @certification.date "D MMMM YYYY"}}</p>
 
+      {{#if @certification.shouldDisplayProfessionalizingWarning}}
+        <p class="user-certifications-detail-header__info-certificate--professionalizing-warning">
+          {{t "pages.certificate.professionalizing-warning"}}</p>
+      {{/if}}
+
     </div>
   </div>
   {{#if @certification.verificationCode}}

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -9,9 +9,6 @@
         {{t "pages.certificate.issued-on"}}
         {{moment-format @certification.deliveredAt "D MMMM YYYY"}}
       </p>
-      <p class="user-certifications-detail-header__info-certificate--grey">
-        {{t "pages.certificate.validity"}}
-      </p>
 
       <p>{{@certification.fullName}}</p>
       <p>

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -1,11 +1,16 @@
 /* eslint ember/no-computed-properties-in-native-classes: 0 */
 
 import Model, { belongsTo, attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 
 export const ACQUIRED = 'acquired';
 
+const professionalizingDate = new Date('2022-01-01');
+
 export default class Certification extends Model {
+  @service url;
+
   static PARTNER_KEY_CLEA = 'PIX_EMPLOI_CLEA';
   // attributes
   @attr('string') firstName;
@@ -41,6 +46,10 @@ export default class Certification extends Model {
   @computed('firstName', 'lastName')
   get fullName() {
     return this.firstName + ' ' + this.lastName;
+  }
+
+  get shouldDisplayProfessionalizingWarning() {
+    return this.url.isFrenchDomainExtension && new Date(this.deliveredAt).getTime() >= professionalizingDate.getTime();
   }
 
   get maxReachablePixCountOnCertificationDate() {

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -39,6 +39,13 @@
         margin-bottom: 10px;
       }
     }
+
+    &--professionalizing-warning {
+      padding-top: 12px;
+      color: $grey-45;
+      font-size: 0.875rem;
+      line-height: 23px;
+    }
   }
 
   @include device-is('mobile') {

--- a/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
@@ -2,18 +2,20 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
-import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import Service from '@ember/service';
 
 describe('Integration | Component | user certifications detail header', function () {
   setupIntlRenderingTest();
 
-  let certification, screen;
-
   context('when certification is complete', function () {
+    let certification, screen;
+    let store;
+
     beforeEach(async function () {
       // given
-      certification = EmberObject.create({
+      store = this.owner.lookup('service:store');
+      certification = store.createRecord('certification', {
         id: 1,
         birthdate: '2000-01-22',
         birthplace: 'Paris',
@@ -62,7 +64,8 @@ describe('Integration | Component | user certifications detail header', function
   context('when certification is not complete', function () {
     it('should not render the user-certifications-detail-header component', async function () {
       // given
-      certification = EmberObject.create({
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
         id: 1,
         birthdate: '2000-01-22',
         birthplace: null,
@@ -82,6 +85,122 @@ describe('Integration | Component | user certifications detail header', function
 
       // then
       expect(screen.queryByText('Né(e) le 22 janvier 2000 à Paris')).to.not.exist;
+    });
+  });
+
+  context('when domain is french', function () {
+    beforeEach(function () {
+      class UrlServiceStub extends Service {
+        get isFrenchDomainExtension() {
+          return true;
+        }
+      }
+      this.owner.register('service:url', UrlServiceStub);
+    });
+
+    context('when certification is delivered after 2022-01-01', function () {
+      it('should display the professionalizing warning', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          id: 1,
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'jean',
+          lastName: 'bon',
+          fullName: 'Jean Bon',
+          date: new Date('2018-02-15T15:15:52Z'),
+          deliveredAt: '2022-05-28',
+          certificationCenter: 'Université de Lyon',
+          isPublished: true,
+          pixScore: 654,
+          status: 'validated',
+          commentForCandidate: 'Comment for candidate',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+
+        // then
+        expect(
+          screen.getByText(
+            'Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix'
+          )
+        ).to.exist;
+      });
+    });
+
+    context('when certification is delivered before 2022-01-01', function () {
+      it('should not display the professionalizing warning', async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certification = store.createRecord('certification', {
+          id: 1,
+          birthdate: '2000-01-22',
+          birthplace: 'Paris',
+          firstName: 'jean',
+          lastName: 'bon',
+          fullName: 'Jean Bon',
+          date: new Date('2018-02-15T15:15:52Z'),
+          deliveredAt: '2021-05-28',
+          certificationCenter: 'Université de Lyon',
+          isPublished: true,
+          pixScore: 654,
+          status: 'validated',
+          commentForCandidate: 'Comment for candidate',
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+
+        // then
+        expect(
+          screen.queryByText(
+            'Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix'
+          )
+        ).to.not.exist;
+      });
+    });
+  });
+
+  context('when domain is not french', function () {
+    it('should not display the professionalizing warning', async function () {
+      // given
+      class UrlServiceStub extends Service {
+        get isFrenchDomainExtension() {
+          return false;
+        }
+      }
+      this.owner.register('service:url', UrlServiceStub);
+      const store = this.owner.lookup('service:store');
+      const certification = store.createRecord('certification', {
+        id: 1,
+        birthdate: '2000-01-22',
+        birthplace: 'Paris',
+        firstName: 'jean',
+        lastName: 'bon',
+        fullName: 'Jean Bon',
+        date: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: '2022-05-28',
+        certificationCenter: 'Université de Lyon',
+        isPublished: true,
+        pixScore: 654,
+        status: 'validated',
+        commentForCandidate: 'Comment for candidate',
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+
+      // then
+      expect(
+        screen.queryByText(
+          'Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix'
+        )
+      ).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { find, render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -8,9 +8,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 describe('Integration | Component | user certifications detail header', function () {
   setupIntlRenderingTest();
 
-  let certification;
-  const PARENT_SELECTOR = '.user-certifications-detail-header';
-  const CONTENT_SELECTOR = `${PARENT_SELECTOR}__info-certificate`;
+  let certification, screen;
 
   context('when certification is complete', function () {
     beforeEach(async function () {
@@ -33,49 +31,40 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      await render(hbs`{{user-certifications-detail-header certification=certification}}`);
-    });
-
-    it('renders', async function () {
-      expect(find(PARENT_SELECTOR)).to.exist;
+      screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
     });
 
     it('should show the certification published date', function () {
-      expect(find(CONTENT_SELECTOR)).to.exist;
-      expect(find(`${CONTENT_SELECTOR} :nth-child(2)`).innerText).to.include('Délivré le 17 février 2018');
+      expect(screen.getByText('Délivré le 17 février 2018')).to.exist;
     });
 
     it('should show the certification exam date', function () {
-      expect(find(`${CONTENT_SELECTOR} :nth-child(7)`).textContent).to.include('Date de passage : 15 février 2018');
+      expect(screen.getByText('Date de passage : 15 février 2018')).to.exist;
     });
 
     it('should show the certification user full name', function () {
-      expect(find(`${CONTENT_SELECTOR} :nth-child(4)`).textContent).to.include('Jean Bon');
+      expect(screen.getByText('Jean Bon')).to.exist;
     });
 
     it('should show the certification user birthdate and birthplace', function () {
-      expect(find(`${CONTENT_SELECTOR} :nth-child(5)`).textContent).to.include('Né(e) le 22 janvier 2000 à Paris');
+      expect(screen.getByText('Né(e) le 22 janvier 2000 à Paris')).to.exist;
     });
 
     it('should show the certification center', function () {
-      expect(find(`${CONTENT_SELECTOR} :nth-child(6)`).textContent).to.include(
-        'Centre de certification : Université de Lyon'
-      );
+      expect(screen.getByText('Centre de certification : Université de Lyon')).to.exist;
     });
 
     it('should show the pix score', function () {
-      const scoreHexagon = find(`${PARENT_SELECTOR} .user-certification-hexagon-score__content-pix-score`);
-      expect(scoreHexagon).to.exist;
-      expect(scoreHexagon.textContent).to.include('654');
+      expect(screen.getByText('654')).to.exist;
     });
   });
 
   context('when certification is not complete', function () {
-    beforeEach(async function () {
+    it('should not render the user-certifications-detail-header component', async function () {
       // given
       certification = EmberObject.create({
         id: 1,
-        birthdate: null,
+        birthdate: '2000-01-22',
         birthplace: null,
         firstName: null,
         lastName: null,
@@ -89,12 +78,10 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      await render(hbs`{{user-certifications-detail-header certification=certification}}`);
-    });
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
 
-    // then
-    it('should not render the user-certifications-detail-header component', function () {
-      expect(find(PARENT_SELECTOR)).to.not.exist;
+      // then
+      expect(screen.queryByText('Né(e) le 22 janvier 2000 à Paris')).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/unit/models/certification_test.js
+++ b/mon-pix/tests/unit/models/certification_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import { ACQUIRED } from 'mon-pix/models/certification';
+import Service from '@ember/service';
 
 describe('Unit | Model | certification', function () {
   setupTest();
@@ -35,6 +36,53 @@ describe('Unit | Model | certification', function () {
     it('should be false when certification has no certified badge image', function () {
       const model = store.createRecord('certification', { certifiedBadgeImages: [] });
       expect(model.hasAcquiredComplementaryCertifications).to.be.false;
+    });
+  });
+
+  describe('#shouldDisplayProfessionalizingWarning', function () {
+    context('when domain is french', function () {
+      beforeEach(function () {
+        class UrlServiceStub extends Service {
+          get isFrenchDomainExtension() {
+            return true;
+          }
+        }
+
+        this.owner.register('service:url', UrlServiceStub);
+      });
+
+      it('should be true when deliveredAt >= 2022-01-01 ', function () {
+        // given
+        const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
+
+        // when / then
+        expect(model.shouldDisplayProfessionalizingWarning).to.be.true;
+      });
+
+      it('should be false when when deliveredAt < 2022-01-01', function () {
+        // given
+        const model = store.createRecord('certification', { deliveredAt: '2021-01-01' });
+
+        // when / then
+        expect(model.shouldDisplayProfessionalizingWarning).to.be.false;
+      });
+    });
+
+    context('when domain is not french', function () {
+      it('should be false', function () {
+        // given
+        class UrlServiceStub extends Service {
+          get isFrenchDomainExtension() {
+            return false;
+          }
+        }
+
+        this.owner.register('service:url', UrlServiceStub);
+        const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
+
+        // when / then
+        expect(model.shouldDisplayProfessionalizingWarning).to.be.false;
+      });
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -226,7 +226,6 @@
       "jury-info": "Notes from the examining body are not displayed on the verification page of your certificate.",
       "jury-title": "Notes from the examining body",
       "temporary-badge-info": "--- \"{level}\" ---",
-      "validity": "Certificate valid for 3 years",
       "verification-code": {
         "title": "Verification code",
         "alt": "Copy",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -226,6 +226,7 @@
       "jury-info": "Notes from the examining body are not displayed on the verification page of your certificate.",
       "jury-title": "Notes from the examining body",
       "temporary-badge-info": "--- \"{level}\" ---",
+      "professionalizing-warning": "The Pix certificate is recognised as professionalising by France Compétences upon reaching a minimum score of 120 pix.",  
       "verification-code": {
         "title": "Verification code",
         "alt": "Copy",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -226,7 +226,8 @@
       "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
       "jury-title": "Observations du jury",
       "temporary-badge-info": "Vous avez obtenu le niveau \"{level}\" dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2",
-      "verification-code": {
+      "professionalizing-warning": "Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix",  
+        "verification-code": {
         "title": "Code de vérification",
         "alt": "Copier",
         "copied": "Code copié !",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -226,7 +226,6 @@
       "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
       "jury-title": "Observations du jury",
       "temporary-badge-info": "Vous avez obtenu le niveau \"{level}\" dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2",
-      "validity": "Certificat valable 3 ans",
       "verification-code": {
         "title": "Code de vérification",
         "alt": "Copier",


### PR DESCRIPTION
## :unicorn: Problème
Le renouvellement de l’inscription de la certification Pix au “Répertoire Spécifique” France Compétences implique quelques modifications produit, dont principalement : 

- un seuil de 120pix minimum pour donner à la certification une valeur professionnalisante

-  la suppression de la durée de validité de 3 ans pour le certificat

## :robot: Solution
Sur TOUS les certificats et certificats partagés Pix, anciens comme nouveaux : 

- supprimer la mention “Certificat valable 3 ans”

- UNIQUEMENT pour les certificats/certificats partagés générés A PARTIR du 01/01/2022 : 

  - afficher la mention suivante : “Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix”

## :100: Pour tester
- Constater que la mention de validité pour 3 ans a disparu de tous les certificats
- Vérifier que sur les anciens certificats (antérieur au 01/01/2022), la mention de professionalisation est absente
- Passer une certifiction avec succès et constater que la mention de professionalisation est affichée sur le certificate privé est le certificat partagé

![image](https://user-images.githubusercontent.com/37305474/173534338-9c1257f5-e882-4ded-8417-6ffd5bac638f.png)

