### PR TITLE
[FEATURE] Retirer le bandeau de renseignement du mail de destinataire de la certification

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -37,11 +37,6 @@ export default class SessionsDetailsController extends Controller {
     return this.hasOneOrMoreCandidates;
   }
 
-  @computed('shouldDisplayPrescriptionScoStudentRegistrationFeature')
-  get shouldDisplayResultRecipientInfoMessage() {
-    return !this.shouldDisplayPrescriptionScoStudentRegistrationFeature;
-  }
-
   get shouldDisplayPrescriptionScoStudentRegistrationFeature() {
     return this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
   }

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -18,8 +18,4 @@ export default class ListController extends Controller {
   goToSessionDetails(sessionId) {
     this.transitionToRoute('authenticated.sessions.details', sessionId);
   }
-
-  get shouldDisplayResultRecipientInfoMessage() {
-    return !this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
-  }
 }

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -25,16 +25,6 @@
     </div>
   </div>
 
-  {{#if this.shouldDisplayResultRecipientInfoMessage}}
-    <PixMessage @withIcon={{true}}>
-      Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br />
-      Pensez à bien renseigner ce champ lors de l'inscription des candidats.
-      <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
-        Plus d'informations ici.
-      </a>
-    </PixMessage>
-  {{/if}}
-
   <div class="panel session-details__controls">
     <nav class="navbar session-details__controls-navbar-tabs">
       <LinkTo @route="authenticated.sessions.details.parameters" class="navbar-item">

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -6,16 +6,6 @@
       <h1 class="page__title page-title">Sessions de certification</h1>
     </div>
 
-    {{#if this.shouldDisplayResultRecipientInfoMessage}}
-      <PixMessage @withIcon={{true}}>
-        Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br />
-        Pensez à bien renseigner ce champ lors de l'inscription des candidats.
-        <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
-          Plus d'informations ici.
-        </a>
-      </PixMessage>
-    {{/if}}
-
     <div class="panel">
       <div class="session-list__header">
         <PixButtonLink @route="authenticated.sessions.new">

--- a/certif/tests/unit/controllers/authenticated/sessions/details_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details_test.js
@@ -15,9 +15,7 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
       const certificationCandidatesCountResult = controller.certificationCandidatesCount;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(certificationCandidatesCountResult, '(2)');
+      assert.strictEqual(certificationCandidatesCountResult, '(2)');
     });
 
     test('should return an empty string when there are no certification candidates in the session', function (assert) {
@@ -29,9 +27,7 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
       const certificationCandidatesCountResult = controller.certificationCandidatesCount;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(certificationCandidatesCountResult, '');
+      assert.strictEqual(certificationCandidatesCountResult, '');
     });
   });
 
@@ -131,40 +127,6 @@ module('Unit | Controller | authenticated/sessions/details', function (hooks) {
 
         // then
         assert.ok(shouldDisplayDownloadButton);
-      });
-    });
-  });
-
-  module('#shouldDisplayResultRecipientInfoMessage', function () {
-    module('when the current user certification center does manage students', function () {
-      test('should return false', function (assert) {
-        // given
-        const controller = this.owner.lookup('controller:authenticated/sessions/details');
-        controller.currentUser = {
-          currentAllowedCertificationCenterAccess: { isScoManagingStudents: true },
-        };
-
-        // when
-        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
-
-        // then
-        assert.notOk(shouldDisplayResultRecipientInfoMessage);
-      });
-    });
-
-    module('when current user does not manage students', function () {
-      test('should return true', function (assert) {
-        // given
-        const controller = this.owner.lookup('controller:authenticated/sessions/details');
-        controller.currentUser = {
-          currentAllowedCertificationCenterAccess: { isScoManagingStudents: false },
-        };
-
-        // when
-        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
-
-        // then
-        assert.ok(shouldDisplayResultRecipientInfoMessage);
       });
     });
   });

--- a/certif/tests/unit/controllers/authenticated/sessions/list_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list_test.js
@@ -57,4 +57,38 @@ module('Unit | Controller | authenticated/sessions/list', function (hooks) {
       });
     });
   });
+
+  module('#displayNoSessionPanel', function () {
+    module('when there are sessions', function () {
+      test('should return false', async function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/sessions/list');
+        controller.model = {
+          meta: { hasSessions: true },
+        };
+
+        // when
+        const displayNoSessionPanel = controller.displayNoSessionPanel;
+
+        // then
+        assert.false(displayNoSessionPanel);
+      });
+    });
+
+    module('when there are no sessions', function () {
+      test('should return true', async function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/sessions/list');
+        controller.model = {
+          meta: { hasSessions: false },
+        };
+
+        // when
+        const displayNoSessionPanel = controller.displayNoSessionPanel;
+
+        // then
+        assert.true(displayNoSessionPanel);
+      });
+    });
+  });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/list_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list_test.js
@@ -1,62 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
-import Service from '@ember/service';
 
 module('Unit | Controller | authenticated/sessions/list', function (hooks) {
   setupTest(hooks);
-
-  module('#shouldDisplayResultRecipientInfoMessage', function () {
-    module('when the current user certification center does manage students', function () {
-      test('should also return false', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const currentAllowedCertificationCenterAccess = run(() =>
-          store.createRecord('allowed-certification-center-access', {
-            id: 123,
-            type: 'SCO',
-            isRelatedToManagingStudentsOrganization: true,
-          })
-        );
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-        const controller = this.owner.lookup('controller:authenticated/sessions/list');
-
-        // when
-        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
-
-        // then
-        assert.notOk(shouldDisplayResultRecipientInfoMessage);
-      });
-    });
-
-    module('when current user is not sco managing students', function () {
-      test('should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const currentAllowedCertificationCenterAccess = run(() =>
-          store.createRecord('allowed-certification-center-access', {
-            id: 123,
-            type: 'SCO',
-            isRelatedToManagingStudentsOrganization: false,
-          })
-        );
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-        const controller = this.owner.lookup('controller:authenticated/sessions/list');
-
-        // when
-        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
-
-        // then
-        assert.ok(shouldDisplayResultRecipientInfoMessage);
-      });
-    });
-  });
 
   module('#displayNoSessionPanel', function () {
     module('when there are sessions', function () {


### PR DESCRIPTION
## :unicorn: Problème
Sur l'espace certification, un bandeau est affiché pour indiquer de renseigner l'adresse email du destinataire des résultats.

## :robot: Solution
On veut le supprimer.

## :rainbow: Remarques
Le bandeau se trouve sur 2 pages celle de la liste des sessions et celle du détail de la session.

## :100: Pour tester
- Se connecter à pix certif avec le mail ```certifsup@example.net```
- Sur l'onglet session, constater que le bandeau n'est plus présent.
- Aller sur le détail d'une session et constater que le bandeau n'est plus présent.