### PR TITLE
[BUGFIX] Corrige le down de la migration 20220510124351_create-target-profile-template-table.js

### DIFF
--- a/api/db/migrations/20220510124351_create-target-profile-template-table.js
+++ b/api/db/migrations/20220510124351_create-target-profile-template-table.js
@@ -23,6 +23,6 @@ exports.down = async function (knex) {
   await knex.schema.table(TARGET_PROFILE_TABLE_NAME, (t) => {
     t.dropColumn('targetProfileTemplateId');
   });
-  await knex.dropTable(TEMPLATE_TUBES_TABLE_NAME);
-  await knex.dropTable(TEMPLATE_TABLE_NAME);
+  await knex.schema.dropTable(TEMPLATE_TUBES_TABLE_NAME);
+  await knex.schema.dropTable(TEMPLATE_TABLE_NAME);
 };


### PR DESCRIPTION
## :unicorn: Problème
La migration down de ` 20220510124351_create-target-profile-template-table.js` ne fonctionne pas: `knex.dropTable is not a function`.

## :robot: Solution
Corriger la migration.

## :100: Pour tester
1. `npm run db:migrate`
2. `npx knex --knexfile db/knexfile.js migrate:rollback --all`
3. S'assurer que les migrations sont bien toutes supprimées.
