### PR TITLE
[TECH] Eviter les injections implicites dans les routes de Pix App (PIX-5270).

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -14,6 +14,7 @@ export default class Application extends Route.extend(ApplicationRouteMixin) {
   @service headData;
   @service featureToggles;
   @service currentDomain;
+  @service router;
 
   activate() {
     this.splash.hide();
@@ -51,7 +52,7 @@ export default class Application extends Route.extend(ApplicationRouteMixin) {
 
     if (isUserAnonymous && isRouteAccessNotAllowedForAnonymousUser) {
       await this._logoutUser();
-      this.replaceWith('/campagnes');
+      this.router.replaceWith('/campagnes');
     }
   }
 
@@ -77,7 +78,7 @@ export default class Application extends Route.extend(ApplicationRouteMixin) {
     const nextURL = this.session.data.nextURL;
     if (nextURL && get(this.session, 'data.authenticated.source') === 'pole_emploi_connect') {
       this.session.set('data.nextURL', undefined);
-      this.replaceWith(nextURL);
+      this.router.replaceWith(nextURL);
     } else {
       _super.call(this, ...arguments);
     }

--- a/mon-pix/app/routes/assessments.js
+++ b/mon-pix/app/routes/assessments.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class AssessmentsRoute extends Route {
   @service intl;
+  @service store;
 
   model(params) {
     return this.store.findRecord('assessment', params.assessment_id);

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -5,6 +5,8 @@ import { inject as service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
   @service currentUser;
+  @service router;
+  @service store;
 
   async model(params) {
     const assessment = await this.modelFor('assessments');
@@ -44,14 +46,14 @@ export default class ChallengeRoute extends Route {
     }).catch((err) => {
       const meta = 'errors' in err ? err.errors.get('firstObject').meta : null;
       if (meta.field === 'authorization') {
-        return this.transitionTo('index');
+        return this.router.transitionTo('index');
       }
     });
   }
 
   async redirect(model) {
     if (!model.challenge) {
-      return this.replaceWith('assessments.resume', model.assessment.id, {
+      return this.router.replaceWith('assessments.resume', model.assessment.id, {
         queryParams: { assessmentHasNoMoreQuestions: true },
       });
     }
@@ -96,12 +98,12 @@ export default class ChallengeRoute extends Route {
         };
       }
 
-      this.transitionTo('assessments.resume', assessment.get('id'), queryParams);
+      this.router.transitionTo('assessments.resume', assessment.get('id'), queryParams);
     } catch (error) {
       answer.rollbackAttributes();
 
       if (this._isAssessmentEndedBySupervisorOrByFinalization(error)) {
-        return this.transitionTo('certifications.results', assessment.certificationCourse.get('id'));
+        return this.router.transitionTo('certifications.results', assessment.certificationCourse.get('id'));
       }
 
       return this.intermediateTransitionTo('error', error);
@@ -110,7 +112,7 @@ export default class ChallengeRoute extends Route {
 
   @action
   resumeAssessment(assessment) {
-    return this.transitionTo('assessments.resume', assessment.get('id'));
+    return this.router.transitionTo('assessments.resume', assessment.get('id'));
   }
 
   @action

--- a/mon-pix/app/routes/assessments/results.js
+++ b/mon-pix/app/routes/assessments/results.js
@@ -1,13 +1,16 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ResultsRoute extends Route {
+  @service router;
+
   model() {
     return this.modelFor('assessments').reload();
   }
 
   async afterModel(assessment) {
     if (assessment.isCertification) {
-      return this.transitionTo('index');
+      return this.router.transitionTo('index');
     }
   }
 }

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -1,8 +1,11 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import ENV from 'mon-pix/config/environment';
+import { inject as service } from '@ember/service';
 
 export default class ResumeRoute extends Route {
+  @service router;
+
   hasSeenCheckpoint = false;
   campaignCode = null;
   newLevel = null;
@@ -82,7 +85,7 @@ export default class ResumeRoute extends Route {
   }
 
   _routeToNextChallenge(assessment) {
-    this.replaceWith('assessments.challenge', assessment.id, assessment.currentChallengeNumber, {
+    this.router.replaceWith('assessments.challenge', assessment.id, assessment.currentChallengeNumber, {
       queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled },
     });
   }
@@ -95,24 +98,24 @@ export default class ResumeRoute extends Route {
 
   _routeToResults(assessment) {
     if (assessment.isCertification) {
-      this.replaceWith('certifications.results', assessment.certificationNumber);
+      this.router.replaceWith('certifications.results', assessment.certificationNumber);
     } else if (assessment.isForCampaign) {
-      this.replaceWith('campaigns.assessment.skill-review', assessment.codeCampaign);
+      this.router.replaceWith('campaigns.assessment.skill-review', assessment.codeCampaign);
     } else if (assessment.isCompetenceEvaluation) {
-      this.replaceWith('competences.results', assessment.competenceId, assessment.id);
+      this.router.replaceWith('competences.results', assessment.competenceId, assessment.id);
     } else {
-      this.replaceWith('assessments.results', assessment.id);
+      this.router.replaceWith('assessments.results', assessment.id);
     }
   }
 
   _routeToCheckpoint(assessment) {
-    this.replaceWith('assessments.checkpoint', assessment.id, {
+    this.router.replaceWith('assessments.checkpoint', assessment.id, {
       queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled },
     });
   }
 
   _routeToFinalCheckpoint(assessment) {
-    this.replaceWith('assessments.checkpoint', assessment.id, {
+    this.router.replaceWith('assessments.checkpoint', assessment.id, {
       queryParams: { finalCheckpoint: true, newLevel: this.newLevel, competenceLeveled: this.competenceLeveled },
     });
   }

--- a/mon-pix/app/routes/campaigns.js
+++ b/mon-pix/app/routes/campaigns.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class CampaignsRoute extends Route {
+  @service store;
+
   async model(params) {
     return this.store.queryRecord('campaign', { filter: { code: params.code } });
   }

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -7,10 +7,12 @@ export default class AccessRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
   @service campaignStorage;
+  @service router;
+  @service store;
 
   beforeModel(transition) {
     if (!transition.from) {
-      return this.replaceWith('campaigns.entry-point');
+      return this.router.replaceWith('campaigns.entry-point');
     }
 
     this.authenticationRoute = 'inscription';
@@ -18,7 +20,7 @@ export default class AccessRoute extends Route.extend(SecuredRouteMixin) {
 
     if (this._shouldVisitPoleEmploiLoginPage(campaign)) {
       this.session.set('attemptedTransition', transition);
-      return this.replaceWith('login-pole-emploi');
+      return this.router.replaceWith('login-pole-emploi');
     } else if (this._shouldLoginToAccessSCORestrictedCampaign(campaign)) {
       this.authenticationRoute = 'campaigns.join.student-sco';
     } else if (this._shouldJoinFromMediacentre(campaign)) {
@@ -43,9 +45,9 @@ export default class AccessRoute extends Route.extend(SecuredRouteMixin) {
     this.campaignStorage.set(campaign.code, 'hasParticipated', hasParticipated);
 
     if (hasParticipated) {
-      this.replaceWith('campaigns.entrance', campaign.code);
+      this.router.replaceWith('campaigns.entrance', campaign.code);
     } else {
-      this.replaceWith('campaigns.invited', campaign.code);
+      this.router.replaceWith('campaigns.invited', campaign.code);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/assessment.js
+++ b/mon-pix/app/routes/campaigns/assessment.js
@@ -1,7 +1,10 @@
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class AssessmentRoute extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   async model() {
     const campaign = this.modelFor('campaigns');
     const campaignParticipation = await this.store.queryRecord('campaignParticipation', {

--- a/mon-pix/app/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/routes/campaigns/assessment/skill-review.js
@@ -1,7 +1,11 @@
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SkillReviewRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+  @service store;
+
   async model() {
     const user = this.currentUser.user;
     const campaign = this.modelFor('campaigns');
@@ -13,7 +17,7 @@ export default class SkillReviewRoute extends Route.extend(SecuredRouteMixin) {
       return { campaign, campaignParticipationResult };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
-        return this.transitionTo('campaigns.entry-point', campaign.code);
+        return this.router.transitionTo('campaigns.entry-point', campaign.code);
       } else throw error;
     }
   }

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -5,6 +5,7 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
+  @service router;
 
   userHasJustConsultedTutorial = false;
 
@@ -19,9 +20,9 @@ export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRo
 
   async redirect({ assessment, campaign }) {
     if (this._shouldShowTutorial(assessment, campaign.isForAbsoluteNovice)) {
-      this.replaceWith('campaigns.assessment.tutorial', campaign.code);
+      this.router.replaceWith('campaigns.assessment.tutorial', campaign.code);
     } else {
-      this.replaceWith('assessments.resume', assessment.id);
+      this.router.replaceWith('assessments.resume', assessment.id);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 export default class CampaignsAssessmentTutorial extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service intl;
+  @service router;
 
   campaignCode = null;
   tutorialPageId = 0;
@@ -33,7 +34,7 @@ export default class CampaignsAssessmentTutorial extends Route.extend(SecuredRou
     await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenAssessmentInstructions: true } });
 
     this.tutorialPageId = 0;
-    this.transitionTo('campaigns.assessment.start-or-resume', this.campaignCode, {
+    this.router.transitionTo('campaigns.assessment.start-or-resume', this.campaignCode, {
       queryParams: {
         hasConsultedTutorial: true,
       },

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -1,9 +1,12 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class CampaignLandingPageRoute extends Route {
+  @service router;
+
   beforeModel(transition) {
     if (!transition.from) {
-      return this.replaceWith('campaigns.entry-point');
+      return this.router.replaceWith('campaigns.entry-point');
     }
   }
 
@@ -13,7 +16,7 @@ export default class CampaignLandingPageRoute extends Route {
 
   afterModel(campaign) {
     if (campaign.isForAbsoluteNovice) {
-      this.replaceWith('campaigns.access', campaign.code);
+      this.router.replaceWith('campaigns.access', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -7,10 +7,11 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
   @service campaignStorage;
   @service store;
   @service currentUser;
+  @service router;
 
   beforeModel(transition) {
     if (!transition.from) {
-      return this.replaceWith('campaigns.entry-point');
+      return this.router.replaceWith('campaigns.entry-point');
     }
     super.beforeModel(...arguments);
   }
@@ -30,9 +31,9 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
     }
 
     if (campaign.isProfilesCollection) {
-      this.replaceWith('campaigns.profiles-collection.start-or-resume', campaign.code);
+      this.router.replaceWith('campaigns.profiles-collection.start-or-resume', campaign.code);
     } else {
-      this.replaceWith('campaigns.assessment.start-or-resume', campaign.code);
+      this.router.replaceWith('campaigns.assessment.start-or-resume', campaign.code);
     }
   }
 
@@ -52,10 +53,10 @@ export default class Entrance extends Route.extend(SecuredRouteMixin) {
 
       if (error.status == 400 && error.detail.includes('participant-external-id')) {
         this.campaignStorage.set(campaign.code, 'participantExternalId', null);
-        return this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
+        return this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
       }
       if (error.detail === 'ORGANIZATION_LEARNER_HAS_ALREADY_PARTICIPATED') {
-        return this.replaceWith('campaigns.existing-participation', campaign.code);
+        return this.router.replaceWith('campaigns.existing-participation', campaign.code);
       }
 
       throw err;

--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -5,6 +5,8 @@ export default class EntryPoint extends Route {
   @service currentUser;
   @service campaignStorage;
   @service session;
+  @service router;
+  @service store;
 
   async beforeModel() {
     if (this.session.isAuthenticated && this.currentUser.user.isAnonymous) {
@@ -39,11 +41,11 @@ export default class EntryPoint extends Route {
     }
 
     if (campaign.isArchived && !hasParticipated) {
-      this.replaceWith('campaigns.archived-error', campaign.code);
+      this.router.replaceWith('campaigns.archived-error', campaign.code);
     } else if (hasParticipated) {
-      this.replaceWith('campaigns.entrance', campaign.code);
+      this.router.replaceWith('campaigns.entrance', campaign.code);
     } else {
-      this.replaceWith('campaigns.campaign-landing-page', campaign.code);
+      this.router.replaceWith('campaigns.campaign-landing-page', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -4,10 +4,11 @@ import { inject as service } from '@ember/service';
 
 export default class InvitedRoute extends Route.extend(SecuredRouteMixin) {
   @service campaignStorage;
+  @service router;
 
   beforeModel(transition) {
     if (!transition.from) {
-      return this.replaceWith('campaigns.entry-point');
+      return this.router.replaceWith('campaigns.entry-point');
     }
     super.beforeModel(...arguments);
   }
@@ -18,11 +19,11 @@ export default class InvitedRoute extends Route.extend(SecuredRouteMixin) {
 
   afterModel(campaign) {
     if (this.shouldAssociateWithScoInformation(campaign)) {
-      this.replaceWith('campaigns.invited.student-sco', campaign.code);
+      this.router.replaceWith('campaigns.invited.student-sco', campaign.code);
     } else if (this.shouldAssociateWithSupInformation(campaign)) {
-      this.replaceWith('campaigns.invited.student-sup', campaign.code);
+      this.router.replaceWith('campaigns.invited.student-sup', campaign.code);
     } else {
-      this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
+      this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
+++ b/mon-pix/app/routes/campaigns/invited/fill-in-participant-external-id.js
@@ -4,6 +4,7 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 export default class FillInParticipantExternalIdRoute extends Route.extend(SecuredRouteMixin) {
   @service campaignStorage;
+  @service router;
 
   async model() {
     return this.modelFor('campaigns');
@@ -11,7 +12,7 @@ export default class FillInParticipantExternalIdRoute extends Route.extend(Secur
 
   afterModel(campaign) {
     if (!this.shouldProvideExternalId(campaign)) {
-      this.replaceWith('campaigns.entrance', campaign.code);
+      this.router.replaceWith('campaigns.entrance', campaign.code);
     }
   }
 

--- a/mon-pix/app/routes/campaigns/invited/student-sco.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sco.js
@@ -7,6 +7,7 @@ export default class StudentScoRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service campaignStorage;
   @service store;
+  @service router;
 
   model() {
     return this.modelFor('campaigns');
@@ -35,7 +36,7 @@ export default class StudentScoRoute extends Route.extend(SecuredRouteMixin) {
 
     if (schoolingRegistration) {
       this.campaignStorage.set(campaign.code, 'associationDone', true);
-      this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
+      this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/invited/student-sup.js
+++ b/mon-pix/app/routes/campaigns/invited/student-sup.js
@@ -6,6 +6,7 @@ export default class StudentSupRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service campaignStorage;
   @service store;
+  @service router;
 
   model() {
     return this.modelFor('campaigns');
@@ -19,7 +20,7 @@ export default class StudentSupRoute extends Route.extend(SecuredRouteMixin) {
 
     if (schoolingRegistration) {
       this.campaignStorage.set(campaign.code, 'associationDone', true);
-      this.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
+      this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }
 }

--- a/mon-pix/app/routes/campaigns/join.js
+++ b/mon-pix/app/routes/campaigns/join.js
@@ -1,10 +1,13 @@
 import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class JoinRoute extends Route.extend(UnauthenticatedRouteMixin) {
+  @service router;
+
   beforeModel(transition) {
     if (!transition.from) {
-      return this.replaceWith('campaigns.entry-point');
+      return this.router.replaceWith('campaigns.entry-point');
     }
     this.routeIfAlreadyAuthenticated = 'campaigns.access';
     super.beforeModel(...arguments);

--- a/mon-pix/app/routes/campaigns/profiles-collection.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection.js
@@ -1,7 +1,10 @@
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ProfilesCollectionRoute extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   async model() {
     const campaign = this.modelFor('campaigns');
     const campaignParticipation = await this.store.queryRecord('campaignParticipation', {

--- a/mon-pix/app/routes/campaigns/profiles-collection/profile-already-shared.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/profile-already-shared.js
@@ -1,7 +1,11 @@
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ProfileAlreadySharedRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+  @service store;
+
   async model() {
     const user = this.currentUser.user;
     const campaign = this.modelFor('campaigns');
@@ -17,7 +21,7 @@ export default class ProfileAlreadySharedRoute extends Route.extend(SecuredRoute
       };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
-        return this.transitionTo('campaigns.entry-point', campaign.code);
+        return this.router.transitionTo('campaigns.entry-point', campaign.code);
       } else throw error;
     }
   }

--- a/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/profiles-collection/start-or-resume.js
@@ -1,15 +1,18 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+
   async model() {
     return this.modelFor('campaigns.profiles-collection');
   }
 
   redirect({ campaign, campaignParticipation }) {
     if (campaignParticipation.isShared) {
-      return this.replaceWith('campaigns.profiles-collection.profile-already-shared', campaign.code);
+      return this.router.replaceWith('campaigns.profiles-collection.profile-already-shared', campaign.code);
     }
-    return this.replaceWith('campaigns.profiles-collection.send-profile', campaign.code);
+    return this.router.replaceWith('campaigns.profiles-collection.send-profile', campaign.code);
   }
 }

--- a/mon-pix/app/routes/certifications/results.js
+++ b/mon-pix/app/routes/certifications/results.js
@@ -1,7 +1,10 @@
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   async model(params) {
     const certificationCourse = await this.store.findRecord('certification-course', params.certification_id);
     await certificationCourse.assessment.reload();

--- a/mon-pix/app/routes/certifications/resume.js
+++ b/mon-pix/app/routes/certifications/resume.js
@@ -1,9 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ResumeRoute extends Route {
+  @service store;
+  @service router;
+
   model(params) {
     const store = this.store;
     const certificationCourse = store.peekRecord('certification-course', params.certification_course_id);
-    this.replaceWith('assessments.resume', certificationCourse.assessment);
+    this.router.replaceWith('assessments.resume', certificationCourse.assessment);
   }
 }

--- a/mon-pix/app/routes/certifications/start.js
+++ b/mon-pix/app/routes/certifications/start.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class StartRoute extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   model(params) {
     return this.store.findRecord('certification-candidate-subscription', params.certification_candidate_id);
   }

--- a/mon-pix/app/routes/challenge-preview.js
+++ b/mon-pix/app/routes/challenge-preview.js
@@ -1,6 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ChallengePreviewRoute extends Route {
+  @service router;
+  @service store;
+
   model(params) {
     this.challengeId = params.challenge_id;
   }
@@ -10,7 +14,7 @@ export default class ChallengePreviewRoute extends Route {
     const assessment = store.createRecord('assessment', { type: 'PREVIEW' });
 
     return assessment.save().then(() => {
-      return this.replaceWith('assessments.challenge', assessment.id, assessment.currentChallengeNumber, {
+      return this.router.replaceWith('assessments.challenge', assessment.id, assessment.currentChallengeNumber, {
         queryParams: { challengeId: this.challengeId },
       });
     });

--- a/mon-pix/app/routes/competences.js
+++ b/mon-pix/app/routes/competences.js
@@ -4,6 +4,7 @@ import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 export default class CompetencesRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
+  @service store;
 
   model(params) {
     const scorecardId = this.currentUser.user.id + '_' + params.competence_id;

--- a/mon-pix/app/routes/competences/details.js
+++ b/mon-pix/app/routes/competences/details.js
@@ -5,6 +5,7 @@ import Route from '@ember/routing/route';
 export default class DetailsRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
+  @service store;
 
   model(params, transition) {
     const scorecardId = this.currentUser.user.id + '_' + transition.to.parent.params.competence_id;

--- a/mon-pix/app/routes/competences/results.js
+++ b/mon-pix/app/routes/competences/results.js
@@ -1,8 +1,11 @@
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   async model(params) {
     const assessmentId = params.assessment_id;
     const competenceEvaluations = await this.store.findAll('competenceEvaluation', {

--- a/mon-pix/app/routes/competences/resume.js
+++ b/mon-pix/app/routes/competences/resume.js
@@ -5,6 +5,7 @@ import Route from '@ember/routing/route';
 export default class ResumeRoute extends Route.extend(SecuredRouteMixin) {
   @service session;
   @service router;
+  @service store;
 
   competenceId = null;
 
@@ -14,6 +15,6 @@ export default class ResumeRoute extends Route.extend(SecuredRouteMixin) {
   }
 
   afterModel(competenceEvaluation) {
-    return this.replaceWith('assessments.resume', competenceEvaluation.get('assessment.id'));
+    return this.router.replaceWith('assessments.resume', competenceEvaluation.get('assessment.id'));
   }
 }

--- a/mon-pix/app/routes/courses/create-assessment.js
+++ b/mon-pix/app/routes/courses/create-assessment.js
@@ -1,9 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class CreateAssessmentRoute extends Route {
+  @service store;
+  @service router;
+
   async afterModel(course) {
     const store = this.store;
     const assessment = await store.createRecord('assessment', { course, type: 'DEMO' }).save();
-    return this.replaceWith('assessments.resume', assessment.id);
+    return this.router.replaceWith('assessments.resume', assessment.id);
   }
 }

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 
 export default class ErrorRoute extends Route {
   @service session;
+  @service router;
 
   hasUnauthorizedError(error) {
     const statusCode = get(error, 'errors[0].status');
@@ -27,7 +28,7 @@ export default class ErrorRoute extends Route {
     }
 
     if (this.hasUnauthorizedError(error)) {
-      return this.transitionTo('logout');
+      return this.router.transitionTo('logout');
     }
   }
 }

--- a/mon-pix/app/routes/index.js
+++ b/mon-pix/app/routes/index.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+
   redirect() {
-    this.replaceWith('user-dashboard');
+    this.router.replaceWith('user-dashboard');
   }
 }

--- a/mon-pix/app/routes/inscription.js
+++ b/mon-pix/app/routes/inscription.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 
 export default class Inscription extends Route.extend(UnauthenticatedRouteMixin) {
   @service session;
+  @service store;
 
   model() {
     // XXX: Model needs to be initialize with empty to handle validations on all fields from Api

--- a/mon-pix/app/routes/login-cnav.js
+++ b/mon-pix/app/routes/login-cnav.js
@@ -36,7 +36,7 @@ export default class LoginCnavRoute extends Route {
 
   afterModel({ shouldValidateCgu, authenticationKey } = {}) {
     if (shouldValidateCgu && authenticationKey) {
-      return this.replaceWith('terms-of-service-cnav', { queryParams: { authenticationKey } });
+      return this.router.replaceWith('terms-of-service-cnav', { queryParams: { authenticationKey } });
     }
   }
 

--- a/mon-pix/app/routes/login-pole-emploi.js
+++ b/mon-pix/app/routes/login-pole-emploi.js
@@ -36,7 +36,7 @@ export default class LoginPoleEmploiRoute extends Route {
 
   afterModel({ shouldValidateCgu, authenticationKey } = {}) {
     if (shouldValidateCgu && authenticationKey) {
-      return this.replaceWith('terms-of-service-pole-emploi', { queryParams: { authenticationKey } });
+      return this.router.replaceWith('terms-of-service-pole-emploi', { queryParams: { authenticationKey } });
     }
   }
 

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -6,6 +6,7 @@ import Route from '@ember/routing/route';
 export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
   @service session;
   @service store;
+  @service router;
 
   @action
   async authenticate(login, password) {
@@ -19,7 +20,7 @@ export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) 
   @action
   async updateExpiredPassword(username, password) {
     this.store.createRecord('reset-expired-password-demand', { username, oneTimePassword: password });
-    return this.replaceWith('update-expired-password');
+    return this.router.replaceWith('update-expired-password');
   }
 
   async _removeExternalUserContext() {

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -9,6 +9,7 @@ export default class LogoutRoute extends Route {
   @service session;
   @service url;
   @service campaignStorage;
+  @service router;
 
   beforeModel() {
     const session = this.session;
@@ -30,7 +31,7 @@ export default class LogoutRoute extends Route {
   }
 
   _redirectToDisconnectedPage() {
-    return this.transitionTo('not-connected');
+    return this.router.transitionTo('not-connected');
   }
 
   _redirectToHome() {

--- a/mon-pix/app/routes/not-found.js
+++ b/mon-pix/app/routes/not-found.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class NotFoundRoute extends Route {
+  @service router;
+
   afterModel(model, transition) {
     transition.abort();
-    this.transitionTo('index');
+    this.router.transitionTo('index');
   }
 }

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -6,6 +6,8 @@ export default class ResetPasswordRoute extends Route {
   @service errors;
   @service intl;
   @service session;
+  @service router;
+  @service store;
 
   async model(params) {
     const passwordResetTemporaryKey = params.temporary_key;
@@ -16,7 +18,7 @@ export default class ResetPasswordRoute extends Route {
       const status = get(error, 'errors[0].status');
       if (status && (status === 401 || (status && 404))) {
         this.errors.push(this.intl.t('pages.reset-password.error.expired-demand'));
-        this.replaceWith('password-reset-demand');
+        this.router.replaceWith('password-reset-demand');
       }
     }
   }

--- a/mon-pix/app/routes/shared-certification.js
+++ b/mon-pix/app/routes/shared-certification.js
@@ -1,13 +1,16 @@
 import Route from '@ember/routing/route';
 import Model from '@ember-data/model';
+import { inject as service } from '@ember/service';
 
 export default class SharedCertificationRoute extends Route {
+  @service router;
+
   async redirect(model, transition) {
     if (!model || !(model instanceof Model)) {
       if (transition && transition.from) {
         transition.abort();
       } else {
-        this.replaceWith('/verification-certificat?unallowedAccess=true');
+        this.router.replaceWith('/verification-certificat?unallowedAccess=true');
       }
     }
   }

--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -5,6 +5,7 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRouteMixin) {
   @service currentUser;
   @service session;
+  @service router;
 
   beforeModel() {
     const isUserExternal = Boolean(this.session.data.externalUser);
@@ -12,7 +13,7 @@ export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRoute
       if (this.session.attemptedTransition) {
         this.session.attemptedTransition.retry();
       } else {
-        this.replaceWith('');
+        this.router.replaceWith('');
       }
     }
   }

--- a/mon-pix/app/routes/update-expired-password.js
+++ b/mon-pix/app/routes/update-expired-password.js
@@ -4,13 +4,14 @@ import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-
 
 export default class UpdateExpiredPasswordRoute extends Route.extend(UnauthenticatedRouteMixin) {
   @service store;
+  @service router;
 
   model() {
     const resetExpiredPasswordDemands = this.store.peekAll('reset-expired-password-demand');
     const resetExpiredPasswordDemand = resetExpiredPasswordDemands.firstObject;
 
     if (!resetExpiredPasswordDemand) {
-      return this.replaceWith('');
+      return this.router.replaceWith('');
     }
 
     return resetExpiredPasswordDemand;

--- a/mon-pix/app/routes/user-account/index.js
+++ b/mon-pix/app/routes/user-account/index.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+
   redirect() {
-    this.replaceWith('user-account.personal-information');
+    this.router.replaceWith('user-account.personal-information');
   }
 }

--- a/mon-pix/app/routes/user-certifications/get.js
+++ b/mon-pix/app/routes/user-certifications/get.js
@@ -1,11 +1,15 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class GetRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+  @service store;
+
   async model(params) {
     const certification = await this.store.findRecord('certification', params.id, { reload: true });
     if (!certification.isPublished || certification.status !== 'validated') {
-      return this.replaceWith('/mes-certifications');
+      return this.router.replaceWith('/mes-certifications');
     }
     return certification;
   }

--- a/mon-pix/app/routes/user-certifications/index.js
+++ b/mon-pix/app/routes/user-certifications/index.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   model() {
     return this.store.findAll('certification');
   }

--- a/mon-pix/app/routes/user-tests.js
+++ b/mon-pix/app/routes/user-tests.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 
 export default class UserTestsRoute extends Route.extend(SecuredRouteMixin) {
   @service store;
+  @service router;
 
   model() {
     const user = this.currentUser.user;
@@ -22,7 +23,7 @@ export default class UserTestsRoute extends Route.extend(SecuredRouteMixin) {
 
   redirect(model) {
     if (isEmpty(model)) {
-      this.replaceWith('');
+      this.router.replaceWith('');
     }
   }
 

--- a/mon-pix/app/routes/user-tutorials/index.js
+++ b/mon-pix/app/routes/user-tutorials/index.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
+  @service router;
+
   redirect() {
-    this.replaceWith('user-tutorials.recommended');
+    this.router.replaceWith('user-tutorials.recommended');
   }
 }

--- a/mon-pix/app/routes/user-tutorials/recommended.js
+++ b/mon-pix/app/routes/user-tutorials/recommended.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class UserTutorialsRecommendedRoute extends Route {
   @service router;
+  @service store;
 
   queryParams = {
     pageNumber: { refreshModel: true },

--- a/mon-pix/app/routes/user-tutorials/saved.js
+++ b/mon-pix/app/routes/user-tutorials/saved.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 
 export default class UserTutorialsSavedRoute extends Route {
   @service router;
+  @service store;
 
   queryParams = {
     pageNumber: { refreshModel: true },

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -108,7 +108,7 @@ describe('Acceptance | Common behavior to all challenges', function () {
       await authenticateByEmail(user);
 
       // when
-      await visit(`/assessments/${assessment.id}/challenges/`);
+      await visit(`/assessments/${assessment.id}/challenges/0`);
 
       // then
       expect(find('.assessment-banner__home-link')).to.not.exist;

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -111,7 +111,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
 
       it('should not display pixScoreAheadOfNextLevel when next level is over the max level', async () => {
         // when
-        await visit(`/competence/${scorecardWithMaxLevel.competenceId}/details`);
+        await visit(`/competences/${scorecardWithMaxLevel.competenceId}/details`);
 
         // then
         expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);

--- a/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
+++ b/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
@@ -42,21 +42,21 @@ describe('Acceptance | Campaigns | Simplified access | Anonymous user access to 
         expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
 
         // when
-        const CHALLENGE_ROUTE = `/assessments/${ID_ASSESSMENT}/challenges/`;
+        const CHALLENGE_ROUTE = `/assessments/${ID_ASSESSMENT}/challenges/0`;
         await visit(`${CHALLENGE_ROUTE}`);
         // then
         expect(currentURL()).to.equal(CHALLENGE_ROUTE);
         expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
 
         // when
-        const CAMPAIGN_DIDACTICIEL_ROUTE = `campagnes/${SIMPLIFIED_CODE_CAMPAIGN}/evaluation/didacticiel`;
+        const CAMPAIGN_DIDACTICIEL_ROUTE = `/campagnes/${SIMPLIFIED_CODE_CAMPAIGN}/evaluation/didacticiel`;
         await visit(CAMPAIGN_DIDACTICIEL_ROUTE);
         // then
         expect(currentURL()).to.equal(CAMPAIGN_DIDACTICIEL_ROUTE);
         expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
 
         // when
-        const CAMPAIGN_ROUTE = `campagnes/${SIMPLIFIED_CODE_CAMPAIGN}`;
+        const CAMPAIGN_ROUTE = `/campagnes/${SIMPLIFIED_CODE_CAMPAIGN}`;
         await visit(CAMPAIGN_ROUTE);
         // then
         expect(currentURL()).to.equal(CAMPAIGN_ROUTE);

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -46,7 +46,7 @@ describe('Unit | Route | Assessments | Challenge', function () {
     currentUserStub = { user: { firstName: 'John', lastname: 'Doe' } };
     route.currentUser = currentUserStub;
     route.store = storeStub;
-    route.transitionTo = sinon.stub();
+    route.router = { transitionTo: sinon.stub() };
     route.modelFor = sinon.stub().returns(assessment);
   });
 
@@ -276,7 +276,7 @@ describe('Unit | Route | Assessments | Challenge', function () {
         );
 
         // then
-        sinon.assert.calledWithExactly(route.transitionTo, 'assessments.resume', assessment.get('id'), {
+        sinon.assert.calledWithExactly(route.router.transitionTo, 'assessments.resume', assessment.get('id'), {
           queryParams: {},
         });
       });
@@ -312,7 +312,7 @@ describe('Unit | Route | Assessments | Challenge', function () {
 
           // then
           sinon.assert.calledWithExactly(
-            route.transitionTo,
+            route.router.transitionTo,
             'assessments.resume',
             assessment.get('id'),
             expectedQueryParams
@@ -337,7 +337,7 @@ describe('Unit | Route | Assessments | Challenge', function () {
 
           // then
           sinon.assert.calledWithExactly(
-            route.transitionTo,
+            route.router.transitionTo,
             'assessments.resume',
             assessment.get('id'),
             expectedQueryParams
@@ -361,7 +361,7 @@ describe('Unit | Route | Assessments | Challenge', function () {
 
           // then
           sinon.assert.calledWithExactly(
-            route.transitionTo,
+            route.router.transitionTo,
             'assessments.resume',
             assessment.get('id'),
             expectedQueryParams
@@ -417,7 +417,7 @@ describe('Unit | Route | Assessments | Challenge', function () {
 
         // then
         sinon.assert.calledWithExactly(
-          route.transitionTo,
+          route.router.transitionTo,
           'certifications.results',
           assessment.certificationCourse.get('id')
         );

--- a/mon-pix/tests/unit/routes/assessments/results_test.js
+++ b/mon-pix/tests/unit/routes/assessments/results_test.js
@@ -16,7 +16,7 @@ describe('Unit | Route | Assessments | Results', function () {
     it('should redirect to homepage if assessment is a certification', function () {
       // given
       const route = this.owner.lookup('route:assessments.results');
-      route.transitionTo = sinon.spy();
+      route.router = { transitionTo: sinon.spy() };
 
       const assessment = EmberObject.create({ id: 123, isCertification: true });
 
@@ -24,13 +24,13 @@ describe('Unit | Route | Assessments | Results', function () {
       route.afterModel(assessment);
 
       // then
-      sinon.assert.calledWith(route.transitionTo, 'index');
+      sinon.assert.calledWith(route.router.transitionTo, 'index');
     });
 
     it('should not redirect to homepage if assessment is not a certification', function () {
       // given
       const route = this.owner.lookup('route:assessments.results');
-      route.transitionTo = sinon.spy();
+      route.router = { transitionTo: sinon.spy() };
 
       const assessment = EmberObject.create({ id: 123, isCertification: false, answers: [] });
 
@@ -38,7 +38,7 @@ describe('Unit | Route | Assessments | Results', function () {
       route.afterModel(assessment);
 
       // then
-      sinon.assert.notCalled(route.transitionTo);
+      sinon.assert.notCalled(route.router.transitionTo);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/assessments/resume_test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume_test.js
@@ -23,7 +23,7 @@ describe('Unit | Route | Assessments | Resume', function () {
 
     route = this.owner.lookup('route:assessments.resume');
     route.set('store', storeStub);
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
   });
 
   describe('#redirect', function () {
@@ -69,8 +69,8 @@ describe('Unit | Route | Assessments | Resume', function () {
 
               // then
               return promise.then(() => {
-                sinon.assert.calledOnce(route.replaceWith);
-                sinon.assert.calledWith(route.replaceWith, 'assessments.challenge', 123);
+                sinon.assert.calledOnce(route.router.replaceWith);
+                sinon.assert.calledWith(route.router.replaceWith, 'assessments.challenge', 123);
               });
             });
           });
@@ -86,8 +86,8 @@ describe('Unit | Route | Assessments | Resume', function () {
 
               // then
               return promise.then(() => {
-                sinon.assert.calledOnce(route.replaceWith);
-                sinon.assert.calledWith(route.replaceWith, 'assessments.checkpoint', 123);
+                sinon.assert.calledOnce(route.router.replaceWith);
+                sinon.assert.calledWith(route.router.replaceWith, 'assessments.checkpoint', 123);
               });
             });
           });
@@ -100,8 +100,8 @@ describe('Unit | Route | Assessments | Resume', function () {
 
             // then
             return promise.then(() => {
-              sinon.assert.calledOnce(route.replaceWith);
-              sinon.assert.calledWith(route.replaceWith, 'assessments.challenge', 123);
+              sinon.assert.calledOnce(route.router.replaceWith);
+              sinon.assert.calledWith(route.router.replaceWith, 'assessments.challenge', 123);
             });
           });
         });
@@ -117,8 +117,8 @@ describe('Unit | Route | Assessments | Resume', function () {
 
           // then
           return promise.then(() => {
-            sinon.assert.calledOnce(route.replaceWith);
-            sinon.assert.calledWith(route.replaceWith, 'assessments.challenge', 123);
+            sinon.assert.calledOnce(route.router.replaceWith);
+            sinon.assert.calledWith(route.router.replaceWith, 'assessments.challenge', 123);
           });
         });
       });
@@ -155,7 +155,7 @@ describe('Unit | Route | Assessments | Resume', function () {
 
               // then
               return promise.then(() => {
-                sinon.assert.calledWith(route.replaceWith, 'campaigns.assessment.skill-review', 'konami');
+                sinon.assert.calledWith(route.router.replaceWith, 'campaigns.assessment.skill-review', 'konami');
               });
             });
           });
@@ -171,8 +171,8 @@ describe('Unit | Route | Assessments | Resume', function () {
 
               // then
               return promise.then(() => {
-                sinon.assert.calledOnce(route.replaceWith);
-                sinon.assert.calledWith(route.replaceWith, 'assessments.checkpoint', 123, {
+                sinon.assert.calledOnce(route.router.replaceWith);
+                sinon.assert.calledWith(route.router.replaceWith, 'assessments.checkpoint', 123, {
                   queryParams: { finalCheckpoint: true, newLevel: null, competenceLeveled: null },
                 });
               });
@@ -191,7 +191,7 @@ describe('Unit | Route | Assessments | Resume', function () {
             route.redirect(assessment);
 
             // then
-            sinon.assert.calledWith(route.replaceWith, 'campaigns.assessment.skill-review', 'konami');
+            sinon.assert.calledWith(route.router.replaceWith, 'campaigns.assessment.skill-review', 'konami');
           });
         });
       });
@@ -208,7 +208,7 @@ describe('Unit | Route | Assessments | Resume', function () {
 
           // then
           return promise.then(() => {
-            sinon.assert.calledWith(route.replaceWith, 'certifications.results', 666);
+            sinon.assert.calledWith(route.router.replaceWith, 'certifications.results', 666);
           });
         });
       });
@@ -225,7 +225,7 @@ describe('Unit | Route | Assessments | Resume', function () {
 
           // then
           return promise.then(() => {
-            sinon.assert.calledWith(route.replaceWith, 'competences.results', competenceId, 123);
+            sinon.assert.calledWith(route.router.replaceWith, 'competences.results', competenceId, 123);
           });
         });
       });
@@ -237,7 +237,7 @@ describe('Unit | Route | Assessments | Resume', function () {
 
           // then
           return promise.then(() => {
-            sinon.assert.calledWith(route.replaceWith, 'assessments.results', 123);
+            sinon.assert.calledWith(route.router.replaceWith, 'assessments.results', 123);
           });
         });
       });

--- a/mon-pix/tests/unit/routes/authentication/login-cnav_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-cnav_test.js
@@ -10,13 +10,13 @@ describe('Unit | Route | login-cnav', function () {
       it("should redirect to cgu's cnav page", async function () {
         // given
         const route = this.owner.lookup('route:login-cnav');
-        route.replaceWith = sinon.stub();
+        route.router = { replaceWith: sinon.stub() };
 
         // when
         await route.afterModel({ authenticationKey: '123', shouldValidateCgu: true });
 
         // then
-        sinon.assert.calledWith(route.replaceWith, 'terms-of-service-cnav', {
+        sinon.assert.calledWith(route.router.replaceWith, 'terms-of-service-cnav', {
           queryParams: { authenticationKey: '123' },
         });
       });
@@ -26,13 +26,13 @@ describe('Unit | Route | login-cnav', function () {
       it("should not redirect to cgu's cnav page", async function () {
         // given
         const route = this.owner.lookup('route:login-cnav');
-        route.replaceWith = sinon.stub();
+        route.router = { replaceWith: sinon.stub() };
 
         // when
         await route.afterModel({ authenticationKey: null, shouldValidateCgu: false });
 
         // then
-        sinon.assert.notCalled(route.replaceWith);
+        sinon.assert.notCalled(route.router.replaceWith);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/authentication/login-pole-emploi_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-pole-emploi_test.js
@@ -10,13 +10,13 @@ describe('Unit | Route | login-pole-emploi', function () {
       it("should redirect to cgu's pole emploi page", async function () {
         // given
         const route = this.owner.lookup('route:login-pole-emploi');
-        route.replaceWith = sinon.stub();
+        route.router = { replaceWith: sinon.stub() };
 
         // when
         await route.afterModel({ authenticationKey: '123', shouldValidateCgu: true });
 
         // then
-        sinon.assert.calledWith(route.replaceWith, 'terms-of-service-pole-emploi', {
+        sinon.assert.calledWith(route.router.replaceWith, 'terms-of-service-pole-emploi', {
           queryParams: { authenticationKey: '123' },
         });
       });
@@ -26,13 +26,13 @@ describe('Unit | Route | login-pole-emploi', function () {
       it("should not redirect to cgu's pole emploi page", async function () {
         // given
         const route = this.owner.lookup('route:login-pole-emploi');
-        route.replaceWith = sinon.stub();
+        route.router = { replaceWith: sinon.stub() };
 
         // when
         await route.afterModel({ authenticationKey: null, shouldValidateCgu: false });
 
         // then
-        sinon.assert.notCalled(route.replaceWith);
+        sinon.assert.notCalled(route.router.replaceWith);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/campaigns/access_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access_test.js
@@ -15,8 +15,7 @@ describe('Unit | Route | Access', function () {
     route = this.owner.lookup('route:campaigns.access');
     route.modelFor = sinon.stub().returns(campaign);
     route.campaignStorage = { get: sinon.stub() };
-    route.router.transitionTo = sinon.stub();
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
   });
 
   describe('#beforeModel', function () {
@@ -25,7 +24,7 @@ describe('Unit | Route | Access', function () {
       await route.beforeModel({ from: null });
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entry-point');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
     });
 
     it('should continue on access route when from is set', async function () {
@@ -33,7 +32,7 @@ describe('Unit | Route | Access', function () {
       await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
       //then
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
 
     it('should override authentication route', async function () {
@@ -62,7 +61,7 @@ describe('Unit | Route | Access', function () {
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
         // then
-        sinon.assert.calledWith(route.replaceWith, 'login-pole-emploi');
+        sinon.assert.calledWith(route.router.replaceWith, 'login-pole-emploi');
       });
     });
 
@@ -77,7 +76,7 @@ describe('Unit | Route | Access', function () {
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
         // then
-        sinon.assert.neverCalledWith(route.replaceWith, 'login-pole-emploi');
+        sinon.assert.neverCalledWith(route.router.replaceWith, 'login-pole-emploi');
       });
     });
 

--- a/mon-pix/tests/unit/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/skill-review_test.js
@@ -16,7 +16,7 @@ describe('Unit | Route | Campaign | Assessment | Skill review', function () {
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.assessment.skill-review');
     route.modelFor = sinon.stub().returns(campaign);
-    route.transitionTo = sinon.stub();
+    route.router = { transitionTo: sinon.stub() };
     route.store = storeStub;
     route.currentUser = currentUserStub;
   });
@@ -29,7 +29,7 @@ describe('Unit | Route | Campaign | Assessment | Skill review', function () {
       it('should redirect to start or resume', async function () {
         await route.model();
 
-        sinon.assert.calledWith(route.transitionTo, 'campaigns.entry-point', 'NEW_CODE');
+        sinon.assert.calledWith(route.router.transitionTo, 'campaigns.entry-point', 'NEW_CODE');
       });
     });
 
@@ -43,7 +43,7 @@ describe('Unit | Route | Campaign | Assessment | Skill review', function () {
       it('should not redirect', async function () {
         await route.model();
 
-        sinon.assert.notCalled(route.transitionTo);
+        sinon.assert.notCalled(route.router.transitionTo);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/campaigns/assessment/tutorial_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/tutorial_test.js
@@ -13,7 +13,7 @@ describe('Unit | Route | campaigns | evaluation | tutorial', function () {
 
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.assessment.tutorial');
-    route.transitionTo = sinon.stub();
+    route.router = { transitionTo: sinon.stub() };
   });
 
   describe('#model', function () {
@@ -76,7 +76,7 @@ describe('Unit | Route | campaigns | evaluation | tutorial', function () {
       sinon.assert.calledWith(route.currentUser.user.save, {
         adapterOptions: { rememberUserHasSeenAssessmentInstructions: true },
       });
-      sinon.assert.calledWith(route.transitionTo, 'campaigns.assessment.start-or-resume', 'AZERTY123');
+      sinon.assert.calledWith(route.router.transitionTo, 'campaigns.assessment.start-or-resume', 'AZERTY123');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/campaign-landing-page_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/campaign-landing-page_test.js
@@ -11,7 +11,7 @@ describe('Unit | Route | campaign-landing-page', function () {
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.campaign-landing-page');
     route.modelFor = sinon.stub();
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
   });
 
   describe('#beforeModel', function () {
@@ -20,7 +20,7 @@ describe('Unit | Route | campaign-landing-page', function () {
       await route.beforeModel({ from: null });
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entry-point');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
     });
 
     it('should continue en entrance route when from is set', async function () {
@@ -28,7 +28,7 @@ describe('Unit | Route | campaign-landing-page', function () {
       await route.beforeModel({ from: 'campaigns.entry-point' });
 
       //then
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
   });
 
@@ -54,7 +54,7 @@ describe('Unit | Route | campaign-landing-page', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.access', campaign.code);
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.access', campaign.code);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -12,7 +12,7 @@ describe('Unit | Route | Entrance', function () {
     route = this.owner.lookup('route:campaigns.entrance');
     route.campaignStorage = { get: sinon.stub(), set: sinon.stub() };
     route.modelFor = sinon.stub();
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
   });
 
   describe('#beforeModel', function () {
@@ -21,7 +21,7 @@ describe('Unit | Route | Entrance', function () {
       await route.beforeModel({ from: null });
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entry-point');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
     });
 
     it('should continue en entrance route when from is set', async function () {
@@ -29,7 +29,7 @@ describe('Unit | Route | Entrance', function () {
       await route.beforeModel({ from: 'campaigns.entry-point' });
 
       //then
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
   });
 
@@ -129,7 +129,11 @@ describe('Unit | Route | Entrance', function () {
 
       //then
       sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', null);
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
+      sinon.assert.calledWith(
+        route.router.replaceWith,
+        'campaigns.invited.fill-in-participant-external-id',
+        campaign.code
+      );
     });
 
     it('should abort campaign participation and redirect to already participated', async function () {
@@ -145,7 +149,7 @@ describe('Unit | Route | Entrance', function () {
       //when
       await route.afterModel(campaign);
 
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.existing-participation', campaign.code);
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.existing-participation', campaign.code);
     });
 
     it('should redirect to profiles-collection when campaign is of type PROFILES COLLECTION', async function () {
@@ -160,7 +164,7 @@ describe('Unit | Route | Entrance', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.profiles-collection.start-or-resume');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.profiles-collection.start-or-resume');
     });
 
     it('should redirect to assessment when campaign is of type ASSESSMENT', async function () {
@@ -175,7 +179,7 @@ describe('Unit | Route | Entrance', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.assessment.start-or-resume');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.assessment.start-or-resume');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -16,7 +16,7 @@ describe('Unit | Route | Entry Point', function () {
     route = this.owner.lookup('route:campaigns.entry-point');
 
     route.store = { queryRecord: sinon.stub() };
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
     route.modelFor = sinon.stub();
     route.campaignStorage = { set: sinon.stub(), clear: sinon.stub() };
     route.session = { isAuthenticated: false, invalidate: sinon.stub() };
@@ -92,7 +92,7 @@ describe('Unit | Route | Entry Point', function () {
         await route.afterModel(campaign, transition);
 
         //then
-        sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-landing-page');
+        sinon.assert.calledWith(route.router.replaceWith, 'campaigns.campaign-landing-page');
       });
 
       describe('archived campaign', function () {
@@ -105,7 +105,7 @@ describe('Unit | Route | Entry Point', function () {
           await route.afterModel(campaign, transition);
 
           //then
-          sinon.assert.calledWith(route.replaceWith, 'campaigns.archived-error');
+          sinon.assert.calledWith(route.router.replaceWith, 'campaigns.archived-error');
         });
       });
     });
@@ -140,7 +140,7 @@ describe('Unit | Route | Entry Point', function () {
         await route.afterModel(campaign, transition);
 
         //then
-        sinon.assert.calledWith(route.replaceWith, 'campaigns.campaign-landing-page');
+        sinon.assert.calledWith(route.router.replaceWith, 'campaigns.campaign-landing-page');
       });
 
       it('should redirect to entrance when ongoing campaign participation is existing', async function () {
@@ -156,7 +156,7 @@ describe('Unit | Route | Entry Point', function () {
         await route.afterModel(campaign, transition);
 
         //then
-        sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance');
+        sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entrance');
       });
 
       describe('archived campaign', function () {
@@ -177,7 +177,7 @@ describe('Unit | Route | Entry Point', function () {
           await route.afterModel(campaign, transition);
 
           //then
-          sinon.assert.calledWith(route.replaceWith, 'campaigns.archived-error');
+          sinon.assert.calledWith(route.router.replaceWith, 'campaigns.archived-error');
         });
 
         it('should redirect to entrance with participation', async function () {
@@ -193,7 +193,7 @@ describe('Unit | Route | Entry Point', function () {
           await route.afterModel(campaign, transition);
 
           //then
-          sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance');
+          sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entrance');
         });
       });
     });

--- a/mon-pix/tests/unit/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -12,7 +12,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
     route = this.owner.lookup('route:campaigns.invited.fill-in-participant-external-id');
     route.campaignStorage = { get: sinon.stub(), set: sinon.stub() };
     route.modelFor = sinon.stub();
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
   });
 
   describe('#model', function () {
@@ -37,7 +37,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign.code);
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entrance', campaign.code);
     });
 
     it('should redirect to entrance page if an external id is not required', async function () {
@@ -51,7 +51,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entrance', campaign.code);
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entrance', campaign.code);
     });
 
     it('should not redirect if an external id is required and not already set', async function () {
@@ -65,7 +65,7 @@ describe('Unit | Route | campaigns/invited/fill-in-participant-external-id', fun
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/invited/student-sco_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/student-sco_test.js
@@ -24,13 +24,17 @@ describe('Unit | Route | campaigns/invited/student-sco', function () {
           user: { id: 'id' },
         })
       );
-      route.replaceWith = sinon.stub();
+      route.router = { replaceWith: sinon.stub() };
 
       // when
       await route.afterModel(campaign);
 
       // then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
+      sinon.assert.calledWith(
+        route.router.replaceWith,
+        'campaigns.invited.fill-in-participant-external-id',
+        campaign.code
+      );
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/invited/student-sup_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited/student-sup_test.js
@@ -24,13 +24,17 @@ describe('Unit | Route | campaigns/invited/student-sup', function () {
           user: { id: 'id' },
         })
       );
-      route.replaceWith = sinon.stub();
+      route.router = { replaceWith: sinon.stub() };
 
       // when
       await route.afterModel(campaign);
 
       // then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
+      sinon.assert.calledWith(
+        route.router.replaceWith,
+        'campaigns.invited.fill-in-participant-external-id',
+        campaign.code
+      );
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/invited_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited_test.js
@@ -11,7 +11,7 @@ describe('Unit | Route | Invited', function () {
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.invited');
     route.modelFor = sinon.stub();
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
     route.campaignStorage = { get: sinon.stub() };
   });
 
@@ -21,7 +21,7 @@ describe('Unit | Route | Invited', function () {
       await route.beforeModel({ from: null });
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entry-point');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
     });
 
     it('should continue en entrance route when from is set', async function () {
@@ -29,7 +29,7 @@ describe('Unit | Route | Invited', function () {
       await route.beforeModel({ from: 'campaigns.entry-point' });
 
       //then
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
   });
 
@@ -56,7 +56,7 @@ describe('Unit | Route | Invited', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sco', campaign.code);
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.invited.student-sco', campaign.code);
     });
 
     it('should redirect to student sup invited page when association is needed', async function () {
@@ -71,7 +71,7 @@ describe('Unit | Route | Invited', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.student-sup', campaign.code);
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.invited.student-sup', campaign.code);
     });
 
     it('should redirect to fill in participant external otherwise', async function () {
@@ -85,7 +85,11 @@ describe('Unit | Route | Invited', function () {
       await route.afterModel(campaign);
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.invited.fill-in-participant-external-id', campaign.code);
+      sinon.assert.calledWith(
+        route.router.replaceWith,
+        'campaigns.invited.fill-in-participant-external-id',
+        campaign.code
+      );
     });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/join_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/join_test.js
@@ -11,7 +11,7 @@ describe('Unit | Route | Join', function () {
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.join');
     route.modelFor = sinon.stub();
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
   });
 
   describe('#beforeModel', function () {
@@ -20,7 +20,7 @@ describe('Unit | Route | Join', function () {
       await route.beforeModel({ from: null });
 
       //then
-      sinon.assert.calledWith(route.replaceWith, 'campaigns.entry-point');
+      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.entry-point');
     });
 
     it('should continue en entrance route when from is set', async function () {
@@ -28,7 +28,7 @@ describe('Unit | Route | Join', function () {
       await route.beforeModel({ from: 'campaigns.entry-point' });
 
       //then
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
 
     it('should redefine routeIfAlreadyAuthenticated', async function () {

--- a/mon-pix/tests/unit/routes/campaigns/profiles-collection/profile-already-shared_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/profiles-collection/profile-already-shared_test.js
@@ -16,7 +16,7 @@ describe('Unit | Route | Campaign | Profiles Collection | Profile already shared
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.profiles-collection.profile-already-shared');
     route.modelFor = sinon.stub().returns(campaign);
-    route.transitionTo = sinon.stub();
+    route.router = { transitionTo: sinon.stub() };
     route.store = storeStub;
     route.currentUser = currentUserStub;
   });
@@ -30,7 +30,7 @@ describe('Unit | Route | Campaign | Profiles Collection | Profile already shared
       it('should redirect to start or resume', async function () {
         await route.model();
 
-        sinon.assert.calledWith(route.transitionTo, 'campaigns.entry-point', 'NEW_CODE');
+        sinon.assert.calledWith(route.router.transitionTo, 'campaigns.entry-point', 'NEW_CODE');
       });
     });
 
@@ -44,7 +44,7 @@ describe('Unit | Route | Campaign | Profiles Collection | Profile already shared
       it('should not redirect', async function () {
         await route.model();
 
-        sinon.assert.notCalled(route.transitionTo);
+        sinon.assert.notCalled(route.router.transitionTo);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/certifications/resume_test.js
+++ b/mon-pix/tests/unit/routes/certifications/resume_test.js
@@ -29,7 +29,7 @@ describe('Unit | Route | Certification | Resume', function () {
       storeStub = Service.create({ query: queryStub, peekRecord: peekRecordStub });
       route = this.owner.lookup('route:certifications.resume');
       route.set('store', storeStub);
-      route.replaceWith = sinon.stub();
+      route.router = { replaceWith: sinon.stub() };
     });
 
     it('should peekRecord the certification course', async function () {
@@ -45,7 +45,7 @@ describe('Unit | Route | Certification | Resume', function () {
       await route.model(params);
 
       // then
-      sinon.assert.calledWith(route.replaceWith, 'assessments.resume', assessment);
+      sinon.assert.calledWith(route.router.replaceWith, 'assessments.resume', assessment);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/competences/results_test.js
+++ b/mon-pix/tests/unit/routes/competences/results_test.js
@@ -28,7 +28,7 @@ describe('Unit | Route | Competences | Results', function () {
       route = this.owner.lookup('route:competences.results');
       route.set('store', storeStub);
       route.set('session', sessionStub);
-      route.transitionTo = sinon.stub();
+      route.router = { transitionTo: sinon.stub() };
     });
 
     it('should return the most recent competence-evaluation for a given assessment', async function () {

--- a/mon-pix/tests/unit/routes/competences/resume_test.js
+++ b/mon-pix/tests/unit/routes/competences/resume_test.js
@@ -24,7 +24,7 @@ describe('Unit | Route | Competence | Resume', function () {
 
     route = this.owner.lookup('route:competences.resume');
     route.set('store', storeStub);
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
   });
 
   describe('#model', function () {
@@ -43,7 +43,7 @@ describe('Unit | Route | Competence | Resume', function () {
   describe('#afterModel', function () {
     it('should transition to assessments.resume', function () {
       // given
-      route.replaceWith.resolves();
+      route.router.replaceWith.resolves();
       const competenceEvaluation = EmberObject.create({ competenceId, assessment: { id: 'assessmentId' } });
 
       // when
@@ -51,8 +51,8 @@ describe('Unit | Route | Competence | Resume', function () {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(route.replaceWith);
-        sinon.assert.calledWith(route.replaceWith, 'assessments.resume', 'assessmentId');
+        sinon.assert.calledOnce(route.router.replaceWith);
+        sinon.assert.calledWith(route.router.replaceWith, 'assessments.resume', 'assessmentId');
       });
     });
   });

--- a/mon-pix/tests/unit/routes/courses/create-assessment_test.js
+++ b/mon-pix/tests/unit/routes/courses/create-assessment_test.js
@@ -22,7 +22,7 @@ describe('Unit | Route | Courses | Create Assessment', function () {
     storeStub = Service.create({ createRecord: createRecordStub });
     route = this.owner.lookup('route:courses.create-assessment');
     route.set('store', storeStub);
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
   });
 
   describe('#afterModel', function () {
@@ -39,7 +39,7 @@ describe('Unit | Route | Courses | Create Assessment', function () {
       await route.afterModel(course);
 
       // then
-      sinon.assert.calledWith(route.replaceWith, 'assessments.resume', createdAssessment.id);
+      sinon.assert.calledWith(route.router.replaceWith, 'assessments.resume', createdAssessment.id);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/index_test.js
+++ b/mon-pix/tests/unit/routes/index_test.js
@@ -9,13 +9,13 @@ describe('Unit | Route | index', function () {
     it('should redirect to /accueil', async function () {
       // Given
       const route = this.owner.lookup('route:index');
-      route.replaceWith = sinon.spy();
+      route.router = { replaceWith: sinon.spy() };
 
       // When
       await route.redirect();
 
       // Then
-      sinon.assert.calledWith(route.replaceWith, 'user-dashboard');
+      sinon.assert.calledWith(route.router.replaceWith, 'user-dashboard');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/login_test.js
+++ b/mon-pix/tests/unit/routes/login_test.js
@@ -72,7 +72,7 @@ describe('Unit | Route | login page', function () {
       const storeStub = { createRecord: createRecordStub };
 
       route.set('store', storeStub);
-      route.replaceWith = sinon.stub();
+      route.router = { replaceWith: sinon.stub() };
 
       // when
       await route.actions.updateExpiredPassword.call(route, username, oneTimePassword);

--- a/mon-pix/tests/unit/routes/shared-certification_test.js
+++ b/mon-pix/tests/unit/routes/shared-certification_test.js
@@ -7,10 +7,10 @@ describe('Unit | Route | shared-certification', function () {
 
   it('should redirect if there a no data (direct access)', function () {
     const route = this.owner.lookup('route:shared-certification');
-    sinon.stub(route, 'replaceWith');
+    sinon.stub(route.router, 'replaceWith');
 
     route.redirect({}, {});
-    sinon.assert.calledWithExactly(route.replaceWith, '/verification-certificat?unallowedAccess=true');
+    sinon.assert.calledWithExactly(route.router.replaceWith, '/verification-certificat?unallowedAccess=true');
   });
 
   it('should not redirect with certification', function () {
@@ -18,9 +18,9 @@ describe('Unit | Route | shared-certification', function () {
     const model = store.createRecord('certification', {});
 
     const route = this.owner.lookup('route:shared-certification');
-    sinon.stub(route, 'replaceWith');
+    sinon.stub(route.router, 'replaceWith');
 
     route.redirect(model, {});
-    sinon.assert.notCalled(route.replaceWith);
+    sinon.assert.notCalled(route.router.replaceWith);
   });
 });

--- a/mon-pix/tests/unit/routes/terms-of-service_test.js
+++ b/mon-pix/tests/unit/routes/terms-of-service_test.js
@@ -9,7 +9,7 @@ describe('Unit | Route | Terms-of-service', function () {
 
   beforeEach(function () {
     route = this.owner.lookup('route:terms-of-service');
-    route.replaceWith = sinon.stub();
+    route.router = { replaceWith: sinon.stub() };
     route.currentUser = { user: { mustValidateTermsOfService: true } };
     route.session = { attemptedTransition: null, data: {} };
   });
@@ -25,7 +25,7 @@ describe('Unit | Route | Terms-of-service', function () {
         await route.beforeModel();
 
         // then
-        sinon.assert.calledWith(route.replaceWith, '');
+        sinon.assert.calledWith(route.router.replaceWith, '');
       });
 
       it('should redirect to attempted transition if there is one', async function () {
@@ -49,7 +49,7 @@ describe('Unit | Route | Terms-of-service', function () {
         await route.beforeModel();
 
         // then
-        sinon.assert.calledWith(route.replaceWith, '');
+        sinon.assert.calledWith(route.router.replaceWith, '');
       });
 
       it('should redirect to attempted transition if there is one', async function () {

--- a/mon-pix/tests/unit/routes/user-certifications/get_test.js
+++ b/mon-pix/tests/unit/routes/user-certifications/get_test.js
@@ -22,7 +22,7 @@ describe('Unit | Route | user certifications/get', function () {
 
     route = this.owner.lookup('route:user-certifications/get');
     route.set('store', storeStub);
-    route.replaceWith = sinon.stub().resolves();
+    route.router.replaceWith = sinon.stub().resolves();
   });
 
   it('exists', function () {
@@ -64,7 +64,7 @@ describe('Unit | Route | user certifications/get', function () {
 
       // then
       return promise.then(() => {
-        expect(route.replaceWith.notCalled).to.be.true;
+        expect(route.router.replaceWith.notCalled).to.be.true;
       });
     });
 
@@ -86,8 +86,8 @@ describe('Unit | Route | user certifications/get', function () {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(route.replaceWith);
-        sinon.assert.calledWith(route.replaceWith, '/mes-certifications');
+        sinon.assert.calledOnce(route.router.replaceWith);
+        sinon.assert.calledWith(route.router.replaceWith, '/mes-certifications');
       });
     });
 
@@ -109,8 +109,8 @@ describe('Unit | Route | user certifications/get', function () {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledOnce(route.replaceWith);
-        sinon.assert.calledWith(route.replaceWith, '/mes-certifications');
+        sinon.assert.calledOnce(route.router.replaceWith);
+        sinon.assert.calledWith(route.router.replaceWith, '/mes-certifications');
       });
     });
   });

--- a/mon-pix/tests/unit/routes/user-tests_test.js
+++ b/mon-pix/tests/unit/routes/user-tests_test.js
@@ -40,19 +40,19 @@ describe('Unit | Route | User-Tests', function () {
   describe('redirect', function () {
     it('should redirect to default page if there is no campaign participation', function () {
       const route = this.owner.lookup('route:user-tests');
-      sinon.stub(route, 'replaceWith');
+      sinon.stub(route.router, 'replaceWith');
 
       route.redirect([], {});
-      sinon.assert.calledWithExactly(route.replaceWith, '');
+      sinon.assert.calledWithExactly(route.router.replaceWith, '');
     });
 
     it('should continue on user-tests if there is some campaign participations', function () {
       const route = this.owner.lookup('route:user-tests');
-      sinon.stub(route, 'replaceWith');
+      sinon.stub(route.router, 'replaceWith');
       const campaignParticipationOverviews = [EmberObject.create({ id: 10 })];
 
       route.redirect(campaignParticipationOverviews, {});
-      sinon.assert.notCalled(route.replaceWith);
+      sinon.assert.notCalled(route.router.replaceWith);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Depuis, la version 3 d'Ember les injections implicites sont dépréciées (cf: https://deprecations.emberjs.com/v3.x/#toc_implicit-injections).

Nos apps continuent d'en avoir ce qui engendre des messages de warnings dans la console et de plus, cela nous limitera dans les futures montées de versions.  

## :robot: Solution
Faire une première passe pour retirer le maximum d'injections implicites sur Pix App

C'est à dire que pour efffectuer une transition, il faut utiliser le service `router` : 
```
this.router.transitionTo()
```
Pour utiliser le store, il faut importer le service, etc.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Naviguer sur Pix APP.
