### PR TITLE
[FEATURE] Améliorer l'info pour les sessions déjà finalisées sur la page de détails (PIX-5182)

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -49,6 +49,10 @@
   flex-wrap: wrap;
   padding: 0 8px;
 
+  &__session-finalized-warning {
+    font-weight: 500;
+  }
+
   &:not(:last-child) {
     border-bottom: 1px solid $grey-20;
   }

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -114,13 +114,16 @@
           Modifier
         </PixButtonLink>
       </div>
-      <div
-        class="session-details-buttons session-details-buttons--push-right
-          {{if this.session.isFinalized 'button--disabled'}}"
-      >
-        <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
-          Finaliser la session
-        </PixButtonLink>
+      <div class="session-details-buttons session-details-buttons--push-right">
+        {{#if this.session.isFinalized}}
+          <p class="session-details-row__session-finalized-warning">
+            Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix
+          </p>
+        {{else}}
+          <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
+            Finaliser la session
+          </PixButtonLink>
+        {{/if}}
       </div>
     {{else}}
       <div class="session-details-buttons">

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -49,9 +49,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
         await visit(`/sessions/${sessionCreated.id}`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/espace-ferme');
+        assert.strictEqual(currentURL(), '/espace-ferme');
       });
     });
 
@@ -80,9 +78,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             await clickByLabel('Finaliser la session');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
+            assert.strictEqual(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
           });
 
           module('when the certification center is not in the end test screen removal whitelist', function () {
@@ -136,9 +132,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           await clickByLabel('Finaliser la session');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/sessions/${sessionFinalized.id}`);
+          assert.strictEqual(currentURL(), `/sessions/${sessionFinalized.id}`);
         });
 
         test('it should throw an error on visiting /finalisation url', async function (assert) {

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -126,13 +126,12 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           server.createList('certification-candidate', 3, { isLinked: true, sessionId: sessionFinalized.id });
         });
 
-        test('it should not redirect to finalize page on click on finalize button', async function (assert) {
+        test('it should session already finalized warning', async function (assert) {
           // when
           await visit(`/sessions/${sessionFinalized.id}`);
-          await clickByLabel('Finaliser la session');
 
           // then
-          assert.strictEqual(currentURL(), `/sessions/${sessionFinalized.id}`);
+          assert.contains('Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix');
         });
 
         test('it should throw an error on visiting /finalisation url', async function (assert) {

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -62,10 +62,10 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             server.createList('certification-candidate', 2, { isLinked: false, sessionId: sessionCreated.id });
 
             // when
-            await visit(`/sessions/${sessionCreated.id}`);
+            const screen = await visit(`/sessions/${sessionCreated.id}`);
 
             // then
-            assert.notContains('Finaliser la session');
+            assert.dom(screen.queryByRole('button', { name: 'Finaliser la session' })).doesNotExist();
           });
 
           test('it should redirect to finalize page on click on finalize button', async function (assert) {
@@ -126,12 +126,19 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           server.createList('certification-candidate', 3, { isLinked: true, sessionId: sessionFinalized.id });
         });
 
-        test('it should session already finalized warning', async function (assert) {
+        test('it should show a "session already finalized" warning', async function (assert) {
           // when
-          await visit(`/sessions/${sessionFinalized.id}`);
+          const screen = await visit(`/sessions/${sessionFinalized.id}`);
 
           // then
-          assert.contains('Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix');
+          assert
+            .dom(
+              screen.getByText(
+                'Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix'
+              )
+            )
+            .exists();
+          assert.dom(screen.queryByRole('button', { name: 'Finaliser la session' })).doesNotExist();
         });
 
         test('it should throw an error on visiting /finalisation url', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, lorsqu’une session de certif est a été finalisée, le bouton “Finaliser la session” devient inactif sur la page de détail de cette session.

Certains utilisateurs contactent le support pensant à un bug.

## :robot: Solution
Afficher un texte explicatif au lieu de désactiver le bouton dès lors qu’une session a été finalisée : 
" Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix"

## :100: Pour tester
- Se connecter à pix-certif en SCO
- Finaliser la session 3
- Constater que le bouton de finalisation n'apparait plus et est remplacé par le texte ci-dessus

![image](https://user-images.githubusercontent.com/37305474/174999035-1730b13c-a265-4426-a316-b66625c62c59.png)

