### PR TITLE
[BUGFIX] Les métriques personnalisées API ne sont plus journalisées

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -46,6 +46,7 @@ const plugins = [
     options: {
       serializers: {
         req: logObjectSerializer,
+        res: logObjectSerializer,
       },
       instance: require('./infrastructure/logger'),
       logQueryParams: true,


### PR DESCRIPTION
## :unicorn: Problème
On ne trace plus les customs métriques coté response hapi.

## :robot: Solution
Remettre le serializer custom coté response hapi

## :rainbow: Remarques
RAF: rajouter un test pour éviter la régression


## :100: Pour tester
Activer les deux variables d'env ENABLE_REQUEST_MONITORING=true LOG_KNEX_QUERIES=true
Vérifier au niveau du log de sortie de la réponse qu'on dispose bien des customs métriques lié aux queries Knex.

```
res: {
      "statusCode": 200,
      "headers": {
        "content-type": "application/json; charset=utf-8",
        "vary": "origin",
        "access-control-expose-headers": "WWW-Authenticate,Server-Authorization",
        "cache-control": "no-cache",
        "content-length": 2880,
        "accept-ranges": "bytes"
      },
      "version": "development",
      "user_id": "-",
      "metrics": {
        "knexQueryCount": 2,
        "knexQueries": [
          {
            "id": "lAKthPvamy_7WP6QsjQs6",
            "sql": "select * from \"knowledge-elements\" where (\"userId\" = $1)",
            "duration": 9.436803996562958
          },
          {
            "id": "rUDrLnj8DSOgh5utSENQI",
            "sql": "select \"competence-evaluations\".* from \"competence-evaluations\" where \"userId\" = $1 order by \"competence-evaluations\".\"createdAt\" asc",
            "duration": 12.551223009824753
          }
        ]
      },
      "route": "/api/users/{id}/profile"
    }
    responseTime: 28
```