### PR TITLE
[FEATURE] Affichage d'une explication pour les catégories C7 et C8 sur la page de finalisation de session

### DIFF
--- a/certif/app/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields.hbs
@@ -25,6 +25,10 @@
     </PixTooltip>
   </div>
   {{#if @nonBlockingCandidateIssueCategory.isChecked}}
+    <PixMessage @type="info" @withIcon={{true}}>
+      Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux
+      questions.
+    </PixMessage>
     <div class="non-blocking-candidate-issue-certification-issue-report-fields__details">
       <label for="text-area-for-category-candidate-issue">Décrivez l'incident rencontré</label>
       <PixTextarea

--- a/certif/app/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields.hbs
@@ -24,6 +24,10 @@
     </PixTooltip>
   </div>
   {{#if @nonBlockingTechnicalIssueCategory.isChecked}}
+    <PixMessage @type="info" @withIcon={{true}}>
+      Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux
+      questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10.
+    </PixMessage>
     <div class="non-blocking-technical-issue-certification-issue-report-fields__details">
       <label for="text-area-for-category-technical-issue">Décrivez l'incident rencontré</label>
       <PixTextarea

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -78,6 +78,10 @@
       margin: 16px 0 8px;
     }
 
+    .pix-message--info {
+      margin-top: 16px;
+    }
+
     .non-blocking-candidate-issue-certification-issue-report-fields__radio-button__tooltip,
     .non-blocking-technical-issue-certification-issue-report-fields__radio-button__tooltip {
       display: flex;

--- a/certif/tests/integration/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields_test.js
@@ -50,5 +50,31 @@ module(
       // then
       assert.dom(screen.getByText("Décrivez l'incident rencontré")).exists();
     });
+
+    test('it should show information message if category is checked', async function (assert) {
+      // given
+      const toggleOnCategory = sinon.stub();
+      const nonBlockingCandidateIssueCategory = { isChecked: true };
+      this.set('toggleOnCategory', toggleOnCategory);
+      this.set('nonBlockingCandidateIssueCategory', nonBlockingCandidateIssueCategory);
+
+      // when
+      const screen = await renderScreen(hbs`
+      <IssueReportModal::NonBlockingCandidateIssueCertificationIssueReportFields
+        @nonBlockingCandidateIssueCategory={{this.nonBlockingCandidateIssueCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+      await click(screen.getByRole('radio'));
+
+      // then
+      assert
+        .dom(
+          screen.getByText(
+            "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions."
+          )
+        )
+        .exists();
+    });
   }
 );

--- a/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields_test.js
@@ -49,5 +49,31 @@ module(
       // then
       assert.dom(screen.getByText("Décrivez l'incident rencontré")).exists();
     });
+
+    test('it should show information message if category is checked', async function (assert) {
+      // given
+      const toggleOnCategory = sinon.stub();
+      const nonBlockingTechnicalIssueCategory = { isChecked: true };
+      this.set('toggleOnCategory', toggleOnCategory);
+      this.set('nonBlockingTechnicalIssueCategory', nonBlockingTechnicalIssueCategory);
+
+      // when
+      const screen = await renderScreen(hbs`
+      <IssueReportModal::NonBlockingTechnicalIssueCertificationIssueReportFields
+        @nonBlockingTechnicalIssueCategory={{this.nonBlockingTechnicalIssueCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+      await click(screen.getByRole('radio'));
+
+      // then
+      assert
+        .dom(
+          screen.getByText(
+            "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10."
+          )
+        )
+        .exists();
+    });
   }
 );


### PR DESCRIPTION
## :unicorn: Problème
Une fois les autres champs libres supprimés, on craint que les utilisateurs utilisent les catégories C7 et C8 pour remonter des incidents bloquants, qui ne seront alors pas pris en compte par le pôle certif.

## :robot: Solution
Ajouter un texte explicatif pour les catégories C7 et C8, pour notamment préciser ce que signifie “non bloquant”, lorsque l’utilisateur sélectionne l’une ou l’autre catégorie : 

texte à afficher pour la catégorie C7 - Incident technique non bloquant

“Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10.”

texte à afficher pour la catégorie C8 - Incident lié au candidat non bloquant 

“Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions.”

## :100: Pour tester
- Se connecter à Pix Certif avec le compte ``certifsco@example.net``
- Aller sur la session 3 et la finaliser
- Cliquer sur Ajouter dans la colonne signalement
- Sélectionner la catégorie C7 et constater le message d'information suivant : 
<img width="638" alt="Capture d’écran 2022-06-16 à 14 21 57" src="https://user-images.githubusercontent.com/103997660/174068663-adeb878b-d139-411a-bc0c-9ff2aee52551.png">
- Sélectionner la catégorie C8 et constater le message suivant :
<img width="638" alt="Capture d’écran 2022-06-16 à 14 23 01" src="https://user-images.githubusercontent.com/103997660/174068820-fdafa34d-85bb-488c-ab21-e303d1caf3a0.png">
