### PR TITLE
[TECH] Déplacer le ticket Jira en review seulement si la PR n'est pas en draft (PIX-5253).

### DIFF
--- a/.github/workflows/jira-transition-to-review.yaml
+++ b/.github/workflows/jira-transition-to-review.yaml
@@ -11,8 +11,9 @@ jobs:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-    if: >
-      contains(github.event.pull_request.labels.*.name, ':eyes: Tech Review Needed')
+    if: |
+      !github.event.pull_request.draft
+        && contains(github.event.pull_request.labels.*.name, ':eyes: Tech Review Needed')
     steps:
       - name: Login
         if: env.JIRA_BASE_URL != ''

--- a/.github/workflows/jira-transition-to-review.yaml
+++ b/.github/workflows/jira-transition-to-review.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - labeled
+      - ready_for_review
 jobs:
   transition-issue:
     name: Transition Issue


### PR DESCRIPTION
## :unicorn: Problème
Par définition une PR draft n’est pas prête à être review, donc le ticket Jira doit rester en “doing” jusqu'à être prête à être review.

## :robot: Solution
1. Vérifier dans le lancement de l'action que la PR n'est pas en draft
2. Déclencher l'action quand une PR passe au statut "Ready for review"

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir l'exemple avec l'historique de cette PR.
