### PR TITLE
[TECH] Télécharger le dernier backup terminé dans le script de restauration de BDD.

### DIFF
--- a/api/scripts/database/restore-dump/download-backup.js
+++ b/api/scripts/database/restore-dump/download-backup.js
@@ -46,7 +46,9 @@ async function getScalingoBackup(configuration) {
 
   const backups = await dbClient.getBackups();
 
-  const backupByLastDate = backups.sort((a, b) => {
+  const backupsCompleted = backups.filter((backup) => backup.status === 'done');
+
+  const backupByLastDate = backupsCompleted.sort((a, b) => {
     return new Date(b['created_at']) - new Date(a['created_at']);
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Quand un backup est en cours dans l'application scalingo qui héberge notre API en production. Le script de restauration de backup de prod tombe avec l'erreur ci-dessous:

`Dump file mismatch, expecting 0 but was 69 for /tmp/dump.tar.gz`

https://github.com/1024pix/pix/blob/f31a0ef70acf2a7a44adb388e4864f3f14da47a0/api/scripts/database/restore-dump/download-backup.js#L14

Vu avec Scalingo, le souci est qu'on ne vérifie pas si le statut du backup est "terminé".

## :robot: Solution
Filtrer la liste des backups pour ne garder que ceux terminés.

## :100: Pour tester

Testé avec succès sur l'environnement BigInt avec un backup en cours en production
scalingo --region XXX --app XXXX run --detached ./scripts/database/restore-dump/download-and-restore-backup.sh

<img width="536" alt="Capture d’écran 2022-06-29 à 19 11 28" src="https://user-images.githubusercontent.com/10045497/176496356-c31a3e40-c431-4698-9315-a11f5d548e6d.png">


<img width="1680" alt="Capture d’écran 2022-06-29 à 19 07 24" src="https://user-images.githubusercontent.com/10045497/176495329-6799ca14-77a4-4cfa-a241-171ab7984f8a.png">

Local mais sans simulation d'un backup en cours:

Importer le dump de recette

Alimenter dans le `.env`
- DUMP_SCALINGO_REGION=osc-fr1
- DUMP_SCALINGO_APPLICATION=pix-api-recette
- DUMP_SCALINGO_API_TOKEN=<VOTRE_TOKEN>
- DUMP_FILE_PATH=/tmp/dump.tar.gz
- DUMP_DATABASE_CLIENT_VERSION=12

Créer une BDD vide
`npm run db:delete && npm run db:create `

Commenter la ligne :sweat_smile: 
`psql "$DATABASE_URL" -c "DROP OWNED BY current_user;"`

Exécuter le script
`DUMP_FILE_PATH=/tmp/dump.tar.gz DATABASE_URL=postgresql://postgres@localhost:5432/pix ./scripts/database/restore-dump/download-and-restore-backup.sh`

### Distant (avec de la volumétrie)

On ne peut pas utiliser la RA pour avoir un test représentatif (ex: dump de production).
Il faut utiliser sur une application scalingo sur `osc-secnum-fr1`

Dans l'application `pix-migration-pg13-test`, alimenter les variables d'environnements:
- DUMP_SCALINGO_REGION=osc-secnum-fr1
- DUMP_SCALINGO_APPLICATION=pix-api-production
- DUMP_SCALINGO_API_TOKEN=<VOTRE_TOKEN>
- DUMP_FILE_PATH=/tmp/dump.tar.gz

Ajouter le repo Scalingo en tant que remote `add bigint-test-scalingo`
```js
git remote add migration-pg13-test-scalingo git@ssh.osc-secnum-fr1.scalingo.com:pix-migration-pg13-test.git
```

Pusher la branche sur le repo scalingo 
```shell
git push --force migration-pg13-test-scalingo tech-import-back-up-from-scalingo:master
```

Lancer le script
``` shell
scalingo --region osc-secnum-fr1 --app pix-migration-pg13-test run --detached ./scripts/database/restore-dump/download-and-restore-backup.sh
```

Suivre l'avancement dans les logs (24h)
```shell
scalingo --region osc-secnum-fr1 --app pix-migration-pg13-test ps
scalingo --region osc-secnum-fr1 --app pix-migration-pg13-test logs --follow --filter one-off-<XXXX>
```

Penser à arrêter le one-off une fois l'import terminé
```shell
scalingo --region osc-secnum-fr1 --app pix-migration-pg13-test one-off-stop one-off-<XXXX>
```
