### PR TITLE
[FEATURE] Modifier le libellé d'un signalement de sous-catégorie E11 (PIX-5290)

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -68,7 +68,7 @@ export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
     'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
   [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
-    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à ne pas répondre à la question',
   [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
     'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -175,7 +175,8 @@ module('Integration | Component | certifications/issue-report', function (hooks)
     },
     {
       subcategory: certificationIssueReportSubcategories.SKIP_ON_OOPS,
-      expectedLabel: 'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+      expectedLabel:
+        'Une page affichant “Oups une erreur est survenue” a contraint le candidat à ne pas répondre à la question',
     },
     {
       subcategory: certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -59,7 +59,7 @@ export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
     'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
   [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
-    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à passer la question',
+    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à ne pas répondre à la question',
   [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
     'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };


### PR DESCRIPTION
## :unicorn: Problème
Le wording pour la sous-catégorie E11 pose problême

## :robot: Solution
Modifier le wording de cette sous-catégorie E11 : 
AVANT: “Une page affichant "Oups une erreur est survenue" a contraint le candidat à passer la question”
APRÈS: “Une page affichant "Oups une erreur est survenue" a contraint le candidat à ne pas répondre à la question.”

## :rainbow: Remarques
R.A.S.

## :100: Pour tester
https://certif-pr4642.review.pix.fr/sessions/4
Finaliser une certification en séléctionnant un signalement E11

Verifier le nom du signalement sur la certification concernée dans admin:
https://admin-pr4642.review.pix.fr/certifications/106476
