### PR TITLE
[TECH] Attendre la fin des requêtes http à la réception de signal d'arrêt sur l'API.

### DIFF
--- a/api/bin/www
+++ b/api/bin/www
@@ -6,32 +6,37 @@ validateEnvironmentVariables();
 
 const createServer = require('../server');
 const logger = require('../lib/infrastructure/logger');
-const { disconnect } = require('../db/knex-database-connection');
+const {disconnect} = require('../db/knex-database-connection');
 
-const start = async () => {
-  try {
+let server;
 
-    const server = await createServer();
-    await server.start();
-
-    logger.info('Server running at %s', server.info.uri);
-  } catch (err) {
-    logger.error(err);
-    process.exit(1);
-  }
+const start = async function () {
+  server = await createServer();
+  await server.start();
 };
 
-function exitOnSignal(signal) {
-  logger.info(`Received signal ${signal}. Closing DB connections before exiting.`);
-  disconnect().then(() => {
-    process.exit(0);
-  }).catch((err) => {
-    logger.error(err);
-    process.exit(1);
-  });
+async function _exitOnSignal(signal) {
+  logger.info(`Received signal: ${signal}.`);
+  logger.info('Stopping HAPI server...');
+  await server.stop({timeout: 30000});
+  logger.info('Closing connexions to database...');
+  await disconnect();
+  process.exit();
 }
 
-process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
-process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
+process.on('SIGTERM', () => {
+  _exitOnSignal('SIGTERM');
+});
+process.on('SIGINT', () => {
+  _exitOnSignal('SIGINT');
+});
 
-start();
+
+(async () => {
+  try {
+    await start();
+  } catch (error) {
+    logger.error(error);
+    throw error;
+  }
+})()

--- a/api/bin/www
+++ b/api/bin/www
@@ -6,7 +6,7 @@ validateEnvironmentVariables();
 
 const createServer = require('../server');
 const logger = require('../lib/infrastructure/logger');
-const {disconnect} = require('../db/knex-database-connection');
+const { disconnect } = require('../db/knex-database-connection');
 
 let server;
 

--- a/api/server.js
+++ b/api/server.js
@@ -20,7 +20,7 @@ let config;
 const setupServer = async () => {
   loadConfiguration();
 
-  const server = await createServer();
+  const server = createServer();
 
   if (settings.logOpsMetrics) await enableOpsMetrics(server);
 
@@ -35,7 +35,7 @@ const setupServer = async () => {
   return server;
 };
 
-const createServer = async function () {
+const createServer = function () {
   const serverConfiguration = {
     compression: false,
     debug: { request: false, log: false },

--- a/api/server.js
+++ b/api/server.js
@@ -17,10 +17,10 @@ monitoringTools.installHapiHook();
 
 let config;
 
-const setupServer = async () => {
+const createServer = async () => {
   loadConfiguration();
 
-  const server = createServer();
+  const server = createBareServer();
 
   if (settings.logOpsMetrics) await enableOpsMetrics(server);
 
@@ -35,7 +35,7 @@ const setupServer = async () => {
   return server;
 };
 
-const createServer = function () {
+const createBareServer = function () {
   const serverConfiguration = {
     compression: false,
     debug: { request: false, log: false },
@@ -98,4 +98,4 @@ const setupOpenApiSpecification = async function (server) {
   }
 };
 
-module.exports = setupServer;
+module.exports = createServer;


### PR DESCRIPTION
## :unicorn: Problème
En cas de réception de signal d'arrêt, le processus linux est arrêté sans attendre la fin de traitement des requêtes en cours.

## :robot: Solution
Attendre la fin, au plus 30 secondes (Scalingo coupe le conteneur au bout de 1 minute)
Utiliser la méthode Hapi `server.stop` ([API](https://hapi.dev/api/?v=20.2.2#-await-serverstopoptions)).

>Stops the server's listener by refusing to accept any new connections or requests (existing connections will continue until closed or timeout).

## :rainbow: Remarques
Remplacement :
- envoi d'un code retour d'erreur (`process.exit(1)`) 
par 
- le renvoi d'une erreur (voir la [recommandation](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-process-exit.md) du linter)

## :100: Pour tester

### Démarrage
Vérifier que l'URL d'écoute est affichée
```shell
[14:01:51] INFO: server started
    created: 1656511311251
    started: 1656511311545
    host: "OCTO-TOPI"
    port: 3000
    protocol: "http"
    id: "OCTO-TOPI:68649:l4zo2c2b"
    uri: "http://OCTO-TOPI:3000"
    address: "0.0.0.0"
```
Envoyer une requête
```shell
curl http://localhost:3000/api/
```

### Signal
Démarrer le serveur
Envoyer SIGINT (Ctrl-C)
Vérifier que les messages d'arrêt sont affichés, et que code retour est 0


```shell
^C[14:01:51] INFO: Received signal: SIGINT.
[14:01:51] INFO: Stopping HAPI server...
[14:01:51] INFO: server stopped
    created: 1656511311251
    started: 0
    host: "OCTO-TOPI"
    port: 3000
    protocol: "http"
    id: "OCTO-TOPI:68649:l4zo2c2b"
    uri: "http://OCTO-TOPI:3000"
    address: "0.0.0.0"
[14:01:51] INFO: Closing connexions to database...

```
### Erreur
 Jeter une erreur avant le démarrage.
 Vérifier que l'erreur est affichée, et que code retour est 1

```js
const start = async () => {
  server = await createServer();
  throw new Error('foo');
  await server.start();
};
```

```shell
[13:57:15] ERROR: foo
    err: {
      "type": "Error",
      "message": "foo",
      "stack":
          Error: foo
              at start (pix/api/bin/www:15:9)
              at processTicksAndRejections (node:internal/process/task_queues:96:5)
              at async /pix/api/bin/www:40:5
    }
node:internal/process/promises:265
            triggerUncaughtException(err, true /* fromPromise */);
            ^

Error: foo
    at start (pix/api/bin/www:15:9)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async pix/api/bin/www:40:5
❯ echo $?
1
```
