### PR TITLE
[FEATURE] Ne pas mentionner la valeur professionnalisante de la certification Pix par France Compétences dans les attestations téléchargées depuis le domaine .org (PIX-5162).

### DIFF
--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -34,6 +34,7 @@ module.exports = {
   async getPDFAttestation(request, h) {
     const userId = request.auth.credentials.userId;
     const certificationId = request.params.id;
+    const isFrenchDomainExtension = Boolean(request.query?.isFrenchDomainExtension);
     const attestation = await usecases.getCertificationAttestation({
       userId,
       certificationId,
@@ -41,6 +42,7 @@ module.exports = {
 
     const { buffer } = await certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
       certificates: [attestation],
+      isFrenchDomainExtension,
     });
 
     const fileName = `attestation-pix-${moment(attestation.deliveredAt).format('YYYYMMDD')}.pdf`;

--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -34,7 +34,7 @@ module.exports = {
   async getPDFAttestation(request, h) {
     const userId = request.auth.credentials.userId;
     const certificationId = request.params.id;
-    const isFrenchDomainExtension = Boolean(request.query?.isFrenchDomainExtension);
+    const isFrenchDomainExtension = request.query.isFrenchDomainExtension;
     const attestation = await usecases.getCertificationAttestation({
       userId,
       certificationId,

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -63,6 +63,9 @@ exports.register = async function (server) {
           params: Joi.object({
             id: identifiersType.certificationCourseId,
           }),
+          query: Joi.object({
+            isFrenchDomainExtension: Joi.boolean().required(),
+          }),
         },
         handler: certificationController.getPDFAttestation,
         notes: [

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -526,7 +526,7 @@ exports.register = async (server) => {
           }),
           query: Joi.object({
             division: Joi.string().required(),
-            isFrenchDomainExtension: Joi.boolean(),
+            isFrenchDomainExtension: Joi.boolean().required(),
           }),
         },
         handler: organizationController.downloadCertificationAttestationsForDivision,

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -526,6 +526,7 @@ exports.register = async (server) => {
           }),
           query: Joi.object({
             division: Joi.string().required(),
+            isFrenchDomainExtension: Joi.boolean(),
           }),
         },
         handler: organizationController.downloadCertificationAttestationsForDivision,

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -134,7 +134,7 @@ module.exports = {
 
   async downloadCertificationAttestationsForDivision(request, h) {
     const organizationId = request.params.id;
-    const { division } = request.query;
+    const { division, isFrenchDomainExtension } = request.query;
 
     const attestations = await usecases.findCertificationAttestationsForDivision({
       organizationId,
@@ -143,6 +143,7 @@ module.exports = {
 
     const { buffer } = await certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
       certificates: attestations,
+      isFrenchDomainExtension,
     });
 
     const now = moment();

--- a/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
+++ b/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
@@ -28,6 +28,7 @@ class AttestationViewModel {
     pixPlusEduCertificationImagePath,
     pixPlusEduTemporaryBadgeMessage,
     competenceDetailViewModels,
+    isFrenchDomainExtension,
   }) {
     this.pixScore = pixScore;
     this.maxReachableScore = maxReachableScore;
@@ -50,6 +51,7 @@ class AttestationViewModel {
     this._hasAcquiredPixPlusDroitCertification = hasAcquiredPixPlusDroitCertification;
     this._hasAcquiredCleaCertification = hasAcquiredCleaCertification;
     this._hasAcquiredPixPlusEduCertification = hasAcquiredPixPlusEduCertification;
+    this._isFrenchDomainExtension = isFrenchDomainExtension;
   }
 
   get certificationDate() {
@@ -77,11 +79,12 @@ class AttestationViewModel {
   }
 
   shouldDisplayProfessionalizingCertificationMessage() {
+    if (!this._isFrenchDomainExtension) return false;
     if (!this._deliveredAt) return false;
     return this._deliveredAt.getTime() >= PROFESSIONALIZING_VALIDITY_START_DATE.getTime();
   }
 
-  static from(certificate) {
+  static from(certificate, isFrenchDomainExtension) {
     const pixScore = certificate.pixScore.toString();
     const maxReachableScore = certificate.maxReachableScore.toString() + '*';
 
@@ -159,6 +162,7 @@ class AttestationViewModel {
       hasAcquiredCleaCertification,
       hasAcquiredPixPlusEduCertification,
       competenceDetailViewModels,
+      isFrenchDomainExtension,
     });
   }
 }

--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -26,11 +26,12 @@ const templates = {
 
 async function getCertificationAttestationsPdfBuffer({
   certificates,
+  isFrenchDomainExtension = false,
   dirname = __dirname,
   fontkit = pdfLibFontkit,
   creationDate = new Date(),
 } = {}) {
-  const viewModels = certificates.map(AttestationViewModel.from);
+  const viewModels = certificates.map((certificate) => AttestationViewModel.from(certificate, isFrenchDomainExtension));
   const generatedPdfDoc = await _initializeNewPDFDocument(fontkit);
   generatedPdfDoc.setCreationDate(creationDate);
   generatedPdfDoc.setModificationDate(creationDate);

--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -26,7 +26,7 @@ const templates = {
 
 async function getCertificationAttestationsPdfBuffer({
   certificates,
-  isFrenchDomainExtension = false,
+  isFrenchDomainExtension,
   dirname = __dirname,
   fontkit = pdfLibFontkit,
   creationDate = new Date(),

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -541,7 +541,7 @@ describe('Acceptance | API | Certifications', function () {
         // given
         options = {
           method: 'GET',
-          url: `/api/attestation/${certificationCourse.id}`,
+          url: `/api/attestation/${certificationCourse.id}?isFrenchDomainExtension=true`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         };
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1598,7 +1598,7 @@ describe('Acceptance | Application | organization-controller', function () {
 
       const options = {
         method: 'GET',
-        url: `/api/organizations/${organization.id}/certification-attestations?division=aDivision`,
+        url: `/api/organizations/${organization.id}/certification-attestations?division=aDivision&isFrenchDomainExtension=true`,
         headers: { authorization: generateValidRequestAuthorizationHeader(adminIsManagingStudent.id) },
       };
 

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -311,7 +311,7 @@ describe('Integration | Application | Organizations | organization-controller', 
         // when
         const response = await httpTestServer.request(
           'GET',
-          '/api/organizations/1234/certification-attestations?division=3b'
+          '/api/organizations/1234/certification-attestations?division=3b&isFrenchDomainExtension=true'
         );
 
         // then
@@ -330,7 +330,7 @@ describe('Integration | Application | Organizations | organization-controller', 
           // when
           const response = await httpTestServer.request(
             'GET',
-            '/api/organizations/1234/certification-attestations?division=3b'
+            '/api/organizations/1234/certification-attestations?division=3b&isFrenchDomainExtension=true'
           );
 
           // then
@@ -341,7 +341,23 @@ describe('Integration | Application | Organizations | organization-controller', 
       context('when no division is provided as query', function () {
         it('should resolve a 400 HTTP response', async function () {
           // when
-          const response = await httpTestServer.request('GET', '/api/organizations/1234/certification-attestations');
+          const response = await httpTestServer.request(
+            'GET',
+            '/api/organizations/1234/certification-attestations?isFrenchDomainExtension=true'
+          );
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
+      context('when no isFrenchDomainExtension is provided as query', function () {
+        it('should resolve a 400 HTTP response', async function () {
+          // when
+          const response = await httpTestServer.request(
+            'GET',
+            '/api/organizations/1234/certification-attestations?division=3A'
+          );
 
           // then
           expect(response.statusCode).to.equal(400);
@@ -360,7 +376,7 @@ describe('Integration | Application | Organizations | organization-controller', 
           // when
           const response = await httpTestServer.request(
             'GET',
-            '/api/organizations/1234/certification-attestations?division=3b'
+            '/api/organizations/1234/certification-attestations?division=3b&isFrenchDomainExtension=true'
           );
 
           // then

--- a/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -160,6 +160,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
         certificateWithoutComplementaryCertificationsAndWithoutProfessionalizingMessage,
         certificateComplementaryCertificationsAndWithProfessionalizingMessage,
       ],
+      isFrenchDomainExtension: true,
       creationDate: new Date('2021-01-01'),
     });
 

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -189,26 +189,22 @@ describe('Unit | Controller | certifications-controller', function () {
   });
 
   describe('#getCertificationAttestation', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const certification = domainBuilder.buildPrivateCertificateWithCompetenceTree();
-    const attestationPDF = 'binary string';
-    const fileName = 'attestation-pix-20181003.pdf';
-    const userId = 1;
-
-    const request = {
-      auth: { credentials: { userId } },
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      params: { id: certification.id },
-    };
-
     beforeEach(function () {
       sinon.stub(usecases, 'getCertificationAttestation');
     });
 
     it('should return binary attestation', async function () {
       // given
+      const certification = domainBuilder.buildPrivateCertificateWithCompetenceTree();
+      const attestationPDF = 'binary string';
+      const fileName = 'attestation-pix-20181003.pdf';
+      const userId = 1;
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: certification.id },
+      };
+
       sinon
         .stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer')
         .resolves({ buffer: attestationPDF, fileName });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1017,23 +1017,25 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const request = {
         auth: { credentials: { userId } },
         params: { id: organizationId },
-        query: { division },
+        query: { division, isFrenchDomainExtension: true },
       };
 
-      sinon.stub(usecases, 'findCertificationAttestationsForDivision');
+      sinon
+        .stub(usecases, 'findCertificationAttestationsForDivision')
+        .withArgs({
+          division,
+          organizationId,
+        })
+        .resolves(certifications);
       sinon
         .stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer')
+        .withArgs({ certificates: certifications, isFrenchDomainExtension: true })
         .resolves({ buffer: attestationsPDF, fileName });
-      usecases.findCertificationAttestationsForDivision.resolves(certifications);
 
       // when
       const response = await organizationController.downloadCertificationAttestationsForDivision(request, hFake);
 
       // then
-      expect(usecases.findCertificationAttestationsForDivision).to.have.been.calledWith({
-        division,
-        organizationId,
-      });
       expect(response.source).to.deep.equal(attestationsPDF);
       expect(response.headers['Content-Disposition']).to.contains('attachment; filename=20210101_attestations_3b.pdf');
     });

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -8,6 +8,7 @@ export default class UserCertificationsDetailHeader extends Component {
   @service intl;
   @service fileSaver;
   @service session;
+  @service url;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
 
@@ -23,7 +24,7 @@ export default class UserCertificationsDetailHeader extends Component {
   @action
   downloadAttestation() {
     const certifId = this.args.certification.id;
-    const url = `/api/attestation/${certifId}`;
+    const url = `/api/attestation/${certifId}?isFrenchDomainExtension=${this.url.isFrenchDomainExtension}`;
     const fileName = 'attestation_pix.pdf';
     const token = this.session.data.authenticated.access_token;
     this.fileSaver.save({ url, fileName, token });

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -9,6 +9,7 @@ export default class AuthenticatedCertificationsController extends Controller {
   @service currentUser;
   @service notifications;
   @service intl;
+  @service url;
 
   @tracked selectedDivision = '';
 
@@ -66,7 +67,7 @@ export default class AuthenticatedCertificationsController extends Controller {
       }
 
       const organizationId = this.currentUser.organization.id;
-      const url = `/api/organizations/${organizationId}/certification-attestations?division=${this.selectedDivision}`;
+      const url = `/api/organizations/${organizationId}/certification-attestations?division=${this.selectedDivision}&isFrenchDomainExtension=${this.url.isFrenchDomainExtension}`;
       const fileName = 'attestations_pix.pdf';
 
       let token = '';

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -181,6 +181,10 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
         save: sinon.stub(),
       };
 
+      controller.url = {
+        isFrenchDomainExtension: true,
+      };
+
       controller.model = {
         options: [{ label: '3èmeA', value: '3èmeA' }],
       };
@@ -197,7 +201,7 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
         controller.fileSaver.save.calledWith({
           token,
           fileName,
-          url: `/api/organizations/${organizationId}/certification-attestations?division=${selectedDivision}`,
+          url: `/api/organizations/${organizationId}/certification-attestations?division=${selectedDivision}&isFrenchDomainExtension=true`,
         })
       );
     });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la phrase "Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix” apparaît sur les attestations téléchargées depuis le domaine .org. Cependant, cette mention ne doit concerner que les attestations téléchargées depuis le domain .fr.

## :robot: Solution
- Ne pas afficher la phrase dans les attestations téléchargées depuis le domaine .org

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certifsco@example.net`.
- Créer une session et y ajouter un élève.
- Passer la certification, finaliser et publier la session.
- Aller sur Pix App en .fr et vérifier que l'attestation comporte bien la phrase.
- Aller sur Pix App en .org et vérifier que l'attestation ne comporte pas la phrase.
- Aller sur Pix Orga en .fr et vérifier que les attestations de la classe comporte bien la phrase.
- Aller sur Pix App en .org et vérifier que les attestations de la classe ne comporte pas la phrase. 
