### PR TITLE
[BUGFIX] Changer la couleur du texte de la bannière d'alerte sur Pix App (PIX-5231)

### DIFF
--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -3,7 +3,7 @@
   border-radius: 0.195em;
   padding: 9px;
   margin-bottom: 11px;
-  color: $pix-neutral-0;
+  color: $pix-neutral-110;
   text-shadow: none;
   font-size: 0.875rem;
   font-weight: $font-normal;
@@ -15,6 +15,7 @@
   &--danger {
     border: 1px solid $pix-error-70;
     background-color: $pix-error-10;
+    color: $pix-error-70;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Depuis l’intégration des couleurs du Design System, nous avons une régression de couleur au niveau de la bannière d’erreur. 
<img width="906" alt="Capture d’écran 2022-07-11 à 10 35 24" src="https://user-images.githubusercontent.com/49011144/178229618-98915fc1-6cf8-478c-af11-0928185a0f09.png">

## :robot: Solution
Changer la couleur du texte avec la bonne couleur.

## :100: Pour tester
Vérifier que les bonnes couleurs sont appliquées.
