### PR TITLE
[BUGFIX] Restaurer les informations des requêtes dans l'API

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -47,8 +47,6 @@ const plugins = [
       serializers: {
         req: logObjectSerializer,
       },
-      // Remove duplicated req property: https://github.com/pinojs/hapi-pino#optionsgetchildbindings-request---key-any-
-      getChildBindings: () => ({}),
       instance: require('./infrastructure/logger'),
       logQueryParams: true,
     },


### PR DESCRIPTION
## :unicorn: Problème
Depuis la mise à jour de hapi-pino, les informations de requêtes sont absent des logs.

## :robot: Solution
Les restaurer

## :rainbow: Remarques
Le fix dans hapi-pino a été fait la: https://github.com/pinojs/hapi-pino/commit/42b3df4dc81073ced07161fcda9dbf12acf39a33

## :100: Pour tester
1. Mettre la variable d'environnement `ENABLE_REQUEST_MONITORING=true` 
2. Faire des requêtes en mode authentifié
3. Vérifier que l'objet req est bien loggé avec le `user_id` 
