### PR TITLE
[BUGFIX] Rendre le bouton "J'envoie mes résultats" lisible par les lecteurs d'écran (PIX-5251)

### DIFF
--- a/mon-pix/app/components/campaign-share-button.hbs
+++ b/mon-pix/app/components/campaign-share-button.hbs
@@ -16,7 +16,6 @@
 {{else}}
   <PixButton
     class="skill-review-share__button"
-    aria-hidden="true"
     @backgroundColor="green"
     @shape="rounded"
     @triggerAction={{@shareCampaignParticipation}}


### PR DESCRIPTION
## :unicorn: Problème
Nous avons une personne aveugle, qui a fait un parcours. Cette personne a pu rejoindre la plateforme, s’inscrire, répondre aux questions, etc... mais par contre il n’a pas pu partager ses résultats avec son organisation .
Après investigation, nous avons remarqué la présence d'un aria-hidden = true sur le bouton de partage des résultats

## :robot: Solution
Enlever l'aria-hidden = true

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à Pix App
- Commencer une campagne, aller jusqu'à la page de partage des résultats
- Allumer lecteur d'écran et entendre que le bouton est lu par le lecteur d'écran
