### PR TITLE
[TECH] Tutos v2.1 - Ajoute le feature toggle pour la sidebar de filtres (PIX-4916)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -185,6 +185,7 @@ module.exports = (function () {
 
     featureToggles: {
       isCertificationFreeFieldsDeletionEnabled: isFeatureEnabled(process.env.FT_CERTIFICATION_FREE_FIELDS_DELETION),
+      isPixAppTutoFiltersEnabled: isFeatureEnabled(process.env.FT_TUTOS_V2_1_FILTERS),
     },
 
     infra: {
@@ -292,6 +293,7 @@ module.exports = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.isCertificationFreeFieldsDeletionEnabled = false;
+    config.featureToggles.isPixAppTutoFiltersEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/sample.env
+++ b/api/sample.env
@@ -648,3 +648,14 @@ RATE_LIMIT_DEFAULT_LIMIT=10
 # type: number
 # default: 60
 RATE_LIMIT_DEFAULT_WINDOW=60
+
+# ===================
+# FEATURE TOGGLES
+# ===================
+
+# Allow user to see the tutorial filters sidebar
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_TUTOS_V2_1_FILTERS=true

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,6 +23,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           type: 'feature-toggles',
           attributes: {
             'is-certification-free-fields-deletion-enabled': false,
+            'is-pix-app-tuto-filters-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,5 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isEndTestScreenRemovalEnabled;
+  @attr('boolean') isPixAppTutoFiltersEnabled;
 }


### PR DESCRIPTION
## :unicorn: Problème
On a besoin de cacher les développements en cours sur la page des tutos.

## :robot: Solution
Création du feature toggle `FT_TUTOS_V2_1_FILTERS` pour ne pas afficher les développements en cours.

## :rainbow: Remarques
Ne pas oublier d'ajouter le FT sur les différents environnements (review, intégration, recette, production).

## :100: Pour tester
Ajouter le feature toggle sur la RA (API), la redeploy et constater que le front récupère bien la bonne valeur dans `/api/feature-toggles`.
