### PR TITLE
[TECH] Générer des données de certification avec un CLI (PIX-5255)

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -4,12 +4,13 @@ const factory = require('./factory/index');
 const databaseBuffer = require('./database-buffer');
 
 module.exports = class DatabaseBuilder {
-  constructor({ knex }) {
+  constructor({ knex, emptyFirst = true }) {
     this.knex = knex;
     this.databaseBuffer = databaseBuffer;
     this.tablesOrderedByDependencyWithDirtinessMap = [];
     this.factory = factory;
     this.isFirstCommit = true;
+    this.emptyFirst = emptyFirst;
   }
 
   async commit() {
@@ -97,7 +98,9 @@ module.exports = class DatabaseBuilder {
   }
 
   async _init() {
-    await this._emptyDatabase();
+    if (this.emptyFirst) {
+      await this._emptyDatabase();
+    }
     await this._initTablesOrderedByDependencyWithDirtinessMap();
     this.isFirstCommit = false;
   }

--- a/api/db/database-builder/factory/build-badge.js
+++ b/api/db/database-builder/factory/build-badge.js
@@ -1,5 +1,6 @@
 const databaseBuffer = require('../database-buffer');
 const buildTargetProfile = require('./build-target-profile');
+const _ = require('lodash');
 
 function buildBadge({
   id = databaseBuffer.getNextId(),
@@ -12,7 +13,7 @@ function buildBadge({
   targetProfileId,
   isAlwaysVisible = false,
 } = {}) {
-  targetProfileId = targetProfileId ? targetProfileId : buildTargetProfile().id;
+  targetProfileId = !_.isUndefined(targetProfileId) ? targetProfileId : buildTargetProfile().id;
 
   const values = {
     id,

--- a/api/db/seeds/data/certification/tooling.js
+++ b/api/db/seeds/data/certification/tooling.js
@@ -10,6 +10,7 @@ const { keys } = require('../../../../lib/domain/models/Badge');
 let allChallenges = [];
 let allPixCompetences = [];
 let allDroitCompetences = [];
+let allEduCompetences = [];
 const skillsByCompetenceId = {};
 
 async function makeUserPixCertifiable({ userId, countCertifiableCompetences, levelOnEachCompetence, databaseBuilder }) {
@@ -25,6 +26,14 @@ async function makeUserPixDroitCertifiable({ userId, databaseBuilder }) {
   await _cacheLearningContent();
   const assessmentId = _createComplementeCompetenceEvaluationAssessment({ userId, databaseBuilder });
   _.each(allDroitCompetences, (competence) => {
+    _makePlusCompetenceCertifiable({ userId, databaseBuilder, competence, assessmentId });
+  });
+}
+
+async function makeUserPixEduCertifiable({ userId, databaseBuilder }) {
+  await _cacheLearningContent();
+  const assessmentId = _createComplementeCompetenceEvaluationAssessment({ userId, databaseBuilder });
+  _.each(allEduCompetences, (competence) => {
     _makePlusCompetenceCertifiable({ userId, databaseBuilder, competence, assessmentId });
   });
 }
@@ -54,6 +63,7 @@ async function _cacheLearningContent() {
     allChallenges = await challengeRepository.list();
     allPixCompetences = _.filter(allCompetences, { origin: 'Pix' });
     allDroitCompetences = _.filter(allCompetences, { origin: 'Droit' });
+    allEduCompetences = _.filter(allCompetences, { origin: 'Edu' });
     await bluebird.mapSeries(allCompetences, async (competence) => {
       skillsByCompetenceId[competence.id] = await skillRepository.findActiveByCompetenceId(competence.id);
     });
@@ -131,4 +141,9 @@ function _findFirstChallengeValidatedBySkillId(skillId) {
   return _.find(allChallenges, { status: 'validé', skill: { id: skillId } });
 }
 
-module.exports = { makeUserPixCertifiable, makeUserPixDroitCertifiable, makeUserCleaCertifiable };
+module.exports = {
+  makeUserPixCertifiable,
+  makeUserPixDroitCertifiable,
+  makeUserCleaCertifiable,
+  makeUserPixEduCertifiable,
+};

--- a/api/db/seeds/data/target-profiles-builder.js
+++ b/api/db/seeds/data/target-profiles-builder.js
@@ -7,8 +7,6 @@ const skillIdsForSkillSet1 = [
   'recPG9ftlGZLiF0O6',
   'recH1pcEWLBUCqXTm',
   'recIDXphXbneOrbux',
-  'recclxUSbi0fvIWpd',
-  'recLCYATl7TGrkZLh',
   'rectL2ZZeWPc7yezp',
   'recndXqXiv4pv2Ukp',
   'recVv1eoSLW7yFgXv',
@@ -22,8 +20,6 @@ const skillIdsForSkillSet1 = [
   'recAuRue2poqxgQG2',
   'recX7RyCsdNV2p168',
   'recxtb5aLs6OAAKIg',
-  'recfLjzQKBD8Umdcx',
-  'recetgnhc67yFnWbl',
   'recPrXhP0X07OdHXe',
   'reclDKLSXIsr4xoZp',
   'recmLZ0CypLpsxm96',
@@ -89,16 +85,12 @@ const skillIdsForSkillSet3 = [
   'recKbNbM8G7mKaloD',
   'recfktfO0ROu1OifX',
   'rec7WOXWi5ClE8BxH',
-  'recHo6D1spbDR9C2N',
-  'recpdpemRXuzV9r10',
   'recWXtN5cNP1JQUVx',
   'rec7EvARki1b9t574',
   'recI4zS51by3N7Ryi',
   'recrV8JAEsieJOAch',
-  'recHBMRraNImyqmDF',
   'recaTPKUCD6uAS0li',
   'recicaqEeoJUtXT6j',
-  'recDotNI5r7ApHfwa',
 ];
 const skillIdsForSkillSet3_V1_only = ['rec6IWrDOSaoX4aLn', 'recZnnTU4WUP6KwwX'];
 const skillIdsForSkillSet3_V2_only = ['recqSPZiRJYzfCDaS', 'recRAXPXVL2cMh5b5'];
@@ -108,7 +100,6 @@ const skillIdsForSkillSet4 = [
   'recTIddrkopID28Ep',
   'recBrDIfDDW2IPpZV',
   'recixKw4lXIiHue01',
-  'recLYUZrWeizc4G5d',
   'recgOc2OreHCosoRp',
   'recb0ZHKckwrnZeb8',
   'recF9oTiR8fMSnQoo',
@@ -126,22 +117,14 @@ const skillIdsForSkillSet4 = [
   'recUdMS2pRSF4sgnk',
   'recVgnoo6RjCxjCQp',
   'recLsem0KbElkpjvp',
-  'recSByLc0DNQ8F0D1',
   'recEAJG3c7SNoiUcj',
-  'reclCMZpPDx3eQ46q',
   'recQdr7rbPZ3Kh6Ef',
   'recLhYgOVFwOmQSLn',
   'recfuk3QLAOzBQzSU',
-  'recXZWPaaJ6jlcmtq',
-  'rec2Kg1bqEZVI8fBh',
-  'rec9IR04aOpn5aSCP',
-  'recJGN6S3MmTZVa5O',
-  'recUCuU7EMEHAysmp',
-  'rec2DvazCDkBnqOmK',
 ];
 const skillIdsForSkillSet4_V1_only = ['recAzV1ljhCdjrasn', 'recx7WnZJCXVgCvN4'];
-const skillIdsForSkillSet4_V2_only = ['rec1XTXVEkhBVKPLW', 'rec2gXP40kiwxd0Kc'];
-const skillIdsForSkillSet4_V3_only = ['rec1XTXVEkhBVKPLW', 'rec2gXP40kiwxd0Kc'];
+const skillIdsForSkillSet4_V2_only = ['rec1XTXVEkhBVKPLW'];
+const skillIdsForSkillSet4_V3_only = ['rec1XTXVEkhBVKPLW'];
 
 const targetProfileSkillIdsForCleaBadgeV1 = [
   skillIdsForSkillSet1,
@@ -225,7 +208,6 @@ function _buildTargetProfilePICDiagnosticInitial(databaseBuilder) {
     'recrvTvLTUXEcUIV1',
     'recX7RyCsdNV2p168',
     'recxtb5aLs6OAAKIg',
-    'receRbbt9Lb661wFB',
     'rec71e3PSct2zLEMj',
     'recFwJlpllhWzuLom',
     'rec0J9OXaAj5v7w3r',
@@ -440,7 +422,6 @@ function _buildTargetProfilePixDroit(databaseBuilder) {
     'recfQIxf8y4Nrs6M1',
     'recPgkHUdzk0HPGt1',
     'reclX9KELFBQeVKoC',
-    'recJLroTYxcfbczfW',
     'reczOCGv8pz976Acl',
     'recOrdJPMeAtA9Zse',
     'recdmDASRPMTzOmVc',
@@ -490,7 +471,6 @@ function _buildTargetProfilePixDroit(databaseBuilder) {
     'recL0AotZshb9quhR',
     'recrOwaV2PTt1N0i5',
     'recI4zS51by3N7Ryi',
-    'recrV8JAEsieJOAch',
     'receMEAc7Jf2hYll6',
     'rec5YCXgs5gMvQHAF',
     'recbZos82xPmwuIKC',

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "3.229.0",
+      "version": "3.235.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -94,6 +94,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-yml": "^1.0.0",
         "form-data": "^4.0.0",
+        "inquirer": "^8.2.4",
         "mocha": "^10.0.0",
         "mocha-junit-reporter": "^2.0.2",
         "nock": "^13.2.7",
@@ -3756,6 +3757,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4184,6 +4239,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -4320,6 +4381,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -4419,6 +4492,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cliui": {
@@ -4790,6 +4872,24 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/defer-to-connect": {
       "version": "1.1.3",
@@ -6036,6 +6136,32 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extract-pg-schema": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/extract-pg-schema/-/extract-pg-schema-3.2.0.tgz",
@@ -6136,6 +6262,21 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7291,6 +7432,140 @@
         "node": ">=8"
       }
     },
+    "node_modules/inquirer": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -7489,6 +7764,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-negative-zero": {
@@ -8975,6 +9259,12 @@
         "mustache": "bin/mustache"
       }
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -9520,6 +9810,123 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
@@ -10791,6 +11198,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -11770,6 +12201,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -12164,6 +12607,15 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {
@@ -15972,6 +16424,45 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -16283,6 +16774,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -16377,6 +16874,12 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true
+    },
     "cli-truncate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -16449,6 +16952,12 @@
           }
         }
       }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
@@ -16740,6 +17249,23 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+          "dev": true
+        }
+      }
     },
     "defer-to-connect": {
       "version": "1.1.3",
@@ -17642,6 +18168,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "extract-pg-schema": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/extract-pg-schema/-/extract-pg-schema-3.2.0.tgz",
@@ -17724,6 +18272,15 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -18569,6 +19126,106 @@
         }
       }
     },
+    "inquirer": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -18713,6 +19370,12 @@
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
       }
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -19848,6 +20511,12 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -20262,6 +20931,89 @@
           "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         }
       }
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -21214,6 +21966,29 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -21973,6 +22748,15 @@
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
       "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -22262,6 +23046,15 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {

--- a/api/package.json
+++ b/api/package.json
@@ -100,6 +100,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-yml": "^1.0.0",
     "form-data": "^4.0.0",
+    "inquirer": "^8.2.4",
     "mocha": "^10.0.0",
     "mocha-junit-reporter": "^2.0.2",
     "nock": "^13.2.7",

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -21,7 +21,7 @@ const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst: false });
 const cache = require('../../lib/infrastructure/caches/learning-content-cache');
 
 /**
- * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1 '[{"candidateNumber": 1, "name": "Pix+ Édu 2nd degré"}]' false
+ * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1 '[{"candidateNumber": 1, "name": "Pix+ Édu 2nd degré"}]'
  */
 
 const PIXCLEA = 'CléA Numérique';
@@ -54,12 +54,6 @@ const questions = [
     name: 'centerType',
     message: 'Quel type de centre ?',
     choices: ['SCO', 'SUP', 'PRO'],
-  },
-  {
-    type: 'confirm',
-    name: 'isSupervisorAccessEnabled',
-    message: "As tu besoin de l'espace surveillant ?",
-    default: true,
   },
   {
     type: 'input',
@@ -116,11 +110,11 @@ const questions = [
   },
 ];
 
-async function main({ centerType, candidateNumber, complementaryCertifications, isSupervisorAccessEnabled }) {
+async function main({ centerType, candidateNumber, complementaryCertifications }) {
   await _updateDatabaseBuilderSequenceNumber();
 
   const certificationCenterId = CERTIFICATION_CENTER_IDS_BY_TYPE[centerType];
-  await _updateCertificationCenterSupervisorPortalAccess(certificationCenterId, isSupervisorAccessEnabled);
+  await _updateCertificationCenterSupervisorPortalAccess(certificationCenterId);
 
   const sessionId = await _createSessionAndReturnId(certificationCenterId, databaseBuilder);
 
@@ -169,8 +163,8 @@ async function _getMaxSequenceId() {
   return max;
 }
 
-async function _updateCertificationCenterSupervisorPortalAccess(id, isSupervisorAccessEnabled) {
-  await knex('certification-centers').update({ isSupervisorAccessEnabled }).where({ id });
+async function _updateCertificationCenterSupervisorPortalAccess(id) {
+  await knex('certification-centers').update({ isSupervisorAccessEnabled: true }).where({ id });
 }
 
 async function _createComplementaryCertificationHabilitations(
@@ -400,13 +394,12 @@ async function _createUser({ firstName, lastName, birthdate, email }, databaseBu
 }
 
 if (process.argv.length > 2 && process.env.NODE_ENV !== 'test') {
-  const [centerType, candidateNumber, complementaryCertifications, isSupervisorAccessEnabled] = process.argv.slice(2);
+  const [centerType, candidateNumber, complementaryCertifications] = process.argv.slice(2);
 
   main({
     centerType,
     candidateNumber,
     complementaryCertifications: JSON.parse(complementaryCertifications),
-    isSupervisorAccessEnabled,
   })
     .catch((error) => {
       logger.error(error);

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -11,6 +11,7 @@ const {
   makeUserPixCertifiable,
   makeUserPixDroitCertifiable,
   makeUserCleaCertifiable,
+  makeUserPixEduCertifiable,
 } = require('../../db/seeds/data/certification/tooling');
 const DatabaseBuilder = require('../../db/database-builder/database-builder');
 const databaseBuffer = require('../../db/database-builder/database-buffer');
@@ -317,6 +318,18 @@ async function _createComplementaryCertificationHability(
         .first();
       databaseBuilder.factory.buildBadgeAcquisition({ badgeId, userId });
       await makeUserCleaCertifiable({ userId, databaseBuilder });
+    } else if (_isEdu1erDegre(complementaryCertificationId)) {
+      const { id: badgeId } = await knex('badges')
+        .where({ key: COMPLEMENTARY_CERTIFICATION_BADGES_BY_NAME[PIXEDU1ERDEGRE] })
+        .first();
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId, userId });
+      await makeUserPixEduCertifiable({ userId, databaseBuilder });
+    } else if (_isEdu2ndDegre(complementaryCertificationId)) {
+      const { id: badgeId } = await knex('badges')
+        .where({ key: COMPLEMENTARY_CERTIFICATION_BADGES_BY_NAME[PIXEDU2NDDEGRE] })
+        .first();
+      databaseBuilder.factory.buildBadgeAcquisition({ badgeId, userId });
+      await makeUserPixEduCertifiable({ userId, databaseBuilder });
     }
   });
 }
@@ -326,6 +339,12 @@ function _isDroit(complementaryCertificationId) {
 }
 function _isClea(complementaryCertificationId) {
   return complementaryCertificationId === COMPLEMENTARY_CERTIFICATION_IDS_BY_NAME[PIXCLEA];
+}
+function _isEdu1erDegre(complementaryCertificationId) {
+  return complementaryCertificationId === COMPLEMENTARY_CERTIFICATION_IDS_BY_NAME[PIXEDU1ERDEGRE];
+}
+function _isEdu2ndDegre(complementaryCertificationId) {
+  return complementaryCertificationId === COMPLEMENTARY_CERTIFICATION_IDS_BY_NAME[PIXEDU2NDDEGRE];
 }
 
 async function _getResults(sessionId) {

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+'use strict';
+const inquirer = require('inquirer');
+require('dotenv').config({ path: `${__dirname}/../../.env` });
+const { knex, disconnect } = require(`../../db/knex-database-connection`);
+const bluebird = require('bluebird');
+const domainBuilder = require('../../tests/tooling/domain-builder/factory');
+const omit = require('lodash/omit');
+const isEmpty = require('lodash/isEmpty');
+const logger = require('../../lib/infrastructure/logger');
+const { getNewSessionCode } = require('../../lib/domain/services/session-code-service');
+const UserToCreate = require('../../lib/domain/models/UserToCreate');
+
+const cache = require('../../lib/infrastructure/caches/learning-content-cache');
+
+/**
+ * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1 '[{"candidateNumber": 1, "name": "Pix+ Édu 2nd degré"}]' false
+ */
+
+const PIXCLEA = 'CléA Numérique';
+const PIXDROIT = 'Pix+ Droit';
+const PIXEDU2NDDEGRE = 'Pix+ Édu 2nd degré';
+const PIXEDU1ERDEGRE = 'Pix+ Édu 1er degré';
+
+const CERTIFICATION_CENTER_IDS_BY_TYPE = {
+  SCO: 1,
+  SUP: 3,
+  PRO: 2,
+};
+
+const COMPLEMENTARY_CERTIFICATION_IDS_BY_NAME = {
+  [PIXCLEA]: 52,
+  [PIXDROIT]: 53,
+  [PIXEDU1ERDEGRE]: 54,
+  [PIXEDU2NDDEGRE]: 55,
+};
+
+const questions = [
+  {
+    type: 'list',
+    name: 'centerType',
+    message: 'Quel type de centre ?',
+    choices: ['SCO', 'SUP', 'PRO'],
+  },
+  {
+    type: 'confirm',
+    name: 'isSupervisorAccessEnabled',
+    message: "As tu besoin de l'espace surveillant ?",
+    default: false,
+  },
+  {
+    type: 'input',
+    name: 'candidateNumber',
+    message: 'Combien de candidats ?',
+    validate(value) {
+      const valid = !isNaN(parseInt(value));
+      return valid || 'Renseigner un nombre';
+    },
+    filter: Number,
+  },
+  {
+    type: 'confirm',
+    name: 'needComplementaryCertifications',
+    message: 'As tu besoin de certifications complémentaires ?',
+    default: false,
+    when({ centerType }) {
+      return centerType !== 'SCO';
+    },
+  },
+  {
+    type: 'checkbox',
+    name: 'complementaryCertifications',
+    message: "Quelles certifications complémentaires souhaitez-vous ? ('space' pour séléctionner)",
+    when({ needComplementaryCertifications }) {
+      return needComplementaryCertifications;
+    },
+    loop: false,
+    choices({ candidateNumber }) {
+      const choices = [];
+      for (let i = 0; i < candidateNumber; i++) {
+        choices.push(
+          new inquirer.Separator(`----- Candidat ${i + 1} -----`),
+          {
+            name: 'Pix+ Édu 1er degré',
+            value: { candidateNumber: i + 1, name: 'Pix+ Édu 1er degré' },
+          },
+          {
+            name: 'Pix+ Édu 2nd degré',
+            value: { candidateNumber: i + 1, name: 'Pix+ Édu 2nd degré' },
+          },
+          {
+            name: 'Pix+ Droit',
+            value: { candidateNumber: i + 1, name: 'Pix+ Droit' },
+          },
+          {
+            name: 'CléA Numérique',
+            value: { candidateNumber: i + 1, name: 'CléA Numérique' },
+          }
+        );
+      }
+      return choices;
+    },
+  },
+];
+
+async function main({ centerType, candidateNumber, complementaryCertifications, isSupervisorAccessEnabled }) {
+  const certificationCenterId = CERTIFICATION_CENTER_IDS_BY_TYPE[centerType];
+
+  await _updateCertificationCenterSupervisorPortalAccess(certificationCenterId, isSupervisorAccessEnabled);
+
+  if (complementaryCertifications?.length) {
+    const complementaryCertificationIds = complementaryCertifications.map((complementaryCertification) => {
+      return COMPLEMENTARY_CERTIFICATION_IDS_BY_NAME[complementaryCertification.name];
+    });
+
+    await _createComplementaryCertificationHabilitations(new Set(complementaryCertificationIds), certificationCenterId);
+  }
+
+  const sessionId = await _createSessionAndReturnId(certificationCenterId);
+
+  if (centerType === 'SCO') {
+    await _createScoCertificationCandidates(certificationCenterId, candidateNumber, sessionId);
+  } else {
+    let complementaryCertificationGroupedByCandidateIndex;
+    if (!isEmpty(complementaryCertifications)) {
+      complementaryCertificationGroupedByCandidateIndex = _groupByCandidateIndex(complementaryCertifications);
+    }
+
+    await _createNonScoCertificationCandidates(
+      candidateNumber,
+      sessionId,
+      complementaryCertificationGroupedByCandidateIndex
+    );
+  }
+
+  const results = await _getResults(sessionId);
+  logger.info({ results });
+}
+
+async function _updateCertificationCenterSupervisorPortalAccess(id, isSupervisorAccessEnabled) {
+  await knex('certification-centers').update({ isSupervisorAccessEnabled }).where({ id });
+}
+
+async function _createComplementaryCertificationHabilitations(complementaryCertificationIds, certificationCenterId) {
+  return bluebird.mapSeries(complementaryCertificationIds, async (complementaryCertificationId) => {
+    await knex('complementary-certification-habilitations').insert(
+      omit(
+        domainBuilder.buildComplementaryCertificationHabilitation({
+          certificationCenterId,
+          complementaryCertificationId,
+        }),
+        ['id']
+      )
+    );
+  });
+}
+
+async function _createSessionAndReturnId(certificationCenterId) {
+  const sessionCode = await getNewSessionCode();
+  const [{ id }] = await knex('sessions')
+    .insert(
+      omit(domainBuilder.buildSession({ certificationCenterId, accessCode: sessionCode }), [
+        'id',
+        'certificationCandidates',
+      ])
+    )
+    .returning('id');
+  return id;
+}
+
+async function _createNonScoCertificationCandidates(
+  candidateNumber,
+  sessionId,
+  complementaryCertificationGroupedByCandidateIndex
+) {
+  for (let i = 0; i < candidateNumber; i++) {
+    const firstName = `c${i}`;
+    const lastName = `c${i}`;
+    const birthdate = new Date('2000-01-01');
+    const user = UserToCreate.createWithTermsOfServiceAccepted({
+      id: null,
+      firstName,
+      lastName,
+      birthdate,
+      email: `${firstName}@example.net`,
+      mustValidateTermsOfService: false,
+    });
+    await knex('users').insert(user).returning('id');
+
+    const certificationCandidate = domainBuilder.buildCertificationCandidate({
+      firstName,
+      lastName,
+      birthdate,
+      sessionId,
+    });
+    const insertableCertificationCandidate = omit(
+      {
+        ...certificationCandidate,
+        organizationLearnerId: certificationCandidate.schoolingRegistrationId,
+      },
+      ['complementaryCertifications', 'schoolingRegistrationId', 'id', 'userId']
+    );
+    const [certificationCandidateId] = await knex('certification-candidates')
+      .insert(insertableCertificationCandidate)
+      .returning('id');
+
+    if (complementaryCertificationGroupedByCandidateIndex) {
+      const complementaryCertifications =
+        complementaryCertificationGroupedByCandidateIndex && complementaryCertificationGroupedByCandidateIndex[i + 1];
+
+      await _createComplementaryCertificationSubscriptions(complementaryCertifications, certificationCandidateId);
+    }
+  }
+}
+
+async function _createScoCertificationCandidates(certificationCenterId, candidateNumber, sessionId) {
+  const organizationLearner = await knex('organization-learners')
+    .select('organization-learners.*')
+    .innerJoin('organizations', 'organizations.id', 'organization-learners.organizationId')
+    .innerJoin('certification-centers', 'certification-centers.externalId', 'organizations.externalId')
+    .where('certification-centers.id', certificationCenterId)
+    .first();
+
+  for (let i = 0; i < candidateNumber; i++) {
+    const firstName = `c${i}`;
+    const lastName = `c${i}`;
+    const birthdate = new Date('2000-01-01');
+
+    const user = UserToCreate.createWithTermsOfServiceAccepted(
+      domainBuilder.buildUser({ firstName, lastName, birthdate, email: `${firstName}@example.net` })
+    );
+    const [{ id: userId }] = await knex('users')
+      .insert({ ...user, id: undefined })
+      .returning('id');
+    const organizationLearnerToPersist = {
+      ...organizationLearner,
+      firstName,
+      lastName,
+      birthdate,
+      nationalStudentId: firstName,
+      studentNumber: i,
+      userId,
+    };
+
+    const [{ id: organizationLearnerId }] = await knex('organization-learners')
+      .insert({ ...organizationLearnerToPersist, id: undefined })
+      .returning('id');
+    await knex('certification-candidates').insert({
+      firstName,
+      lastName,
+      birthdate,
+      organizationLearnerId,
+      sessionId,
+    });
+  }
+}
+
+async function _createComplementaryCertificationSubscriptions(complementaryCertifications, certificationCandidateId) {
+  return bluebird.mapSeries(complementaryCertifications, async (name) => {
+    const { id: complementaryCertificationId } = await knex('complementary-certifications').where({ name }).first();
+
+    await knex('complementary-certification-subscriptions').insert({
+      complementaryCertificationId,
+      certificationCandidateId,
+    });
+  });
+}
+
+async function _getResults(sessionId) {
+  return knex('sessions')
+    .select({
+      sessionId: 'sessions.id',
+      accessCode: 'sessions.accessCode',
+      firstName: 'certification-candidates.firstName',
+      lastName: 'certification-candidates.lastName',
+      birthdate: 'certification-candidates.birthdate',
+      complementaryCertifications: knex.raw('json_agg("complementary-certifications"."name")'),
+    })
+    .join('certification-candidates', 'certification-candidates.sessionId', 'sessions.id')
+    .leftJoin(
+      'complementary-certification-subscriptions',
+      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-candidates.id'
+    )
+    .leftJoin(
+      'complementary-certifications',
+      'complementary-certifications.id',
+      'complementary-certification-subscriptions.complementaryCertificationId'
+    )
+    .where('sessions.id', sessionId)
+    .groupBy('sessions.id', 'certification-candidates.id');
+}
+
+function _groupByCandidateIndex(complementaryCertifications) {
+  return complementaryCertifications.reduce((acc, { candidateNumber, name }) => {
+    acc[candidateNumber] = (acc[candidateNumber] || []).concat(name);
+    return acc;
+  }, {});
+}
+
+if (process.argv.length > 2) {
+  const [centerType, candidateNumber, isSupervisorAccessEnabled] = process.argv.slice(2);
+  main({ centerType, candidateNumber, complementaryCertifications: [], isSupervisorAccessEnabled })
+    .catch((error) => {
+      logger.error(error);
+      throw error;
+    })
+    .finally(_disconnect);
+} else if (require.main === module) {
+  inquirer
+    .prompt(questions)
+    .then(async (answers) => {
+      logger.info('\nDetails:');
+      logger.info(JSON.stringify(answers, null, '  '));
+      await main(answers);
+    })
+    .catch((error) => {
+      logger.error(error);
+      throw error;
+    })
+    .finally(_disconnect);
+} else {
+  module.exports = {
+    main,
+  };
+}
+
+async function _disconnect() {
+  logger.info('Closing connexions to PG...');
+  await disconnect();
+  logger.info('Closing connexions to cache...');
+  cache.quit();
+  logger.info('Exiting process gracefully...');
+}

--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -45,7 +45,6 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
               centerType: type,
               candidateNumber: 2,
               complementaryCertifications: false,
-              isSupervisorAccessEnabled: false,
             });
 
             // then
@@ -102,7 +101,6 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
                   { candidateNumber: 1, name: 'Pix+ Édu 2nd degré' },
                   { candidateNumber: 1, name: 'Pix+ Édu 1er degré' },
                 ],
-                isSupervisorAccessEnabled: false,
               });
 
               // then
