### PR TITLE
[TECH][ADMIN]Ajouter un service pour intercepter et notifier des erreurs de requêtes api (PIX-5244)

### DIFF
--- a/admin/app/services/error-response-handler.js
+++ b/admin/app/services/error-response-handler.js
@@ -1,0 +1,44 @@
+import every from 'lodash/every';
+import isEmpty from 'lodash/isEmpty';
+
+import { inject as service } from '@ember/service';
+import Service from '@ember/service';
+
+export default class ErrorResponseHandlerService extends Service {
+  @service notifications;
+
+  ERROR_MESSAGES_BY_STATUS = {
+    DEFAULT: 'Une erreur est survenue.',
+    STATUS_422: 'Cette opération est impossible.',
+    STATUS_404: 'Non trouvé.',
+  };
+
+  notify(errorResponse, customErrorMessageByStatus) {
+    if (!_isJSONAPIError(errorResponse)) {
+      return this.notifications.error(errorResponse);
+    }
+
+    const { errors } = errorResponse;
+    if (!errors) {
+      return this.notifications.error(this.ERROR_MESSAGES_BY_STATUS.DEFAULT);
+    }
+
+    errors.map((error) => {
+      switch (error.status) {
+        case '422':
+          this.notifications.error(customErrorMessageByStatus?.STATUS_422 || this.ERROR_MESSAGES_BY_STATUS.STATUS_422);
+          break;
+        case '404':
+          this.notifications.error(customErrorMessageByStatus?.STATUS_404 || this.ERROR_MESSAGES_BY_STATUS.STATUS_404);
+          break;
+        default:
+          this.notifications.error(customErrorMessageByStatus?.DEFAULT || this.ERROR_MESSAGES_BY_STATUS.DEFAULT);
+          break;
+      }
+    });
+  }
+}
+
+function _isJSONAPIError(errorResponse) {
+  return !isEmpty(errorResponse.errors) && every(errorResponse.errors, (error) => error.title);
+}

--- a/admin/tests/acceptance/authenticated/team/add-member_test.js
+++ b/admin/tests/acceptance/authenticated/team/add-member_test.js
@@ -80,6 +80,7 @@ module('Acceptance | Team | Add member', function (hooks) {
                 {
                   status: '404',
                   code: 'USER_ACCOUNT_NOT_FOUND',
+                  title: 'User not found',
                 },
               ],
             }
@@ -95,7 +96,7 @@ module('Acceptance | Team | Add member', function (hooks) {
       await click(screen.getByRole('button', { name: 'Donner accès à un agent Pix' }));
 
       // then
-      assert.dom(screen.getByText("Cet utilisateur n'existe pas")).exists();
+      assert.dom(screen.getByText("Cet utilisateur n'existe pas.")).exists();
       assert.dom(screen.getByRole('table', { name: 'Liste des membres' })).doesNotContainText('marie.tim@example.net');
     });
   });

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -111,9 +111,16 @@ module('Acceptance | Team | List', function (hooks) {
       this.server.patch(
         '/admin/admin-members/:id',
         () => ({
-          errors: [{ detail: 'Erreur lors de la mise à jour du rôle de cet agent Pix.' }],
+          errors: [
+            {
+              code: 'UPDATE_ADMIN_MEMBER_ERROR',
+              detail: 'A problem occured while trying to update an admin member role',
+              status: '422',
+              title: 'Unprocessable entity',
+            },
+          ],
         }),
-        400
+        422
       );
 
       // when

--- a/admin/tests/integration/components/team/list_test.js
+++ b/admin/tests/integration/components/team/list_test.js
@@ -134,7 +134,9 @@ module('Integration | Component | team | list', function (hooks) {
 
         test('should display an error message and close the modal when an error occurs while disabling', async function (assert) {
           // given
-          const deactivateAdminMemberModelStub = sinon.stub().throws({ errors: [{ status: 422 }] });
+          const deactivateAdminMemberModelStub = sinon
+            .stub()
+            .throws({ errors: [{ status: '422', title: 'Erreur inconnue' }] });
 
           const notificationErrorStub = sinon.stub();
           class NotificationsStub extends Service {

--- a/admin/tests/unit/routes/authenticated/certifications/certification/profile_test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification/profile_test.js
@@ -25,9 +25,7 @@ module('Unit | Route | authenticated/certifications/certification/profile', func
       const model = await route.model();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model, expectedModel);
+      assert.deepEqual(model, expectedModel);
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all_test.js
@@ -198,9 +198,7 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         const returnedSessions = await route.model({});
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(returnedSessions, 'someSessions');
+        assert.deepEqual(returnedSessions, 'someSessions');
       });
     });
   });
@@ -226,27 +224,13 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         route.resetController(controller, true);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certificationCenterName, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certificationCenterType, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, 'finalized');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.resultsSentToPrescriberAt, null);
+        assert.deepEqual(controller.pageNumber, 1);
+        assert.deepEqual(controller.pageSize, 10);
+        assert.deepEqual(controller.id, null);
+        assert.deepEqual(controller.certificationCenterName, null);
+        assert.deepEqual(controller.certificationCenterType, null);
+        assert.deepEqual(controller.status, 'finalized');
+        assert.deepEqual(controller.resultsSentToPrescriberAt, null);
       });
     });
 
