### PR TITLE
[FEATURE] App - Allonge le cache pour les polices de Pix UI

### DIFF
--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -90,6 +90,13 @@ server {
     expires max;
   }
 
+  location /@1024pix/pix-ui/fonts/ {
+    # Design System fonts are not hash-suffixed but can be cached for a long time
+    expires 1y;
+    add_header Cache-Control "public";
+    add_header ETag "";
+  }
+
   location /images/ {
     expires 24h;
   }


### PR DESCRIPTION
## :unicorn: Problème
Les polices d'écritures récupérées de Pix UI ne sont mises en cache navigateur que pour 24h sur Pix App.

## :robot: Solution
Allonger la durée du cache pour durer 1 an sur le navigateur. C'est la valeur utilisée par Google Fonts.

## :rainbow: Remarques
J'ai repris et tweaké les headers de https://github.com/1024pix/pix-site/pull/301.

## :100: Pour tester
Vérifier sur [la RA](https://pix-front-review-pr4618.osc-fr1.scalingo.io/) la durée du `cache-control` `max-age` qui doit valoir `31536000`. Le review router ne permet pas de conserver ces headers donc j'ai du ajouter la var d'env `PROJECT_DIR=mon-pix` pour tester sans en accédant direct à l'URL Scalingo.
