### PR TITLE
[FEATURE] Modifier les signalements (PIX-5192).

### DIFF
--- a/admin/app/components/certifications/issue-report.hbs
+++ b/admin/app/components/certifications/issue-report.hbs
@@ -34,6 +34,10 @@
       <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Résoudre le
         signalement</PixButton>
     {{/if}}
+    {{#if @issueReport.canBeModified}}
+      <PixButton @size="small" @isBorderVisible={{true}} @triggerAction={{this.toggleResolveModal}}>Modifier la
+        résolution</PixButton>
+    {{/if}}
     {{#if this.showResolveModal}}
       <Certifications::IssueReports::ResolveIssueReportModal
         @toggleResolveModal={{this.toggleResolveModal}}

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -6,6 +6,7 @@
       @value={{@issueReport.resolution}}
       type="text"
       maxLength="255"
+      @errorMessage={{this.errorMessage}}
       {{on "change" this.onChangeLabel}}
       {{focus}}
     />

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -1,4 +1,4 @@
-<PixModal @title="{{this.title}}" @onCloseButtonClick={{@toggleResolveModal}}>
+<PixModal @title="{{this.actionName}}" @onCloseButtonClick={{@toggleResolveModal}}>
   <:content>
     <PixTextarea
       @id="resolve-reason"
@@ -20,6 +20,6 @@
     >
       Annuler
     </PixButton>
-    <PixButton @size="small" @triggerAction={{this.resolve}}>{{this.buttonName}}</PixButton>
+    <PixButton @size="small" @triggerAction={{this.resolve}}>{{this.actionName}}</PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.hbs
@@ -1,8 +1,9 @@
-<PixModal @title="Résoudre un signalement" @onCloseButtonClick={{@toggleResolveModal}}>
+<PixModal @title="{{this.title}}" @onCloseButtonClick={{@toggleResolveModal}}>
   <:content>
     <PixTextarea
       @id="resolve-reason"
       @label="Résolution"
+      @value={{@issueReport.resolution}}
       type="text"
       maxLength="255"
       {{on "change" this.onChangeLabel}}
@@ -19,6 +20,6 @@
     >
       Annuler
     </PixButton>
-    <PixButton @size="small" @triggerAction={{this.resolve}}>Résoudre le signalement</PixButton>
+    <PixButton @size="small" @triggerAction={{this.resolve}}>{{this.buttonName}}</PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
@@ -19,11 +19,7 @@ export default class CertificationIssueReportModal extends Component {
     this.label = event.target.value;
   }
 
-  get title() {
-    return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre un signalement';
-  }
-
-  get buttonName() {
-    return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre le signalement';
+  get actionName() {
+    return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre ce signalement';
   }
 }

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
@@ -1,15 +1,19 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CertificationIssueReportModal extends Component {
-  @service notifications;
-
   @tracked label = null;
+  @tracked errorMessage = null;
 
   @action
   resolve() {
+    if (this._isInvalid()) {
+      this.errorMessage = 'Le motif de résolution doit être renseigné.';
+      return;
+    }
+
+    this.errorMessage = null;
     this.args.resolveIssueReport(this.args.issueReport, this.label);
     this.args.closeResolveModal();
   }
@@ -21,5 +25,9 @@ export default class CertificationIssueReportModal extends Component {
 
   get actionName() {
     return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre ce signalement';
+  }
+
+  _isInvalid() {
+    return this.args.issueReport.isResolved && !this.label?.trim();
   }
 }

--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
@@ -18,4 +18,12 @@ export default class CertificationIssueReportModal extends Component {
   onChangeLabel(event) {
     this.label = event.target.value;
   }
+
+  get title() {
+    return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre un signalement';
+  }
+
+  get buttonName() {
+    return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre le signalement';
+  }
 }

--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -107,6 +107,10 @@ export default class CertificationIssueReportModel extends Model {
     return this.isImpactful && !this.isResolved;
   }
 
+  get canBeModified() {
+    return this.isResolved && this.isImpactful;
+  }
+
   resolve = memberAction({
     type: 'patch',
     before(resolution) {

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -617,7 +617,8 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                 await fillByLabel('Résolution', resolution);
 
                 // when
-                await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(1));
+                await click(screen.getAllByRole('button', { name: 'Résoudre ce signalement' }).at(0));
+                assert.true(true);
 
                 // then
                 assert.dom(screen.getByText('Le signalement a été résolu.')).exists();
@@ -648,7 +649,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
               await fillByLabel('Résolution', 'Fraude');
 
               // when
-              await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(1));
+              await click(screen.getAllByRole('button', { name: 'Résoudre ce signalement' }).at(0));
 
               // then
               assert.dom(screen.getByText(/une erreur est survenue/i)).exists();

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -599,13 +599,14 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
                   resolvedAt: null,
                 });
                 certification.update({ certificationIssueReports: [certificationIssueReport] });
+                const resolution = 'Fraude';
                 this.server.patch(
                   `/certification-issue-reports/${certificationIssueReport.id}`,
                   (schema) => {
                     const certificationIssueReportToUpdate = schema.certificationIssueReports.find(
                       certificationIssueReport.id
                     );
-                    certificationIssueReportToUpdate.update({ resolvedAt: new Date(), resolution: 'Fraud' });
+                    certificationIssueReportToUpdate.update({ resolvedAt: new Date(), resolution });
                     return new Response({});
                   },
                   204
@@ -613,14 +614,14 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
                 const screen = await visit(`/certifications/${certification.id}`);
                 await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(0));
-                await fillByLabel('Résolution', 'Fraude');
+                await fillByLabel('Résolution', resolution);
 
                 // when
                 await click(screen.getAllByRole('button', { name: 'Résoudre le signalement' }).at(1));
 
                 // then
                 assert.dom(screen.getByText('Le signalement a été résolu.')).exists();
-                assert.dom(screen.getByText('Résolution : Fraud')).exists();
+                assert.dom(screen.getByText('Résolution : Fraude')).exists();
               });
             });
           });

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -99,6 +99,28 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       // Then
       assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
     });
