### PR TITLE
[BUGFIX] Ne pas afficher le nouveau membre dans la liste si une erreur survient (PIX-5183)

### DIFF
--- a/admin/app/components/team/add-member.js
+++ b/admin/app/components/team/add-member.js
@@ -25,13 +25,16 @@ export default class AddMember extends Component {
       return this.notifications.error('Cet agent a déjà accès');
     }
 
+    let adminMember;
+
     try {
-      const adminMember = this.store.createRecord('admin-member', { email: this.email, role: this.role });
+      adminMember = this.store.createRecord('admin-member', { email: this.email, role: this.role });
       await adminMember.save();
       this.email = '';
       this.role = 'SUPER_ADMIN';
       this.notifications.success("L'agent a dorénavant accès");
     } catch (error) {
+      this.store.deleteRecord(adminMember);
       let errorMessage = "Une erreur s'est produite, veuillez réessayer.";
 
       if (error?.errors?.length) {

--- a/admin/tests/acceptance/authenticated/team/add-member_test.js
+++ b/admin/tests/acceptance/authenticated/team/add-member_test.js
@@ -96,6 +96,7 @@ module('Acceptance | Team | Add member', function (hooks) {
 
       // then
       assert.dom(screen.getByText("Cet utilisateur n'existe pas")).exists();
+      assert.dom(screen.getByRole('table', { name: 'Liste des membres' })).doesNotContainText('marie.tim@example.net');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'ajout d'un member qui n'existe pas, une erreur doit être remontée et aucune nouvelle ligne doit être ajoutée dans le tableau des membres. Ce qui n'est pas le cas.

## :robot: Solution

Faire appel à la méthode `deleteRecord` avec en paramètre la référence vers le nouveau record qui a été créé dans le store ember.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter avec le compte `superadmin@example.net`
- Allez sur la page `Équipe`
- Tentez de donner accès avec une adresse e-mail qui n'existe pas en base de données
- Constatez l'affichage d'une notification et d'un message en dessous de l'input
- Constatez qu'aucune nouvelle ligne n'est apparue dans la liste des membres