@@ -256,27 +240,13 @@ module('Unit | Route | authenticated/sessions/list/all', function (hooks) {
         route.resetController(controller, false);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 'somePageNumber');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 'somePageSize');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, 'someId');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certificationCenterName, 'someName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, 'someStatus');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certificationCenterType, 'someType');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.resultsSentToPrescriberAt, 'someValue');
+        assert.deepEqual(controller.pageNumber, 'somePageNumber');
+        assert.deepEqual(controller.pageSize, 'somePageSize');
+        assert.deepEqual(controller.id, 'someId');
+        assert.deepEqual(controller.certificationCenterName, 'someName');
+        assert.deepEqual(controller.status, 'someStatus');
+        assert.deepEqual(controller.certificationCenterType, 'someType');
+        assert.deepEqual(controller.resultsSentToPrescriberAt, 'someValue');
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/sessions/list/to-be-published_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/to-be-published_test.js
@@ -33,9 +33,7 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function (h
       const result = await route.model();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, toBePublishedSessions);
+      assert.deepEqual(result, toBePublishedSessions);
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/sessions/session_test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session_test.js
@@ -15,9 +15,7 @@ module('Unit | Route | authenticated/sessions/session', function (hooks) {
     route.setupController(sessions, { id });
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(sessions.inputId, id);
+    assert.deepEqual(sessions.inputId, id);
   });
 
   test('#error', function (assert) {

--- a/admin/tests/unit/routes/authenticated/target-profiles/list_test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list_test.js
@@ -78,18 +78,10 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, null);
+        assert.deepEqual(controller.pageNumber, 1);
+        assert.deepEqual(controller.pageSize, 10);
+        assert.deepEqual(controller.name, null);
+        assert.deepEqual(controller.id, null);
       });
     });
 
@@ -99,18 +91,10 @@ module('Unit | Route | authenticated/target-profiles/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 'somePageNumber');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 'somePageSize');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, 'someName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, 'someId');
+        assert.deepEqual(controller.pageNumber, 'somePageNumber');
+        assert.deepEqual(controller.pageSize, 'somePageSize');
+        assert.deepEqual(controller.name, 'someName');
+        assert.deepEqual(controller.id, 'someId');
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations_test.js
@@ -28,21 +28,11 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         route.resetController(controller, true);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, null);
+        assert.deepEqual(controller.pageNumber, 1);
+        assert.deepEqual(controller.pageSize, 10);
+        assert.deepEqual(controller.name, null);
+        assert.deepEqual(controller.type, null);
+        assert.deepEqual(controller.externalId, null);
       });
     });
 
@@ -52,21 +42,11 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         route.resetController(controller, false);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 'somePageNumber');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 'somePageSize');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, 'someName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, 'someType');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, 'someExternalId');
+        assert.deepEqual(controller.pageNumber, 'somePageNumber');
+        assert.deepEqual(controller.pageSize, 'somePageSize');
+        assert.deepEqual(controller.name, 'someName');
+        assert.deepEqual(controller.type, 'someType');
+        assert.deepEqual(controller.externalId, 'someExternalId');
       });
     });
   });

