### PR TITLE
[BUGFIX] Après être réconcilié on ne peut pas accéder a une autre campagne SCO de la même organisation (PIX-5328). 

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -335,7 +335,7 @@ function _buildHighSchools({ databaseBuilder }) {
     division: '2A',
     group: null,
     organizationId: SCO_HIGH_SCHOOL_ID,
-    nationalStudentId: '123456789BB',
+    nationalStudentId: 'autreINE',
     createdAt: new Date('2020-08-14'),
   });
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-learner-identity-serializer.js
@@ -2,7 +2,7 @@ const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
   serialize(organizationLearnerIdentity) {
-    return new Serializer('organization-learner', {
+    return new Serializer('schooling-registration-user-association', {
       attributes: ['lastName', 'firstName'],
     }).serialize(organizationLearnerIdentity);
   },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-learner-identity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-learner-identity-serializer_test.js
@@ -14,7 +14,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-identity-serializer
 
       const expectedSerializedOrganizationLearner = {
         data: {
-          type: 'organization-learners',
+          type: 'schooling-registration-user-associations',
           id: '5',
           attributes: {
             'first-name': organizationLearner.firstName,


### PR DESCRIPTION
## :unicorn: Problème
Après être réconcilié pour une organisation SCO, on ne peut plus accéder a une autre campagne de la même organisation.

## :robot: Solution
Corriger le nom du model dans le serializer de l'API.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de rejoindre plusieurs campagnes de la même organisation.
