### PR TITLE
[BUGFIX] Admin: Tooltips de la navbar cachées par les infos de la certification

### DIFF
--- a/admin/app/templates/authenticated/certifications/certification/details.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/details.hbs
@@ -2,7 +2,7 @@
 <div class="certification-details">
   <div class="row">
     <div class="col">
-      <div class="card border-primary sticky-top certification-details__info">
+      <div class="card border-primary certification-details__info">
         <div class="card-body">
           <div class="row">
             <div class="col">Statut :</div>


### PR DESCRIPTION
## :unicorn: Problème

Le `z-index` des infos de la certification sur la page de détail est trop élevé, les tooltips de la navbar se retrouvent en dessous :

![image](https://user-images.githubusercontent.com/19571875/174076305-8c6de9ca-4ef6-4482-84a9-6aa4f66eb1aa.png)

## :robot: Solution

Supprimer la classe `sticky-top` sur la card.
Cette classe provient de `bootstrap` et n'avait pas l'effet escompté (à cause du `overflow: auto` de `<main class="page-body">`).

## :rainbow: Remarques

N/A

## :100: Pour tester

Aller sur le détail d'une certification et vérifier que les tooltips de la navbar ne s'affichent pas en dessous de la card d'info :
https://admin-pr4532.review.pix.fr/certifications/200/details
