### PR TITLE
[FEATURE] Ajouter le bouton de filtre sur Pix App (PIX-4930)

### DIFF
--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -6,6 +6,11 @@
     </p>
 
     <div class="user-tutorials-banner-v2__filters">
+      {{#if this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled}}
+        <PixButton @backgroundColor="transparent-light" @isBorderVisible={{false}}>
+          {{t "pages.user-tutorials.filter"}}
+        </PixButton>
+      {{/if}}
       <ChoiceChip @route="user-tutorials.recommended">
         {{t "pages.user-tutorials.recommended"}}
       </ChoiceChip>

--- a/mon-pix/app/components/tutorials/header.js
+++ b/mon-pix/app/components/tutorials/header.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class Header extends Component {
+  @service featureToggles;
+}

--- a/mon-pix/tests/integration/components/tutorials/header_test.js
+++ b/mon-pix/tests/integration/components/tutorials/header_test.js
@@ -1,9 +1,10 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { find, render, findAll } from '@ember/test-helpers';
+import { find, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
+import { render } from '@1024pix/ember-testing-library';
 
 describe('Integration | Component | Tutorials | Header', function () {
   setupIntlRenderingTest();
@@ -28,5 +29,19 @@ describe('Integration | Component | Tutorials | Header', function () {
     expect(find('a.pix-choice-chip,a.pix-choice-chip--active'))
       .to.have.property('textContent')
       .that.contains('Recommandés');
+  });
+
+  it('should render filter button when tutorial filter feature toggle is activate', async function () {
+    // given
+    class FeatureTogglesStub extends Service {
+      featureToggles = { isPixAppTutoFiltersEnabled: true };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+    // when
+    const screen = await render(hbs`<Tutorials::Header />`);
+
+    // then
+    expect(screen.getByRole('button', { name: 'Filtrer' })).to.exist;
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -225,7 +225,7 @@
       "issued-on": "Delivered on",
       "jury-info": "Notes from the examining body are not displayed on the verification page of your certificate.",
       "jury-title": "Notes from the examining body",
-      "professionalizing-warning": "The Pix certificate is recognised as professionalising by France Compétences upon reaching a minimum score of 120 pix.",  
+      "professionalizing-warning": "The Pix certificate is recognised as professionalising by France Compétences upon reaching a minimum score of 120 pix.",
       "verification-code": {
         "title": "Verification code",
         "alt": "Copy",
@@ -1497,6 +1497,7 @@
         },
         "image-link": "images/illustrations/user-tutorials/illustration-en.svg"
       },
+      "filter": "Filter",
       "label": "Tutorials",
       "list": {
         "title": "My list",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -225,7 +225,7 @@
       "issued-on": "Délivré le",
       "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
       "jury-title": "Observations du jury",
-      "professionalizing-warning": "Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix",  
+      "professionalizing-warning": "Le certificat Pix est reconnu comme professionnalisant par France compétences à compter d’un score minimal de 120 pix",
         "verification-code": {
         "title": "Code de vérification",
         "alt": "Copier",
@@ -1497,6 +1497,7 @@
         },
         "image-link": "images/illustrations/user-tutorials/illustration-fr.svg"
       },
+      "filter": "Filtrer",
       "label": "tutoriels",
       "list": {
         "title": "Ma liste",


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix app, nous ne pouvons pas filtrer les tutoriels.

## :robot: Solution
Dans le but de filtrer les tutoriels, cette PR ajoute un bouton de filtre.

## :rainbow: Remarques
Cette PR ne contient que l'ajout du bouton soumis à un feature toggle.

## :100: Pour tester
Activer le feature toggle sur la RA et constater la présence du bouton de filtre.