### PR TITLE
[BUGFIX] Afficher le résultat d'une campagne inactive seulement pour les participations partagées (PIX-5296)

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -13,7 +13,7 @@
     <div
       class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content__content-archived"
     >
-      {{#if this.isCompleted}}
+      {{#if @model.isShared}}
         {{#if this.hasStages}}
           <PixStars
             @count={{@model.validatedStagesCount}}

--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.js
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.js
@@ -1,10 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class Disabled extends Component {
-  get isCompleted() {
-    return ['TO_SHARE', 'SHARED'].includes(this.args.model.status);
-  }
-
   get hasStages() {
     return this.args.model.totalStagesCount > 0;
   }

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
@@ -15,8 +15,8 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
   });
 
   describe('when card has "ARCHIVED" status', function () {
-    context("when the participation doesn't have a mastery percentage", () => {
-      it('should render explanatory text', async function () {
+    context('when the participation is not completed', () => {
+      it('should render explanatory text given started status', async function () {
         // given
         const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
           createdAt: '2020-01-01',
@@ -42,10 +42,8 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' })))
           .to.exist;
       });
-    });
 
-    context('when the participation has a mastery percentage', () => {
-      it('should render the result with percentage', async function () {
+      it('should render explanatory text given to_share status', async function () {
         // given
         const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
           createdAt: '2020-01-01',
@@ -53,7 +51,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
           status: 'TO_SHARE',
           campaignTitle: 'My campaign',
           organizationName: 'My organization',
-          masteryRate: 0.56,
+          masteryRate: null,
         });
         this.set('campaignParticipationOverview', campaignParticipationOverview);
 
@@ -63,34 +61,66 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         );
 
         // then
-
-        expect(contains('56 % de réussite')).to.exist;
+        expect(contains('My organization')).to.exist;
+        expect(contains('My campaign')).to.exist;
+        expect(contains('Parcours désactivé par votre organisation.\nVous ne pouvez plus envoyer vos résultats.')).to
+          .exist;
+        expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.disabled').toUpperCase())).to.exist;
+        expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' })))
+          .to.exist;
       });
     });
 
-    context('when the campaign has stages', () => {
-      it('should render the result with stars', async function () {
-        // given
-        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
-          createdAt: '2020-01-01',
-          disabledAt: '2020-01-03',
-          status: 'TO_SHARE',
-          campaignTitle: 'My campaign',
-          organizationName: 'My organization',
-          masteryRate: '0.56',
-          totalStagesCount: 3,
-          validatedStagesCount: 1,
+    context('when the participation is completed', function () {
+      context('when the participation has a mastery percentage', () => {
+        it('should render the result with percentage', async function () {
+          // given
+          const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+            createdAt: '2020-01-01',
+            disabledAt: '2020-01-03',
+            status: 'SHARED',
+            isShared: true,
+            campaignTitle: 'My campaign',
+            organizationName: 'My organization',
+            masteryRate: 0.56,
+          });
+          this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+          // when
+          await render(
+            hbs`<CampaignParticipationOverview::Card::Disabled @model={{this.campaignParticipationOverview}} />`
+          );
+
+          // then
+          expect(contains('56 % de réussite')).to.exist;
         });
+      });
 
-        this.set('campaignParticipationOverview', campaignParticipationOverview);
+      context('when the campaign has stages', () => {
+        it('should render the result with stars', async function () {
+          // given
+          const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+            createdAt: '2020-01-01',
+            disabledAt: '2020-01-03',
+            status: 'SHARED',
+            isShared: true,
+            campaignTitle: 'My campaign',
+            organizationName: 'My organization',
+            masteryRate: '0.56',
+            totalStagesCount: 3,
+            validatedStagesCount: 1,
+          });
 
-        // when
-        const screen = await renderScreen(
-          hbs`<CampaignParticipationOverview::Card::Disabled @model={{campaignParticipationOverview}} />`
-        );
+          this.set('campaignParticipationOverview', campaignParticipationOverview);
 
-        // then
-        expect(screen.getByLabelText('1 étoile sur 3')).to.exist;
+          // when
+          const screen = await renderScreen(
+            hbs`<CampaignParticipationOverview::Card::Disabled @model={{campaignParticipationOverview}} />`
+          );
+
+          // then
+          expect(screen.getByLabelText('1 étoile sur 3')).to.exist;
+        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Sur un campagne inactive, nous affichions le résultat pour les campagnes is_shared et shared.  Or le résultat n'est disponible qu'une fois la participation partagée.

## :robot: Solution
N'afficher le résultat que pour les participations partagées

## :rainbow: Remarques

## :100: Pour tester
Participer a une campagne avec le compte jaune.attend@example.net . ne pas partager ses résultats. Archiver la campagne. Vérifier que la carte affcihe bien le message 

``Parcours désactivé par votre organisation.
Vous ne pouvez plus envoyer vos résultats.``