@@ -136,7 +134,6 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
             centerType: 'SCO',
             candidateNumber: 2,
             complementaryCertifications: false,
-            isSupervisorAccessEnabled: false,
           });
 
           // then

--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -1,0 +1,116 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { main } = require('../../../../scripts/data-generation/generate-certif-cli');
+
+describe('Integration | Scripts | generate-certif-cli.js', function () {
+  const certificationCenterSup = { id: 3, type: 'SUP' };
+  const certificationCenterPro = { id: 2, type: 'PRO' };
+  const certificationCenterSco = {
+    id: 1,
+    type: 'SCO',
+    externalId: 'SCOID',
+  };
+
+  beforeEach(function () {
+    databaseBuilder.factory.buildCertificationCenter(certificationCenterSco);
+    databaseBuilder.factory.buildCertificationCenter(certificationCenterPro);
+    databaseBuilder.factory.buildCertificationCenter(certificationCenterSup);
+
+    databaseBuilder.factory.buildComplementaryCertification({ id: 52 });
+    databaseBuilder.factory.buildComplementaryCertification({ id: 53 });
+    databaseBuilder.factory.buildComplementaryCertification({ id: 54 });
+    databaseBuilder.factory.buildComplementaryCertification({ id: 55 });
+
+    return databaseBuilder.commit();
+  });
+
+  afterEach(async function () {
+    await knex('complementary-certification-subscriptions').delete();
+    await knex('complementary-certifications').delete();
+    await knex('certification-candidates').delete();
+    await knex('organization-learners').delete();
+    await knex('organizations').delete();
+    await knex('users').delete();
+    await knex('sessions').delete();
+    await knex('certification-centers').delete();
+  });
+
+  describe('#main', function () {
+    context('when asking for 2 candidates', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [certificationCenterSup, certificationCenterPro].forEach(({ id: certificationCenterId, type }) => {
+        context(`when asking for ${type}`, function () {
+          it(`should create 2 ${type} candidates`, async function () {
+            // when
+            await main({
+              centerType: type,
+              candidateNumber: 2,
+              complementaryCertifications: false,
+              isSupervisorAccessEnabled: false,
+            });
+
+            // then
+            const session = await knex('sessions').select('id', 'certificationCenterId', 'accessCode').first();
+            const certificationCandidates = await knex('certification-candidates').select(
+              'birthdate',
+              'firstName',
+              'lastName',
+              'sessionId'
+            );
+            expect(session.accessCode).to.exist;
+            expect(session.certificationCenterId).to.equal(certificationCenterId);
+            expect(certificationCandidates).to.have.length(2);
+            expect(certificationCandidates[0]).to.deep.equals({
+              birthdate: '2000-01-01',
+              firstName: 'c0',
+              lastName: 'c0',
+              sessionId: session.id,
+            });
+          });
+        });
+      });
+
+      context(`when asking for SCO`, function () {
+        it('should create 2 SCO candidates', async function () {
+          // given
+          databaseBuilder.factory.buildOrganization({ id: 1, externalId: certificationCenterSco.externalId });
+          databaseBuilder.factory.buildOrganizationLearner({
+            firstName: 'b',
+            lastName: 'b',
+            birthdate: '2000-01-01',
+            organizationId: 1,
+            userId: null,
+          });
+          databaseBuilder.factory.buildOrganizationLearner({ organizationId: 1, userId: null });
+          databaseBuilder.commit();
+
+          // when
+          await main({
+            centerType: 'SCO',
+            candidateNumber: 2,
+            complementaryCertifications: false,
+            isSupervisorAccessEnabled: false,
+          });
+
+          // then
+          const session = await knex('sessions').select('id', 'certificationCenterId', 'accessCode').first();
+          const certificationCandidates = await knex('certification-candidates').select(
+            'birthdate',
+            'firstName',
+            'lastName',
+            'sessionId'
+          );
+
+          expect(session.accessCode).to.exist;
+          expect(session.certificationCenterId).to.equal(1);
+          expect(certificationCandidates).to.have.length(2);
+          expect(certificationCandidates[0]).to.deep.equals({
+            birthdate: '2000-01-01',
+            firstName: 'c0',
+            lastName: 'c0',
+            sessionId: session.id,
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour tester les certifs en local/RA, il est necessaire de creer des session/users et c’est tres fastidieux

## :robot: Solution
Creer un CLI pour ajouter des donnees a la demande:
- Quel type de centre? (SCO/SUP/PRO)
- Combien de candidats?
- Doit on activer le portail surveillant?
- Doit on inscrire les candidats a une/plusieurs certification complementaire?

## :rainbow: Remarques
On cree des users certifiable pour chaque candidat
On peut lancer le script en mode CLI (pas de parametre)
On peut lancer le script en mode script classique en ajoutant les parametres dans la ligne de commande

- [x] Ajouter les infos "perso" pour pouvoir rejoindre une certification
- [x] Permettre de lancer en mode script
- [x] Gérer l'éligibilité à la certification
- [x] Gérer l'eligibilité au certifications complementaires  

⚠️ Lors de l'import du databaseBuilder, l'objet Cache est construit, ce qui affiche des logs. Ceux-ci se croisent avec le CLI. On pourrait améliorer cela avec un timeout (ou alors en modifiant le fonctionnement de l'import du databaseBuilder)

⚠️⚠️⚠️ La librairie `inquirer` est en `dev-dependencies` et n'est donc pas installé sur les environnements "production" (scalingo).
Pour lancer le script sur scalingo, il faut lancer au préalable l'installation d'inquirer
`NODE_ENV=development npm install inquirer@8 && ...`


## :100: Pour tester
Lancer le script en CLI et lancer une certif avec un des candidat cree
Lancer le script avec les parametres `LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1 '[{"candidateNumber": 1, "name": "Pix+ Édu 2nd degré"}]'`

Il n'y a pas de test automatisé pour la certifiabilité des candidats. Il faudrait pour cela avoir creer des target profile et utiliser des données de production
