### PR TITLE
[FEATURE] Affichage du nombre de participations dans l'onglet élèves (PIX-5169).

### DIFF
--- a/api/lib/domain/models/UserWithOrganizationLearner.js
+++ b/api/lib/domain/models/UserWithOrganizationLearner.js
@@ -12,6 +12,7 @@ class UserWithOrganizationLearner {
     studentNumber,
     division,
     group,
+    participationCount,
   } = {}) {
     this.id = id;
     this.lastName = lastName;
@@ -25,6 +26,7 @@ class UserWithOrganizationLearner {
     this.studentNumber = studentNumber;
     this.division = division;
     this.group = group;
+    this.participationCount = participationCount;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer.js
@@ -14,6 +14,7 @@ module.exports = {
         'studentNumber',
         'division',
         'group',
+        'participationCount',
       ],
       meta,
     }).serialize(students);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -957,6 +957,7 @@ describe('Acceptance | Application | organization-controller', function () {
                 'student-number': organizationLearner.studentNumber,
                 division: organizationLearner.division,
                 group: organizationLearner.group,
+                'participation-count': 0,
               },
               id: organizationLearner.id.toString(),
               type: 'students',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer_test.js
@@ -18,6 +18,7 @@ describe('Unit | Serializer | JSONAPI | UserWithOrganizationLearner-serializer',
         studentNumber: '123456789',
         division: '3A',
         group: 'AB1',
+        participationCount: 2,
       });
 
       const expectedSerializedUserWithOrganizationLearner = {
@@ -35,6 +36,7 @@ describe('Unit | Serializer | JSONAPI | UserWithOrganizationLearner-serializer',
             'student-number': userWithOrganizationLearner.studentNumber,
             division: userWithOrganizationLearner.division,
             group: userWithOrganizationLearner.group,
+            'participation-count': 2,
           },
         },
       };

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -6,6 +6,7 @@
       <col />
       <col />
       <col />
+      <col class="table__column--right" />
       <col class="hide-on-mobile" />
     </colgroup>
     <thead>
@@ -15,6 +16,7 @@
         <Table::Header>{{t "pages.students-sco.table.column.date-of-birth"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.division"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
+        <Table::Header @align="right">{{t "pages.students-sco.table.column.participation-count"}}</Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
@@ -51,6 +53,7 @@
           @ariaLabel={{t "pages.students-sco.table.filter.login-method.aria-label"}}
           @emptyOptionLabel={{t "pages.students-sco.table.filter.login-method.empty-option"}}
         />
+        <Table::Header class="table__column--right" />
         <Table::Header />
       </tr>
     </thead>
@@ -68,6 +71,7 @@
                 <p>{{t authenticationMethod}}</p>
               {{/each}}
             </td>
+            <td class="table__column--right">{{student.participationCount}}</td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if student.isStudentAssociated}}
                 <Dropdown::IconTrigger

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -17,6 +17,7 @@ export default class Student extends Model {
   @attr('string') studentNumber;
   @attr('string') division;
   @attr('string') group;
+  @attr('number') participationCount;
   @attr('boolean') isAuthenticatedFromGar;
   @belongsTo('organization') organization;
 

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -59,9 +59,17 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
     assert.dom('[aria-label="Élève"]').exists({ count: 2 });
   });
 
-  test('it should display the firstName, lastName, birthdate and division of student', async function (assert) {
+  test('it should display the firstName, lastName, birthdate, division and participation count of student', async function (assert) {
     // given
-    const students = [{ lastName: 'La Terreur', firstName: 'Gigi', division: '3B', birthdate: new Date('2010-02-01') }];
+    const students = [
+      {
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        division: '3B',
+        birthdate: new Date('2010-02-01'),
+        participationCount: 42,
+      },
+    ];
     this.set('students', students);
 
     // when
@@ -72,6 +80,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
     assert.contains('Gigi');
     assert.contains('01/02/2010');
     assert.contains('3B');
+    assert.contains('42');
   });
 
   module('when user is filtering some users', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -772,7 +772,8 @@
           "division": "Class",
           "first-name": "First name",
           "last-name": "Last name",
-          "login-method": "Log in method(s)"
+          "login-method": "Log in method(s)",
+          "participation-count": "Number of participations"
         },
         "empty": "No students.",
         "filter": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -771,7 +771,8 @@
           "division": "Classe",
           "first-name": "Prénom",
           "last-name": "Nom",
-          "login-method": "Méthode(s) de connexion"
+          "login-method": "Méthode(s) de connexion",
+          "participation-count": "Nombre de participations"
         },
         "empty": "Aucun élève.",
         "filter": {


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs n'ont pour l'instant aucun moyen de voir combien de participations les élèves ont réalisées.

## :robot: Solution
Ajouter une colonne dans l'onglet élèves.

## :rainbow: Remarques
Il sera nécéssaire de renommer et séparer les routes sco et sup, cela sera fait ultérieurement.

## :100: Pour tester
Aller dans l'onglet élèves et voir le nombre de participations. Supprimer une participation, le nombre doit diminuer. Repasser une participation, le nombre doit rester le même.
