### PR TITLE
[TECH] Ajouter la colonne "level" à la table complementary-certification-badges (PIX-5203)

### DIFF
--- a/api/db/migrations/20220711194824_add-level-to-complementary-certification-badges.js
+++ b/api/db/migrations/20220711194824_add-level-to-complementary-certification-badges.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'complementary-certification-badges';
+const COLUMN_NAME = 'level';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().defaultTo(1);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20220712082535_insert-complementary-certification-badges.js
+++ b/api/db/migrations/20220712082535_insert-complementary-certification-badges.js
@@ -1,0 +1,134 @@
+const TABLE_NAME = 'complementary-certification-badges';
+const { keys } = require('../../lib/domain/models/Badge');
+const {
+  PIX_EMPLOI_CLEA_V1,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_EMPLOI_CLEA_V3,
+
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_DROIT_MAITRE_CERTIF,
+
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+} = keys;
+
+const DROIT = 'Pix+ Droit';
+const CLEA = 'CléA Numérique';
+const EDU_1 = 'Pix+ Édu 1er degré';
+const EDU_2 = 'Pix+ Édu 2nd degré';
+
+const data = [
+  {
+    keys: [PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3],
+    level: 1,
+    complementaryCourseKey: CLEA,
+  },
+  {
+    keys: [PIX_DROIT_MAITRE_CERTIF],
+    level: 1,
+    complementaryCourseKey: DROIT,
+  },
+  {
+    keys: [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE],
+    level: 1,
+    complementaryCourseKey: EDU_1,
+  },
+  {
+    keys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
+    level: 1,
+    complementaryCourseKey: EDU_2,
+  },
+  {
+    keys: [PIX_DROIT_EXPERT_CERTIF],
+    level: 2,
+    complementaryCourseKey: DROIT,
+  },
+  {
+    keys: [PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME],
+    level: 2,
+    complementaryCourseKey: EDU_1,
+  },
+  {
+    keys: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME],
+    level: 2,
+    complementaryCourseKey: EDU_2,
+  },
+
+  { keys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME], level: 3, complementaryCourseKey: EDU_1 },
+  { keys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME], level: 3, complementaryCourseKey: EDU_2 },
+
+  { keys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE], level: 4, complementaryCourseKey: EDU_1 },
+  { keys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE], level: 4, complementaryCourseKey: EDU_2 },
+  { keys: [PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT], level: 5, complementaryCourseKey: EDU_1 },
+  { keys: [PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT], level: 5, complementaryCourseKey: EDU_2 },
+];
+
+exports.up = async function (knex) {
+  await _insertComplementaryCertifications();
+
+  await knex(TABLE_NAME).del();
+
+  const complementaryCertificationBadges = await _getCertifiableBadges();
+  const complementaryCertifications = await knex('complementary-certifications').select('id', 'name');
+
+  const insertData = data.reduce((array, { keys, level, complementaryCourseKey }) => {
+    const complementaryCertification = complementaryCertifications.find(({ name }) => name === complementaryCourseKey);
+    keys.forEach((badgeKey) => {
+      const badge = complementaryCertificationBadges.find(({ key }) => key === badgeKey);
+      if (!badge) return;
+      array.push({
+        complementaryCertificationId: complementaryCertification.id,
+        level,
+        badgeId: badge.id,
+      });
+    });
+
+    return array;
+  }, []);
+  await knex.batchInsert(TABLE_NAME, insertData);
+
+  async function _insertComplementaryCertifications() {
+    const complementaryCertifications = await knex('complementary-certifications').select('name').pluck('name');
+    if (!complementaryCertifications.includes(DROIT))
+      await knex('complementary-certifications').insert({ name: DROIT });
+    if (!complementaryCertifications.includes(CLEA)) await knex('complementary-certifications').insert({ name: CLEA });
+    if (!complementaryCertifications.includes(EDU_1))
+      await knex('complementary-certifications').insert({ name: EDU_1 });
+    if (!complementaryCertifications.includes(EDU_2))
+      await knex('complementary-certifications').insert({ name: EDU_2 });
+  }
+
+  async function _getCertifiableBadges() {
+    return knex('badges')
+      .select('id', 'key')
+      .whereIn('key', [
+        PIX_EMPLOI_CLEA_V1,
+        PIX_EMPLOI_CLEA_V2,
+        PIX_EMPLOI_CLEA_V3,
+        PIX_DROIT_EXPERT_CERTIF,
+        PIX_DROIT_MAITRE_CERTIF,
+        PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+        PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+        PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+        PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+      ]);
+  }
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
## :unicorn: Problème
le lien entre une certification complémentaire et les badges certifiables associés est déclaré à plusieurs endroit dans le code. Cela entraîne une certaine duplication de code et empêche de rajouter/modifier rapidement et facilement des niveaux à des certifications complémentaires. 

## :robot: Solution
<ul class="ak-ul" data-indent-level="1" style="margin: 12px 0px 0px; padding: 0px 0px 0px 24px; box-sizing: border-box; list-style-type: disc; display: flow-root; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><p data-renderer-start-pos="331" style="margin: 0px; padding: 0px; font-size: 1em; line-height: 1.714; font-weight: normal; letter-spacing: -0.005em;">Ajouter une colonne <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">level</code> à la table  <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">complementary-certification-badges</code></p><ul class="ak-ul" data-indent-level="2" style="margin: 4px 0px 0px; padding: 0px 0px 0px 24px; box-sizing: border-box; list-style-type: circle; display: flow-root;"><li><p data-renderer-start-pos="407" style="margin: 0px; padding: 0px; font-size: 1em; line-height: 1.714; font-weight: normal; letter-spacing: -0.005em;">Cette colonne à une valeur numérique exprimant l’ordre d’un badge (ex: <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">level</code> = 1 pour le badge <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">PIX_DROIT_MAITRE_CERTIF</code>, <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">level</code> = 2 pour <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">PIX_DROIT_EXPERT_CERTIF</code> )</p></li></ul></li><li style="margin-top: 4px;"><p data-renderer-start-pos="573" style="margin: 0px; padding: 0px; font-size: 1em; line-height: 1.714; font-weight: normal; letter-spacing: -0.005em;">Alimenter la table <code class="code css-9z42f9" data-renderer-mark="true" style="font-family: SFMono-Medium, &quot;SF Mono&quot;, &quot;Segoe UI Mono&quot;, &quot;Roboto Mono&quot;, &quot;Ubuntu Mono&quot;, Menlo, Consolas, Courier, monospace; font-size: 0.875em; font-weight: normal; background-color: var(--ds--code--bg-color,#F4F5F7); color: rgb(23, 43, 77); border: 1px none rgb(204, 204, 204); border-radius: 3px; display: inline; padding: 2px 0.5ch; white-space: pre-wrap; overflow-wrap: break-word; overflow: auto; -webkit-box-decoration-break: clone; background-image: initial; background-position: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; line-height: 1.33333; --ds--code--bg-color:var(--ds-background-neutral, rgba(9, 30, 66, 0.08));">complementary-certification-badges</code>(elle est vide à l’heure actuelle)</p><ul class="ak-ul" data-indent-level="2" style="margin: 4px 0px 0px; padding: 0px 0px 0px 24px; box-sizing: border-box; list-style-type: circle; display: flow-root;"><li><p data-renderer-start-pos="664" style="margin: 0px; padding: 0px; font-size: 1em; line-height: 1.714; font-weight: normal; letter-spacing: -0.005em;">Cette table fait le lien entre une certification complémentaire (représenté par son id) et un badge (représenté par son id).</p></li><li style="margin-top: 4px;"><p data-renderer-start-pos="792" style="margin: 0px; padding: 0px; font-size: 1em; line-height: 1.714; font-weight: normal; letter-spacing: -0.005em;">Voici les données telles qu’elles doivent être ajoutés dans la table.</p></li></ul></li></ul><div class="pm-table-container " data-layout="default" style="margin: 0px auto 16px; padding: 0px; position: relative; box-sizing: border-box; clear: both; z-index: 0; transition: all 0.1s linear 0s; display: flex; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; width: inherit;"><div class="pm-table-wrapper" style="margin: 0px; padding: 0px; overflow-x: auto;">

Certification complémentaire | Badge | Niveau
-- | -- | --
CléA Numérique | PIX_EMPLOI_CLEA | 1
CléA Numérique | PIX_EMPLOI_CLEA_V2 | 1
CléA Numérique | PIX_EMPLOI_CLEA_V3 | 1
Pix+ Droit | PIX_DROIT_MAITRE_CERTIF | 1
Pix+ Droit | PIX_DROIT_MAITRE_CERTIF | 2
Pix+ Édu 2nd degré | PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE | 1
Pix+ Édu 2nd degré | PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME | 2
Pix+ Édu 2nd degré | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME | 3
Pix+ Édu 2nd degré | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE | 4
Pix+ Édu 2nd degré | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT | 5
Pix+ Édu 1er degré | PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE | 1
Pix+ Édu 1er degré | PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME | 2
Pix+ Édu 1er degré | PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME | 3
Pix+ Édu 1er degré | PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE | 4
Pix+ Édu 1er degré | PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT | 5

</div></div>

## :rainbow: Remarques
La table est vide en recette/production. On ajoute les lignes

## :100: Pour tester
Lancer la migration `npm run db:migrate`
Verifier les valeurs dans la colonne level:
```sql
select cc.name, badges.key, ccb.level
from "complementary-certification-badges"  ccb
inner join "badges" on ccb."badgeId" = badges.id
inner join "complementary-certifications" cc on cc."id" = ccb."complementaryCertificationId"
order by ccb."complementaryCertificationId", ccb.level;
```

| name | key | level |
|---|---|---|
  |      CléA Numérique        |                      PIX_EMPLOI_CLEA_V2                      | 1 |
|        CléA Numérique     | PIX_EMPLOI_CLEA_V3                            |     1 |
|        CléA Numérique     | PIX_EMPLOI_CLEA                               |     1 |
|        Pix+ Droit         | PIX_DROIT_MAITRE_CERTIF                       |     1 |
| Pix+ Droit         | PIX_DROIT_EXPERT_CERTIF                       |     2 |
| Pix+ Édu 1er degré | PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE   |     1 |
| Pix+ Édu 1er degré | PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME |     2 |
| Pix+ Édu 1er degré | PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME |     3 |
| Pix+ Édu 1er degré | PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE   |     4 |
| Pix+ Édu 1er degré | PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT   |     5 |
| Pix+ Édu 2nd degré | PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE   |     1 |
| Pix+ Édu 2nd degré | PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME |     2 |
| Pix+ Édu 2nd degré | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME |     3 |
| Pix+ Édu 2nd degré | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE   |     4 |
| Pix+ Édu 2nd degré | PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT   |     5 |
