### PR TITLE
[FEATURE] Augmenter la taille des macarons dans les certificats et certificats partagés (PIX-5126).

### DIFF
--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -31,8 +31,8 @@
     text-align: center;
 
     img {
-      width: 110px;
-      height: 110px;
+      width: 190px;
+      height: 190px;
     }
 
     span {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, les textes sur les macarons des certif complémentaires affichés sur le certificat/certificat partagé ne sont pas très lisibles car trop petits.

## :robot: Solution
Augmenter la taille des macarons

## :rainbow: Remarques
Les macarons ne sont pas tous à la même taille.

## :100: Pour tester
- Se connecter à Pix App avec le compte `certif-success@example.net`
- Visualiser la certification obtenue par l'utilisateur
- Vérifier que la largeur et hauteur des macarons correspondent bien à 190px
- Faire la même vérification sur le certificat partagé (https://app-pr4530.review.pix.fr/verification-certificat)
