### PR TITLE
[FEATURE] Traduire les compétences sur le certificat/certificat partagé en EN (PIX-5231)

### DIFF
--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -3,6 +3,8 @@ const events = require('../../domain/events');
 const privateCertificateSerializer = require('../../infrastructure/serializers/jsonapi/private-certificate-serializer');
 const shareableCertificateSerializer = require('../../infrastructure/serializers/jsonapi/shareable-certificate-serializer');
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
+
 const moment = require('moment');
 
 module.exports = {
@@ -16,10 +18,12 @@ module.exports = {
   async getCertification(request) {
     const userId = request.auth.credentials.userId;
     const certificationId = request.params.id;
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     const privateCertificate = await usecases.getPrivateCertificate({
       userId,
       certificationId,
+      locale,
     });
     return privateCertificateSerializer.serialize(privateCertificate);
   },

--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -30,8 +30,9 @@ module.exports = {
 
   async getCertificationByVerificationCode(request) {
     const verificationCode = request.payload.verificationCode;
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
-    const shareableCertificate = await usecases.getShareableCertificate({ verificationCode });
+    const shareableCertificate = await usecases.getShareableCertificate({ verificationCode, locale });
     return shareableCertificateSerializer.serialize(shareableCertificate);
   },
 

--- a/api/lib/domain/usecases/certificate/get-private-certificate.js
+++ b/api/lib/domain/usecases/certificate/get-private-certificate.js
@@ -1,7 +1,12 @@
 const { NotFoundError } = require('../../errors');
 
-module.exports = async function getPrivateCertificate({ certificationId, userId, privateCertificateRepository }) {
-  const privateCertificate = await privateCertificateRepository.get(certificationId);
+module.exports = async function getPrivateCertificate({
+  certificationId,
+  userId,
+  locale,
+  privateCertificateRepository,
+}) {
+  const privateCertificate = await privateCertificateRepository.get(certificationId, { locale });
   if (privateCertificate.userId !== userId) {
     throw new NotFoundError();
   }

--- a/api/lib/domain/usecases/certificate/get-shareable-certificate.js
+++ b/api/lib/domain/usecases/certificate/get-shareable-certificate.js
@@ -1,5 +1,5 @@
-module.exports = async function getShareableCertificate({ verificationCode, shareableCertificateRepository }) {
-  const shareableCertificate = await shareableCertificateRepository.getByVerificationCode(verificationCode);
+module.exports = async function getShareableCertificate({ verificationCode, shareableCertificateRepository, locale }) {
+  const shareableCertificate = await shareableCertificateRepository.getByVerificationCode(verificationCode, { locale });
 
   return shareableCertificate;
 };

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -18,13 +18,16 @@ function _toDomain({ areaData, locale }) {
   });
 }
 
-async function list() {
+async function list({ locale } = {}) {
   const areaDataObjects = await areaDatasource.list();
-  return areaDataObjects.map((areaData) => _toDomain({ areaData }));
+  return areaDataObjects.map((areaData) => _toDomain({ areaData, locale }));
 }
 
 async function listWithPixCompetencesOnly({ locale } = {}) {
-  const [areas, competences] = await Promise.all([list(), competenceRepository.listPixCompetencesOnly({ locale })]);
+  const [areas, competences] = await Promise.all([
+    list({ locale }),
+    competenceRepository.listPixCompetencesOnly({ locale }),
+  ]);
   areas.forEach((area) => {
     area.competences = _.filter(competences, { area: { id: area.id } });
   });

--- a/api/lib/infrastructure/repositories/competence-tree-repository.js
+++ b/api/lib/infrastructure/repositories/competence-tree-repository.js
@@ -2,7 +2,8 @@ const areaRepository = require('./area-repository');
 const CompetenceTree = require('../../domain/models/CompetenceTree');
 
 module.exports = {
-  get() {
-    return areaRepository.listWithPixCompetencesOnly().then((areas) => new CompetenceTree({ areas }));
+  async get({ locale } = {}) {
+    const areas = await areaRepository.listWithPixCompetencesOnly({ locale });
+    return new CompetenceTree({ areas });
   },
 };

--- a/api/lib/infrastructure/repositories/private-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/private-certificate-repository.js
@@ -28,7 +28,7 @@ const CompetenceMark = require('../../domain/models/CompetenceMark');
 const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
 
 module.exports = {
-  async get(id) {
+  async get(id, { locale } = {}) {
     const certificationCourseDTO = await _selectPrivateCertificates()
       .where('certification-courses.id', '=', id)
       .groupBy('certification-courses.id', 'sessions.id', 'assessments.id', 'assessment-results.id')
@@ -41,7 +41,7 @@ module.exports = {
     const cleaCertificationResult = await _getCleaCertificationResult(id);
     const certifiedBadgeImages = await _getCertifiedBadgeImages(id);
 
-    const competenceTree = await competenceTreeRepository.get();
+    const competenceTree = await competenceTreeRepository.get({ locale });
 
     return _toDomain({
       certificationCourseDTO,

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -28,7 +28,7 @@ const ComplementaryCertificationCourseResult = require('../../domain/models/Comp
 const CertifiedBadges = require('../../domain/read-models/CertifiedBadges');
 
 module.exports = {
-  async getByVerificationCode(verificationCode) {
+  async getByVerificationCode(verificationCode, { locale } = {}) {
     const shareableCertificateDTO = await _selectShareableCertificates()
       .groupBy('certification-courses.id', 'sessions.id', 'assessments.id', 'assessment-results.id')
       .where({ verificationCode })
@@ -38,7 +38,7 @@ module.exports = {
       throw new NotFoundError(`There is no certification course with verification code "${verificationCode}"`);
     }
 
-    const competenceTree = await competenceTreeRepository.get();
+    const competenceTree = await competenceTreeRepository.get({ locale });
 
     const cleaCertificationResult = await _getCleaCertificationResult(shareableCertificateDTO.id);
     const certifiedBadgeImages = await _getCertifiedBadgeImages(shareableCertificateDTO.id);

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -56,6 +56,33 @@ describe('Integration | Repository | area-repository', function () {
         },
       ]);
     });
+
+    describe('when locale is "en"', function () {
+      it('should return all areas with english title', async function () {
+        // given
+        const locale = 'en';
+        // when
+        const areas = await areaRepository.list({ locale });
+
+        // then
+        expect(areas[0].title).to.equal(area0.titleEnUs);
+        expect(areas[1].title).to.equal(area1.titleEnUs);
+      });
+    });
+
+    describe('when locale is not "en"', function () {
+      it('should return all areas with french title', async function () {
+        // given
+        const locale = 'fr';
+
+        // when
+        const areas = await areaRepository.list({ locale });
+
+        // then
+        expect(areas[0].title).to.equal(area0.titleFrFr);
+        expect(areas[1].title).to.equal(area1.titleFrFr);
+      });
+    });
   });
 
   describe('#listWithPixCompetencesOnly', function () {

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -143,6 +143,8 @@ describe('Unit | Controller | certifications-controller', function () {
     it('should return a serialized shareable certificate given by verification code', async function () {
       // given
       const request = { payload: { verificationCode: 'P-123456BB' } };
+      const locale = 'fr-fr';
+      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest');
       const shareableCertificate = domainBuilder.buildShareableCertificate({
         id: 123,
         firstName: 'Dorothé',
@@ -159,7 +161,10 @@ describe('Unit | Controller | certifications-controller', function () {
         maxReachableLevelOnCertificationDate: 6,
       });
       sinon.stub(usecases, 'getShareableCertificate');
-      usecases.getShareableCertificate.withArgs({ verificationCode: 'P-123456BB' }).resolves(shareableCertificate);
+      usecases.getShareableCertificate
+        .withArgs({ verificationCode: 'P-123456BB', locale })
+        .resolves(shareableCertificate);
+      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
 
       // when
       const response = await certificationController.getCertificationByVerificationCode(request, hFake);

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -6,6 +6,7 @@ const certificationAttestationPdf = require('../../../../lib/infrastructure/util
 const events = require('../../../../lib/domain/events');
 const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
 const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
+const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Controller | certifications-controller', function () {
   describe('#findUserCertifications', function () {
@@ -79,6 +80,9 @@ describe('Unit | Controller | certifications-controller', function () {
         auth: { credentials: { userId } },
         params: { id: certificationId },
       };
+      const locale = 'fr-fr';
+      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest');
+
       const privateCertificate = domainBuilder.buildPrivateCertificate.validated({
         id: certificationId,
         firstName: 'Dorothé',
@@ -97,7 +101,8 @@ describe('Unit | Controller | certifications-controller', function () {
         maxReachableLevelOnCertificationDate: 6,
       });
       sinon.stub(usecases, 'getPrivateCertificate');
-      usecases.getPrivateCertificate.withArgs({ userId, certificationId }).resolves(privateCertificate);
+      usecases.getPrivateCertificate.withArgs({ userId, certificationId, locale }).resolves(privateCertificate);
+      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
 
       // when
       const response = await certificationController.getCertification(request, hFake);

--- a/api/tests/unit/domain/usecases/get-private-certificate_test.js
+++ b/api/tests/unit/domain/usecases/get-private-certificate_test.js
@@ -18,12 +18,14 @@ describe('Unit | UseCase | getPrivateCertificate', function () {
         id: 123,
         userId: 789,
       });
-      privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
+      const locale = 'fr';
+      privateCertificateRepository.get.withArgs(123, { locale }).resolves(privateCertificate);
 
       // when
       const error = await catchErr(getPrivateCertificate)({
         certificationId: 123,
         userId: 456,
+        locale,
         privateCertificateRepository,
       });
 
@@ -39,12 +41,14 @@ describe('Unit | UseCase | getPrivateCertificate', function () {
         id: 123,
         userId: 456,
       });
-      privateCertificateRepository.get.withArgs(123).resolves(privateCertificate);
+      const locale = 'fr';
+      privateCertificateRepository.get.withArgs(123, { locale }).resolves(privateCertificate);
 
       // when
       const actualPrivateCertificate = await getPrivateCertificate({
         certificationId: 123,
         userId: 456,
+        locale,
         privateCertificateRepository,
       });
 

--- a/api/tests/unit/domain/usecases/get-shareable-certificate_test.js
+++ b/api/tests/unit/domain/usecases/get-shareable-certificate_test.js
@@ -18,11 +18,15 @@ describe('Unit | UseCase | get-shareable-certificate', function () {
       verificationCode: 'P-123456CC',
       resultCompetenceTree,
     });
-    shareableCertificateRepository.getByVerificationCode.withArgs('P-123456CC').resolves(shareableCertificate);
+    const locale = 'fr';
+    shareableCertificateRepository.getByVerificationCode
+      .withArgs('P-123456CC', { locale })
+      .resolves(shareableCertificate);
 
     // when
     const finalShareableCertificate = await getCertificationByVerificationCode({
       verificationCode: 'P-123456CC',
+      locale,
       shareableCertificateRepository,
     });
 

--- a/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
@@ -9,7 +9,7 @@ describe('Unit | Repository | competence-tree-repository', function () {
   });
 
   describe('#get', function () {
-    it('should return a competence tree populated with Areas and Competences', function () {
+    it('should return a competence tree populated with Areas and Competences', async function () {
       // given
       const area = {
         id: 'recvoGdo7z2z7pXWa',
@@ -29,7 +29,7 @@ describe('Unit | Repository | competence-tree-repository', function () {
         ],
       };
 
-      areaRepository.listWithPixCompetencesOnly.resolves([area]);
+      areaRepository.listWithPixCompetencesOnly.withArgs({ locale: 'fr' }).resolves([area]);
 
       const expectedTree = {
         id: 1,
@@ -55,13 +55,11 @@ describe('Unit | Repository | competence-tree-repository', function () {
       };
 
       // when
-      const promise = competenceTreeRepository.get();
+      const competenceTree = await competenceTreeRepository.get({ locale: 'fr' });
 
       // then
-      return promise.then((result) => {
-        expect(result).to.be.an.instanceof(CompetenceTree);
-        expect(result).to.deep.equal(expectedTree);
-      });
+      expect(competenceTree).to.be.an.instanceof(CompetenceTree);
+      expect(competenceTree).to.deep.equal(expectedTree);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
lorsque l'on ouvre un certificat/certificat partagé sur [pix.org](http://pix.org/) langue EN, tout le certificat est traduit en anglais SAUF la partie référentiel

## :robot: Solution
traduire la partie référentiel 

## :100: Pour tester
- Se connecter à mon pix.org ou changer la langue en en ```?lang=en```
- Afficher un certificat privé ou partagé
- Constater que la partie réferentiel est traduite

![image](https://user-images.githubusercontent.com/37305474/176901767-98055151-56a3-4f68-bcff-2963506367c2.png)