--- a/admin/tests/unit/services/error-response-handler_test.js
+++ b/admin/tests/unit/services/error-response-handler_test.js
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | error-response-handler', function (hooks) {
+  setupTest(hooks);
+
+  test('it notifies a non-JSONAPI error as a single notification', function (assert) {
+    // given
+    const service = this.owner.lookup('service:error-response-handler');
+    const errorMock = sinon.stub();
+    service.notifications = {
+      error: errorMock,
+    };
+    const errorResponse = new Error('a generic error');
+
+    // when
+    service.notify(errorResponse);
+
+    // then
+    assert.ok(errorMock.calledWith(errorResponse));
+  });
+
+  module('Without custom error messages', function () {
+    test('it notifies JSONAPI bundled errors as several notifications with error default messages', function (assert) {
+      // given
+      const service = this.owner.lookup('service:error-response-handler');
+      const errorMock = sinon.stub();
+      service.notifications = {
+        error: errorMock,
+      };
+      const errorResponse = {
+        errors: [
+          {
+            status: '422',
+            title: 'Something went wrong',
+            detail: 'the provided id is invalid',
+          },
+          {
+            status: '404',
+            title: 'Something else went wrong too !',
+          },
+          {
+            title: 'Something went wrong',
+            detail: 'the provided id is invalid',
+          },
+        ],
+      };
+
+      // when
+      service.notify(errorResponse);
+
+      // then
+      sinon.assert.calledWith(errorMock, 'Cette opération est impossible.');
+      sinon.assert.calledWith(errorMock, 'Non trouvé.');
+      sinon.assert.calledWith(errorMock, 'Une erreur est survenue.');
+      assert.ok(true);
+    });
+  });
+
+  module('With custom error messages', function () {
+    test('it notifies JSONAPI bundled errors as several notifications with custom messages', function (assert) {
+      // given
+      const service = this.owner.lookup('service:error-response-handler');
+      const errorMock = sinon.stub();
+      service.notifications = {
+        error: errorMock,
+      };
+      const errorResponse = {
+        errors: [
+          {
+            status: '422',
+            title: 'Something went wrong',
+            detail: 'the provided id is invalid',
+          },
+          {
+            status: '404',
+            title: 'Something else went wrong too !',
+          },
+          {
+            status: ' 666',
+            title: 'Unknown error',
+          },
+        ],
+      };
+
+      const customErrorMessagesByStatus = {
+        DEFAULT: 'Une problème est survenu, veuillez ressayez.',
+        STATUS_422: 'Opération impossible.',
+        STATUS_404: 'Information non trouvée.',
+      };
+
+      // when
+      service.notify(errorResponse, customErrorMessagesByStatus);
+
+      // then
+      sinon.assert.calledWith(errorMock, customErrorMessagesByStatus.DEFAULT);
+      sinon.assert.calledWith(errorMock, customErrorMessagesByStatus.STATUS_422);
+      sinon.assert.calledWith(errorMock, customErrorMessagesByStatus.STATUS_404);
+      assert.ok(true);
+    });
+  });
+});

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -815,12 +815,6 @@ class AdminMemberError extends DomainError {
   }
 }
 
