### PR TITLE
[FEATURE] Ignorer les INEs vides quand on vérifie si plusieurs utilisateurs sont associés au même compte (PIX-5072).

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -320,7 +320,6 @@ function _buildHighSchools({ databaseBuilder }) {
     division: '2B',
     group: null,
     organizationId: SCO_HIGH_SCHOOL_ID,
-    nationalStudentId: '123456789CC',
     createdAt: new Date('2020-08-14'),
   });
 

--- a/api/lib/domain/services/sco-account-recovery-service.js
+++ b/api/lib/domain/services/sco-account-recovery-service.js
@@ -4,7 +4,7 @@ const {
   UserNotFoundError,
   UserHasAlreadyLeftSCO,
 } = require('../errors');
-const _ = require('lodash');
+const { uniqBy } = require('lodash');
 
 async function retrieveOrganizationLearner({
   accountRecoveryDemandRepository,
@@ -92,8 +92,9 @@ async function _getUserIdByMatchingStudentInformationWithOrganizationLearner({
 
 async function _checkIfThereAreMultipleUserForTheSameAccount({ userId, organizationLearnerRepository }) {
   const organizationLearners = await organizationLearnerRepository.findByUserId({ userId });
+  const nonEmptyNationalStudentIds = organizationLearners.filter((learner) => !!learner.nationalStudentId);
 
-  if (_.uniqBy(organizationLearners, 'nationalStudentId').length > 1) {
+  if (uniqBy(nonEmptyNationalStudentIds, 'nationalStudentId').length > 1) {
     throw new MultipleOrganizationLearnersWithDifferentNationalStudentIdError();
   }
 }

--- a/api/tests/unit/domain/services/sco-account-recovery-service_test.js
+++ b/api/tests/unit/domain/services/sco-account-recovery-service_test.js
@@ -95,7 +95,7 @@ describe('Unit | Service | sco-account-recovery-service', function () {
     });
 
     context('when user is reconciled to several organizations', function () {
-      context('when all organization learners have the same INE', function () {
+      context('when all organization learners have the same INE, some are empty', function () {
         it('should return the last reconciled user account information', async function () {
           // given
           const studentInformation = {
@@ -114,21 +114,29 @@ describe('Unit | Service | sco-account-recovery-service', function () {
           });
           const firstOrganization = domainBuilder.buildOrganization({ id: 8, name: 'Collège Beauxbâtons' });
           const secondOrganization = domainBuilder.buildOrganization({ id: 7, name: 'Lycée Poudlard' });
+          const thirdOrganization = domainBuilder.buildOrganization({ id: 9, name: 'Lycée The Night Watch' });
           const firstOrganizationLearner = domainBuilder.buildOrganizationLearner({
             id: 2,
             userId: expectedUser.id,
             organization: firstOrganization,
             updatedAt: new Date('2000-01-01T15:00:00Z'),
             ...studentInformation,
-            nationalStudentId: studentInformation.inaIna,
+            nationalStudentId: studentInformation.ineIna,
           });
-          const lastOrganizationLearner = domainBuilder.buildOrganizationLearner({
+          const secondOrganizationLearner = domainBuilder.buildOrganizationLearner({
             id: 3,
             userId: expectedUser.id,
             organization: secondOrganization,
+            updatedAt: new Date('2004-01-01T15:00:00Z'),
+            ...studentInformation,
+            nationalStudentId: studentInformation.ineIna,
+          });
+          const lastOrganizationLearner = domainBuilder.buildOrganizationLearner({
+            id: 4,
+            userId: expectedUser.id,
+            organization: thirdOrganization,
             updatedAt: new Date('2005-01-01T15:00:00Z'),
             ...studentInformation,
-            nationalStudentId: studentInformation.inaIna,
           });
           const accountRecoveryDemand = domainBuilder.buildAccountRecoveryDemand({
             userId: expectedUser.id,
@@ -148,7 +156,7 @@ describe('Unit | Service | sco-account-recovery-service', function () {
 
           organizationLearnerRepository.findByUserId
             .withArgs({ userId: expectedUser.id })
-            .resolves([firstOrganizationLearner, lastOrganizationLearner]);
+            .resolves([firstOrganizationLearner, secondOrganizationLearner, lastOrganizationLearner]);
 
           accountRecoveryDemandRepository.findByUserId.withArgs(expectedUser.id).resolves([accountRecoveryDemand]);
 
@@ -169,15 +177,15 @@ describe('Unit | Service | sco-account-recovery-service', function () {
             lastName: 'Monchose',
             username: 'nanou.monchose0705',
             email: 'nanou.monchose@example.net',
-            id: 3,
+            id: 4,
             userId: 9,
-            organizationId: 7,
+            organizationId: 9,
           };
           expect(result).to.deep.equal(expectedResult);
         });
       });
 
-      context('when at least one organization learners has a different INE', function () {
+      context('when at least one organization learner has a different INE with some empty', function () {
         it('should throw an error', async function () {
           // given
           const studentInformation = {
@@ -209,6 +217,13 @@ describe('Unit | Service | sco-account-recovery-service', function () {
             lastName: 'Monchose',
             birthdate: '2004-05-07',
           });
+          const thirdOrganizationLearner = domainBuilder.buildOrganizationLearner({
+            id: 9,
+            userId: user.id,
+            firstName: 'Nanou',
+            lastName: 'Monchose',
+            birthdate: '2004-05-07',
+          });
           const accountRecoveryDemand = domainBuilder.buildAccountRecoveryDemand({
             userId: user.id,
             schoolingRegistrationId: secondOrganizationLearner.id,
@@ -227,7 +242,7 @@ describe('Unit | Service | sco-account-recovery-service', function () {
 
           organizationLearnerRepository.findByUserId
             .withArgs({ userId: user.id })
-            .resolves([firstOrganizationLearner, secondOrganizationLearner]);
+            .resolves([firstOrganizationLearner, secondOrganizationLearner, thirdOrganizationLearner]);
 
           accountRecoveryDemandRepository.findByUserId.withArgs(user.id).resolves([accountRecoveryDemand]);
 


### PR DESCRIPTION
## :unicorn: Problème
Quand un utilisateur SCO veut récupérer son compte, on vérifie s'il y a plusieurs `organizationLearners` avec des INE différents, incluant s'il est vide. 

## :robot: Solution
Ignorer les INEs vides quand on fait la vérification.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Allez sur [Pix App](https://app-pr4554.review.pix.fr/recuperer-mon-compte) pour récupérer un compte
- Entrez les données suivantes
    - INE : 123456789DD
    - Prénom : Blue Ivy
    - Nom : Carter
    - Date de naissance : 07/01/2012
- Vérifiez que son compte est bien récupérer