+
+    test('it should display resolution modification button', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: new Date('2020-01-01'),
+      });
+      this.set('issueReport', issueReport);
+
+      class AccessControlStub extends Service {
+        hasAccessToCertificationActionsScope = true;
+      }
+
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
+
+      // Then
+      assert.dom(screen.queryByText('Modifier la résolution')).exists();
+    });
   });
 
   [

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -7,6 +7,28 @@ import sinon from 'sinon';
 module('Integration | Component | certifications/issue-reports/resolve-issue-report-modal', function (hooks) {
   setupRenderingTest(hooks);
 
+  test('it should display a report resolution title', async function (assert) {
+    // Given
+    const store = this.owner.lookup('service:store');
+    const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+    this.set('issueReport', issueReport);
+
+    this.toggleResolveModal = sinon.stub().returns();
+    this.resolveIssueReport = sinon.stub().resolves();
+    this.closeResolveModal = sinon.stub().returns();
+
+    // When
+    const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+    // Then
+    assert.dom(screen.getByRole('dialog', { name: 'Résoudre un signalement' })).exists();
+  });
+
   test('it should display resolve button', async function (assert) {
     // Given
     const store = this.owner.lookup('service:store');

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -27,7 +27,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
       // Then
-      assert.dom(screen.getByRole('dialog', { name: 'Résoudre un signalement' })).exists();
+      assert.dom(screen.getByRole('dialog', { name: 'Résoudre ce signalement' })).exists();
     });
 
     test('it should display resolve button', async function (assert) {
@@ -49,7 +49,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
       // Then
-      assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Résoudre ce signalement' })).exists();
     });
   });
 
@@ -78,7 +78,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
       assert.ok(true);
     });
   });
