### PR TITLE
[FEATURE] Rajouter le contexte pour les tutoriels (PIX-4649).

### DIFF
--- a/api/lib/domain/read-models/TutorialForUser.js
+++ b/api/lib/domain/read-models/TutorialForUser.js
@@ -1,10 +1,11 @@
 const Tutorial = require('../models/Tutorial');
 
 class TutorialForUser extends Tutorial {
-  constructor({ userTutorial, tutorialEvaluation, ...tutorial }) {
+  constructor({ userTutorial, tutorialEvaluation, skillId, ...tutorial }) {
     super(tutorial);
     this.userTutorial = userTutorial;
     this.tutorialEvaluation = tutorialEvaluation;
+    this.skillId = skillId;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/tutorial-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tutorial-serializer.js
@@ -16,6 +16,7 @@ module.exports = {
         'tubePracticalDescription',
         'tutorialEvaluation',
         'userTutorial',
+        'skillId',
       ],
       tutorialEvaluation: tutorialEvaluationAttributes,
       userTutorial: userTutorialAttributes,

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -298,6 +298,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example.html',
               source: 'tuto.com',
               title: 'tuto1',
+              'skill-id': 'recSkill1',
             },
             id: 'tuto1',
             relationships: {
@@ -323,6 +324,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example2.html',
               source: 'tuto.com',
               title: 'tuto2',
+              'skill-id': 'recSkill1',
             },
             id: 'tuto2',
             relationships: {
@@ -342,6 +344,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example4.html',
               source: 'tuto.com',
               title: 'tuto4',
+              'skill-id': 'recSkill3',
             },
             id: 'tuto4',
             relationships: {
@@ -408,6 +411,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example.html',
               source: 'tuto.com',
               title: 'tuto1',
+              'skill-id': 'recSkill1',
             },
             id: 'tuto1',
             relationships: {
@@ -427,6 +431,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example2.html',
               source: 'tuto.com',
               title: 'tuto2',
+              'skill-id': 'recSkill1',
             },
             id: 'tuto2',
             relationships: {
@@ -561,7 +566,11 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
         // given
         mockLearningContent(learningContentObjects);
 
-        databaseBuilder.factory.buildUserSavedTutorial({ id: 101, userId: 4444, tutorialId: 'tuto1' });
+        databaseBuilder.factory.buildUserSavedTutorial({
+          id: 101,
+          userId: 4444,
+          tutorialId: 'tuto1',
+        });
 
         await databaseBuilder.commit();
 
@@ -573,6 +582,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example.html',
               source: 'tuto.com',
               title: 'tuto1',
+              'skill-id': undefined,
             },
             relationships: {
               'user-tutorial': { data: { id: '101', type: 'user-tutorial' } },
@@ -636,6 +646,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example3.html',
               source: 'tuto.com',
               title: 'tuto3',
+              'skill-id': undefined,
             },
             id: 'tuto3',
             relationships: {
@@ -658,6 +669,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example2.html',
               source: 'tuto.com',
               title: 'tuto2',
+              'skill-id': undefined,
             },
             id: 'tuto2',
             relationships: {

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -544,6 +544,11 @@ describe('Integration | Repository | tutorial-repository', function () {
             {
               id: 'tuto1',
               locale: 'fr-fr',
+              link: 'https//example.net/tuto1',
+              source: 'wikipedia',
+              title: 'Mon super tuto',
+              format: 'video',
+              duration: '2min',
             },
             {
               id: 'tuto2',
@@ -572,7 +577,15 @@ describe('Integration | Repository | tutorial-repository', function () {
         const { results } = await tutorialRepository.findPaginatedRecommendedByUserId({ userId });
 
         // then
-        expect(results.map((tutorial) => tutorial.id)).to.exactlyContain(['tuto2', 'tuto1', 'tuto5']);
+        expect(_.omit(results[0], ['userTutorial', 'tutorialEvaluation'])).to.deep.equal({
+          id: 'tuto1',
+          link: 'https//example.net/tuto1',
+          source: 'wikipedia',
+          title: 'Mon super tuto',
+          format: 'video',
+          duration: '2min',
+        });
+        expect(results.map((tutorial) => tutorial.id)).to.exactlyContain(['tuto1', 'tuto2', 'tuto5']);
       });
 
       it('should return tutorial related to user locale', async function () {

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -584,6 +584,7 @@ describe('Integration | Repository | tutorial-repository', function () {
           title: 'Mon super tuto',
           format: 'video',
           duration: '2min',
+          skillId: 'recSkill1',
         });
         expect(results.map((tutorial) => tutorial.id)).to.exactlyContain(['tuto1', 'tuto2', 'tuto5']);
       });

--- a/api/tests/tooling/domain-builder/factory/build-tutorial-for-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-tutorial-for-user.js
@@ -6,6 +6,7 @@ module.exports = function buildTutorialForUser({
   tutorial = buildTutorial(),
   userTutorial = buildUserSavedTutorial(),
   tutorialEvaluation,
+  skillId,
 } = {}) {
-  return new TutorialForUser({ ...tutorial, tutorialEvaluation, userTutorial });
+  return new TutorialForUser({ ...tutorial, tutorialEvaluation, userTutorial, skillId });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
@@ -7,8 +7,12 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       // given
       const tutorialId = 123;
 
-      const tutorial = domainBuilder.buildTutorial({
-        id: tutorialId,
+      const skillId = 'rec123';
+
+      const tutorial = domainBuilder.buildTutorialForUser({
+        tutorial: domainBuilder.buildTutorial({ id: tutorialId }),
+        userTutorial: null,
+        skillId,
       });
 
       const expectedSerializedResult = {
@@ -21,6 +25,15 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
             link: 'https://youtube.fr',
             source: 'Youtube',
             title: 'Savoir regarder des vidéos youtube.',
+            'skill-id': 'rec123',
+          },
+          relationships: {
+            'tutorial-evaluation': {
+              data: null,
+            },
+            'user-tutorial': {
+              data: null,
+            },
           },
         },
       };
@@ -31,6 +44,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       // then
       expect(result).to.deep.equal(expectedSerializedResult);
     });
+
     it('should return a serialized JSON data object, enhanced by tube information', function () {
       // given
       const tutorialId = 123;
@@ -74,12 +88,14 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
       const tutorialId = 123;
       const tutorialEvaluationId = `${userId}_${tutorialId}`;
       const userTutorialId = `${userId}_${tutorialId}`;
+      const skillId = 'rec123';
 
-      const tutorial = domainBuilder.buildTutorial({
-        id: tutorialId,
+      const tutorial = domainBuilder.buildTutorialForUser({
+        tutorial: domainBuilder.buildTutorial({ id: tutorialId }),
+        tutorialEvaluation: { userId, id: tutorialEvaluationId, tutorialId },
+        userTutorial: { userId, id: userTutorialId, tutorialId },
+        skillId,
       });
-      tutorial.tutorialEvaluation = { userId, id: tutorialEvaluationId, tutorialId };
-      tutorial.userTutorial = { userId, id: userTutorialId, tutorialId };
 
       const expectedSerializedResult = {
         data: {
@@ -91,6 +107,7 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
             link: 'https://youtube.fr',
             source: 'Youtube',
             title: 'Savoir regarder des vidéos youtube.',
+            'skill-id': 'rec123',
           },
           relationships: {
             'tutorial-evaluation': {

--- a/mon-pix/app/models/tutorial.js
+++ b/mon-pix/app/models/tutorial.js
@@ -13,6 +13,7 @@ export default class Tutorial extends Model {
   @attr('string') tubeName;
   @attr('string') tubePracticalTitle;
   @attr('string') tubePracticalDescription;
+  @attr('string') skillId;
 
   // includes
   @belongsTo('scorecard') scorecard;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous n'avons pas connaissance du contexte dans lequel un tutoriel est proposé. Ce qui fait que nous ne pouvons pas filtrer sur celui-ci ou encore avoir ce dernier au moment de l'enregistrement du tutoriel.

## :robot: Solution
Dans cette PR, nous remontons le contexte, à savoir le `skillId`, obtenu grâce au KE invalidé correspondant.

## :rainbow: Remarques
Nous utilisons pas ce contexte au moment de l'enregistrement pour l'instant.  

## :100: Pour tester
- Se connecter sur Pix App
- Se rendre sur la page `/mes-tutos/recommandes`
- Constater dans l'inspecteur d'Ember que le skillId est présent dans les tuples des Tutoriels. 
