### PR TITLE
[FEATURE] Ramener le contexte des tutoriels lorsqu'ils sont présentés au moment de la correction (PIX-5326).

### DIFF
--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -57,7 +57,9 @@ function _convertSkillToHint({ skill, locale }) {
 async function _getTutorials({ userId, skill, tutorialIdsProperty, locale }) {
   const tutorialIds = skill[tutorialIdsProperty];
   if (!_.isEmpty(tutorialIds)) {
-    return tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialIds, userId, locale });
+    const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialIds, userId, locale });
+    tutorials.forEach((tutorial) => (tutorial.skillId = skill.id));
+    return tutorials;
   }
   return [];
 }

--- a/api/lib/infrastructure/serializers/jsonapi/tutorial-attributes.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tutorial-attributes.js
@@ -4,7 +4,7 @@ const userTutorialAttributes = require('./user-tutorial-attributes');
 module.exports = {
   ref: 'id',
   includes: true,
-  attributes: ['id', 'duration', 'format', 'link', 'source', 'title', 'tutorialEvaluation', 'userTutorial'],
+  attributes: ['id', 'duration', 'format', 'link', 'source', 'title', 'tutorialEvaluation', 'userTutorial', 'skillId'],
   tutorialEvaluation: tutorialEvaluationAttributes,
   userTutorial: userTutorialAttributes,
 };

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -125,6 +125,7 @@ describe('Acceptance | Controller | answer-controller-get-correction', function 
                 format: 'vidéo',
                 id: 'french-tutorial-id',
                 link: 'http://www.example.com/this-is-an-example.html',
+                'skill-id': 'q_first_acquis',
                 source: 'Source Example, Example',
                 title: 'Communiquer',
               },

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -108,6 +108,10 @@ describe('Unit | Repository | correction-repository', function () {
         expect(result).to.be.an.instanceof(Correction);
         expect(result).to.deep.equal(expectedCorrection);
         expect(challengeDatasource.get).to.have.been.calledWith(recordId);
+        expect(expectedCorrection.tutorials.map(({ skillId }) => skillId)).to.deep.equal([
+          'recSK0X22abcdefgh',
+          'recSK0X22abcdefgh',
+        ]);
       });
 
       it('should return the correction with validated hint', async function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
@@ -23,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | correction-serializer', function () {
               title: 'Comment dresser un panda',
             }),
             userTutorial: { id: 'userTutorial1', userId: 'userId', tutorialId: 'recTuto1' },
+            skillId: 'skill1',
           },
           {
             ...new Tutorial({
@@ -133,6 +134,7 @@ describe('Unit | Serializer | JSONAPI | correction-serializer', function () {
               id: 'recTuto1',
               link: 'https://youtube.fr',
               source: 'Youtube',
+              'skill-id': 'skill1',
               title: 'Comment dresser un panda',
             },
             id: 'recTuto1',


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons enregistrer le contexte dans lequel un tutoriel a été proposé. Le contexte correspond au `skillId` qui contenait le tutoriel. Ce contexte nous permettre à l'avenir de pouvoir filtrer sur nos tutoriels enregistrés et recommandés. 

Actuellement, dans le cadre des tutoriels proposé lors de la correction d'une épreuve le `skillId` n'est pas remonté au front.   

## :robot: Solution
Remonter le skillId. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App
- Passer des épreuves jusqu'au checkpoint
- Au checkpoint ouvrir la correction 
- Constater dans l'extension ember que les tutoriels ramenés contiennent bien un `skillId`. 