### PR TITLE
[FEATURE] Tracer la résolution automatique sur les signalements (PIX-5258)

### DIFF
--- a/api/db/database-builder/factory/build-certification-issue-report.js
+++ b/api/db/database-builder/factory/build-certification-issue-report.js
@@ -9,6 +9,7 @@ module.exports = function buildCertificationIssueReport({
   category = CertificationIssueReportCategories.OTHER,
   description = 'Une super description',
   subcategory = null,
+  hasBeenAutomaticallyResolved = null,
   questionNumber = null,
   resolvedAt = null,
   resolution = null,
@@ -22,6 +23,7 @@ module.exports = function buildCertificationIssueReport({
     description,
     subcategory,
     questionNumber,
+    hasBeenAutomaticallyResolved,
     resolvedAt,
     resolution,
   };

--- a/api/db/migrations/20220712125907_add-hasBeenAutomaticallyResolved-column-to-certification-issue-reports.js
+++ b/api/db/migrations/20220712125907_add-hasBeenAutomaticallyResolved-column-to-certification-issue-reports.js
@@ -1,0 +1,31 @@
+const autoResolveSentencePattern = 'Aucune question ne correspond au numéro %';
+
+const autoResolveSentences = [
+  'Cette question a été neutralisée automatiquement',
+  "Cette question n'a pas été neutralisée car elle ne contient ni image ni application/simulateur",
+  "Cette question n'a pas été neutralisée car elle ne contient pas de fichier à télécharger",
+  "Cette question n'a pas été neutralisée car ce n'est pas une question focus",
+  "Cette question n'a pas été neutralisée car elle n'est pas chronométrée",
+  "Cette question n'a pas été neutralisée car la réponse est correcte",
+  "Cette question n'a pas été neutralisée car la réponse n'a pas été abandonnée ou le focus n'a pas été perdu",
+  'Cette réponse a été acceptée automatiquement',
+];
+
+exports.up = async function (knex) {
+  await knex.schema.table('certification-issue-reports', (table) => {
+    table.boolean('hasBeenAutomaticallyResolved').nullable();
+  });
+
+  await knex('certification-issue-reports').whereNotNull('resolvedAt').update({ hasBeenAutomaticallyResolved: false });
+
+  await knex('certification-issue-reports')
+    .whereIn('resolution', autoResolveSentences)
+    .orWhere('resolution', 'LIKE', autoResolveSentencePattern)
+    .update({ hasBeenAutomaticallyResolved: true });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table('certification-issue-reports', (table) => {
+    table.dropColumn('hasBeenAutomaticallyResolved');
+  });
+};

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -135,6 +135,7 @@ class CertificationIssueReport {
     description,
     subcategory,
     questionNumber,
+    hasBeenAutomaticallyResolved,
     resolvedAt,
     resolution,
   } = {}) {
@@ -144,6 +145,7 @@ class CertificationIssueReport {
     this.subcategory = subcategory;
     this.description = description;
     this.questionNumber = questionNumber;
+    this.hasBeenAutomaticallyResolved = hasBeenAutomaticallyResolved;
     this.resolvedAt = resolvedAt;
     this.resolution = resolution;
     this.isImpactful = _isImpactful({ category, subcategory });
@@ -176,6 +178,7 @@ class CertificationIssueReport {
       description,
       subcategory,
       questionNumber,
+      hasBeenAutomaticallyResolved: null,
       resolvedAt: null,
       resolution: null,
     });

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -210,9 +210,10 @@ class CertificationIssueReport {
     return Boolean(this.resolvedAt);
   }
 
-  resolve(resolution) {
+  resolveManually(resolution) {
     this.resolvedAt = new Date();
     this.resolution = resolution;
+    this.hasBeenAutomaticallyResolved = false;
   }
 
   resolveAutomatically(resolution) {

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -214,6 +214,12 @@ class CertificationIssueReport {
     this.resolvedAt = new Date();
     this.resolution = resolution;
   }
+
+  resolveAutomatically(resolution) {
+    this.resolvedAt = new Date();
+    this.resolution = resolution;
+    this.hasBeenAutomaticallyResolved = true;
+  }
 }
 
 module.exports = CertificationIssueReport;

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -207,13 +207,13 @@ async function _resolveWithNoSuchQuestion(
   certificationIssueReport,
   questionNumber
 ) {
-  certificationIssueReport.resolve(`Aucune question ne correspond au numéro ${questionNumber}`);
+  certificationIssueReport.resolveAutomatically(`Aucune question ne correspond au numéro ${questionNumber}`);
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
 
 async function _resolveWithQuestionNeutralized(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve('Cette question a été neutralisée automatiquement');
+  certificationIssueReport.resolveAutomatically('Cette question a été neutralisée automatiquement');
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithEffect();
 }
@@ -222,7 +222,7 @@ async function _resolveWithNeitherImageNorEmbedInChallenge(
   certificationIssueReportRepository,
   certificationIssueReport
 ) {
-  certificationIssueReport.resolve(
+  certificationIssueReport.resolveAutomatically(
     "Cette question n'a pas été neutralisée car elle ne contient ni image ni application/simulateur"
   );
   await certificationIssueReportRepository.save(certificationIssueReport);
@@ -230,7 +230,7 @@ async function _resolveWithNeitherImageNorEmbedInChallenge(
 }
 
 async function _resolveWithNoAttachmentInChallenge(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve(
+  certificationIssueReport.resolveAutomatically(
     "Cette question n'a pas été neutralisée car elle ne contient pas de fichier à télécharger"
   );
   await certificationIssueReportRepository.save(certificationIssueReport);
@@ -238,19 +238,23 @@ async function _resolveWithNoAttachmentInChallenge(certificationIssueReportRepos
 }
 
 async function _resolveWithNoFocusedChallenge(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve("Cette question n'a pas été neutralisée car ce n'est pas une question focus");
+  certificationIssueReport.resolveAutomatically(
+    "Cette question n'a pas été neutralisée car ce n'est pas une question focus"
+  );
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
 
 async function _resolveWithChallengeNotTimed(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve("Cette question n'a pas été neutralisée car elle n'est pas chronométrée");
+  certificationIssueReport.resolveAutomatically(
+    "Cette question n'a pas été neutralisée car elle n'est pas chronométrée"
+  );
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
 
 async function _resolveWithAnswerIsCorrect(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve("Cette question n'a pas été neutralisée car la réponse est correcte");
+  certificationIssueReport.resolveAutomatically("Cette question n'a pas été neutralisée car la réponse est correcte");
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithoutEffect();
 }
@@ -259,7 +263,7 @@ async function _resolveWithNeitherSkippedNorFocusedOutAnswer(
   certificationIssueReportRepository,
   certificationIssueReport
 ) {
-  certificationIssueReport.resolve(
+  certificationIssueReport.resolveAutomatically(
     "Cette question n'a pas été neutralisée car la réponse n'a pas été abandonnée ou le focus n'a pas été perdu"
   );
   await certificationIssueReportRepository.save(certificationIssueReport);
@@ -267,7 +271,7 @@ async function _resolveWithNeitherSkippedNorFocusedOutAnswer(
 }
 
 async function _resolveWithAnswerValidated(certificationIssueReportRepository, certificationIssueReport) {
-  certificationIssueReport.resolve('Cette réponse a été acceptée automatiquement');
+  certificationIssueReport.resolveAutomatically('Cette réponse a été acceptée automatiquement');
   await certificationIssueReportRepository.save(certificationIssueReport);
   return CertificationIssueReportResolutionAttempt.resolvedWithEffect();
 }

--- a/api/lib/domain/usecases/manually-resolve-certification-issue-report.js
+++ b/api/lib/domain/usecases/manually-resolve-certification-issue-report.js
@@ -4,6 +4,6 @@ module.exports = async function manuallyResolveCertificationIssueReport({
   certificationIssueReportRepository,
 }) {
   const certificationIssueReport = await certificationIssueReportRepository.get(certificationIssueReportId);
-  certificationIssueReport.resolve(resolution);
+  certificationIssueReport.resolveManually(resolution);
   await certificationIssueReportRepository.save(certificationIssueReport);
 };

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -106,6 +106,7 @@ async function _toDomainWithComplementaryCertifications({
         questionNumber: certificationIssueReport.questionNumber,
         resolvedAt: certificationIssueReport.resolvedAt,
         resolution: certificationIssueReport.resolution,
+        hasBeenAutomaticallyResolved: certificationIssueReport.hasBeenAutomaticallyResolved,
       })
   );
 

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -170,6 +170,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         questionNumber: 1,
         resolvedAt: new Date('2022-05-05'),
         resolution: 'super',
+        hasBeenAutomaticallyResolved: false,
       });
       const expectedCertificationIssueReportB = domainBuilder.buildCertificationIssueReport.notImpactful({
         id: 123,
@@ -178,6 +179,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         questionNumber: 12,
         resolvedAt: new Date('2021-12-25'),
         resolution: 'les doigts dans le nez',
+        hasBeenAutomaticallyResolved: false,
       });
       const anotherIssueReport = domainBuilder.buildCertificationIssueReport.notImpactful({
         id: 789,

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -89,6 +89,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
               subcategory: null,
               questionNumber: null,
               category: CertificationIssueReportCategories.OTHER,
+              hasBeenAutomaticallyResolved: null,
               resolvedAt: null,
               resolution: null,
             }),
@@ -200,11 +201,13 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
           description: 'first certification issue report',
+          hasBeenAutomaticallyResolved: false,
         });
         const issueReport2 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
           description: 'second certification issue report',
+          hasBeenAutomaticallyResolved: false,
         });
 
         dbf.buildAssessmentResult({
@@ -228,6 +231,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             category: issueReport1.category,
             certificationCourseId: manyAsrCertification.id,
             description: 'first certification issue report',
+            hasBeenAutomaticallyResolved: false,
             subcategory: null,
             questionNumber: null,
             resolvedAt: null,
@@ -238,6 +242,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             category: issueReport2.category,
             certificationCourseId: manyAsrCertification.id,
             description: 'second certification issue report',
+            hasBeenAutomaticallyResolved: false,
             subcategory: null,
             questionNumber: null,
             resolvedAt: null,

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -11,6 +11,7 @@ const buildCertificationIssueReport = function ({
   subcategory = CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
   description = 'Une super description',
   questionNumber = null,
+  hasBeenAutomaticallyResolved = null,
   resolvedAt = null,
   resolution = null,
 } = {}) {
@@ -21,6 +22,7 @@ const buildCertificationIssueReport = function ({
     subcategory,
     description,
     questionNumber,
+    hasBeenAutomaticallyResolved,
     resolvedAt,
     resolution,
   });
@@ -33,6 +35,7 @@ buildCertificationIssueReport.impactful = function ({
   questionNumber,
   resolvedAt,
   resolution,
+  hasBeenAutomaticallyResolved,
 } = {}) {
   return buildCertificationIssueReport({
     id,
@@ -43,6 +46,7 @@ buildCertificationIssueReport.impactful = function ({
     resolution,
     category: CertificationIssueReportCategories.FRAUD,
     subcategory: null,
+    hasBeenAutomaticallyResolved,
   });
 };
 
@@ -53,6 +57,7 @@ buildCertificationIssueReport.notImpactful = function ({
   questionNumber,
   resolvedAt,
   resolution,
+  hasBeenAutomaticallyResolved,
 } = {}) {
   return buildCertificationIssueReport({
     id,
@@ -63,6 +68,7 @@ buildCertificationIssueReport.notImpactful = function ({
     resolution,
     category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
     subcategory: null,
+    hasBeenAutomaticallyResolved,
   });
 };
 

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -89,6 +89,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
 
     // then
     expect(certificationIssueReport.isResolved()).to.be.true;
+    expect(certificationIssueReport.hasBeenAutomaticallyResolved).to.be.true;
     expect(certificationAssessmentRepository.save).to.have.been.calledWith(certificationAssessment);
   });
 

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -513,4 +513,20 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
       expect(certificationIssueReport.resolution).to.equal('RESOLVED');
     });
   });
+  describe('#resolveAutomatically', function () {
+    it('sets the issue report as resolved automatically', function () {
+      // given
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        resolvedAt: null,
+      });
+
+      // when
+      certificationIssueReport.resolveAutomatically('RESOLVED');
+
+      // then
+      expect(certificationIssueReport.resolvedAt).not.to.be.null;
+      expect(certificationIssueReport.hasBeenAutomaticallyResolved).to.be.true;
+      expect(certificationIssueReport.resolution).to.equal('RESOLVED');
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -498,7 +498,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
       expect(isResolved).to.be.true;
     });
   });
-  describe('#resolve', function () {
+  describe('#resolveManually', function () {
     it('Sets the issue report as resolved', function () {
       // given
       const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
@@ -506,10 +506,11 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
       });
 
       // when
-      certificationIssueReport.resolve('RESOLVED');
+      certificationIssueReport.resolveManually('RESOLVED');
 
       // then
       expect(certificationIssueReport.resolvedAt).not.to.be.null;
+      expect(certificationIssueReport.hasBeenAutomaticallyResolved).to.be.false;
       expect(certificationIssueReport.resolution).to.equal('RESOLVED');
     });
   });

--- a/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | manually-resolve-certification-issue-report', functio
     };
     const resolution = 'issue solved';
     const certificationIssueReportId = 1;
-    const expectedCertificationIssueReport = { resolve: sinon.stub() };
+    const expectedCertificationIssueReport = { resolveManually: sinon.stub() };
     certificationIssueReportRepository.get.resolves(expectedCertificationIssueReport);
     certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
 
@@ -24,6 +24,6 @@ describe('Unit | UseCase | manually-resolve-certification-issue-report', functio
     // then
     expect(certificationIssueReportRepository.get).to.have.been.called;
     expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
-    expect(expectedCertificationIssueReport.resolve).to.have.been.calledWith(resolution);
+    expect(expectedCertificationIssueReport.resolveManually).to.have.been.calledWith(resolution);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la résolution auto met à jour certification-issue-reports avec:
- resolvedAt = maintenant
- resolution = 1 des 4 motifs (Cette qestion a été neutralisée, Cette qestion  n'a pas été neutralisée..)

Si l’on veut faire des stats auto/manuel, cela complique les requêtes de savoir s’il a été résolu automatiquement: il faut tester si le motif est l’une des 4 phrases.

## :robot: Solution
Faire évoluer l’auto-jury et la résolution manuelle pour renseigner un booléen nullable `hasBeenAutomaticallyResolved`

## :rainbow: Remarques
Suppression de Bookshelf dans un repository modifié

## :100: Pour tester
Créer un signalement
- qui peut être résolu automatiquement, et le sera
- qui peut être résolu automatiquement, mais ne le sera pas
- qui sera résolu manuellement

Vérifier que le champ `hasBeenAutomaticallyResolved` est NULL dans les trois cas

Finaliser la session

Vérifier que le champ `hasBeenAutomaticallyResolved` est
- à TRUE dans les deux premiers cas 
- à FALSE dans le dernier cas
