### PR TITLE
[FEATURE] A11Y - Ajouter une description aux tableaux complexes (PIX-3920)

### DIFF
--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -25,6 +25,13 @@
   <div class="table content-text content-text--small certification-candidates-table">
     {{#if (or @certificationCandidates this.candidatesInStaging)}}
       <table class="certification-candidates-table-cpf-toggle-enabled">
+        <caption class="sr-only">
+          {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+            {{t "pages.sessions.enrolled-candidates.without-details-description"}}
+          {{else}}
+            {{t "pages.sessions.enrolled-candidates.with-details-description"}}
+          {{/if}}
+        </caption>
         <thead>
           <tr>
             <th class="certification-candidates-table__column-last-name">

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -1,13 +1,16 @@
 <div class="table session-finalization-reports-information-step">
-  {{#if (gt @session.uncompletedCertificationReports.length 0)}}
-    <div class="session-finalization-reports-information-step__title-completed">
-      <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
-      Certification(s) terminée(s)
-    </div>
-  {{/if}}
-  <table aria-label="Certification(s) terminée(s)">
-    <caption>
-    </caption>
+  <table>
+    {{#if (gt @session.uncompletedCertificationReports.length 0)}}
+      <caption>
+        <div class="session-finalization-reports-information-step__title-completed">
+          <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
+          Certification(s) terminée(s)
+        </div>
+        <span class="sr-only">
+          {{t "pages.sessions.finalize.finished-test-list-description"}}
+        </span>
+      </caption>
+    {{/if}}
     <thead>
       <tr>
         <th>Nom</th>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -6,6 +6,9 @@
         <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon" />
         Ces candidats n'ont pas fini leur test de certification
       </div>
+      <span class="sr-only">
+        {{t "pages.sessions.finalize.unfinished-test-list-description"}}
+      </span>
     </caption>
     <thead>
       <tr>

--- a/certif/tests/helpers/setup-intl-rendering.js
+++ b/certif/tests/helpers/setup-intl-rendering.js
@@ -1,0 +1,7 @@
+import setupIntl from './setup-intl';
+import { setupRenderingTest } from 'ember-qunit';
+
+export default function setupIntlRenderingTest(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+}

--- a/certif/tests/helpers/setup-intl.js
+++ b/certif/tests/helpers/setup-intl.js
@@ -1,0 +1,6 @@
+export default function setupIntl(hooks, locale = ['fr']) {
+  hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
+    this.intl.setLocale(locale);
+  });
+}

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import setupIntlRenderingTest from '../../helpers/setup-intl-rendering'
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -13,6 +13,33 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
+  });
+
+  test('it should have an accessible table description', async function (assert) {
+    //given
+    const candidate = _buildCertificationCandidate({
+      birthdate: new Date('2019-04-28'),
+    });
+
+    const certificationCandidate = store.createRecord('certification-candidate', candidate);
+
+    this.set('certificationCandidates', [certificationCandidate]);
+
+    // when
+    const screen = await renderScreen(hbs`
+        <EnrolledCandidates
+          @sessionId="1"
+          @certificationCandidates={{certificationCandidates}}
+          >
+        </EnrolledCandidates>
+      `);
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('table', { name: this.intl.t('pages.sessions.enrolled-candidates.with-details-description') })
+      )
+      .exists();
   });
 
   test('it displays candidate information', async function (assert) {

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering'
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | enrolled-candidates', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const DELETE_BUTTON_SELECTOR = 'certification-candidates-actions__delete-button';
   const DELETE_BUTTON_DISABLED_SELECTOR = `${DELETE_BUTTON_SELECTOR}--disabled`;

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { A } from '@ember/array';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -8,7 +8,7 @@ import { certificationIssueReportCategories } from 'pix-certif/models/certificat
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | SessionFinalization::CompletedReportsInformationStep', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let reportA;
   let reportB;
   let store;
@@ -120,7 +120,7 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     this.set('session', session);
 
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
         <SessionFinalization::CompletedReportsInformationStep
           @session={{this.session}}
           @certificationReports={{this.certificationReports}}
@@ -131,7 +131,13 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
       `);
 
     // then
-    assert.contains('Certification(s) terminée(s)');
+    assert
+      .dom(
+        screen.getByRole('table', {
+          name: `Certification(s) terminée(s) ${this.intl.t('pages.sessions.finalize.finished-test-list-description')}`,
+        })
+      )
+      .exists();
   });
 
   test('it does not show "Certification(s) terminée(s)" if there is no uncomplete certification report', async function (assert) {
@@ -157,31 +163,6 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
 
     // then
     assert.dom('.session-finalization-reports-information-step__title-completed').doesNotExist();
-  });
-
-  test('it has an accessible label', async function (assert) {
-    // given
-    this.certificationReports = [
-      store.createRecord('certification-report', {
-        hasSeenEndTestScreen: null,
-      }),
-    ];
-    this.issueReportDescriptionMaxLength = 500;
-    this.toggleCertificationReportHasSeenEndTestScreen = sinon.stub().returns();
-    this.toggleAllCertificationReportsHasSeenEndTestScreen = sinon.stub().returns();
-
-    // when
-    const screen = await renderScreen(hbs`
-      <SessionFinalization::CompletedReportsInformationStep
-        @certificationReports={{this.certificationReports}}
-        @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
-        @onHasSeenEndTestScreenCheckboxClicked={{this.toggleCertificationReportHasSeenEndTestScreen}}
-        @onAllHasSeenEndTestScreenCheckboxesClicked={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
-      />
-    `);
-
-    // then
-    assert.dom(screen.getByRole('table', { name: 'Certification(s) terminée(s)' })).exists();
   });
 
   module('when the end test screen removal feature is disabled', function () {

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { A } from '@ember/array';
 import { click, render, find, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -10,7 +10,7 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 
 module('Integration | Component | SessionFinalization::UncompletedReportsInformationStep', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let reportA;
   let reportB;
   let store;
@@ -236,7 +236,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
     assert.dom(screen.getByText('Modification infos candidat')).exists();
   });
 
-  test('it has an accessible label', async function (assert) {
+  test('it has an accessible label and caption', async function (assert) {
     // given
     this.certificationReports = [
       run(() =>
@@ -259,6 +259,14 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
     `);
 
     // then
-    assert.dom(screen.getByRole('table', { name: "Ces candidats n'ont pas fini leur test de certification" })).exists();
+    assert
+      .dom(
+        screen.getByRole('table', {
+          name: `Ces candidats n'ont pas fini leur test de certification ${this.intl.t(
+            'pages.sessions.finalize.unfinished-test-list-description'
+          )}`,
+        })
+      )
+      .exists();
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -3,6 +3,12 @@
   "pages": {
     "login": {
       "title": "Login"
+    },
+    "sessions": {
+      "finalize": {
+        "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
+        "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
+      }
     }
   }
 }

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -5,6 +5,10 @@
       "title": "Login"
     },
     "sessions": {
+      "enrolled-candidates": {
+        "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",
+        "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne."
+      },
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -5,6 +5,10 @@
       "title": "Connectez-vous"
     },
     "sessions": {
+      "enrolled-candidates": {
+        "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",
+        "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne."
+      },
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -3,6 +3,12 @@
   "pages": {
     "login": {
       "title": "Connectez-vous"
+    },
+    "sessions": {
+      "finalize": {
+        "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
+        "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
+      }
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’[audit accessibilité](https://docs.google.com/spreadsheets/d/1opOxK1nzON2PBjWrSAxx9gI5PPrUccWR/edit#gid=2021874496) de Pix Certif dans le cadre duquel l’app a obtenu le score de 40%, nous cherchons à améliorer notre % de conformité à 50%.

## :robot: Solution
Ajouter une balise caption comprenant les descriptions des tableaux complexes

## :rainbow: Remarques

L'intégralité des textes des pages visitées dans cette PR n'est pas traduite, causant des assertions dans les tests qui mélangent des textes en dur à des textes traduits.
Considérant toutefois que cela correspond à une autre responsabilité, je propose de s'occuper des traductions dans une autre PR dédiée.

## :100: Pour tester

Dans pix-certif:

Sur la page de la liste des candidats participant à une session, vérifier dans la console la présence de la `caption` avec le texte suivant : 
```
Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.
```

Sur la page de finalisation d'une session, vérifier dans la console la présence pour les personnes **n'ayant pas** fini leur test de la `caption` suivante : 
```
Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.
```

Sur la page de finalisation d'une session, vérifier dans la console la présence pour les personnes **ayant** fini leur test de la `caption` suivante : 
```
Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.
```