### PR TITLE
[FEATURE] Afficher les informations d'un profil utilisateur dans Pix Admin (PIX-5268)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information.hbs
@@ -21,6 +21,10 @@
   />
 </section>
 
+<section class="page-section mb_10">
+  <Users::UserDetailPersonalInformation::UserProfile @profile={{@user.profile}} />
+</section>
+
 <ConfirmPopup
   @message="Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible."
   @confirm={{this.anonymizeUser}}

--- a/admin/app/components/users/user-detail-personal-information/user-profile.hbs
+++ b/admin/app/components/users/user-detail-personal-information/user-profile.hbs
@@ -1,0 +1,32 @@
+<h2 class="page-section__title">Profil utilisateur</h2>
+
+<div class="user-profile-total-pix">
+  <p class="user-profile-total-pix__score">{{@profile.pixScore}}</p>
+  <p>Total pix obtenu</p>
+</div>
+
+<div class="user-profile-table">
+  <table class="table-admin">
+    <caption class="sr-only">Pix et niveau obtenus en fonction des compétences</caption>
+    <thead>
+      <tr>
+        <th scope="col">Compétences</th>
+        <th scope="col">Pix</th>
+        <th scope="col">Niveau</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @profile.scorecards as |scorecard|}}
+        <tr>
+          <td>{{scorecard.name}}</td>
+          <td>{{scorecard.earnedPix}}</td>
+          <td>{{scorecard.level}}</td>
+        </tr>
+      {{else}}
+        <tr>
+          <td colspan="10" class="table-admin-empty">Aucun résultat</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/admin/app/models/profile.js
+++ b/admin/app/models/profile.js
@@ -4,8 +4,4 @@ export default class Profile extends Model {
   @attr('number') pixScore;
 
   @hasMany('scorecard') scorecards;
-
-  get areasCode() {
-    return this.scorecards.mapBy('area.code').uniq();
-  }
 }