-class AdminMemberRoleUpdateError extends DomainError {
-  constructor(message = 'Erreur lors de la mise à jour du rôle du membre Pix Admin.') {
-    super(message);
-  }
-}
-
 class SessionAlreadyFinalizedError extends DomainError {
   constructor(message = 'Erreur, tentatives de finalisation multiples de la session.') {
     super(message);
@@ -1124,7 +1118,6 @@ module.exports = {
   AccountRecoveryUserAlreadyConfirmEmail,
   AcquiredBadgeForbiddenDeletionError,
   AdminMemberError,
-  AdminMemberRoleUpdateError,
   AlreadyAcceptedOrCancelledOrganizationInvitationError,
   AlreadyExistingAdminMemberError,
   AlreadyExistingEntityError,

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -1,6 +1,6 @@
 const { knex } = require('../bookshelf');
 const AdminMember = require('../../domain/models/AdminMember');
-const { AdminMemberRoleUpdateError, AdminMemberError } = require('../../domain/errors');
+const { AdminMemberError } = require('../../domain/errors');
 
 const TABLE_NAME = 'pix-admin-roles';
 
@@ -36,7 +36,10 @@ module.exports = {
       .returning('*');
 
     if (!updatedAdminMember) {
-      throw new AdminMemberRoleUpdateError();
+      throw new AdminMemberError(
+        'A problem occured while trying to update an admin member role',
+        'UPDATE_ADMIN_MEMBER_ERROR'
+      );
     }
 
     return new AdminMember(updatedAdminMember);

--- a/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-member-repository_test.js
@@ -3,7 +3,7 @@ const { expect, databaseBuilder, knex, catchErr } = require('../../../test-helpe
 const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
 const adminMemberRepository = require('../../../../lib/infrastructure/repositories/admin-member-repository');
 const AdminMember = require('../../../../lib/domain/models/AdminMember');
-const { AdminMemberRoleUpdateError, AdminMemberError } = require('../../../../lib/domain/errors');
+const { AdminMemberError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Infrastructure | Repository | adminMemberRepository', function () {
   describe('#findAll', function () {
@@ -209,7 +209,7 @@ describe('Integration | Infrastructure | Repository | adminMemberRepository', fu
       const error = await catchErr(adminMemberRepository.update)(nonExistingAdminMember);
 
       // then
-      expect(error).to.be.instanceOf(AdminMemberRoleUpdateError);
+      expect(error).to.be.instanceOf(AdminMemberError);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Sur pix-admin nous ne gérons pas toujours les erreurs des requêtes notamment au niveau des routes (findAll, store.query, etc.) et quand c'est fait dans les composants, c'est de différentes manières.

Par exemple, si je suis sur une page qui récupère la liste des organisations via une requête api et que cela est fait au niveau de la route, si la requête est en erreur, cela n'est pas catché.

Il existe un `ErrorNotifierService` assez peu utilisé sur Admin.

Ce service est générique mais il affiche les erreurs api `title` et `details` et cela pose deux problèmes :
- on affiche à l'utilisateur nos erreurs techniques en anglais
- on ne peut pas afficher des messages différents en fonction d'un status ou d'un code erreur, ex, sur une 404 on pourrait afficher un message d'erreur liés au contexte



## :robot: Solution
Pour faire en sorte que les erreurs soient un peu mieux gérées notamment la méthode privée `_handleErrorResponse` a été transformée en service :
- on peut lui passer des messages custom
-  il ne gère que la 404 et la 422 pour la moment et un message par défaut
- il est implémenté comme exemple sur la page équipe

## :rainbow: Remarques
C'est une proposition  

1. Il reste en place notamment un service errorNotifier (utilisé sur deux routes) qui sert d'inspiration pour le nouveau service


`@action
error(anError) {
    this.errorNotifier.notify(anError);
    this.router.transitionTo('authenticated.certifications');
  }`

2. Nous sommes limités par le fait que les erreurs côté api ne sont pas toutes non plus au même format. Un status et ou un code, un code qui peut être une code style `CECI_EST_UN_CODE_ERREUR` ou alors '422' ou alors 422.
Ce service peut-être utilisé sur d'anciens composants mais il faudra s'assurer des erreurs renvoyés par les requêtes api et de leur format. Ceci dit, cela peut encourager à uniformiser nos formats d'erreurs


## :100: Pour tester

- se connecter en tant que super admin et aller sur la page équipe
- inviter un membre qui n'existe pas et voir une notification d'erreur
- désactiver un membre en BDD puis tenter de le désactiver via la page admin et voir apparaître une notification d'erreur (cf copie d'écran)
- modifier un bout de code, ex dans le usecase ajouter l'erreur et voir apparaître une notification d'erreur


![Capture d’écran 2022-07-12 à 15 28 04](https://user-images.githubusercontent.com/7688741/178505525-1009e383-37f0-423a-86de-caaa606b48de.png)
