### PR TITLE
[TECH] Générer l'url de déconnexion de Pôle Emploi depuis l'API (PIX-4950)

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -110,10 +110,10 @@ module.exports = {
       oidcAuthenticationService,
     });
 
-    if (result.pixAccessToken && result.poleEmploiAuthenticationSessionContent) {
+    if (result.pixAccessToken && result.logoutUrlUUID) {
       return {
         access_token: result.pixAccessToken,
-        id_token: result.poleEmploiAuthenticationSessionContent.idToken,
+        logout_url_uuid: result.logoutUrlUUID,
       };
     } else {
       const message = "L'utilisateur n'a pas de compte Pix";

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -1,0 +1,30 @@
+const Joi = require('joi');
+const OidcController = require('./oidc-controller');
+
+exports.register = async (server) => {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/oidc/redirect-logout-url',
+      config: {
+        validate: {
+          query: Joi.object({
+            identity_provider: Joi.string().required().valid('POLE_EMPLOI'),
+            redirect_uri: Joi.string().uri().required(),
+            logout_url_uuid: Joi.string()
+              .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
+              .required(),
+          }),
+        },
+        handler: OidcController.getRedirectLogoutUrl,
+        notes: [
+          "Cette route reçoit un identity provider ainsi qu'une uri de redirection" +
+            " et renvoie une uri de déconnexion auprès de l'identity provider renseigné.",
+        ],
+        tags: ['api', 'oidc', 'authentication'],
+      },
+    },
+  ]);
+};
+
+exports.name = 'oidc-authentication-api';

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -10,7 +10,6 @@ exports.register = async (server) => {
         validate: {
           query: Joi.object({
             identity_provider: Joi.string().required().valid('POLE_EMPLOI'),
-            redirect_uri: Joi.string().uri().required(),
             logout_url_uuid: Joi.string()
               .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
               .required(),

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -1,0 +1,16 @@
+const authenticationServiceRegistry = require('../../../domain/services/authentication/authentication-service-registry');
+
+module.exports = {
+  async getRedirectLogoutUrl(request, h) {
+    const userId = request.auth.credentials.userId;
+    const {
+      identity_provider: identityProvider,
+      redirect_uri: redirectUri,
+      logout_url_uuid: logoutUrlUUID,
+    } = request.query;
+    const { authenticationService } = authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
+    const redirectLogoutUrl = await authenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID, redirectUri });
+
+    return h.response({ redirectLogoutUrl }).code(200);
+  },
+};

--- a/api/lib/application/pole-emploi/pole-emploi-controller.js
+++ b/api/lib/application/pole-emploi/pole-emploi-controller.js
@@ -17,11 +17,12 @@ module.exports = {
       AuthenticationMethod.identityProviders.POLE_EMPLOI
     );
     const accessToken = oidcAuthenticationService.createAccessToken(userId);
+    const logoutUrlUUID = await poleEmploiAuthenticationService.saveIdToken({ idToken, userId });
     await userRepository.updateLastLoggedAt({ userId });
 
     const response = {
       access_token: accessToken,
-      id_token: idToken,
+      logout_url_uuid: logoutUrlUUID,
     };
     return h.response(response).code(200);
   },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -216,6 +216,7 @@ module.exports = (function () {
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
       authUrl: process.env.POLE_EMPLOI_OIDC_AUTHENTICATION_URL,
+      logoutUrl: process.env.POLE_EMPLOI_OIDC_LOGOUT_URL,
       temporaryStorage: {
         expirationDelaySeconds:
           parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
@@ -339,6 +340,7 @@ module.exports = (function () {
     config.poleEmploi.sendingUrl = 'http://sendingUrl.fr';
     config.poleEmploi.userInfoUrl = 'http://userInfoUrl.fr';
     config.poleEmploi.authUrl = 'http://authurl.fr';
+    config.poleEmploi.logoutUrl = 'http://logout-url.fr';
     config.poleEmploi.temporaryStorage.redisUrl = null;
 
     config.temporaryStorage.redisUrl = null;

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -220,6 +220,7 @@ module.exports = (function () {
         expirationDelaySeconds:
           parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
         redisUrl: process.env.REDIS_URL,
+        idTokenLifespanMs: ms(process.env.POLE_EMPLOI_ID_TOKEN_LIFESPAN || '7d'),
       },
       poleEmploiSendingsLimit: _getNumber(process.env.POLE_EMPLOI_SENDING_LIMIT, 100),
       poleEmploiIdentityProvider: process.env.POLE_EMPLOI_IDENTITY_PROVIDER || 'POLE_EMPLOI',

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -217,6 +217,7 @@ module.exports = (function () {
       userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
       authUrl: process.env.POLE_EMPLOI_OIDC_AUTHENTICATION_URL,
       logoutUrl: process.env.POLE_EMPLOI_OIDC_LOGOUT_URL,
+      afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
       temporaryStorage: {
         expirationDelaySeconds:
           parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
@@ -341,6 +342,7 @@ module.exports = (function () {
     config.poleEmploi.userInfoUrl = 'http://userInfoUrl.fr';
     config.poleEmploi.authUrl = 'http://authurl.fr';
     config.poleEmploi.logoutUrl = 'http://logout-url.fr';
+    config.poleEmploi.afterLogoutUrl = 'http://after-logout.url';
     config.poleEmploi.temporaryStorage.redisUrl = null;
 
     config.temporaryStorage.redisUrl = null;

--- a/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
@@ -66,12 +66,12 @@ function getAuthUrl({ redirectUri }) {
   return { redirectTarget: redirectTarget.toString(), state, nonce };
 }
 
-async function getRedirectLogoutUrl({ userId, logoutUrlUUID, redirectUri }) {
+async function getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
   const redirectTarget = new URL(settings.poleEmploi.logoutUrl);
   const idToken = await logoutUrlTemporaryStorage.get(`${userId}:${logoutUrlUUID}`);
   const params = [
     { key: 'id_token_hint', value: idToken },
-    { key: 'redirect_uri', value: redirectUri },
+    { key: 'redirect_uri', value: settings.poleEmploi.afterLogoutUrl },
   ];
 
   params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));

--- a/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
@@ -1,14 +1,19 @@
-const settings = require('../../../config');
 const { v4: uuidv4 } = require('uuid');
-const httpAgent = require('../../../infrastructure/http/http-agent');
 const querystring = require('querystring');
-const { AuthenticationTokenRetrievalError } = require('../../errors');
-const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
 const jsonwebtoken = require('jsonwebtoken');
-
-const DomainTransaction = require('../../../infrastructure/DomainTransaction');
-const AuthenticationMethod = require('../../models/AuthenticationMethod');
 const moment = require('moment');
+const AuthenticationMethod = require('../../models/AuthenticationMethod');
+const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
+const settings = require('../../../config');
+const { AuthenticationTokenRetrievalError } = require('../../errors');
+const DomainTransaction = require('../../../infrastructure/DomainTransaction');
+const httpAgent = require('../../../infrastructure/http/http-agent');
+const logoutUrlTemporaryStorage = require('../../../infrastructure/temporary-storage').withPrefix('logout-url:');
+
+async function _extractClaimsFromIdToken(idToken) {
+  const { given_name, family_name, nonce, idIdentiteExterne } = await jsonwebtoken.decode(idToken);
+  return { given_name, family_name, nonce, idIdentiteExterne };
+}
 
 async function exchangeCodeForTokens({ code, redirectUri }) {
   const data = {
@@ -72,11 +77,6 @@ async function getUserInfo({ idToken }) {
   };
 }
 
-async function _extractClaimsFromIdToken(idToken) {
-  const { given_name, family_name, nonce, idIdentiteExterne } = await jsonwebtoken.decode(idToken);
-  return { given_name, family_name, nonce, idIdentiteExterne };
-}
-
 async function createUserAccount({
   user,
   sessionContent,
@@ -106,9 +106,23 @@ async function createUserAccount({
   };
 }
 
+async function saveIdToken({ idToken, userId }) {
+  const uuid = uuidv4();
+  const { idTokenLifespanMs } = settings.poleEmploi.temporaryStorage;
+
+  await logoutUrlTemporaryStorage.save({
+    key: `${userId}:${uuid}`,
+    value: idToken,
+    expirationDelaySeconds: idTokenLifespanMs / 1000,
+  });
+
+  return uuid;
+}
+
 module.exports = {
   exchangeCodeForTokens,
   getAuthUrl,
   getUserInfo,
   createUserAccount,
+  saveIdToken,
 };

--- a/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
@@ -66,6 +66,19 @@ function getAuthUrl({ redirectUri }) {
   return { redirectTarget: redirectTarget.toString(), state, nonce };
 }
 
+async function getRedirectLogoutUrl({ userId, logoutUrlUUID, redirectUri }) {
+  const redirectTarget = new URL(settings.poleEmploi.logoutUrl);
+  const idToken = await logoutUrlTemporaryStorage.get(`${userId}:${logoutUrlUUID}`);
+  const params = [
+    { key: 'id_token_hint', value: idToken },
+    { key: 'redirect_uri', value: redirectUri },
+  ];
+
+  params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
+
+  return redirectTarget.toString();
+}
+
 async function getUserInfo({ idToken }) {
   const { given_name, family_name, nonce, idIdentiteExterne } = await _extractClaimsFromIdToken(idToken);
 
@@ -122,6 +135,7 @@ async function saveIdToken({ idToken, userId }) {
 module.exports = {
   exchangeCodeForTokens,
   getAuthUrl,
+  getRedirectLogoutUrl,
   getUserInfo,
   createUserAccount,
   saveIdToken,

--- a/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
@@ -37,6 +37,7 @@ module.exports = async function authenticatePoleEmploiUser({
   });
 
   let pixAccessToken;
+  let userId = authenticatedUserId;
 
   if (authenticatedUserId) {
     pixAccessToken = await _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
@@ -58,6 +59,7 @@ module.exports = async function authenticatePoleEmploiUser({
       const authenticationKey = await authenticationSessionService.save(poleEmploiAuthenticationSessionContent);
       return { authenticationKey };
     } else {
+      userId = user.id;
       pixAccessToken = await _getPixAccessTokenFromPoleEmploiUser({
         user,
         authenticationComplement,
@@ -69,9 +71,14 @@ module.exports = async function authenticatePoleEmploiUser({
     }
   }
 
+  const logoutUrlUUID = await poleEmploiAuthenticationService.saveIdToken({
+    idToken: poleEmploiAuthenticationSessionContent.idToken,
+    userId,
+  });
+
   return {
     pixAccessToken,
-    poleEmploiAuthenticationSessionContent,
+    logoutUrlUUID,
   };
 };
 

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -5,6 +5,7 @@ module.exports = [
   require('./application/assessment-results'),
   require('./application/assessments'),
   require('./application/authentication'),
+  require('./application/authentication/oidc'),
   require('./application/badges'),
   require('./application/cache'),
   require('./application/campaign-participations'),

--- a/api/sample.env
+++ b/api/sample.env
@@ -461,6 +461,13 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_OIDC_AUTHENTICATION_URL=
 
+# Logout URL
+# Refer to https://pole-emploi.io/data/api/pole-emploi-connect
+#
+# presence: required for POLE EMPLOI logout, optional otherwise
+# type: URL
+# sample: POLE_EMPLOI_OIDC_LOGOUT_URL=
+
 # Temporary storage expiration delay
 #
 # presence: optional

--- a/api/sample.env
+++ b/api/sample.env
@@ -468,6 +468,13 @@ AUTH_SECRET=Change me!
 # default: 1140
 # sample: POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
 
+# Temporary storage idToken expiration delay in milliseconds
+#
+# presence: optional
+# type: Integer
+# default: 7d
+# sample: POLE_EMPLOI_ID_TOKEN_LIFESPAN=
+
 # Test result URL
 # Refer to https://pole-emploi.io/data/api/pole-emploi-connect
 #

--- a/api/sample.env
+++ b/api/sample.env
@@ -468,6 +468,13 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_OIDC_LOGOUT_URL=
 
+# After logout URL
+# Refer to https://pole-emploi.io/data/api/pole-emploi-connect
+#
+# presence: required for POLE EMPLOI logout, optional otherwise
+# type: URL
+# sample: POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL=
+
 # Temporary storage expiration delay
 #
 # presence: optional

--- a/api/tests/acceptance/application/pole-emploi/token-route-post_test.js
+++ b/api/tests/acceptance/application/pole-emploi/token-route-post_test.js
@@ -16,6 +16,8 @@ const AuthenticationMethod = require('../../../../lib/domain/models/Authenticati
 const AuthenticationSessionContent = require('../../../../lib/domain/models/AuthenticationSessionContent');
 const authenticationSessionService = require('../../../../lib/domain/services/authentication/authentication-session-service');
 
+const uuidPattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+
 describe('Acceptance | Route | pole emploi token', function () {
   describe('POST /api/pole-emploi/token', function () {
     let server;
@@ -315,7 +317,7 @@ describe('Acceptance | Route | pole emploi token', function () {
           );
         });
 
-        it('should return an 200 with access_token and id_token when authentication is ok', async function () {
+        it('should return an 200 with access_token and logout_url_uuid when authentication is ok', async function () {
           // given
           const firstName = 'John';
           const lastName = 'John';
@@ -369,7 +371,7 @@ describe('Acceptance | Route | pole emploi token', function () {
           expect(response.statusCode).to.equal(200);
           expect(getAccessTokenRequest.isDone()).to.be.true;
           expect(response.result['access_token']).to.exist;
-          expect(response.result['id_token']).to.equal(idToken);
+          expect(response.result['logout_url_uuid']).to.match(uuidPattern);
         });
       });
     });
@@ -478,7 +480,7 @@ describe('Acceptance | Route | pole emploi token', function () {
           expect(response.statusCode).to.equal(200);
           expect(getAccessTokenRequest.isDone()).to.be.true;
           expect(response.result['access_token']).to.exist;
-          expect(response.result['id_token']).to.equal(idToken);
+          expect(response.result['logout_url_uuid']).to.match(uuidPattern);
         });
       });
 
@@ -631,7 +633,7 @@ describe('Acceptance | Route | pole emploi token', function () {
         expect(response.statusCode).to.equal(200);
         expect(getAccessTokenRequest.isDone()).to.be.true;
         expect(response.result['access_token']).to.exist;
-        expect(response.result['id_token']).to.equal(idToken);
+        expect(response.result['logout_url_uuid']).to.match(uuidPattern);
       });
     });
 

--- a/api/tests/integration/application/authentication/oidc/index_test.js
+++ b/api/tests/integration/application/authentication/oidc/index_test.js
@@ -15,9 +15,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
       // given & when
       const { statusCode } = await server.inject({
         method: 'GET',
-        url:
-          '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720&redirect_uri=' +
-          encodeURIComponent('https://pix.fr'),
+        url: '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
         headers: { authorization: generateValidRequestAuthorizationHeader() },
       });
 
@@ -45,9 +43,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
           // given & when
           const { statusCode } = await server.inject({
             method: 'GET',
-            url:
-              '/api/oidc/redirect-logout-url?logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720&redirect_uri=' +
-              encodeURIComponent('https://pix.fr'),
+            url: '/api/oidc/redirect-logout-url?logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
             headers: { authorization: generateValidRequestAuthorizationHeader() },
           });
 
@@ -61,23 +57,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
           // given & when
           const { statusCode } = await server.inject({
             method: 'GET',
-            url:
-              '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&redirect_uri=' +
-              encodeURIComponent('https://pix.fr'),
-            headers: { authorization: generateValidRequestAuthorizationHeader() },
-          });
-
-          // then
-          expect(statusCode).to.equal(400);
-        });
-      });
-
-      context('redirect_uri', function () {
-        it('should return a response with HTTP status code 400', async function () {
-          // given & when
-          const { statusCode } = await server.inject({
-            method: 'GET',
-            url: '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
+            url: '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI',
             headers: { authorization: generateValidRequestAuthorizationHeader() },
           });
 
@@ -92,9 +72,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
         // given & when
         const { statusCode } = await server.inject({
           method: 'GET',
-          url:
-            '/api/oidc/redirect-logout-url?identity_provider=MY_IDP&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720&redirect_uri=' +
-            encodeURIComponent('https://pix.fr'),
+          url: '/api/oidc/redirect-logout-url?identity_provider=MY_IDP&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
           headers: { authorization: generateValidRequestAuthorizationHeader() },
         });
 

--- a/api/tests/integration/application/authentication/oidc/index_test.js
+++ b/api/tests/integration/application/authentication/oidc/index_test.js
@@ -1,0 +1,106 @@
+const { expect, sinon, generateValidRequestAuthorizationHeader } = require('../../../../test-helper');
+const createServer = require('../../../../../server');
+const oidcController = require('../../../../../lib/application/authentication/oidc/oidc-controller');
+
+describe('Integration | Application | Route | OidcRouter', function () {
+  let server;
+
+  beforeEach(async function () {
+    sinon.stub(oidcController, 'getRedirectLogoutUrl').callsFake((request, h) => h.response('ok').code(200));
+    server = await createServer();
+  });
+
+  describe('GET /api/oidc/redirect-logout-url', function () {
+    it('should return a response with HTTP status code 200', async function () {
+      // given & when
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url:
+          '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720&redirect_uri=' +
+          encodeURIComponent('https://pix.fr'),
+        headers: { authorization: generateValidRequestAuthorizationHeader() },
+      });
+
+      // then
+      expect(statusCode).to.equal(200);
+    });
+
+    context('when missing required parameters', function () {
+      context('all', function () {
+        it('should return a response with HTTP status code 400', async function () {
+          // given & when
+          const { statusCode } = await server.inject({
+            method: 'GET',
+            url: '/api/oidc/redirect-logout-url',
+            headers: { authorization: generateValidRequestAuthorizationHeader() },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('identity_provider', function () {
+        it('should return a response with HTTP status code 400', async function () {
+          // given & when
+          const { statusCode } = await server.inject({
+            method: 'GET',
+            url:
+              '/api/oidc/redirect-logout-url?logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720&redirect_uri=' +
+              encodeURIComponent('https://pix.fr'),
+            headers: { authorization: generateValidRequestAuthorizationHeader() },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('logout_url_uuid', function () {
+        it('should return a response with HTTP status code 400', async function () {
+          // given & when
+          const { statusCode } = await server.inject({
+            method: 'GET',
+            url:
+              '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&redirect_uri=' +
+              encodeURIComponent('https://pix.fr'),
+            headers: { authorization: generateValidRequestAuthorizationHeader() },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+
+      context('redirect_uri', function () {
+        it('should return a response with HTTP status code 400', async function () {
+          // given & when
+          const { statusCode } = await server.inject({
+            method: 'GET',
+            url: '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
+            headers: { authorization: generateValidRequestAuthorizationHeader() },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+    });
+
+    context('when identity_provider parameter is not POLE_EMPLOI', function () {
+      it('should return a response with HTTP status code 400', async function () {
+        // given & when
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url:
+            '/api/oidc/redirect-logout-url?identity_provider=MY_IDP&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720&redirect_uri=' +
+            encodeURIComponent('https://pix.fr'),
+          headers: { authorization: generateValidRequestAuthorizationHeader() },
+        });
+
+        // then
+        expect(statusCode).to.equal(400);
+      });
+    });
+  });
+});

--- a/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
@@ -8,7 +8,7 @@ describe('Integration | Domain | Services | pole-emploi-authentication-service',
   describe('#saveIdToken', function () {
     it('should return an uuid', async function () {
       // given
-      const v4RexExp = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+      const uuidPattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
       const idToken =
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
       const userId = '123';
@@ -18,9 +18,34 @@ describe('Integration | Domain | Services | pole-emploi-authentication-service',
       const result = await logoutUrlTemporaryStorage.get(`123:${uuid}`);
 
       // then
-      expect(uuid.match(v4RexExp)).to.be.ok;
+      expect(uuid.match(uuidPattern)).to.be.ok;
       expect(result).to.equal(
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+      );
+    });
+  });
+
+  describe('#getRedirectLogoutUrl', function () {
+    it('should return a redirect logout url', async function () {
+      // given
+      const redirectUri = 'https://example.org/please-redirect-to-pix';
+      const idToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const userId = '1';
+      const logoutUrlUUID = '1f3dbb71-f399-4c1c-85ae-0a863c78aeea';
+      const key = `${userId}:${logoutUrlUUID}`;
+      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
+
+      // when
+      const redirectTarget = await poleEmploiAuthenticationService.getRedirectLogoutUrl({
+        userId,
+        logoutUrlUUID,
+        redirectUri,
+      });
+
+      // then
+      expect(redirectTarget).to.equal(
+        'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=https%3A%2F%2Fexample.org%2Fplease-redirect-to-pix'
       );
     });
   });

--- a/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
@@ -1,0 +1,27 @@
+const { expect } = require('../../../../test-helper');
+const poleEmploiAuthenticationService = require('../../../../../lib/domain/services/authentication/pole-emploi-authentication-service');
+const logoutUrlTemporaryStorage = require('../../../../../lib/infrastructure/temporary-storage').withPrefix(
+  'logout-url:'
+);
+
+describe('Integration | Domain | Services | pole-emploi-authentication-service', function () {
+  describe('#saveIdToken', function () {
+    it('should return an uuid', async function () {
+      // given
+      const v4RexExp = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+      const idToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const userId = '123';
+
+      // when
+      const uuid = await poleEmploiAuthenticationService.saveIdToken({ idToken, userId });
+      const result = await logoutUrlTemporaryStorage.get(`123:${uuid}`);
+
+      // then
+      expect(uuid.match(v4RexExp)).to.be.ok;
+      expect(result).to.equal(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+      );
+    });
+  });
+});

--- a/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
@@ -28,7 +28,6 @@ describe('Integration | Domain | Services | pole-emploi-authentication-service',
   describe('#getRedirectLogoutUrl', function () {
     it('should return a redirect logout url', async function () {
       // given
-      const redirectUri = 'https://example.org/please-redirect-to-pix';
       const idToken =
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
       const userId = '1';
@@ -40,12 +39,11 @@ describe('Integration | Domain | Services | pole-emploi-authentication-service',
       const redirectTarget = await poleEmploiAuthenticationService.getRedirectLogoutUrl({
         userId,
         logoutUrlUUID,
-        redirectUri,
       });
 
       // then
       expect(redirectTarget).to.equal(
-        'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=https%3A%2F%2Fexample.org%2Fplease-redirect-to-pix'
+        'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=http%3A%2F%2Fafter-logout.url'
       );
     });
   });

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,7 +1,7 @@
 const { sinon, expect, catchErr, hFake } = require('../../../test-helper');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases');
-const authenticationRegistry = require('../../../../lib/domain/services/authentication/authentication-service-registry');
+const authenticationServiceRegistry = require('../../../../lib/domain/services/authentication/authentication-service-registry');
 
 const { UnauthorizedError } = require('../../../../lib/application/http-errors');
 
@@ -77,7 +77,7 @@ describe('Unit | Application | Controller | Authentication', function () {
       sinon.stub(usecases, 'authenticateCnavUser').resolves({ pixAccessToken, isAuthenticationComplete: true });
       const oidcAuthenticationService = {};
       sinon
-        .stub(authenticationRegistry, 'lookupAuthenticationService')
+        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
         .withArgs('CNAV')
         .returns({ oidcAuthenticationService });
 
@@ -213,7 +213,7 @@ describe('Unit | Application | Controller | Authentication', function () {
       // given
       const oidcAuthenticationService = {};
       sinon
-        .stub(authenticationRegistry, 'lookupAuthenticationService')
+        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
         .withArgs('POLE_EMPLOI')
         .returns({ oidcAuthenticationService });
 

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,7 +1,6 @@
 const { sinon, expect, catchErr, hFake } = require('../../../test-helper');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases');
-const AuthenticationSessionContent = require('../../../../lib/domain/models/AuthenticationSessionContent');
 const authenticationRegistry = require('../../../../lib/domain/services/authentication/authentication-service-registry');
 
 const { UnauthorizedError } = require('../../../../lib/application/http-errors');
@@ -194,12 +193,6 @@ describe('Unit | Application | Controller | Authentication', function () {
     const state_received = 'state';
 
     const pixAccessToken = 'pixAccessToken';
-    const poleEmploiAuthenticationSessionContent = new AuthenticationSessionContent({
-      accessToken: 'poleEmploiAccessToken',
-      expiresIn: 60,
-      idToken: 'idToken',
-      refreshToken: 'refreshToken',
-    });
 
     let request;
 
@@ -224,7 +217,10 @@ describe('Unit | Application | Controller | Authentication', function () {
         .withArgs('POLE_EMPLOI')
         .returns({ oidcAuthenticationService });
 
-      usecases.authenticatePoleEmploiUser.resolves({ pixAccessToken, poleEmploiAuthenticationSessionContent });
+      usecases.authenticatePoleEmploiUser.resolves({
+        pixAccessToken,
+        logoutUrlUUID: '0208f50b-f612-46aa-89a0-7cdb5fb0d312',
+      });
       const expectedParameters = {
         authenticatedUserId: undefined,
         code,
@@ -243,10 +239,13 @@ describe('Unit | Application | Controller | Authentication', function () {
 
     it('should return PIX access token and Pole emploi ID token', async function () {
       // given
-      usecases.authenticatePoleEmploiUser.resolves({ pixAccessToken, poleEmploiAuthenticationSessionContent });
+      usecases.authenticatePoleEmploiUser.resolves({
+        pixAccessToken,
+        logoutUrlUUID: '0208f50b-f612-46aa-89a0-7cdb5fb0d312',
+      });
       const expectedResult = {
         access_token: pixAccessToken,
-        id_token: poleEmploiAuthenticationSessionContent.idToken,
+        logout_url_uuid: '0208f50b-f612-46aa-89a0-7cdb5fb0d312',
       };
 
       // when

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -1,0 +1,48 @@
+const { sinon, expect, hFake } = require('../../../../test-helper');
+const authenticationServiceRegistry = require('../../../../../lib/domain/services/authentication/authentication-service-registry');
+const oidcController = require('../../../../../lib/application/authentication/oidc/oidc-controller');
+
+describe('Unit | Application | Controller | Authentication | OIDC', function () {
+  describe('#getRedirectLogoutUrl', function () {
+    context('when identity provider is POLE_EMPLOI', function () {
+      it('should call pole emploi authentication service to generate the redirect logout url', async function () {
+        // given
+        const request = {
+          auth: { credentials: { userId: '123' } },
+          query: {
+            identity_provider: 'POLE_EMPLOI',
+            redirect_uri: 'http://example.net/',
+            logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
+          },
+        };
+        const authenticationService = {
+          getRedirectLogoutUrl: sinon.stub(),
+        };
+        authenticationService.getRedirectLogoutUrl
+          .withArgs({
+            userId: '123',
+            logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
+            redirectUri: 'http://example.net/',
+          })
+          .resolves(
+            'http://logoutUrl.fr/id_token_hint=ID_TOKEN_HINT&redirect_uri=' + encodeURIComponent('http://example.net/')
+          );
+        sinon
+          .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+          .withArgs('POLE_EMPLOI')
+          .returns({ authenticationService });
+
+        // when
+        await oidcController.getRedirectLogoutUrl(request, hFake);
+
+        // then
+        expect(authenticationServiceRegistry.lookupAuthenticationService).to.have.been.calledWith('POLE_EMPLOI');
+        expect(authenticationService.getRedirectLogoutUrl).to.have.been.calledWith({
+          userId: '123',
+          logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
+          redirectUri: 'http://example.net/',
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -80,7 +80,7 @@ describe('Unit | Controller | pole-emploi-controller', function () {
       expect(userRepository.updateLastLoggedAt).to.have.been.calledWith({ userId: 7 });
     });
 
-    it('should return access token and id token', async function () {
+    it('should return access token and logout url UUID', async function () {
       // given
       const request = { query: { 'authentication-key': 'abcde' } };
       const userId = 7;
@@ -101,13 +101,17 @@ describe('Unit | Controller | pole-emploi-controller', function () {
           },
         });
       createAccessTokenStub.withArgs(userId).returns(accessToken);
+      sinon
+        .stub(poleEmploiAuthenticationService, 'saveIdToken')
+        .withArgs({ idToken, userId })
+        .resolves('842213eb-d19b-45a1-9842-787276f34f6c');
 
       // when
       const result = await poleEmploiController.createUser(request, hFake);
 
       // then
       expect(result.source.access_token).to.equal(accessToken);
-      expect(result.source.id_token).to.equal(idToken);
+      expect(result.source.logout_url_uuid).to.equal('842213eb-d19b-45a1-9842-787276f34f6c');
     });
   });
 

--- a/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
@@ -25,7 +25,12 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     poleEmploiAuthenticationService = {
       exchangeCodeForTokens: sinon.stub(),
       getUserInfo: sinon.stub(),
+      createAccessToken: sinon.stub(),
+      saveIdToken: sinon.stub(),
     };
+    poleEmploiAuthenticationService.saveIdToken
+      .withArgs({ idToken: 'idToken', userId: 1 })
+      .resolves('ce945751-b7f5-4786-8979-63e25a4f182b');
 
     authenticationMethodRepository = {
       create: sinon.stub().resolves(),
@@ -136,9 +141,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       expect(poleEmploiAuthenticationService.getUserInfo).to.have.been.calledWith({ idToken: 'idToken' });
     });
 
-    it('should return accessToken and idToken', async function () {
+    it('should return accessToken and logoutUrlUUID', async function () {
       // given
-      const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
+      _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
       const authenticatedUserId = 1;
       const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
@@ -163,7 +168,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       // then
       const expectedResult = {
         pixAccessToken: 'access-token',
-        poleEmploiAuthenticationSessionContent,
+        logoutUrlUUID: 'ce945751-b7f5-4786-8979-63e25a4f182b',
       };
       expect(result).to.deep.equal(expectedResult);
     });

--- a/mon-pix/app/authenticators/pole-emploi.js
+++ b/mon-pix/app/authenticators/pole-emploi.js
@@ -120,11 +120,7 @@ export default class PoleEmploiAuthenticator extends BaseAuthenticator {
       url = this._generateRedirectLogoutUrl(id_token);
     } else {
       const response = await fetch(
-        `${
-          ENV.APP.API_HOST
-        }/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&redirect_uri=${encodeURIComponent(
-          afterLogoutUri
-        )}&logout_url_uuid=${logout_url_uuid}`,
+        `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=${logout_url_uuid}`,
         {
           headers: {
             Authorization: `Bearer ${access_token}`,

--- a/mon-pix/app/authenticators/pole-emploi.js
+++ b/mon-pix/app/authenticators/pole-emploi.js
@@ -71,7 +71,7 @@ export default class PoleEmploiAuthenticator extends BaseAuthenticator {
 
     return {
       access_token: data.access_token,
-      id_token: data.id_token,
+      logout_url_uuid: data.logout_url_uuid,
       source: decodedAccessToken.source,
       user_id: decodedAccessToken.user_id,
       identity_provider: decodedAccessToken.identity_provider,

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -43,7 +43,6 @@ module.exports = function (environment) {
     },
 
     poleEmploi: {
-      afterLogoutUri: process.env.POLE_EMPLOI_AFTER_LOGOUT_URI,
       endSessionEndpoint: '/compte/deconnexion',
       expiresIn: 60000, // Short expire time (60s) for testing purpose,
       host: process.env.POLE_EMPLOI_AUTHENTICATION_BASE_URL,
@@ -178,7 +177,6 @@ module.exports = function (environment) {
     }
 
     ENV.poleEmploi.host = 'https://authentification-candidat-r.pe-qvr.fr';
-    ENV.poleEmploi.afterLogoutUri = 'http://localhost.fr:4200/';
   }
 
   if (environment === 'test') {
@@ -202,7 +200,6 @@ module.exports = function (environment) {
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
 
     ENV.poleEmploi.host = 'https://authentification-candidat-r.pe-qvr.fr';
-    ENV.poleEmploi.afterLogoutUri = 'http://localhost.fr:4200/';
   }
 
   if (environment === 'production') {

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -26,7 +26,6 @@ import putSaveTutorial from './routes/put-save-tutorial';
 import deleteUserTutorial from './routes/delete-user-tutorial';
 import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import postPoleEmploiUser from './routes/post-pole-emploi-user';
-import postPoleEmploiToken from './routes/post-pole-emploi-token';
 import postSharedCertifications from './routes/post-shared-certifications';
 import loadUserTutorialsRoutes from './routes/get-user-tutorials';
 import loadSavedTutorialsRoutes from './routes/get-saved-tutorials';
@@ -79,7 +78,6 @@ export default function () {
   this.put('/users/tutorials/:tutorialId/evaluate', putTutorialEvaluation);
 
   this.post('/pole-emploi/users', postPoleEmploiUser);
-  this.post('/pole-emploi/token', postPoleEmploiToken);
 
   this.get('/feature-toggles', getFeatureToggles);
 
@@ -95,6 +93,13 @@ export default function () {
       redirectTarget: `https://pole-emploi/connexion/oauth2/authorize?redirect_uri=${redirectUri}`,
       state: 'a8a3344f-6d7c-469d-9f84-bdd791e04fdf',
       nonce: '555c86fe-ed0a-4a80-80f3-45b1f7c2df8c',
+    };
+  });
+
+  this.get('/oidc/redirect-logout-url', () => {
+    return {
+      redirectLogoutUrl:
+        'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion',
     };
   });
 }

--- a/mon-pix/mirage/routes/auth/index.js
+++ b/mon-pix/mirage/routes/auth/index.js
@@ -44,7 +44,7 @@ export default function index(config) {
         'aaa.' +
         btoa(`{"user_id":${createdUser.id},"source":"pole_emploi_connect","iat":1545321469,"exp":4702193958}`) +
         '.bbb',
-      id_token: 'id_token',
+      logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
       user_id: createdUser.id,
     };
   });

--- a/mon-pix/mirage/routes/auth/index.js
+++ b/mon-pix/mirage/routes/auth/index.js
@@ -42,7 +42,9 @@ export default function index(config) {
     return {
       access_token:
         'aaa.' +
-        btoa(`{"user_id":${createdUser.id},"source":"pole_emploi_connect","iat":1545321469,"exp":4702193958}`) +
+        btoa(
+          `{"user_id":${createdUser.id},"source":"pole_emploi_connect","iat":1545321469,"exp":4702193958,"identity_provider":"POLE_EMPLOI"}`
+        ) +
         '.bbb',
       logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
       user_id: createdUser.id,

--- a/mon-pix/tests/acceptance/pole-emploi/pole-emploi-authentication-flow_test.js
+++ b/mon-pix/tests/acceptance/pole-emploi/pole-emploi-authentication-flow_test.js
@@ -1,0 +1,43 @@
+/* eslint ember/no-classic-classes: 0 */
+
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click, visit } from '@ember/test-helpers';
+import Service from '@ember/service';
+import sinon from 'sinon';
+import setupIntl from '../../helpers/setup-intl';
+import { clickByLabel } from '../../helpers/click-by-label';
+
+describe('Acceptance | Pôle Emploi | authentication flow', function () {
+  setupApplicationTest();
+  setupMirage();
+  setupIntl();
+
+  context('when user is logged in', function () {
+    context('on log out', function () {
+      it('should redirect to logout url', async function () {
+        // given
+        await visit('/connexion-pole-emploi?code=code&state=state');
+        const replaceLocationStub = sinon.stub().resolves();
+        this.owner.register(
+          'service:location',
+          Service.extend({
+            replace: replaceLocationStub,
+          })
+        );
+
+        // when
+        await click('#pix-cgu');
+        await clickByLabel(this.intl.t('pages.terms-of-service-pole-emploi.form.button'));
+        await clickByLabel('Paul');
+        await clickByLabel(this.intl.t('navigation.user.sign-out'));
+
+        // then
+        sinon.assert.calledWith(
+          replaceLocationStub,
+          'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion'
+        );
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/authenticators/pole-emploi_test.js
+++ b/mon-pix/tests/unit/authenticators/pole-emploi_test.js
@@ -3,6 +3,7 @@ import { setupTest } from 'ember-mocha';
 import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import Service from '@ember/service';
+import * as fetch from 'fetch';
 
 import ENV from '../../../config/environment';
 
@@ -12,37 +13,81 @@ describe('Unit | Authenticator | pole-emploi', function () {
   setupTest();
 
   describe('#invalidate', function () {
-    it('when invalidate session on logout should redirect to right url', async function () {
-      // given
-      const replaceLocationStub = sinon.stub().resolves();
-      this.owner.register(
-        'service:location',
-        // eslint-disable-next-line ember/no-classic-classes
-        Service.extend({
-          replace: replaceLocationStub,
-        })
-      );
+    context('when user still has an idToken in their session', function () {
+      it('should redirect to the correct url', async function () {
+        // given
+        const replaceLocationStub = sinon.stub().resolves();
+        this.owner.register(
+          'service:location',
+          // eslint-disable-next-line ember/no-classic-classes
+          Service.extend({
+            replace: replaceLocationStub,
+          })
+        );
 
-      const sessionStub = Service.create({
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            source: AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI,
-            id_token: 'ajwtToken',
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+          data: {
+            authenticated: {
+              source: AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI,
+              id_token: 'ID_TOKEN',
+            },
           },
-        },
+        });
+
+        const authenticator = this.owner.lookup('authenticator:pole-emploi');
+        authenticator.session = sessionStub;
+
+        // when
+        await authenticator.invalidate();
+
+        // then
+        expect(replaceLocationStub.getCall(0).args[0]).to.equal(
+          'https://authentification-candidat-r.pe-qvr.fr/compte/deconnexion?redirect_uri=http://localhost.fr:4200/&id_token_hint=ID_TOKEN'
+        );
       });
+    });
 
-      const authenticator = this.owner.lookup('authenticator:pole-emploi');
-      authenticator.session = sessionStub;
+    context('when user has logoutUrlUUID in their session', function () {
+      it('should redirect to the correct url', async function () {
+        // given
+        const replaceLocationStub = sinon.stub().resolves();
+        this.owner.register(
+          'service:location',
+          // eslint-disable-next-line ember/no-classic-classes
+          Service.extend({
+            replace: replaceLocationStub,
+          })
+        );
+        const sessionStub = Service.create({
+          isAuthenticated: true,
+          data: {
+            authenticated: {
+              source: AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI,
+              logout_url_uuid: 'da689777-0158-4bfc-ae21-ee6fcd41e62c',
+            },
+          },
+        });
+        const authenticator = this.owner.lookup('authenticator:pole-emploi');
+        authenticator.session = sessionStub;
+        sinon.stub(fetch, 'default').resolves({
+          json: () =>
+            new Promise((resolve) =>
+              resolve({
+                redirectLogoutUrl:
+                  'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion',
+              })
+            ),
+        });
 
-      // when
-      await authenticator.invalidate();
+        // when
+        await authenticator.invalidate();
 
-      // then
-      expect(replaceLocationStub.getCall(0).args[0]).to.equal(
-        'https://authentification-candidat-r.pe-qvr.fr/compte/deconnexion?redirect_uri=http://localhost.fr:4200/&id_token_hint=ajwtToken'
-      );
+        // then
+        expect(replaceLocationStub.getCall(0).args[0]).to.equal(
+          'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion'
+        );
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/authenticators/pole-emploi_test.js
+++ b/mon-pix/tests/unit/authenticators/pole-emploi_test.js
@@ -43,7 +43,7 @@ describe('Unit | Authenticator | pole-emploi', function () {
 
         // then
         expect(replaceLocationStub.getCall(0).args[0]).to.equal(
-          'https://authentification-candidat-r.pe-qvr.fr/compte/deconnexion?redirect_uri=http://localhost.fr:4200/&id_token_hint=ID_TOKEN'
+          'https://authentification-candidat-r.pe-qvr.fr/compte/deconnexion?id_token_hint=ID_TOKEN'
         );
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on est connecté sur Pix avec un compte Pôle Emploi et que l'on se déconnecte par la suite, cette déconnexion va entrainer une redirection vers le site de Pôle Emploi pour également supprimer la session en cours sur Pôle Emploi.

Actuellement la gestion de génération de l'url de déconnexion à Pôle Emploi se fait au niveau de l'application front. Pour que cette génération puisse se faire, l'`id_token` doit être stocké au niveau du client (navigateur, localStorage).

## :robot: Solution

1. Enregistrer l'idToken sur redis et générer un uuid
2. Remplacer l'idToken au niveau du front par l'uuid généré
3. Générer l'url de déconnexion au niveau du back (une nouvelle route)
4. Faire l'appel à cette nouvelle route sur le front

## :rainbow: Remarques

- ⚠️ Pôle Emploi ne gère pas la redirection vers Pix une fois la session de l'utilisateur sur Pôle Emploi détruite.
- ⚠️ Le code précédent doit encore exister pour les personnes qui seraient connectées avant cette modification.
- ⚠️ Ajouter la variable d'environnement `POLE_EMPLOI_OIDC_LOGOUT_URL=https://authentification-candidat-r.pe-qvr.fr/compte/deconnexion` en Prod
- ⚠️ Ajouter la variable d'environnement `POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL=https://app.pix.fr/` en Prod
- ⚠️ Ajouter la variable d'environnement `POLE_EMPLOI_ID_TOKEN_LIFESPAN`

## :100: Pour tester

Ajouter ces variables d'environnement dans votre `.env` au niveau de l'api

```
POLE_EMPLOI_OIDC_LOGOUT_URL=https://authentification-candidat-r.pe-qvr.fr/compte/deconnexion
POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL=http://localhost.fr:4200/

# 7 jours par défaut
POLE_EMPLOI_ID_TOKEN_LIFESPAN=
```

1. Se connecter sur [Pix App](https://app-pr4575.review.pix.fr/) via le bouton `Se connecter avec pôle emploi`.
6. Utiliser l'identifiant `cecile62` avec son mot de passe.
7. Accepter les CGU si ce n'est déjà fait.
8. Sur le dashboard, dans le menu de navigation, cliquez sur le prénom de l'utilisateur connecté (CECILE)
9. Dans le menu déroulé, cliquez sur `Se déconnecter`
10. Constater que l'utilisateur est déconnecté et arrive sur le site de Pôle Emploi
