### PR TITLE
[TECH] Empêcher le chevauchement :horse: des seeds et des données de test automatiques.

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -47,10 +47,16 @@ module.exports = class DatabaseBuilder {
   }
 
   /**
+   * Database builder is used to create data:
+   *   - for automated tests;
+   *   - for manual tests (aka "seeds").
+   *
+   * To make tests and seeds easier to write, identifiers are defined in the file and passed to the database builder.
+   * (In a production environment, this never happens. The database is the only in charge of supplying an identifier
+   * using a sequence).
    * Inserting elements in PGSQL when specifying their ID does not update the sequence for that id.
-   * THis results in id conflict errors when trying to insert a new elements in the base.
-   * Making the sequences start at an arbitrary high number prevents the problem from happening for a time.
-   * (time being enough for dev ou review apps - seed are not run on staging or prod)
+   * It is hence important to update sequences to avoid conflict with hard coded identifier
+   * i.e. ERROR: duplicate key value violates unique constraint "pk_***"
    */
   async fixSequences() {
     const dirtyTables = this._selectDirtyTables();

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const bluebird = require('bluebird');
 const factory = require('./factory/index');
 const databaseBuffer = require('./database-buffer');
 
@@ -43,6 +44,50 @@ module.exports = class DatabaseBuilder {
     }
     this.databaseBuffer.purge();
     this._purgeDirtiness();
+  }
+
+  /**
+   * Inserting elements in PGSQL when specifying their ID does not update the sequence for that id.
+   * THis results in id conflict errors when trying to insert a new elements in the base.
+   * Making the sequences start at an arbitrary high number prevents the problem from happening for a time.
+   * (time being enough for dev ou review apps - seed are not run on staging or prod)
+   */
+  async fixSequences() {
+    const dirtyTables = this._selectDirtyTables();
+    if (dirtyTables.length === 0) {
+      return;
+    }
+    const dirtyTablesSequencesInfo = await this._getSequencesInfo(dirtyTables);
+
+    return bluebird.mapSeries(dirtyTablesSequencesInfo, async ({ tableName, sequenceName }) => {
+      const sequenceRestartAtNumber = (await this._getTableMaxId(tableName)) + 1;
+      if (sequenceRestartAtNumber !== 0) {
+        /* eslint-disable-next-line knex/avoid-injections */
+        await this.knex.raw(`ALTER SEQUENCE "${sequenceName}" RESTART WITH ${sequenceRestartAtNumber};`);
+      }
+    });
+  }
+
+  async _getSequencesInfo(dirtyTables) {
+    const database = this.knex.client.database();
+
+    const rawSequencesInfo = await this.knex
+      .from('information_schema.columns')
+      .select('table_name', 'column_default')
+      .whereRaw("column_default like 'nextval%'")
+      .where({ table_catalog: database, column_name: 'id' })
+      .whereIn('table_name', dirtyTables);
+
+    const sequencesInfo = rawSequencesInfo.map(({ table_name, column_default }) => ({
+      tableName: table_name,
+      sequenceName: column_default.replaceAll('"', '').slice("nextval('".length, -"'::regclass)".length),
+    }));
+    return sequencesInfo;
+  }
+
+  async _getTableMaxId(tableName) {
+    const { max } = await this.knex.from(tableName).max('id').first();
+    return max;
   }
 
   async _init() {

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -6,10 +6,10 @@ const SCO_AGRI_ID = 7;
 const SCO_AEFE_ID = 9;
 const SCO_STUDENT_ID = 99;
 const CANADA_INSEE_CODE = '401';
-const SCO_FOREIGNER_USER_ID = 9912;
-const SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION = 9913;
-const SCO_FRENCH_USER_ID = 2339213;
-const SCO_DISABLED_USER_ID = 777;
+const SCO_FOREIGNER_USER_ID = 301;
+const SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION = 302;
+const SCO_FRENCH_USER_ID = 311;
+const SCO_DISABLED_USER_ID = 321;
 const SCO_ADMIN_ID = 4;
 const SCO_MEMBER_ID = 5;
 
@@ -366,7 +366,6 @@ function _buildHighSchools({ databaseBuilder }) {
     userId: null,
     nationalStudentId: '987654321NN',
   });
-
 }
 
 function _buildAgri({ databaseBuilder }) {


### PR DESCRIPTION
## :unicorn: Problème
- Le database-builder fourni les ids via le database-buffer. Une fois toutes les insertions `commit`, les séquences ne sont plus à jour. 
On prends alors l'id du dernier objet inséré et on met à jour les séquences avec.

Cela peut engendrer des erreurs et en particulier si l'on souhaite relancer un database-builder après avoir lancer les seeds, par exemple pour un CLI https://github.com/1024pix/pix/pull/4594
- La creation d'un utilisateur certifiable créé un assessment par compétence et ce n'est pas nécessaire

## :robot: Solution
- On récupère pour chaque table son max id et on met à jour la séquence associée avec la valeur. 
- On met à jour uniquement les séquences des tables "dirty"
- La creation d'un utilisateur certifiable créé un unique assessment pour toutes les compétences

## :rainbow: Remarques
Les ids statiques des database builders doivent être réduit au minimum

## :100: Pour tester
En local ou RA seulement:
Lancer les seeds, s'assurer qu'il n'y a pas d'erreur. 
S'assurer aussi qu'on peut se logger sur une app et créé des utilisateurs/sessions...
