### PR TITLE
[BUGFIX] Supprimer le flickering en arrivant sur certaines pages de Pix App (PIX-4684).

### DIFF
--- a/mon-pix/app/routes/certifications/join.js
+++ b/mon-pix/app/routes/certifications/join.js
@@ -1,12 +1,18 @@
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
-export default class StartRoute extends Route.extend(SecuredRouteMixin) {
+export default class JoinRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
 
   model() {
     const user = this.currentUser.user;
     return user.belongsTo('isCertifiable').reload();
+  }
+
+  @action
+  loading() {
+    return false;
   }
 }

--- a/mon-pix/app/routes/profile.js
+++ b/mon-pix/app/routes/profile.js
@@ -1,17 +1,18 @@
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 export default class ProfileRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
 
-  model() {
+  async model() {
+    await this.currentUser.user.belongsTo('profile').reload();
     return this.currentUser.user;
   }
 
-  async afterModel(user) {
-    // This reloads are necessary to keep the ui in sync when the
-    // user navigates back to this route
-    user.belongsTo('profile').reload();
+  @action
+  loading() {
+    return false;
   }
 }

--- a/mon-pix/app/routes/user-certifications/index.js
+++ b/mon-pix/app/routes/user-certifications/index.js
@@ -1,8 +1,14 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
   model() {
     return this.store.findAll('certification');
+  }
+
+  @action
+  loading() {
+    return false;
   }
 }

--- a/mon-pix/app/routes/user-tests.js
+++ b/mon-pix/app/routes/user-tests.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 
 export default class UserTestsRoute extends Route.extend(SecuredRouteMixin) {
@@ -23,5 +24,10 @@ export default class UserTestsRoute extends Route.extend(SecuredRouteMixin) {
     if (isEmpty(model)) {
       this.replaceWith('');
     }
+  }
+
+  @action
+  loading() {
+    return false;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix APP,  lorsqu'on clique sur la page "Certification", "Mes certifications" ou "Mes parcours" dans la barre de navigation nous pouvons apercevoir un rafraichissement de toute la page. 

## :robot: Solution
Quand nous nous rendons sur la page, le hook `model` est déclenché. Un appel est déclenché vers l'API car il y a un `.reload()` de présent, cela engendre donc une transaction. 
Cette transaction a pour conséquence de lancer l'event `loading`. 
Cet event cherche le template `loading.hbs` le plus proche ou [propose une méthode pour redéfinir celui-ci](https://guides.emberjs.com/release/routing/loading-and-error-substates/#toc_the-loading-event).
Cette dernière propose de `return false` quand on ne souhaite pas la page de loading, ce que l'on souhaite dans notre cas. 

Il nous suffit alors d'ajouter ce qui suit pour ne pas avoir le flickering.

```js
 @action
  loading() {
    return false;
  }
```


## :rainbow: Remarques
Nous avions en réalité le même problème sur la page compétence, mais comme il manquait un `await` dans l'`afterModel`, la promesse ne déclenchait pas l'event `loading`.

## :100: Pour tester
- Se connecter à Pix App
- Faire des aller-retour entre n'importe quelle page de la barre de navigation ou du menu.
- Constater qu'il n'y a pas de flickering
