### PR TITLE
[FEATURE] Fusionner les stratégies de résolution des signalements E1 et E2 (PIX-5115).

### DIFF
--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -223,7 +223,7 @@ async function _resolveWithNeitherImageNorEmbedInChallenge(
   certificationIssueReport
 ) {
   certificationIssueReport.resolve(
-    "Cette question n' a pas été neutralisée car elle ne contient ni image ni application/simulateur"
+    "Cette question n'a pas été neutralisée car elle ne contient ni image ni application/simulateur"
   );
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
@@ -231,20 +231,20 @@ async function _resolveWithNeitherImageNorEmbedInChallenge(
 
 async function _resolveWithNoAttachmentInChallenge(certificationIssueReportRepository, certificationIssueReport) {
   certificationIssueReport.resolve(
-    "Cette question n' a pas été neutralisée car elle ne contient pas de fichier à télécharger"
+    "Cette question n'a pas été neutralisée car elle ne contient pas de fichier à télécharger"
   );
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
 
 async function _resolveWithNoFocusedChallenge(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve("Cette question n' a pas été neutralisée car ce n'est pas une question focus");
+  certificationIssueReport.resolve("Cette question n'a pas été neutralisée car ce n'est pas une question focus");
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
 
 async function _resolveWithChallengeNotTimed(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve("Cette question n' a pas été neutralisée car elle n'est pas chronométrée");
+  certificationIssueReport.resolve("Cette question n'a pas été neutralisée car elle n'est pas chronométrée");
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -22,7 +22,7 @@ async function neutralizeIfTimedChallengeStrategy({
   return _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport);
 }
 
-async function neutralizeIfEmbedStrategy({
+async function neutralizeIfImageOrEmbedStrategy({
   certificationIssueReport,
   certificationAssessment,
   certificationIssueReportRepository,
@@ -37,30 +37,8 @@ async function neutralizeIfEmbedStrategy({
 
   const challenge = await challengeRepository.get(recId);
 
-  if (!challenge.hasEmbed()) {
-    return _resolveWithNoEmbedInChallenge(certificationIssueReportRepository, certificationIssueReport);
-  }
-
-  return _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport);
-}
-
-async function neutralizeIfImageStrategy({
-  certificationIssueReport,
-  certificationAssessment,
-  certificationIssueReportRepository,
-  challengeRepository,
-}) {
-  const questionNumber = certificationIssueReport.questionNumber;
-  const recId = certificationAssessment.getChallengeRecIdByQuestionNumber(questionNumber);
-
-  if (!recId) {
-    return _resolveWithNoSuchQuestion(certificationIssueReportRepository, certificationIssueReport, questionNumber);
-  }
-
-  const challenge = await challengeRepository.get(recId);
-
-  if (!challenge.hasIllustration()) {
-    return _resolveWithNoImageInChallenge(certificationIssueReportRepository, certificationIssueReport);
+  if (!challenge.hasIllustration() && !challenge.hasEmbed()) {
+    return _resolveWithNeitherImageNorEmbedInChallenge(certificationIssueReportRepository, certificationIssueReport);
   }
 
   return _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport);
@@ -137,8 +115,7 @@ async function doNotResolveStrategy() {
 class CertificationIssueReportResolutionStrategies {
   constructor({
     neutralizeWithoutChecking = neutralizeWithoutCheckingStrategy,
-    neutralizeIfImage = neutralizeIfImageStrategy,
-    neutralizeIfEmbed = neutralizeIfEmbedStrategy,
+    neutralizeIfImageOrEmbed = neutralizeIfImageOrEmbedStrategy,
     neutralizeIfAttachment = neutralizeIfAttachmentStrategy,
     doNotResolve = doNotResolveStrategy,
     neutralizeIfTimedChallenge = neutralizeIfTimedChallengeStrategy,
@@ -147,8 +124,7 @@ class CertificationIssueReportResolutionStrategies {
     challengeRepository,
   }) {
     this._neutralizeWithoutChecking = neutralizeWithoutChecking;
-    this._neutralizeIfImage = neutralizeIfImage;
-    this._neutralizeIfEmbed = neutralizeIfEmbed;
+    this._neutralizeIfImageOrEmbed = neutralizeIfImageOrEmbed;
     this._neutralizeIfAttachment = neutralizeIfAttachment;
     this._doNotResolve = doNotResolve;
     this._neutralizeIfTimedChallenge = neutralizeIfTimedChallenge;
@@ -173,9 +149,8 @@ class CertificationIssueReportResolutionStrategies {
       case CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE:
         return await this._neutralizeWithoutChecking(strategyParameters);
       case CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING:
-        return await this._neutralizeIfImage(strategyParameters);
       case CertificationIssueReportSubcategories.EMBED_NOT_WORKING:
-        return await this._neutralizeIfEmbed(strategyParameters);
+        return await this._neutralizeIfImageOrEmbed(strategyParameters);
       case CertificationIssueReportSubcategories.FILE_NOT_OPENING:
         return await this._neutralizeIfAttachment(strategyParameters);
       case CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED:
@@ -190,8 +165,7 @@ class CertificationIssueReportResolutionStrategies {
 
 module.exports = {
   neutralizeWithoutCheckingStrategy,
-  neutralizeIfImageStrategy,
-  neutralizeIfEmbedStrategy,
+  neutralizeIfImageOrEmbedStrategy,
   neutralizeIfAttachmentStrategy,
   doNotResolveStrategy,
   neutralizeIfTimedChallengeStrategy,
@@ -244,8 +218,13 @@ async function _resolveWithQuestionNeutralized(certificationIssueReportRepositor
   return CertificationIssueReportResolutionAttempt.resolvedWithEffect();
 }
 
-async function _resolveWithNoImageInChallenge(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve("Cette question n' a pas été neutralisée car elle ne contient pas d'image");
+async function _resolveWithNeitherImageNorEmbedInChallenge(
+  certificationIssueReportRepository,
+  certificationIssueReport
+) {
+  certificationIssueReport.resolve(
+    "Cette question n' a pas été neutralisée car elle ne contient ni image ni application/simulateur"
+  );
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
@@ -253,14 +232,6 @@ async function _resolveWithNoImageInChallenge(certificationIssueReportRepository
 async function _resolveWithNoAttachmentInChallenge(certificationIssueReportRepository, certificationIssueReport) {
   certificationIssueReport.resolve(
     "Cette question n' a pas été neutralisée car elle ne contient pas de fichier à télécharger"
-  );
-  await certificationIssueReportRepository.save(certificationIssueReport);
-  return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
-}
-
-async function _resolveWithNoEmbedInChallenge(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve(
-    "Cette question n' a pas été neutralisée car elle ne contient pas d'application/simulateur"
   );
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -379,7 +379,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
         // then
         expect(certificationIssueReport.resolution).to.equal(
-          "Cette question n' a pas été neutralisée car elle ne contient ni image ni application/simulateur"
+          "Cette question n'a pas été neutralisée car elle ne contient ni image ni application/simulateur"
         );
         expect(neutralizationAttempt).to.deepEqualInstance(
           CertificationIssueReportResolutionAttempt.resolvedWithoutEffect()
@@ -1343,7 +1343,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         // then
         expect(certificationIssueReport.isResolved()).to.be.true;
         expect(certificationIssueReport.resolution).to.equal(
-          "Cette question n' a pas été neutralisée car ce n'est pas une question focus"
+          "Cette question n'a pas été neutralisée car ce n'est pas une question focus"
         );
         expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
       });

--- a/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReportResolutionStrategies_test.js
@@ -9,8 +9,7 @@ const {
 } = require('../../../../lib/domain/models/CertificationIssueReportResolutionStrategies');
 const {
   neutralizeWithoutCheckingStrategy,
-  neutralizeIfImageStrategy,
-  neutralizeIfEmbedStrategy,
+  neutralizeIfImageOrEmbedStrategy,
   neutralizeIfAttachmentStrategy,
   neutralizeIfTimedChallengeStrategy,
   neutralizeOrValidateIfFocusedChallengeStrategy,
@@ -142,76 +141,150 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
   });
 
-  context('#NEUTRALIZE_IF_IMAGE', function () {
+  context('#NEUTRALIZE_IF_IMAGE_OR_EMBED', function () {
     context('When challenge is neutralizable', function () {
-      it('neutralizes successfully', async function () {
-        // given
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
-        const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [certificationAnswer],
-        });
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
-        };
+      context('When challenge contains an image', function () {
+        it('neutralizes successfully', async function () {
+          // given
+          const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+          const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            certificationChallenges: [certificationChallenge],
+            certificationAnswersByDate: [certificationAnswer],
+          });
+          const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            category: CertificationIssueReportCategories.IN_CHALLENGE,
+            questionNumber: 1,
+          });
+          const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+          const certificationIssueReportRepository = {
+            save: sinon.stub(),
+          };
+          const challengeRepository = {
+            get: sinon.stub().resolves(challengeWithImage),
+          };
 
-        // when
-        const neutralizationAttempt = await neutralizeIfImageStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
+          // when
+          const neutralizationAttempt = await neutralizeIfImageOrEmbedStrategy({
+            certificationIssueReport,
+            certificationAssessment,
+            certificationIssueReportRepository,
+            challengeRepository,
+          });
+
+          // then
+          expect(neutralizationAttempt).to.deepEqualInstance(
+            CertificationIssueReportResolutionAttempt.resolvedWithEffect()
+          );
         });
 
-        // then
-        expect(neutralizationAttempt).to.deepEqualInstance(
-          CertificationIssueReportResolutionAttempt.resolvedWithEffect()
-        );
+        it('resolves the issue report', async function () {
+          // given
+          const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+          const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            certificationChallenges: [certificationChallenge],
+            certificationAnswersByDate: [certificationAnswer],
+          });
+          const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            category: CertificationIssueReportCategories.IN_CHALLENGE,
+            questionNumber: 1,
+          });
+          const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+
+          const certificationIssueReportRepository = {
+            save: sinon.stub(),
+          };
+          const challengeRepository = {
+            get: sinon.stub().resolves(challengeWithImage),
+          };
+
+          // when
+          await neutralizeIfImageOrEmbedStrategy({
+            certificationIssueReport,
+            certificationAssessment,
+            certificationIssueReportRepository,
+            challengeRepository,
+          });
+
+          // then
+          expect(certificationIssueReport.isResolved()).to.be.true;
+          expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+        });
       });
 
-      it('resolves the issue report', async function () {
-        // given
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
-        const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [certificationAnswer],
-        });
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
+      context('When challenge contains an embed', function () {
+        it('neutralizes successfully', async function () {
+          // given
+          const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+          const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            certificationChallenges: [certificationChallenge],
+            certificationAnswersByDate: [certificationAnswer],
+          });
+          const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            category: CertificationIssueReportCategories.IN_CHALLENGE,
+            questionNumber: 1,
+          });
+          const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+          const certificationIssueReportRepository = {
+            save: sinon.stub(),
+          };
+          const challengeRepository = {
+            get: sinon.stub().resolves(challengeWithEmbed),
+          };
 
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
-        };
+          // when
+          const neutralizationAttempt = await neutralizeIfImageOrEmbedStrategy({
+            certificationIssueReport,
+            certificationAssessment,
+            certificationIssueReportRepository,
+            challengeRepository,
+          });
 
-        // when
-        await neutralizeIfImageStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
+          // then
+          expect(neutralizationAttempt).to.deepEqualInstance(
+            CertificationIssueReportResolutionAttempt.resolvedWithEffect()
+          );
         });
 
-        // then
-        expect(certificationIssueReport.isResolved()).to.be.true;
-        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+        it('resolves the issue report', async function () {
+          // given
+          const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
+          const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            certificationChallenges: [certificationChallenge],
+            certificationAnswersByDate: [certificationAnswer],
+          });
+          const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+            subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+            category: CertificationIssueReportCategories.IN_CHALLENGE,
+            questionNumber: 1,
+          });
+          const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+
+          const certificationIssueReportRepository = {
+            save: sinon.stub(),
+          };
+          const challengeRepository = {
+            get: sinon.stub().resolves(challengeWithEmbed),
+          };
+
+          // when
+          await neutralizeIfImageOrEmbedStrategy({
+            certificationIssueReport,
+            certificationAssessment,
+            certificationIssueReportRepository,
+            challengeRepository,
+          });
+
+          // then
+          expect(certificationIssueReport.isResolved()).to.be.true;
+          expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
+        });
       });
     });
 
@@ -224,9 +297,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -234,7 +305,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfImageStrategy({
+        const neutralizationAttempt = await neutralizeIfImageOrEmbedStrategy({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,
@@ -262,7 +333,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfImageStrategy({
+        await neutralizeIfImageOrEmbedStrategy({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,
@@ -274,7 +345,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       });
     });
 
-    context('the challenge does not contain an image', function () {
+    context('the challenge does not contain an image nor an embed', function () {
       it('returns a successful resolution without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
@@ -282,12 +353,15 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithoutIllustration = domainBuilder.buildChallenge({ illustrationUrl: null });
+        const challengeWithoutIllustrationAndEmbed = domainBuilder.buildChallenge({
+          illustrationUrl: null,
+          embedUrl: null,
+        });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithoutIllustration),
+          get: sinon.stub().resolves(challengeWithoutIllustrationAndEmbed),
         };
         const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -296,284 +370,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        const neutralizationAttempt = await neutralizeIfImageStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
-        });
-
-        // then
-        expect(neutralizationAttempt).to.deepEqualInstance(
-          CertificationIssueReportResolutionAttempt.resolvedWithoutEffect()
-        );
-      });
-
-      it('resolves the certification issue report anyway', async function () {
-        // given
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithoutIllustration = domainBuilder.buildChallenge({ illustrationUrl: null });
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithoutIllustration),
-        };
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
-        });
-
-        // when
-        await neutralizeIfImageStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
-        });
-
-        // then
-        expect(certificationIssueReport.isResolved()).to.be.true;
-        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
-      });
-    });
-
-    context('When challenge is not neutralizable', function () {
-      it('returns a successful resolution attempt without effect', async function () {
-        // given
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
-        const certificationAnswer = domainBuilder.buildAnswer.ok({ challengeId: certificationChallenge.challengeId });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [certificationAnswer],
-        });
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
-        };
-
-        // when
-        const neutralizationAttempt = await neutralizeIfImageStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
-        });
-
-        // then
-        expect(neutralizationAttempt).to.deepEqualInstance(
-          CertificationIssueReportResolutionAttempt.resolvedWithoutEffect()
-        );
-      });
-
-      it('resolves the certification issue report anyway', async function () {
-        // given
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
-        const certificationAnswer = domainBuilder.buildAnswer.ok({ challengeId: certificationChallenge.challengeId });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [certificationAnswer],
-        });
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithImage),
-        };
-
-        // when
-        await neutralizeIfImageStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
-        });
-
-        // then
-        expect(certificationIssueReport.isResolved()).to.be.true;
-        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
-      });
-    });
-  });
-
-  context('#NEUTRALIZE_IF_EMBED', function () {
-    context('When challenge is neutralizable', function () {
-      it('neutralizes successfully', async function () {
-        // given
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
-        const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [certificationAnswer],
-        });
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithEmbed),
-        };
-
-        // when
-        const neutralizationAttempt = await neutralizeIfEmbedStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
-        });
-
-        // then
-        expect(neutralizationAttempt).to.deepEqualInstance(
-          CertificationIssueReportResolutionAttempt.resolvedWithEffect()
-        );
-      });
-
-      it('resolves the issue report', async function () {
-        // given
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
-        const certificationAnswer = domainBuilder.buildAnswer.ko({ challengeId: certificationChallenge.challengeId });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [certificationAnswer],
-        });
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-
-        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
-
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithEmbed),
-        };
-
-        // when
-        await neutralizeIfEmbedStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-          challengeRepository,
-        });
-
-        // then
-        expect(certificationIssueReport.isResolved()).to.be.true;
-        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
-      });
-    });
-
-    context('the challenge does not contain the question designated by the question number', function () {
-      it('returns a successful resolution attempt without effect', async function () {
-        // given
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
-        };
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
-          certificationAnswersByDate: [],
-        });
-
-        // when
-        const neutralizationAttempt = await neutralizeIfEmbedStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-        });
-
-        // then
-        expect(neutralizationAttempt).to.deepEqualInstance(
-          CertificationIssueReportResolutionAttempt.resolvedWithoutEffect()
-        );
-      });
-
-      it('resolves the certification issue report anyway', async function () {
-        // given
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const certificationIssueReportRepository = {
-          save: sinon.stub(),
-        };
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
-          certificationAnswersByDate: [],
-        });
-
-        // when
-        await neutralizeIfEmbedStrategy({
-          certificationIssueReport,
-          certificationAssessment,
-          certificationIssueReportRepository,
-        });
-
-        // then
-        expect(certificationIssueReport.isResolved()).to.be.true;
-        expect(certificationIssueReportRepository.save).to.have.been.calledOnceWithExactly(certificationIssueReport);
-      });
-    });
-
-    context('the challenge does not contain an embed', function () {
-      it('returns a successful resolution without effect', async function () {
-        // given
-        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-          category: CertificationIssueReportCategories.IN_CHALLENGE,
-          questionNumber: 1,
-        });
-        const challengeWithoutEmbed = domainBuilder.buildChallenge({ embedUrl: null });
-        const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
-        };
-        const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithoutEmbed),
-        };
-        const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationChallenges: [certificationChallenge],
-          certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: certificationChallenge.challengeId })],
-        });
-
-        // when
-        const neutralizationAttempt = await neutralizeIfEmbedStrategy({
+        const neutralizationAttempt = await neutralizeIfImageOrEmbedStrategy({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,
@@ -582,7 +379,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
 
         // then
         expect(certificationIssueReport.resolution).to.equal(
-          "Cette question n' a pas été neutralisée car elle ne contient pas d'application/simulateur"
+          "Cette question n' a pas été neutralisée car elle ne contient ni image ni application/simulateur"
         );
         expect(neutralizationAttempt).to.deepEqualInstance(
           CertificationIssueReportResolutionAttempt.resolvedWithoutEffect()
@@ -596,12 +393,12 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithoutEmbed = domainBuilder.buildChallenge({ embedUrl: null });
+        const challengeWithoutIllustration = domainBuilder.buildChallenge({ illustrationUrl: null });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithoutEmbed),
+          get: sinon.stub().resolves(challengeWithoutIllustration),
         };
         const certificationChallenge = domainBuilder.buildCertificationChallengeWithType();
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -610,7 +407,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
 
         // when
-        await neutralizeIfEmbedStrategy({
+        await neutralizeIfImageOrEmbedStrategy({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,
@@ -624,7 +421,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('When challenge is not neutralizable', function () {
-      it('returns a successful resolution without effect', async function () {
+      it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok({ challengeId: certificationChallenge.challengeId });
@@ -633,20 +430,20 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithEmbed),
+          get: sinon.stub().resolves(challengeWithImage),
         };
 
         // when
-        const neutralizationAttempt = await neutralizeIfEmbedStrategy({
+        const neutralizationAttempt = await neutralizeIfImageOrEmbedStrategy({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,
@@ -668,20 +465,20 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           certificationAnswersByDate: [certificationAnswer],
         });
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-          subcategory: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+          subcategory: CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
           questionNumber: 1,
         });
-        const challengeWithEmbed = domainBuilder.buildChallenge({ embedUrl: 'embed_url' });
+        const challengeWithImage = domainBuilder.buildChallenge({ illustrationUrl: 'image_url' });
         const certificationIssueReportRepository = {
           save: sinon.stub(),
         };
         const challengeRepository = {
-          get: sinon.stub().resolves(challengeWithEmbed),
+          get: sinon.stub().resolves(challengeWithImage),
         };
 
         // when
-        await neutralizeIfEmbedStrategy({
+        await neutralizeIfImageOrEmbedStrategy({
           certificationIssueReport,
           certificationAssessment,
           certificationIssueReportRepository,
@@ -783,9 +580,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -834,7 +629,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('the challenge does not contain an attachment', function () {
-      it('returns a successful resolution without effect', async function () {
+      it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
           subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
@@ -843,9 +638,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const challengeWithoutAttachment = domainBuilder.buildChallenge({ attachments: [] });
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const challengeRepository = {
           get: sinon.stub().resolves(challengeWithoutAttachment),
@@ -905,7 +698,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('When challenge is not neutralizable', function () {
-      it('returns a successful resolution without effect', async function () {
+      it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok({ challengeId: certificationChallenge.challengeId });
@@ -1068,9 +861,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -1119,7 +910,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('the challenge is not timed', function () {
-      it('returns a successful resolution without effect', async function () {
+      it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
           subcategory: CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
@@ -1128,9 +919,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const notTimedChallenge = domainBuilder.buildChallenge({});
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const challengeRepository = {
           get: sinon.stub().resolves(notTimedChallenge),
@@ -1190,7 +979,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('When challenge is not neutralizable', function () {
-      it('returns a successful resolution without effect', async function () {
+      it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationChallenge = domainBuilder.buildCertificationChallengeWithType({});
         const certificationAnswer = domainBuilder.buildAnswer.ok({ challengeId: certificationChallenge.challengeId });
@@ -1439,9 +1228,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
           questionNumber: 1,
         });
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           certificationChallenges: [domainBuilder.buildCertificationChallengeWithType()],
@@ -1491,7 +1278,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
     });
 
     context('When challenge is not focused', function () {
-      it('returns a successful resolution without effect', async function () {
+      it('returns a successful resolution attempt without effect', async function () {
         // given
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
           subcategory: CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
@@ -1500,9 +1287,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
         });
         const notFocusedChallenge = domainBuilder.buildChallenge({ focused: false });
         const certificationIssueReportRepository = {
-          save: () => {
-            return;
-          },
+          save: () => {},
         };
         const challengeRepository = {
           get: sinon.stub().resolves(notFocusedChallenge),
@@ -1637,7 +1422,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
-        strategyToBeApplied: 'neutralizeIfImage',
+        strategyToBeApplied: 'neutralizeIfImageOrEmbed',
       },
 
       {
@@ -1649,7 +1434,7 @@ describe('Unit | Domain | Models | CertificationIssueReportResolutionStrategies'
       {
         // eslint-disable-next-line mocha/no-setup-in-describe
         subCategoryToBeResolved: CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
-        strategyToBeApplied: 'neutralizeIfEmbed',
+        strategyToBeApplied: 'neutralizeIfImageOrEmbed',
       },
 
       {


### PR DESCRIPTION
## :unicorn: Problème
Les surveillants se trompent parfois lorsqu’ils souhaitent remonter un problème sur une question avec une image ou avec un simulateur. En effet, ils sélectionnent par ex la sous-catégorie “E1 - l’image ne s’affiche pas” pour une question avec un simulateur, donc lors du traitement automatique, la question n’est pas neutralisée automatiquement car l'épreuve concernée ne contient pas d’image. 

## :robot: Solution
Fusionner les stratégies de résolution des signalements E1 et E2.

## :100: Pour tester
- Créer une session de certification dans Pix Certif.
- Inscrire un candidat et passer la certification.
- Finaliser la session en ajoutant les signalements suivants:
    - E1 sur une épreuve avec image.
    - E1 sur une épreuve avec embed.
    - E1 sur une épreuve sans image.
    - E1 sur une épreuve sans embed.
    - E2 sur une épreuve avec image.
    - E2 sur une épreuve avec embed.
    - E2 sur une épreuve sans image.
    - E2 sur une épreuve sans embed.
- Vérifier que les épreuves qui devaient être neutralisées le sont bien (celles contenant bien une image ou embed) et que celles qui ne devaient pas l'être ne l'ont pas été.   
