### PR TITLE
[TECH] Monter la version des BDD de tests de 13.3 à 13.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: cimg/node:16.14.0
-      - image: postgres:13.3-alpine
+      - image: postgres:13.7-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -237,7 +237,7 @@ jobs:
   e2e_test:
     docker:
       - image: cimg/node:16.14.0-browsers
-      - image: postgres:13.3-alpine
+      - image: postgres:13.7-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:13.3-alpine
+    image: postgres:13.7-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:13.3-alpine
+    image: postgres:13.7-alpine
     container_name: pix-e2e-postgres
     environment:
       POSTGRES_DB: pix


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version de BDD est disponible et installée sur Scalingo.

## :robot: Solution
Configurer la BDD locale et de CI 
[=> voir Wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1549434939/Mises+jour+hors+npm)

## :rainbow: Remarques
La montée de version manuelle des applications Scalingo Intégration/Recette/Production a déjà été effectuée

## :100: Pour tester
Vérifier que la suite de test passe local
Vérifier que la suite de test passe en CI
