### PR TITLE
[FEATURE] Revenir sur la page d'origine de la liste des sessions (PIX-5259).

### DIFF
--- a/certif/app/routes/authenticated/sessions/list.js
+++ b/certif/app/routes/authenticated/sessions/list.js
@@ -30,10 +30,14 @@ export default class ListRoute extends Route {
     );
   }
 
-  resetController(controller, isExiting) {
-    if (isExiting) {
+  resetController(controller, isExiting, transition) {
+    if (this._isNotComingFromSessionsDetails(isExiting, transition)) {
       controller.pageNumber = 1;
       controller.pageSize = 25;
     }
+  }
+
+  _isNotComingFromSessionsDetails(isExiting, transition) {
+    return isExiting && transition.to.parent.name !== 'authenticated.sessions.details';
   }
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -1,6 +1,7 @@
 import Response from 'ember-cli-mirage/response';
 import { upload } from 'ember-file-upload/mirage';
 import { findPaginatedStudents } from './handlers/find-paginated-students';
+import { findPaginatedSessionSummaries } from './handlers/find-paginated-session-summaries';
 
 function parseQueryString(queryString) {
   const result = Object.create(null);
@@ -215,14 +216,7 @@ export default function () {
     return schema.divisions.all();
   });
 
-  this.get('/certification-centers/:id/session-summaries', (schema, request) => {
-    const certificationCenterId = request.params.id;
-    const results = schema.sessionSummaries.where({ certificationCenterId });
-    const json = this.serializerOrRegistry.serialize(results, request);
-    json.meta = { hasSessions: results.length > 0 };
-
-    return json;
-  });
+  this.get('/certification-centers/:id/session-summaries', findPaginatedSessionSummaries);
 
   this.get('/countries', (schema, _) => {
     return schema.countries.all();

--- a/certif/mirage/handlers/find-paginated-session-summaries.js
+++ b/certif/mirage/handlers/find-paginated-session-summaries.js
@@ -1,0 +1,20 @@
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
+
+export function findPaginatedSessionSummaries(schema, request) {
+  const certificationCenterId = request.params.id;
+  const sessionSummaries = schema.sessionSummaries.where({ certificationCenterId }).models;
+  const rowCount = sessionSummaries.length;
+  const pagination = getPaginationFromQueryParams(request.queryParams);
+  const paginatedSessionSummaries = applyPagination(sessionSummaries, pagination);
+
+  const json = this.serialize({ modelName: 'session-summary', models: paginatedSessionSummaries }, 'session-summary');
+
+  json.meta = {
+    hasSessions: sessionSummaries.length > 0,
+    ...pagination,
+    rowCount,
+    pageCount: Math.ceil(rowCount / pagination.pageSize),
+  };
+
+  return json;
+}

--- a/certif/mirage/serializers/session-summary.js
+++ b/certif/mirage/serializers/session-summary.js
@@ -1,0 +1,3 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({});

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -268,6 +268,34 @@ module('Acceptance | Session List', function (hooks) {
         assert.dom(screen.getByText('La session a déjà commencé.')).exists();
         assert.dom(screen.getByRole('button', { name: 'Supprimer la session 123' })).exists();
       });
+
+      test('it should redirect to the same page of session list', async function (assert) {
+        // given
+        server.createList('session-summary', 30, {
+          address: 'Adresse',
+          certificationCenterId: 123,
+          date: '2020-01-01',
+          time: '14:00',
+        });
+        server.create('session', {
+          id: 26,
+          address: 'Adresse',
+          certificationCenterId: 123,
+          date: '2020-01-01',
+          time: '14:00',
+        });
+
+        const screen = await visitScreen('/sessions/liste');
+        await click(screen.getByRole('link', { name: 'Aller à la page suivante' }));
+        await click(screen.getByRole('link', { name: 'Session 26' }));
+
+        // when
+        await click(screen.getByRole('link', { name: 'Retour à la liste des sessions' }));
+
+        // then
+        assert.contains('Page 2 / 2');
+        assert.strictEqual(currentURL(), '/sessions/liste?pageNumber=2');
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, lorsqu’un utilisateur Pix Certif est sur une page dans la liste des sessions qui n’est pas la 1ère, puis ouvre une page de détail de session, et clique sur “Retour à la liste des sessions”, il revient sur la page 1. Si l’utilisateur était sur la page 11 par exemple, et souhaite retourner sur la page 11 pour continuer à la visualiser après avoir ouvert une page de détails, il doit retourner manuellement sur cette page.

## :robot: Solution
Retourner sur la page ouverte précédemment dans la liste des sessions lorsqu’un utilisateur ouvre la page de détails d’une session
## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Dans Pix-certif:
- Aller sur la page de sessions
- Aller à la page suivante de votre choix (s'il n'y a pas assez de sessions disponibles, ajouter `?pageSize=xxxx` à la fin de l'URL)
- Aller sur les détails d'une session
- Revenir à la liste des sessions
- Vérifier que la nouvelle page correspond à la dernière page visitée et non la première page
