### PR TITLE
[TECH] Arrêter gracieusement les exécutions.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -36,3 +36,5 @@ rules:
   mocha/no-skipped-tests: error
   mocha/no-top-level-hooks: error
   no-empty-function: warn
+  # Refer to scripts/_template.js for reliable alternatives to process.exit()
+  node/no-process-exit: error

--- a/api/lib/application/run-jobs.js
+++ b/api/lib/application/run-jobs.js
@@ -13,7 +13,7 @@ async function runJobs() {
 
   process.on('SIGINT', async () => {
     await jobQueue.stop();
-    // eslint-disable-next-line no-process-exit
+    // eslint-disable-next-line node/no-process-exit,no-process-exit
     process.exit(0);
   });
 

--- a/api/scripts/.eslintrc.yaml
+++ b/api/scripts/.eslintrc.yaml
@@ -6,3 +6,5 @@ env:
 rules:
   no-console:
     - off
+  # Refer to scripts/_template.js for reliable alternatives to process.exit()
+  node/no-process-exit: warn

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -1,0 +1,38 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const logger = require('../lib/infrastructure/logger');
+const { knex, disconnect } = require('../db/knex-database-connection');
+
+const doSomething = async ({ throwError }) => {
+  if (throwError) {
+    throw new Error('An error occurred');
+  }
+  const data = await knex.select('id').from('users').first();
+  return data;
+};
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  await doSomething({ throwError: false });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = { doSomething };

--- a/api/scripts/bigint/knowledge-elements/prepare-ke-bigint-id-to-be-used-as-primary-key.js
+++ b/api/scripts/bigint/knowledge-elements/prepare-ke-bigint-id-to-be-used-as-primary-key.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 
-const { knex } = require('../db/knex-database-connection');
-const logger = require('../lib/infrastructure/logger');
+const { knex } = require('../../../db/knex-database-connection');
+const logger = require('../../../lib/infrastructure/logger');
 
 const migrateExistingData = async () => {
   const chunkSize = parseInt(process.env.KNOWLEDGE_ELEMENTS_BIGINT_MIGRATION_CHUNK_SIZE);

--- a/api/tests/acceptance/scripts/_template.test.js
+++ b/api/tests/acceptance/scripts/_template.test.js
@@ -1,0 +1,32 @@
+const { expect, catchErr, databaseBuilder } = require('../../test-helper');
+const { doSomething } = require('../../../scripts/_template');
+
+describe('#doSomething', function () {
+  describe('#if throwError is false', function () {
+    it('should return an identifier ', async function () {
+      // given
+      databaseBuilder.factory.buildUser({ id: 1 });
+      await databaseBuilder.commit();
+      const throwError = false;
+
+      // when
+      const data = await doSomething({ throwError });
+
+      // then
+      expect(data).to.deep.equal({ id: 1 });
+    });
+  });
+  describe('#if throwError is true', function () {
+    it('should throw a error', async function () {
+      // given
+      const throwError = true;
+
+      // when
+      const error = await catchErr(doSomething)({ throwError });
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.be.equal('An error occurred');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un script ou un serveur 
- rencontre une erreur irrécupérable, on force la sortie du processus linux avec `process.exit(1)`.
- s'arrête normalement, on force la sortie du processus linux avec `process.exit(0)`.

L'utilisation de `process.exit()` n'est pas recommandée car il ne permet pas à l'event-loop de terminer normalement.
https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-process-exit.md

## :robot: Solution

### Arrêt attendu

#### Possibilités
Ne rien faire (ne pas appeler `process.exit(0)`.

Si la fin ne se produit pas, c'est qu'il reste des évenèments dans l'event loop (ex: ressources non libérées).

Trouver l'origine et appeller la méthode prévue pour les traiter :
- `server.stop` pour HapiJS #4588 
- déconnecter le pool de connexion pour knex

 ### Arrêt inattendu
Lorsque NodeJS rencontre une erreur non interceptée (catched), il :
- écrit la stacktrace sur la sortie d'erreur `stderr`
- renvoie un code retour d'erreur `1`

Lorsque NodeJS n'a plus d'instructions à exécuter, il renvoie le code d'erreur 0, sauf si un autre code a été renseigné dans la variable globale `process.exitCode`, auquel cas il renvoie le code retour correspondant.

Il y a donc deux solutions:
- soit lever une erreur et ne pas la catcher (laisser NodeJS l'intercepter);
- soit catcher l'erreur au niveau haut du script et positionner `process.exitCode`.

Dans le premier cas, les ressources ne seront pas libérées.

#### Proposition
Dans le cas du serveur API HTTP, il est important de libérer les ressources (HTTP + BDD).
Dans le cas des scripts qui se connectent à la base de données, et qui effectuent leur travail séquentiellement, les deux solutions sont possibles, bien que la solution n°2 rend explicte la libération des ressources.

Un template a été mis à disposition qui utilise la solution n°2.
Les scripts existants n'ont pas été modifiés, mais un warning a été ajouté

Dès que[ cette issue ](https://github.com/amanda-mitchell/suppress-eslint-errors/issues/231) sera résolue, un TODO pourra être ajouté pour mentionner la solution
```js
npx suppress-eslint-errors . --message="TODO: Refer to scripts/_template.js for reliable alternatives to process.exit()"
```

## :rainbow: Remarques
Déplacement des scripts de schéma BDD dans le dossier dédié `db/scripts` 

## :100: Pour tester

### Arrêt attendu
Demander l'arrêt et vérifier que :
- le terminal rend la main;
- le code retour est 0.

 ### Arrêt inattendu
Provoquer l'arrêt (ajouter une erreur dans le code) et vérifier que :
- le terminal rend la main;
- le code retour est 1;
- la stacktrace est affichée.

