### PR TITLE
[FEATURE] Ajout de la colonne 'identityProviderForCampaigns' dans la table 'organizations' (PIX-5111)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -19,6 +19,7 @@ const buildOrganization = function buildOrganization({
   showSkills = false,
   archivedBy = null,
   archivedAt = null,
+  identityProviderForCampaigns = null,
 } = {}) {
   const values = {
     id,
@@ -39,6 +40,7 @@ const buildOrganization = function buildOrganization({
     showSkills,
     archivedBy,
     archivedAt,
+    identityProviderForCampaigns,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20220620123740_add-identity-provider-for-campaigns-column-in-organizations-table.js
+++ b/api/db/migrations/20220620123740_add-identity-provider-for-campaigns-column-in-organizations-table.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'identityProviderForCampaigns';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.string(COLUMN_NAME).nullable();
+  });
+
+  return knex.raw(
+    'ALTER TABLE "organizations" ADD CONSTRAINT "organizations_identityProviderForCampaigns_check" CHECK ( "identityProviderForCampaigns" IN (\'POLE_EMPLOI\', \'CNAV\') )'
+  );
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -32,6 +32,7 @@ describe('Integration | Repository | UserOrgaSettings', function () {
     'createdBy',
     'archivedAt',
     'archivedBy',
+    'identityProviderForCampaigns',
   ];
 
   let user;

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -23,6 +23,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', fun
         'tags',
         'createdBy',
         'archivedBy',
+        'identityProviderForCampaigns',
       ]);
 
       await databaseBuilder.commit();

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -30,6 +30,7 @@ function buildOrganization({
   formNPSUrl = 'https://pix.fr',
   showSkills = false,
   archivedAt = null,
+  identityProviderForCampaigns = null,
 } = {}) {
   return new Organization({
     id,
@@ -50,6 +51,7 @@ function buildOrganization({
     formNPSUrl,
     showSkills,
     archivedAt,
+    identityProviderForCampaigns,
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème

L’utilisation des tags dans le code pose problème : 

- Les tags ne doivent servir qu’aux stats et à la documentation. Seulement aujourd’hui ils sont utilisés dans de la logique fonctionnelle.
- Or il est facile d’ajouter ou retirer un tag dans Pix Admin en un clic, sans forcément qu’on ait conscience des conséquences que ça a, d’où un risque d’accident.

Il faut donc remplacer l’utilisation du tag POLE EMPLOI dans l’accès restreint aux campagnes.

## :robot: Solution

- Créer une nouvelle colonne dans la table ‘organizations’ : 'identityProviderForCampaigns'
- Les valeurs attendues : `POLE_EMPLOI`, `CNAV` ou `null`. Il faut donc mettre une contrainte sur les IDP. (comme déjà fait dans la colonne **'identity-provider'** de la table **’authentication-methods'**)

## :rainbow: Remarques

- Modification des builders : `database` et `domain`
- Mise à jour des tests

## :100: Pour tester

#### Ajout de la nouvelle colonne

- Récupérez la branche en local
- Allez dans le dossier `api` du projet
- Exécutez la commande `npm run db:migrate` ou `npm run db:reset` en fonction de l'état de votre repository en local
- Constatez que le script se termine sans erreur
- Vérifiez via une application ou en ligne de commande l'ajout de la nouvelle colonne `identityProviderForOrganizations` dans la table `organizations` et qu'aucune valeur n'y est renseignée (NULL)
- Vérifiez que la contrainte associée à cette nouvelle colonne existe

#### Retrait de la nouvelle colonne

- Exécutez la commande `npm run db:rollback:latest`
- Constatez que le script se termine sans erreur
- Vérifiez via une application ou en ligne de commande le retrait de la colonne `identityProviderForOrganizations` dans la table `organizations`
- Vérifiez que la contrainte associée à cette colonne n'existe plus