### PR TITLE
[FEATURE] Déconnecter un agent Pix qui a été désactivé sur Pix Admin (PIX-5279).

### DIFF
--- a/api/lib/domain/usecases/deactivate-admin-member.js
+++ b/api/lib/domain/usecases/deactivate-admin-member.js
@@ -1,3 +1,5 @@
-module.exports = async function deactivateAdminMember({ id, adminMemberRepository }) {
+module.exports = async function deactivateAdminMember({ id, adminMemberRepository, refreshTokenService }) {
+  const { userId } = await adminMemberRepository.getById(id);
   await adminMemberRepository.deactivate({ id });
+  await refreshTokenService.revokeRefreshTokensForUserId({ userId });
 };

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -16,15 +16,26 @@ module.exports = {
     return members.map((member) => new AdminMember(member));
   },
 
+  getById: async function (id) {
+    const adminMember = await knex
+      .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role', 'disabledAt')
+      .from(TABLE_NAME)
+      .where({ 'pix-admin-roles.id': id })
+      .join('users', 'users.id', `${TABLE_NAME}.userId`)
+      .first();
+
+    return adminMember ? new AdminMember(adminMember) : undefined;
+  },
+
   get: async function ({ userId }) {
-    const member = await knex
+    const adminMember = await knex
       .select(`${TABLE_NAME}.id`, 'users.id as userId', 'firstName', 'lastName', 'email', 'role', 'disabledAt')
       .from(TABLE_NAME)
       .where({ userId })
       .join('users', 'users.id', `${TABLE_NAME}.userId`)
       .first();
 
-    return member ? new AdminMember(member) : undefined;
+    return adminMember ? new AdminMember(adminMember) : undefined;
   },
 
   async update({ id, attributesToUpdate }) {

--- a/api/tests/unit/domain/usecases/deactivate-admin-member_test.js
+++ b/api/tests/unit/domain/usecases/deactivate-admin-member_test.js
@@ -2,19 +2,40 @@ const { sinon, expect } = require('../../../test-helper');
 const deactivateAdminMember = require('../../../../lib/domain/usecases/deactivate-admin-member');
 
 describe('Unit | UseCase | deactivate-admin-member', function () {
-  it('should deactivate the given admin member', async function () {
+  it("should deactivate the given admin member and revoke all user's refresh tokens", async function () {
     // given
-    const adminMemberRepository = { deactivate: sinon.stub() };
-
+    const adminMemberRepository = { deactivate: sinon.stub(), getById: sinon.stub() };
     adminMemberRepository.deactivate.withArgs({ id: 7 }).resolves(undefined);
+    adminMemberRepository.getById.withArgs(7).resolves({ userId: 2 });
+
+    const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
 
     // when
     const adminMember = await deactivateAdminMember({
       id: 7,
       adminMemberRepository,
+      refreshTokenService,
     });
 
     // then
     expect(adminMember).to.be.undefined;
+  });
+
+  it("should revoke all user's refresh tokens", async function () {
+    // given
+    const adminMemberRepository = { deactivate: sinon.stub(), getById: sinon.stub() };
+    adminMemberRepository.deactivate.withArgs({ id: 7 }).resolves(undefined);
+    adminMemberRepository.getById.withArgs(7).resolves({ userId: 2 });
+    const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
+
+    // when
+    await deactivateAdminMember({
+      id: 7,
+      adminMemberRepository,
+      refreshTokenService,
+    });
+
+    // then
+    expect(refreshTokenService.revokeRefreshTokensForUserId).to.have.been.calledWithExactly({ userId: 2 });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'ajout de la fonctionnalité https://github.com/1024pix/pix/pull/4549 et lorsque l'utilisateur courant est désactivé, sa session reste active mais il n'a plus les droits pour voir certaines pages et/ou faire certaines requêtes api. Ce qui affiche des erreurs (et l'utilisateur peut rester sur une page d'erreur sans pouvoir se déconnecter par exemple).

Sur pix-admin nous ne gérons pas toujours les erreurs des requêtes notamment au niveau des routes (findAll, store.query, etc.) et quand c'est fait dans les composants, c'est de différentes manières.

Par exemple, si je suis sur une page qui récupère la liste des organisations via une requête api et que cela est fait au niveau de la route, si la requête est en erreur, cela n'est pas catché.


## :robot: Solution

+ revocation du refresh token pour forcer la déconnexion à l'expiration de l'accès token et donc limiter la connexion à maximum 4h en production

## :rainbow: Remarques

Il reste plusieurs problèmes :
- si la session expire, il y aura des 401 en réponse aux appels api et ça n'est pas géré
- l'utilisateur sera deconnecté de toutes les applications pix
- si l'utilisateur clique sur un lien qui amène à une route dans laquelle les erreurs ne sont pas catchés, il a une `erreur ember`

![Capture d’écran 2022-07-25 à 11 31 30](https://user-images.githubusercontent.com/7688741/180745920-620ee9e0-f5ff-4150-a4f8-bf1d46116cbb.png)


## :100: Pour tester

**Mettre une valeur faible pour le refresh token, par exemple `ACCESS_TOKEN_LIFESPAN=60s` et relancer l'api**

Se mettre sur dev, se connecter en tant que super admin et se désactiver soi-même, observer les nombreuses erreurs dont l'impossibilité de se déconnecter même )


### Manière 1 (vérifier que l'utilisateur n'a pas de refresh token valide)

- se connecter en tant que super admin sur un navigateur
- se connecter sur un autre navigateur avec un autre rôle, par exemple CERTIF
- désactiver le rôle de l'admin qui est CERTIF dans le premier navigateur
- rester dans le deuxième navigateur (en tant que CERTIF) sur la page sur laquelle on est !
- essayer de faire une action
- observer des 403 en réponse api si on clique sur une route protégée qui ne génère pas d'erreur comme `équipe`
- attendre que le accès token token expire (on voit que les post sur /token renvoie une 401)

![Capture d’écran 2022-07-19 à 11 17 51](https://user-images.githubusercontent.com/7688741/179715174-642af891-b212-4bec-bd3c-0b10d0c6763c.png)

- faire une action et voir que les appels api renvoient une 401
- Cliquer sur un des éléments du menu (la page outil n'est pas protégé, il ne se passe rien)
  - si on va sur la liste des orgas qui n'est pas protégée, comme les erreurs ne sont pas catchées, ça génère une erreur `Error dans Ember !`
  - si on va sur une route protégé qui ne génère pas d'erreur, il ne se passe rien :-(


### Manière  2
- se connecter en tant que **super admin** sur un navigateur
-  Aller sur la page **EQUIPE** et se désactiver
-  Essayer de faire une action
- observer des 403 en réponse api si on clique sur une route protégée qui ne génère pas d'erreur comme `équipe`
-  observer des 401 en réponse api à l'expiration du token


Cas nominal : 

- Essaye de de connecter avec son compte désactivé et observer que vous ne pouvez plus vous connecter (cas passant)

