### PR TITLE
[A11Y] Ajouter une description au tableau d'analyse pour les lecteurs d'écrans(PIX-4252)

### DIFF
--- a/orga/app/components/campaign/analysis/recommendations.hbs
+++ b/orga/app/components/campaign/analysis/recommendations.hbs
@@ -8,6 +8,7 @@
     class="panel panel--light-shadow content-text content-text--small campaign-details-analysis__table"
     aria-label={{t "pages.campaign-review.table.analysis.title"}}
   >
+    <caption class="sr-only">{{t "pages.campaign-review.table.analysis.caption"}}</caption>
     <thead>
       <tr>
         <Table::Header @size="wide">{{t

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -8,6 +8,7 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
   setupIntlRenderingTest(hooks);
 
   let store;
+  let screen;
 
   module('when the analysis is displayed', function (hooks) {
     hooks.beforeEach(async function () {
@@ -35,41 +36,42 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
 
       this.campaignTubeRecommendations = [campaignTubeRecommendation_1, campaignTubeRecommendation_2];
 
-      await render(hbs`<Campaign::Analysis::Recommendations
+      screen = await render(hbs`<Campaign::Analysis::Recommendations
       @campaignTubeRecommendations={{campaignTubeRecommendations}}
       @displayAnalysis={{true}}
     />`);
     });
 
     test('it should display the tube analysis list of the campaign', async function (assert) {
-      assert.dom('[aria-label="Sujet"]').exists({ count: 2 });
-      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+      const subjects = screen.getAllByLabelText('Sujet');
+      assert.strictEqual(subjects.length, 2);
+      assert.dom(subjects[0]).containsText('Tube A');
     });
 
     test('it should display tube details', async function (assert) {
-      const firstTube = '[aria-label="Sujet"]:first-child';
+      const firstTube = screen.getAllByLabelText('Sujet')[0];
       assert.dom(firstTube).containsText('Tube A');
       assert.dom(firstTube).containsText('Competence A');
     });
 
     test('it should order by recommendation desc by default', async function (assert) {
-      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+      assert.dom(screen.getAllByLabelText('Sujet')[0]).containsText('Tube A');
     });
 
     test('it should order by recommendation asc', async function (assert) {
-      await click('[aria-label="Trier par pertinence"]');
+      await click(screen.getByLabelText('Trier par pertinence'));
 
-      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube B');
+      assert.dom(screen.getAllByLabelText('Sujet')[0]).containsText('Tube B');
     });
 
     test('it should order by recommendation desc', async function (assert) {
-      await click('[aria-label="Trier par pertinence"]');
-      await click('[aria-label="Trier par pertinence"]');
+      await click(screen.getByLabelText('Trier par pertinence'));
+      await click(screen.getByLabelText('Trier par pertinence'));
 
-      assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+      assert.dom(screen.getAllByLabelText('Sujet')[0]).containsText('Tube A');
     });
 
-    test('it should have a caption to desbribe the table', async function (assert) {
+    test('it should have a caption to describe the table', async function (assert) {
       assert.contains(this.intl.t('pages.campaign-review.table.analysis.caption'));
     });
   });

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, render } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -66,6 +67,10 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
       await click('[aria-label="Trier par pertinence"]');
 
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
+    });
+
+    test('it should have a caption to desbribe the table', async function (assert) {
+      assert.contains(this.intl.t('pages.campaign-review.table.analysis.caption'));
     });
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -491,6 +491,7 @@
       "sub-title": "Recommendations of topics to focus on",
       "table": {
         "analysis": {
+          "caption": "Table of topics to work on, sorted by relevance. Some have additional columns showing the number of tutorials that exist related to the topic and how to access these tutorials",
           "title": "Review by topic",
           "column": {
             "relevance": "Relevance",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -490,6 +490,7 @@
       "sub-title": "Recommandation de sujets à travailler",
       "table": {
         "analysis": {
+          "caption": "Tableau des sujets à travailler, certains présentent des colonnes supplémentaires indiquant le nombre de tutoriels existant en lien avec le sujet et un accès à ces tutoriels",
           "title": "Analyse par sujet",
           "column": {
             "relevance": "Pertinence",


### PR DESCRIPTION
## :unicorn: Problème
Le tableau d'analyse est un tableau complexe. Il doit donc avoir une description qui sera lu par les lecteurs d'écrans.

## :robot: Solution
Ajouter cette description

## :rainbow: Remarques


## :100: Pour tester
- Se connecter sur Pix Orga
- Aller dans l'onglet d'analyse
- Constater la présence de la phrase dans DOM
