### PR TITLE
[BUGFIX] Garder le champ vide quand l'information de dernière connexion n'est pas disponible (PIX-5193).

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -3,16 +3,12 @@
 </header>
 
 <dl>
-  {{#if @user.lastLoggedAt}}
-    <div class="authentication-method__connexions-information">
-      <dt>Date de dernière connexion :</dt>
+  <div class="authentication-method__connexions-information">
+    <dt>Date de dernière connexion :</dt>
+    {{#if @user.lastLoggedAt}}
       <dd>{{dayjs-format @user.lastLoggedAt "DD/MM/YYYY"}}</dd>
-    </div>
-  {{else}}
-    <div class="authentication-method__connexions-information">
-      L'utilisateur ne s'est jamais connecté
-    </div>
-  {{/if}}
+    {{/if}}
+  </div>
   {{#if @user.emailConfirmedAt}}
     <div class="authentication-method__connexions-information">
       <dt>Adresse e-mail confirmée le :</dt>

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -43,7 +43,7 @@ module('Integration | Component | users | user-detail-personal-information/authe
         });
       });
 
-      module('when user has logged in', function () {
+      module('when last logged date exists', function () {
         test('should display date of latest connection', async function (assert) {
           // given
           this.set('user', { lastLoggedAt: new Date('2022-07-01') });
@@ -54,12 +54,13 @@ module('Integration | Component | users | user-detail-personal-information/authe
             <Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`);
 
           // then
+          assert.dom(screen.getByText('Date de dernière connexion :')).exists();
           assert.dom(screen.getByText('01/07/2022')).exists();
         });
       });
 
-      module('when user never logged in', function () {
-        test("it should display `L'utilisateur ne s'est jamais connecté`", async function (assert) {
+      module('when last logged date does not exist', function () {
+        test('it should only display label', async function (assert) {
           // given
           this.set('user', { lastLoggedAt: null });
           this.owner.register('service:access-control', AccessControlStub);
@@ -69,7 +70,8 @@ module('Integration | Component | users | user-detail-personal-information/authe
             <Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`);
 
           // then
-          assert.dom(screen.getByText("L'utilisateur ne s'est jamais connecté")).exists();
+          assert.dom(screen.getByText('Date de dernière connexion :')).exists();
+          assert.dom(screen.queryByText('Invalid date')).doesNotExist();
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour certains utilisateurs, la date de dernière connexion peut être vide.

## :robot: Solution
Garder le champ vide avec la label `Date de dernière connexion :`

## :rainbow: Remarques
RAS

## :100: Pour tester
- Visitez [User](https://admin-pr4555.review.pix.fr/users/1)
- Vérifiez que la date de dernière connexion s'affiche.
- Modifiez la table `users` dans la bdd et supprimez la valeur de la colonne `lastLoggedAt` pour le user avec id `1`
- Rafraichissez la page et vérifiez que `Date de dernière connexion :` s'affiche sans valeur
