### PR TITLE
[BUGFIX] Rendre ses couleurs au certificat/certificat partagé (PIX-5230)

### DIFF
--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -98,6 +98,26 @@
   }
 }
 
+.user-certifications-detail-competence--jaffa {
+  @include coloriseElements($information-light);
+}
+
+.user-certifications-detail-competence--emerald {
+  @include coloriseElements($content-light);
+}
+
+.user-certifications-detail-competence--cerulean {
+  @include coloriseElements($communication-light);
+}
+
+.user-certifications-detail-competence--wild-strawberry {
+  @include coloriseElements($security-light);
+}
+
+.user-certifications-detail-competence--butterfly-bush {
+  @include coloriseElements($environment-light);
+}
+
 @include device-is('mobile') {
 
   .user-certifications-detail-competence {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui les polices des compétences sur les certificats et certificats partagés sur mon-pix sont noires.

![image](https://user-images.githubusercontent.com/37305474/176644467-b7f2dbe0-55e4-4161-a686-7bdc1080c312.png)


## :robot: Solution
Remettre des couleurs


## :100: Pour tester
- Se connecter à mon-pix avec anne-success
- Vérifier son certificat https://app-pr4596.review.pix.fr/mes-certifications/200
- Constater le retour des couleurs par compétence

- Vérifier son certificat partagé https://app-pr4596.review.pix.fr/verification-certificat (P-H7TT4RM7)
- Constater le retour des couleurs par compétence

![image](https://user-images.githubusercontent.com/37305474/176644818-9a4960d4-b7bb-440d-acf1-fbe6d2397b21.png)

