### PR TITLE
[FEATURE] Affichage de la date de dernière participation dans l'onglet élèves (PIX-5170).

### DIFF
--- a/api/lib/domain/models/UserWithOrganizationLearner.js
+++ b/api/lib/domain/models/UserWithOrganizationLearner.js
@@ -13,6 +13,7 @@ class UserWithOrganizationLearner {
     division,
     group,
     participationCount,
+    lastParticipationDate,
   } = {}) {
     this.id = id;
     this.lastName = lastName;
@@ -27,6 +28,7 @@ class UserWithOrganizationLearner {
     this.division = division;
     this.group = group;
     this.participationCount = participationCount;
+    this.lastParticipationDate = lastParticipationDate;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -331,6 +331,9 @@ module.exports = {
         'authentication-methods.externalIdentifier as samlId',
         knex.raw(
           'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) OVER (partition by "organization-learners"."id") AS "participationCount"'
+        ),
+        knex.raw(
+          'max("campaign-participations"."createdAt") FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isImproved" IS FALSE AND "campaign-participations"."deletedAt" IS NULL) OVER (partition by "organization-learners"."id") AS "lastParticipationDate"'
         )
       )
       .leftJoin('campaign-participations', 'campaign-participations.organizationLearnerId', 'organization-learners.id')

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer.js
@@ -15,6 +15,7 @@ module.exports = {
         'division',
         'group',
         'participationCount',
+        'lastParticipationDate',
       ],
       meta,
     }).serialize(students);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -958,6 +958,7 @@ describe('Acceptance | Application | organization-controller', function () {
                 division: organizationLearner.division,
                 group: organizationLearner.group,
                 'participation-count': 0,
+                'last-participation-date': null,
               },
               id: organizationLearner.id.toString(),
               type: 'students',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-organization-learner-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | UserWithOrganizationLearner-serializer',
         division: '3A',
         group: 'AB1',
         participationCount: 2,
+        lastParticipationDate: new Date('2021-10-10'),
       });
 
       const expectedSerializedUserWithOrganizationLearner = {
@@ -36,7 +37,8 @@ describe('Unit | Serializer | JSONAPI | UserWithOrganizationLearner-serializer',
             'student-number': userWithOrganizationLearner.studentNumber,
             division: userWithOrganizationLearner.division,
             group: userWithOrganizationLearner.group,
-            'participation-count': 2,
+            'participation-count': userWithOrganizationLearner.participationCount,
+            'last-participation-date': userWithOrganizationLearner.lastParticipationDate,
           },
         },
       };

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -7,6 +7,7 @@
       <col />
       <col />
       <col class="table__column--right" />
+      <col />
       <col class="hide-on-mobile" />
     </colgroup>
     <thead>
