### PR TITLE
[TECH] Préciser la cause de la certification en erreur lorsque l'utilisateur n'a pas répondu à toutes les questions (PIX-5084)

### DIFF
--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -13,7 +13,9 @@ class CertificationContract {
     });
 
     if (someUnansweredChallenges) {
-      throw new CertificationComputeError('L’utilisateur n’a pas répondu à toutes les questions');
+      throw new CertificationComputeError(
+        "L’utilisateur n’a pas répondu à toutes les questions, alors qu'aucune raison d'abandon n'a été fournie."
+      );
     }
   }
 

--- a/api/tests/unit/domain/models/CertificationContract_test.js
+++ b/api/tests/unit/domain/models/CertificationContract_test.js
@@ -59,7 +59,9 @@ describe('Unit | Domain | Models | CertificationContract', function () {
 
         // then
         expect(error).to.be.instanceOf(CertificationComputeError);
-        expect(error.message).to.equal('L’utilisateur n’a pas répondu à toutes les questions');
+        expect(error.message).to.equal(
+          "L’utilisateur n’a pas répondu à toutes les questions, alors qu'aucune raison d'abandon n'a été fournie."
+        );
       });
 
       it('should not throw', async function () {

--- a/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
@@ -313,7 +313,7 @@ describe('Unit | Service | Certification Result Service', function () {
       });
     });
 
-    context('When there are more challenges than answers ', function () {
+    context('When there are less answers than challenges', function () {
       it('should throw', async function () {
         // given
         const certificationAnswersByDate = _.map(
@@ -355,7 +355,9 @@ describe('Unit | Service | Certification Result Service', function () {
 
         // then
         expect(error).to.be.instanceOf(CertificationComputeError);
-        expect(error.message).to.equal('L’utilisateur n’a pas répondu à toutes les questions');
+        expect(error.message).to.equal(
+          "L’utilisateur n’a pas répondu à toutes les questions, alors qu'aucune raison d'abandon n'a été fournie."
+        );
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le message d'erreur n'explicite pas la cause
 
## :robot: Solution
La mentionner

## :rainbow: Remarques
La cause sera corrigée dans un autre ticket

## :100: Pour tester
Créer une certification avec 2 candidats
Commencer la certification avec le premier
Ouvrir l'écran de certification
Renseigner un motif d'abandon pour le premier
Commencer la certification avec le deuxième
Cliquer sur finaliser la session


Vérifier que le message d'erreur sur le deuxième candidat dans `assement-results.message` est 
```js
L’utilisateur n’a pas répondu à toutes les questions, alors qu'aucune raison d'abandon n'a été fournie.
```
