### PR TITLE
[FEATURE] Afficher les infos complémentaires de la session dans PixAdmin (PIX-4952)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -44,6 +44,8 @@ export default class Session extends Model {
   @attr() publishedAt;
   @attr() juryComment;
   @attr() juryCommentedAt;
+  @attr('boolean') hasIncident;
+  @attr('boolean') hasJoiningIssue;
   @attr('boolean') hasSupervisorAccess;
 
   @hasMany('jury-certification-summary') juryCertificationSummaries;
@@ -58,6 +60,10 @@ export default class Session extends Model {
   @computed('examinerGlobalComment')
   get hasExaminerGlobalComment() {
     return !isEmpty(trim(this.examinerGlobalComment));
+  }
+
+  get hasComplementaryInfo() {
+    return Boolean(this.hasIncident || this.hasJoiningIssue);
   }
 
   @computed('juryCertificationSummaries.@each.isPublished')

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -18,6 +18,7 @@
 
   &__list-item {
     display: flex;
+    border-bottom: 1px solid $grey-10;
 
     span {
       width: 50%;

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -97,6 +97,19 @@
             data-test-id="session-info__number-of-started-or-error-certifications"
           >{{this.sessionModel.countStartedAndInErrorCertifications}}</span>
         </li>
+        {{#if this.sessionModel.hasComplementaryInfo}}
+          <li class="session-info__list-item">
+            <span>Informations complémentaires :</span>
+            {{#if this.sessionModel.hasIncident}}
+              <span>Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de
+                certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats.</span>
+            {{/if}}
+            {{#if this.sessionModel.hasJoiningIssue}}
+              <span>Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre
+                la session.</span>
+            {{/if}}
+          </li>
+        {{/if}}
         {{#if this.sessionModel.hasExaminerGlobalComment}}
           <li class="session-info__list-item">
             <span>Commentaire global :</span>

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -35,6 +35,43 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
       assert.strictEqual(currentURL(), '/sessions/1');
     });
 
+    module('When session is finalized', function () {
+      module('When session has a global comment', function () {
+        test('it should display the global comment section', async function (assert) {
+          // given
+          server.create('session', {
+            id: '3',
+            finalizedAt: new Date(),
+            examinerGlobalComment: 'Vraiment, super session!',
+          });
+
+          // when
+          const screen = await visit('/sessions/3');
+
+          // then
+          assert.dom(screen.getByText('Commentaire global :')).exists();
+          assert.dom(screen.getByText('Vraiment, super session!')).exists();
+        });
+      });
+
+      module('When session has no global comment', function () {
+        test('it should not display the global comment section', async function (assert) {
+          // given
+          server.create('session', {
+            id: '3',
+            finalizedAt: new Date(),
+            examinerGlobalComment: '',
+          });
+
+          // when
+          const screen = await visit('/sessions/3');
+
+          // then
+          assert.dom(screen.queryByText('Commentaire global :')).doesNotExist();
+        });
+      });
+    });
+
     module('When session has a jury comment', function () {
       test('it should display a jury comment for session', async function (assert) {
         // given

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -70,6 +70,90 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
           assert.dom(screen.queryByText('Commentaire global :')).doesNotExist();
         });
       });
+
+      module('When session has complementary information', function () {
+        test('it should display the complementary information section', async function (assert) {
+          // given
+          server.create('session', {
+            id: '3',
+            finalizedAt: new Date(),
+            hasIncident: true,
+            hasJoiningIssue: true,
+          });
+
+          // when
+          const screen = await visit('/sessions/3');
+
+          // then
+          assert.dom(screen.getByText('Informations complémentaires :')).exists();
+        });
+
+        module('When session has a sessionJoiningIssue', function () {
+          test('it should display the incident text', async function (assert) {
+            // given
+            server.create('session', {
+              id: '3',
+              finalizedAt: new Date(),
+              hasIncident: false,
+              hasJoiningIssue: true,
+            });
+
+            // when
+            const screen = await visit('/sessions/3');
+
+            // then
+            assert
+              .dom(
+                screen.getByText(
+                  "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session."
+                )
+              )
+              .exists();
+          });
+        });
+
+        module('When session has incident', function () {
+          test('it should display the incident text', async function (assert) {
+            // given
+            server.create('session', {
+              id: '3',
+              finalizedAt: new Date(),
+              hasIncident: true,
+              hasJoiningIssue: false,
+            });
+
+            // when
+            const screen = await visit('/sessions/3');
+
+            // then
+            assert
+              .dom(
+                screen.getByText(
+                  'Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats.'
+                )
+              )
+              .exists();
+          });
+        });
+      });
+
+      module('When session has no complementary information', function () {
+        test('it should not display the complementary information section', async function (assert) {
+          // given
+          server.create('session', {
+            id: '3',
+            finalizedAt: new Date(),
+            hasIncident: false,
+            hasJoiningIssue: false,
+          });
+
+          // when
+          const screen = await visit('/sessions/3');
+
+          // then
+          assert.dom(screen.queryByText('Informations complémentaires :')).doesNotExist();
+        });
+      });
     });
 
     module('When session has a jury comment', function () {

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -85,6 +85,49 @@ module('Unit | Model | session', function (hooks) {
     });
   });
 
+  module('#hasComplementaryInfo', function () {
+    module('when hasIncident is false', function () {
+      test('it should return false', function (assert) {
+        // given
+        const session = store.createRecord('session', {
+          hasIncident: false,
+        });
+
+        // when
+        const hasComplementaryInfo = session.hasComplementaryInfo;
+
+        // then
+        assert.false(hasComplementaryInfo);
+      });
+    });
+
+    module('when hasJoiningIssue is false', function () {
+      test('it should also return false', function (assert) {
+        // given
+        const session = store.createRecord('session', { hasJoiningIssue: false });
+
+        // when
+        const hasComplementaryInfo = session.hasComplementaryInfo;
+
+        // then
+        assert.false(hasComplementaryInfo);
+      });
+    });
+
+    module('when hasIncident & hasJoiningIssue are true', function () {
+      test('it should return true', function (assert) {
+        // given
+        const session = store.createRecord('session', { hasJoiningIssue: true, hasIncident: true });
+
+        // when
+        const hasComplementaryInfo = session.hasComplementaryInfo;
+
+        // then
+        assert.true(hasComplementaryInfo);
+      });
+    });
+  });
+
   module('#isPublished', function () {
     module('when there is no certification', function () {
       let sessionWithoutCertifications;

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -199,7 +199,7 @@ exports.register = async (server) => {
           payload: Joi.object({
             data: {
               attributes: {
-                'examiner-global-comment': Joi.string().optional().allow('').max(500),
+                'examiner-global-comment': Joi.string().optional().allow(null).allow('').max(500),
                 'has-incident': Joi.boolean().required(),
                 'has-joining-issue': Joi.boolean().required(),
               },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -272,6 +272,8 @@ module.exports = (function () {
     config.features.dayBeforeCompetenceResetV2 = 7;
     config.features.garAccessV2 = false;
     config.features.numberOfChallengesForFlashMethod = 10;
+    config.features.pixCertifScoBlockedAccessDateLycee = null;
+    config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/domain/models/JurySession.js
+++ b/api/lib/domain/models/JurySession.js
@@ -22,6 +22,8 @@ class JurySession {
     juryComment,
     juryCommentedAt,
     juryCommentAuthor,
+    hasIncident,
+    hasJoiningIssue,
   } = {}) {
     this.id = id;
     this.certificationCenterName = certificationCenterName;
@@ -43,6 +45,8 @@ class JurySession {
     this.juryComment = juryComment;
     this.juryCommentedAt = juryCommentedAt;
     this.juryCommentAuthor = juryCommentAuthor;
+    this.hasIncident = hasIncident;
+    this.hasJoiningIssue = hasJoiningIssue;
   }
 
   get status() {

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -29,6 +29,8 @@ module.exports = {
         'juryCommentAuthorId',
         'juryCommentedAt',
         'hasSupervisorAccess',
+        'hasJoiningIssue',
+        'hasIncident',
         // included
         'assignedCertificationOfficer',
         'juryCommentAuthor',

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -18,24 +18,29 @@ describe('Acceptance | Controller | session-controller-get-jury-session', functi
     let expectedJurySession;
     let certificationCenter;
 
-    beforeEach(function () {
+    beforeEach(async function () {
       const assignedCertificationOfficerId = databaseBuilder.factory.buildUser({
+        id: 100002,
         firstName: 'Pix',
         lastName: 'Doe',
       }).id;
-      certificationCenter = databaseBuilder.factory.buildCertificationCenter({ type: 'SCO', externalId: 'EXT_ID' });
+      certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        id: 100003,
+        type: 'SCO',
+        externalId: 'EXT_ID',
+      });
       expectedJurySession = databaseBuilder.factory.buildSession({
+        id: 100004,
         assignedCertificationOfficerId,
         certificationCenterId: certificationCenter.id,
         certificationCenter: certificationCenter.name,
       });
       databaseBuilder.factory.buildSupervisorAccess({ sessionId: expectedJurySession.id });
-      databaseBuilder.factory.buildSession();
+      databaseBuilder.factory.buildSession({ id: 1000099 });
       options = {
         method: 'GET',
         url: `/api/admin/sessions/${expectedJurySession.id}`,
       };
-
       return databaseBuilder.commit();
     });
 

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -50,36 +50,43 @@ describe('Acceptance | Controller | session-controller-get-jury-session', functi
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data.type).to.equal('sessions');
-        expect(parseInt(response.result.data.id)).to.equal(expectedJurySession.id);
-        expect(response.result.data.attributes['certification-center-name']).to.equal(
-          expectedJurySession.certificationCenter
-        );
-        expect(response.result.data.attributes['certification-center-type']).to.equal('SCO');
-        expect(response.result.data.attributes['certification-center-external-id']).to.equal(
-          certificationCenter.externalId
-        );
-        expect(response.result.data.attributes['address']).to.equal(expectedJurySession.address);
-        expect(response.result.data.attributes['room']).to.equal(expectedJurySession.room);
-        expect(response.result.data.attributes['examiner']).to.equal(expectedJurySession.examiner);
-        expect(response.result.data.attributes['date']).to.equal(expectedJurySession.date);
-        expect(response.result.data.attributes['time']).to.equal(expectedJurySession.time);
-        expect(response.result.data.attributes['access-code']).to.equal(expectedJurySession.accessCode);
-        expect(response.result.data.attributes['description']).to.equal(expectedJurySession.description);
-        expect(response.result.data.attributes['examiner-global-comment']).to.equal(
-          expectedJurySession.examinerGlobalComment
-        );
-        expect(response.result.data.attributes['finalized-at']).to.equal(expectedJurySession.finalizedAt);
-        expect(response.result.data.attributes['results-sent-to-prescriber-at']).to.equal(
-          expectedJurySession.resultsSentToPrescriberAt
-        );
-        expect(response.result.data.attributes['published-at']).to.equal(expectedJurySession.publishedAt);
-        expect(response.result.data.attributes['has-supervisor-access']).to.be.true;
-        expect(response.result.data.attributes['has-incident']).to.equal(false);
-        expect(response.result.data.attributes['has-joining-issue']).to.equal(false);
-        expect(parseInt(response.result.included[0].id)).to.equal(expectedJurySession.assignedCertificationOfficerId);
-        expect(response.result.included[0].attributes['first-name']).to.equal('Pix');
-        expect(response.result.included[0].attributes['last-name']).to.equal('Doe');
+        expect(response.result).to.deep.equal({
+          included: [{ type: 'user', id: '100002', attributes: { 'first-name': 'Pix', 'last-name': 'Doe' } }],
+          data: {
+            type: 'sessions',
+            id: '100004',
+            attributes: {
+              'certification-center-name': 'some name',
+              'certification-center-type': 'SCO',
+              'certification-center-id': 100003,
+              'certification-center-external-id': 'EXT_ID',
+              address: '3 rue des églantines',
+              room: 'B315',
+              examiner: 'Ginette',
+              date: '2020-01-15',
+              time: '15:30:00',
+              'access-code': 'FMKP39',
+              status: 'in_process',
+              description: 'La session se déroule dans le jardin',
+              'examiner-global-comment': '',
+              'finalized-at': null,
+              'results-sent-to-prescriber-at': null,
+              'published-at': null,
+              'jury-comment': null,
+              'jury-commented-at': null,
+              'has-supervisor-access': true,
+              'has-joining-issue': false,
+              'has-incident': false,
+            },
+            relationships: {
+              'assigned-certification-officer': { data: { type: 'user', id: '100002' } },
+              'jury-comment-author': { data: null },
+              'jury-certification-summaries': {
+                links: { related: '/api/admin/sessions/100004/jury-certification-summaries' },
+              },
+            },
+          },
+        });
       });
     });
 

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -75,6 +75,8 @@ describe('Acceptance | Controller | session-controller-get-jury-session', functi
         );
         expect(response.result.data.attributes['published-at']).to.equal(expectedJurySession.publishedAt);
         expect(response.result.data.attributes['has-supervisor-access']).to.be.true;
+        expect(response.result.data.attributes['has-incident']).to.equal(false);
+        expect(response.result.data.attributes['has-joining-issue']).to.equal(false);
         expect(parseInt(response.result.included[0].id)).to.equal(expectedJurySession.assignedCertificationOfficerId);
         expect(response.result.included[0].attributes['first-name']).to.equal('Pix');
         expect(response.result.included[0].attributes['last-name']).to.equal('Doe');

--- a/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/jury-session-repository_test.js
@@ -31,6 +31,8 @@ describe('Integration | Repository | JurySession', function () {
           juryComment: 'Les mecs ils font des sessions de certif dans le jardin ??',
           juryCommentAuthorId: juryCommentAuthor.id,
           juryCommentedAt: new Date('2020-02-28T14:30:25Z'),
+          hasIncident: true,
+          hasJoiningIssue: true,
         }).id;
 
         return databaseBuilder.commit();
@@ -52,6 +54,8 @@ describe('Integration | Repository | JurySession', function () {
           accessCode: 'GHKM26',
           description: 'La session se déroule dans le jardin',
           examinerGlobalComment: '',
+          hasIncident: true,
+          hasJoiningIssue: true,
           finalizedAt: null,
           resultsSentToPrescriberAt: null,
           publishedAt: null,

--- a/api/tests/tooling/domain-builder/factory/build-jury-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-session.js
@@ -23,6 +23,8 @@ const buildJurySession = function ({
   juryComment = null,
   juryCommentedAt = null,
   juryCommentAuthor = null,
+  hasIncident = false,
+  hasJoiningIssue = false,
 } = {}) {
   if (_.isUndefined(certificationCenterId)) {
     const certificationCenter = domainBuilder.buildCertificationCenter();
@@ -53,6 +55,8 @@ const buildJurySession = function ({
     juryComment,
     juryCommentedAt,
     juryCommentAuthor,
+    hasIncident,
+    hasJoiningIssue,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -45,6 +45,8 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
           examinerGlobalComment: 'someComment',
           finalizedAt: new Date('2020-02-17T14:23:56Z'),
           assignedCertificationOfficer,
+          hasJoiningIssue: true,
+          hasIncident: true,
         });
 
         // when
@@ -74,6 +76,8 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'results-sent-to-prescriber-at': null,
               'jury-comment': null,
               'jury-commented-at': null,
+              'has-incident': true,
+              'has-joining-issue': true,
             },
             relationships: {
               'jury-certification-summaries': {
@@ -156,6 +160,8 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'published-at': null,
               'jury-comment': 'Si on n’avait pas perdu une heure et quart, on serait là depuis une heure et quart.',
               'jury-commented-at': new Date('2021-02-21T14:23:56Z'),
+              'has-incident': false,
+              'has-joining-issue': false,
             },
             relationships: {
               'jury-certification-summaries': {
@@ -234,6 +240,9 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'jury-comment': null,
               'jury-commented-at': null,
               'has-supervisor-access': true,
+
+              'has-incident': false,
+              'has-joining-issue': false,
             },
             relationships: {
               'jury-certification-summaries': {
@@ -303,6 +312,8 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function () {
               'published-at': new Date('2020-02-21T14:23:56Z'),
               'jury-comment': null,
               'jury-commented-at': null,
+              'has-incident': false,
+              'has-joining-issue': false,
             },
             relationships: {
               'jury-certification-summaries': {


### PR DESCRIPTION
## :unicorn: Problème
La section “Commentaire global” sur la page de finalisation d’une session va être remplacée par une section “Informations complémentaires”. Il faut, en cas de besoin, que le pôle certif puisse voir depuis Pix Admin les infos complémentaires sélectionnées le cas échéant.

## :robot: Solution
Dans Pix Admin > Page de détails d’une session > afficher un champ “Informations complémentaires” et afficher la/les options sélectionnée(s) lors de la finalisation de session : 
- à afficher à la place du champ actuel “Commentaire global” 
- ne PAS afficher ce champ si aucune option a été sélectionnée

## :rainbow: Remarques
On garde les 2 affichages, cela permettra d'afficher les commentaires globaux pour les "anciennes" sessions et d'avoir les nouveaux champs pour les plus récentes.

La sauvegarde des champs se fait dans PIX-4951
Cette PR fix un bug introduit par PIX-4951 qui ne empêche de finaliser une session



## :100: Pour tester
Sur le detail d'un session avec commentaire global:
s'assurer que le commentaire s'affiche correctement (pas de régression)
Sur le detail d'un session sans commentaire global (FT activé) avec les cases cochés:
s'assurer que les informations complémentaire s'affichent correctement