@@ -17,6 +18,7 @@
         <Table::Header>{{t "pages.students-sco.table.column.division"}}</Table::Header>
         <Table::Header>{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
         <Table::Header @align="right">{{t "pages.students-sco.table.column.participation-count"}}</Table::Header>
+        <Table::Header>{{t "pages.students-sco.table.column.last-participation-date"}}</Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
@@ -55,6 +57,7 @@
         />
         <Table::Header class="table__column--right" />
         <Table::Header />
+        <Table::Header />
       </tr>
     </thead>
 
@@ -72,6 +75,7 @@
               {{/each}}
             </td>
             <td class="table__column--right">{{student.participationCount}}</td>
+            <td>{{moment-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if student.isStudentAssociated}}
                 <Dropdown::IconTrigger

--- a/orga/app/components/student/sco/list.hbs
+++ b/orga/app/components/student/sco/list.hbs
@@ -3,22 +3,28 @@
     <colgroup class="table__column">
       <col />
       <col />
-      <col />
+      <col class="table__column--center" />
       <col />
       <col />
       <col class="table__column--right" />
-      <col />
+      <col class="table__column--center" />
       <col class="hide-on-mobile" />
     </colgroup>
     <thead>
       <tr>
-        <Table::Header>{{t "pages.students-sco.table.column.last-name"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sco.table.column.first-name"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sco.table.column.date-of-birth"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sco.table.column.division"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
-        <Table::Header @align="right">{{t "pages.students-sco.table.column.participation-count"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sco.table.column.last-participation-date"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sco.table.column.last-name"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sco.table.column.first-name"}}</Table::Header>
+        <Table::Header @size="medium" @align="center">
+          {{t "pages.students-sco.table.column.date-of-birth"}}
+        </Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sco.table.column.division"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sco.table.column.login-method"}}</Table::Header>
+        <Table::Header @size="medium" @align="right">
+          {{t "pages.students-sco.table.column.participation-count"}}
+        </Table::Header>
+        <Table::Header @size="medium" @align="center">
+          {{t "pages.students-sco.table.column.last-participation-date"}}
+        </Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
@@ -67,15 +73,17 @@
           <tr aria-label={{t "pages.students-sco.table.row-title"}}>
             <td class="ellipsis" title={{student.lastName}}>{{student.lastName}}</td>
             <td class="ellipsis" title={{student.firstName}}>{{student.firstName}}</td>
-            <td>{{moment-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
-            <td>{{student.division}}</td>
+            <td class="table__column--center">{{moment-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
+            <td class="ellipsis">{{student.division}}</td>
             <td class="list-students-page__authentication-methods">
               {{#each student.authenticationMethods as |authenticationMethod|}}
                 <p>{{t authenticationMethod}}</p>
               {{/each}}
             </td>
             <td class="table__column--right">{{student.participationCount}}</td>
-            <td>{{moment-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</td>
+            <td class="table__column--center">
+              {{moment-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}
+            </td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if student.isStudentAssociated}}
                 <Dropdown::IconTrigger

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -18,6 +18,7 @@ export default class Student extends Model {
   @attr('string') division;
   @attr('string') group;
   @attr('number') participationCount;
+  @attr('date') lastParticipationDate;
   @attr('boolean') isAuthenticatedFromGar;
   @belongsTo('organization') organization;
 

--- a/orga/tests/integration/components/students/sco/list_test.js
+++ b/orga/tests/integration/components/students/sco/list_test.js
@@ -59,7 +59,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
     assert.dom('[aria-label="Élève"]').exists({ count: 2 });
   });
 
-  test('it should display the firstName, lastName, birthdate, division and participation count of student', async function (assert) {
+  test('it should display the firstName, lastName, birthdate, division, participation count and last participation date of student', async function (assert) {
     // given
     const students = [
       {
@@ -68,6 +68,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
         division: '3B',
         birthdate: new Date('2010-02-01'),
         participationCount: 42,
+        lastParticipationDate: new Date('2022-01-03'),
       },
     ];
     this.set('students', students);
@@ -81,6 +82,7 @@ module('Integration | Component | Student::Sco::List', function (hooks) {
     assert.contains('01/02/2010');
     assert.contains('3B');
     assert.contains('42');
+    assert.contains('03/01/2022');
   });
 
   module('when user is filtering some users', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -772,6 +772,7 @@
           "division": "Class",
           "first-name": "First name",
           "last-name": "Last name",
+          "last-participation-date": "Latest participation",
           "login-method": "Log in method(s)",
           "participation-count": "Number of participations"
         },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -771,6 +771,7 @@
           "division": "Classe",
           "first-name": "Prénom",
           "last-name": "Nom",
+          "last-participation-date": "Dernière participation",
           "login-method": "Méthode(s) de connexion",
           "participation-count": "Nombre de participations"
         },


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs n'ont pour l'instant aucun moyen de voir la date de la dernière participations que les élèves ont réalisées.

## :robot: Solution
Ajouter une colonne dans l'onglet élèves.

## :rainbow: Remarques
Il sera nécéssaire de renommer et séparer les routes sco et sup, cela sera fait ultérieurement.

## :100: Pour tester
Aller dans l'onglet élèves et voir la date de dernière participation. Supprimer une participation, la date doit changer. Repasser une participation, la date doit changer.