-  module('when clicking on "Résoudre le signalement" button', function () {
+  module('when clicking on "Résoudre ce signalement" button', function () {
     test('it should close the modal', async function (assert) {
       // Given
       const store = this.owner.lookup('service:store');
@@ -96,7 +96,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
       // When
-      await clickByName('Résoudre le signalement');
+      await clickByName('Résoudre ce signalement');
 
       // Then
       sinon.assert.calledOnce(this.closeResolveModal);
@@ -121,7 +121,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
         // When
-        await clickByName('Résoudre le signalement');
+        await clickByName('Résoudre ce signalement');
 
         // Then
         sinon.assert.calledWith(this.resolveIssueReport, this.issueReport);
@@ -147,7 +147,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
 
         // When
         await fillByLabel('Résolution', 'This is a fraud, its certification has been revoked');
-        await clickByName('Résoudre le signalement');
+        await clickByName('Résoudre ce signalement');
 
         // Then
         sinon.assert.calledWith(

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -186,6 +186,35 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
       // Then
       assert.dom(screen.getByRole('dialog', { name: 'Modifier le signalement' })).exists();
     });
+    module('when updating the resolution with an empty text', function () {
+      test('it should display an error message', async function (assert) {
+        // Given
+        const store = this.owner.lookup('service:store');
+        const issueReport = store.createRecord('certification-issue-report', {
+          isImpactful: true,
+          resolvedAt: new Date(),
+          resolution: 'resolved',
+        });
+        this.set('issueReport', issueReport);
+
+        this.toggleResolveModal = sinon.stub().returns();
+        this.resolveIssueReport = sinon.stub().resolves();
+        this.closeResolveModal = sinon.stub().returns();
+
+        const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                     @toggleResolveModal={{this.toggleResolveModal}}
+                     @issueReport={{this.issueReport}}
+                     @resolvecandidateIssueReport={{this.resolveIssueReport}}
+                     @closeResolveModal={{this.closeResolveModal}}
+                    />`);
+
+        // when
+        await clickByName('Modifier le signalement');
+
+        // Then
+        assert.dom(screen.getByText('Le motif de résolution doit être renseigné.')).exists();
+      });
+    });
     test('it should display modification button', async function (assert) {
       // Given
       const store = this.owner.lookup('service:store');

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -7,49 +7,52 @@ import sinon from 'sinon';
 module('Integration | Component | certifications/issue-reports/resolve-issue-report-modal', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display a report resolution title', async function (assert) {
-    // Given
-    const store = this.owner.lookup('service:store');
-    const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
-    this.set('issueReport', issueReport);
+  module('when the issue is not resolved', function () {
+    test('it should display a report resolution title', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+      this.set('issueReport', issueReport);
 
-    this.toggleResolveModal = sinon.stub().returns();
-    this.resolveIssueReport = sinon.stub().resolves();
-    this.closeResolveModal = sinon.stub().returns();
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
 
-    // When
-    const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
                    @toggleResolveModal={{this.toggleResolveModal}}
                    @issueReport={{this.issueReport}}
                    @resolveIssueReport={{this.resolveIssueReport}}
                    @closeResolveModal={{this.closeResolveModal}}
                   />`);
 
-    // Then
-    assert.dom(screen.getByRole('dialog', { name: 'Résoudre un signalement' })).exists();
-  });
+      // Then
+      assert.dom(screen.getByRole('dialog', { name: 'Résoudre un signalement' })).exists();
+    });
 
-  test('it should display resolve button', async function (assert) {
-    // Given
-    const store = this.owner.lookup('service:store');
-    const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
-    this.set('issueReport', issueReport);
+    test('it should display resolve button', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', { isImpactful: true, resolvedAt: null });
+      this.set('issueReport', issueReport);
 
-    this.toggleResolveModal = sinon.stub().returns();
-    this.resolveIssueReport = sinon.stub().resolves();
-    this.closeResolveModal = sinon.stub().returns();
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
 
-    // When
-    const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
                    @toggleResolveModal={{this.toggleResolveModal}}
                    @issueReport={{this.issueReport}}
                    @resolveIssueReport={{this.resolveIssueReport}}
                    @closeResolveModal={{this.closeResolveModal}}
                   />`);
 
-    // Then
-    assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
+      // Then
+      assert.dom(screen.getByRole('button', { name: 'Résoudre le signalement' })).exists();
+    });
   });
+
   module('when clicking on Cancel button', function () {
     test('it should close the modal', async function (assert) {
       // Given
@@ -154,6 +157,84 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
         );
         assert.ok(true);
       });
+    });
+  });
+
+  module('when the issue report is already resolved', function () {
+    test('it should display a report resolution title', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: new Date(),
+        resolution: 'resolved',
+      });
+      this.set('issueReport', issueReport);
+
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                     @toggleResolveModal={{this.toggleResolveModal}}
+                     @issueReport={{this.issueReport}}
+                     @resolveIssueReport={{this.resolveIssueReport}}
+                     @closeResolveModal={{this.closeResolveModal}}
+                    />`);
+
+      // Then
+      assert.dom(screen.getByRole('dialog', { name: 'Modifier le signalement' })).exists();
+    });
+    test('it should display modification button', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: new Date(),
+        resolution: '',
+      });
+      this.set('issueReport', issueReport);
+
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+      // Then
+      assert.dom(screen.getByRole('button', { name: 'Modifier le signalement' })).exists();
+    });
+    test('it should display actual resolution text', async function (assert) {
+      // Given
+      const store = this.owner.lookup('service:store');
+      const issueReport = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: new Date(),
+        resolution: 'resolved by John Doe',
+      });
+      this.set('issueReport', issueReport);
+
+      this.toggleResolveModal = sinon.stub().returns();
+      this.resolveIssueReport = sinon.stub().resolves();
+      this.closeResolveModal = sinon.stub().returns();
+
+      // When
+      const screen = await renderScreen(hbs`<Certifications::IssueReports::ResolveIssueReportModal
+                   @toggleResolveModal={{this.toggleResolveModal}}
+                   @issueReport={{this.issueReport}}
+                   @resolveIssueReport={{this.resolveIssueReport}}
+                   @closeResolveModal={{this.closeResolveModal}}
+                  />`);
+
+      // Then
+      assert.dom(screen.getByRole('textbox', { name: 'Résolution' })).hasValue('resolved by John Doe');
     });
   });
 });

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 import map from 'lodash/map';
 import ENV from 'pix-admin/config/environment';
 
