### PR TITLE
[FEATURE]  Rajouter un filtre pour chercher par nom et prénom sur la liste des participations de la page résultats (PIX-5060).

### DIFF
--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -172,6 +172,7 @@ exports.register = async function (server) {
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[badges][]': [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
             'filter[stages][]': [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
+            'filter[search]': Joi.string().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'page[size]': Joi.number().integer().empty(''),
           }),

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -303,6 +303,7 @@ exports.register = async function (server) {
           query: Joi.object({
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'filter[search]': Joi.string().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'page[size]': Joi.number().integer().empty(''),
           }),

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1042,6 +1042,69 @@ describe('Acceptance | API | Campaign Controller', function () {
         });
       });
     });
+
+    context('Search filter', function () {
+      it('should returns profiles collection campaign participations', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildMembership({
+          userId,
+          organizationId: organization.id,
+          organizationRole: Membership.roles.MEMBER,
+        });
+        const targetProfile = databaseBuilder.factory.buildTargetProfile({
+          ownerOrganizationId: organization.id,
+          name: 'Profile 3',
+        });
+        const campaign = databaseBuilder.factory.buildCampaign({
+          name: 'Campagne de Test N°3',
+          organizationId: organization.id,
+          targetProfileId: targetProfile.id,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            firstName: 'Barry',
+            lastName: 'White',
+            organizationId: organization.id,
+            group: 'L1',
+          },
+          {
+            campaignId: campaign.id,
+          }
+        );
+
+        databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+          {
+            firstName: 'Marvin',
+            lastName: 'Gaye',
+            organizationId: organization.id,
+            group: 'L2',
+          },
+          {
+            campaignId: campaign.id,
+          }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const options = {
+          method: 'GET',
+          url: `/api/campaigns/${campaign.id}/profiles-collection-participations?filter[search]=Marvin G`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.have.lengthOf(1);
+        expect(response.result.data[0].attributes['last-name']).to.equal('Gaye');
+      });
+    });
   });
 
   describe('GET /api/campaigns/{id}/divisions', function () {

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-find-shared-participations_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-find-shared-participations_test.js
@@ -94,5 +94,20 @@ describe('Acceptance | API | Campaign Participations | Results', function () {
       expect(response.result.data).to.have.lengthOf(1);
       expect(participation['first-name']).to.equal(participant1.firstName);
     });
+
+    it('should return the participation results for an assessment campaign filtered by search as JSONAPI', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/assessment-results?page[number]=1&page[size]=10&filter[search]=Holly M`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(200);
+      const participation = response.result.data[0].attributes;
+      expect(response.result.data).to.have.lengthOf(1);
+      expect(participation['first-name']).to.equal(participant2.firstName);
+    });
   });
 });

--- a/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
@@ -1,0 +1,44 @@
+const { expect, mockLearningContent, databaseBuilder } = require('../../../test-helper');
+const useCases = require('../../../../lib/domain/usecases');
+
+describe('Integration | UseCase | find-assessment-participation-result-list', function () {
+  let organizationId;
+  let campaignId;
+  const page = { number: 1 };
+
+  beforeEach(async function () {
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    const skill = { id: 'recSkill', status: 'actif' };
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId: targetProfileId,
+      skillId: skill.id,
+    });
+
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
+
+    const participation1 = { participantExternalId: 'Yubaba', campaignId, status: 'SHARED' };
+    const participant1 = { firstName: 'Chihiro', lastName: 'Ogino' };
+    databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(participant1, participation1);
+
+    const participation2 = { participantExternalId: 'Meï', campaignId, status: 'SHARED' };
+    const participant2 = { firstName: 'Tonari', lastName: 'No Totoro' };
+    databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(participant2, participation2);
+
+    mockLearningContent({ skills: [skill], tubes: [], competences: [], areas: [] });
+
+    await databaseBuilder.commit();
+  });
+
+  context('when there are filters', function () {
+    it('returns the assessmentParticipationResultMinimal list filtered by the search', async function () {
+      const { participations } = await useCases.findAssessmentParticipationResultList({
+        campaignId,
+        filters: { search: 'Tonari N' },
+        page,
+      });
+
+      expect(participations.length).to.equal(1);
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/integration/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -1,0 +1,44 @@
+const { expect, mockLearningContent, databaseBuilder } = require('../../../test-helper');
+const useCases = require('../../../../lib/domain/usecases');
+
+describe('Integration | UseCase | find-campaign-profiles-collection-participation-summaries', function () {
+  let organizationId;
+  let campaignId;
+  let userId;
+
+  beforeEach(async function () {
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    userId = databaseBuilder.factory.buildUser().id;
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
+
+    databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+    mockLearningContent({ skills: [], tubes: [], competences: [], areas: [] });
+
+    await databaseBuilder.commit();
+  });
+
+  context('when there are filters', function () {
+    beforeEach(async function () {
+      const participation1 = { participantExternalId: 'Yubaba', campaignId, status: 'SHARED' };
+      const participant1 = { firstName: 'Chihiro', lastName: 'Ogino' };
+      databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(participant1, participation1);
+
+      const participation2 = { participantExternalId: 'Meï', campaignId, status: 'SHARED' };
+      const participant2 = { firstName: 'Tonari', lastName: 'No Totoro' };
+      databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(participant2, participation2);
+
+      await databaseBuilder.commit();
+    });
+    it('returns the list filtered by the search', async function () {
+      const { data } = await useCases.findCampaignProfilesCollectionParticipationSummaries({
+        userId,
+        campaignId,
+        filters: { search: 'Tonari N' },
+      });
+      expect(data.length).to.equal(1);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -884,5 +884,294 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         expect(participantExternalIds).to.exactlyContain(['Sans', 'Papyrus']);
       });
     });
+
+    context('when there is a filter on the firstname and lastname', function () {
+      beforeEach(async function () {
+        // given
+        campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill1' }]);
+
+        await databaseBuilder.commit();
+
+        const learningContent = [
+          {
+            id: 'recArea1',
+            competences: [
+              {
+                id: 'recCompetence1',
+                tubes: [
+                  {
+                    id: 'recTube1',
+                    skills: [{ id: 'Skill1', name: '@Acquis1', challenges: [] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+        mockLearningContent(learningContentObjects);
+      });
+
+      it('returns all participants if the filter is empty', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Saphira',
+            lastName: 'Eurasier',
+          }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: '' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+      });
+
+      it('return Choupette participant when we search part its firstname', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          }
+        );
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The boy',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Salto',
+            lastName: 'Irish terrier',
+          }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: 'Chou' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when we search contains a space before', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: ' Cho' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when we search contains a space after', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: 'Cho ' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant when we search part its lastname', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          }
+        );
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The boy',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Salto',
+            lastName: 'Irish terrier',
+          }
+        );
+
+        await databaseBuilder.commit();
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: 'Eura' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+        expect(participations[0].lastName).to.equal('Eurasier');
+      });
+
+      it('return Choupette participant when we search part its fullname', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          }
+        );
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The boy',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Salto',
+            lastName: 'Irish terrier',
+          }
+        );
+
+        await databaseBuilder.commit();
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: 'Choupette E' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+        expect(participations[0].firstName).to.equal('Choupette');
+      });
+
+      it('return Choupette participant only for the involved campaign when we search part of its full name', async function () {
+        const otherCampaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, [{ id: 'Skill2' }]);
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Eurasier',
+          }
+        );
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: otherCampaign.id,
+          },
+          {
+            firstName: 'Choupette',
+            lastName: 'Wrong',
+          }
+        );
+
+        await databaseBuilder.commit();
+
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: 'Choupette' },
+        });
+
+        // then
+        expect(participations.length).to.equal(1);
+        expect(participations[0].lastName).to.equal('Eurasier');
+      });
+
+      it('return all participants when we search similar part of firstname', async function () {
+        // given
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The boy',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Salto',
+            lastName: 'Irish terrier',
+          }
+        );
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(
+          {
+            participantExternalId: 'The girl',
+            campaignId: campaign.id,
+          },
+          {
+            firstName: 'Saphira',
+            lastName: 'Young',
+          }
+        );
+
+        await databaseBuilder.commit();
+        // when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+          filters: { search: 'Sa' },
+        });
+
+        // then
+        expect(participations.length).to.equal(2);
+        expect(participations[0].firstName).to.equal('Salto');
+        expect(participations[1].firstName).to.equal('Saphira');
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -335,7 +335,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
     });
 
     describe('when there is a filter on the firstname and lastname', function () {
-      beforeEach(async function () {
+      it('returns all participants if the filter is empty', async function () {
         // given
         const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
@@ -343,6 +343,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           firstName: 'Laa-Laa',
           lastName: 'Teletubbies',
         });
+
         const participation1 = {
           participantExternalId: "Can't get Enough Of Your Love, Baby",
           campaignId,
@@ -356,6 +357,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           firstName: 'Dipsy',
           lastName: 'Teletubbies',
         });
+
         const participation2 = {
           participantExternalId: "You're The First, The last, My Everything",
           campaignId,
@@ -363,23 +365,8 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         };
         databaseBuilder.factory.buildCampaignParticipation(participation2);
 
-        const { id: organizationLearnerId3 } = databaseBuilder.factory.buildOrganizationLearner({
-          organizationId,
-          group: 'Barry',
-          firstName: 'Po',
-          lastName: 'Teletubbies',
-        });
-        const participation3 = {
-          participantExternalId: "Ain't No Mountain High Enough",
-          campaignId,
-          organizationLearnerId: organizationLearnerId3,
-        };
-        databaseBuilder.factory.buildCampaignParticipation(participation3);
-
         await databaseBuilder.commit();
-      });
 
-      it('returns all participants if the filter is empty', async function () {
         // when
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
           campaignId,
@@ -388,10 +375,41 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(3);
+        expect(results.data.length).to.equal(2);
       });
 
       it('returns Laa-Laa when we search part of its firstname', async function () {
+        // given
+        const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Laa-Laa',
+          lastName: 'Teletubbies',
+        });
+
+        const participation1 = {
+          participantExternalId: "Can't get Enough Of Your Love, Baby",
+          campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
+
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'White',
+          firstName: 'Dipsy',
+          lastName: 'Teletubbies',
+        });
+
+        const participation2 = {
+          participantExternalId: "You're The First, The last, My Everything",
+          campaignId,
+          organizationLearnerId: organizationLearnerId2,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
+
+        await databaseBuilder.commit();
+
         // when
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
           campaignId,
@@ -405,6 +423,37 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
 
       it('returns Laa-Laa when we search part of its firstname with a space before', async function () {
+        // given
+        const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Laa-Laa',
+          lastName: 'Teletubbies',
+        });
+
+        const participation1 = {
+          participantExternalId: "Can't get Enough Of Your Love, Baby",
+          campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
+
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'White',
+          firstName: 'Dipsy',
+          lastName: 'Teletubbies',
+        });
+
+        const participation2 = {
+          participantExternalId: "You're The First, The last, My Everything",
+          campaignId,
+          organizationLearnerId: organizationLearnerId2,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
+
+        await databaseBuilder.commit();
+
         // when
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
           campaignId,
@@ -418,6 +467,37 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
 
       it('returns Laa-Laa when we search part of its firstname with a space after', async function () {
+        // given
+        const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Laa-Laa',
+          lastName: 'Teletubbies',
+        });
+
+        const participation1 = {
+          participantExternalId: "Can't get Enough Of Your Love, Baby",
+          campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
+
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'White',
+          firstName: 'Dipsy',
+          lastName: 'Teletubbies',
+        });
+
+        const participation2 = {
+          participantExternalId: "You're The First, The last, My Everything",
+          campaignId,
+          organizationLearnerId: organizationLearnerId2,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
+
+        await databaseBuilder.commit();
+
         // when
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
           campaignId,
@@ -431,6 +511,37 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
 
       it('returns Laa-Laa when we search part of its fullname', async function () {
+        // given
+        const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Laa-Laa',
+          lastName: 'Teletubbies',
+        });
+
+        const participation1 = {
+          participantExternalId: "Can't get Enough Of Your Love, Baby",
+          campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
+
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'White',
+          firstName: 'Dipsy',
+          lastName: 'Teletubbies',
+        });
+
+        const participation2 = {
+          participantExternalId: "You're The First, The last, My Everything",
+          campaignId,
+          organizationLearnerId: organizationLearnerId2,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
+
+        await databaseBuilder.commit();
+
         // when
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
           campaignId,
@@ -444,6 +555,45 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       });
 
       it('returns Laa-Laa when we search similar part of lastname', async function () {
+        // given
+        const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Laa-Laa',
+          lastName: 'Teletubbies',
+        });
+        const participation1 = {
+          participantExternalId: "Can't get Enough Of Your Love, Baby",
+          campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'White',
+          firstName: 'Dipsy',
+          lastName: 'Teletubbies',
+        });
+        const participation2 = {
+          participantExternalId: "You're The First, The last, My Everything",
+          campaignId,
+          organizationLearnerId: organizationLearnerId2,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
+        const { id: organizationLearnerId3 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Maya',
+          lastName: 'L abeille',
+        });
+        const participation3 = {
+          participantExternalId: "Ain't No Mountain High Enough",
+          campaignId,
+          organizationLearnerId: organizationLearnerId3,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation3);
+        await databaseBuilder.commit();
+
         // when
         const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
           campaignId,
@@ -452,10 +602,9 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         );
 
         // then
-        expect(results.data.length).to.equal(3);
+        expect(results.data.length).to.equal(2);
         expect(results.data[0].firstName).to.equal('Dipsy');
         expect(results.data[1].firstName).to.equal('Laa-Laa');
-        expect(results.data[2].firstName).to.equal('Po');
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -333,6 +333,131 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         ]);
       });
     });
+
+    describe('when there is a filter on the firstname and lastname', function () {
+      beforeEach(async function () {
+        // given
+        const { id: organizationLearnerId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Laa-Laa',
+          lastName: 'Teletubbies',
+        });
+        const participation1 = {
+          participantExternalId: "Can't get Enough Of Your Love, Baby",
+          campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation1);
+
+        const { id: organizationLearnerId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'White',
+          firstName: 'Dipsy',
+          lastName: 'Teletubbies',
+        });
+        const participation2 = {
+          participantExternalId: "You're The First, The last, My Everything",
+          campaignId,
+          organizationLearnerId: organizationLearnerId2,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation2);
+
+        const { id: organizationLearnerId3 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          group: 'Barry',
+          firstName: 'Po',
+          lastName: 'Teletubbies',
+        });
+        const participation3 = {
+          participantExternalId: "Ain't No Mountain High Enough",
+          campaignId,
+          organizationLearnerId: organizationLearnerId3,
+        };
+        databaseBuilder.factory.buildCampaignParticipation(participation3);
+
+        await databaseBuilder.commit();
+      });
+
+      it('returns all participants if the filter is empty', async function () {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { search: '' }
+        );
+
+        // then
+        expect(results.data.length).to.equal(3);
+      });
+
+      it('returns Laa-Laa when we search part of its firstname', async function () {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { search: 'La' }
+        );
+
+        // then
+        expect(results.data.length).to.equal(1);
+        expect(results.data[0].firstName).to.equal('Laa-Laa');
+      });
+
+      it('returns Laa-Laa when we search part of its firstname with a space before', async function () {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { search: ' La' }
+        );
+
+        // then
+        expect(results.data.length).to.equal(1);
+        expect(results.data[0].firstName).to.equal('Laa-Laa');
+      });
+
+      it('returns Laa-Laa when we search part of its firstname with a space after', async function () {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { search: 'La ' }
+        );
+
+        // then
+        expect(results.data.length).to.equal(1);
+        expect(results.data[0].firstName).to.equal('Laa-Laa');
+      });
+
+      it('returns Laa-Laa when we search part of its fullname', async function () {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { search: 'Laa-Laa Tel' }
+        );
+
+        // then
+        expect(results.data.length).to.equal(1);
+        expect(results.data[0].firstName).to.equal('Laa-Laa');
+      });
+
+      it('returns Laa-Laa when we search similar part of lastname', async function () {
+        // when
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(
+          campaignId,
+          undefined,
+          { search: 'Teletub' }
+        );
+
+        // then
+        expect(results.data.length).to.equal(3);
+        expect(results.data[0].firstName).to.equal('Dipsy');
+        expect(results.data[1].firstName).to.equal('Laa-Laa');
+        expect(results.data[2].firstName).to.equal('Po');
+      });
+    });
   });
 });
 

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -23,16 +23,10 @@
         @selected={{@selectedDivisions}}
         @onSelect={{this.onSelectDivision}}
         @placeholder={{t "pages.campaign-results.filters.type.divisions.placeholder"}}
-        class="participant-filter-banner__multi-select"
       />
     {{/if}}
     {{#if this.displayGroupsFilter}}
-      <Ui::GroupsFilter
-        @campaign={{@campaign}}
-        @onSelect={{this.onSelectGroup}}
-        @selectedGroups={{@selectedGroups}}
-        class="participant-filter-banner__multi-select"
-      />
+      <Ui::GroupsFilter @campaign={{@campaign}} @onSelect={{this.onSelectGroup}} @selectedGroups={{@selectedGroups}} />
     {{/if}}
     {{#if this.displaySearchFilter}}
       <Ui::SearchInput
@@ -50,6 +44,7 @@
         @onSelect={{this.onSelectStage}}
         @selected={{@selectedStages}}
         @options={{this.stageOptions}}
+        class="participant-filter-banner__stages"
         as |stage|
       >
         <Campaign::StageStars @result={{stage.threshold}} @stages={{@campaign.stages}} />
@@ -62,6 +57,7 @@
         @onSelect={{this.onSelectBadge}}
         @selected={{@selectedBadges}}
         @options={{this.badgeOptions}}
+        class="participant-filter-banner__badges"
         as |badge|
       >
         {{badge.label}}

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -7,9 +7,9 @@
     @selectedGroups={{@selectedGroups}}
     @selectedBadges={{@selectedBadges}}
     @selectedStages={{@selectedStages}}
+    @searchFilter={{@searchFilter}}
     @rowCount={{@participations.meta.rowCount}}
     @isHiddenStatus={{true}}
-    @isHiddenSearch={{true}}
     @onResetFilter={{@onResetFilter}}
     @onFilter={{@onFilter}}
   />

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -6,10 +6,10 @@
     @selectedDivisions={{@selectedDivisions}}
     @selectedGroups={{@selectedGroups}}
     @rowCount={{@profiles.meta.rowCount}}
+    @searchFilter={{@searchFilter}}
     @onFilter={{@onFilter}}
     @onResetFilter={{@onReset}}
     @isHiddenStatus={{true}}
-    @isHiddenSearch={{true}}
   />
 
   <div class="panel">

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -11,6 +11,7 @@ export default class AssessmentResultsController extends Controller {
   @tracked groups = [];
   @tracked badges = [];
   @tracked stages = [];
+  @tracked search = null;
 
   @action
   goToAssessmentPage(campaignId, participantId, event) {
@@ -31,6 +32,9 @@ export default class AssessmentResultsController extends Controller {
     this.groups = filters.groups || this.groups;
     this.badges = filters.badges || this.badges;
     this.stages = filters.stages || this.stages;
+    if (filters.search !== undefined) {
+      this.search = filters.search;
+    }
   }
 
   @action
@@ -40,5 +44,6 @@ export default class AssessmentResultsController extends Controller {
     this.groups = [];
     this.badges = [];
     this.stages = [];
+    this.search = null;
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
@@ -8,6 +8,7 @@ export default class ProfilesController extends Controller {
   @tracked pageSize = 25;
   @tracked divisions = [];
   @tracked groups = [];
+  @tracked search = null;
 
   @action
   goToProfilePage(campaignId, campaignParticipationId, event) {
@@ -19,8 +20,11 @@ export default class ProfilesController extends Controller {
   @action
   triggerFiltering(filters) {
     this.pageNumber = null;
-    this.divisions = filters.divisions;
-    this.groups = filters.groups;
+    this.divisions = filters.divisions || this.divisions;
+    this.groups = filters.groups || this.groups;
+    if (filters.search !== undefined) {
+      this.search = filters.search;
+    }
   }
 
   @action
@@ -28,5 +32,6 @@ export default class ProfilesController extends Controller {
     this.pageNumber = null;
     this.divisions = [];
     this.groups = [];
+    this.search = null;
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -22,6 +22,9 @@ export default class AssessmentResultsRoute extends Route {
     stages: {
       refreshModel: true,
     },
+    search: {
+      refreshModel: true,
+    },
   };
 
   async model(params) {
@@ -50,6 +53,7 @@ export default class AssessmentResultsRoute extends Route {
         groups: params.groups,
         badges: params.badges,
         stages: params.stages,
+        search: params.search,
       },
       campaignId: params.campaignId,
     });
@@ -63,6 +67,7 @@ export default class AssessmentResultsRoute extends Route {
       controller.groups = [];
       controller.badges = [];
       controller.stages = [];
+      controller.search = null;
     }
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -16,6 +16,9 @@ export default class ProfilesRoute extends Route {
     groups: {
       refreshModel: true,
     },
+    search: {
+      refreshModel: true,
+    },
   };
 
   @action
@@ -39,6 +42,7 @@ export default class ProfilesRoute extends Route {
         campaignId: params.campaignId,
         divisions: params.divisions,
         groups: params.groups,
+        search: params.search,
       },
       page: {
         number: params.pageNumber,
@@ -53,6 +57,7 @@ export default class ProfilesRoute extends Route {
       controller.pageSize = 25;
       controller.divisions = [];
       controller.groups = [];
+      controller.search = null;
     }
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -48,6 +48,7 @@
 @import 'components/login-or-register';
 @import 'components/manage-authentication-method-modal';
 @import 'components/modal';
+@import 'components/participation-filters';
 
 // pages
 @import 'pages/login';

--- a/orga/app/styles/components/participation-filters.scss
+++ b/orga/app/styles/components/participation-filters.scss
@@ -1,0 +1,11 @@
+.participant-filter-banner {
+  margin: 12px 0;
+
+  &__stages {
+    min-width: 160px;
+  }
+
+  &__badges {
+    min-width: 250px;
+  }
+}

--- a/orga/app/styles/components/search-input.scss
+++ b/orga/app/styles/components/search-input.scss
@@ -2,13 +2,15 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  font-size: 0.875rem;
-  height: 36px;
-  min-width: 250px;
   box-sizing: border-box;
 
+  &:focus-within {
+    border-color: $pix-primary;
+    box-shadow: inset 0 0 0 0.6px $pix-primary;
+  }
+
   svg {
-    color: $pix-neutral-70;
+    color: $pix-neutral-30;
   }
 
   &__invisible-field {
@@ -19,7 +21,7 @@
     padding: 0 10px;
     border-radius: 3px;
     font-family: $font-roboto;
-    font-size: 0.875em;
+    font-size: 0.875rem;
     background: transparent;
 
     &:focus {

--- a/orga/app/styles/components/search-input.scss
+++ b/orga/app/styles/components/search-input.scss
@@ -2,7 +2,9 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  font-size: 1rem;
+  font-size: 0.875rem;
+  height: 36px;
+  min-width: 250px;
   box-sizing: border-box;
 
   svg {

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -162,10 +162,10 @@ p.label {
 }
 
 .input {
-  height: 38px;
+  height: 36px;
   border: 1px solid $pix-neutral-40;
   border-radius: 4px;
-  font-size: 1rem;
+  font-size: 0.875rem;
   padding-left: 15px;
   color: $pix-neutral-100;
   outline: none;

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -6,18 +6,12 @@ table {
   box-sizing: border-box;
 
   .table__input {
-    height: 36px;
-    width: 100%;
-
     &:focus-within {
       border: 1px solid $pix-primary;
     }
   }
 
   .table__multi-select {
-    height: 36px;
-    min-width: 100%;
-
     > label {
       > input[type='text']::placeholder {
         color: $pix-neutral-30;

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -32,11 +32,3 @@
     }
   }
 }
-
-.participant-filter-banner {
-  margin: 12px 0;
-
-  &__multi-select {
-    width: auto;
-  }
-}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -18,6 +18,7 @@
     @selectedGroups={{this.groups}}
     @selectedBadges={{this.badges}}
     @selectedStages={{this.stages}}
+    @searchFilter={{this.search}}
     @onClickParticipant={{this.goToAssessmentPage}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "pix-orga",
-      "version": "3.230.0",
+      "version": "3.231.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^14.5.0",
+        "@1024pix/pix-ui": "^15.0.2",
         "@ember/optional-features": "^2.0.0",
         "@formatjs/intl-getcanonicallocales": "^1.5.3",
         "@formatjs/intl-locale": "^2.4.14",
@@ -269,10 +269,11 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.5.0.tgz",
-      "integrity": "sha512-OjIXh7kcNDpO0fgrT97wqICoCEQ69u+5K2RhYz1uxP+BDSQmFRMKiyNt0ayEkcirytIPJAojPevxTb83Ff6LNg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-15.0.2.tgz",
+      "integrity": "sha512-D8u3E5oBqMt/uwzvF7KKngRX1FBWJ49USaQ39RIBJzjVDoNbC5Nvbu3qaQyWHHCiefvuJdIF4sVEyPJkZEkFdQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.6.2",
@@ -283,7 +284,8 @@
         "ember-truth-helpers": "^3.0.0"
       },
       "engines": {
-        "node": "^16.13.0"
+        "node": "16.14.0",
+        "npm": ">=8.3.1 <=8.13.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -36217,9 +36219,15 @@
       }
     },
     "@1024pix/pix-ui": {
+<<<<<<< HEAD
       "version": "14.5.0",
       "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.5.0.tgz",
       "integrity": "sha512-OjIXh7kcNDpO0fgrT97wqICoCEQ69u+5K2RhYz1uxP+BDSQmFRMKiyNt0ayEkcirytIPJAojPevxTb83Ff6LNg==",
+=======
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-15.0.2.tgz",
+      "integrity": "sha512-D8u3E5oBqMt/uwzvF7KKngRX1FBWJ49USaQ39RIBJzjVDoNbC5Nvbu3qaQyWHHCiefvuJdIF4sVEyPJkZEkFdQ==",
+>>>>>>> ced6d3039a (chore(orga) Update pix-ui to v15.0.2)
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^14.5.0",
+    "@1024pix/pix-ui": "^15.0.2",
     "@ember/optional-features": "^2.0.0",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",
     "@formatjs/intl-locale": "^2.4.14",

--- a/orga/tests/acceptance/campaign-assessment-results_test.js
+++ b/orga/tests/acceptance/campaign-assessment-results_test.js
@@ -125,4 +125,16 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       assert.dom('.page-size option:checked').hasText(changedPageSize.toString());
     });
   });
+
+  module('when prescriber is already on participants page and set filters', () => {
+    test('should set search filter', async function (assert) {
+      // when
+      await visit('/campagnes/1/resultats-evaluation');
+
+      await fillByLabel('Recherche sur le nom et prénom', 'Choupette');
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/1/resultats-evaluation?search=Choupette');
+    });
+  });
 });

--- a/orga/tests/acceptance/campaign-profiles_test.js
+++ b/orga/tests/acceptance/campaign-profiles_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
 import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
@@ -94,6 +94,18 @@ module('Acceptance | Campaign Profiles', function (hooks) {
       assert.dom('table tbody tr').exists({ count: changedPageSize });
       assert.contains('Page 1 / 2');
       assert.dom('.page-size option:checked').hasText(changedPageSize.toString());
+    });
+  });
+
+  module('when  user is already on profiles page and set filters', () => {
+    test('should set search filter', async function (assert) {
+      // when
+      await visit('/campagnes/1/profils');
+
+      await fillByLabel('Recherche sur le nom et prénom', 'Choupette');
+
+      // then
+      assert.strictEqual(currentURL(), '/campagnes/1/profils?search=Choupette');
     });
   });
 });

--- a/orga/tests/acceptance/preselect-target-profile_test.js
+++ b/orga/tests/acceptance/preselect-target-profile_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, clickByName } from '@1024pix/ember-testing-library';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
 import authenticateSession from '../helpers/authenticate-session';
 import { setupApplicationTest } from 'ember-qunit';
@@ -17,9 +17,9 @@ module('Acceptance | preselect-target-profile', function (hooks) {
 
   test('it should display tubes', async function (assert) {
     // given
-    server.create('tube', { id: 'recTube1', name: 'Tube 1' });
-    server.create('tube', { id: 'recTube2', name: 'Tube 2' });
-    server.create('tube', { id: 'recTube3', name: 'Tube 3' });
+    server.create('tube', { id: 'recTube1', practicalTitle: 'Tube 1' });
+    server.create('tube', { id: 'recTube2', practicalTitle: 'Tube 2' });
+    server.create('tube', { id: 'recTube3', practicalTitle: 'Tube 3' });
     server.create('thematic', {
       id: 'recThematic1',
       name: 'Competence 1',
@@ -29,9 +29,14 @@ module('Acceptance | preselect-target-profile', function (hooks) {
     server.create('area', { title: 'Area 1', competenceIds: ['recCompetence1'] });
 
     // when
-    await visit('/selection-sujets');
+    const screen = await visit('/selection-sujets');
+
+    await clickByName('· Area 1');
 
     // then
-    assert.dom('.row-tube').exists({ count: 3 });
+
+    assert.dom(screen.getByLabelText('Tube 1 :')).exists();
+    assert.dom(screen.getByLabelText('Tube 2 :')).exists();
+    assert.dom(screen.getByLabelText('Tube 3 :')).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render as renderScreen, fillByLabel } from '@1024pix/ember-testing-library';
 import { render, click } from '@ember/test-helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
@@ -335,6 +335,38 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
 
       // then
       assert.ok(resetFilters.called);
+    });
+  });
+
+  module('when user set a search filter', function () {
+    test('that in the fullname search input we will have the value that we put', async function (assert) {
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+      });
+      this.set('campaign', campaign);
+      this.set('searchFilter', 'chichi');
+      const screen = await renderScreen(
+        hbs`<Campaign::Results::AssessmentList  @campaign={{campaign}} @searchFilter={{searchFilter}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByLabelText('Recherche sur le nom et prénom')).hasValue('chichi');
+    });
+    test('that while filling the search input we will trigger the filtering', async function (assert) {
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+      });
+      const triggerFiltering = sinon.stub();
+      this.set('campaign', campaign);
+      this.set('triggerFiltering', triggerFiltering);
+      await renderScreen(
+        hbs`<Campaign::Results::AssessmentList  @campaign={{campaign}} @onFilter={{triggerFiltering}} />`
+      );
+      await fillByLabel('Recherche sur le nom et prénom', 'Chichi');
+      // then
+      assert.ok(triggerFiltering.calledWith({ search: 'Chichi' }));
     });
   });
 });

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -353,6 +353,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
       // then
       assert.dom(screen.getByLabelText('Recherche sur le nom et prénom')).hasValue('chichi');
     });
