### PR TITLE
[FEATURE] Affichage du nombre de participations dans l'onglet étudiants (PIX-5172).

### DIFF
--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -2,11 +2,16 @@
   <table class="table content-text content-text--small">
     <thead>
       <tr>
-        <Table::Header>{{t "pages.students-sup.table.column.student-number"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sup.table.column.last-name"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sup.table.column.first-name"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sup.table.column.date-of-birth"}}</Table::Header>
-        <Table::Header>{{t "pages.students-sup.table.column.group"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sup.table.column.student-number"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sup.table.column.last-name"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sup.table.column.first-name"}}</Table::Header>
+        <Table::Header @size="medium" @align="center">
+          {{t "pages.students-sup.table.column.date-of-birth"}}
+        </Table::Header>
+        <Table::Header @size="wide">{{t "pages.students-sup.table.column.group"}}</Table::Header>
+        <Table::Header @size="medium" @align="right">
+          {{t "pages.students-sup.table.column.participation-count"}}
+        </Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
@@ -42,6 +47,7 @@
           @ariaLabel={{t "pages.students-sup.table.filter.group.aria-label"}}
           @emptyMessage={{t "pages.students-sup.table.filter.group.empty"}}
         />
+        <Table::Header class="table__column--right" />
         <Table::Header />
       </tr>
     </thead>
@@ -50,11 +56,12 @@
       <tbody>
         {{#each @students as |student|}}
           <tr aria-label={{t "pages.students-sup.table.row-title"}}>
-            <td>{{student.studentNumber}}</td>
-            <td>{{student.lastName}}</td>
-            <td>{{student.firstName}}</td>
-            <td>{{moment-format student.birthdate "DD/MM/YYYY"}}</td>
-            <td>{{student.group}}</td>
+            <td class="ellipsis">{{student.studentNumber}}</td>
+            <td class="ellipsis">{{student.lastName}}</td>
+            <td class="ellipsis">{{student.firstName}}</td>
+            <td class="table__column--center">{{moment-format student.birthdate "DD/MM/YYYY"}}</td>
+            <td class="ellipsis">{{student.group}}</td>
+            <td class="table__column--right">{{student.participationCount}}</td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if this.currentUser.isAdminInOrganization}}
                 <Dropdown::IconTrigger

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -52,7 +52,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.dom('[aria-label="Étudiant"]').exists({ count: 2 });
   });
 
-  test('it should display the student number, firstName, lastName and birthdate of student', async function (assert) {
+  test('it should display the student number, firstName, lastName, birthdate, group and participation count of student', async function (assert) {
     // given
     const students = [
       {
@@ -61,6 +61,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
         firstName: 'Gigi',
         birthdate: new Date('2010-02-01'),
         group: 'AB1',
+        participationCount: 88,
       },
     ];
 
@@ -76,6 +77,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.contains('Gigi');
     assert.contains('01/02/2010');
     assert.contains('AB1');
+    assert.contains('88');
   });
 
   module('when user is filtering some users', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -825,6 +825,7 @@
           "first-name": "First name",
           "group": "Groups",
           "last-name": "Last name",
+          "participation-count": "Number of participations",
           "student-number": "Student number"
         },
         "empty": "No students.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -824,6 +824,7 @@
           "first-name": "Prénom",
           "group": "Groupes",
           "last-name": "Nom",
+          "participation-count": "Nombre de participations",
           "student-number": "Numéro étudiant"
         },
         "empty": "Aucun étudiant.",


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs n'ont pour l'instant aucun moyen de voir combien de participations les étudiants ont réalisées.

## :robot: Solution
Ajouter une colonne dans l'onglet étudiants.

## :rainbow: Remarques
Il sera nécéssaire de renommer et séparer les routes sco et sup, cela sera fait ultérieurement.

## :100: Pour tester
Aller dans l'onglet étudiants et voir le nombre de participations. Supprimer une participation, le nombre doit diminuer. Repasser une participation, le nombre doit rester le même.
