### PR TITLE
[BUGFIX] Uniformisation du wording sur la modale de mise à jour de résolution (PIX-5276).

### DIFF
--- a/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
+++ b/admin/app/components/certifications/issue-reports/resolve-issue-report-modal.js
@@ -24,7 +24,7 @@ export default class CertificationIssueReportModal extends Component {
   }
 
   get actionName() {
-    return this.args.issueReport.isResolved ? 'Modifier le signalement' : 'Résoudre ce signalement';
+    return this.args.issueReport.isResolved ? 'Modifier la résolution' : 'Résoudre ce signalement';
   }
 
   _isInvalid() {

--- a/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
+++ b/admin/tests/integration/components/certifications/issue-reports/resolve-issue-report-modal_test.js
@@ -184,7 +184,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                     />`);
 
       // Then
-      assert.dom(screen.getByRole('dialog', { name: 'Modifier le signalement' })).exists();
+      assert.dom(screen.getByRole('dialog', { name: 'Modifier la résolution' })).exists();
     });
     module('when updating the resolution with an empty text', function () {
       test('it should display an error message', async function (assert) {
@@ -209,7 +209,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                     />`);
 
         // when
-        await clickByName('Modifier le signalement');
+        await clickByName('Modifier la résolution');
 
         // Then
         assert.dom(screen.getByText('Le motif de résolution doit être renseigné.')).exists();
@@ -238,7 +238,7 @@ module('Integration | Component | certifications/issue-reports/resolve-issue-rep
                   />`);
 
       // Then
-      assert.dom(screen.getByRole('button', { name: 'Modifier le signalement' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Modifier la résolution' })).exists();
     });
     test('it should display actual resolution text', async function (assert) {
       // Given


### PR DESCRIPTION
## :unicorn: Problème

Le wording sur la page de détail d'une session et la modale de mise à jour de la résolution d'une modale ne sont pas uniformes.

## :robot: Solution

Modification du wording de la modale en question

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur la page de détails d'une résolution de session dans Pix-Admin, constater que le titre de la modale de modification de résolution ainsi que le bouton de mise à jour contiennent l'intitulé: `Modifier la résolution`