+
     test('that while filling the search input we will trigger the filtering', async function (assert) {
       const campaign = store.createRecord('campaign', {
         id: 1,

--- a/orga/tests/integration/components/campaign/results/profile-list_test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list_test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
+import { render as renderScreen, fillByLabel } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -203,6 +204,45 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
 
       // then
       assert.ok(this.onFilter.calledWith({ divisions: ['d1'] }));
+    });
+
+    module('when user set a search filter', function () {
+      test('that in the fullname search input we will have the value that we put', async function (assert) {
+        console.log('hi');
+        const campaign = store.createRecord('campaign', {
+          id: 1,
+          name: 'campagne 1',
+          stages: [],
+          participationsCount: 1,
+        });
+        this.set('campaign', campaign);
+        this.set('searchFilter', 'chichi');
+        const screen = await renderScreen(
+          hbs`<Campaign::Results::ProfileList  @campaign={{campaign}} @searchFilter={{searchFilter}}/>`
+        );
+
+        // then
+        assert.dom(screen.getByLabelText('Recherche sur le nom et prénom')).hasValue('chichi');
+      });
+
+      test('that while filling the search input we will trigger the filtering', async function (assert) {
+        const campaign = store.createRecord('campaign', {
+          id: 1,
+          name: 'campagne 1',
+          stages: [],
+          participationsCount: 1,
+        });
+        const triggerFiltering = sinon.stub();
+        this.set('campaign', campaign);
+        this.set('triggerFiltering', triggerFiltering);
+        await renderScreen(
+          hbs`<Campaign::Results::ProfileList  @campaign={{campaign}} @onFilter={{triggerFiltering}} />`
+        );
+        await fillByLabel('Recherche sur le nom et prénom', 'Chichi');
+
+        // then
+        assert.ok(triggerFiltering.calledWith({ search: 'Chichi' }));
+      });
     });
   });
 });

