### PR TITLE
[BUGFIX] Formattage des dates différents sur certains environnements

### DIFF
--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -2,6 +2,7 @@
 import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
+import dayjs from 'dayjs';
 
 export default class CertificationDetails extends Model {
   @attr() competencesWithMark;
@@ -50,12 +51,12 @@ export default class CertificationDetails extends Model {
 
   @computed('createdAt')
   get creationDate() {
-    return new Date(this.createdAt).toLocaleString('fr-FR');
+    return dayjs(this.createdAt).format('DD/MM/YYYY, HH:mm:ss');
   }
 
   @computed('completedAt')
   get completionDate() {
-    return new Date(this.completedAt).toLocaleString('fr-FR');
+    return dayjs(this.completedAt).format('DD/MM/YYYY, HH:mm:ss');
   }
 
   neutralizeChallenge = memberAction({

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -2,6 +2,7 @@
 import { computed } from '@ember/object';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
+import dayjs from 'dayjs';
 
 export const ACQUIRED = 'acquired';
 export const REJECTED = 'rejected';
@@ -50,12 +51,12 @@ export default class Certification extends Model {
 
   @computed('createdAt')
   get creationDate() {
-    return new Date(this.createdAt).toLocaleString('fr-FR');
+    return dayjs(this.createdAt).format('DD/MM/YYYY, HH:mm:ss');
   }
 
   @computed('completedAt')
   get completionDate() {
-    return this.completedAt ? new Date(this.completedAt).toLocaleString('fr-FR') : null;
+    return this.completedAt ? dayjs(this.completedAt).format('DD/MM/YYYY, HH:mm:ss') : null;
   }
 
   @computed('status')

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 import find from 'lodash/find';
 import { certificationStatuses } from 'pix-admin/models/certification';
+import dayjs from 'dayjs';
 
 export const ENDED_BY_SUPERVISOR = 'endedBySupervisor';
 export const juryCertificationSummaryStatuses = [{ value: ENDED_BY_SUPERVISOR, label: 'Terminée par le surveillant' }];
@@ -25,12 +26,12 @@ export default class JuryCertificationSummary extends Model {
 
   @computed('createdAt')
   get creationDate() {
-    return new Date(this.createdAt).toLocaleString('fr-FR');
+    return dayjs(this.createdAt).format('DD/MM/YYYY, HH:mm:ss');
   }
 
   @computed('completedAt')
   get completionDate() {
-    return this.completedAt ? new Date(this.completedAt).toLocaleString('fr-FR') : null;
+    return this.completedAt ? dayjs(this.completedAt).format('DD/MM/YYYY, HH:mm:ss') : null;
   }
 
   get complementaryCertificationsLabel() {


### PR DESCRIPTION
## :unicorn: Problème

L'utilisation de [`Date.toLocaleString()`](https://mdn.io/Date.toLocaleString) ne donne pas le même résultat sur certains environnements ; dans certains cas la date et l'heure sont séparées par une virgule, dans d'autres cas non.

Node 16.14.0 (notamment la CI) :
```js
new Date('2021-06-30 15:10:45').toLocaleString('fr-FR') // '30/06/2021, 15:10:45'
```

Chrome 103 :
```js
new Date('2021-06-30 15:10:45').toLocaleString('fr-FR') // '30/06/2021 15:10:45'
```

Firefox 101 :
```js
new Date('2021-06-30 15:10:45').toLocaleString('fr-FR') // '30/06/2021 15:10:45'
```

## :robot: Solution

Utiliser `dayjs` pour avoir un formattage des dates stable.

## :rainbow: Remarques

N/A

## :100: Pour tester

Aller voir une certification dans admin, et vérifier que les champs "Terminée le" et "Créée le" contiennent bien une virgule :
https://admin-pr4531.review.pix.fr/certifications/200
