### PR TITLE
[BUGFIX] Les message de format de code de vérification de l'attestation sont incohérents (PIX-5161).

### DIFF
--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -40,6 +40,11 @@ exports.register = async function (server) {
       method: 'POST',
       path: '/api/shared-certifications',
       config: {
+        validate: {
+          payload: Joi.object({
+            verificationCode: Joi.string().min(10).max(10),
+          }),
+        },
         auth: false,
         handler: certificationController.getCertificationByVerificationCode,
         notes: [

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -45,7 +45,7 @@ exports.register = async function (server) {
         notes: [
           "- **Route accessible par n'importe qui**\n" +
             '- Récupération des informations d’une certification d’un utilisateur' +
-            ' via un PixScore et un code de vérification',
+            ' via un code de vérification',
         ],
         tags: ['api', 'certifications', 'shared-certifications'],
       },

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -7,6 +7,9 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const {
+  generateCertificateVerificationCode,
+} = require('../../../../lib/domain/services/verify-certificate-code-service');
 
 describe('Acceptance | API | Certifications', function () {
   let server, options;
@@ -24,6 +27,7 @@ describe('Acceptance | API | Certifications', function () {
       userId,
       isPublished: true,
       maxReachableLevelOnCertificationDate: 3,
+      verificationCode: await generateCertificateVerificationCode(),
     });
     assessment = databaseBuilder.factory.buildAssessment({
       userId,
@@ -503,7 +507,7 @@ describe('Acceptance | API | Certifications', function () {
 
       it('should return notFound 404 HTTP status code when param is incorrect', async function () {
         // given
-        const verificationCode = 'P-WRONG-CODE';
+        const verificationCode = 'P-12345678';
         options = {
           method: 'POST',
           url: '/api/shared-certifications',

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
@@ -41,7 +41,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function (
       await controller.actions.checkCertificate.call(controller, event);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Veuillez vérifier le format de votre code (P-XXXXXXX).');
+      expect(controller.get('errorMessage')).to.equal('Veuillez vérifier le format de votre code (P-XXXXXXXX).');
     });
 
     it('should set showNotFoundCertificationErrorMessage to true when no certificate is found', async () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -766,9 +766,9 @@
       "title": "Verify the authenticity of a Pix Certificate",
       "description": "The Pix Certification assesses digital literacy and is recognised throughout Europe and in the business world.",
       "errors": {
-        "missing-code": "Please enter the verification code in this format: P-XXXXXXX",
+        "missing-code": "Please enter the verification code in this format: P-XXXXXXXX",
         "not-found": "There is no corresponding Pix Certificate.",
-        "unallowed-access": "Please fill out the field above with the verification code in this format: P-XXXXXXX",
+        "unallowed-access": "Please fill out the field above with the verification code in this format: P-XXXXXXXX",
         "wrong-format": "Please check your verification code"
       },
       "first-title": "Verify the score of a Pix Certificate",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -769,7 +769,7 @@
         "missing-code": "Merci de renseigner le code de vérification.",
         "not-found": "Il n'y a pas de certificat Pix correspondant.",
         "unallowed-access": "Merci de renseigner le code de vérification au format P-XXXXXXXX dans le champ ci-dessus.",
-        "wrong-format": "Veuillez vérifier le format de votre code (P-XXXXXXX)."
+        "wrong-format": "Veuillez vérifier le format de votre code (P-XXXXXXXX)."
       },
       "first-title": "Vérifier un certificat Pix",
       "label": "Code de vérification (P-XXXXXXXX)",


### PR DESCRIPTION
## :unicorn: Problème
Il est:
- à 10 caractères P-XXXXXXXX dans le champ de saisie
- à 9 caractères P-XXXXXXX dans le message d’erreur

## :robot: Solution
Utiliser la version conforme, à 10 caractères

## :rainbow: Remarques
Ajout d'une validation Joi

## :100: Pour tester
- Visiter la page https://app-pr4533.review.pix.fr//verification-certificat
- Entrer 1 dans le code
- Vérifier que le message est `Veuillez vérifier le format de votre code (P-XXXXXXXX).`
- Entrer "P-P4GQ4B7K"
- Verifier que le certificat partagé s'affiche correctement