### PR TITLE
[BUGFIX] Erreur de fichier de config babel manquant lors du lint de l'API en local

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -5,6 +5,7 @@ extends:
   - 'plugin:prettier/recommended'
 parserOptions:
   ecmaVersion: 2020
+  requireConfigFile: false
 
 parser: "@babel/eslint-parser"
 

--- a/api/package.json
+++ b/api/package.json
@@ -81,7 +81,6 @@
     "xregexp": "^5.1.1",
     "yargs": "^17.5.1"
   },
-  "babel": {},
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",
     "@ls-lint/ls-lint": "^1.11.2",


### PR DESCRIPTION
## :unicorn: Problème

La commande `npm run lint:code` sur l'api renvoie parfois l'erreur suivante :

```
Parsing error: No Babel config file detected for /home/nico/git/pix/pix/api/translations/index.js. Either disable config file checking with requireConfigFile: false, or configure Babel so that it can find the config files
```

Le bug a été introduit par #4585 

## :robot: Solution
Voir https://github.com/vercel/next.js/discussions/35098
Configurer `@babel/eslint-parser` pour ne pas utiliser de fichier de config babel.

## :rainbow: Remarques
Cela ne se produit pas sur la CI

## :100: Pour tester

Lancer la commande `npm run lint:code` sur l'api.
