### PR TITLE
[FEATURE] Affichage de la date de dernière participation dans l'onglet étudiants (PIX-5173). 

### DIFF
--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -12,7 +12,10 @@
         <Table::Header @size="medium" @align="right">
           {{t "pages.students-sup.table.column.participation-count"}}
         </Table::Header>
-        <Table::Header @size="small" class="hide-on-mobile" />
+        <Table::Header @size="medium" @align="center">
+          {{t "pages.students-sup.table.column.last-participation-date"}}
+        </Table::Header>
+        <Table::Header @size="medium" class="hide-on-mobile" />
       </tr>
       <tr class="hide-on-mobile">
         <Table::HeaderFilterInput
@@ -49,6 +52,7 @@
         />
         <Table::Header class="table__column--right" />
         <Table::Header />
+        <Table::Header />
       </tr>
     </thead>
 
@@ -62,6 +66,9 @@
             <td class="table__column--center">{{moment-format student.birthdate "DD/MM/YYYY"}}</td>
             <td class="ellipsis">{{student.group}}</td>
             <td class="table__column--right">{{student.participationCount}}</td>
+            <td class="table__column--center">
+              {{moment-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}
+            </td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if this.currentUser.isAdminInOrganization}}
                 <Dropdown::IconTrigger

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -52,7 +52,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.dom('[aria-label="Étudiant"]').exists({ count: 2 });
   });
 
-  test('it should display the student number, firstName, lastName, birthdate, group and participation count of student', async function (assert) {
+  test('it should display the student number, firstName, lastName, birthdate, group, participation count and and last participation date of student', async function (assert) {
     // given
     const students = [
       {
@@ -62,6 +62,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
         birthdate: new Date('2010-02-01'),
         group: 'AB1',
         participationCount: 88,
+        lastParticipationDate: new Date('2022-01-03'),
       },
     ];
 
@@ -78,6 +79,7 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.contains('01/02/2010');
     assert.contains('AB1');
     assert.contains('88');
+    assert.contains('03/01/2022');
   });
 
   module('when user is filtering some users', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -848,6 +848,7 @@
           "first-name": "First name",
           "group": "Groups",
           "last-name": "Last name",
+          "last-participation-date": "Latest participation",
           "participation-count": "Number of participations",
           "student-number": "Student number"
         },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -847,6 +847,7 @@
           "first-name": "Prénom",
           "group": "Groupes",
           "last-name": "Nom",
+          "last-participation-date": "Dernière participation",
           "participation-count": "Nombre de participations",
           "student-number": "Numéro étudiant"
         },


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs n'ont pour l'instant aucun moyen de voir la date de la dernière participations que les étudiants ont réalisées.

## :robot: Solution
Ajouter une colonne dans l'onglet étudiants.

## :rainbow: Remarques
Il sera nécéssaire de renommer et séparer les routes sco et sup, cela sera fait ultérieurement.

## :100: Pour tester
Aller dans l'onglet étudiants et voir la date de dernière participation. Supprimer une participation, la date doit changer. Repasser une participation, la date doit changer.