### PR TITLE
[TECH] Glimmerizer les dernières routes de Pix APP.

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,5 +1,3 @@
-/* eslint ember/no-classic-classes: 0 */
-
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
 import Route from '@ember/routing/route';
@@ -7,19 +5,19 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import get from 'lodash/get';
 
-export default Route.extend(ApplicationRouteMixin, {
-  splash: service(),
-  currentUser: service(),
-  session: service(),
-  intl: service(),
-  moment: service(),
-  headData: service(),
-  featureToggles: service(),
-  currentDomain: service(),
+export default class Application extends Route.extend(ApplicationRouteMixin) {
+  @service splash;
+  @service currentUser;
+  @service session;
+  @service intl;
+  @service moment;
+  @service headData;
+  @service featureToggles;
+  @service currentDomain;
 
   activate() {
     this.splash.hide();
-  },
+  }
 
   async _checkForURLAuthentication(transition) {
     if (transition.to.queryParams && transition.to.queryParams.externalUser) {
@@ -32,7 +30,7 @@ export default Route.extend(ApplicationRouteMixin, {
       await this._logoutUser();
       return this.session.authenticate('authenticator:oauth2', { token: transition.to.queryParams.token });
     }
-  },
+  }
 
   async _checkAnonymousAccess(transition) {
     const allowedRoutesForAnonymousAccess = [
@@ -55,7 +53,7 @@ export default Route.extend(ApplicationRouteMixin, {
       await this._logoutUser();
       this.replaceWith('/campagnes');
     }
-  },
+  }
 
   async beforeModel(transition) {
     this.headData.description = this.intl.t('application.description');
@@ -68,10 +66,10 @@ export default Route.extend(ApplicationRouteMixin, {
 
     await this._loadCurrentUser();
     await this._handleLocale(locale);
-  },
+  }
 
   async sessionAuthenticated() {
-    const _super = this._super;
+    const _super = super.sessionAuthenticated;
 
     await this._loadCurrentUser();
     await this._handleLocale();
@@ -83,13 +81,13 @@ export default Route.extend(ApplicationRouteMixin, {
     } else {
       _super.call(this, ...arguments);
     }
-  },
+  }
 
   // We need to override the sessionInvalidated from ApplicationRouteMixin
   // to avoid the automatic redirection to login
   // when coming from the GAR authentication
   // https://github.com/simplabs/ember-simple-auth/blob/a3d51d65b7d8e3a2e069c0af24aca2e12c7c3a95/addon/mixins/application-route-mixin.js#L132
-  sessionInvalidated() {},
+  sessionInvalidated() {}
 
   async _handleLocale(localeFromQueryParam = null) {
     const isUserLoaded = !!this.currentUser.user;
@@ -126,21 +124,21 @@ export default Route.extend(ApplicationRouteMixin, {
         await this._setLocale(defaultLocale);
       }
     }
-  },
+  }
 
   _setLocale(locale) {
     const defaultLocale = 'fr';
     this.intl.setLocale([locale, defaultLocale]);
     this.moment.setLocale(locale);
-  },
+  }
 
   _loadCurrentUser() {
     return this.currentUser.load().catch(() => this.session.invalidate());
-  },
+  }
 
   _logoutUser() {
     delete this.session.data.expectedUserId;
     delete this.session.data.externalUser;
     return this.session.invalidate();
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -1,6 +1,3 @@
-/* eslint ember/no-actions-hash: 0 */
-/* eslint ember/no-classic-classes: 0 */
-
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import { inject as service } from '@ember/service';

--- a/mon-pix/app/routes/inscription.js
+++ b/mon-pix/app/routes/inscription.js
@@ -1,12 +1,10 @@
-/* eslint ember/no-actions-hash: 0 */
-/* eslint ember/no-classic-classes: 0 */
-
 import { inject as service } from '@ember/service';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend(UnauthenticatedRouteMixin, {
-  session: service(),
+export default class Inscription extends Route.extend(UnauthenticatedRouteMixin) {
+  @service session;
 
   model() {
     // XXX: Model needs to be initialize with empty to handle validations on all fields from Api
@@ -17,17 +15,17 @@ export default Route.extend(UnauthenticatedRouteMixin, {
       password: '',
       cgu: false,
     });
-  },
+  }
 
-  actions: {
-    refresh() {
-      this.refresh();
-    },
+  @action
+  refresh() {
+    this.refresh();
+  }
 
-    authenticateUser(credentials) {
-      const { login, password } = credentials;
-      const scope = 'mon-pix';
-      return this.session.authenticate('authenticator:oauth2', { login, password, scope });
-    },
-  },
-});
+  @action
+  authenticateUser(credentials) {
+    const { login, password } = credentials;
+    const scope = 'mon-pix';
+    return this.session.authenticate('authenticator:oauth2', { login, password, scope });
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Toutes les routes de Pix APP ne sont pas glimmerizer. L'ancienne façon de faire n'est plus recommandée et nous bloquera pour les montées de versions.

## :robot: Solution
Glimmerizer les dernières routes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier l'inscription
- Vérifier le comportement global de Pix APP. 