--- a/admin/app/models/scorecard.js
+++ b/admin/app/models/scorecard.js
@@ -1,16 +1,8 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class Scorecard extends Model {
-  @attr('string') description;
   @attr('number') earnedPix;
   @attr('number') index;
   @attr('number') level;
   @attr('string') name;
-  @attr('number') pixScoreAheadOfNextLevel;
-  @attr('number') remainingDaysBeforeReset;
-  @attr('number') remainingDaysBeforeImproving;
-  @attr('string') status;
-
-  // references
-  @attr('string') competenceId;
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -64,6 +64,7 @@
 @import 'components/sessions/list-items.scss';
 @import 'components/users/user-detail-personal-information-section';
 @import 'components/users/user-detail-personal-information/authentication-method';
+@import 'components/users/user-detail-personal-information/user-profile';
 @import 'components/target-profiles/badges';
 @import 'components/target-profiles/target-profile';
 @import 'components/target-profiles/badge-form';

--- a/admin/app/styles/components/users/user-detail-personal-information/user-profile.scss
+++ b/admin/app/styles/components/users/user-detail-personal-information/user-profile.scss
@@ -1,0 +1,14 @@
+.user-profile-table {
+  margin-top: 30px;
+}
+
+.user-profile-total-pix {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  &__score {
+    margin: 0;
+    font-size: 50px;
+  }
+}

--- a/admin/tests/integration/components/users/user-detail-personal-information/schooling-registration-information_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/schooling-registration-information_test.js
@@ -15,6 +15,38 @@ module(
         hasAccessToUsersActionsScope = true;
       }
 
+      module('When user has no schoolingRegistrations', function () {
+        test('should display no result in schooling registrations table', async function (assert) {
+          // given
+          this.toggleDisplayDissociateModal = sinon.spy();
+          this.set('user', { schoolingRegistrations: [] });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(
+            hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}}/>`
+          );
+
+          // then
+          assert.dom(screen.getByText('Aucun résultat')).exists();
+        });
+      });
+
+      test('should display schooling registrations in table', async function (assert) {
+        // given
+        this.toggleDisplayDissociateModal = sinon.spy();
+        this.set('user', { schoolingRegistrations: [{ id: 1 }, { id: 2 }] });
+        this.owner.register('service:access-control', AccessControlStub);
+
+        // when
+        const screen = await render(
+          hbs`<Users::UserDetailPersonalInformation::SchoolingRegistrationInformation @user={{this.user}} @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}}/>`
+        );
+
+        // then
+        assert.strictEqual(screen.getAllByLabelText('Inscription').length, 2);
+      });
+
       test('should display schooling registration’s info', async function (assert) {
         // given
         this.toggleDisplayDissociateModal = sinon.spy();

--- a/admin/tests/integration/components/users/user-detail-personal-information/user-profile_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/user-profile_test.js
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@1024pix/ember-testing-library';
+
+module('Integration | Component |  users | user-detail-personal-information/user-profile', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should display user’s profile', async function (assert) {
+    // given
+    this.set('profile', {
+      pixScore: 1024,
+      scorecards: [
+        { name: 'Ma superbe compétence', earnedPix: 16, level: 1 },
+        { name: 'Ma botte secrète', earnedPix: 48, level: 7 },
+      ],
+    });
+
+    //  when
+    const component = await render(hbs`<Users::UserDetailPersonalInformation::UserProfile @profile={{profile}} />`);
+
+    // then
+    assert.dom(component.getByText(this.profile.pixScore)).exists();
+    assert.dom(component.getByText(this.profile.scorecards[0].name)).exists();
+    assert.dom(component.getByText(this.profile.scorecards[0].earnedPix)).exists();
+    assert.dom(component.getByText(this.profile.scorecards[0].level)).exists();
+    assert.dom(component.getByText(this.profile.scorecards[1].name)).exists();
+    assert.dom(component.getByText(this.profile.scorecards[1].earnedPix)).exists();
+    assert.dom(component.getByText(this.profile.scorecards[1].level)).exists();
+  });
+
+  module('when user profile is empty', function () {
+    test('should display the empty message', async function (assert) {
+      // given
+      this.set('profile', {
+        pixScore: 0,
+      });
+
+      //  when
+      const component = await render(hbs`<Users::UserDetailPersonalInformation::UserProfile @profile={{profile}} />`);
+
+      // then
+      assert.dom(component.getByText('Aucun résultat')).exists();
+    });
+  });
+});

--- a/admin/tests/integration/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information_test.js
@@ -13,62 +13,6 @@ module('Integration | Component | users | user-detail-personal-information', fun
     hasAccessToUsersActionsScope = true;
   }
 
-  module('schooling registrations', function () {
-    module('When user has no schoolingRegistrations', function () {
-      test('should display no result in schooling registrations table', async function (assert) {
-        // given
-        this.set('user', { schoolingRegistrations: [] });
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        // then
-        assert.dom(screen.getByText('Aucun résultat')).exists();
-      });
-    });
-
-    module('When user has schoolingRegistrations', function () {
-      test('should display schooling registrations in table', async function (assert) {
-        // given
-        this.set('user', { schoolingRegistrations: [{ id: 1 }, { id: 2 }] });
-        this.owner.register('service:access-control', AccessControlStub);
-
-        // when
-        const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        // then
-        assert.strictEqual(screen.getAllByLabelText('Inscription').length, 2);
-      });
-
-      module('Display the schooling registrations status', function () {
-        test('Should display a green tick mark on the table when "isDisabled = false"', async function (assert) {
-          // given
-          this.set('user', { schoolingRegistrations: [{ id: 1, isDisabled: false }] });
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
-
-          // then
-          assert.dom(screen.getByLabelText('Inscription activée')).exists();
-        });
-
-        test('Should display a red cross on the table when "isDisabled= true"', async function (assert) {
-          // given
-          this.set('user', { schoolingRegistrations: [{ id: 1, isDisabled: true }] });
-          this.owner.register('service:access-control', AccessControlStub);
-
-          // when
-          const screen = await render(hbs`<Users::UserDetailPersonalInformation @user={{this.user}}/>`);
-
-          // then
-          assert.dom(screen.getByLabelText('Inscription désactivée')).exists();
-        });
-      });
-    });
-  });
-
   module('when the admin member click on anonymize button', function (hooks) {
     let user = null;
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'est pas possible de visualiser le nomber de pix d'un user par compétence dans pix-admin. On souhaite afficher les informations de la même manière que sur le dashboard de metabase :

![image](https://user-images.githubusercontent.com/26234185/177127745-4db05e7f-2a66-4179-84bf-da523afc3fe2.png)

## :robot: Solution
Faire un appel au endpoint créé dans cette PR : https://github.com/1024pix/pix/pull/4600 afin de ramener les informations du profile d'un user dans pix-admin

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter à pix-admin 
- Aller voir le detail d'un user ({review-app-url}/users/{userId})
- Constater qu'en bas de la page on visualise un nouveau tableau contenant les informations du profile d'un user : 

https://user-images.githubusercontent.com/26234185/177132118-b3a3d33e-3d69-437e-8843-ba336ba9c7ca.mov


