### PR TITLE
[FEATURE] Mettre à jour le nom de l'étape des signalements dans la finalisation de session (PIX-5186)

### DIFF
--- a/certif/app/styles/components/session-finalization-step-container.scss
+++ b/certif/app/styles/components/session-finalization-step-container.scss
@@ -4,6 +4,7 @@
   margin-bottom: 24px;
 
   &__header {
+    align-items: center;
     border-radius: 8px;
     display: flex;
     background: $grey-10;

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -16,6 +16,10 @@
       "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
       "Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
     }}
+    @subtitle={{if
+      this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+      "Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc)."
+    }}
     @icon="/icons/session-finalization-user.svg"
     @iconAlt=""
   >

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -137,7 +137,25 @@ module('Acceptance | Session Finalization', function (hooks) {
           )
           .exists();
       });
+
+      test('it should not contain a subtitle', async function (assert) {
+        // given
+        server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: false });
+
+        // when
+        const screen = await visit(`/sessions/${session.id}/finalisation`);
+
+        // then
+        assert
+          .dom(
+            screen.queryByText(
+              'Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc).'
+            )
+          )
+          .doesNotExist();
+      });
     });
+
     module('when FT_CERTIFICATION_FREE_FIELDS_DELETION is on', function () {
       test('it should not display the comment step section', async function (assert) {
         // given
@@ -188,7 +206,7 @@ module('Acceptance | Session Finalization', function (hooks) {
           .exists();
       });
 
-      test('it should not contain "Etape 1" in title', async function (assert) {
+      test('it should display the uncompleted reports title and subtitle', async function (assert) {
         // given
         server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: true });
 
@@ -203,6 +221,20 @@ module('Acceptance | Session Finalization', function (hooks) {
             )
           )
           .exists();
+        assert
+          .dom(
+            screen.getByText(
+              'Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc).'
+            )
+          )
+          .exists();
+        assert
+          .dom(
+            screen.queryByText(
+              "Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+            )
+          )
+          .doesNotExist();
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
On souhaite rajouter un sous-titre à l'étape d'ajout de signalement lors de la finalisation d'une session de certification. 

## :robot: Solution
Rajouter un sous-titre lorsque le feature toggle est activé

## :rainbow: Remarques
J'ai ajouté un fix pour l'icône de cette première étape qui se déformait lorsque le header prenait plus de hauteur. 

## :100: Pour tester
- Activer le feature toggle FT_CERTIFICATION_FREE_FIELDS_DELETION
- Se rendre sur Pix Certif avec un compte tel que certifsup@example.net
- Aller sur une session à finaliser
- Cliquer sur finaliser
- Constater qu'un sous-titre apparait dans la section dont le titre est "Signalement : reporter pour chaque candidat, les signalements renseignés sur le PV d'incident."
