### PR TITLE
[TECH] Utiliser l'attribut responseTime au lieu de duration dans les métriques remontés à Datadog.

### DIFF
--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -14,14 +14,14 @@ class HttpResponse {
 module.exports = {
   async post({ url, payload, headers }) {
     const startTime = performance.now();
-    let duration = null;
+    let responseTime = null;
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
-      duration = performance.now() - startTime;
+      responseTime = performance.now() - startTime;
       logInfoWithCorrelationIds({
-        metrics: { duration },
+        metrics: { responseTime },
         message: `End POST request to ${url} success: ${httpResponse.status}`,
       });
 
@@ -31,7 +31,7 @@ module.exports = {
         isSuccessful: true,
       });
     } catch (httpErr) {
-      duration = performance.now() - startTime;
+      responseTime = performance.now() - startTime;
       let code = null;
       let data;
 
@@ -43,7 +43,7 @@ module.exports = {
       }
 
       logErrorWithCorrelationIds({
-        metrics: { duration },
+        metrics: { responseTime },
         message: `End POST request to ${url} error: ${code || ''} ${data.toString()}`,
       });
 
@@ -56,13 +56,13 @@ module.exports = {
   },
   async get({ url, payload, headers }) {
     const startTime = performance.now();
-    let duration = null;
+    let responseTime = null;
     try {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
-      duration = performance.now() - startTime;
+      responseTime = performance.now() - startTime;
       logInfoWithCorrelationIds({
-        metrics: { duration },
+        metrics: { responseTime },
         message: `End GET request to ${url} success: ${httpResponse.status}`,
       });
 
@@ -72,7 +72,7 @@ module.exports = {
         isSuccessful: true,
       });
     } catch (httpErr) {
-      duration = performance.now() - startTime;
+      responseTime = performance.now() - startTime;
       const isSuccessful = false;
 
       let code;
@@ -87,7 +87,7 @@ module.exports = {
       }
 
       logErrorWithCorrelationIds({
-        metrics: { duration },
+        metrics: { responseTime },
         message: `End GET request to ${url} error: ${code}`,
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Le métrique responseTime renvoyé par Hapi permet de mesurer le temps de réponse d'un appel API en millisecond.
Or Datadog s'attend à avoir cette durée en nanosecond. Ce métrique est donc converti au niveau de la configuration du pipeline des logs Hapi dans un autre métrique Duration.

<img width="902" alt="Capture d’écran 2022-06-28 à 16 07 08" src="https://user-images.githubusercontent.com/10045497/176199541-264c9303-942a-4355-8816-7d848ff0f1e2.png">

Le problème consiste à un déphasage d'unité entre le métrique duration calculé par datadog et le métrique duration custom tracé par l'application.

![image](https://user-images.githubusercontent.com/10045497/176207730-bfe047e4-c1c3-4644-836d-481a6ac68446.png)


## :robot: Solution
Afin d'uniformiser, on propose d'utiliser le métrique responseTime pour tracer tous les temps de réponses.

## :rainbow: Remarques
Détail thread slack: https://1024pix.slack.com/archives/C6SGTNVUK/p1655815732190659?thread_ts=1655799718.820869&cid=C6SGTNVUK

## :100: Pour tester
Vérifier dans Datadog lors d'un appel à l'API Pôle Emploi par exemple que les unités sont allignés.
On peut vérifier aussi l'appel /api/assessments en corrélant les appels de l'API et les logs des appels externes à PE

![image](https://user-images.githubusercontent.com/10045497/176207730-bfe047e4-c1c3-4644-836d-481a6ac68446.png)
