### PR TITLE
[TECH] Supprimer des exemples de configuration de debug front

### DIFF
--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -93,11 +93,6 @@ module.exports = function (environment) {
   };
 
   if (environment === 'development') {
-    // ENV.APP.LOG_RESOLVER = true;
-    // ENV.APP.LOG_ACTIVE_GENERATION = true;
-    // ENV.APP.LOG_TRANSITIONS = true;
-    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    // ENV.APP.LOG_VIEW_LOOKUPS = true;
     if (analyticsEnabled) {
       ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
@@ -119,8 +114,6 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
-    // here you can enable a production-specific feature
-    //ENV.APP.API_HOST = 'https://pix.fr/api';
     if (analyticsEnabled) {
       ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
     }


### PR DESCRIPTION
## :unicorn: Problème
La configuration de PixCertif comporte des [exemples de debug](https://guides.emberjs.com/release/configuring-ember/debugging/) qui ne sont pas utilisés par les développeurs.
Elle ne sont peut-être plus à jour.

## :robot: Solution
Les supprimer

## :rainbow: Remarques
Si besoin, on peut mettre le lien dans le code

## :100: Pour tester
Vérifier que la CI passe
