### PR TITLE
[FEATURE] Mettre à jour le titre de la section avec les signalements individuels sur la page de finalisation de session (PIX-5148)

### DIFF
--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -11,7 +11,11 @@
   </div>
 
   <SessionFinalizationStepContainer
-    @title="Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+    @title={{if
+      this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+      "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+      "Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+    }}
     @icon="/icons/session-finalization-user.svg"
     @iconAlt=""
   >

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -120,6 +120,23 @@ module('Acceptance | Session Finalization', function (hooks) {
           )
           .exists();
       });
+
+      test('it should contain "Etape 1" in title', async function (assert) {
+        // given
+        server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: false });
+
+        // when
+        const screen = await visit(`/sessions/${session.id}/finalisation`);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              "Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+            )
+          )
+          .exists();
+      });
     });
     module('when FT_CERTIFICATION_FREE_FIELDS_DELETION is on', function () {
       test('it should not display the comment step section', async function (assert) {
@@ -167,6 +184,23 @@ module('Acceptance | Session Finalization', function (hooks) {
             screen.getByRole('checkbox', {
               name: "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.",
             })
+          )
+          .exists();
+      });
+
+      test('it should not contain "Etape 1" in title', async function (assert) {
+        // given
+        server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: true });
+
+        // when
+        const screen = await visit(`/sessions/${session.id}/finalisation`);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+            )
           )
           .exists();
       });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la suppression des champs libres, nous allons supprimer la notion d'étape de la page de finalisation de session. La nouvelle section “Informations complémentaires” ne précise ainsi pas de numéro d'étape.


Pour le moment, la section avec les signalements individuels indique toujours un numéro d'étape.

## :robot: Solution
Mettre à jour le titre de la 1ère section afin d’en supprimer la notion d'étape


## :100: Pour tester
- Activer FT_CERTIFICATION_FREE_FIELDS_DELETION
- finaliser une session et constater que la mention d'étape 1 n'apparaît plus

![image](https://user-images.githubusercontent.com/37305474/174045967-55e8d80c-f503-4a7d-b1c0-16fc88323f8d.png)
