### PR TITLE
[BUGFIX] Améliorer le message indiquant la présence d'une alternative textuelle sur les illustrations dans une épreuve sur Pix App (PIX-5271)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -564,7 +564,7 @@
         },
         "sr-only": {
           "embed": "This question uses a simulator.",
-          "alternative-instruction": "This question has an alternative instruction."
+          "alternative-instruction": "This question contains an illustration with a text alternative."
         }
       },
       "timed": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -564,7 +564,7 @@
         },
         "sr-only": {
           "embed": "Cette épreuve contient un simulateur.",
-          "alternative-instruction": "Cette épreuve a une consigne alternative."
+          "alternative-instruction": "Cette épreuve contient une illustration avec une alternative textuelle."
         }
       },
       "timed": {


### PR DESCRIPTION
## :unicorn: Problème
Le message indiquant qu'il existe une alternative textuelle sur les illustrations dans une épreuve n'était pas assez explicite.

## :robot: Solution
Améliorer son wording.

## :100: Pour tester
Tester avec le lecteur d'écran sur une épreuve contenant une alternative textuelle que le message est bien retranscrit.
