### PR TITLE
[TECH] Recalculer l'acquisitions des badges grâce à un script (PIX-5310).

### DIFF
--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const { performance } = require('perf_hooks');
 const logger = require('../lib/infrastructure/logger');
+const cache = require('../lib/infrastructure/caches/learning-content-cache');
 const { knex, disconnect } = require('../db/knex-database-connection');
 
 const doSomething = async ({ throwError }) => {
@@ -31,6 +32,7 @@ async function main() {
       process.exitCode = 1;
     } finally {
       await disconnect();
+      cache.quit();
     }
   }
 })();

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -46,7 +46,7 @@ async function computeBadgeAcquisition({
 }) {
   const associatedBadges = await _fetchPossibleCampaignAssociatedBadges(campaignParticipation, badgeRepository);
   if (_.isEmpty(associatedBadges)) {
-    return;
+    return 0;
   }
   const targetProfile = await targetProfileRepository.getByCampaignParticipationId(campaignParticipation.id);
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: campaignParticipation.userId });
@@ -66,6 +66,8 @@ async function computeBadgeAcquisition({
   if (!_.isEmpty(badgesAcquisitionToCreate)) {
     await badgeAcquisitionRepository.createOrUpdate(badgesAcquisitionToCreate);
   }
+
+  return badgesAcquisitionToCreate.length;
 }
 
 function _fetchPossibleCampaignAssociatedBadges(campaignParticipation, badgeRepository) {

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -38,12 +38,13 @@ function _getAllArgs() {
 
 async function computeBadgeAcquisition({
   campaignParticipation,
+  dryRun = false,
   badgeCriteriaService,
   badgeAcquisitionRepository,
   badgeRepository,
   knowledgeElementRepository,
   targetProfileRepository,
-}) {
+} = {}) {
   const associatedBadges = await _fetchPossibleCampaignAssociatedBadges(campaignParticipation, badgeRepository);
   if (_.isEmpty(associatedBadges)) {
     return 0;
@@ -63,7 +64,7 @@ async function computeBadgeAcquisition({
     };
   });
 
-  if (!_.isEmpty(badgesAcquisitionToCreate)) {
+  if (!_.isEmpty(badgesAcquisitionToCreate) && !dryRun) {
     await badgeAcquisitionRepository.createOrUpdate(badgesAcquisitionToCreate);
   }
 

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const logger = require('../../lib/infrastructure/logger');
+const { disconnect } = require('../../db/knex-database-connection');
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script compute badge acquisitions has started`);
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = {};

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -4,6 +4,8 @@ const logger = require('../../lib/infrastructure/logger');
 const { disconnect } = require('../../db/knex-database-connection');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
+const { knex } = require('../../db/knex-database-connection');
+const CampaignParticipation = require('../../lib/domain/models/CampaignParticipation');
 
 async function main() {
   const startTime = performance.now();
@@ -34,6 +36,11 @@ function _getAllArgs() {
     .help().argv;
 }
 
+async function getCampaignParticipationsBetweenIds({ idMin, idMax }) {
+  const campaignParticipations = await knex('campaign-participations').whereBetween('id', [idMin, idMax]);
+  return campaignParticipations.map((campaignParticipation) => new CampaignParticipation(campaignParticipation));
+}
+
 const isLaunchedFromCommandLine = require.main === module;
 
 (async () => {
@@ -49,4 +56,4 @@ const isLaunchedFromCommandLine = require.main === module;
   }
 })();
 
-module.exports = {};
+module.exports = { getCampaignParticipationsBetweenIds };

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -2,13 +2,36 @@ require('dotenv').config();
 const { performance } = require('perf_hooks');
 const logger = require('../../lib/infrastructure/logger');
 const { disconnect } = require('../../db/knex-database-connection');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
 
 async function main() {
   const startTime = performance.now();
   logger.info(`Script compute badge acquisitions has started`);
+  const args = _getAllArgs();
+
   const endTime = performance.now();
   const duration = Math.round(endTime - startTime);
   logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+function _getAllArgs() {
+  return yargs(hideBin(process.argv))
+    .option('idMin', {
+      type: 'number',
+      demand: true,
+      description: 'id de la première campagne participation',
+    })
+    .option('idMax', {
+      type: 'number',
+      demand: true,
+      description: 'id de la dernière campagne participation',
+    })
+    .option('dryRun', {
+      type: 'boolean',
+      description: 'permet de lancer le script sans créer les badges manquants',
+    })
+    .help().argv;
 }
 
 const isLaunchedFromCommandLine = require.main === module;

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -1,0 +1,24 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const { getCampaignParticipationsBetweenIds } = require('../../../../scripts/prod/compute-badge-acquisitions');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+describe('Script | Prod | Compute Badge Acquisitions', function () {
+  describe('#getCampaignParticipationsBetweenIds', function () {
+    it('should return campaign participation between idMin and idMax', async function () {
+      // given
+      databaseBuilder.factory.buildCampaignParticipation();
+      const id2 = databaseBuilder.factory.buildCampaignParticipation().id;
+      const id3 = databaseBuilder.factory.buildCampaignParticipation().id;
+      const id4 = databaseBuilder.factory.buildCampaignParticipation().id;
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipations = await getCampaignParticipationsBetweenIds({ idMin: id2, idMax: id4 });
+
+      // then
+      expect(campaignParticipations.length).to.equal(3);
+      expect(campaignParticipations.map(({ id }) => id)).to.deep.equal([id2, id3, id4]);
+      expect(campaignParticipations[0]).to.be.instanceOf(CampaignParticipation);
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -7,6 +7,7 @@ const {
   knex,
 } = require('../../../test-helper');
 const {
+  computeAllBadgeAcquisitions,
   computeBadgeAcquisition,
   getCampaignParticipationsBetweenIds,
 } = require('../../../../scripts/prod/compute-badge-acquisitions');
@@ -35,6 +36,147 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       expect(campaignParticipations.length).to.equal(3);
       expect(campaignParticipations.map(({ id }) => id)).to.deep.equal([id2, id3, id4]);
       expect(campaignParticipations[0]).to.be.instanceOf(CampaignParticipation);
+    });
+  });
+
+  describe('Integration | #computeAllBadgeAcquisitions', function () {
+    let userId1, userId2;
+    let badgeCompleted;
+    let campaignParticipation1, campaignParticipation2;
+
+    beforeEach(async function () {
+      const listSkill = ['web1', 'web2', 'web3', 'web4'];
+
+      const learningContent = [
+        {
+          id: 'recArea1',
+          titleFrFr: 'area1_Title',
+          color: 'someColor',
+          competences: [
+            {
+              id: 'competenceId',
+              nameFrFr: 'Mener une recherche et une veille d’information',
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube0_0',
+                  skills: [
+                    {
+                      id: listSkill[0],
+                      nom: '@web1',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                    {
+                      id: listSkill[1],
+                      nom: '@web2',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                    {
+                      id: listSkill[2],
+                      nom: 'web3',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                    {
+                      id: listSkill[3],
+                      nom: 'web4',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      userId1 = databaseBuilder.factory.buildUser().id;
+      userId2 = databaseBuilder.factory.buildUser().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web1', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web2', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web3', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web4', status: 'invalidated' });
+
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId2, skillId: 'web1', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId2, skillId: 'web2', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId2, skillId: 'web3', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId: userId2, skillId: 'web4', status: 'invalidated' });
+
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId: userId1 });
+      campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId: userId2 });
+
+      badgeCompleted = databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        key: 'Badge1',
+      });
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badgeCompleted.id,
+        threshold: 40,
+      });
+
+      const badgeNotCompletedId = databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        key: 'Badge2',
+      }).id;
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badgeNotCompletedId,
+        threshold: 90,
+      });
+
+      databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        badgeCriteria: [],
+        key: 'Badge3',
+      }).id;
+
+      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+      mockLearningContent(learningContentObjects);
+
+      return databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('badge-acquisitions').delete();
+    });
+
+    it('should compute badge acquisition for all campaign participations', async function () {
+      // when
+      const numberOfCreatedBadges = await computeAllBadgeAcquisitions({
+        idMin: campaignParticipation1.id,
+        idMax: campaignParticipation2.id,
+      });
+
+      // then
+      const badgeAcquisitions = await knex('badge-acquisitions');
+      expect(badgeAcquisitions.length).to.equal(2);
+      expect(numberOfCreatedBadges).to.equal(2);
+    });
+
+    context('when dry run option is provided', function () {
+      it('should not create badge', async function () {
+        // given
+        const dryRun = true;
+
+        // when
+        const numberOfSupposedlyCreatedBadges = await computeAllBadgeAcquisitions({
+          idMin: campaignParticipation1.id,
+          idMax: campaignParticipation2.id,
+          dryRun,
+        });
+
+        // then
+        const badgeAcquisitions = await knex('badge-acquisitions');
+        expect(badgeAcquisitions.length).to.equal(0);
+        expect(numberOfSupposedlyCreatedBadges).to.equal(2);
+      });
     });
   });
 

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -104,14 +104,14 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
         sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
       });
 
-      it('should create a badge when badge requirements are fulfilled', async function () {
+      it('should create a badge when badge requirements are fulfilled and return number of badge created', async function () {
         // given
         badgeCriteriaService.areBadgeCriteriaFulfilled
           .withArgs({ targetProfile, knowledgeElements, badge })
           .returns(true);
 
         // when
-        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+        const numberOfCreatedBadges = await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
 
         // then
         expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
@@ -121,6 +121,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
             campaignParticipationId: campaignParticipation.id,
           },
         ]);
+        expect(numberOfCreatedBadges).to.equal(1);
       });
 
       it('should not create a badge when badge requirements are not fulfilled', async function () {
@@ -130,10 +131,11 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
           .returns(false);
 
         // when
-        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+        const numberOfCreatedBadges = await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
 
         // then
         expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
+        expect(numberOfCreatedBadges).to.equal(0);
       });
     });
 
@@ -182,7 +184,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
           .returns(false);
 
         // when
-        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+        const numberOfCreatedBadges = await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
 
         // then
         expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
@@ -192,6 +194,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
             campaignParticipationId: campaignParticipation.id,
           },
         ]);
+        expect(numberOfCreatedBadges).to.equal(1);
       });
 
       it('should create two badges when both badges requirements are fulfilled', async function () {
@@ -204,7 +207,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
           .returns(true);
 
         // when
-        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+        const numberOfCreatedBadges = await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
 
         // then
         expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
@@ -219,6 +222,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
             campaignParticipationId: campaignParticipation.id,
           },
         ]);
+        expect(numberOfCreatedBadges).to.equal(2);
       });
     });
 
@@ -231,10 +235,11 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
         sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
 
         // when
-        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+        const numberOfCreatedBadges = await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
 
         // then
         expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
+        expect(numberOfCreatedBadges).to.equal(0);
       });
     });
   });
@@ -342,7 +347,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
 
     it('should save only the validated badges', async function () {
       // when
-      await computeBadgeAcquisition({
+      const numberOfCreatedBadges = await computeBadgeAcquisition({
         campaignParticipation,
         badgeCriteriaService,
         badgeAcquisitionRepository,
@@ -356,6 +361,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       expect(badgeAcquisitions.length).to.equal(1);
       expect(badgeAcquisitions[0].userId).to.equal(userId);
       expect(badgeAcquisitions[0].badgeId).to.equal(badgeCompleted.id);
+      expect(numberOfCreatedBadges).to.equal(1);
     });
   });
 });

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -1,6 +1,22 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
-const { getCampaignParticipationsBetweenIds } = require('../../../../scripts/prod/compute-badge-acquisitions');
+const {
+  expect,
+  databaseBuilder,
+  sinon,
+  learningContentBuilder,
+  mockLearningContent,
+  knex,
+} = require('../../../test-helper');
+const {
+  computeBadgeAcquisition,
+  getCampaignParticipationsBetweenIds,
+} = require('../../../../scripts/prod/compute-badge-acquisitions');
+const _ = require('lodash');
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+const badgeCriteriaService = require('../../../../lib/domain/services/badge-criteria-service');
+const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
+const badgeRepository = require('../../../../lib/infrastructure/repositories/badge-repository');
+const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
+const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
 
 describe('Script | Prod | Compute Badge Acquisitions', function () {
   describe('#getCampaignParticipationsBetweenIds', function () {
@@ -19,6 +35,327 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       expect(campaignParticipations.length).to.equal(3);
       expect(campaignParticipations.map(({ id }) => id)).to.deep.equal([id2, id3, id4]);
       expect(campaignParticipations[0]).to.be.instanceOf(CampaignParticipation);
+    });
+  });
+
+  describe('Unit | #computeBadgeAcquisition', function () {
+    let badgeRepository, targetProfileRepository, knowledgeElementRepository, badgeAcquisitionRepository;
+    let badgeCriteriaService;
+    let dependencies;
+    let campaignParticipation;
+
+    beforeEach(function () {
+      campaignParticipation = {
+        id: 1,
+        userId: 123,
+      };
+
+      badgeRepository = {
+        findByCampaignParticipationId: _.noop,
+      };
+      targetProfileRepository = {
+        getByCampaignParticipationId: _.noop,
+      };
+      knowledgeElementRepository = {
+        findUniqByUserId: _.noop,
+      };
+      badgeAcquisitionRepository = {
+        createOrUpdate: _.noop,
+      };
+      badgeCriteriaService = {
+        areBadgeCriteriaFulfilled: _.noop,
+      };
+
+      dependencies = {
+        badgeAcquisitionRepository,
+        badgeCriteriaService,
+        badgeRepository,
+        knowledgeElementRepository,
+        targetProfileRepository,
+      };
+    });
+
+    context('when the campaign is associated to one badge', function () {
+      let badge;
+      let targetProfile;
+      let knowledgeElements;
+      let badgeId;
+
+      beforeEach(function () {
+        badgeId = Symbol('badgeId');
+        targetProfile = Symbol('targetProfile');
+        knowledgeElements = Symbol('knowledgeElements');
+
+        sinon.stub(badgeRepository, 'findByCampaignParticipationId');
+        badge = {
+          id: badgeId,
+          badgeCriteria: Symbol('badgeCriteria'),
+        };
+        badgeRepository.findByCampaignParticipationId.withArgs(campaignParticipation.id).resolves([badge]);
+
+        sinon.stub(targetProfileRepository, 'getByCampaignParticipationId');
+        targetProfileRepository.getByCampaignParticipationId.withArgs(campaignParticipation.id).resolves(targetProfile);
+
+        sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
+        knowledgeElementRepository.findUniqByUserId
+          .withArgs({ userId: campaignParticipation.userId })
+          .resolves(knowledgeElements);
+        sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
+        sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
+      });
+
+      it('should create a badge when badge requirements are fulfilled', async function () {
+        // given
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ targetProfile, knowledgeElements, badge })
+          .returns(true);
+
+        // when
+        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+
+        // then
+        expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
+          {
+            badgeId,
+            userId: campaignParticipation.userId,
+            campaignParticipationId: campaignParticipation.id,
+          },
+        ]);
+      });
+
+      it('should not create a badge when badge requirements are not fulfilled', async function () {
+        // given
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ targetProfile, knowledgeElements, badge })
+          .returns(false);
+
+        // when
+        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+
+        // then
+        expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
+      });
+    });
+
+    context('when the campaign is associated to two badges', function () {
+      let badge1, badge2;
+      let badgeId_1, badgeId_2;
+      let targetProfile;
+      let knowledgeElements;
+
+      beforeEach(function () {
+        badgeId_1 = Symbol('badgeId_1');
+        badgeId_2 = Symbol('badgeId_2');
+        targetProfile = Symbol('targetProfile');
+        knowledgeElements = Symbol('knowledgeElements');
+
+        sinon.stub(badgeRepository, 'findByCampaignParticipationId');
+        badge1 = {
+          id: badgeId_1,
+          badgeCriteria: Symbol('badgeCriteria'),
+        };
+        badge2 = {
+          id: badgeId_2,
+          badgeCriteria: Symbol('badgeCriteria'),
+        };
+        badgeRepository.findByCampaignParticipationId.withArgs(campaignParticipation.id).resolves([badge1, badge2]);
+
+        sinon.stub(targetProfileRepository, 'getByCampaignParticipationId');
+        targetProfileRepository.getByCampaignParticipationId.withArgs(campaignParticipation.id).resolves(targetProfile);
+
+        sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
+        knowledgeElementRepository.findUniqByUserId
+          .withArgs({ userId: campaignParticipation.userId })
+          .resolves(knowledgeElements);
+
+        sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
+        sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
+      });
+
+      it('should create one badge when only one badge requirements are fulfilled', async function () {
+        // given
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ targetProfile, knowledgeElements, badge: badge1 })
+          .returns(true);
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ targetProfile, knowledgeElements, badge: badge2 })
+          .returns(false);
+
+        // when
+        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+
+        // then
+        expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
+          {
+            badgeId: badge1.id,
+            userId: campaignParticipation.userId,
+            campaignParticipationId: campaignParticipation.id,
+          },
+        ]);
+      });
+
+      it('should create two badges when both badges requirements are fulfilled', async function () {
+        // given
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ targetProfile, knowledgeElements, badge: badge1 })
+          .returns(true);
+        badgeCriteriaService.areBadgeCriteriaFulfilled
+          .withArgs({ targetProfile, knowledgeElements, badge: badge2 })
+          .returns(true);
+
+        // when
+        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+
+        // then
+        expect(badgeAcquisitionRepository.createOrUpdate).to.have.been.calledWithExactly([
+          {
+            badgeId: badge1.id,
+            userId: campaignParticipation.userId,
+            campaignParticipationId: campaignParticipation.id,
+          },
+          {
+            badgeId: badge2.id,
+            userId: campaignParticipation.userId,
+            campaignParticipationId: campaignParticipation.id,
+          },
+        ]);
+      });
+    });
+
+    context('when the campaign is not associated to a badge', function () {
+      it('should not create a badge', async function () {
+        // given
+        sinon.stub(badgeRepository, 'findByCampaignParticipationId');
+        badgeRepository.findByCampaignParticipationId.withArgs(campaignParticipation.id).resolves([]);
+
+        sinon.stub(badgeAcquisitionRepository, 'createOrUpdate');
+
+        // when
+        await computeBadgeAcquisition({ campaignParticipation, ...dependencies });
+
+        // then
+        expect(badgeAcquisitionRepository.createOrUpdate).to.not.have.been.called;
+      });
+    });
+  });
+
+  describe('Integration | #computeBadgeAcquisition', function () {
+    let userId;
+    let badgeCompleted;
+    let campaignParticipation;
+
+    beforeEach(async function () {
+      const listSkill = ['web1', 'web2', 'web3', 'web4'];
+
+      const learningContent = [
+        {
+          id: 'recArea1',
+          titleFrFr: 'area1_Title',
+          color: 'someColor',
+          competences: [
+            {
+              id: 'competenceId',
+              nameFrFr: 'Mener une recherche et une veille d’information',
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube0_0',
+                  skills: [
+                    {
+                      id: listSkill[0],
+                      nom: '@web1',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                    {
+                      id: listSkill[1],
+                      nom: '@web2',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                    {
+                      id: listSkill[2],
+                      nom: 'web3',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                    {
+                      id: listSkill[3],
+                      nom: 'web4',
+                      status: 'actif',
+                      challenges: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      userId = databaseBuilder.factory.buildUser().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
+
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId });
+
+      badgeCompleted = databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        key: 'Badge1',
+      });
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badgeCompleted.id,
+        threshold: 40,
+      });
+
+      const badgeNotCompletedId = databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        key: 'Badge2',
+      }).id;
+      databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badgeNotCompletedId,
+        threshold: 90,
+      });
+
+      databaseBuilder.factory.buildBadge({
+        targetProfileId,
+        badgeCriteria: [],
+        key: 'Badge3',
+      }).id;
+
+      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+      mockLearningContent(learningContentObjects);
+
+      return databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('badge-acquisitions').delete();
+    });
+
+    it('should save only the validated badges', async function () {
+      // when
+      await computeBadgeAcquisition({
+        campaignParticipation,
+        badgeCriteriaService,
+        badgeAcquisitionRepository,
+        badgeRepository,
+        knowledgeElementRepository,
+        targetProfileRepository,
+      });
+
+      // then
+      const badgeAcquisitions = await knex('badge-acquisitions').where({ userId: userId });
+      expect(badgeAcquisitions.length).to.equal(1);
+      expect(badgeAcquisitions[0].userId).to.equal(userId);
+      expect(badgeAcquisitions[0].badgeId).to.equal(badgeCompleted.id);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il peut arriver qu'un utilisateur n'obtienne pas un badge alors qu'il a les critères pour. 
En effet, durant la chorégraphie de l'event dispatcher le container peut se crasher : l'`assessment` est alors déjà marqué comme complété, mais le badge ne sera pas acquis. 

## :robot: Solution
Une des solutions envisagés était d'utiliser pgboss à l'avenir, cependant depuis l'apparition du channel `#alert-event-dispatcher` nous recensons un unique cas. Bien que nous sommes conscients de la limite de l'alerting de cas. 

Cependant, comme un cas s'est déjà produit, nous devons reprendre les données pour vérifier à nouveau si l'utilisateur ne devait pas obtenir un badge. 

Pour cela, nous avons créé un script de reprise des données. Il se base sur les participations à une campagne (table: `campaignParticipations`.

Cette table étant volumineuse et les calculs d'un badge faisant appel à la table `knowledge-elements`, nous avons décidé de pouvoir lancer le script uniquement entre 2 id de la table `campaignParticipations` avec une fourchette maximale de `100 000` participations à une campagne maximum. Ce chiffre a été choisi de façon aléatoire et ne repose pas sur un constat.

De plus, une option permet de lancer le script en `dry-run`, c'est-à-dire sans effectuer de modification en base de données, mais en indiquant le nombre de badges qui aurait été impacté. 

## :rainbow: Remarques
Le template de script a été enrichi pour ajouter la déconnexion au redis via `cache.quit();`. 

## :100: Pour tester
- Se connecter au postgres de la RA : `scalingo -a pix-api-review-pr4637 pgsql-console`
- Supprimer les badges acquis : `delete from "badge-acquisitions";`

### Vérification du `dryRun` 
- Lancer la commande : 
```
scalingo -a pix-api-review-pr4637 run node scripts/prod/compute-badge-acquisitions.js --idMin 26000 --idMax 108008 --dryRun
```
- Constater que dans les logs : 1 badge peut être créé. 
- Vérifier qu'aucun badge acquisition ait été créé : `select * from "badge-acquisitions";`

### Vérification de la création  
- Relancer la commande sans l'option `dryRun` : 
```
scalingo -a pix-api-review-pr4637 run node scripts/prod/compute-badge-acquisitions.js --idMin 26000 --idMax 108008
```
- Vérifier qu'un badge acquisition ait été créé : `select * from "badge-acquisitions";`

### Vérification de non mis à jour de l'existant 
- Lancer la commande : 
```
scalingo -a pix-api-review-pr4637 run node scripts/prod/compute-badge-acquisitions.js --idMin 26000 --idMax 108008
```
- Constater qu'il y a toujours qu'une entrée dans la table. 


