### PR TITLE
[FEATURE] Supprimer la catégorie "A2 - Autres" dans la modale de signalements  (PIX-5282)

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -45,11 +45,13 @@
           @maxlength={{@maxlength}}
         />
 
-        <IssueReportModal::OtherCertificationIssueReportFields
-          @otherCategory={{this.otherCategory}}
-          @toggleOnCategory={{this.toggleOnCategory}}
-          @maxlength={{@maxlength}}
-        />
+        {{#unless this.isCertificationFreeFieldsDeletionEnabled}}
+          <IssueReportModal::OtherCertificationIssueReportFields
+            @otherCategory={{this.otherCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
+        {{/unless}}
       </div>
 
       {{#if this.showCategoryMissingError}}

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -112,6 +112,7 @@ export class RadioButtonCategoryWithSubcategoryAndQuestionNumber extends RadioBu
 
 export default class AddIssueReportModal extends Component {
   @service store;
+  @service featureToggles;
 
   @tracked otherCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.OTHER });
   @tracked lateOrLeavingCategory = new RadioButtonCategoryWithSubcategoryWithDescription({
@@ -174,5 +175,9 @@ export default class AddIssueReportModal extends Component {
       issueReportToSave.rollbackAttributes();
       this.showIssueReportSubmitError = true;
     }
+  }
+
+  get isCertificationFreeFieldsDeletionEnabled() {
+    return this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -41,6 +41,10 @@ export default class SessionsFinalizeController extends Controller {
     return !this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled;
   }
 
+  get isCertificationFreeFieldsDeletionEnabled() {
+    return this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled;
+  }
+
   showErrorNotification(message, options = {}) {
     this.notifications.error(message, options);
   }

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -6,7 +6,7 @@
     </PixReturnTo>
     <h1 class="page-title">Finaliser la session {{this.session.id}}</h1>
   </div>
-  {{#unless this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled}}
+  {{#unless this.isCertificationFreeFieldsDeletionEnabled}}
     <div class="finalize__subtitle">
       Pour finaliser la session, complétez les trois étapes puis validez.
     </div>
@@ -14,12 +14,12 @@
 
   <SessionFinalizationStepContainer
     @title={{if
-      this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+      this.isCertificationFreeFieldsDeletionEnabled
       "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
       "Étape 1 : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
     }}
     @subtitle={{if
-      this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled
+      this.isCertificationFreeFieldsDeletionEnabled
       "Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc)."
     }}
     @icon="/icons/session-finalization-user.svg"
@@ -56,7 +56,7 @@
     </SessionFinalizationStepContainer>
   {{/if}}
 
-  {{#if this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled}}
+  {{#if this.isCertificationFreeFieldsDeletionEnabled}}
     <SessionFinalizationStepContainer
       @title="Informations complémentaires (facultatif)"
       @subtitle="Vous pouvez indiquer, le cas échéant, les événements survenus lors de la session. Il n'est pas nécessaire de renseigner les candidats absents."

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -6,9 +6,11 @@
     </PixReturnTo>
     <h1 class="page-title">Finaliser la session {{this.session.id}}</h1>
   </div>
-  <div class="finalize__subtitle">
-    Pour finaliser la session, complétez les trois étapes puis validez.
-  </div>
+  {{#unless this.featureToggles.featureToggles.isCertificationFreeFieldsDeletionEnabled}}
+    <div class="finalize__subtitle">
+      Pour finaliser la session, complétez les trois étapes puis validez.
+    </div>
+  {{/unless}}
 
   <SessionFinalizationStepContainer
     @title={{if

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
@@ -279,10 +279,7 @@ module('Acceptance | Session Finalization', function (hooks) {
           const addOrDeleteCertificationIssueReportsButtonsBeforeFilling = screen.queryAllByText('Ajouter / supprimer');
 
           await click(addCertificationIssueReportsButtonsBeforeFilling[1]);
-          await click(
-            screen.getByLabelText('A2 Autre (si aucune des catégories ci-dessus ne correspond au signalement)', {})
-          );
-          await fillIn(screen.getByLabelText('Décrivez l’incident', {}), 'Coucou');
+          await click(screen.getByLabelText('C6 Suspicion de fraude'));
           await click(screen.getByLabelText('Ajouter le signalement'));
 
           const addOrDeleteCertificationIssueReportsButtonsAfterFilling = screen.getAllByText('Ajouter / supprimer');

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -138,6 +138,17 @@ module('Acceptance | Session Finalization', function (hooks) {
           .exists();
       });
 
+      test('it should contain a 3-step subtitle', async function (assert) {
+        // given
+        server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: false });
+
+        // when
+        const screen = await visit(`/sessions/${session.id}/finalisation`);
+
+        // then
+        assert.dom(screen.getByText('Pour finaliser la session, complétez les trois étapes puis validez.')).exists();
+      });
+
       test('it should not contain a subtitle', async function (assert) {
         // given
         server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: false });
@@ -157,6 +168,19 @@ module('Acceptance | Session Finalization', function (hooks) {
     });
 
     module('when FT_CERTIFICATION_FREE_FIELDS_DELETION is on', function () {
+      test('it should not contain a 3-step subtitle', async function (assert) {
+        // given
+        server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: true });
+
+        // when
+        const screen = await visit(`/sessions/${session.id}/finalisation`);
+
+        // then
+        assert
+          .dom(screen.queryByText('Pour finaliser la session, complétez les trois étapes puis validez.'))
+          .doesNotExist();
+      });
+
       test('it should not display the comment step section', async function (assert) {
         // given
         server.create('feature-toggle', { id: 0, isCertificationFreeFieldsDeletionEnabled: true });

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import omit from 'lodash/omit';
 
@@ -47,7 +47,7 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
       this.set('maxlength', 500);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
           <IssueReportModal::AddIssueReportModal
             @closeModal={{this.closeAddIssueReportModal}}
             @report={{this.reportToEdit}}
@@ -56,7 +56,7 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
         `);
 
       // then
-      assert.contains(`E1-E10\u00a0${categoryToLabel['IN_CHALLENGE']}`);
+      assert.dom(screen.getByLabelText(`E1-E10 ${categoryToLabel['IN_CHALLENGE']}`, { exact: false })).exists();
     });
 
     test('it should show OTHER category', async function (assert) {
@@ -73,7 +73,7 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
       this.set('maxlength', 500);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
           <IssueReportModal::AddIssueReportModal
             @closeModal={{this.closeAddIssueReportModal}}
             @report={{this.reportToEdit}}
@@ -82,7 +82,7 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
         `);
 
       // then
-      assert.contains(`Autre (si aucune des catégories ci-dessus ne correspond au signalement)`);
+      assert.dom(screen.getByLabelText(`A2 ${categoryToLabel['OTHER']}`, { exact: false })).exists();
     });
   });
 
@@ -105,7 +105,7 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
       this.set('maxlength', 500);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
           <IssueReportModal::AddIssueReportModal
             @closeModal={{this.closeAddIssueReportModal}}
             @report={{this.reportToEdit}}
@@ -114,7 +114,7 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
         `);
 
       // then
-      assert.notContains(`Autre (si aucune des catégories ci-dessus ne correspond au signalement)`);
+      assert.dom(screen.queryByLabelText(`A2 ${categoryToLabel['OTHER']}`, { exact: false })).doesNotExist();
     });
 
     test('it show candidate informations in title', async function (assert) {
@@ -131,17 +131,16 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
       this.set('maxlength', 500);
 
       // when
-      await render(hbs`
-      <IssueReportModal::AddIssueReportModal
-        @closeModal={{this.closeAddIssueReportModal}}
-        @report={{this.reportToEdit}}
-        @maxlength={{@issueReportDescriptionMaxLength}}
-      />
-    `);
+      const screen = await renderScreen(hbs`
+          <IssueReportModal::AddIssueReportModal
+            @closeModal={{this.closeAddIssueReportModal}}
+            @report={{this.reportToEdit}}
+            @maxlength={{@issueReportDescriptionMaxLength}}
+          />
+        `);
 
       // then
-      assert.contains('Signalement du candidat');
-      assert.contains('Lisa Monpud');
+      assert.dom(screen.getByText('Signalement du candidat : Lisa Monpud', { exact: false })).exists();
     });
 
     test('it should show all categories code & label', async function (assert) {
@@ -158,17 +157,19 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
       this.set('maxlength', 500);
 
       // when
-      await render(hbs`
-        <IssueReportModal::AddIssueReportModal
-          @closeModal={{this.closeAddIssueReportModal}}
-          @report={{this.reportToEdit}}
-          @maxlength={{@issueReportDescriptionMaxLength}}
-        />
-      `);
+      const screen = await renderScreen(hbs`
+          <IssueReportModal::AddIssueReportModal
+            @closeModal={{this.closeAddIssueReportModal}}
+            @report={{this.reportToEdit}}
+            @maxlength={{@issueReportDescriptionMaxLength}}
+          />
+        `);
 
       // then
       for (const category of Object.values(omit(certificationIssueReportCategories, ['OTHER']))) {
-        assert.contains(`${categoryToCode[category]}\u00a0${categoryToLabel[category]}`);
+        assert
+          .dom(screen.getByLabelText(`${categoryToCode[category]} ${categoryToLabel[category]}`, { exact: false }))
+          .exists();
       }
     });
 
@@ -184,19 +185,21 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
       this.set('closeAddIssueReportModal', closeAddIssueReportModalStub);
       this.set('reportToEdit', report);
       this.set('maxlength', 500);
-      await render(hbs`
-        <IssueReportModal::AddIssueReportModal
-          @closeModal={{this.closeAddIssueReportModal}}
-          @report={{this.reportToEdit}}
-          @maxlength={{@issueReportDescriptionMaxLength}}
-        />
-      `);
 
       // when
-      await click('[aria-label="Ajouter le signalement"]');
+      const screen = await renderScreen(hbs`
+          <IssueReportModal::AddIssueReportModal
+            @closeModal={{this.closeAddIssueReportModal}}
+            @report={{this.reportToEdit}}
+            @maxlength={{@issueReportDescriptionMaxLength}}
+          />
+        `);
+
+      // when
+      await click(screen.getByLabelText('Ajouter le signalement'));
 
       // then
-      assert.contains('Veuillez selectionner une catégorie');
+      assert.dom(screen.getByText('Veuillez selectionner une catégorie')).exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Le but de l'épix “Suppression des champs textes libre” est, comme son nom l’indique, de supprimer tous les champs libres du PV d’incident/page de finalisation de session (sauf C7 et C8 qui ne sont pas impactants).

La catégorie A2 Autre est toujours présente

## :robot: Solution
Supprimer la catégorie “A2 - Autre” sur la page de finalisation de session 
Supprimer la phrase qui mentionne les 3 étapes sous le numéro de session 


## :100: Pour tester
- Activer FT_CERTIFICATION_FREE_FIELDS_DELETION
- Finaliser une session
- Constater que la catégorie A2 Autres n'apparaît plus
- Constater que la mention "Pour finaliser la session, complétez les trois étapes puis validez." n'apparait plus

Avec Toggle on:
![image](https://user-images.githubusercontent.com/37305474/177525096-355c5d86-9b0a-4daa-b6a5-6f278c110069.png)

![image](https://user-images.githubusercontent.com/37305474/177525014-526eb211-80ed-4ca5-83e5-5025b03ebc05.png)


Avec toggle off:
![image](https://user-images.githubusercontent.com/37305474/177525306-a61e3f2a-6f29-4660-a4f0-48bdfe37af55.png)

![image](https://user-images.githubusercontent.com/37305474/177525353-2ed62b0a-f347-47b1-9a6a-d72400c05221.png)

