### PR TITLE
[FEATURE] Ajouter un bouton raccourcis pour le dashboard metabase (PIX-3861)

### DIFF
--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -119,13 +119,21 @@
               {{/if}}
             {{/each}}
           </ul>
-          <PixButton
-            @backgroundColor="transparent-light"
-            @isBorderVisible={{true}}
-            @size="small"
-            @triggerAction={{this.enterEditMode}}
-          >Editer les informations
-          </PixButton>
+          <div class="certification-center-information__button-section">
+            <PixButton @size="small" @triggerAction={{this.enterEditMode}}>
+              Editer les informations
+            </PixButton>
+
+            <PixButtonLink
+              @backgroundColor="transparent-light"
+              @isBorderVisible={{true}}
+              @href={{this.externalURL}}
+              @size="small"
+              class="pix-button__secondary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >Tableau de bord</PixButtonLink>
+          </div>
         </div>
       </div>
     {{/if}}

--- a/admin/app/components/certification-centers/information.js
+++ b/admin/app/components/certification-centers/information.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { getOwner } from '@ember/application';
 import { types } from '../../models/certification-center';
+import ENV from 'pix-admin/config/environment';
 
 const Validations = buildValidations({
   name: {
@@ -57,6 +58,11 @@ export default class Information extends Component {
   @computed('args.availableHabilitations.@each.id')
   get availableHabilitations() {
     return this.args.availableHabilitations?.sortBy('id');
+  }
+
+  get externalURL() {
+    const urlDashboardPrefix = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL;
+    return urlDashboardPrefix && urlDashboardPrefix + this.args.certificationCenter.id;
   }
 
   constructor() {

--- a/admin/app/styles/components/certification-centers/information.scss
+++ b/admin/app/styles/components/certification-centers/information.scss
@@ -4,6 +4,12 @@
     padding-bottom: 16px;
   }
 
+  &__button-section {
+    display: flex;
+    gap: 8px;
+    max-height: 60px;
+  }
+
   &__display {
 
     &__name {
@@ -20,10 +26,6 @@
       &:last-child {
         border-bottom: none;
       }
-    }
-
-    button {
-      margin: 16px 0;
     }
   }
 

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -57,6 +57,7 @@ module.exports = function (environment) {
         minValue: 1,
       }),
       ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
+      CERTIFICATION_CENTER_DASHBOARD_URL: process.env.CERTIFICATION_CENTER_DASHBOARD_URL,
       USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL,
       MAX_LEVEL: 8,
       MAX_REACHABLE_LEVEL: _getEnvironmentVariableAsNumber({

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -51,6 +51,24 @@ module('Integration | Component | certification-centers/information', function (
     assert.dom(screen.getByLabelText('Non-habilité pour Cléa')).exists();
   });
 
+  test('it should show button to direct user to metabase dashboard', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    this.certificationCenter = store.createRecord('certification-center', {
+      name: 'Centre SCO',
+      type: 'SCO',
+      externalId: 'AX129',
+    });
+
+    // when
+    const screen = await render(
+      hbs`<CertificationCenters::Information @certificationCenter={{this.certificationCenter}} />`
+    );
+
+    // then
+    assert.dom(screen.getByText('Tableau de bord')).exists();
+  });
+
   test('it enters edition mode when click on Edit button', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');

--- a/admin/tests/unit/components/certification-centers/information_test.js
+++ b/admin/tests/unit/components/certification-centers/information_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import ENV from 'pix-admin/config/environment';
 
 module('Unit | Component | certification-center informations', function (hooks) {
   setupTest(hooks);
@@ -41,5 +42,14 @@ module('Unit | Component | certification-center informations', function (hooks) 
       // then
       assert.false(component.form.habilitations.includes(pixSurfHabilitation));
     });
+  });
+
+  test('it should generate link based on environment and object', async function (assert) {
+    // given
+    ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL = 'https://superdashboard?id=';
+    component.args = { certificationCenter: { id: 7 } };
+
+    // when & then
+    assert.strictEqual(component.externalURL, 'https://superdashboard?id=7');
   });
 });

--- a/admin/tests/unit/components/organizations/information-section_test.js
+++ b/admin/tests/unit/components/organizations/information-section_test.js
@@ -6,25 +6,13 @@ import ENV from 'pix-admin/config/environment';
 module('Unit | Component | organizations/information-section', function (hooks) {
   setupTest(hooks);
 
-  let component;
-
-  hooks.beforeEach(function () {
-    component = createGlimmerComponent('component:organizations/information-section');
-  });
-
   test('it should generate link based on environment and object', async function (assert) {
     // given
-    const args = { organization: { id: 1 } };
-    const baseURL = 'https://metabase.pix.fr/dashboard/137/?id=';
-    const expectedURL = baseURL + args.organization.id;
+    const component = createGlimmerComponent('component:organizations/information-section');
+    ENV.APP.ORGANIZATION_DASHBOARD_URL = 'https://metabase.pix.fr/dashboard/137/?id=';
+    component.args = { organization: { id: 1 } };
 
-    ENV.APP.ORGANIZATION_DASHBOARD_URL = baseURL;
-    component.args = args;
-
-    // when
-    // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.externalURL, expectedURL);
+    // when & then
+    assert.strictEqual(component.externalURL, 'https://metabase.pix.fr/dashboard/137/?id=1');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui pour aller voir davantage d’infos sur un centre de certif depuis Pix Admin, les utilisateurs doivent tout faire eux même (aller sur metabase, rechercher l'id du centre de certif).

## :robot: Solution
Rajouter un bouton "Tableau de bord" sur la page de détail d'un Centre de Certif qui est un racourcis pour aller voir le tableau de bord du centre de certif associé.

## :rainbow: Remarques
Nouvelle variable d'env rajoutée en prod : 
- [x] ```CERTIFICATION_CENTER_DASHBOARD_URL=https://metabase.pix.fr/dashboard/290?centre_certif_id=```

## :100: Pour tester

**En RA :** 
- aller sur la page https://admin-pr4583.review.pix.fr/certification-centers/1 


**En local:** 
- démarrer Pix Admin avec: `CERTIFICATION_CENTER_DASHBOARD_URL=https://metabase.pix.fr/dashboard/290?centre_certif_id= npm start`

- aller sur la page d'un centre de certif (le 1 par exemple)

**Puis....** 
- je cliquer sur le bouton ‘Tableau de bord’

- constater que vous êtes redirigé vers la page https://metabase.pix.fr/dashboard/290?centre_certif_id=1, et sur la page, je vois les infos uniquement de ce centre de certif
