### PR TITLE
[BUGFIX] Permettre la suppression de session lorsqu'un surveillant a rejoint l'espace surveillant (PIX-5280)

### DIFF
--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -148,6 +148,12 @@ module.exports = {
       const certificationCandidateIdsInSession = await knex('certification-candidates')
         .where({ sessionId })
         .pluck('id');
+      const supervisorAccessIds = await knex('supervisor-accesses').where({ sessionId }).pluck('id');
+
+      if (supervisorAccessIds) {
+        await trx('supervisor-accesses').whereIn('id', supervisorAccessIds).del();
+      }
+
       if (certificationCandidateIdsInSession.length) {
         await trx('complementary-certification-subscriptions')
           .whereIn('certificationCandidateId', certificationCandidateIdsInSession)

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -628,6 +628,26 @@ describe('Integration | Repository | Session', function () {
         });
       });
 
+      context('when the session has been accessed by one or more supervisor', function () {
+        it('should remove supervisor accesses and delete the session', async function () {
+          // given
+          const sessionId = databaseBuilder.factory.buildSession().id;
+          databaseBuilder.factory.buildSupervisorAccess({ sessionId });
+          databaseBuilder.factory.buildSupervisorAccess({ sessionId });
+
+          await databaseBuilder.commit();
+
+          // when
+          await sessionRepository.delete(sessionId);
+
+          // then
+          const foundSession = await knex('sessions').select('id').where({ id: sessionId }).first();
+          const supervisorAccesses = await knex('supervisor-accesses').where({ sessionId });
+          expect(foundSession).to.be.undefined;
+          expect(supervisorAccesses).to.be.empty;
+        });
+      });
+
       context('when the session has no candidates', function () {
         it('should delete the session', async function () {
           // given

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -61,24 +61,33 @@
               <td>{{sessionSummary.effectiveCandidatesCount}}</td>
               <td>{{sessionSummary.statusLabel}}</td>
               <td>
-                <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-session-button">
-                  <:triggerElement>
+                <div class="session-summary-list__delete">
+                  {{#if sessionSummary.hasEffectiveCandidates}}
+                    <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-session-button">
+                      <:triggerElement>
+                        <PixIconButton
+                          @icon="trash-alt"
+                          aria-label="Supprimer la session {{sessionSummary.id}}"
+                          disabled={{true}}
+                          aria-describedby="tooltip-delete-session-button"
+                          @withBackground={{true}}
+                          @triggerAction={{fn this.openSessionDeletionConfirmModal sessionSummary.id}}
+                        />
+                      </:triggerElement>
+                      <:tooltip
+                      >{{"Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer."}}</:tooltip>
+                    </PixTooltip>
+                  {{else}}
                     <PixIconButton
                       @icon="trash-alt"
-                      class="session-summary-list__delete-button"
                       aria-label="Supprimer la session {{sessionSummary.id}}"
-                      disabled={{sessionSummary.hasEffectiveCandidates}}
+                      disabled={{false}}
                       aria-describedby="tooltip-delete-session-button"
                       @withBackground={{true}}
                       @triggerAction={{fn this.openSessionDeletionConfirmModal sessionSummary.id}}
                     />
-                  </:triggerElement>
-                  <:tooltip>{{if
-                      sessionSummary.hasEffectiveCandidates
-                      "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer."
-                      "Supprimer la session."
-                    }}</:tooltip>
-                </PixTooltip>
+                  {{/if}}
+                </div>
               </td>
             </tr>
           {{/each}}

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -28,7 +28,7 @@ export default class SessionSummaryList extends Component {
     const sessionSummary = this.store.peekRecord('session-summary', this.currentSessionToBeDeletedId);
     try {
       await sessionSummary.destroyRecord();
-      this.notifications.success('La session a été supprimée.');
+      this.notifications.success('La session a été supprimée avec succès.');
     } catch (err) {
       if (this._doesNotExist(err)) {
         this._handleSessionDoesNotExistsError();

--- a/certif/app/styles/components/session-summary-list.scss
+++ b/certif/app/styles/components/session-summary-list.scss
@@ -6,8 +6,10 @@
   }
 
   &__delete {
+    position: relative;
     display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: flex-end;
+    padding-right: 16px;
   }
 }

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -165,7 +165,7 @@ module('Acceptance | Session List', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/sessions/liste');
-        assert.dom(screen.getByText('La session a été supprimée.')).exists();
+        assert.dom(screen.getByText('La session a été supprimée avec succès.')).exists();
         assert.dom(screen.queryByRole('button', { name: 'Supprimer la session 123' })).doesNotExist();
         assert.dom(screen.queryByRole('button', { name: 'Supprimer la session 456' })).exists();
       });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un surveillant s'est connecté à l'espace surveillant, la suppression de session tombe en erreur.

## :robot: Solution
Rendre possible la suppression de session lorsque aucun candidat et  aucun surveillant n'a rejoint la session

## :rainbow: Remarques
Bonus: Ne pas afficher de tooltip quand la session est supprimable

## :100: Pour tester
- Créer une session de certification avec un centre ayant accès à l'espace surveillant
- Rejoindre l'espace surveillant de la session
- Retourner dans la liste des sessions
- Tenter de supprimer la session
- Constater la suppression