### PR TITLE
[FEATURE] Nouvel affichage page détails d'un profil cible (PIX-5311)

### DIFF
--- a/admin/app/components/target-profiles/details.hbs
+++ b/admin/app/components/target-profiles/details.hbs
@@ -1,51 +1,57 @@
-{{#each this.competenceList as |competence|}}
-  <section class="page-section competence">
-    <span class="competence__border competence__border--{{competence.area.color}}"></span>
-    <div>
-      <header class="competence__header">
-        <h2 class="competence__title">{{competence.name}}</h2>
-        <sub class="competence__subtitle">{{competence.area.title}}</sub>
-      </header>
-      <table class="table-admin">
-        <thead>
-          <tr>
-            <th class="table__column table__column--wide">Sujet</th>
-            <th class="table__column table__column--small table__column--center">Niveau 1</th>
-            <th class="table__column table__column--small table__column--center">Niveau 2</th>
-            <th class="table__column table__column--small table__column--center">Niveau 3</th>
-            <th class="table__column table__column--small table__column--center">Niveau 4</th>
-            <th class="table__column table__column--small table__column--center">Niveau 5</th>
-            <th class="table__column table__column--small table__column--center">Niveau 6</th>
-            <th class="table__column table__column--small table__column--center">Niveau 7</th>
-            <th class="table__column table__column--small table__column--center">Niveau 8</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each competence.tubes as |tube|}}
-            <tr>
-              <td>{{tube.practicalTitle}}</td>
-              {{#each tube.skills as |skill|}}
-                <td class="table__column--center skill-column">
-                  {{#if skill}}
-                    <PixTooltip @position="bottom">
-                      <:triggerElement>
-                        <FaIcon @icon="check" class="skill-column--check" aria-label={{skill.name}} />
-                      </:triggerElement>
-                      <:tooltip>{{concat skill.id " " skill.name}}</:tooltip>
-                    </PixTooltip>
-                  {{else}}
-                    <FaIcon @icon="times" class="skill-column--uncheck" />
-                  {{/if}}
-                </td>
-              {{/each}}
-            </tr>
-          {{/each}}
-        </tbody>
-      </table>
-    </div>
-  </section>
+{{#if @targetProfile.tubesSelection}}
+  {{#each @tubesSelectionAreas as |area|}}
+    <TargetProfiles::TubesDetails::Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
+  {{/each}}
 {{else}}
-  <section class="page-section">
-    <div class="table__empty">Profil cible vide.</div>
-  </section>
-{{/each}}
+  {{#each this.competenceList as |competence|}}
+    <section class="page-section competence">
+      <span class="competence__border competence__border--{{competence.area.color}}"></span>
+      <div>
+        <header class="competence__header">
+          <h2 class="competence__title">{{competence.name}}</h2>
+          <sub class="competence__subtitle">{{competence.area.title}}</sub>
+        </header>
+        <table class="table-admin">
+          <thead>
+            <tr>
+              <th class="table__column table__column--wide">Sujet</th>
+              <th class="table__column table__column--small table__column--center">Niveau 1</th>
+              <th class="table__column table__column--small table__column--center">Niveau 2</th>
+              <th class="table__column table__column--small table__column--center">Niveau 3</th>
+              <th class="table__column table__column--small table__column--center">Niveau 4</th>
+              <th class="table__column table__column--small table__column--center">Niveau 5</th>
+              <th class="table__column table__column--small table__column--center">Niveau 6</th>
+              <th class="table__column table__column--small table__column--center">Niveau 7</th>
+              <th class="table__column table__column--small table__column--center">Niveau 8</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each competence.tubes as |tube|}}
+              <tr>
+                <td>{{tube.practicalTitle}}</td>
+                {{#each tube.skills as |skill|}}
+                  <td class="table__column--center skill-column">
+                    {{#if skill}}
+                      <PixTooltip @position="bottom">
+                        <:triggerElement>
+                          <FaIcon @icon="check" class="skill-column--check" aria-label={{skill.name}} />
+                        </:triggerElement>
+                        <:tooltip>{{concat skill.id " " skill.name}}</:tooltip>
+                      </PixTooltip>
+                    {{else}}
+                      <FaIcon @icon="times" class="skill-column--uncheck" />
+                    {{/if}}
+                  </td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {{else}}
+    <section class="page-section">
+      <div class="table__empty">Profil cible vide.</div>
+    </section>
+  {{/each}}
+{{/if}}

--- a/admin/app/components/target-profiles/tubes-details/area.hbs
+++ b/admin/app/components/target-profiles/tubes-details/area.hbs
@@ -1,0 +1,8 @@
+<div class="area-border-container">
+  <div class="area-border {{@color}}"></div>
+  <PixCollapsible @title="{{@title}}" class="{{@color}} list-competences">
+    {{#each @competences as |competence|}}
+      <TargetProfiles::TubesDetails::Competence @title={{competence.title}} @thematics={{competence.thematics}} />
+    {{/each}}
+  </PixCollapsible>
+</div>

--- a/admin/app/components/target-profiles/tubes-details/areas.hbs
+++ b/admin/app/components/target-profiles/tubes-details/areas.hbs
@@ -1,0 +1,3 @@
+{{#each @areas as |area|}}
+  <TargetProfiles::TubesDetails::Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
+{{/each}}

--- a/admin/app/components/target-profiles/tubes-details/areas.hbs
+++ b/admin/app/components/target-profiles/tubes-details/areas.hbs
@@ -1,3 +1,0 @@
-{{#each @areas as |area|}}
-  <TargetProfiles::TubesDetails::Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
-{{/each}}

--- a/admin/app/components/target-profiles/tubes-details/competence.hbs
+++ b/admin/app/components/target-profiles/tubes-details/competence.hbs
@@ -1,0 +1,43 @@
+<div class="competence-container">
+  <PixCollapsible @title="{{@title}}">
+    <div class="panel">
+      <table class="table content-text content-text--small select-tube-table">
+        <caption class="sr-only">Sélection des sujets</caption>
+        <thead>
+          <tr>
+            <Table::Header @size="medium" scope="col">
+              <p>Thématiques</p>
+            </Table::Header>
+            <Table::Header @size="wide" scope="col">
+              <p>Sujets</p>
+            </Table::Header>
+            <Table::Header @size="small" scope="col">
+              <p>Niveau</p>
+            </Table::Header>
+            <Table::Header @size="medium" @align="center" scope="col">
+              <p>Compatibilité</p>
+            </Table::Header>
+          </tr>
+        </thead>
+
+        <tbody>
+          {{#each @thematics as |thematic|}}
+            {{#each thematic.tubes as |tube index|}}
+              <tr class="row-tube" aria-label="Sujet">
+                {{#if (eq index 0)}}
+                  <TargetProfiles::TubesDetails::Thematic @name={{thematic.name}} @nbTubes={{thematic.tubes.length}} />
+                {{/if}}
+                <TargetProfiles::TubesDetails::Tube
+                  @title={{tube.title}}
+                  @level={{tube.level}}
+                  @mobile={{tube.mobile}}
+                  @tablet={{tube.tablet}}
+                />
+              </tr>
+            {{/each}}
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
+  </PixCollapsible>
+</div>

--- a/admin/app/components/target-profiles/tubes-details/thematic.hbs
+++ b/admin/app/components/target-profiles/tubes-details/thematic.hbs
@@ -1,0 +1,3 @@
+<th rowspan={{@nbTubes}}>
+  {{@name}}
+</th>

--- a/admin/app/components/target-profiles/tubes-details/tube.hbs
+++ b/admin/app/components/target-profiles/tubes-details/tube.hbs
@@ -1,0 +1,20 @@
+<td>
+  {{@title}}
+</td>
+<td class="table__column--center">
+  {{@level}}
+</td>
+<td class="table__column--center">
+  <div class="icon-container" aria-label="{{if @mobile "compatible mobile" "incompatible mobile"}}">
+    <FaIcon @icon="mobile-alt" class="fa-2x {{if @mobile "is-responsive"}}" />
+    {{#unless @mobile}}
+      <FaIcon @icon="slash" class="fa-2x not-responsive" />
+    {{/unless}}
+  </div>
+  <div class="icon-container" aria-label="{{if @tablet "compatible tablette" "incompatible tablette"}}">
+    <FaIcon @icon="tablet-alt" class="fa-2x {{if @tablet "is-responsive"}}" />
+    {{#unless @tablet}}
+      <FaIcon @icon="slash" class="fa-2x not-responsive" />
+    {{/unless}}
+  </div>
+</td>

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/details.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/details.js
@@ -1,0 +1,35 @@
+import Controller from '@ember/controller';
+
+export default class TargetProfileDetailsController extends Controller {
+  get tubesSelectionAreas() {
+    return this.model.tubesSelectionAreas.map((area) => ({
+      title: `${area.code} · ${area.title}`,
+      color: area.color,
+      competences: area.competences.map((area) => this.buildCompetenceViewModel(area)),
+    }));
+  }
+
+  buildCompetenceViewModel(competence) {
+    return {
+      title: `${competence.index} ${competence.name}`,
+      thematics: competence.thematics.map((thematic) => this.buildThematicViewModel(thematic)),
+    };
+  }
+
+  buildThematicViewModel(thematic) {
+    return {
+      name: thematic.name,
+      nbTubes: thematic.tubes.length,
+      tubes: thematic.tubes.map((tube) => this.buildTubeViewModel(tube)),
+    };
+  }
+
+  buildTubeViewModel(tube) {
+    return {
+      title: `${tube.practicalTitle} : ${tube.practicalDescription}`,
+      level: tube.level,
+      mobile: tube.mobile,
+      tablet: tube.tablet,
+    };
+  }
+}

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -35,6 +35,7 @@ export default class TargetProfile extends Model {
   @hasMany('tube') tubes;
   @hasMany('competence') competences;
   @hasMany('area') areas;
+  @hasMany('area') tubesSelectionAreas;
 
   attachOrganizations = memberAction({
     path: 'attach-organizations',

--- a/admin/app/models/tube.js
+++ b/admin/app/models/tube.js
@@ -6,6 +6,7 @@ export default class Tube extends Model {
   @attr('string') competenceId;
   @attr('boolean') mobile;
   @attr('boolean') tablet;
+  @attr('number') level;
 
   @hasMany('skill') skills;
 }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/details.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/details.hbs
@@ -1,1 +1,1 @@
-<TargetProfiles::Details @targetProfile={{@model}} />
+<TargetProfiles::Details @targetProfile={{@model}} @tubesSelectionAreas={{this.tubesSelectionAreas}} />

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -119,6 +119,18 @@ class Challenge {
     return this.focused;
   }
 
+  get isMobileCompliant() {
+    return this._isCompliant('Smartphone');
+  }
+
+  get isTabletCompliant() {
+    return this._isCompliant('Tablet');
+  }
+
+  _isCompliant(type) {
+    return this.responsive?.includes(type);
+  }
+
   static createValidatorForChallengeType({ challengeType, solution }) {
     switch (challengeType) {
       case ChallengeType.QCU:

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -20,6 +20,7 @@ class TargetProfileWithLearningContent {
     category,
     isSimplifiedAccess,
     tubesSelection,
+    tubesSelectionAreas,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -39,6 +40,7 @@ class TargetProfileWithLearningContent {
     this.category = category;
     this.isSimplifiedAccess = isSimplifiedAccess;
     this.tubesSelection = tubesSelection;
+    this.tubesSelectionAreas = tubesSelectionAreas;
   }
 
   get skillNames() {

--- a/api/lib/domain/models/TargetedArea.js
+++ b/api/lib/domain/models/TargetedArea.js
@@ -1,6 +1,7 @@
 class TargetedArea {
-  constructor({ id, title, color, competences = [] } = {}) {
+  constructor({ id, code, title, color, competences = [] } = {}) {
     this.id = id;
+    this.code = code;
     this.title = title;
     this.color = color;
     this.competences = competences;

--- a/api/lib/domain/models/TargetedCompetence.js
+++ b/api/lib/domain/models/TargetedCompetence.js
@@ -1,13 +1,14 @@
 const _ = require('lodash');
 
 class TargetedCompetence {
-  constructor({ id, name, index, origin, areaId, tubes = [] } = {}) {
+  constructor({ id, name, index, origin, areaId, tubes = [], thematics = [] } = {}) {
     this.id = id;
     this.name = name;
     this.index = index;
     this.origin = origin;
     this.areaId = areaId;
     this.tubes = tubes;
+    this.thematics = thematics;
   }
 
   get skillCount() {

--- a/api/lib/domain/models/TargetedThematic.js
+++ b/api/lib/domain/models/TargetedThematic.js
@@ -1,0 +1,8 @@
+module.exports = class TargetedThematic {
+  constructor({ id, name, index, tubes = [] } = {}) {
+    this.id = id;
+    this.name = name;
+    this.index = index;
+    this.tubes = tubes;
+  }
+};

--- a/api/lib/domain/models/TargetedTube.js
+++ b/api/lib/domain/models/TargetedTube.js
@@ -1,14 +1,34 @@
 class TargetedTube {
-  constructor({ id, practicalTitle, description, competenceId, skills = [] } = {}) {
+  constructor({
+    id,
+    practicalTitle,
+    practicalDescription,
+    description,
+    competenceId,
+    skills = [],
+    level,
+    challenges = [],
+  } = {}) {
     this.id = id;
     this.practicalTitle = practicalTitle;
+    this.practicalDescription = practicalDescription;
     this.description = description;
     this.competenceId = competenceId;
     this.skills = skills;
+    this.level = level;
+    this.challenges = challenges;
   }
 
   hasSkill(skillId) {
     return this.skills.some((skill) => skill.id === skillId);
+  }
+
+  get mobile() {
+    return this.challenges && this.challenges.length > 0 && this.challenges.every((c) => c.isMobileCompliant);
+  }
+
+  get tablet() {
+    return this.challenges && this.challenges.length > 0 && this.challenges.every((c) => c.isTabletCompliant);
   }
 }
 

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -77,6 +77,13 @@ module.exports = {
       throw err;
     }
   },
+
+  async findByRecordIds({ competenceIds, locale }) {
+    const [competenceDatas, areaDatas] = await Promise.all([competenceDatasource.list(), areaDatasource.list()]);
+    return competenceDatas
+      .filter(({ id }) => competenceIds.includes(id))
+      .map((competenceData) => _toDomain({ competenceData, areaDatas, locale }));
+  },
 };
 
 function _list({ locale }) {

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
@@ -1,7 +1,7 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(targetProfiles, meta) {
+  serialize(targetProfiles) {
     return new Serializer('target-profile', {
       attributes: [
         'name',
@@ -21,7 +21,32 @@ module.exports = {
         'category',
         'isSimplifiedAccess',
         'tubesSelection',
+        'tubesSelectionAreas',
       ],
+      typeForAttribute(attribute) {
+        if (attribute === 'tubesSelectionAreas') return 'areas';
+        return undefined;
+      },
+      tubesSelectionAreas: {
+        ref: 'id',
+        included: true,
+        attributes: ['title', 'color', 'code', 'competences'],
+        competences: {
+          ref: 'id',
+          included: true,
+          attributes: ['name', 'index', 'thematics'],
+          thematics: {
+            ref: 'id',
+            included: true,
+            attributes: ['name', 'index', 'tubes'],
+            tubes: {
+              ref: 'id',
+              included: true,
+              attributes: ['practicalTitle', 'practicalDescription', 'level', 'mobile', 'tablet'],
+            },
+          },
+        },
+      },
       skills: {
         ref: 'id',
         included: true,
@@ -62,7 +87,6 @@ module.exports = {
           },
         },
       },
-      meta,
     }).serialize(targetProfiles);
   },
 };

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | target-profile-controller', function () {
         origin: 'Pix',
       },
     ],
+    thematics: [],
     tubes: [
       {
         id: 'recArea1_Competence1_Tube1',

--- a/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
@@ -25,7 +25,7 @@ describe('Integration | UseCase | find-assessment-participation-result-list', fu
     const participant2 = { firstName: 'Tonari', lastName: 'No Totoro' };
     databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(participant2, participation2);
 
-    mockLearningContent({ skills: [skill], tubes: [], competences: [], areas: [] });
+    mockLearningContent({ skills: [skill], tubes: [], thematics: [], competences: [], areas: [], challenges: [] });
 
     await databaseBuilder.commit();
   });

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -136,12 +136,14 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
             origin: 'Pix',
           },
         ],
+        thematics: [],
         tubes: [{ id: 'recTube1', competenceId: 'recCompetence1' }],
         skills: [
           { id: 'recSkillWeb1', name: '@web1', tubeId: 'recTube1', status: 'actif', competenceId: 'recCompetence1' },
           { id: 'recSkillWeb2', name: '@web2', tubeId: 'recTube1', status: 'actif', competenceId: 'recCompetence1' },
           { id: 'recSkillWeb3', name: '@web3', tubeId: 'recTube1', status: 'actif', competenceId: 'recCompetence1' },
         ],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -41,6 +41,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
             nameEnUs: 'English competence 2',
           },
         ],
+        thematics: [],
         tubes: [
           {
             id: 'recTube1',
@@ -67,6 +68,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
             competenceId: 'rec1',
           },
         ],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -69,6 +69,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
         competences: [{ id: 'competence1', skillIds: [skillId], origin: 'Pix' }],
         tubes: [{ id: 'tube1', competenceId: 'competence1' }],
         skills: [{ id: skillId, tubeId: 'tube1', status: 'actif' }],
+        thematics: [],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);
@@ -124,6 +126,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
       const area1 = domainBuilder.buildTargetedArea({
         id: 'recArea1',
         title: 'area1_Title',
+        color: 'area1_color',
+        code: 'area1_code',
         competences: [competence1_1, competence1_2],
       });
       const targetProfileDB = databaseBuilder.factory.buildTargetProfile({
@@ -164,7 +168,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
           {
             id: 'recArea1',
             titleFrFr: 'area1_Title',
-            color: 'someColor',
+            color: 'area1_color',
+            code: 'area1_code',
             competenceIds: ['recArea1_Competence1', 'recArea1_Competence2'],
           },
         ],
@@ -218,6 +223,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);
@@ -274,6 +281,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);
@@ -342,6 +351,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);
@@ -380,6 +391,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             id: 'areaId',
             titleEnUs: 'someTitle',
             color: 'someColor',
+            code: 'someCode',
             competenceIds: ['competenceId'],
           },
         ],
@@ -411,6 +423,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
       mockLearningContent(learningContent);
       await databaseBuilder.commit();
@@ -452,11 +466,29 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
         skillId: basicTargetProfile.skills[0].id,
       });
 
+      const expectedTubesSelectionAreas = [
+        domainBuilder.buildTargetedArea({
+          id: 'recArea1',
+          competences: [
+            {
+              id: 'recArea1_Competence1',
+              name: 'someName',
+              index: 'someIndex',
+              areaId: 'recArea1',
+              origin: 'Pix',
+              thematics: [],
+              tubes: [],
+            },
+          ],
+        }),
+      ];
+
       const learningContent = {
         areas: [
           {
             id: 'recArea1',
             titleFrFr: 'someTitle',
+            code: 'someCode',
             color: 'someColor',
             competenceIds: ['recArea1_Competence1'],
           },
@@ -473,7 +505,12 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
         ],
         tubes: [
           {
-            id: 'recArea1_Competence1_Tube1',
+            id: 'tubeId123',
+            competenceId: 'recArea1_Competence1',
+            practicalTitleFrFr: 'somePracticalTitle',
+          },
+          {
+            id: 'tubeId456',
             competenceId: 'recArea1_Competence1',
             practicalTitleFrFr: 'somePracticalTitle',
           },
@@ -483,11 +520,13 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             id: basicTargetProfile.skills[0].id,
             name: 'someSkillName5',
             status: 'actif',
-            tubeId: 'recArea1_Competence1_Tube1',
+            tubeId: 'tubeId123',
             competenceId: 'recArea1_Competence1',
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);
@@ -498,6 +537,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
 
       // then
       expect(targetProfile.tubesSelection).to.deep.eq(expectedTubesSelection);
+      expect(targetProfile.tubesSelectionAreas).to.deep.eq(expectedTubesSelectionAreas);
     });
 
     it('should throw a NotFoundError when targetProfile does not exists', async function () {
@@ -549,6 +589,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
       mockLearningContent(learningContent);
 
@@ -604,6 +646,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
       const area1 = domainBuilder.buildTargetedArea({
         id: 'recArea1',
         title: 'area1_Title',
+        code: 'area1_code',
+        color: 'area1_color',
         competences: [competence1_1, competence1_2],
       });
       const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
@@ -636,7 +680,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
           {
             id: 'recArea1',
             titleFrFr: 'area1_Title',
-            color: 'someColor',
+            code: 'area1_code',
+            color: 'area1_color',
             competenceIds: ['recArea1_Competence1', 'recArea1_Competence2'],
           },
         ],
@@ -690,6 +735,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
 
       mockLearningContent(learningContent);
@@ -747,6 +794,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
       mockLearningContent(learningContent);
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileDB.id }).id;
@@ -807,6 +856,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
       mockLearningContent(learningContent);
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileDB.id }).id;
@@ -854,6 +905,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             id: 'areaId',
             titleEnUs: 'someTitle',
             color: 'someColor',
+            code: 'someCode',
             competenceIds: ['competenceId'],
           },
         ],
@@ -885,6 +937,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
       mockLearningContent(learningContent);
       await databaseBuilder.commit();
@@ -950,6 +1004,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', func
             tutorialIds: [],
           },
         ],
+        thematics: [],
+        challenges: [],
       };
       mockLearningContent(learningContent);
 

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
@@ -23,6 +23,7 @@ const buildTargetProfileWithLearningContent = function buildTargetProfileWithLea
   imageUrl,
   category = 'OTHER',
   tubesSelection = [],
+  tubesSelectionAreas = [],
 } = {}) {
   return new TargetProfileWithLearningContent({
     id,
@@ -43,6 +44,7 @@ const buildTargetProfileWithLearningContent = function buildTargetProfileWithLea
     imageUrl,
     category,
     tubesSelection,
+    tubesSelectionAreas,
   });
 };
 
@@ -61,6 +63,7 @@ buildTargetProfileWithLearningContent.withSimpleLearningContent = function withS
   stages = [],
   category = 'OTHER',
   tubesSelection = [],
+  tubesSelectionAreas = [],
 } = {}) {
   const skill = buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
   const tube = buildTargetedTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
@@ -78,6 +81,7 @@ buildTargetProfileWithLearningContent.withSimpleLearningContent = function withS
     description,
     comment,
     tubesSelection,
+    tubesSelectionAreas,
     skills: [skill],
     tubes: [tube],
     competences: [competence],

--- a/api/tests/tooling/domain-builder/factory/build-targeted-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-area.js
@@ -5,12 +5,14 @@ const buildTargetedArea = function buildTargetedArea({
   id = 'someAreaId',
   title = 'someTitle',
   color = 'someColor',
+  code = 'someCode',
   competences = [buildTargetedCompetence()],
 } = {}) {
   return new TargetedArea({
     id,
     title,
     color,
+    code,
     competences,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-targeted-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-competence.js
@@ -8,6 +8,7 @@ const buildTargetedCompetence = function buildTargetedCompetence({
   origin = 'Pix',
   areaId = 'someAreaId',
   tubes = [buildTargetedTube()],
+  thematics = [],
 } = {}) {
   return new TargetedCompetence({
     id,
@@ -16,6 +17,7 @@ const buildTargetedCompetence = function buildTargetedCompetence({
     origin,
     areaId,
     tubes,
+    thematics,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-targeted-thematic.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-thematic.js
@@ -1,0 +1,16 @@
+const TargetedThematic = require('../../../../lib/domain/models/TargetedThematic');
+const buildTargetedTube = require('./build-targeted-tube');
+
+module.exports = function buildTargetedThematic({
+  id = 'someThematicId',
+  name = 'someName',
+  index = 'someIndex',
+  tubes = [buildTargetedTube()],
+} = {}) {
+  return new TargetedThematic({
+    id,
+    name,
+    index,
+    tubes,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-targeted-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-tube.js
@@ -4,16 +4,22 @@ const buildTargetedSkill = require('./build-targeted-skill');
 const buildTargetedTube = function buildTargetedTube({
   id = 'someTubeId',
   practicalTitle = 'somePracticalTitle',
+  practicalDescription,
   description = 'someDescription',
+  level,
   competenceId = 'someCompetenceId',
   skills = [buildTargetedSkill()],
+  challenges = [],
 } = {}) {
   return new TargetedTube({
     id,
     practicalTitle,
+    practicalDescription,
     description,
+    level,
     competenceId,
     skills,
+    challenges,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -111,6 +111,7 @@ module.exports = {
   buildTargetedArea: require('./build-targeted-area'),
   buildTargetedCompetence: require('./build-targeted-competence'),
   buildTargetedSkill: require('./build-targeted-skill'),
+  buildTargetedThematic: require('./build-targeted-thematic'),
   buildTargetedTube: require('./build-targeted-tube'),
   buildTargetProfile: require('./build-target-profile'),
   buildOrganizationsToAttachToTargetProfile: require('./build-organizations-to-attach-to-target-profile'),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
@@ -2,7 +2,7 @@ const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer');
 const TargetProfileWithLearningContent = require('../../../../../lib/domain/models/TargetProfileWithLearningContent');
 const TargetProfileTube = require('../../../../../lib/domain/models/TargetProfileTube');
-const buildTargetedSkill = require('../../../../tooling/domain-builder/factory/build-targeted-skill');
+const domainBuilder = require('../../../../tooling/domain-builder/factory');
 
 describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-serializer', function () {
   describe('#serialize', function () {
@@ -17,16 +17,52 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
         ownerOrganizationId: 12,
         description: 'Un super profil cible',
         comment: 'commentaire',
-        skills: [buildTargetedSkill({ id: 'rec1', name: '@url4', tubeId: 'rec2' })],
-        tubes: [{ id: 'rec2', practicalTitle: 'Url', competenceId: 'rec3' }],
-        competences: [{ id: 'rec3', name: 'Comprendre', areaId: 'rec4', index: '1.1' }],
-        areas: [{ id: 'rec4', title: 'Connaître', color: 'blue' }],
+        skills: [domainBuilder.buildTargetedSkill({ id: 'rec1', name: '@url4', tubeId: 'rec2' })],
+        tubes: [domainBuilder.buildTargetedTube({ id: 'rec2', practicalTitle: 'Url', competenceId: 'rec3' })],
+        competences: [
+          domainBuilder.buildTargetedCompetence({ id: 'rec3', name: 'Comprendre', areaId: 'rec4', index: '1.1' }),
+        ],
+        areas: [domainBuilder.buildTargetedArea({ id: 'rec4', title: 'Connaître', color: 'blue' })],
         organizations: [{ id: 42 }],
         category: 'OTHER',
         isSimplifiedAccess: false,
         tubesSelection: [
           new TargetProfileTube({ id: 'tubeId1', level: 6 }),
           new TargetProfileTube({ id: 'tubeId2', level: 3 }),
+        ],
+        tubesSelectionAreas: [
+          domainBuilder.buildTargetedArea({
+            id: 'rec4',
+            title: 'Connaître',
+            color: 'blue',
+            code: 'areaCode4',
+            competences: [
+              domainBuilder.buildTargetedCompetence({
+                id: 'rec3',
+                name: 'Comprendre',
+                index: '1.1',
+                thematics: [
+                  domainBuilder.buildTargetedThematic({
+                    id: 'idThematic1',
+                    name: 'La cuisine',
+                    index: '1',
+                    tubes: [
+                      domainBuilder.buildTargetedTube({
+                        id: 'rec2',
+                        practicalTitle: 'Url',
+                        practicalDescription: 'Uniform Resource Locator',
+                        level: 5,
+                        challenges: [
+                          domainBuilder.buildChallenge({ responsive: ['Smartphone'] }),
+                          domainBuilder.buildChallenge({ responsive: ['Smartphone', 'Tablet'] }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
         ],
       });
 
@@ -51,10 +87,18 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             ],
           },
           relationships: {
+            'tubes-selection-areas': {
+              data: [
+                {
+                  id: targetProfileWithLearningContent.tubesSelectionAreas[0].id,
+                  type: 'areas',
+                },
+              ],
+            },
             skills: {
               data: [
                 {
-                  id: targetProfileWithLearningContent.skills[0].id.toString(),
+                  id: targetProfileWithLearningContent.skills[0].id,
                   type: 'skills',
                 },
               ],
@@ -62,7 +106,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             tubes: {
               data: [
                 {
-                  id: targetProfileWithLearningContent.tubes[0].id.toString(),
+                  id: targetProfileWithLearningContent.tubes[0].id,
                   type: 'tubes',
                 },
               ],
@@ -70,7 +114,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             competences: {
               data: [
                 {
-                  id: targetProfileWithLearningContent.competences[0].id.toString(),
+                  id: targetProfileWithLearningContent.competences[0].id,
                   type: 'competences',
                 },
               ],
@@ -78,7 +122,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             areas: {
               data: [
                 {
-                  id: targetProfileWithLearningContent.areas[0].id.toString(),
+                  id: targetProfileWithLearningContent.areas[0].id,
                   type: 'areas',
                 },
               ],
@@ -97,7 +141,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
         },
         included: [
           {
-            id: targetProfileWithLearningContent.skills[0].id.toString(),
+            id: targetProfileWithLearningContent.skills[0].id,
             type: 'skills',
             attributes: {
               name: targetProfileWithLearningContent.skills[0].name,
@@ -106,28 +150,74 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             },
           },
           {
-            id: targetProfileWithLearningContent.tubes[0].id.toString(),
+            id: targetProfileWithLearningContent.tubes[0].id,
             type: 'tubes',
             attributes: {
               'practical-title': targetProfileWithLearningContent.tubes[0].practicalTitle,
               'competence-id': targetProfileWithLearningContent.tubes[0].competenceId,
+              level: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].tubes[0].level,
+              'practical-description':
+                targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].tubes[0]
+                  .practicalDescription,
+              mobile:
+                targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].tubes[0].mobile,
             },
+            relationships: {},
           },
           {
-            id: targetProfileWithLearningContent.competences[0].id.toString(),
+            id: targetProfileWithLearningContent.competences[0].id,
             type: 'competences',
             attributes: {
               name: targetProfileWithLearningContent.competences[0].name,
               'area-id': targetProfileWithLearningContent.competences[0].areaId,
               index: targetProfileWithLearningContent.competences[0].index,
             },
+            relationships: {
+              thematics: {
+                data: [
+                  {
+                    id: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].id,
+                    type: 'thematics',
+                  },
+                ],
+              },
+            },
           },
           {
-            id: targetProfileWithLearningContent.areas[0].id.toString(),
+            id: targetProfileWithLearningContent.areas[0].id,
             type: 'areas',
             attributes: {
               title: targetProfileWithLearningContent.areas[0].title,
               color: targetProfileWithLearningContent.areas[0].color,
+              code: targetProfileWithLearningContent.tubesSelectionAreas[0].code,
+            },
+            relationships: {
+              competences: {
+                data: [
+                  {
+                    id: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].id,
+                    type: 'competences',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            id: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].id,
+            type: 'thematics',
+            attributes: {
+              name: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].name,
+              index: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].index,
+            },
+            relationships: {
+              tubes: {
+                data: [
+                  {
+                    id: targetProfileWithLearningContent.tubesSelectionAreas[0].competences[0].thematics[0].tubes[0].id,
+                    type: 'tubes',
+                  },
+                ],
+              },
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible de visualiser la sélection de sujets sur la page de détail d'un "nouveau profil cible".

## :robot: Solution

Sur la page de détail d'un profil cible, si celui ci possède une sélection de sujets, on offre un nouvel affichage permettant de visualiser cette sélection.

Si le profil cible ne possède pas de sélection de sujets, on garde l'ancien affichage.

## :rainbow: Remarques

N/A

## :100: Pour tester

Créer un nouveau profil cible, et vérifier que sa page de détail offre le nouvel affichage.
