### PR TITLE
[A11Y] Ajout de traductions pour les recommandations (PIX-5049).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -22,14 +22,14 @@ Fonctionnalité: Gestion des Campagnes
     Alors je vois 2 résultats par compétence
     Lorsque je clique sur "Analyse"
     Alors je vois 2 sujets
-    Et je vois que le sujet "Capitales" est "Fortement recommandé"
+    Et je vois que le sujet "Capitales" est "Très recommandé"
     Et je vois que le sujet "Philosophes" est "Assez recommandé"
     Lorsque je retourne au détail de la campagne
     Et je clique sur "Résultats (1)"
     Alors je vois la moyenne des résultats à 50%
     Lorsque je clique sur "Analyse"
     Alors je vois 2 sujets
-    Et je vois que le sujet "Capitales" est "Fortement recommandé"
+    Et je vois que le sujet "Capitales" est "Très recommandé"
     Et je vois que le sujet "Philosophes" est "Assez recommandé"
     Lorsque j'ouvre le sujet "Capitales"
     Alors je vois 1 tutoriel

--- a/orga/app/components/campaign/analysis/recommendation-indicator.js
+++ b/orga/app/components/campaign/analysis/recommendation-indicator.js
@@ -1,14 +1,17 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 const RECOMMENDED = 75;
-const HIGHLY_RECOMMENDED = 50;
-const STRONGLY_RECOMMENDED = 25;
+const STRONGLY_RECOMMENDED = 50;
+const VERY_STRONGLY_RECOMMENDED = 25;
 
 export default class RecommendationIndicator extends Component {
+  @service intl;
+
   get bubblesCount() {
     const value = this.args.value;
-    if (value <= STRONGLY_RECOMMENDED) return 4;
-    if (value <= HIGHLY_RECOMMENDED) return 3;
+    if (value <= VERY_STRONGLY_RECOMMENDED) return 4;
+    if (value <= STRONGLY_RECOMMENDED) return 3;
     if (value <= RECOMMENDED) return 2;
     return 1;
   }
@@ -19,10 +22,12 @@ export default class RecommendationIndicator extends Component {
 
   get label() {
     const value = this.args.value;
-    if (value <= STRONGLY_RECOMMENDED) return 'Fortement recommandé';
-    if (value <= HIGHLY_RECOMMENDED) return 'Très recommandé';
-    if (value <= RECOMMENDED) return 'Recommandé';
-    return 'Assez recommandé';
+    if (value <= VERY_STRONGLY_RECOMMENDED)
+      return this.intl.t('pages.campaign-review.table.analysis.recommendations.very-strongly-recommended');
+    if (value <= STRONGLY_RECOMMENDED)
+      return this.intl.t('pages.campaign-review.table.analysis.recommendations.strongly-recommended');
+    if (value <= RECOMMENDED) return this.intl.t('pages.campaign-review.table.analysis.recommendations.recommended');
+    return this.intl.t('pages.campaign-review.table.analysis.recommendations.moderately-recommended');
   }
 
   get bubbleWidth() {

--- a/orga/tests/integration/components/campaign/analysis/recommendation-indicator_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendation-indicator_test.js
@@ -1,20 +1,27 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Campaign::Analysis::RecommendationIndicator', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
+  let screen;
 
   test('should display recommendation indicator with a level of 4 for value 0', async function (assert) {
     // given
     this.value = 0;
 
     // when
-    await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
+    screen = await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
 
     // then
-    assert.dom('[aria-label="Fortement recommandé"]').exists();
+    assert
+      .dom(
+        screen.getByLabelText(
+          this.intl.t('pages.campaign-review.table.analysis.recommendations.very-strongly-recommended')
+        )
+      )
+      .exists();
   });
 
   test('should display recommendation indicator with a level of 4 for value 25', async function (assert) {
@@ -22,10 +29,16 @@ module('Integration | Component | Campaign::Analysis::RecommendationIndicator', 
     this.value = 25;
 
     // when
-    await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
+    screen = await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
 
     // then
-    assert.dom('[aria-label="Fortement recommandé"]').exists();
+    assert
+      .dom(
+        screen.getByLabelText(
+          this.intl.t('pages.campaign-review.table.analysis.recommendations.very-strongly-recommended')
+        )
+      )
+      .exists();
   });
 
   test('should display recommendation indicator with a level of 3 for value 50', async function (assert) {
@@ -33,10 +46,14 @@ module('Integration | Component | Campaign::Analysis::RecommendationIndicator', 
     this.value = 50;
 
     // when
-    await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
+    screen = await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
 
     // then
-    assert.dom('[aria-label="Très recommandé"]').exists();
+    assert
+      .dom(
+        screen.getByLabelText(this.intl.t('pages.campaign-review.table.analysis.recommendations.strongly-recommended'))
+      )
+      .exists();
   });
 
   test('should display recommendation indicator with a level of 2 for value 75', async function (assert) {
@@ -44,10 +61,12 @@ module('Integration | Component | Campaign::Analysis::RecommendationIndicator', 
     this.value = 75;
 
     // when
-    await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
+    screen = await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
 
     // then
-    assert.dom('[aria-label="Recommandé"]').exists();
+    assert
+      .dom(screen.getByLabelText(this.intl.t('pages.campaign-review.table.analysis.recommendations.recommended')))
+      .exists();
   });
 
   test('should display recommendation indicator with a level of 1 for value 100', async function (assert) {
@@ -55,9 +74,15 @@ module('Integration | Component | Campaign::Analysis::RecommendationIndicator', 
     this.value = 100;
 
     // when
-    await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
+    screen = await render(hbs`<Campaign::Analysis::RecommendationIndicator @value={{value}} />`);
 
     // then
-    assert.dom('[aria-label="Assez recommandé"]').exists();
+    assert
+      .dom(
+        screen.getByLabelText(
+          this.intl.t('pages.campaign-review.table.analysis.recommendations.moderately-recommended')
+        )
+      )
+      .exists();
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -502,6 +502,12 @@
               "value": "{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
             }
           },
+          "recommendations": {
+            "moderately-recommended": "Moderately recommended",
+            "recommended": "Recommended",
+            "strongly-recommended": "Strongly recommended",
+            "very-strongly-recommended": "Very strongly recommended"
+          },
           "row-title": "Topic",
           "sort": {
             "relevance": "Sort by relevance"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -501,6 +501,12 @@
               "value": "{count, plural, =1 {1 tuto} other {{count} tutos}}"
             }
           },
+          "recommendations": {
+            "moderately-recommended": "Assez recommandé",
+            "recommended": "Recommandé",
+            "strongly-recommended": "Fortement recommandé",
+            "very-strongly-recommended": "Très recommandé"
+          },
           "row-title": "Sujet",
           "sort": {
             "relevance": "Trier par pertinence"


### PR DESCRIPTION
## :unicorn: Problème
Dans le tableau de l'onglet Analyse, nous avons des boulettes de pertinence. Mais ces dernières n'avaient pas de traduction

## :robot: Solution
Ajouter une traduction

## :rainbow: Remarques


## :100: Pour tester
- Aller sur Pix Orga puis dans l'onglet "Analyse" d'une campagne
- Regarder au niveau des boulettes, un aria-label avec la trad correspondante