@@ -21,7 +20,7 @@ module('Unit | Model | certification issue report', function (hooks) {
     const store = this.owner.lookup('service:store');
 
     const models = map(certificationIssueReportCategories, (category) => {
-      return run(() => store.createRecord('certification-issue-report', { category }));
+      return store.createRecord('certification-issue-report', { category });
     });
 
     // when / then
@@ -36,7 +35,7 @@ module('Unit | Model | certification issue report', function (hooks) {
     const store = this.owner.lookup('service:store');
 
     const models = map(certificationIssueReportSubcategories, (subcategory) => {
-      return run(() => store.createRecord('certification-issue-report', { subcategory }));
+      return store.createRecord('certification-issue-report', { subcategory });
     });
 
     // when / then
@@ -49,7 +48,7 @@ module('Unit | Model | certification issue report', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
 
-    const model = run(() => store.createRecord('certification-issue-report', { subcategory: null }));
+    const model = store.createRecord('certification-issue-report', { subcategory: null });
 
     // when / then
     assert.strictEqual(model.subcategoryLabel, '');
@@ -59,13 +58,11 @@ module('Unit | Model | certification issue report', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
 
-      const model = run(() =>
-        store.createRecord('certification-issue-report', {
-          isImpactful: true,
-          resolvedAt: new Date('2020-01-01'),
-          resolution: 'resolved',
-        })
-      );
+      const model = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: new Date('2020-01-01'),
+        resolution: 'resolved',
+      });
 
       // when / then
       assert.false(model.canBeResolved);
@@ -74,13 +71,11 @@ module('Unit | Model | certification issue report', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
 
-      const model = run(() =>
-        store.createRecord('certification-issue-report', {
-          isImpactful: true,
-          resolvedAt: null,
-          resolution: null,
-        })
-      );
+      const model = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: null,
+        resolution: null,
+      });
 
       // when / then
       assert.true(model.canBeResolved);
@@ -92,13 +87,11 @@ module('Unit | Model | certification issue report', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
 
-      const model = run(() =>
-        store.createRecord('certification-issue-report', {
-          isImpactful: true,
-          resolvedAt: null,
-          resolution: null,
-        })
-      );
+      const model = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: null,
+        resolution: null,
+      });
 
       // when / then
       assert.false(model.canBeModified);
@@ -108,13 +101,11 @@ module('Unit | Model | certification issue report', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
 
-      const model = run(() =>
-        store.createRecord('certification-issue-report', {
-          isImpactful: true,
-          resolvedAt: new Date(),
-          resolution: 'resolved',
-        })
-      );
+      const model = store.createRecord('certification-issue-report', {
+        isImpactful: true,
+        resolvedAt: new Date(),
+        resolution: 'resolved',
+      });
 
       // when / then
       assert.true(model.canBeModified);
@@ -123,13 +114,11 @@ module('Unit | Model | certification issue report', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
 
-      const model = run(() =>
-        store.createRecord('certification-issue-report', {
-          isImpactful: false,
-          resolvedAt: null,
-          resolution: null,
-        })
-      );
+      const model = store.createRecord('certification-issue-report', {
+        isImpactful: false,
+        resolvedAt: null,
+        resolution: null,
+      });
 
       // when / then
       assert.false(model.canBeModified);
@@ -144,13 +133,11 @@ module('Unit | Model | certification issue report', function (hooks) {
       sinon.stub(adapter, 'ajax');
       adapter.ajax.resolves({});
 
-      const model = run(() =>
-        store.createRecord('certification-issue-report', {
-          id: 1,
-          isImpactful: true,
-          resolvedAt: null,
-        })
-      );
+      const model = store.createRecord('certification-issue-report', {
+        id: 1,
+        isImpactful: true,
+        resolvedAt: null,
+      });
       // when
       model.resolve('resolved!');
 

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -55,7 +55,7 @@ module('Unit | Model | certification issue report', function (hooks) {
     assert.strictEqual(model.subcategoryLabel, '');
   });
   module('#canBeResolved', function () {
-    test('it should return false is the issue is impactful and already resolved', function (assert) {
+    test('it should return false if the issue is impactful and already resolved', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
 
@@ -70,7 +70,7 @@ module('Unit | Model | certification issue report', function (hooks) {
       // when / then
       assert.false(model.canBeResolved);
     });
-    test('it should return true is the issue is impactful and not resolved yet', function (assert) {
+    test('it should return true if the issue is impactful and not resolved yet', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
 
@@ -84,6 +84,55 @@ module('Unit | Model | certification issue report', function (hooks) {
 
       // when / then
       assert.true(model.canBeResolved);
+    });
+  });
+
+  module('#canBeModified', function () {
+    test('it should return false if the issue is impactful but not resolved', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const model = run(() =>
+        store.createRecord('certification-issue-report', {
+          isImpactful: true,
+          resolvedAt: null,
+          resolution: null,
+        })
+      );
+
+      // when / then
+      assert.false(model.canBeModified);
+    });
+
+    test('it should return true if the issue is impactful and resolved', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const model = run(() =>
+        store.createRecord('certification-issue-report', {
+          isImpactful: true,
+          resolvedAt: new Date(),
+          resolution: 'resolved',
+        })
+      );
+
+      // when / then
+      assert.true(model.canBeModified);
+    });
+    test('it should return false if the issue is not impactful and not resolved', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const model = run(() =>
+        store.createRecord('certification-issue-report', {
+          isImpactful: false,
+          resolvedAt: null,
+          resolution: null,
+        })
+      );
+
+      // when / then
+      assert.false(model.canBeModified);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un signalement non traité automatiquement est remonté par un surveillant, le pôle certif peut résoudre le signalement manuellement, et renseigner la résolution. Une fois ajouté, il est actuellement impossible de modifier la résolution.

## :robot: Solution
Afficher un bouton “Modifier la résolution” pour tous les signalements manuels résolus et avec une résolution déjà renseignée - même design que le bouton “Résoudre le signalement”

Cliquer sur ce bouton affiche une pop-up (même design que celle pour l’ajout d’une résolution) avec le texte suivant : 
* titre : modifier la résolution
* champ texte rempli avec le texte actuel
* boutons : “Annuler”, “Modifier le signalement”

Cliquer sur “Modifier le signalement” remplace l’ancien texte par le nouveau

:warning: Cette action ne doit être possible que pour les rôles SUPER_ADMIN, CERTIF et SUPPORT 

## :rainbow: Remarques
Ajout de tests sur l'existant

## :100: Pour tester
Vérifier que le signalement peut être résolu
Vérifier que le signalement peut être modifié