### PR TITLE
[BUGFIX] Supprimer l'erreur `TransitionAborted` lors du passage du didacticiel (PIX-5167).

### DIFF
--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -36,7 +36,7 @@ export default class CampaignsAssessmentTutorial extends Route.extend(SecuredRou
     await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenAssessmentInstructions: true } });
 
     this.tutorialPageId = 0;
-    return this.transitionTo('campaigns.assessment.start-or-resume', this.campaignCode, {
+    this.transitionTo('campaigns.assessment.start-or-resume', this.campaignCode, {
       queryParams: {
         hasConsultedTutorial: true,
       },

--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -4,20 +4,21 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
-export default Route.extend(SecuredRouteMixin, {
-  currentUser: service(),
-  intl: service(),
+export default class CampaignsAssessmentTutorial extends Route.extend(SecuredRouteMixin) {
+  @service currentUser;
+  @service intl;
 
-  campaignCode: null,
-  tutorialPageId: 0,
-  tutorialPageCount: 5,
+  campaignCode = null;
+  tutorialPageId = 0;
+  tutorialPageCount = 5;
 
   _setupPaging(numberOfPages, currentTutorialPageId) {
     const classOfTutorialPages = new Array(numberOfPages);
     classOfTutorialPages[currentTutorialPageId] = 'dot__active';
     return classOfTutorialPages;
-  },
+  }
 
   model() {
     this.campaignCode = this.paramsFor('campaigns').code;
@@ -28,26 +29,26 @@ export default Route.extend(SecuredRouteMixin, {
       showNextButton: this.tutorialPageId < this.tutorialPageCount - 1,
       paging: this._setupPaging(this.tutorialPageCount, this.tutorialPageId),
     };
-  },
+  }
 
-  actions: {
-    async submit() {
-      await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenAssessmentInstructions: true } });
+  @action
+  async submit() {
+    await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenAssessmentInstructions: true } });
 
-      this.tutorialPageId = 0;
-      return this.transitionTo('campaigns.assessment.start-or-resume', this.campaignCode, {
-        queryParams: {
-          hasConsultedTutorial: true,
-        },
-      });
-    },
+    this.tutorialPageId = 0;
+    return this.transitionTo('campaigns.assessment.start-or-resume', this.campaignCode, {
+      queryParams: {
+        hasConsultedTutorial: true,
+      },
+    });
+  }
 
-    next() {
-      const nextTutorialPageId = this.tutorialPageId + 1;
-      if (nextTutorialPageId < this.tutorialPageCount) {
-        this.tutorialPageId = nextTutorialPageId;
-        this.refresh();
-      }
-    },
-  },
-});
+  @action
+  next() {
+    const nextTutorialPageId = this.tutorialPageId + 1;
+    if (nextTutorialPageId < this.tutorialPageCount) {
+      this.tutorialPageId = nextTutorialPageId;
+      this.refresh();
+    }
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, lorsqu'un utilisateur passe ou fini le didacticiel dans une campagne, l'erreur `TransitionAborted` et ajouté dans la console. 

## :robot: Solution
- Retirer le `return` de la transition permet d'éviter cette erreur

## :rainbow: Remarques
- Au passage le router a été passé en Octane.

- Pas de bonne pratique préconisé par ember ? 🤔 On peut même [voir une RFC ](https://emberjs.github.io/rfcs/0674-deprecate-transition-methods-of-controller-and-route.html)où ils font un `return`. 
- Pas de `return` présent dans le livre Rock and Roll with Ember cependant.

## :100: Pour tester
- Se connecter à Pix App
- Lancer une campagne 
- Voir le didacticiel 
- Le passer 
- Constater qu'il n'y a pas d'erreur dans la console
