### PR TITLE
[FEATURE] Ramener le profil utilisateur dans Pix Admin - Partie 1 (PIX-5130).

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -24,7 +24,7 @@ $ npm install
 > Vous devez au préalable avoir une instance de [Pix API](https://github.com/1024pix/pix/tree/dev/api) qui tourne à l'URL : [http://localhost:3000](http://localhost:3000).
 
 ```bash
-$ npm run dev
+$ npm run start
 ```
 
 Accédez à l'application locale via l'URL : [http://localhost:4202](http://localhost:4202).

--- a/admin/app/models/profile.js
+++ b/admin/app/models/profile.js
@@ -1,0 +1,11 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class Profile extends Model {
+  @attr('number') pixScore;
+
+  @hasMany('scorecard') scorecards;
+
+  get areasCode() {
+    return this.scorecards.mapBy('area.code').uniq();
+  }
+}

--- a/admin/app/models/scorecard.js
+++ b/admin/app/models/scorecard.js
@@ -1,0 +1,16 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Scorecard extends Model {
+  @attr('string') description;
+  @attr('number') earnedPix;
+  @attr('number') index;
+  @attr('number') level;
+  @attr('string') name;
+  @attr('number') pixScoreAheadOfNextLevel;
+  @attr('number') remainingDaysBeforeReset;
+  @attr('number') remainingDaysBeforeImproving;
+  @attr('string') status;
+
+  // references
+  @attr('string') competenceId;
+}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -1,4 +1,4 @@
-import Model, { hasMany, attr } from '@ember-data/model';
+import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed } from '@ember/object';
 
@@ -17,6 +17,9 @@ export default class User extends Model {
   @attr() lastPixCertifTermsOfServiceValidatedAt;
   @attr() lastLoggedAt;
   @attr() emailConfirmedAt;
+
+  // includes
+  @belongsTo('profile', { async: false }) profile;
 
   @hasMany('membership') memberships;
   @hasMany('certification-center-membership') certificationCenterMemberships;

--- a/admin/app/routes/authenticated/users/get.js
+++ b/admin/app/routes/authenticated/users/get.js
@@ -5,8 +5,12 @@ import { inject as service } from '@ember/service';
 export default class AuthenticatedUsersGetRoute extends Route {
   @service store;
 
-  model(params) {
-    return this.store.findRecord('user', params.user_id, { include: 'schoolingRegistrations,authenticationMethods' });
+  async model(params) {
+    const user = await this.store.findRecord('user', params.user_id, {
+      include: 'schoolingRegistrations,authenticationMethods',
+    });
+    await user.belongsTo('profile').reload();
+    return user;
   }
 
   @action

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -236,6 +236,33 @@ exports.register = async function (server) {
         tags: ['api', 'admin', 'user'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/users/{id}/profile',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.userHasAtLeastOneAccessOf([
+                securityPreHandlers.checkUserHasRoleSuperAdmin,
+                securityPreHandlers.checkUserHasRoleCertif,
+                securityPreHandlers.checkUserHasRoleSupport,
+                securityPreHandlers.checkUserHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.getProfileForAdmin,
+        notes: [
+          "- Permet à un administrateur de récupérer le nombre total de Pix d'un utilisateur\n et de ses scorecards",
+        ],
+        tags: ['api', 'user', 'profile'],
+      },
+    },
   ];
 
   server.route([

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -7,6 +7,7 @@ const profileSerializer = require('../../infrastructure/serializers/jsonapi/prof
 const participantResultSerializer = require('../../infrastructure/serializers/jsonapi/participant-result-serializer');
 const sharedProfileForCampaignSerializer = require('../../infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
+const userForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-for-admin-serializer');
 const userWithActivitySerializer = require('../../infrastructure/serializers/jsonapi/user-with-activity-serializer');
 const emailVerificationSerializer = require('../../infrastructure/serializers/jsonapi/email-verification-serializer');
 const userDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
@@ -155,7 +156,7 @@ module.exports = {
       filter: options.filter,
       page: options.page,
     });
-    return userSerializer.serialize(users, pagination);
+    return userForAdminSerializer.serialize(users, pagination);
   },
 
   getCampaignParticipations(request) {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -193,6 +193,13 @@ module.exports = {
     return usecases.getUserProfile({ userId: authenticatedUserId, locale }).then(profileSerializer.serialize);
   },
 
+  getProfileForAdmin(request) {
+    const userId = request.params.id;
+    const locale = extractLocaleFromRequest(request);
+
+    return usecases.getUserProfile({ userId, locale }).then(profileSerializer.serialize);
+  },
+
   resetScorecard(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     const competenceId = request.params.competenceId;

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -6,6 +6,7 @@ module.exports = {
     return new Serializer('user', {
       transform(record) {
         record.schoolingRegistrations = record.organizationLearners;
+        record.profile = null;
         return record;
       },
       attributes: [
@@ -26,6 +27,7 @@ module.exports = {
         'schoolingRegistrations',
         'organizationLearners',
         'authenticationMethods',
+        'profile',
       ],
       schoolingRegistrations: {
         ref: 'id',
@@ -65,6 +67,15 @@ module.exports = {
         ref: 'id',
         includes: true,
         attributes: ['identityProvider'],
+      },
+      profile: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/admin/users/${parent.id}/profile`;
+          },
+        },
       },
     }).serialize(usersDetailsForAdmin);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/user-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-for-admin-serializer.js
@@ -1,0 +1,71 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(users, meta) {
+    return new Serializer('user', {
+      transform(record) {
+        record.profile = null;
+        return record;
+      },
+      attributes: [
+        'firstName',
+        'lastName',
+        'email',
+        'username',
+        'cgu',
+        'lastTermsOfServiceValidatedAt',
+        'mustValidateTermsOfService',
+        'pixOrgaTermsOfServiceAccepted',
+        'pixCertifTermsOfServiceAccepted',
+        'lang',
+        'isAnonymous',
+        'memberships',
+        'certificationCenterMemberships',
+        'pixScore',
+        'scorecards',
+        'profile',
+        'campaignParticipations',
+        'hasSeenAssessmentInstructions',
+        'isCertifiable',
+        'hasSeenNewDashboardInfo',
+        'hasSeenFocusedChallengeTooltip',
+        'hasSeenOtherChallengesTooltip',
+      ],
+      memberships: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+      },
+      certificationCenterMemberships: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+      },
+      pixScore: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+      },
+      scorecards: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+      },
+      profile: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/admin/users/${parent.id}/profile`;
+          },
+        },
+      },
+      campaignParticipations: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+      },
+      isCertifiable: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+      },
+      meta,
+    }).serialize(users);
+  },
+};

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -1,0 +1,113 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+  sinon,
+} = require('../../../test-helper');
+
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-get-user-profile', function () {
+  let options;
+  let server;
+  let user;
+  let clock;
+
+  beforeEach(async function () {
+    clock = sinon.useFakeTimers({
+      now: Date.now(),
+      toFake: ['Date'],
+    });
+    user = databaseBuilder.factory.buildUser({});
+    await databaseBuilder.commit();
+    options = {
+      method: 'GET',
+      url: `/api/admin/users/${user.id}`,
+      payload: {},
+      headers: {},
+    };
+    server = await createServer();
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('GET /admin/users/:id', function () {
+    describe('Resource access management', function () {
+      it('should respond with a 403 - forbidden access - if requested user is not the same as authenticated user', async function () {
+        // given
+        const otherUserId = 9999;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('Success case', function () {
+      beforeEach(async function () {
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        options.headers.authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return 200', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return user serialized', async function () {
+        // when
+        const response = await server.inject(options);
+
+        const expectedScorecardJSONApi = {
+          data: {
+            attributes: {
+              cgu: true,
+              'created-at': new Date(),
+              email: user.email,
+              'email-confirmed-at': null,
+              'first-name': user.firstName,
+              lang: 'fr',
+              'last-logged-at': new Date(),
+              'last-name': user.lastName,
+              'last-pix-certif-terms-of-service-validated-at': null,
+              'last-pix-orga-terms-of-service-validated-at': null,
+              'last-terms-of-service-validated-at': null,
+              'pix-certif-terms-of-service-accepted': false,
+              'pix-orga-terms-of-service-accepted': false,
+              username: user.username,
+            },
+            id: `${user.id}`,
+            relationships: {
+              'authentication-methods': {
+                data: [],
+              },
+              'organization-learners': {
+                data: [],
+              },
+              'schooling-registrations': {
+                data: [],
+              },
+            },
+            type: 'users',
+          },
+          included: undefined,
+        };
+
+        // then
+        expect(response.result.data).to.deep.equal(expectedScorecardJSONApi.data);
+        expect(response.result.included).to.deep.equal(expectedScorecardJSONApi.included);
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -98,6 +98,11 @@ describe('Acceptance | Controller | users-controller-get-user-profile', function
               'schooling-registrations': {
                 data: [],
               },
+              profile: {
+                links: {
+                  related: `/api/admin/users/${user.id}/profile`,
+                },
+              },
             },
             type: 'users',
           },

--- a/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-profile-for-admin_test.js
@@ -1,0 +1,185 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
+
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-get-user-profile-for-admin', function () {
+  let options;
+  let server;
+  let userId;
+
+  const skillWeb1Id = 'recAcquisWeb1';
+  const skillWeb1Name = '@web1';
+
+  const competenceId = 'recCompetence';
+
+  const area = {
+    id: 'recvoGdo7z2z7pXWa',
+    titleFrFr: 'Information et données',
+    color: 'jaffa',
+    code: '1',
+    competenceIds: [competenceId],
+  };
+
+  const competence = {
+    id: competenceId,
+    nameFrFr: 'Mener une recherche et une veille d’information',
+    descriptionFrFr: 'Une description',
+    index: '1.1',
+    origin: 'Pix',
+    areaId: 'recvoGdo7z2z7pXWa',
+  };
+
+  const learningContent = {
+    areas: [area],
+    competences: [competence],
+    skills: [
+      {
+        id: skillWeb1Id,
+        name: skillWeb1Name,
+        status: 'actif',
+        competenceId: competenceId,
+      },
+    ],
+  };
+
+  beforeEach(async function () {
+    userId = databaseBuilder.factory.buildUser({}).id;
+    await databaseBuilder.commit();
+    options = {
+      method: 'GET',
+      url: `/api/admin/users/${userId}/profile`,
+      payload: {},
+      headers: {},
+    };
+    server = await createServer();
+  });
+
+  let knowledgeElement;
+
+  describe('GET /admin/users/:id/profile', function () {
+    describe('Ressource access management', function () {
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should respond with a 403 - forbidden access - if requested user is not admin', async function () {
+        // given
+        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('Success case', function () {
+      beforeEach(async function () {
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        options.headers.authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+        mockLearningContent(learningContent);
+
+        knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+          userId,
+          competenceId: competenceId,
+        });
+
+        const assessmentId = databaseBuilder.factory.buildAssessment({ state: 'started' }).id;
+        databaseBuilder.factory.buildCompetenceEvaluation({
+          userId,
+          assessmentId,
+          competenceId: competenceId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return 200', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it("should return user's serialized scorecards", async function () {
+        // when
+        const response = await server.inject(options);
+
+        const expectedScorecardJSONApi = {
+          data: {
+            id: userId.toString(),
+            type: 'Profiles',
+            attributes: {
+              'pix-score': knowledgeElement.earnedPix,
+            },
+            relationships: {
+              scorecards: {
+                data: [
+                  {
+                    id: `${userId}_${competenceId}`,
+                    type: 'scorecards',
+                  },
+                ],
+              },
+            },
+          },
+          included: [
+            {
+              attributes: {
+                code: area.code,
+                title: area.titleFrFr,
+                color: area.color,
+              },
+              id: area.id,
+              type: 'areas',
+            },
+            {
+              attributes: {
+                name: competence.nameFrFr,
+                description: competence.descriptionFrFr,
+                index: competence.index,
+                'competence-id': competenceId,
+                'earned-pix': knowledgeElement.earnedPix,
+                level: Math.round(knowledgeElement.earnedPix / 8),
+                'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
+                status: 'STARTED',
+                'remaining-days-before-reset': 0,
+                'remaining-days-before-improving': 0,
+              },
+              id: `${userId}_${competenceId}`,
+              type: 'scorecards',
+              relationships: {
+                area: {
+                  data: {
+                    id: area.id,
+                    type: 'areas',
+                  },
+                },
+              },
+            },
+          ],
+        };
+
+        // then
+        expect(response.result.data).to.deep.equal(expectedScorecardJSONApi.data);
+        expect(response.result.included).to.deep.equal(expectedScorecardJSONApi.included);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -774,6 +774,35 @@ describe('Unit | Controller | user-controller', function () {
     });
   });
 
+  describe('#getProfileForAdmin', function () {
+    beforeEach(function () {
+      sinon.stub(usecases, 'getUserProfile').resolves({
+        pixScore: 3,
+        scorecards: [],
+      });
+      sinon.stub(profileSerializer, 'serialize').resolves();
+    });
+
+    it('should call the expected usecase', async function () {
+      // given
+      const userId = '12';
+      const locale = 'fr';
+
+      const request = {
+        params: {
+          id: userId,
+        },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      await userController.getProfileForAdmin(request);
+
+      // then
+      expect(usecases.getUserProfile).to.have.been.calledWith({ userId, locale });
+    });
+  });
+
   describe('#resetScorecard', function () {
     beforeEach(function () {
       sinon.stub(usecases, 'resetScorecard').resolves({

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -15,6 +15,7 @@ const membershipSerializer = require('../../../../lib/infrastructure/serializers
 const scorecardSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer');
 const profileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/profile-serializer');
 const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
+const userForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-for-admin-serializer');
 const userWithActivitySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-activity-serializer');
 const userAnonymizedDetailsForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer');
 const userDetailsForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
@@ -514,7 +515,7 @@ describe('Unit | Controller | user-controller', function () {
     beforeEach(function () {
       sinon.stub(queryParamsUtils, 'extractParameters');
       sinon.stub(usecases, 'findPaginatedFilteredUsers');
-      sinon.stub(userSerializer, 'serialize');
+      sinon.stub(userForAdminSerializer, 'serialize');
     });
 
     it('should return a list of JSON API users fetched from the data repository', async function () {
@@ -522,14 +523,14 @@ describe('Unit | Controller | user-controller', function () {
       const request = { query: {} };
       queryParamsUtils.extractParameters.withArgs({}).returns({});
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
-      userSerializer.serialize.returns({ data: {}, meta: {} });
+      userForAdminSerializer.serialize.returns({ data: {}, meta: {} });
 
       // when
       await userController.findPaginatedFilteredUsers(request, hFake);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledOnce;
-      expect(userSerializer.serialize).to.have.been.calledOnce;
+      expect(userForAdminSerializer.serialize).to.have.been.calledOnce;
     });
 
     it('should return a JSON API response with pagination information', async function () {
@@ -544,7 +545,7 @@ describe('Unit | Controller | user-controller', function () {
       await userController.findPaginatedFilteredUsers(request, hFake);
 
       // then
-      expect(userSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedPagination);
+      expect(userForAdminSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedPagination);
     });
 
     it('should allow to filter users by first name', async function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -65,6 +65,11 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
                 },
               ],
             },
+            profile: {
+              links: {
+                related: `/api/admin/users/${userDetailsForAdmin.id}/profile`,
+              },
+            },
           },
           id: `${userDetailsForAdmin.id}`,
           type: 'users',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-for-admin-serializer_test.js
@@ -1,0 +1,78 @@
+const { expect } = require('../../../../test-helper');
+
+const User = require('../../../../../lib/domain/models/User');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-for-admin-serializer');
+
+describe('Unit | Serializer | JSONAPI | user-for-adminserializer', function () {
+  describe('#serialize', function () {
+    let userModelObject;
+
+    beforeEach(function () {
+      userModelObject = new User({
+        id: '234567',
+        firstName: 'Luke',
+        lastName: 'Skywalker',
+        email: 'lskywalker@deathstar.empire',
+        username: 'luke.skywalker1234',
+        cgu: true,
+        lang: 'fr',
+        isAnonymous: false,
+        lastTermsOfServiceValidatedAt: '2020-05-04T13:18:26.323Z',
+        mustValidateTermsOfService: true,
+        pixOrgaTermsOfServiceAccepted: false,
+        pixCertifTermsOfServiceAccepted: false,
+        hasSeenAssessmentInstructions: false,
+        hasSeenFocusedChallengeTooltip: false,
+        hasSeenOtherChallengesTooltip: false,
+      });
+    });
+
+    describe('when user has no userOrgaSettings', function () {
+      it('should serialize excluding password', function () {
+        // given
+        const expectedSerializedUser = {
+          data: {
+            type: 'users',
+            id: userModelObject.id,
+            attributes: {
+              'first-name': userModelObject.firstName,
+              'last-name': userModelObject.lastName,
+              email: userModelObject.email,
+              username: userModelObject.username,
+              cgu: userModelObject.cgu,
+              lang: userModelObject.lang,
+              'is-anonymous': userModelObject.isAnonymous,
+              'last-terms-of-service-validated-at': userModelObject.lastTermsOfServiceValidatedAt,
+              'must-validate-terms-of-service': userModelObject.mustValidateTermsOfService,
+              'pix-orga-terms-of-service-accepted': userModelObject.pixOrgaTermsOfServiceAccepted,
+              'pix-certif-terms-of-service-accepted': userModelObject.pixCertifTermsOfServiceAccepted,
+              'has-seen-assessment-instructions': userModelObject.hasSeenAssessmentInstructions,
+              'has-seen-new-dashboard-info': userModelObject.hasSeenNewDashboardInfo,
+              'has-seen-focused-challenge-tooltip': userModelObject.hasSeenFocusedChallengeTooltip,
+              'has-seen-other-challenges-tooltip': userModelObject.hasSeenOtherChallengesTooltip,
+            },
+            relationships: {
+              memberships: {},
+              'certification-center-memberships': {},
+              'pix-score': {},
+              profile: {
+                links: {
+                  related: `/api/admin/users/${userModelObject.id}/profile`,
+                },
+              },
+              scorecards: {},
+              'campaign-participations': {},
+              'is-certifiable': {},
+            },
+          },
+        };
+
+        // when
+        const json = serializer.serialize(userModelObject);
+
+        // then
+        expect(json).to.be.deep.equal(expectedSerializedUser);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'équipe support s'appuie sur une requête SQL dans un dashboard Metabase pour obtenir les infos d'un profil utilisateur. 
Cependant, la requête SQL faite pour calculer le profil ne prends pas en compte toutes les règles métiers, nous voulons remonter les mêmes informations que sur Pix App dans le "profil". 

## :robot: Solution
- Ajouter une route `/api/admin/users/{id}/profile` qui utilise le même use-case que la route `/api/users/{id}/profile` mais qui est accessible uniquement pour les personnes ayant accès à Pix Admin.

## :rainbow: Remarques
- Nous avons ajouté un serializer d'user spécialement pour Pix Admin avec des liens adaptés. 

## :100: Pour tester
- Se connecter sur Pix Admin
- Chercher un utilisateur
- Se rendre sur la fiche d'un utilisateur et constater qu'une requête vers `/admin/users/{id}/profile` est faite et que le store est bien chargé. 