### PR TITLE
[FEATURE] Ajouter un endpoint permettant de télécharger un export XML pour le CPF (PIX-5260)

### DIFF
--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -134,6 +134,28 @@ exports.register = async function (server) {
         tags: ['api'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/cpf/export',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationController.getCpfExport,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN OU CERTIF **\n' +
+            '- Récupération des certifications publiées entre deux dates au format XML pour le CPF',
+        ],
+        tags: ['api', 'certifications', 'CPF'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -269,6 +269,12 @@ module.exports = (function () {
         source: 'poleEmploi',
       },
     ],
+
+    cpf: {
+      idClient: '03VML243',
+      idContrat: 'MCFCER000209',
+      codeFranceConnect: 'RS5875',
+    },
   };
 
   if (config.environment === 'development') {

--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -1,3 +1,5 @@
+const EuropeanNumericLevelFactory = require('./EuropeanNumericLevelFactory');
+
 class CpfCertificationResult {
   constructor({
     id,
@@ -21,6 +23,10 @@ class CpfCertificationResult {
     this.publishedAt = publishedAt;
     this.pixScore = pixScore;
     this.competenceMarks = competenceMarks;
+  }
+
+  get europeanNumericLevels() {
+    return EuropeanNumericLevelFactory.buildFromCompetenceMarks(this.competenceMarks);
   }
 }
 

--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -1,0 +1,27 @@
+class CpfCertificationResult {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    sex,
+    birthINSEECode,
+    birthPostalCode,
+    publishedAt,
+    pixScore,
+    competenceMarks,
+  } = {}) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.birthdate = birthdate;
+    this.sex = sex;
+    this.birthINSEECode = birthINSEECode;
+    this.birthPostalCode = birthPostalCode;
+    this.publishedAt = publishedAt;
+    this.pixScore = pixScore;
+    this.competenceMarks = competenceMarks;
+  }
+}
+
+module.exports = CpfCertificationResult;

--- a/api/lib/domain/read-models/EuropeanNumericLevel.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevel.js
@@ -1,0 +1,14 @@
+class EuropeanNumericLevel {
+  constructor({ domainCompetenceId, competenceId, level }) {
+    this.domainCompetenceId = domainCompetenceId;
+    this.competenceId = competenceId;
+    this.level = level;
+  }
+
+  static from({ competenceCode, level }) {
+    const [domainCompetenceId, competenceId] = competenceCode.split('.');
+    return new EuropeanNumericLevel({ domainCompetenceId, competenceId, level });
+  }
+}
+
+module.exports = EuropeanNumericLevel;

--- a/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
@@ -1,0 +1,86 @@
+const EuropeanNumericLevel = require('./EuropeanNumericLevel');
+
+class EuropeanNumericLevelFactory {
+  static buildFromCompetenceMarks(competenceMarks) {
+    const europeanNumericLevels = [];
+    competenceMarks.forEach(({ competenceCode, level }) => {
+      if (['3.4', '4.1', '4.2', '5.1', '5.2'].includes(competenceCode)) {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode, level }));
+      }
+
+      if (competenceCode === '1.1') {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '1.1', level }));
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '1.2', level }));
+      }
+
+      if (competenceCode === '2.1') {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '2.1', level }));
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '2.5', level }));
+      }
+
+      if (competenceCode === '2.3') {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '2.4', level }));
+      }
+
+      if (competenceCode === '2.4') {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '2.3', level }));
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '2.6', level }));
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '5.4', level }));
+      }
+
+      if (competenceCode === '3.3') {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '3.2', level }));
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '3.3', level }));
+      }
+
+      if (competenceCode === '4.3') {
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '4.3', level }));
+        europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode: '4.4', level }));
+      }
+    });
+
+    const europeanNumericLevel1_3 = _buildEuropeanNumericLevelFromMergedCompetenceMarks({
+      competenceMarks,
+      competenceCodesToMerge: ['1.2', '1.3'],
+      mergedCompetenceCode: '1.3',
+    });
+    if (europeanNumericLevel1_3) europeanNumericLevels.push(europeanNumericLevel1_3);
+
+    const europeanNumericLevel3_1 = _buildEuropeanNumericLevelFromMergedCompetenceMarks({
+      competenceMarks,
+      competenceCodesToMerge: ['3.1', '3.2'],
+      mergedCompetenceCode: '3.1',
+    });
+    if (europeanNumericLevel3_1) europeanNumericLevels.push(europeanNumericLevel3_1);
+
+    const averageGlobalScore = Math.round(
+      europeanNumericLevels.reduce((total, { level }) => total + level, 0) / europeanNumericLevels.length
+    );
+    europeanNumericLevels.push(
+      new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: averageGlobalScore })
+    );
+
+    return europeanNumericLevels;
+  }
+}
+
+function _buildEuropeanNumericLevelFromMergedCompetenceMarks({
+  competenceMarks,
+  competenceCodesToMerge,
+  mergedCompetenceCode,
+}) {
+  const foundCompetenceMarks = [];
+  competenceCodesToMerge.forEach((competenceCodeToFind) => {
+    const foundCompetenceMark = competenceMarks.find(({ competenceCode }) => competenceCode === competenceCodeToFind);
+    if (foundCompetenceMark) foundCompetenceMarks.push(foundCompetenceMark);
+  });
+
+  if (foundCompetenceMarks.length !== competenceCodesToMerge.length) return null;
+
+  const level = Math.round(
+    foundCompetenceMarks.reduce((total, { level }) => total + level, 0) / foundCompetenceMarks.length
+  );
+  return EuropeanNumericLevel.from({ competenceCode: mergedCompetenceCode, level });
+}
+
+module.exports = EuropeanNumericLevelFactory;

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -1,0 +1,122 @@
+const { cpf } = require('../../config');
+const { createCB } = require('xmlbuilder2');
+const { v4: uuidv4 } = require('uuid');
+const moment = require('moment');
+const bluebird = require('bluebird');
+
+const schemaVersion = '1.0.0';
+
+// prettier-ignore
+function getXmlExport({ cpfCertificationResults, writableStream, opts = {} }) {
+  const xmlBuilder = createCB({
+    data: (text) => writableStream.write(text),
+    end: () => writableStream.end(),
+    error: (error) => {
+      throw new Error(error);
+    },
+    allowEmptyTags: true,
+    ...opts,
+  });
+
+  xmlBuilder
+    .dec()
+    .ele('cpf:flux', {
+      'xmlns:cpf': `urn:cdc:cpf:pc5:schema:${schemaVersion}`,
+      'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+    })
+      .ele('cpf:idFlux').txt(uuidv4()).up()
+      .ele('cpf:horodatage').txt(moment().format('YYYY-MM-DDThh:mm:ssZ')).up()
+      .ele('cpf:emetteur')
+        .ele('cpf:idClient').txt(cpf.idClient).up()
+        .ele('cpf:certificateurs')
+          .ele('cpf:certificateur')
+            .ele('cpf:idClient').txt(cpf.idClient).up()
+            .ele('cpf:idContrat').txt(cpf.idContrat).up()
+            .ele('cpf:certifications')
+              .ele('cpf:certification')
+                .ele('cpf:type').txt('RS').up()
+                .ele('cpf:code').txt(cpf.codeFranceConnect).up()
+                .ele('cpf:natureDeposant').txt('CERTIFICATEUR').up()
+                .ele('cpf:passageCertifications');
+
+  bluebird
+    .each(
+      cpfCertificationResults,
+      async function ({
+        id,
+        publishedAt,
+        pixScore,
+        firstName,
+        lastName,
+        birthdate,
+        sex,
+        birthINSEECode,
+        birthPostalCode,
+        europeanNumericLevels,
+      }) {
+        const [yearOfBirth, monthOfBirth, dayOfBirth] = birthdate.split('-');
+        xmlBuilder
+          .ele('cpf:passageCertification')
+            .ele('cpf:idTechnique').txt(id).up()
+            .ele('cpf:obtentionCertification').txt('PAR_SCORING').up()
+            .ele('cpf:donneeCertifiee').txt(true).up()
+            .ele('cpf:dateDebutValidite').txt(moment(publishedAt).format('YYYY-MM-DD')).up()
+            .ele('cpf:dateFinValidite', { 'xsi:nil': true }).up()
+            .ele('cpf:presenceNiveauLangueEuro').txt(false).up()
+            .ele('cpf:presenceNiveauNumeriqueEuro').txt(true).up()
+            .ele('cpf:niveauNumeriqueEuropeen')
+              .ele('cpf:scoreGeneral').txt(pixScore).up()
+              .ele('cpf:resultats');
+
+        europeanNumericLevels.forEach(({ domainCompetenceId, competenceId, level }) => {
+          xmlBuilder
+            .ele('cpf:resultat')
+              .ele('cpf:niveau').txt(level).up()
+              .ele('cpf:domaineCompetenceId').txt(domainCompetenceId).up()
+              .ele('cpf:competenceId').txt(competenceId).up()
+            .up();
+        });
+
+        xmlBuilder.up().up();
+        xmlBuilder
+          .ele('cpf:scoring').txt(pixScore).up()
+          .ele('cpf:mentionValidee', { 'xsi:nil': true }).up()
+          .ele('cpf:modalitesInscription')
+            .ele('cpf:modaliteAcces', { 'xsi:nil': true }).up()
+          .up()
+          .ele('cpf:identificationTitulaire')
+            .ele('cpf:titulaire')
+              .ele('cpf:nomNaissance').txt(lastName).up()
+              .ele('cpf:nomUsage', { 'xsi:nil': true }).up()
+              .ele('cpf:prenom1').txt(firstName).up()
+              .ele('cpf:anneeNaissance').txt(yearOfBirth).up()
+              .ele('cpf:moisNaissance').txt(monthOfBirth).up()
+              .ele('cpf:jourNaissance').txt(dayOfBirth).up()
+              .ele('cpf:sexe').txt(sex).up()
+              .ele('cpf:codeCommuneNaissance')
+
+        if (birthINSEECode) {
+          xmlBuilder.ele('cpf:codeInseeNaissance')
+                      .ele('cpf:codeInsee').txt(birthINSEECode).up()
+                    .up();
+        } else if (birthPostalCode) {
+          xmlBuilder.ele('cpf:codePostalNaissance')
+                      .ele('cpf:codePostal').txt(birthPostalCode).up()
+                    .up();
+        } else {
+          xmlBuilder.ele('cpf:codePostalNaissance')
+                      .ele('cpf:codePostal', { 'xsi:nil': true }).up()
+                    .up();
+        }
+        xmlBuilder.up().up().up().up();
+      }
+    )
+    .then(() => {
+      xmlBuilder.up().up().up().up();
+      xmlBuilder.end();
+    });
+}
+
+module.exports = {
+  getXmlExport,
+};

--- a/api/lib/domain/usecases/get-cpf-certification-results.js
+++ b/api/lib/domain/usecases/get-cpf-certification-results.js
@@ -1,0 +1,3 @@
+module.exports = async function getCpfCertificationResults({ startDate, endDate, cpfCertificationResultRepository }) {
+  return cpfCertificationResultRepository.findByTimeRange({ startDate, endDate });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -70,6 +70,7 @@ const dependencies = {
   correctionRepository: require('../../infrastructure/repositories/correction-repository'),
   countryRepository: require('../../infrastructure/repositories/country-repository'),
   courseRepository: require('../../infrastructure/repositories/course-repository'),
+  cpfCertificationResultRepository: require('../../infrastructure/repositories/cpf-certification-result-repository'),
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
   endTestScreenRemovalService: require('../services/end-test-screen-removal-service'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -301,6 +301,7 @@ module.exports = injectDependencies(
     getCertificationPointOfContact: require('./get-certification-point-of-contact'),
     getChallengeForPixAutoAnswer: require('./get-challenge-for-pix-auto-answer'),
     getCorrectionForAnswer: require('./get-correction-for-answer'),
+    getCpfCertificationResults: require('./get-cpf-certification-results'),
     getCurrentUser: require('./get-current-user'),
     getExternalAuthenticationRedirectionUrl: require('./get-external-authentication-redirection-url'),
     getJurySession: require('./get-jury-session'),

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -1,0 +1,37 @@
+const { knex } = require('../bookshelf');
+const CpfCertificationResult = require('../../domain/read-models/CpfCertificationResult');
+const AssessmentResult = require('../../domain/models/AssessmentResult');
+
+module.exports = {
+  async findByTimeRange({ startDate, endDate }) {
+    const certificationCourses = await knex('certification-courses')
+      .select('certification-courses.*', 'assessment-results.pixScore', 'sessions.publishedAt')
+      .select(
+        knex.raw(`
+        json_agg(json_build_object(
+          'competenceCode', "competence-marks"."competence_code",
+          'level', "competence-marks"."level"
+        ) ORDER BY "competence-marks"."competence_code" asc) as "competenceMarks"`)
+      )
+      .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
+      .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+      .innerJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+      .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
+      .whereNotExists(
+        knex
+          .select(1)
+          .from({ 'last-assessment-results': 'assessment-results' })
+          .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
+          .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
+      )
+      .where('certification-courses.isPublished', true)
+      .where('certification-courses.isCancelled', false)
+      .where('assessment-results.status', AssessmentResult.status.VALIDATED)
+      .where('sessions.publishedAt', '>=', startDate)
+      .where('sessions.publishedAt', '<=', endDate)
+      .groupBy('certification-courses.id', 'assessment-results.pixScore', 'sessions.publishedAt')
+      .orderBy(['sessions.publishedAt', 'certification-courses.lastName', 'certification-courses.firstName']);
+
+    return certificationCourses.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
+  },
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -71,6 +71,7 @@
         "xlsx": "^0.18.5",
         "xml-buffer-tostring": "^0.2.0",
         "xml2js": "^0.4.23",
+        "xmlbuilder2": "^3.0.2",
         "xmldom": "^0.6.0",
         "xregexp": "^5.1.1",
         "yargs": "^17.5.1"
@@ -98,6 +99,7 @@
         "npm-run-all": "^4.1.5",
         "pino-pretty": "^8.0.0",
         "prettier": "^2.7.1",
+        "proxyquire": "^2.1.3",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
         "stream-to-promise": "^3.0.0"
@@ -1347,6 +1349,50 @@
       "integrity": "sha512-6RU5ol2lDtO8bD9Yxe6CZkl0DArdv0qkuoZC+ZwowU+cdRlVE1157wjCmlA5Rsf1Xc/brACnsZa5PZpEDfTFFg==",
       "dependencies": {
         "make-plural": "^7.0.0"
+      }
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/@pdf-lib/fontkit": {
@@ -4507,6 +4553,19 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5868,6 +5927,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -6830,6 +6898,12 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "dev": true
+    },
     "node_modules/messageformat": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
@@ -7217,6 +7291,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true
     },
     "node_modules/moment": {
       "version": "2.29.3",
@@ -8516,6 +8596,17 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "node_modules/psl": {
@@ -10761,6 +10852,41 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xmlbuilder2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz",
+      "integrity": "sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "@types/node": "*",
+        "js-yaml": "3.14.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/xmldom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
@@ -12008,6 +12134,38 @@
       "requires": {
         "make-plural": "^7.0.0"
       }
+    },
+    "@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "requires": {
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ=="
     },
     "@pdf-lib/fontkit": {
       "version": "1.1.1",
@@ -14404,6 +14562,16 @@
         "token-types": "^4.1.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -15391,6 +15559,12 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true
+    },
     "is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -16145,6 +16319,12 @@
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "dev": true
+    },
     "messageformat": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
@@ -16432,6 +16612,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true
     },
     "moment": {
       "version": "2.29.3",
@@ -17413,6 +17599,17 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
     },
     "psl": {
       "version": "1.1.31",
@@ -19108,6 +19305,37 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "xmlbuilder2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz",
+      "integrity": "sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==",
+      "requires": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "@types/node": "*",
+        "js-yaml": "3.14.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
     },
     "xmldom": {
       "version": "0.6.0",

--- a/api/package.json
+++ b/api/package.json
@@ -77,6 +77,7 @@
     "xlsx": "^0.18.5",
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.4.23",
+    "xmlbuilder2": "^3.0.2",
     "xmldom": "^0.6.0",
     "xregexp": "^5.1.1",
     "yargs": "^17.5.1"
@@ -104,6 +105,7 @@
     "npm-run-all": "^4.1.5",
     "pino-pretty": "^8.0.0",
     "prettier": "^2.7.1",
+    "proxyquire": "^2.1.3",
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
     "stream-to-promise": "^3.0.0"

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -4,6 +4,7 @@ const {
   generateValidRequestAuthorizationHeader,
   mockLearningContent,
   learningContentBuilder,
+  insertUserWithRoleSuperAdmin,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
@@ -554,6 +555,28 @@ describe('Acceptance | API | Certifications', function () {
         expect(response.headers['content-disposition']).to.include('filename=attestation-pix');
         expect(response.file).not.to.be.null;
       });
+    });
+  });
+
+  describe('GET /api/admin/cpf/export', function () {
+    it('should return a XML file with the certification information for the CPF', async function () {
+      // given
+      const admin = await insertUserWithRoleSuperAdmin();
+      options = {
+        method: 'GET',
+        url: `/api/admin/cpf/export?startDate=2022-01-01&endDate=2022-01-10`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(admin.id) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.headers['content-type']).to.equal('text/xml;charset=utf-8');
+      expect(response.headers['content-disposition']).to.include(
+        'attachment; filename="pix-cpf-export-from-2022-01-01-to-2022-01-10.xml"'
+      );
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -1,0 +1,319 @@
+const { databaseBuilder, domainBuilder, expect } = require('../../../test-helper');
+const cpfCertificationResultRepository = require('../../../../lib/infrastructure/repositories/cpf-certification-result-repository');
+const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+
+describe('Integration | Repository | CpfCertificationResult', function () {
+  describe('#findByTimeRange', function () {
+    it('should return an array of CpfCertificationResult', async function () {
+      // given
+      const startDate = new Date('2022-01-01');
+      const endDate = new Date('2022-01-10');
+
+      const firstPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 145,
+        firstName: 'Barack',
+        lastName: 'Afritt',
+        birthdate: '2004-10-22',
+        sex: 'M',
+        birthINSEECode: '75116',
+        birthPostalCode: null,
+        isPublished: true,
+        sessionId: firstPublishedSessionId,
+      }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 2244,
+        pixScore: 132,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 145,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 5,
+        competence_code: '1.2',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 5,
+        competence_code: '2.3',
+      });
+
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 245,
+        firstName: 'Ahmed',
+        lastName: 'Épan',
+        birthdate: '2004-06-12',
+        sex: 'M',
+        birthINSEECode: null,
+        birthPostalCode: '75008',
+        isPublished: true,
+        sessionId: firstPublishedSessionId,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 4466,
+        pixScore: 112,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 245,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4466,
+        level: 5,
+        competence_code: '3.1',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4466,
+        level: 4,
+        competence_code: '2.3',
+      });
+
+      const secondPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-10') }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 345,
+        firstName: 'Cécile',
+        lastName: 'En cieux',
+        birthdate: '2004-03-04',
+        sex: 'F',
+        birthINSEECode: '75114',
+        birthPostalCode: null,
+        isPublished: true,
+        sessionId: secondPublishedSessionId,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 4467,
+        pixScore: 268,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 345,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4467,
+        level: 2,
+        competence_code: '2.1',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4467,
+        level: 4,
+        competence_code: '3.1',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        startDate,
+        endDate,
+      });
+
+      // then
+      expect(cpfCertificationResults).to.deepEqualArray([
+        domainBuilder.buildCpfCertificationResult({
+          id: 145,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          pixScore: 132,
+          publishedAt: new Date('2022-01-04'),
+          competenceMarks: [
+            {
+              competenceCode: '1.2',
+              level: 5,
+            },
+            {
+              competenceCode: '2.3',
+              level: 5,
+            },
+          ],
+        }),
+        domainBuilder.buildCpfCertificationResult({
+          id: 245,
+          firstName: 'Ahmed',
+          lastName: 'Épan',
+          birthdate: '2004-06-12',
+          sex: 'M',
+          birthINSEECode: null,
+          birthPostalCode: '75008',
+          pixScore: 112,
+          publishedAt: new Date('2022-01-04'),
+          competenceMarks: [
+            {
+              competenceCode: '2.3',
+              level: 4,
+            },
+            {
+              competenceCode: '3.1',
+              level: 5,
+            },
+          ],
+        }),
+        domainBuilder.buildCpfCertificationResult({
+          id: 345,
+          firstName: 'Cécile',
+          lastName: 'En cieux',
+          birthdate: '2004-03-04',
+          sex: 'F',
+          birthINSEECode: '75114',
+          birthPostalCode: null,
+          pixScore: 268,
+          publishedAt: new Date('2022-01-10'),
+          competenceMarks: [
+            {
+              competenceCode: '2.1',
+              level: 2,
+            },
+            {
+              competenceCode: '3.1',
+              level: 4,
+            },
+          ],
+        }),
+      ]);
+    });
+
+    context('when the certification course is not published', function () {
+      it('should return an empty array', async function () {
+        // given
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+
+        const publishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-05') }).id;
+        databaseBuilder.factory.buildCertificationCourse({
+          id: 145,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          isPublished: false,
+          sessionId: publishedSessionId,
+        }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
+
+    context('when the certification course is cancelled', function () {
+      it('should return an empty array', async function () {
+        // given
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+
+        const publishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-05') }).id;
+        databaseBuilder.factory.buildCertificationCourse({
+          id: 145,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          isPublished: true,
+          isCancelled: true,
+          sessionId: publishedSessionId,
+        }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
+
+    context('when the latest assessment result is not validated', function () {
+      it('should return an empty array', async function () {
+        // given
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+
+        const publishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-05') }).id;
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          id: 145,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          isPublished: true,
+          isCancelled: false,
+          sessionId: publishedSessionId,
+        }).id;
+        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+          pixScore: 268,
+          status: AssessmentResult.status.REJECTED,
+          assessmentId: databaseBuilder.factory.buildAssessment({
+            certificationCourseId,
+          }).id,
+        }).id;
+        databaseBuilder.factory.buildCompetenceMark({
+          assessmentResultId,
+          level: 2,
+          competence_code: '2.1',
+        });
+        databaseBuilder.factory.buildCompetenceMark({
+          assessmentResultId,
+          level: 4,
+          competence_code: '3.1',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
+
+    context('when the session publication date is ouf of bounds', function () {
+      it('should return an empty array', async function () {
+        // given
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+
+        const publishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-15') }).id;
+        databaseBuilder.factory.buildCertificationCourse({
+          id: 145,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          isPublished: true,
+          sessionId: publishedSessionId,
+        }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
@@ -1,0 +1,30 @@
+const CpfCertificationResult = require('../../../../lib/domain/read-models/CpfCertificationResult');
+
+module.exports = function buildCpfCertificationResult({
+  id = 1234,
+  firstName = 'John',
+  lastName = 'Doe',
+  birthdate = new Date('2000-01-01'),
+  sex = 'M',
+  birthINSEECode = '75115',
+  birthPostalCode = '75015',
+  publishedAt = new Date(),
+  pixScore = 100,
+  competenceMarks = [
+    { competenceCode: '1.2', level: 3 },
+    { competenceCode: '2.4', level: 5 },
+  ],
+} = {}) {
+  return new CpfCertificationResult({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    sex,
+    birthINSEECode,
+    birthPostalCode,
+    publishedAt,
+    pixScore,
+    competenceMarks,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -65,6 +65,7 @@ module.exports = {
   buildComplementaryCertificationHabilitation: require('./build-complementary-certification-habilitation'),
   buildCountry: require('./build-country'),
   buildCourse: require('./build-course'),
+  buildCpfCertificationResult: require('./build-cpf-certification-result'),
   buildFinalizedSession: require('./build-finalized-session'),
   buildHint: require('./build-hint'),
   buildSupOrganizationLearner: require('./build-sup-organization-learner'),

--- a/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
+++ b/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
@@ -1,0 +1,311 @@
+const { expect } = require('../../../test-helper');
+const EuropeanNumericLevelFactory = require('../../../../lib/domain/read-models/EuropeanNumericLevelFactory');
+const EuropeanNumericLevel = require('../../../../lib/domain/read-models/EuropeanNumericLevel');
+
+describe('Unit | Domain | Read-models | EuropeanNumericLevelFactory', function () {
+  describe('static #buildFromCompetenceMarks', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    ['3.4', '4.1', '4.2', '5.1', '5.2'].forEach((competenceCode) => {
+      it(`should build an EuropeanNumericLevel with for competence '${competenceCode}'`, function () {
+        // given
+        const competenceMark = { competenceCode, level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        const [domainCompetenceId, competenceId] = competenceCode.split('.');
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId,
+            competenceId,
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when competence code is '1.1'`, function () {
+      it(`should return two EuropeanNumericLevel for competence '1.1' and '1.2'`, function () {
+        // given
+        const competenceMark = { competenceCode: '1.1', level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '1',
+            competenceId: '1',
+            level: 4,
+          }),
+          new EuropeanNumericLevel({
+            domainCompetenceId: '1',
+            competenceId: '2',
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when competence code is '2.1'`, function () {
+      it(`should return two EuropeanNumericLevel for competence '2.1' and '2.5'`, function () {
+        // given
+        const competenceMark = { competenceCode: '2.1', level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '2',
+            competenceId: '1',
+            level: 4,
+          }),
+          new EuropeanNumericLevel({
+            domainCompetenceId: '2',
+            competenceId: '5',
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when competence code is '2.3'`, function () {
+      it(`should return an EuropeanNumericLevel for competence '2.4'`, function () {
+        // given
+        const competenceMark = { competenceCode: '2.3', level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '2',
+            competenceId: '4',
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when competence code is '2.4'`, function () {
+      it(`should return two EuropeanNumericLevel for competences '2.3', '2.6' and '5.4'`, function () {
+        // given
+        const competenceMark = { competenceCode: '2.4', level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '2',
+            competenceId: '3',
+            level: 4,
+          }),
+          new EuropeanNumericLevel({
+            domainCompetenceId: '2',
+            competenceId: '6',
+            level: 4,
+          }),
+          new EuropeanNumericLevel({
+            domainCompetenceId: '5',
+            competenceId: '4',
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when competence code is '3.3'`, function () {
+      it(`should return two EuropeanNumericLevel for competences '3.2' and '3.3'`, function () {
+        // given
+        const competenceMark = { competenceCode: '3.3', level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '3',
+            competenceId: '2',
+            level: 4,
+          }),
+          new EuropeanNumericLevel({
+            domainCompetenceId: '3',
+            competenceId: '3',
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when competence code is '4.3'`, function () {
+      it(`should return two EuropeanNumericLevel for competences '4.3' and '4.4'`, function () {
+        // given
+        const competenceMark = { competenceCode: '4.3', level: 4 };
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks([competenceMark]);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '4',
+            competenceId: '3',
+            level: 4,
+          }),
+          new EuropeanNumericLevel({
+            domainCompetenceId: '4',
+            competenceId: '4',
+            level: 4,
+          })
+        );
+      });
+    });
+
+    context(`when there are competence marks for competence '1.2' and '1.3'`, function () {
+      it(`should return an EuropeanNumericLevel for competence '1.3' with the level equals to the average of both levels`, function () {
+        // given
+        const competenceMarks = [
+          { competenceCode: '1.2', level: 4 },
+          { competenceCode: '1.3', level: 8 },
+        ];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '1',
+            competenceId: '3',
+            level: 6,
+          })
+        );
+      });
+    });
+
+    context(`when there is a competence mark for competence '1.2' but none for competence '1.3'`, function () {
+      it(`should not return an EuropeanNumericLevel for competence '1.3'`, function () {
+        // given
+        const competenceMarks = [{ competenceCode: '1.2', level: 4 }];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.not.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '1',
+            competenceId: '3',
+            level: 6,
+          })
+        );
+      });
+    });
+
+    context(`when there is a competence mark for competence '1.3' but none for competence '1.2'`, function () {
+      it(`should not return an EuropeanNumericLevel for competence '1.3'`, function () {
+        // given
+        const competenceMarks = [{ competenceCode: '1.3', level: 4 }];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.not.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '1',
+            competenceId: '3',
+            level: 6,
+          })
+        );
+      });
+    });
+
+    context(`when there are competence marks for competence '3.1' and '3.2'`, function () {
+      it(`should return an EuropeanNumericLevel for competence '3.1' with the level equals to the average of both levels `, function () {
+        // given
+        const competenceMarks = [
+          { competenceCode: '3.1', level: 4 },
+          { competenceCode: '3.2', level: 8 },
+        ];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '3',
+            competenceId: '1',
+            level: 6,
+          })
+        );
+      });
+    });
+
+    context(`when there is a competence mark for competence '3.1' but none for competence '3.2'`, function () {
+      it(`should not return an EuropeanNumericLevel for competence '3.1'`, function () {
+        // given
+        const competenceMarks = [{ competenceCode: '3.1', level: 4 }];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.not.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '3',
+            competenceId: '1',
+            level: 6,
+          })
+        );
+      });
+    });
+
+    context(`when there is a competence mark for competence '3.2' but none for competence '3.1'`, function () {
+      it(`should not return an EuropeanNumericLevel for competence '3.1'`, function () {
+        // given
+        const competenceMarks = [{ competenceCode: '3.2', level: 4 }];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.not.deep.contains(
+          new EuropeanNumericLevel({
+            domainCompetenceId: '3',
+            competenceId: '1',
+            level: 6,
+          })
+        );
+      });
+    });
+
+    context('when there are competence marks', function () {
+      it(`should return an EuropeanNumericLevel for competence '5.3' with level equal to the average of all competence marks levels`, function () {
+        // given
+        const competenceMarks = [
+          { competenceCode: '3.4', level: 8 },
+          { competenceCode: '4.1', level: 5 },
+          { competenceCode: '4.2', level: 3 },
+        ];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.deep.contains(
+          new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: 5 })
+        );
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -1,0 +1,325 @@
+const { expect, domainBuilder, sinon, streamToPromise } = require('../../../test-helper');
+const { PassThrough } = require('stream');
+const proxyquire = require('proxyquire');
+const moment = require('moment');
+const cpfCertificationXmlExportService = proxyquire(
+  '../../../../lib/domain/services/cpf-certification-xml-export-service',
+  {
+    uuid: {
+      v4: () => {
+        return '5d079a5d-0a4d-45ac-854d-256b01cacdfe';
+      },
+    },
+  }
+);
+
+describe('Unit | Services | cpf-certification-xml-export-service', function () {
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('getXmlExport', function () {
+    it('should return an writable stream with cpf certification results', async function () {
+      // given
+      const firstCpfCertificationResult = domainBuilder.buildCpfCertificationResult({
+        id: 1234,
+        firstName: 'Bart',
+        lastName: 'Haba',
+        birthdate: '1993-05-23',
+        sex: 'M',
+        birthINSEECode: null,
+        birthPostalCode: '75002',
+        publishedAt: '2022-01-03',
+        pixScore: 324,
+        competenceMarks: [
+          { competenceCode: '2.1', level: 4 },
+          { competenceCode: '3.2', level: 3 },
+        ],
+      });
+
+      const secondCpfCertificationResult = domainBuilder.buildCpfCertificationResult({
+        id: 4567,
+        firstName: 'Eva',
+        lastName: 'Porée',
+        birthdate: '1992-11-03',
+        sex: 'F',
+        birthINSEECode: '75114',
+        birthPostalCode: null,
+        publishedAt: '2022-01-07',
+        pixScore: 512,
+        competenceMarks: [
+          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '4.2', level: 2 },
+        ],
+      });
+      const writableStream = new PassThrough();
+
+      // when
+      cpfCertificationXmlExportService.getXmlExport({
+        cpfCertificationResults: [firstCpfCertificationResult, secondCpfCertificationResult],
+        writableStream,
+        opts: { prettyPrint: true },
+      });
+
+      //then
+      const expectedXmlExport = _getExpectedXmlExport();
+      const xmlExport = await streamToPromise(writableStream);
+      expect(xmlExport).to.equal(expectedXmlExport);
+    });
+  });
+});
+
+function _getExpectedXmlExport() {
+  return `<?xml version="1.0"?>
+<cpf:flux xmlns:cpf="urn:cdc:cpf:pc5:schema:1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <cpf:idFlux>
+    5d079a5d-0a4d-45ac-854d-256b01cacdfe
+  </cpf:idFlux>
+  <cpf:horodatage>
+    ${moment(new Date()).format('YYYY-MM-DDThh:mm:ssZ')}
+  </cpf:horodatage>
+  <cpf:emetteur>
+    <cpf:idClient>
+      03VML243
+    </cpf:idClient>
+    <cpf:certificateurs>
+      <cpf:certificateur>
+        <cpf:idClient>
+          03VML243
+        </cpf:idClient>
+        <cpf:idContrat>
+          MCFCER000209
+        </cpf:idContrat>
+        <cpf:certifications>
+          <cpf:certification>
+            <cpf:type>
+              RS
+            </cpf:type>
+            <cpf:code>
+              RS5875
+            </cpf:code>
+            <cpf:natureDeposant>
+              CERTIFICATEUR
+            </cpf:natureDeposant>
+            <cpf:passageCertifications>
+              <cpf:passageCertification>
+                <cpf:idTechnique>
+                  1234
+                </cpf:idTechnique>
+                <cpf:obtentionCertification>
+                  PAR_SCORING
+                </cpf:obtentionCertification>
+                <cpf:donneeCertifiee>
+                  true
+                </cpf:donneeCertifiee>
+                <cpf:dateDebutValidite>
+                  2022-01-03
+                </cpf:dateDebutValidite>
+                <cpf:dateFinValidite xsi:nil="true"></cpf:dateFinValidite>
+                <cpf:presenceNiveauLangueEuro>
+                  false
+                </cpf:presenceNiveauLangueEuro>
+                <cpf:presenceNiveauNumeriqueEuro>
+                  true
+                </cpf:presenceNiveauNumeriqueEuro>
+                <cpf:niveauNumeriqueEuropeen>
+                  <cpf:scoreGeneral>
+                    324
+                  </cpf:scoreGeneral>
+                  <cpf:resultats>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        4
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        2
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        1
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        4
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        2
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        5
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        4
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        5
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        3
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                  </cpf:resultats>
+                </cpf:niveauNumeriqueEuropeen>
+                <cpf:scoring>
+                  324
+                </cpf:scoring>
+                <cpf:mentionValidee xsi:nil="true"></cpf:mentionValidee>
+                <cpf:modalitesInscription>
+                  <cpf:modaliteAcces xsi:nil="true"></cpf:modaliteAcces>
+                </cpf:modalitesInscription>
+                <cpf:identificationTitulaire>
+                  <cpf:titulaire>
+                    <cpf:nomNaissance>
+                      Haba
+                    </cpf:nomNaissance>
+                    <cpf:nomUsage xsi:nil="true"></cpf:nomUsage>
+                    <cpf:prenom1>
+                      Bart
+                    </cpf:prenom1>
+                    <cpf:anneeNaissance>
+                      1993
+                    </cpf:anneeNaissance>
+                    <cpf:moisNaissance>
+                      05
+                    </cpf:moisNaissance>
+                    <cpf:jourNaissance>
+                      23
+                    </cpf:jourNaissance>
+                    <cpf:sexe>
+                      M
+                    </cpf:sexe>
+                    <cpf:codeCommuneNaissance>
+                      <cpf:codePostalNaissance>
+                        <cpf:codePostal>
+                          75002
+                        </cpf:codePostal>
+                      </cpf:codePostalNaissance>
+                    </cpf:codeCommuneNaissance>
+                  </cpf:titulaire>
+                </cpf:identificationTitulaire>
+              </cpf:passageCertification>
+              <cpf:passageCertification>
+                <cpf:idTechnique>
+                  4567
+                </cpf:idTechnique>
+                <cpf:obtentionCertification>
+                  PAR_SCORING
+                </cpf:obtentionCertification>
+                <cpf:donneeCertifiee>
+                  true
+                </cpf:donneeCertifiee>
+                <cpf:dateDebutValidite>
+                  2022-01-07
+                </cpf:dateDebutValidite>
+                <cpf:dateFinValidite xsi:nil="true"></cpf:dateFinValidite>
+                <cpf:presenceNiveauLangueEuro>
+                  false
+                </cpf:presenceNiveauLangueEuro>
+                <cpf:presenceNiveauNumeriqueEuro>
+                  true
+                </cpf:presenceNiveauNumeriqueEuro>
+                <cpf:niveauNumeriqueEuropeen>
+                  <cpf:scoreGeneral>
+                    512
+                  </cpf:scoreGeneral>
+                  <cpf:resultats>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        1
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        1
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        1
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        1
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        1
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        2
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        2
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        4
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        2
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                    <cpf:resultat>
+                      <cpf:niveau>
+                        1
+                      </cpf:niveau>
+                      <cpf:domaineCompetenceId>
+                        5
+                      </cpf:domaineCompetenceId>
+                      <cpf:competenceId>
+                        3
+                      </cpf:competenceId>
+                    </cpf:resultat>
+                  </cpf:resultats>
+                </cpf:niveauNumeriqueEuropeen>
+                <cpf:scoring>
+                  512
+                </cpf:scoring>
+                <cpf:mentionValidee xsi:nil="true"></cpf:mentionValidee>
+                <cpf:modalitesInscription>
+                  <cpf:modaliteAcces xsi:nil="true"></cpf:modaliteAcces>
+                </cpf:modalitesInscription>
+                <cpf:identificationTitulaire>
+                  <cpf:titulaire>
+                    <cpf:nomNaissance>
+                      Porée
+                    </cpf:nomNaissance>
+                    <cpf:nomUsage xsi:nil="true"></cpf:nomUsage>
+                    <cpf:prenom1>
+                      Eva
+                    </cpf:prenom1>
+                    <cpf:anneeNaissance>
+                      1992
+                    </cpf:anneeNaissance>
+                    <cpf:moisNaissance>
+                      11
+                    </cpf:moisNaissance>
+                    <cpf:jourNaissance>
+                      03
+                    </cpf:jourNaissance>
+                    <cpf:sexe>
+                      F
+                    </cpf:sexe>
+                    <cpf:codeCommuneNaissance>
+                      <cpf:codeInseeNaissance>
+                        <cpf:codeInsee>
+                          75114
+                        </cpf:codeInsee>
+                      </cpf:codeInseeNaissance>
+                    </cpf:codeCommuneNaissance>
+                  </cpf:titulaire>
+                </cpf:identificationTitulaire>
+              </cpf:passageCertification>
+            </cpf:passageCertifications>
+          </cpf:certification>
+        </cpf:certifications>
+      </cpf:certificateur>
+    </cpf:certificateurs>
+  </cpf:emetteur>
+</cpf:flux>`;
+}

--- a/api/tests/unit/domain/usecases/get-cpf-certification-results_test.js
+++ b/api/tests/unit/domain/usecases/get-cpf-certification-results_test.js
@@ -1,0 +1,38 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const getCpfCertificationResults = require('../../../../lib/domain/usecases/get-cpf-certification-results');
+
+describe('Unit | UseCase | get-cpf-certification-results', function () {
+  let cpfCertificationResultRepository;
+
+  beforeEach(function () {
+    cpfCertificationResultRepository = {
+      findByTimeRange: sinon.stub(),
+    };
+  });
+
+  it('should return cpf certification results', async function () {
+    // given
+    const startDate = new Date('2022-01-01');
+    const endDate = new Date('2022-01-10');
+
+    const expectedCpfCertificationResults = [
+      domainBuilder.buildCpfCertificationResult(),
+      domainBuilder.buildCpfCertificationResult(),
+      domainBuilder.buildCpfCertificationResult(),
+    ];
+
+    cpfCertificationResultRepository.findByTimeRange
+      .withArgs({ startDate, endDate })
+      .resolves(expectedCpfCertificationResults);
+
+    // when
+    const cpfCertificationResults = await getCpfCertificationResults({
+      startDate,
+      endDate,
+      cpfCertificationResultRepository,
+    });
+
+    // then
+    expect(cpfCertificationResults).to.deepEqualArray(expectedCpfCertificationResults);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Conformément au décret [n° 2019-1490 du 27 décembre 2019](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000039685260) et au décret [n° 2020-894 du 22 juillet 2020](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042138295/), Pix a l’obligation depuis le premier juillet 2021 de transmettre au système d'information du compte personnel de formation des informations relatives aux titulaires des certifications enregistrées aux répertoires nationaux. En l’occurrence, cela concerne toute personne titulaire de la certification Pix dans les trois mois maximum suivant la délivrance de la certification.

Les données dont la transmission est obligatoire sont maintenant collectées pour nos certif. Il s’agit maintenant de permettre à transmission de ces données au CPF.

La procédure retenue par le CPF actuellement consiste à générer un ou plusieurs fichiers XML, de 200 Mo maximum, et de l'/les envoyer via un formulaire mis à disposition par le CPF.

## :robot: Solution
- Créer un endpoint permettant de télécharger un fichier au format XML respectant le dictionnaire des données fourni (
[Dictionnaire-des-donnees-Accrochage-Certificateurs.pdf](https://github.com/1024pix/pix/files/9029074/Dictionnaire-des-donnees-Accrochage-Certificateurs.pdf))

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Ouvrir le lien https://app-pr4604.review.pix.fr/api/admin/cpf/export?startDate=2022-01-01&endDate=2022-01-02 et vérifier que le fichier se télécharge bien