### PR TITLE
[FEATURE] Afficher le nombre de participations dans l'onglet "Participants"(PIX-5123)

### DIFF
--- a/api/lib/domain/read-models/OrganizationParticipant.js
+++ b/api/lib/domain/read-models/OrganizationParticipant.js
@@ -1,8 +1,9 @@
 class OrganizationParticipant {
-  constructor({ id, firstName, lastName } = {}) {
+  constructor({ id, firstName, lastName, participationCount } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
+    this.participationCount = participationCount;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/organization-participant-repository.js
@@ -4,12 +4,20 @@ const { fetchPage } = require('../utils/knex-utils');
 
 async function getParticipantsByOrganizationId({ organizationId, page }) {
   const query = knex('organization-learners')
-    .select(['organization-learners.id', 'organization-learners.lastName', 'organization-learners.firstName'])
+    .select([
+      'organization-learners.id',
+      'organization-learners.lastName',
+      'organization-learners.firstName',
+      knex.raw(
+        'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organizationLearnerId") AS "participationCount"'
+      ),
+    ])
     .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
     .leftJoin('users', 'organization-learners.userId', 'users.id')
     .where({ organizationId })
     .where('users.isAnonymous', '=', false)
     .whereNull('campaign-participations.deletedAt')
+    .where('campaign-participations.isImproved', '=', false)
     .orderBy(['organization-learners.lastName', 'organization-learners.firstName', 'organization-learners.id'])
     .distinct('organization-learners.id');
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize({ organizationParticipants, pagination }) {
     return new Serializer('organization-participants', {
       id: 'id',
-      attributes: ['firstName', 'lastName'],
+      attributes: ['firstName', 'lastName', 'participationCount'],
       meta: pagination,
     }).serialize(organizationParticipants);
   },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
@@ -1,17 +1,23 @@
-const { expect, domainBuilder } = require('../../../../../test-helper');
+const { expect } = require('../../../../../test-helper');
+const OrganizationParticipant = require('../../../../../../lib/domain/read-models/OrganizationParticipant');
 const serializer = require('../../../../../../lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer');
+
 describe('Unit | Serializer | JSONAPI | organization-participants-serializer', function () {
   describe('#serialize', function () {
     it('should convert an organization participant model object into JSON API data', function () {
       // given
       const organizationParticipants = [
-        domainBuilder.buildOrganizationLearner({
+        new OrganizationParticipant({
           id: 777,
-          organizationId: 2,
+          firstName: 'Alex',
+          lastName: 'Vasquez',
+          participationCount: 4,
         }),
-        domainBuilder.buildOrganizationLearner({
+        new OrganizationParticipant({
           id: 778,
-          organizationId: 2,
+          firstName: 'Sam',
+          lastName: 'Simpson',
+          participationCount: 3,
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -24,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
             attributes: {
               'first-name': organizationParticipants[0].firstName,
               'last-name': organizationParticipants[0].lastName,
+              'participation-count': organizationParticipants[0].participationCount,
             },
           },
           {
@@ -32,6 +39,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
             attributes: {
               'first-name': organizationParticipants[1].firstName,
               'last-name': organizationParticipants[1].lastName,
+              'participation-count': organizationParticipants[1].participationCount,
             },
           },
         ],

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -4,6 +4,9 @@
       <tr>
         <Table::Header>{{t "pages.organization-participants.table.column.last-name"}}</Table::Header>
         <Table::Header>{{t "pages.organization-participants.table.column.first-name"}}</Table::Header>
+        <Table::Header @align="right">{{t
+            "pages.organization-participants.table.column.participation-count"
+          }}</Table::Header>
       </tr>
     </thead>
 
@@ -13,6 +16,7 @@
           <tr aria-label={{t "pages.organization-participants.table.row-title"}}>
             <td class="ellipsis" title={{participant.lastName}}>{{participant.lastName}}</td>
             <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
+            <td class="table__column--right">{{participant.participationCount}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/orga/app/models/organization-participant.js
+++ b/orga/app/models/organization-participant.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class OrganizationParticipant extends Model {
   @attr('string') lastName;
   @attr('string') firstName;
+  @attr('number') participationCount;
 }

--- a/orga/tests/integration/components/organization-participants/list_test.js
+++ b/orga/tests/integration/components/organization-participants/list_test.js
@@ -25,6 +25,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // then
     assert.contains('Nom');
     assert.contains('Prénom');
+    assert.contains('Nombre de participations');
   });
 
   test('it should display a list of participants', async function (assert) {
@@ -60,5 +61,23 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // then
     assert.contains('La Terreur');
     assert.contains('Gigi');
+  });
+
+  test('it should display the number of participations for each participant', async function (assert) {
+    // given
+    const participants = [
+      { lastName: 'La Terreur', firstName: 'Gigi', id: 34, participationCount: 4 },
+      { lastName: "L'asticot", firstName: 'Gogo', id: 56, participationCount: 1 },
+    ];
+
+    this.set('participants', participants);
+
+    // when
+    const screen = await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    const allRows = screen.getAllByLabelText(this.intl.t('pages.organization-participants.table.row-title'));
+
+    // then
+    assert.dom(allRows[0]).containsText(4);
+    assert.dom(allRows[1]).containsText(1);
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -656,7 +656,8 @@
       "table": {
         "column": {
           "first-name": "First name",
-          "last-name": "Last name"
+          "last-name": "Last name",
+          "participation-count": "Number of participations"
         },
         "empty": "No participants",
         "row-title": "Participant"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -655,7 +655,8 @@
       "table": {
         "column": {
           "first-name": "Prénom",
-          "last-name": "Nom"
+          "last-name": "Nom",
+          "participation-count": "Nombre de participations"
         },
         "empty": "Aucun participant",
         "row-title": "Participant"


### PR DESCRIPTION
## :unicorn: Problème
Dans la continuité de l'amélioration de l'onglet 'Participant', on souhaite préciser le nombre de participations d'un participant.

## :robot: Solution
Afficher cette donnée.

## :rainbow: Remarques
Contrairement aux orgas SUP & SCO, on n peut pas avoir un participant avec 0 participation.

## :100: Pour tester
- Aller sur pix Orga avec un compte pro
- Aller dans l'onglet "Participants"
- Constater la colonnes "Nombre de participants"
