### PR TITLE
[BUGFIX] Corriger le design de la checkbox sur la page d'inscription de Pix App (PIX-5241)

### DIFF
--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -69,7 +69,7 @@ input[type=checkbox]::before {
   position: relative;
   height: 18px;
   width: 18px;
-  top: -3px;
+  top: calc(50% - 9px);
   border: 2px solid $grey-40;
   content: ' ';
   display: block;
@@ -87,7 +87,7 @@ input[type=checkbox]:checked::after {
   height: 18px;
   width: 18px;
   position: relative;
-  top: -21px;
+  top: -9px;
   font-size: 0.875rem;
   color: $white;
   font-weight: $font-bold;


### PR DESCRIPTION
## :unicorn: Problème
Le design sous Chrome de la checkbox est cassé : 
<img width="518" alt="image" src="https://user-images.githubusercontent.com/38167520/177132788-f7e6c453-b3a3-4adb-a69b-a9d8038e8197.png">

## :robot: Solution
En fait la position de la checkbox était fixe (en pixel), hors, dès que le texte contenu dans le bloc parent bouge un peu cela casse le style car ce n'est pas responsive. 
Adapter la taille des pseudo éléments (::before, ::after) qui servent à personnaliser la checkbox pour qu'ils s'adaptent à la taille du bloc parent. 

## :rainbow: Remarques
Il semblerait que le bug remonte à avant la version v3.144.0 😱 ... (soit avant décembre 2021 voir même bien avant, je suis pas remontée plus loin)
Il faudrait faire la checkbox sur Pix-UI. 

## :100: Pour tester
- Lancer mon-pix sous chrome.
- Aller sur le formulaire pour s'inscrire.
- Constater que la checkbox des cgu a une tête normale (pas de dupplication)
