### PR TITLE
[TECH] Utiliser la bonne route avec les bons droits d'accès pour la dissociation des schoolings registrations (PIX-5217)

### DIFF
--- a/admin/app/adapters/schooling-registration.js
+++ b/admin/app/adapters/schooling-registration.js
@@ -1,7 +1,9 @@
 import ApplicationAdapter from './application';
 
 export default class SchoolingRegistrationAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
   urlForDeleteRecord(id) {
-    return `${this.host}/${this.namespace}/schooling-registration-user-associations/${id}`;
+    return `${this.host}/${this.namespace}/organization-learners/${id}/association`;
   }
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -289,7 +289,7 @@ export default function () {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
 
-  this.delete('/schooling-registration-user-associations/:id', (schema, request) => {
+  this.delete('/admin/organization-learners/:id/association', (schema, request) => {
     const schoolingRegistrationId = request.params.id;
     schema.db.schoolingRegistrations.remove(schoolingRegistrationId);
     return new Response(204);

--- a/admin/tests/unit/adapters/schooling-registration_test.js
+++ b/admin/tests/unit/adapters/schooling-registration_test.js
@@ -15,16 +15,14 @@ module('Unit | Adapter | schooling-registration', function (hooks) {
   module('#urlForDeleteRecord', function () {
     test('it performs the request to dissociate user from student', async function (assert) {
       // given
-      const schoolingRegistration = { id: 12345 };
-      const expectedUrl = `${ENV.APP.API_HOST}/api/schooling-registration-user-associations/${schoolingRegistration.id}`;
+      const organizationLearner = { id: 12345 };
+      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/organization-learners/${organizationLearner.id}/association`;
 
       // when
-      const url = adapter.urlForDeleteRecord(schoolingRegistration.id);
+      const url = adapter.urlForDeleteRecord(organizationLearner.id);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, expectedUrl);
+      assert.strictEqual(url, expectedUrl);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Il existe actuellement 2 routes permettant de dissocier un utilisateur :

1. DELETE /api/schooling-registration-user-associations/{id}
2. DELETE /api/admin/organization-learners/{id}/association

Cette action n'est disponible que sur l'application Pix Admin.

La 1ère route est utilisée par l'application Pix Admin. Dans un but de cohérence au niveau de l'API, la route devrait se trouver sous le chemin `/admin`. De plus, une modification du nom de la ressource `schooling-registration-user-associations` en `organization-learners` a été effectué. 

## :robot: Solution

#### Pix Admin

Utiliser la nouvelle route `DELETE /api/admin/organization-learners/{id}/association`.

#### Pix Api

Retirer la route qui n'est plus utilisée `DELETE /api/schooling-registration-user-associations/{id}`

## :rainbow: Remarques

RAS

## :100: Pour tester

#### Super admin ou Support

1. Se connecter sur [Pix Admin](https://admin-pr4617.review.pix.fr/) avec le compte `superadmin@example.net` ou `pixsupport@example.net`.
4. Ouvrir la console développeur dans l'onglet `Network`.
5. Cliquer sur l'onglet `Utilisateurs`.
6. Rechercher `Lyanna` comme prénom (ou un autre).
7. Ouvrer la page de détails de cet utilisateur.
8. Dans l'encadré `Informations prescrit`, cliquez sur le bouton `Dissocier`.
9. Puis sur le bouton `Oui, je dissocie` sur la fenêtre qui vient de s'afficher.
10. Constater que dans l'encadré `Informations prescrit` qu'aucune action n'est disponible (le bouton `Dissocier` n'est plus visible)
11. Constater dans la console développeur dans l'onglet `Network` l'appel à la nouvelle route `DELETE /api/admin/organization-learners/{id}/association`

#### Certif et Metier

1. Se connecter sur [Pix Admin](https://admin-pr4617.review.pix.fr/) avec le compte `pixcertif@example.net` ou `pixmetier@example.net`
2. Cliquer sur l'onglet `Utilisateurs`.
3. Rechercher `Lyanna` comme prénom (ou un autre).
4. Ouvrer la page de détails de cet utilisateur.
5. Dans l'encadré `Informations prescrit`, constatez que le bouton `Dissocier` n'est pas visible.