### PR TITLE
[TECH] Déplacer les tickets Jira grâce au nom de branche

### DIFF
--- a/.github/workflows/jira-transition-to-dev-in-progress.yaml
+++ b/.github/workflows/jira-transition-to-dev-in-progress.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: atlassian/gajira-find-issue-key@master
         continue-on-error: true
         with:
-          string: ${{ github.event.pull_request.title }}
+          from: branch
 
       - name: Transition issue
         uses: atlassian/gajira-transition@master


### PR DESCRIPTION
## :unicorn: Problème
Le script ajoutant un commentaire aux tickets Jira pour donner les liens de RA se base sur le nom de la branche (préfix en pix-1234-).

Les GitHub Actions de transition de tickets Jira se basent sur le titre de la PR.

## :robot: Solution
Ajouter `from: branch` dans le paramétrage de la GitHub Action [gajira-find-issue-key](https://github.com/atlassian/gajira-find-issue-key#inputs) pour déplacer les tickets même si on oublie de le mettre dans le titre de la PR.

## :rainbow: Remarques
RAS

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
