### PR TITLE
[BUGFIX] Afficher les dates formattées que si elles existent dans Pix Admin (PIX-5141).

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -3,10 +3,16 @@
 </header>
 
 <dl>
-  <div class="authentication-method__connexions-information">
-    <dt>Date de dernière connexion :</dt>
-    <dd>{{dayjs-format @user.lastLoggedAt "DD/MM/YYYY"}}</dd>
-  </div>
+  {{#if @user.lastLoggedAt}}
+    <div class="authentication-method__connexions-information">
+      <dt>Date de dernière connexion :</dt>
+      <dd>{{dayjs-format @user.lastLoggedAt "DD/MM/YYYY"}}</dd>
+    </div>
+  {{else}}
+    <div class="authentication-method__connexions-information">
+      L'utilisateur ne s'est jamais connecté
+    </div>
+  {{/if}}
   {{#if @user.emailConfirmedAt}}
     <div class="authentication-method__connexions-information">
       <dt>Adresse e-mail confirmée le :</dt>

--- a/admin/app/components/users/user-detail-personal-information/user-overview.js
+++ b/admin/app/components/users/user-detail-personal-information/user-overview.js
@@ -105,18 +105,26 @@ export default class UserOverview extends Component {
   }
 
   get userHasValidatePixAppTermsOfService() {
-    const formattedDate = dayjs(this.args.user.lastTermsOfServiceValidatedAt).format('DD/MM/YYYY');
-    return this.args.user.cgu ? `OUI, le ${formattedDate}` : 'NON';
+    return this._formatValidatedTermsOfServiceText(this.args.user.lastTermsOfServiceValidatedAt, this.args.user.cgu);
   }
 
   get userHasValidatePixOrgaTermsOfService() {
-    const formattedDate = dayjs(this.args.user.lastPixOrgaTermsOfServiceValidatedAt).format('DD/MM/YYYY');
-    return this.args.user.pixOrgaTermsOfServiceAccepted ? `OUI, le ${formattedDate}` : 'NON';
+    return this._formatValidatedTermsOfServiceText(
+      this.args.user.lastPixOrgaTermsOfServiceValidatedAt,
+      this.args.user.pixOrgaTermsOfServiceAccepted
+    );
   }
 
   get userHasValidatePixCertifTermsOfService() {
-    const formattedDate = dayjs(this.args.user.lastPixCertifTermsOfServiceValidatedAt).format('DD/MM/YYYY');
-    return this.args.user.pixCertifTermsOfServiceAccepted ? `OUI, le ${formattedDate}` : 'NON';
+    return this._formatValidatedTermsOfServiceText(
+      this.args.user.lastPixCertifTermsOfServiceValidatedAt,
+      this.args.user.pixCertifTermsOfServiceAccepted
+    );
+  }
+
+  _formatValidatedTermsOfServiceText(date, hasValidatedTermsOfService) {
+    const formattedDateText = date ? `, le ${dayjs(date).format('DD/MM/YYYY')}` : '';
+    return hasValidatedTermsOfService ? `OUI${formattedDateText}` : 'NON';
   }
 
   _initForm() {

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -14,9 +14,9 @@ module('Integration | Component | users | user-detail-personal-information/authe
 
     module('When user has authentication methods', function () {
       module('when user has confirmed his email address', function () {
-        test('should display last connection and email confirmed dates', async function (assert) {
+        test('should display email confirmed date', async function (assert) {
           // given
-          this.set('user', { lastLoggedAt: new Date('2022-07-01'), emailConfirmedAt: new Date('2020-10-30') });
+          this.set('user', { emailConfirmedAt: new Date('2020-10-30') });
           this.owner.register('service:access-control', AccessControlStub);
 
           // when
@@ -24,15 +24,14 @@ module('Integration | Component | users | user-detail-personal-information/authe
             <Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`);
 
           // then
-          assert.dom(screen.getByText('01/07/2022')).exists();
           assert.dom(screen.getByText('30/10/2020')).exists();
         });
       });
 
-      module('when user has not confirmed his email address', function () {
+      module('when user has not confirmed their email address', function () {
         test('it should display "Adresse e-mail non confirmée"', async function (assert) {
           // given
-          this.set('user', { lastLoggedAt: null, emailConfirmedAt: null });
+          this.set('user', { emailConfirmedAt: null });
           this.owner.register('service:access-control', AccessControlStub);
 
           // when
@@ -41,6 +40,36 @@ module('Integration | Component | users | user-detail-personal-information/authe
 
           // then
           assert.dom(screen.getByText('Adresse e-mail non confirmée')).exists();
+        });
+      });
+
+      module('when user has logged in', function () {
+        test('should display date of latest connection', async function (assert) {
+          // given
+          this.set('user', { lastLoggedAt: new Date('2022-07-01') });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`
+            <Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`);
+
+          // then
+          assert.dom(screen.getByText('01/07/2022')).exists();
+        });
+      });
+
+      module('when user never logged in', function () {
+        test("it should display `L'utilisateur ne s'est jamais connecté`", async function (assert) {
+          // given
+          this.set('user', { lastLoggedAt: null });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(hbs`
+            <Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`);
+
+          // then
+          assert.dom(screen.getByText("L'utilisateur ne s'est jamais connecté")).exists();
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Il est possible que la date de dernière connection ou de validation des CGU pour Pix App, Pix Certif, ou Pix Orga soit vide, et dans ce cas il ne faudrait pas les formatter sinon `Invalid Date` s'affiche.

## :robot: Solution
Formatter la date que si elle existe.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Visitez [User](https://admin-pr4539.review.pix.fr/users/1)
- Vérifiez que toutes les dates apparaissent.
- Modifiez la table `users` dans la bdd et supprimez la valeurs des colonnes suivantes pour le user avec id `1` 
    - `lastLoggedAt`, 
    - `lastTermsOfServiceValidatedAt`, 
    - `lastPixOrgaTermsOfServiceValidatedAt`,
    - `lastPixCertifTermsOfServiceValidatedAt`
- Rafraichissez la page et vérifiez que `Invalid date` ne s'affiche pas