--- a/orga/tests/integration/components/tube/list_test.js
+++ b/orga/tests/integration/components/tube/list_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import moment from 'moment';
 import sinon from 'sinon';
@@ -55,12 +54,12 @@ module('Integration | Component | tube:list', function (hooks) {
     this.set('areas', areas);
 
     // when
-    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
-
+    const screen = await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+    await clickByName('1 · Titre domaine');
     // then
-    assert.dom('.row-tube').exists({ count: 2 });
-    assert.dom(this.element.querySelector('[for="tube-tubeId1"]')).hasText('Titre 1 : Description 1');
-    assert.dom(this.element.querySelector('[for="tube-tubeId2"]')).hasText('Titre 2 : Description 2');
+
+    assert.dom(screen.getByLabelText('Titre 1 : Description 1')).exists();
+    assert.dom(screen.getByLabelText('Titre 2 : Description 2')).exists();
   });
 
   test('it should disable the download button if not tube is selected', async function (assert) {
@@ -68,10 +67,10 @@ module('Integration | Component | tube:list', function (hooks) {
     this.set('areas', areas);
 
     // when
-    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+    const screen = await render(hbs`<Tube::list @areas={{this.areas}}/>`);
 
     // then
-    assert.dom('.download-file__button').hasClass('pix-button--disabled');
+    assert.dom(screen.getByText('Télécharger la sélection des sujets (JSON, 0.00ko)')).hasClass('pix-button--disabled');
   });
 
   test('it should enable the download button if a tube is selected', async function (assert) {
@@ -80,13 +79,19 @@ module('Integration | Component | tube:list', function (hooks) {
     this.set('organization', { name: 'mon orga' });
 
     // when
-    await render(hbs`<Tube::list @areas={{this.areas}} @organization={{this.organization}}/>`);
+    const screen = await render(hbs`<Tube::list @areas={{this.areas}} @organization={{this.organization}}/>`);
+
     await clickByName('1 · Titre domaine');
     await clickByName('Titre 1 : Description 1');
 
     // then
-    assert.dom('.download-file__button').doesNotHaveClass('pix-button--disabled');
-    assert.dom(`.download-file__button[download="${expectedAttr}"]`).exists();
+    assert
+      .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.01ko)'))
+      .doesNotHaveClass('pix-button--disabled');
+
+    assert
+      .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.01ko)'))
+      .hasAttribute('download', expectedAttr);
   });
 
   test('Enable the download button if a thematic is selected', async function (assert) {
@@ -95,6 +100,7 @@ module('Integration | Component | tube:list', function (hooks) {
 
     // when
     await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+
     await clickByName('1 · Titre domaine');
     await clickByName('thematic1');
 
@@ -107,15 +113,14 @@ module('Integration | Component | tube:list', function (hooks) {
     this.set('areas', areas);
 
     // when
-    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
-    const tube1 = document.getElementById('tube-tubeId1');
-    const tube2 = document.getElementById('tube-tubeId2');
+    const screen = await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+
     await clickByName('1 · Titre domaine');
     await clickByName('thematic1');
 
     // then
-    assert.dom(tube1).isChecked();
-    assert.dom(tube2).isChecked();
+    assert.dom(screen.getByLabelText('Titre 1 : Description 1')).isChecked();
+    assert.dom(screen.getByLabelText('Titre 2 : Description 2')).isChecked();
   });
 
   test('Should check the thematics if all corresponding tubes are selected', async function (assert) {
@@ -123,13 +128,13 @@ module('Integration | Component | tube:list', function (hooks) {
     this.set('areas', areas);
 
     // when
-    await render(hbs`<Tube::list @areas={{this.areas}}/>`);
-    const thematic = document.getElementById('thematic-thematicId');
+    const screen = await render(hbs`<Tube::list @areas={{this.areas}}/>`);
+
     await clickByName('1 · Titre domaine');
     await clickByName('Titre 1 : Description 1');
     await clickByName('Titre 2 : Description 2');
 
     // then
-    assert.dom(thematic).isChecked();
+    assert.dom(screen.getByLabelText('thematic1')).isChecked();
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessment-results_test.js
@@ -46,6 +46,31 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessment-results'
       });
     });
 
+    module('search filter', function () {
+      test('update the search filter', function (assert) {
+        // given
+        controller.triggerFiltering({ search: 'Something' });
+        // then
+        assert.deepEqual(controller.search, 'Something');
+      });
+
+      test('it removes the search filter', function (assert) {
+        // given
+        controller.triggerFiltering({ search: '' });
+        // then
+        assert.deepEqual(controller.search, '');
+      });
+
+      test('should keep other filters when is stage updated', function (assert) {
+        // when
+        controller.set('divisions', ['division1']);
+        // given
+        controller.triggerFiltering({ search: 'Something' });
+        // then
+        assert.deepEqual(controller.divisions, ['division1']);
+      });
+    });
+
     module('stage filter', function () {
       test('update the stage filter', function (assert) {
         // given

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profile-results_test.js
@@ -34,6 +34,31 @@ module('Unit | Controller | authenticated/campaigns/campaign/profile-results', f
     });
   });
 
+  module('search filter', function () {
+    test('update the search filter', function (assert) {
+      // given
+      controller.triggerFiltering({ search: 'Something' });
+      // then
+      assert.deepEqual(controller.search, 'Something');
+    });
+
+    test('it removes the search filter', function (assert) {
+      // given
+      controller.triggerFiltering({ search: '' });
+      // then
+      assert.deepEqual(controller.search, '');
+    });
+
+    test('should keep other filters when is stage updated', function (assert) {
+      // when
+      controller.set('divisions', ['division1']);
+      // given
+      controller.triggerFiltering({ search: 'Something' });
+      // then
+      assert.deepEqual(controller.divisions, ['division1']);
+    });
+  });
+
   module('resetFiltering', function () {
     test('reset params', function (assert) {
       //given

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
@@ -35,6 +35,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         groups: [],
         badges: [],
         stages: [],
+        search: null,
         campaignId: 3,
       };
       const expectedParticipations = [
@@ -54,6 +55,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
             groups: params.groups,
             badges: params.badges,
             stages: params.stages,
+            search: params.search,
           },
           campaignId: params.campaignId,
         })
@@ -61,9 +63,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
 
       const participations = route.fetchResultMinimalList(params);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(participations, expectedParticipations);
+      assert.strictEqual(participations, expectedParticipations);
     });
   });
 
@@ -72,17 +72,13 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
       test('it reset pageNumber', function (assert) {
         const controller = { pageNumber: 2 };
         route.resetController(controller, true);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
+        assert.strictEqual(controller.pageNumber, 1);
       });
 
       test('it reset pageSize', function (assert) {
         const controller = { pageSize: 10 };
         route.resetController(controller, true);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 25);
+        assert.strictEqual(controller.pageSize, 25);
       });
 
       test('it reset divisions', function (assert) {
@@ -108,23 +104,25 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         route.resetController(controller, true);
         assert.deepEqual(controller.stages, []);
       });
+
+      test('it reset search', function (assert) {
+        const controller = { search: 'Dalida' };
+        route.resetController(controller, true);
+        assert.deepEqual(controller.search, null);
+      });
     });
 
     module('when isExiting is false', function () {
       test('it does not reset pageNumber', function (assert) {
         const controller = { pageNumber: 2 };
         route.resetController(controller, false);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 2);
+        assert.strictEqual(controller.pageNumber, 2);
       });
 
       test('it does not reset pageSize', function (assert) {
         const controller = { pageSize: 10 };
         route.resetController(controller, false);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
+        assert.strictEqual(controller.pageSize, 10);
       });
 
       test('it does not reset divisions', function (assert) {
@@ -149,6 +147,12 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
         const controller = { stages: ['10'] };
         route.resetController(controller, false);
         assert.deepEqual(controller.stages, ['10']);
+      });
+
+      test('it does not reset search', function (assert) {
+        const controller = { search: 'Dalida' };
+        route.resetController(controller, false);
+        assert.deepEqual(controller.search, 'Dalida');
       });
     });
   });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
