### PR TITLE
[BUGFIX] Remettre l'image quand il n'y a pas de campagne(PIX-5135)

### DIFF
--- a/orga/app/components/campaign/no-campaign-panel.hbs
+++ b/orga/app/components/campaign/no-campaign-panel.hbs
@@ -1,5 +1,5 @@
 <section class="no-campaign-panel panel">
-  <img src="https://orga-pr3921.review.pix.fr/images/empty-state.svg" alt="" role="none" />
+  <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none" />
 
   <p class="no-campaign-panel__information-text hide-on-mobile">
     {{t "pages.campaigns-list.no-campaign"}}

--- a/orga/tests/integration/components/campaign/no-campaign-panel_test.js
+++ b/orga/tests/integration/components/campaign/no-campaign-panel_test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl, t } from 'ember-intl/test-support';
+
+module('Integration | Component | Campaign::NoCampaignPanel', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it displays the empty message', async function (assert) {
+    await render(hbs`<Campaign::NoCampaignPanel />`);
+
+    assert.contains(t('pages.campaigns-list.no-campaign'));
+  });
+
+  test('it displays the empty image', async function (assert) {
+    await render(hbs`<Campaign::NoCampaignPanel />`);
+
+    assert.dom('img[src="/images/empty-state.svg"]').exists();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsque qu'il n'y a pas de campagne dans une organisation, normalement on affiche une image 'empty state'. Mais cette image a disparu.

## :robot: Solution
Afficher de nouveau l'image

## :rainbow: Remarques


## :100: Pour tester
- Aller sur Pix Admin pour créer une nouvelle organisation et y ajouter `Daenerys`.
- Se connecter à Pix ORGA avec `pro.admin`
- Aller sur l'orga fraichement créée et constater le retour de l'image
