### PR TITLE
[BUGFIX] Suppression de la section "Autres certif comp" sur un certificat avec un commentaire (PIX-5274).

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/components/user-certifications-detail-result.hbs
@@ -12,20 +12,25 @@
     </PixBlock>
   {{/if}}
 
-  <h2>{{t "pages.certificate.complementary.title"}}</h2>
-  <PixBlock>
-    {{#if @certification.hasCleaCertif}}
-      <div class="user-certifications-detail-result__complementary-certification">
-        <img src="https://images.pix.fr/badges/CleA_Num_certif.svg" alt="{{t "pages.certificate.clea.alternative"}}" />
-      </div>
-    {{/if}}
-    {{#each @certification.certifiedBadgeImages as |certifiedBadgeImage|}}
-      <div class="user-certifications-detail-result__complementary-certification">
-        <img src={{certifiedBadgeImage.path}} alt="{{t "pages.certificate.complementary.alternative"}}" />
-        {{#if certifiedBadgeImage.message}}
-          <span>{{certifiedBadgeImage.message}}</span>
-        {{/if}}
-      </div>
-    {{/each}}
-  </PixBlock>
+  {{#if @certification.hasAcquiredComplementaryCertifications}}
+    <h2>{{t "pages.certificate.complementary.title"}}</h2>
+    <PixBlock>
+      {{#if @certification.hasCleaCertif}}
+        <div class="user-certifications-detail-result__complementary-certification">
+          <img
+            src="https://images.pix.fr/badges/CleA_Num_certif.svg"
+            alt="{{t "pages.certificate.clea.alternative"}}"
+          />
+        </div>
+      {{/if}}
+      {{#each @certification.certifiedBadgeImages as |certifiedBadgeImage|}}
+        <div class="user-certifications-detail-result__complementary-certification">
+          <img src={{certifiedBadgeImage.path}} alt="{{t "pages.certificate.complementary.alternative"}}" />
+          {{#if certifiedBadgeImage.message}}
+            <span>{{certifiedBadgeImage.message}}</span>
+          {{/if}}
+        </div>
+      {{/each}}
+    </PixBlock>
+  {{/if}}
 </div>

--- a/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
@@ -73,6 +73,7 @@ describe('Integration | Component | user certifications detail result', function
         status: 'validated',
         commentForCandidate: null,
         hasCleaCertif: true,
+        hasAcquiredComplementaryCertifications: true,
       });
       this.set('certification', certification);
 
@@ -123,6 +124,7 @@ describe('Integration | Component | user certifications detail result', function
         isPublished: true,
         pixScore: 654,
         status: 'validated',
+        hasAcquiredComplementaryCertifications: true,
         certifiedBadgeImages: [
           {
             url: '/some/img',
@@ -152,6 +154,7 @@ describe('Integration | Component | user certifications detail result', function
           isPublished: true,
           pixScore: 654,
           status: 'validated',
+          hasAcquiredComplementaryCertifications: true,
           certifiedBadgeImages: [
             {
               url: '/some/img',
@@ -194,6 +197,35 @@ describe('Integration | Component | user certifications detail result', function
       const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
       // then
       expect(screen.queryByRole('img', { name: 'Certification complémentaire' })).to.not.exist;
+    });
+  });
+
+  context('when certification has jury comments but no complementary certifed badges', function () {
+    it('should not show the complementary certification badge section', async function () {
+      // given
+      certification = EmberObject.create({
+        id: 1,
+        birthdate: new Date('2000-01-22T15:15:52Z'),
+        firstName: 'Jean',
+        lastName: 'Bon',
+        date: new Date('2018-02-15T15:15:52Z'),
+        certificationCenter: 'Université de Lyon',
+        isPublished: true,
+        pixScore: 654,
+        status: 'validated',
+        commentForCandidate: 'Commentaire du jury',
+        hasCleaCertif: false,
+        certifiedBadgeImages: [],
+      });
+      this.set('certification', certification);
+
+      // when
+      const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
+
+      // then
+      expect(
+        screen.queryByRole('heading', { name: this.intl.t('pages.certificate.complementary.title') })
+      ).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
@@ -35,7 +35,7 @@ describe('Integration | Component | user certifications detail result', function
     });
   });
 
-  context('when certification has no comment for user', function () {
+  context('when certification has no comment for the user', function () {
     it('should not show the comment for candidate', async function () {
       // given
       const certification = EmberObject.create({
@@ -54,7 +54,7 @@ describe('Integration | Component | user certifications detail result', function
 
       // when
       const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
-      expect(screen.queryByText(this.intl.t('pages.certificate.jury-title'))).to.not.exist;
+      expect(screen.queryByRole('heading', { name: this.intl.t('pages.certificate.jury-title') })).to.not.exist;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix-app, sur la page d'un certificat obtenu, si le certificat contient un ou plusieurs commentaires du jury mais pas de certifications complémentaires, la section relative à cette dernière est quand même visible.

![image](https://user-images.githubusercontent.com/36371437/178298836-84cf9e82-ae7c-419c-bd12-46c996b9cb63.png)

## :robot: Solution

Suppression de la section relative aux certifications complémentaires si elle n'est pas nécessaire.

<img width="425" alt="Capture d’écran 2022-07-11 à 18 02 32" src="https://user-images.githubusercontent.com/36371437/178307572-fdd1ed50-06dc-4a68-bdd7-8cd426dcaf9d.png">

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Se connecter à Pix-app avec le compte `certif-success@example.net`.
Aller sur la page des certificats
Vérifier sur un certificat sans certification complémentaire que la section relative à ces dernières n'est plus présente sur la page.
