### PR TITLE
[FEATURE] ETQ Pix Certif user, JV pouvoir supprimer une session (PIX-5150)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -316,6 +316,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SessionAlreadyFinalizedError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.SessionStartedDeletionError) {
+    return new HttpErrors.ConflictError(error.message);
+  }
   if (error instanceof DomainErrors.OrganizationLearnerAlreadyLinkedToUserError) {
     return new HttpErrors.ConflictError(error.message, error.code, error.meta);
   }

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -733,6 +733,29 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'DELETE',
+      path: '/api/sessions/{id}',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+          }),
+        },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: sessionController.delete,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès au centre de certification**\n" +
+            "- Supprime la session et les candidats si la session n'a pas démarrée",
+        ],
+        tags: ['api', 'session'],
+      },
+    },
+    {
       method: 'PUT',
       path: '/api/sessions/{id}/enroll-students-to-session',
       config: {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -329,6 +329,14 @@ module.exports = {
     return h.response().code(204);
   },
 
+  async delete(request, h) {
+    const sessionId = request.params.id;
+
+    await usecases.deleteSession({ sessionId });
+
+    return h.response().code(204);
+  },
+
   async deleteJuryComment(request, h) {
     const sessionId = request.params.id;
     await usecases.deleteSessionJuryComment({ sessionId });

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1111,6 +1111,12 @@ class CampaignParticipationDeletedError extends DomainError {
   }
 }
 
+class SessionStartedDeletionError extends DomainError {
+  constructor(message = 'La session a déjà commencé.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -1232,6 +1238,7 @@ module.exports = {
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionNotAccessible,
+  SessionStartedDeletionError,
   SiecleXmlImportError,
   SupervisorAccessNotAuthorizedError,
   TargetProfileInvalidError,

--- a/api/lib/domain/usecases/delete-session.js
+++ b/api/lib/domain/usecases/delete-session.js
@@ -1,0 +1,16 @@
+const { SessionStartedDeletionError } = require('../errors');
+
+module.exports = async function deleteSession({ sessionId, sessionRepository, certificationCourseRepository }) {
+  if (await _isSessionStarted(certificationCourseRepository, sessionId)) {
+    throw new SessionStartedDeletionError();
+  }
+
+  await sessionRepository.delete(sessionId);
+};
+
+async function _isSessionStarted(certificationCourseRepository, sessionId) {
+  const foundCertificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({
+    sessionId,
+  });
+  return foundCertificationCourses.length > 0;
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -222,6 +222,7 @@ module.exports = injectDependencies(
     deleteCampaignParticipation: require('./delete-campaign-participation'),
     deleteCertificationIssueReport: require('./delete-certification-issue-report'),
     deleteSessionJuryComment: require('./delete-session-jury-comment'),
+    deleteSession: require('./delete-session'),
     deleteUnassociatedBadge: require('./delete-unassociated-badge'),
     deleteUnlinkedCertificationCandidate: require('./delete-unlinked-certification-candidate'),
     deneutralizeChallenge: require('./deneutralize-challenge'),

--- a/api/tests/acceptance/application/session/session-controller-delete_test.js
+++ b/api/tests/acceptance/application/session/session-controller-delete_test.js
@@ -1,0 +1,37 @@
+const { knex, expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | sessions-controller', function () {
+  describe('DELETE /sessions/{id}', function () {
+    it('should respond with 204', async function () {
+      // given
+      const server = await createServer();
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const { id: certificationCenterId, name: certificationCenter } =
+        databaseBuilder.factory.buildCertificationCenter();
+
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId, certificationCenter }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+
+      await databaseBuilder.commit();
+      const options = {
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+        method: 'DELETE',
+        url: `/api/sessions/${sessionId}`,
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+
+      const session = await knex('sessions').where({ id: sessionId }).first();
+
+      expect(response.statusCode).to.equal(204);
+      expect(session).to.be.undefined;
+    });
+  });
+});

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -24,6 +24,7 @@ const {
   UserShouldNotBeReconciledOnAnotherAccountError,
   CertificationCandidateOnFinalizedSessionError,
   CertificationEndedByFinalizationError,
+  SessionStartedDeletionError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -414,6 +415,19 @@ describe('Unit | Application | ErrorManager', function () {
     it('should instantiate ConflictError when CertificationEndedByFinalizationError', async function () {
       // given
       const error = new CertificationEndedByFinalizationError();
+      sinon.stub(HttpErrors, 'ConflictError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate ConflictError when SessionStartedDeletionError', async function () {
+      // given
+      const error = new SessionStartedDeletionError();
       sinon.stub(HttpErrors, 'ConflictError');
       const params = { request: {}, h: hFake, error };
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1002,4 +1002,19 @@ describe('Unit | Application | Sessions | Routes', function () {
       });
     });
   });
+
+  describe('DELETE /api/sessions/{id}', function () {
+    it('returns a 404 NOT_FOUND error if verifySessionAuthorization fails', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/sessions/3');
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+  });
 });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -1029,6 +1029,31 @@ describe('Unit | Controller | sessionController', function () {
     });
   });
 
+  describe('#delete', function () {
+    it('should delete the session', async function () {
+      // given
+      const sessionId = 1;
+      const userId = 1;
+      sinon.stub(usecases, 'deleteSession');
+      request = {
+        params: { id: sessionId },
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
+      };
+
+      // when
+      await sessionController.delete(request, hFake);
+
+      // then
+      expect(usecases.deleteSession).to.have.been.calledWithExactly({
+        sessionId,
+      });
+    });
+  });
+
   describe('#deleteJuryComment', function () {
     it('should delete the session comment', async function () {
       // given

--- a/api/tests/unit/domain/usecases/delete-session_test.js
+++ b/api/tests/unit/domain/usecases/delete-session_test.js
@@ -1,0 +1,46 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const deleteSession = require('../../../../lib/domain/usecases/delete-session');
+const { SessionStartedDeletionError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | delete-session', function () {
+  context('when there are no certification courses', function () {
+    it('should delete the session', async function () {
+      // given
+      const sessionRepository = { delete: sinon.stub() };
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      certificationCourseRepository.findCertificationCoursesBySessionId.resolves([]);
+
+      // when
+      await deleteSession({
+        sessionId: 123,
+        sessionRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(sessionRepository.delete).to.have.been.calledWithExactly(123);
+    });
+  });
+
+  context('when there are certification courses', function () {
+    it('should throw SessionStartedDeletionError error', async function () {
+      // given
+      const sessionRepository = { delete: sinon.stub() };
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      certificationCourseRepository.findCertificationCoursesBySessionId.resolves([
+        domainBuilder.buildCertificationCourse({ sessionId: 123 }),
+      ]);
+
+      // when
+      const error = await catchErr(deleteSession)({
+        sessionId: 123,
+        sessionRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(SessionStartedDeletionError);
+      expect(sessionRepository.delete).to.not.have.been.called;
+    });
+  });
+});

--- a/certif/app/adapters/session-summary.js
+++ b/certif/app/adapters/session-summary.js
@@ -1,7 +1,7 @@
 import ApplicationAdapter from './application';
 import { inject as service } from '@ember/service';
 
-export default class CompetenceEvaluation extends ApplicationAdapter {
+export default class SessionSummary extends ApplicationAdapter {
   @service currentUser;
 
   urlForQuery(_) {

--- a/certif/app/adapters/session-summary.js
+++ b/certif/app/adapters/session-summary.js
@@ -8,4 +8,8 @@ export default class SessionSummary extends ApplicationAdapter {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
     return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/session-summaries`;
   }
+
+  urlForDeleteRecord(id) {
+    return `${this.host}/${this.namespace}/sessions/${id}`;
+  }
 }

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -2,8 +2,10 @@
   <PixModal @title="Supprimer la session" @onCloseButtonClick={{@close}}>
     <:content>
       <p>Souhaitez-vous supprimer la session <span>{{@sessionId}}</span> ?</p>
+      <PixMessage @type="warning" @withIcon={{true}}>
+        Attention, cette action est irréversible.
+      </PixMessage>
     </:content>
-
     <:footer>
       <PixButton
         aria-label="Annuler la suppression de la session"

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -1,0 +1,27 @@
+{{#if @show}}
+  <PixModal @title="Supprimer la session" @onCloseButtonClick={{@close}}>
+    <:content>
+      <p>Souhaitez-vous supprimer la session <span>{{@sessionId}}</span> ?</p>
+    </:content>
+
+    <:footer>
+      <PixButton
+        aria-label="Annuler la suppression de la session"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{@close}}
+      >
+        Annuler
+      </PixButton>
+
+      <PixButton
+        aria-label="Supprimer la session"
+        @triggerAction={{@confirm}}
+        @loadingColor="white"
+        @backgroundColor="blue"
+      >
+        Supprimer
+      </PixButton>
+    </:footer>
+  </PixModal>
+{{/if}}

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -5,7 +5,7 @@
         <thead>
           <tr>
             <th class="table__column table__column--small">
-              ID session
+              Numéro de session
             </th>
             <th class="table__column table__column--small">
               Nom du site
@@ -23,17 +23,15 @@
               Surveillant(s)
             </th>
             <th class="table__column table__column">
-              Nombre de candidats inscrits
+              Candidats inscrits
             </th>
             <th class="table__column table__column">
-              Nombre de certifications passées
+              Certifications passées
             </th>
             <th class="table__column table__column--small">
               Statut
             </th>
-            <th class="table__column table__column--small">
-              Action
-            </th>
+            <th class="table__column table__column--small"></th>
           </tr>
         </thead>
 

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -31,6 +31,9 @@
             <th class="table__column table__column--small">
               Statut
             </th>
+            <th class="table__column table__column--small">
+              Action
+            </th>
           </tr>
         </thead>
 
@@ -59,6 +62,26 @@
               <td>{{sessionSummary.enrolledCandidatesCount}}</td>
               <td>{{sessionSummary.effectiveCandidatesCount}}</td>
               <td>{{sessionSummary.statusLabel}}</td>
+              <td>
+
+                <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-session-button">
+                  <:triggerElement>
+                    <PixIconButton
+                      @icon="trash-alt"
+                      class="session-summary-list__delete-button"
+                      aria-label="Supprimer la session {{sessionSummary.id}}"
+                      disabled={{sessionSummary.hasEffectiveCandidates}}
+                      aria-describedby="tooltip-delete-session-button"
+                      @withBackground={{true}}
+                    />
+                  </:triggerElement>
+                  <:tooltip>{{if
+                      sessionSummary.hasEffectiveCandidates
+                      "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer."
+                      "Supprimer la session."
+                    }}</:tooltip>
+                </PixTooltip>
+              </td>
             </tr>
           {{/each}}
         </tbody>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -63,7 +63,6 @@
               <td>{{sessionSummary.effectiveCandidatesCount}}</td>
               <td>{{sessionSummary.statusLabel}}</td>
               <td>
-
                 <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-session-button">
                   <:triggerElement>
                     <PixIconButton
@@ -73,6 +72,7 @@
                       disabled={{sessionSummary.hasEffectiveCandidates}}
                       aria-describedby="tooltip-delete-session-button"
                       @withBackground={{true}}
+                      @triggerAction={{fn this.openSessionDeletionConfirmModal sessionSummary.id}}
                     />
                   </:triggerElement>
                   <:tooltip>{{if
@@ -96,3 +96,10 @@
 </div>
 
 <PaginationControl @pagination={{@sessionSummaries.meta}} />
+
+<SessionDeleteConfirmModal
+  @show={{this.shouldDisplaySessionDeletionModal}}
+  @close={{this.closeSessionDeletionConfirmModal}}
+  @sessionId={{this.currentSessionToBeDeletedId}}
+  @confirm={{this.deleteSession}}
+/>

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -1,10 +1,14 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
 export default class SessionSummaryList extends Component {
   @tracked shouldDisplaySessionDeletionModal = false;
   @tracked currentSessionToBeDeletedId = null;
+  @service store;
+  @service notifications;
 
   @action
   openSessionDeletionConfirmModal(sessionId, event) {
@@ -12,8 +16,48 @@ export default class SessionSummaryList extends Component {
     this.currentSessionToBeDeletedId = sessionId;
     this.shouldDisplaySessionDeletionModal = true;
   }
+
   @action
   closeSessionDeletionConfirmModal() {
     this.shouldDisplaySessionDeletionModal = false;
+  }
+
+  @action
+  async deleteSession() {
+    this.notifications.clearAll();
+    const sessionSummary = this.store.peekRecord('session-summary', this.currentSessionToBeDeletedId);
+    try {
+      await sessionSummary.destroyRecord();
+      this.notifications.success('La session a été supprimée.');
+    } catch (err) {
+      if (this._doesNotExist(err)) {
+        this._handleSessionDoesNotExistsError();
+      } else if (this._sessionHasStarted(err)) {
+        this._handleSessionHasStartedError();
+      } else {
+        this._handleUnknownSavingError();
+      }
+    }
+    this.closeSessionDeletionConfirmModal();
+  }
+
+  _sessionHasStarted(err) {
+    return get(err, 'errors[0].status') === '409';
+  }
+
+  _doesNotExist(err) {
+    return get(err, 'errors[0].status') === '404';
+  }
+
+  _handleUnknownSavingError() {
+    this.notifications.error("Une erreur s'est produite lors de la suppression de la session.");
+  }
+
+  _handleSessionDoesNotExistsError() {
+    this.notifications.error("La session que vous tentez de supprimer n'existe pas.");
+  }
+
+  _handleSessionHasStartedError() {
+    this.notifications.error('La session a déjà commencé.');
   }
 }

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class SessionSummaryList extends Component {
+  @tracked shouldDisplaySessionDeletionModal = false;
+  @tracked currentSessionToBeDeletedId = null;
+
+  @action
+  openSessionDeletionConfirmModal(sessionId, event) {
+    event.stopPropagation();
+    this.currentSessionToBeDeletedId = sessionId;
+    this.shouldDisplaySessionDeletionModal = true;
+  }
+  @action
+  closeSessionDeletionConfirmModal() {
+    this.shouldDisplaySessionDeletionModal = false;
+  }
+}

--- a/certif/app/models/session-summary.js
+++ b/certif/app/models/session-summary.js
@@ -18,4 +18,8 @@ export default class Session extends Model {
     if (this.status === 'processed') return 'Résultats transmis par Pix';
     return 'Créée';
   }
+
+  get hasEffectiveCandidates() {
+    return this.effectiveCandidatesCount > 0;
+  }
 }

--- a/certif/app/models/session-summary.js
+++ b/certif/app/models/session-summary.js
@@ -2,7 +2,7 @@ import Model, { attr } from '@ember-data/model';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 
-export default class Session extends Model {
+export default class SessionSummary extends Model {
   @attr() address;
   @attr() room;
   @attr('date-only') date;

--- a/certif/app/styles/components/session-summary-list.scss
+++ b/certif/app/styles/components/session-summary-list.scss
@@ -4,4 +4,10 @@
     color: $grey-80;
     text-decoration: none;
   }
+
+  &__delete {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -252,4 +252,8 @@ export default function () {
     await candidate.update({ authorizedToStart: true });
     return new Response(204);
   });
+
+  this.delete('/sessions/:id', async () => {
+    return new Response(204);
+  });
 }

--- a/certif/tests/integration/components/session-delete-confirm-modal_test.js
+++ b/certif/tests/integration/components/session-delete-confirm-modal_test.js
@@ -1,0 +1,119 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { click } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+
+module('Integration | Component | session-delete-confirm-modal', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('when shouldDisplaySessionDeletionModal is true', function () {
+    test('it should render the modal', async function (assert) {
+      // given
+      this.shouldDisplaySessionDeletionModal = true;
+      this.closeSessionDeletionConfirmModalStub = sinon.stub();
+      this.currentSessionToBeDeletedId = 123;
+
+      // when
+      const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
+      @show={{this.shouldDisplaySessionDeletionModal}}
+      @close={{this.closeSessionDeletionConfirmModalStub}}
+      @sessionId={{this.currentSessionToBeDeletedId}}
+    />`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+      assert
+        .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
+        .hasText('Souhaitez-vous supprimer la session 123 ?');
+    });
+  });
+
+  module('when shouldDisplaySessionDeletionModal is false', function () {
+    test('it should not render the modal', async function (assert) {
+      // given
+      this.shouldDisplaySessionDeletionModal = false;
+      this.closeSessionDeletionConfirmModalStub = sinon.stub();
+      this.currentSessionToBeDeletedId = 123;
+
+      // when
+      const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
+      @show={{this.shouldDisplaySessionDeletionModal}}
+      @close={{this.closeSessionDeletionConfirmModalStub}}
+      @sessionId={{this.currentSessionToBeDeletedId}}
+    />`);
+
+      // then
+      assert.dom(screen.queryByText('Supprimer la session')).doesNotExist();
+    });
+  });
+
+  module('when clicking on close button', function () {
+    test('it should call closeSessionDeletionConfirmModal method', async function (assert) {
+      // given
+      this.shouldDisplaySessionDeletionModal = true;
+      this.closeSessionDeletionConfirmModalStub = sinon.stub();
+      this.currentSessionToBeDeletedId = 123;
+
+      const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
+        @show={{this.shouldDisplaySessionDeletionModal}}
+        @close={{this.closeSessionDeletionConfirmModalStub}}
+        @sessionId={{this.currentSessionToBeDeletedId}}
+      />`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'Fermer' }));
+
+      // then
+      sinon.assert.calledOnce(this.closeSessionDeletionConfirmModalStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when clicking on footer close button', function () {
+    test('it should call closeSessionDeletionConfirmModal method', async function (assert) {
+      // given
+      this.shouldDisplaySessionDeletionModal = true;
+      this.closeSessionDeletionConfirmModalStub = sinon.stub();
+      this.currentSessionToBeDeletedId = 123;
+
+      const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
+        @show={{this.shouldDisplaySessionDeletionModal}}
+        @close={{this.closeSessionDeletionConfirmModalStub}}
+        @sessionId={{this.currentSessionToBeDeletedId}}
+      />`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'Annuler la suppression de la session' }));
+
+      // then
+      sinon.assert.calledOnce(this.closeSessionDeletionConfirmModalStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when clicking on suppression button', function () {
+    test('it should call deleteSession method', async function (assert) {
+      // given
+      this.shouldDisplaySessionDeletionModal = true;
+      this.closeSessionDeletionConfirmModalStub = sinon.stub();
+      this.currentSessionToBeDeletedId = 123;
+      this.deleteSessionStub = sinon.stub();
+
+      const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
+        @show={{this.shouldDisplaySessionDeletionModal}}
+        @close={{this.closeSessionDeletionConfirmModalStub}}
+        @sessionId={{this.currentSessionToBeDeletedId}}
+        @confirm={{this.deleteSessionStub}}
+      />`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'Supprimer la session' }));
+
+      // then
+      sinon.assert.calledOnce(this.deleteSessionStub);
+      assert.ok(true);
+    });
+  });
+});

--- a/certif/tests/integration/components/session-delete-confirm-modal_test.js
+++ b/certif/tests/integration/components/session-delete-confirm-modal_test.js
@@ -24,6 +24,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+      assert.dom(screen.getByText('Attention, cette action est irréversible.')).exists();
       assert
         .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
         .hasText('Souhaitez-vous supprimer la session 123 ?');

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -25,15 +25,14 @@ module('Integration | Component | session-summary-list', function (hooks) {
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
     // then
-    assert.dom(screen.getByRole('columnheader', { name: 'ID session' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Numéro de session' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Nom du site' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Salle' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Date' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Heure' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Surveillant(s)' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Nombre de candidats inscrits' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Nombre de certifications passées' })).exists();
-    assert.dom(screen.getByRole('columnheader', { name: 'Action' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Candidats inscrits' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Certifications passées' })).exists();
   });
 
   module('When there are no sessions to display', function () {

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -13,6 +13,29 @@ module('Integration | Component | session-summary-list', function (hooks) {
     this.set('goToSessionDetailsSpy', () => {});
   });
 
+  test('it should display an header', async function (assert) {
+    // given
+    const sessionSummaries = [];
+    sessionSummaries.meta = { rowCount: 0 };
+    this.sessionSummaries = sessionSummaries;
+
+    // when
+    const screen = await renderScreen(hbs`<SessionSummaryList
+                  @sessionSummaries={{this.sessionSummaries}}
+                  @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
+
+    // then
+    assert.dom(screen.getByRole('columnheader', { name: 'ID session' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom du site' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Salle' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Date' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Heure' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Surveillant(s)' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nombre de candidats inscrits' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nombre de certifications passées' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Action' })).exists();
+  });
+
   module('When there are no sessions to display', function () {
     test('it should display an empty list message', async function (assert) {
       // given

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -4,7 +4,6 @@ import { render, click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import { setupRenderingTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Integration | Component | session-summary-list', function (hooks) {
   setupRenderingTest(hooks);
@@ -56,16 +55,12 @@ module('Integration | Component | session-summary-list', function (hooks) {
     test('it should display a list of sessions', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const sessionSummary1 = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-        })
-      );
-      const sessionSummary2 = run(() =>
-        store.createRecord('session-summary', {
-          id: 456,
-        })
-      );
+      const sessionSummary1 = store.createRecord('session-summary', {
+        id: 123,
+      });
+      const sessionSummary2 = store.createRecord('session-summary', {
+        id: 456,
+      });
       const sessionSummaries = [sessionSummary1, sessionSummary2];
       sessionSummaries.meta = {
         rowCount: 2,
@@ -85,19 +80,17 @@ module('Integration | Component | session-summary-list', function (hooks) {
     test('it should display all the attributes of the session summary in the row', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const sessionSummary = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-          address: 'TicTac',
-          room: 'Jambon',
-          date: '2020-12-01',
-          time: '15:00:00',
-          examiner: 'Bibiche',
-          enrolledCandidatesCount: 3,
-          effectiveCandidatesCount: 2,
-          status: 'finalized',
-        })
-      );
+      const sessionSummary = store.createRecord('session-summary', {
+        id: 123,
+        address: 'TicTac',
+        room: 'Jambon',
+        date: '2020-12-01',
+        time: '15:00:00',
+        examiner: 'Bibiche',
+        enrolledCandidatesCount: 3,
+        effectiveCandidatesCount: 2,
+        status: 'finalized',
+      });
       const sessionSummaries = [sessionSummary];
       sessionSummaries.meta = {
         rowCount: 1,
@@ -125,11 +118,9 @@ module('Integration | Component | session-summary-list', function (hooks) {
       // given
       this.goToSessionDetailsSpy = sinon.stub();
       const store = this.owner.lookup('service:store');
-      const sessionSummary = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-        })
-      );
+      const sessionSummary = store.createRecord('session-summary', {
+        id: 123,
+      });
       const sessionSummaries = [sessionSummary];
       sessionSummaries.meta = {
         rowCount: 1,
@@ -151,11 +142,9 @@ module('Integration | Component | session-summary-list', function (hooks) {
       // given
       this.goToSessionDetailsSpy = sinon.stub();
       const store = this.owner.lookup('service:store');
-      const sessionSummary = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-        })
-      );
+      const sessionSummary = store.createRecord('session-summary', {
+        id: 123,
+      });
       const sessionSummaries = [sessionSummary];
       sessionSummaries.meta = {
         rowCount: 1,
@@ -176,13 +165,11 @@ module('Integration | Component | session-summary-list', function (hooks) {
         // given
         this.goToSessionDetailsSpy = sinon.stub();
         const store = this.owner.lookup('service:store');
-        const sessionSummary = run(() =>
-          store.createRecord('session-summary', {
-            id: 123,
-            enrolledCandidatesCount: 1,
-            effectiveCandidatesCount: 1,
-          })
-        );
+        const sessionSummary = store.createRecord('session-summary', {
+          id: 123,
+          enrolledCandidatesCount: 1,
+          effectiveCandidatesCount: 1,
+        });
         const sessionSummaries = [sessionSummary];
         sessionSummaries.meta = {
           rowCount: 1,
@@ -204,11 +191,9 @@ module('Integration | Component | session-summary-list', function (hooks) {
         // given
         this.goToSessionDetailsSpy = sinon.stub();
         const store = this.owner.lookup('service:store');
-        const sessionSummary = run(() =>
-          store.createRecord('session-summary', {
-            id: 123,
-          })
-        );
+        const sessionSummary = store.createRecord('session-summary', {
+          id: 123,
+        });
         const sessionSummaries = [sessionSummary];
         sessionSummaries.meta = {
           rowCount: 1,
@@ -256,11 +241,9 @@ module('Integration | Component | session-summary-list', function (hooks) {
             // given
             this.goToSessionDetailsSpy = sinon.stub();
             const store = this.owner.lookup('service:store');
-            const sessionSummary = run(() =>
-              store.createRecord('session-summary', {
-                id: 123,
-              })
-            );
+            const sessionSummary = store.createRecord('session-summary', {
+              id: 123,
+            });
             const sessionSummaries = [sessionSummary];
             sessionSummaries.meta = {
               rowCount: 1,

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -201,6 +201,63 @@ module('Integration | Component | session-summary-list', function (hooks) {
         // then
         assert.dom(screen.getByRole('button', { name: 'Supprimer la session 123' })).isEnabled();
       });
+
+      module('when clicking on delete button', function () {
+        test('it should open the modal', async function (assert) {
+          // given
+          this.goToSessionDetailsSpy = sinon.stub();
+          const store = this.owner.lookup('service:store');
+          const sessionSummary = store.createRecord('session-summary', {
+            id: 123,
+            meta: {
+              rowCount: 1,
+            },
+          });
+          this.sessionSummaries = [sessionSummary];
+
+          const screen = await renderScreen(hbs`<SessionSummaryList
+                  @sessionSummaries={{this.sessionSummaries}}
+                  @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
+
+          // when
+          await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+
+          // then
+          assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+          assert
+            .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
+            .hasText('Souhaitez-vous supprimer la session 123 ?');
+        });
+
+        module('when clicking on modal delete button', function () {
+          test('it should close the modal', async function (assert) {
+            // given
+            this.goToSessionDetailsSpy = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const sessionSummary = run(() =>
+              store.createRecord('session-summary', {
+                id: 123,
+              })
+            );
+            const sessionSummaries = [sessionSummary];
+            sessionSummaries.meta = {
+              rowCount: 1,
+            };
+            this.sessionSummaries = sessionSummaries;
+
+            const screen = await renderScreen(hbs`<SessionSummaryList
+                  @sessionSummaries={{this.sessionSummaries}}
+                  @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
+            await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+
+            // when
+            await click(screen.getByRole('button', { name: 'Fermer' }));
+
+            // then
+            assert.dom(screen.queryByText('Supprimer la session')).doesNotExist();
+          });
+        });
+      });
     });
   });
 });

--- a/certif/tests/unit/adapters/session-summary_test.js
+++ b/certif/tests/unit/adapters/session-summary_test.js
@@ -29,4 +29,18 @@ module('Unit | Adapters | session-summary', function (hooks) {
       assert.true(url.endsWith('/api/certification-centers/123/session-summaries'));
     });
   });
+
+  module('#urlForDeleteRecord', function () {
+    test('it should return the modified URL from session id', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:session-summary');
+      const sessionId = 123;
+
+      // when
+      const url = adapter.urlForDeleteRecord(sessionId);
+
+      // then
+      assert.true(url.endsWith(`/sessions/${sessionId}`));
+    });
+  });
 });

--- a/certif/tests/unit/components/session-summary-list_test.js
+++ b/certif/tests/unit/components/session-summary-list_test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | session-summary', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:session-summary-list');
+  });
+
+  module('#openSessionDeletionConfirmModal', function () {
+    test('should set shouldDisplaySessionDeletionModal to true', async function (assert) {
+      // given
+      const sessionId = null;
+      component.shouldDisplaySessionDeletionModal = false;
+      const event = {
+        stopPropagation: sinon.stub(),
+      };
+
+      // when
+      await component.openSessionDeletionConfirmModal(sessionId, event);
+
+      // then
+      assert.true(component.shouldDisplaySessionDeletionModal);
+    });
+
+    test('should call stopPropagation method', async function (assert) {
+      // given
+      const sessionId = null;
+      component.shouldDisplaySessionDeletionModal = false;
+      const event = {
+        stopPropagation: sinon.stub(),
+      };
+
+      // when
+      await component.openSessionDeletionConfirmModal(sessionId, event);
+
+      // then
+      sinon.assert.calledOnce(event.stopPropagation);
+      assert.ok(true);
+    });
+  });
+
+  module('#closeSessionDeletionConfirmModal', function () {
+    test('should set shouldDisplaySessionDeletionModal to false', async function (assert) {
+      // given
+      component.shouldDisplaySessionDeletionModal = true;
+
+      // when
+      await component.closeSessionDeletionConfirmModal();
+
+      // then
+      assert.false(component.shouldDisplaySessionDeletionModal);
+    });
+  });
+});

--- a/certif/tests/unit/models/session-summary_test.js
+++ b/certif/tests/unit/models/session-summary_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | session-summary', function (hooks) {
   setupTest(hooks);
@@ -9,12 +8,10 @@ module('Unit | Model | session-summary', function (hooks) {
     test('it should return "Finalisée" when status is finalized', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const sessionSummary = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-          status: 'finalized',
-        })
-      );
+      const sessionSummary = store.createRecord('session-summary', {
+        id: 123,
+        status: 'finalized',
+      });
 
       // when/then
       assert.strictEqual(sessionSummary.statusLabel, 'Finalisée');
@@ -23,12 +20,10 @@ module('Unit | Model | session-summary', function (hooks) {
     test('it should return "Résultats transmis par Pix" when status is processed', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const sessionSummary = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-          status: 'processed',
-        })
-      );
+      const sessionSummary = store.createRecord('session-summary', {
+        id: 123,
+        status: 'processed',
+      });
 
       // when/then
       assert.strictEqual(sessionSummary.statusLabel, 'Résultats transmis par Pix');
@@ -37,12 +32,10 @@ module('Unit | Model | session-summary', function (hooks) {
     test('it should return Créée else', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const sessionSummary = run(() =>
-        store.createRecord('session-summary', {
-          id: 123,
-          status: 'created',
-        })
-      );
+      const sessionSummary = store.createRecord('session-summary', {
+        id: 123,
+        status: 'created',
+      });
 
       // when/then
       assert.strictEqual(sessionSummary.statusLabel, 'Créée');
@@ -50,34 +43,25 @@ module('Unit | Model | session-summary', function (hooks) {
   });
 
   module('#hasEffectiveCandidates', function () {
-    module('when at least one candidate has joined the session', function () {
-      test('it should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const sessionSummary = run(() =>
-          store.createRecord('session-summary', {
-            effectiveCandidatesCount: 2,
-          })
-        );
-
-        // when/then
-        assert.true(sessionSummary.hasEffectiveCandidates);
+    test('it should return true when at least one candidate has joined the session', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const sessionSummary = store.createRecord('session-summary', {
+        effectiveCandidatesCount: 2,
       });
+
+      // when/then
+      assert.true(sessionSummary.hasEffectiveCandidates);
     });
-
-    module('when no candidate has joined the session', function () {
-      test('it should return false ', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const sessionSummary = run(() =>
-          store.createRecord('session-summary', {
-            effectiveCandidatesCount: 0,
-          })
-        );
-
-        // when/then
-        assert.false(sessionSummary.hasEffectiveCandidates);
+    test('it should return false when no candidate has joined the session', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const sessionSummary = store.createRecord('session-summary', {
+        effectiveCandidatesCount: 0,
       });
+
+      // when/then
+      assert.false(sessionSummary.hasEffectiveCandidates);
     });
   });
 });

--- a/certif/tests/unit/models/session-summary_test.js
+++ b/certif/tests/unit/models/session-summary_test.js
@@ -17,9 +17,7 @@ module('Unit | Model | session-summary', function (hooks) {
       );
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionSummary.statusLabel, 'Finalisée');
+      assert.strictEqual(sessionSummary.statusLabel, 'Finalisée');
     });
 
     test('it should return "Résultats transmis par Pix" when status is processed', function (assert) {
@@ -33,9 +31,7 @@ module('Unit | Model | session-summary', function (hooks) {
       );
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionSummary.statusLabel, 'Résultats transmis par Pix');
+      assert.strictEqual(sessionSummary.statusLabel, 'Résultats transmis par Pix');
     });
 
     test('it should return Créée else', function (assert) {
@@ -49,9 +45,39 @@ module('Unit | Model | session-summary', function (hooks) {
       );
 
       // when/then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionSummary.statusLabel, 'Créée');
+      assert.strictEqual(sessionSummary.statusLabel, 'Créée');
+    });
+  });
+
+  module('#hasEffectiveCandidates', function () {
+    module('when at least one candidate has joined the session', function () {
+      test('it should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const sessionSummary = run(() =>
+          store.createRecord('session-summary', {
+            effectiveCandidatesCount: 2,
+          })
+        );
+
+        // when/then
+        assert.true(sessionSummary.hasEffectiveCandidates);
+      });
+    });
+
+    module('when no candidate has joined the session', function () {
+      test('it should return false ', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const sessionSummary = run(() =>
+          store.createRecord('session-summary', {
+            effectiveCandidatesCount: 0,
+          })
+        );
+
+        // when/then
+        assert.false(sessionSummary.hasEffectiveCandidates);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Même s’il est possible de modifier les infos d’une session de certif depuis Pix Certif, certains utilisateurs souhaitent pouvoir supprimer une session car une session qui n’a pas eu lieu pollue la liste des sessions, et peut entraîner des risques d’erreur (ex : session avec des candidats importés, qui diffère des candidats présents en salle car mauvais code d’accès etc communiqués).

## :robot: Solution
Permettre de supprimer une session de certification : 

- ajouter une icône de suppression active pour toutes les sessions (l’icône devient inactive dès lors qu’au moins 1 candidat a rejoint la session) : 

 sans candidat inscrit

 avec candidats inscrits mais aucun ayant rejoint la session

- cliquer sur l’icône affiche une pop-up de confirmation 


## :rainbow: Remarques
Ajout de tests manquants

## :100: Pour tester
- Se connecter à Pix Certif
- Créer une session sans candidat ou avec des candidats n'ayant pas rejoint la session de certification
  - Constater que l'icone de suppression dans la liste de sessions est active
  - Cliquer sur l'icone ouvre une modale de confirmation
  - Constater que la modale est conforme à la maquette
  - Confirmer la suppression
  - Constater l'absence de la session supprimée dans la liste des sessions

- Créer une session avec des candidats ayant rejoint la session de certification
  - Constater que l'icone de suppression est désactivée et qu'on ne peut pas supprimer la session
