### PR TITLE
[BUGFIX] L'API ne se déploie plus à cause d'une vérification de version Hapi en échec (PIX-5219)

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -88,7 +88,7 @@ function pushInContext(path, value) {
 function installHapiHook() {
   if (!settings.hapi.enableRequestMonitoring) return;
 
-  if (require('@hapi/hapi/package.json').version !== '20.2.1') {
+  if (require('@hapi/hapi/package.json').version !== '20.2.2') {
     throw new Error('Hapi version changed, please check if patch still works');
   }
 


### PR DESCRIPTION
## :unicorn: Problème
IL y a des hooks côté Hapi pour faire du monitoring et dans le code on check la version en dur de hapi. Or hapi a été mis à jour récemment.

## :robot: Solution
Solution de déblocage : modifier la chaîne de caractères de la version.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
