### PR TITLE
[TECH] Créer un nouvelle méthode pour le scénario de changement de mot de passe sur Pix App (PIX-4977).

### DIFF
--- a/api/lib/application/passwords/index.js
+++ b/api/lib/application/passwords/index.js
@@ -48,7 +48,7 @@ exports.register = async function (server) {
             data: {
               attributes: {
                 username: Joi.string().required(),
-                expiredPassword: Joi.string().required(),
+                oneTimePassword: Joi.string().required(),
                 newPassword: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
               },
               type: Joi.string(),

--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -26,8 +26,8 @@ module.exports = {
   },
 
   async updateExpiredPassword(request, h) {
-    const { username, expiredPassword, newPassword } = request.payload.data.attributes;
-    await usecases.updateExpiredPassword({ username, expiredPassword, newPassword });
+    const { username, oneTimePassword, newPassword } = request.payload.data.attributes;
+    await usecases.updateExpiredPassword({ username, oneTimePassword, newPassword });
 
     return h.response({ data: { type: 'reset-expired-password-demands' } }).created();
   },

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -22,7 +22,7 @@ module.exports = async function updateExpiredPassword({
     });
   } catch (error) {
     if (error instanceof UserNotFoundError) {
-      logger.warn({ username }, 'Trying to change his password with incorrect username');
+      logger.warn('Trying to change his password with incorrect username');
     }
 
     throw error;

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -8,17 +8,18 @@ module.exports = async function updateExpiredPassword({
   expiredPassword,
   newPassword,
   username,
-  pixAuthenticationService,
   encryptionService,
   authenticationMethodRepository,
   userRepository,
 }) {
   let foundUser;
   try {
-    foundUser = await pixAuthenticationService.getUserByUsernameAndPassword({
-      username,
+    foundUser = await userRepository.getUserWithPixAuthenticationMethodByUsername(username);
+    const passwordHash = foundUser.authenticationMethods[0].authenticationComplement.password;
+
+    await encryptionService.checkPassword({
       password: expiredPassword,
-      userRepository,
+      passwordHash,
     });
   } catch (error) {
     if (error instanceof UserNotFoundError) {

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -5,7 +5,7 @@ const { UserNotFoundError } = require('../../domain/errors');
 const logger = require('../../../lib/infrastructure/logger');
 
 module.exports = async function updateExpiredPassword({
-  expiredPassword,
+  oneTimePassword,
   newPassword,
   username,
   encryptionService,
@@ -18,7 +18,7 @@ module.exports = async function updateExpiredPassword({
     const passwordHash = foundUser.authenticationMethods[0].authenticationComplement.password;
 
     await encryptionService.checkPassword({
-      password: expiredPassword,
+      password: oneTimePassword,
       passwordHash,
     });
   } catch (error) {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -61,6 +61,28 @@ module.exports = {
       });
   },
 
+  async getUserWithPixAuthenticationMethodByUsername(username) {
+    const normalizeUsername = username.toLowerCase().trim();
+    const foundUser = await knex
+      .select('users.id as userId', 'authentication-methods.*')
+      .from('users')
+      .join('authentication-methods', 'authentication-methods.userId', 'users.id')
+      .where((queryBuilder) => {
+        queryBuilder.where({ username: normalizeUsername }).orWhere({ email: normalizeUsername });
+      })
+      .andWhere('authentication-methods.identityProvider', '=', AuthenticationMethod.identityProviders.PIX)
+      .first();
+    if (!foundUser) {
+      throw new UserNotFoundError();
+    }
+    const authenticationMethod = AuthenticationMethod.buildPixAuthenticationMethod({
+      userId: foundUser.userId,
+      password: foundUser.authenticationComplement.password,
+      shouldChangePassword: foundUser.authenticationComplement.shouldChangePassword,
+    });
+    return new User({ id: foundUser.userId, authenticationMethods: [authenticationMethod] });
+  },
+
   get(userId) {
     return BookshelfUser.where({ id: userId })
       .fetch()

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -149,7 +149,7 @@ describe('Acceptance | Controller | password-controller', function () {
 
   describe('POST /api/expired-password-updates', function () {
     const username = 'firstname.lastname0511';
-    const expiredPassword = 'Password01';
+    const oneTimePassword = 'Password01';
     const newPassword = 'Password02';
 
     const options = {
@@ -157,7 +157,7 @@ describe('Acceptance | Controller | password-controller', function () {
       url: '/api/expired-password-updates',
       payload: {
         data: {
-          attributes: { username, expiredPassword, newPassword },
+          attributes: { username, oneTimePassword, newPassword },
         },
       },
     };
@@ -165,7 +165,7 @@ describe('Acceptance | Controller | password-controller', function () {
     beforeEach(async function () {
       databaseBuilder.factory.buildUser.withRawPassword({
         username,
-        rawPassword: expiredPassword,
+        rawPassword: oneTimePassword,
         shouldChangePassword: true,
       });
       await databaseBuilder.commit();
@@ -189,7 +189,7 @@ describe('Acceptance | Controller | password-controller', function () {
       context('when username does not exist', function () {
         it('should respond 404 HTTP status code', async function () {
           // given
-          options.payload.data.attributes = { username: 'unknow', expiredPassword, newPassword };
+          options.payload.data.attributes = { username: 'unknow', oneTimePassword, newPassword };
 
           // when
           const response = await server.inject(options);
@@ -203,7 +203,7 @@ describe('Acceptance | Controller | password-controller', function () {
       context('when password is invalid', function () {
         it('should respond 401 HTTP status code', async function () {
           // given
-          options.payload.data.attributes = { username, expiredPassword: 'wrongPassword01', newPassword };
+          options.payload.data.attributes = { username, oneTimePassword: 'wrongPassword01', newPassword };
 
           // when
           const response = await server.inject(options);
@@ -219,11 +219,11 @@ describe('Acceptance | Controller | password-controller', function () {
           const username = 'jean.oubliejamais0105';
           databaseBuilder.factory.buildUser.withRawPassword({
             username,
-            rawPassword: expiredPassword,
+            rawPassword: oneTimePassword,
             shouldChangePassword: false,
           });
 
-          options.payload.data.attributes = { username, expiredPassword, newPassword };
+          options.payload.data.attributes = { username, oneTimePassword, newPassword };
 
           await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -148,7 +148,7 @@ describe('Acceptance | Controller | password-controller', function () {
   });
 
   describe('POST /api/expired-password-updates', function () {
-    const username = 'firstName.lastName0511';
+    const username = 'firstname.lastname0511';
     const expiredPassword = 'Password01';
     const newPassword = 'Password02';
 

--- a/api/tests/integration/application/passwords/index_test.js
+++ b/api/tests/integration/application/passwords/index_test.js
@@ -60,7 +60,7 @@ describe('Integration | Application | Password | Routes', function () {
         data: {
           attributes: {
             username: 'firstname.lastname0512',
-            expiredPassword: 'expiredPassword01',
+            oneTimePassword: 'expiredPassword01',
             newPassword: 'newPassword02',
           },
         },

--- a/api/tests/integration/application/passwords/index_test.js
+++ b/api/tests/integration/application/passwords/index_test.js
@@ -58,9 +58,8 @@ describe('Integration | Application | Password | Routes', function () {
       const url = '/api/expired-password-updates';
       const payload = {
         data: {
-          type: 'organization-invitations',
           attributes: {
-            username: 'firstName.lastName0512',
+            username: 'firstname.lastname0512',
             expiredPassword: 'expiredPassword01',
             newPassword: 'newPassword02',
           },

--- a/api/tests/integration/application/passwords/password-controller_test.js
+++ b/api/tests/integration/application/passwords/password-controller_test.js
@@ -151,7 +151,7 @@ describe('Integration | Application | Passwords | password-controller', function
         type: 'organization-invitations',
         attributes: {
           username: 'firstname.lastname0512',
-          expiredPassword: 'expiredPassword01',
+          oneTimePassword: 'expiredPassword01',
           newPassword: 'newPassword02',
         },
       },

--- a/api/tests/integration/application/passwords/password-controller_test.js
+++ b/api/tests/integration/application/passwords/password-controller_test.js
@@ -150,7 +150,7 @@ describe('Integration | Application | Passwords | password-controller', function
       data: {
         type: 'organization-invitations',
         attributes: {
-          username: 'firstName.lastName0512',
+          username: 'firstname.lastname0512',
           expiredPassword: 'expiredPassword01',
           newPassword: 'newPassword02',
         },

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -467,6 +467,105 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       });
     });
 
+    describe('#getUserWithPixAuthenticationMethodByUsername', function () {
+      it('should return user information for the given username', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser({
+          id: 123,
+          username: 'jean.registre1010',
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+          id: 27634,
+          userId: user.id,
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+          id: 234,
+          userId: user.id,
+          hashedPassword: 'ABCDEF1234',
+          shouldChangePassword: true,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundUser = await userRepository.getUserWithPixAuthenticationMethodByUsername(user.username);
+
+        // then
+        expect(foundUser).to.be.an.instanceof(User);
+        expect(foundUser.id).to.equal(123);
+        expect(foundUser.authenticationMethods[0].identityProvider).to.equal('PIX');
+        expect(foundUser.authenticationMethods[0].authenticationComplement.password).to.equal('ABCDEF1234');
+        expect(foundUser.authenticationMethods[0].authenticationComplement.shouldChangePassword).to.equal(true);
+      });
+
+      it('should return user information for the given email', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser({
+          id: 123,
+          email: 'jean.registre@example.net',
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+          id: 27634,
+          userId: user.id,
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+          id: 234,
+          userId: user.id,
+          hashedPassword: 'ABCDEF1234',
+          shouldChangePassword: true,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundUser = await userRepository.getUserWithPixAuthenticationMethodByUsername(user.email);
+
+        // then
+        expect(foundUser).to.be.an.instanceof(User);
+        expect(foundUser.id).to.equal(123);
+        expect(foundUser.authenticationMethods[0].identityProvider).to.equal('PIX');
+        expect(foundUser.authenticationMethods[0].authenticationComplement.password).to.equal('ABCDEF1234');
+        expect(foundUser.authenticationMethods[0].authenticationComplement.shouldChangePassword).to.equal(true);
+      });
+
+      context('when no user was found with the given username', function () {
+        it('should reject with a UserNotFound error', async function () {
+          // given
+          const notExistingUsername = 'john.doe0909';
+
+          // when
+          const result = await catchErr(userRepository.getUserWithPixAuthenticationMethodByUsername)(
+            notExistingUsername
+          );
+
+          // then
+          expect(result).to.be.instanceOf(UserNotFoundError);
+        });
+      });
+
+      context('when user has no pix authentication method', function () {
+        it('should reject with a UserNotFound error', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser({
+            id: 123,
+            username: 'toto1010',
+          });
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+            id: 27634,
+            userId: user.id,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const result = await catchErr(userRepository.getUserWithPixAuthenticationMethodByUsername)(user.username);
+
+          // then
+          expect(result).to.be.instanceOf(UserNotFoundError);
+        });
+      });
+    });
+
     describe('#getWithMemberships', function () {
       beforeEach(async function () {
         await _insertUserWithOrganizationsAndCertificationCenterAccesses();

--- a/api/tests/unit/application/passwords/index_test.js
+++ b/api/tests/unit/application/passwords/index_test.js
@@ -84,7 +84,7 @@ describe('Unit | Router | Password router', function () {
         data: {
           attributes: {
             username: 'firstName.lastName0110',
-            expiredPassword: 'expiredPassword01',
+            oneTimePassword: 'expiredPassword01',
             newPassword: 'Password123',
           },
           type: 'password-reset',
@@ -99,7 +99,7 @@ describe('Unit | Router | Password router', function () {
     });
 
     context(
-      'When the payload has the wrong format or no username or expiredPassword or newPassword is provided.',
+      'When the payload has the wrong format or no username or oneTimePassword or newPassword is provided.',
       function () {
         it('should return 400 http status code', async function () {
           // given
@@ -110,7 +110,7 @@ describe('Unit | Router | Password router', function () {
             data: {
               attributes: {
                 username: 'firstName.lastName0110',
-                expiredPassword: 'expiredPassword01',
+                oneTimePassword: 'expiredPassword01',
                 newPassword: null,
               },
               type: 'password-reset',

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -85,7 +85,7 @@ describe('Unit | Controller | PasswordController', function () {
         data: {
           attributes: {
             username: 'uzinagaz.hheer1206',
-            expiredPassword: 'expiredPassword01',
+            oneTimePassword: 'expiredPassword01',
             newPassword: 'Password123',
           },
         },

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -99,10 +99,7 @@ describe('Unit | UseCase | update-expired-password', function () {
       });
 
       // then
-      expect(logger.warn).to.have.been.calledWith(
-        { username: 'bad-username' },
-        'Trying to change his password with incorrect username'
-      );
+      expect(logger.warn).to.have.been.calledWith('Trying to change his password with incorrect username');
     });
 
     it('should throw PasswordNotMatching when expiredPassword is invalid', async function () {

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -7,7 +7,7 @@ const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Unit | UseCase | update-expired-password', function () {
   const username = 'firstName.lastName0511';
-  const expiredPassword = 'Password01';
+  const oneTimePassword = 'Password01';
   const newPassword = 'Password02';
   const hashedPassword = 'ABCDEF123';
 
@@ -20,7 +20,7 @@ describe('Unit | UseCase | update-expired-password', function () {
     user = domainBuilder.buildUser({ username });
     const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword({
       userId: user.id,
-      rawPassword: expiredPassword,
+      rawPassword: oneTimePassword,
       shouldChangePassword: true,
     });
     user.authenticationMethods = [authenticationMethod];
@@ -44,7 +44,7 @@ describe('Unit | UseCase | update-expired-password', function () {
   it('should update user password with a hashed password', async function () {
     // when
     await updateExpiredPassword({
-      expiredPassword,
+      oneTimePassword,
       newPassword,
       username,
       encryptionService,
@@ -68,7 +68,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
       // when
       const error = await catchErr(updateExpiredPassword)({
-        expiredPassword,
+        oneTimePassword,
         newPassword,
         username,
         encryptionService,
@@ -87,7 +87,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
       // when
       await catchErr(updateExpiredPassword)({
-        expiredPassword,
+        oneTimePassword,
         newPassword,
         username: 'bad-username',
         encryptionService,
@@ -99,13 +99,13 @@ describe('Unit | UseCase | update-expired-password', function () {
       expect(logger.warn).to.have.been.calledWith('Trying to change his password with incorrect username');
     });
 
-    it('should throw PasswordNotMatching when expiredPassword is invalid', async function () {
+    it('should throw PasswordNotMatching when oneTimePassword is invalid', async function () {
       // given
       userRepository.getUserWithPixAuthenticationMethodByUsername.rejects(new PasswordNotMatching());
 
       // when
       const error = await catchErr(updateExpiredPassword)({
-        expiredPassword,
+        oneTimePassword,
         newPassword,
         username,
         encryptionService,
@@ -123,7 +123,7 @@ describe('Unit | UseCase | update-expired-password', function () {
       // given
       const authenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword({
         userId: user.id,
-        rawPassword: expiredPassword,
+        rawPassword: oneTimePassword,
         shouldChangePassword: false,
       });
       user.authenticationMethods = [authenticationMethod];
@@ -132,7 +132,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
       // when
       const error = await catchErr(updateExpiredPassword)({
-        expiredPassword,
+        oneTimePassword,
         newPassword,
         username,
         encryptionService,

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -48,7 +48,7 @@
     "id": 8,
     "firstName": "Tommen",
     "lastName": "Baratheon",
-    "username": "user.shouldChangePassword1234"
+    "username": "tommen.baratheon1234"
   },
   {
     "id": 9,

--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -6,7 +6,7 @@ Given(`je me connecte avec le compte {string}`, (email) => {
 });
 
 Given(`je me connecte avec un mot de passe temporaire`, () => {
-  cy.get('input[name="login"]').type('user.shouldChangePassword1234');
+  cy.get('input[name="login"]').type('tommen.baratheon1234');
   cy.get('input[name="password"]').type('Pix12345');
   cy.get('button[type=submit]').click();
 });

--- a/mon-pix/app/adapters/reset-expired-password-demand.js
+++ b/mon-pix/app/adapters/reset-expired-password-demand.js
@@ -4,10 +4,10 @@ export default class ResetExpiredPasswordDemand extends ApplicationAdapter {
   createRecord(store, type, snapshot) {
     const url = this.buildURL('expired-password-update', null, snapshot, 'createRecord');
 
-    const { username, oneTimePassword: expiredPassword, newPassword } = snapshot.record;
+    const { username, oneTimePassword, newPassword } = snapshot.record;
     const payload = {
       data: {
-        attributes: { username, expiredPassword, newPassword },
+        attributes: { username, oneTimePassword, newPassword },
       },
     };
 

--- a/mon-pix/mirage/routes/post-expired-password-updates.js
+++ b/mon-pix/mirage/routes/post-expired-password-updates.js
@@ -1,8 +1,8 @@
 export default function (schema, request) {
   const params = JSON.parse(request.requestBody);
-  const { username, expiredPassword, newPassword } = params.data.attributes;
+  const { username, oneTimePassword, newPassword } = params.data.attributes;
 
-  const foundUser = schema.users.findBy({ username, password: expiredPassword });
+  const foundUser = schema.users.findBy({ username, password: oneTimePassword });
 
   if (foundUser) {
     foundUser.update({ password: newPassword, shouldChangePassword: false });

--- a/mon-pix/tests/unit/adapters/reset-expired-password-demand_test.js
+++ b/mon-pix/tests/unit/adapters/reset-expired-password-demand_test.js
@@ -9,15 +9,15 @@ describe('Unit | Adapters | reset-expired-password-demand', function () {
     it('should call expired-password-updates ', async function () {
       // given
       const username = 'username123';
-      const expiredPassword = 'Password123';
+      const oneTimePassword = 'Password123';
       const newPassword = 'Password456';
-      const resetExpiredPasswordDemand = { username, newPassword, oneTimePassword: expiredPassword };
+      const resetExpiredPasswordDemand = { username, newPassword, oneTimePassword };
       const expectedUrl = 'http://localhost:3000/api/expired-password-updates';
       const expectedMethod = 'POST';
       const expectedData = {
         data: {
           data: {
-            attributes: { username, expiredPassword, newPassword },
+            attributes: { username, oneTimePassword, newPassword },
           },
         },
       };

--- a/mon-pix/tests/unit/components/update-expired-password_test.js
+++ b/mon-pix/tests/unit/components/update-expired-password_test.js
@@ -62,7 +62,7 @@ describe('Unit | Component | Update Expired Password', () => {
 
   describe('#handleUpdatePasswordAndAuthenticate', () => {
     const username = 'username.123';
-    const expiredPassword = 'Pix12345';
+    const oneTimePassword = 'Pix12345';
     const newPassword = 'Pix67890';
     const scope = 'mon-pix';
 
@@ -73,7 +73,7 @@ describe('Unit | Component | Update Expired Password', () => {
 
       const resetExpiredPasswordDemand = {
         username,
-        password: expiredPassword,
+        password: oneTimePassword,
         save: sinon.stub().resolves(),
         set: sinon.stub().resolves(),
         unloadRecord: sinon.stub().resolves(),


### PR DESCRIPTION
## :unicorn: Problème
Des utilisateurs nous ont remonté des soucis sur le scénario de réinitialisation de mot de passe temporaire.
Nous avons donc investigué sur le sujet et décidé de log les détails sur Datadog avec un warn. 
En ajoutant l'info de l'identifiant dans le log, nous voulions nous assurer qu'ils existaient en BDD. 

Après analyse des erreurs, la grande majorité des identifiants existent. Et pourtant chaque utilisateur a rencontré plusieurs 404 (compte introuvable) avant de finalement réussir leur changement de mot de passe. 
Après discussion, nous allons garder le log pour continuer à identifier facilement le soucis mais il n'est plus nécessaire de garder l'identifiant.
Nous avons également constaté que la méthode de repository pour chercher l'utilisateur était partagé avec d'autres scénarios fonctionnels, et va chercher plusieurs choses qui n'ont pas d’intérêt pour notre cas. 
L'identifiant était transmis au repository sans contrôler la casse, ce qui peut également avoir un impact sur le résultat. 

## :robot: Solution
- Supprimer l'identifiant dans le log
- Création d'une nouvelle méthode de repository pour notre scénario

## :rainbow: Remarques
Un autre ticket est prévu pour remplacer les valeurs 

## :100: Pour tester
Tester que le username n'apparaît plus : 

- Simuler une erreur 404, par exemple en ajoutant `throw new UserNotFoundError()` dans la méthode nouvelle méthode `getUserWithPixAuthenticationMethodByUsername` du user-repository (et ne pas oublier de redémarrer l'API)
- Constater que l'erreur apparaît sans le username dans les logs de l'API

Tester le scénario classique : 
- Aller sur Pix Orga et se connecter (sco.admin)
- Dans le menu de gauche, aller sur Élèves
- Choisir un élève possédant une méthode identifiant et/ou adresse e-mail et cliquer sur le bouton d'action tout à droite "Gérer le compte"
- Cliquer sur le bouton "Réinitialiser le mot de passe"
- récupérer l'identifiant et nouveau mot de passe de l'élève et aller sur Mon Pix
- Sur la page connexion, renseigner les deux informations
- Renseigner un nouveau mot de passe
- constater que l'on est bien connecté

On peut reproduire le scénario jusqu'a l'étape où l'on renseigne le nouveau mot de passe 
- Avant de valider le mot de passe, aller sur la console
- Aller dans l'onglet Ember (plugin) , colonne Data, puis cliquer sur reset-password-updates
- Vous pouvez ici modifier le username que le front à stocké pour y mettre des majuscules
- Constater que ça passe quand même