@@ -50,6 +50,7 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
             divisions: params.divisions,
             groups: params.groups,
             campaignId: params.campaignId,
+            search: params.search,
           },
         })
         .returns(expectedSummaries);


### PR DESCRIPTION
## :unicorn: Problème
Suite aux PRs https://github.com/1024pix/pix/pull/4467 et https://github.com/1024pix/pix/pull/4499 qui ajoutent une recherche sur l'onglet activité d'une campagne, et sur la recherche de propriétaires dans la page "toutes les campagnes' on souhaite propager cette recherche et l'ajouter dans l'onglet résultats d'une campagne (que ce soit collecte de profile ou d'évaluation).


## :robot: Solution
Pour cela nous allons continuer d'utiliser pg_trgm qui permet de calculer la distance entre deux chaînes de caractères.

## :rainbow: Remarques
Le composant search-input n'était pas raccord avec les autres filtres, nous en avons donc profité pour corriger cela.

## :100: Pour tester
1. Se connecter à PixOrga avec "[sco.admin@example.net](mailto:sco.admin@example.net)"
2. Aller sur la page http://localhost:4201/campagnes/toutes
3. Sélectionner une campagne de collecte de profiles
4. Aller dans l'onglet "Résultat"
5. Essayer de chercher par nom, prénom ou des deux à la fois dans la liste des participations
6. Retourner sur la page http://localhost:4201/campagnes/toutes
7. Sélectionner une campagne d'évaluation
8. Aller dans l'onglet "Résultat"
9. Essayer de chercher par nom, prénom ou des deux à la fois dans la liste des participations