### PR TITLE
[BUGFIX] Corriger la checkbox seulement sur la page d'inscription (PIX-5294)

### DIFF
--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -17,9 +17,10 @@
   }
 
   &__cgu {
-    margin-top: 7px;
+    margin-top: 5px;
     font-size: 1rem;
     font-weight: $font-medium;
+    width: 24px;
   }
 
   &__cgu-label {
@@ -36,4 +37,12 @@
       padding: 10px 0;
     }
   }
+}
+
+input[type=checkbox].signup-form__cgu::before {
+  top: 9px;
+}
+
+input[type=checkbox].signup-form__cgu:checked::after {
+  top: -9px;
 }

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -69,7 +69,7 @@ input[type=checkbox]::before {
   position: relative;
   height: 18px;
   width: 18px;
-  top: calc(50% - 9px);
+  top: -3px;
   border: 2px solid $pix-neutral-40;
   content: ' ';
   display: block;
@@ -87,7 +87,7 @@ input[type=checkbox]:checked::after {
   height: 18px;
   width: 18px;
   position: relative;
-  top: -9px;
+  top: -21px;
   font-size: 0.875rem;
   color: $pix-neutral-0;
   font-weight: $font-bold;


### PR DESCRIPTION
## :unicorn: Problème
La correction de la checkbox sur la page d'inscription (https://github.com/1024pix/pix/pull/4610), a impacté d'autres checkbox (celles des épreuves).

## :robot: Solution
N'appliquer le correctif que sur la checkbox d'inscription , pas sur les styles globaux des autres checkbox

## :rainbow: Remarques
C'est un fix rapide, le fix plus pérenne est d'utiliser la PixCheckbox, qui est en cours de création sur Pix-UI. 

## :100: Pour tester
Vérifier le design de la checkbox (sous chrome) : 
- sur la page d'inscription
- sur n'importe quel challenge
