### PR TITLE
[BUGFIX] Complète le `title` des liens des consignes d'épreuves (PIX-5324)

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -78,6 +78,7 @@ export default class ChallengeStatement extends Component {
 
   _insertLinkTitle(markdownLink) {
     const markdownLinkWithoutLastChar = markdownLink.substring(0, markdownLink.length - 1);
-    return `${markdownLinkWithoutLastChar} "${this.linkTitle}")`;
+    const linkDestination = markdownLink.substring(1, markdownLink.indexOf(']'));
+    return `${markdownLinkWithoutLastChar} "${linkDestination} (${this.linkTitle})")`;
   }
 }

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -78,6 +78,6 @@ export default class ChallengeStatement extends Component {
 
   _insertLinkTitle(markdownLink) {
     const markdownLinkWithoutLastChar = markdownLink.substring(0, markdownLink.length - 1);
-    return markdownLinkWithoutLastChar + ' "' + this.linkTitle + '")';
+    return `${markdownLinkWithoutLastChar} "${this.linkTitle}")`;
   }
 }

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -98,7 +98,7 @@ describe('Integration | Component | ChallengeStatement', function () {
       expect(find('.challenge-statement-instruction__text')).to.not.exist;
     });
 
-    it('should add title "Nouvelle fenêtre" to external links', async function () {
+    it('should add title "destination (nouvelle fenêtre)" to external links', async function () {
       // given
       addAssessmentToContext(this, { id: '267845' });
       addChallengeToContext(this, {
@@ -110,10 +110,8 @@ describe('Integration | Component | ChallengeStatement', function () {
       await renderChallengeStatement(this);
 
       // then
-      const linkCount = find('.challenge-statement-instruction__text').innerHTML.match(
-        /title="Nouvelle fenêtre"/g
-      ).length;
-      expect(linkCount).to.equal(2);
+      expect(find('.challenge-statement-instruction__text a[title="lien 1 (nouvelle fenêtre)"]')).to.exist;
+      expect(find('.challenge-statement-instruction__text a[title="lien 2 (nouvelle fenêtre)"]')).to.exist;
     });
 
     it('should display a specific style', async function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -540,7 +540,7 @@
             "hide": "Hide alternative instruction"
           }
         },
-        "external-link-title": "New window",
+        "external-link-title": "new window",
         "file-download": {
           "actions": {
             "choose-type": "Select the type of file you would like to use",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -540,7 +540,7 @@
             "hide": "Cacher l'alternative textuelle"
           }
         },
-        "external-link-title": "Nouvelle fenêtre",
+        "external-link-title": "nouvelle fenêtre",
         "file-download": {
           "actions": {
             "choose-type": "Choisissez le type de fichier que vous voulez utiliser",


### PR DESCRIPTION
## :unicorn: Problème
Retour de Tanaguru : l'attribut `title` des liens externes que nous mettons dans nos épreuves devrait correspondre au texte du lien lui-même + "nouvelle fenêtre", et pas seulement "nouvelle fenêtre", car les utilisateurs de lecteurs d'écran peuvent le paramétrer afin de lire seulement l'attribut `title` ou bien le plus long entre le contenu de la balise `<a>` et son attribut `title`.

## :robot: Solution
Compléter le `title` des liens.

## :rainbow: Remarques
Comment s'assurer que les liens du contenu ne contiennent pas de caractères qui pourrait casser la regex ?

## :100: Pour tester
Accéder à une question avec des liens et s'assurer que le title affiche à la fois la destination et "nouvelle fenêtre". 

Exemple d'épreuve : [`challenges/recRPcaiXk8ggWMSB/preview`](https://app-pr4644.review.pix.fr/challenges/recRPcaiXk8ggWMSB/preview)
