### PR TITLE
[TECH] Amélioration des consignes des QCU et QCM (PIX-5151).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -515,8 +515,8 @@
       "parts": {
         "answer-input": "Your answer",
         "answer-instructions": {
-          "qcm": "Select the right answers",
-          "qcu": "Select the right answer"
+          "qcm": "Select several answers",
+          "qcu": "Select one answer"
         },
         "feedback": "Report a problem",
         "instruction": "Instructions to answer the question",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -515,8 +515,8 @@
       "parts": {
         "answer-input": "Votre réponse",
         "answer-instructions": {
-          "qcm": "Choisissez les bonnes réponses.",
-          "qcu": "Choisissez la bonne réponse."
+          "qcm": "Choisissez plusieurs réponses.",
+          "qcu": "Choisissez une seule réponse."
         },
         "feedback": "Signaler un problème",
         "instruction": "Consigne de l'épreuve",


### PR DESCRIPTION
## :unicorn: Problème

Les instructions utilisées pour les QCU et QCM ne sont pas très bien tournées.

## :robot: Solution

Update de ces instructions en français.

## :rainbow: Remarques
N/A

## :100: Pour tester

Vérifier que les instructions ont changé pour les QCU et QCM.