### PR TITLE
[FEATURE] Ramener le contexte des tutoriels lorsqu'ils sont présentés dans la page de détail d'une compétence (PIX-5338).

### DIFF
--- a/api/lib/domain/usecases/find-tutorials.js
+++ b/api/lib/domain/usecases/find-tutorials.js
@@ -56,6 +56,7 @@ async function _getTutorialsWithTubesList(easiestSkills, tubes, tutorialReposito
         tutorial.tubeName = tube.name;
         tutorial.tubePracticalTitle = tube.practicalTitle;
         tutorial.tubePracticalDescription = tube.practicalDescription;
+        tutorial.skillId = skill.id;
         return tutorial;
       });
     })

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -13,10 +13,9 @@ const paginateModule = require('../utils/paginate');
 module.exports = {
   async findByRecordIdsForCurrentUser({ ids, userId, locale }) {
     const tutorials = await _findByRecordIds({ ids, locale });
-    const userSavedTutorials = await userTutorialRepository.find({ userId });
+    const userTutorials = await userTutorialRepository.find({ userId });
     const tutorialEvaluations = await tutorialEvaluationRepository.find({ userId });
-    _.forEach(tutorials, _assignUserInformation(userSavedTutorials, tutorialEvaluations));
-    return tutorials;
+    return _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials });
   },
 
   async findByRecordIds(ids) {
@@ -106,25 +105,4 @@ async function _findByRecordIds({ ids, locale }) {
 
 function _extractLangFromLocale(locale) {
   return locale && locale.split('-')[0];
-}
-
-function _getUserSavedTutorial(userSavedTutorials, tutorial) {
-  return _.find(userSavedTutorials, (userSavedTutorial) => userSavedTutorial.tutorialId === tutorial.id);
-}
-
-function _getTutorialEvaluation(tutorialEvaluations, tutorial) {
-  return _.find(tutorialEvaluations, (tutorialEvaluation) => tutorialEvaluation.tutorialId === tutorial.id);
-}
-
-function _assignUserInformation(userSavedTutorials, tutorialEvaluations) {
-  return (tutorial) => {
-    const userSavedTutorial = _getUserSavedTutorial(userSavedTutorials, tutorial);
-    if (userSavedTutorial) {
-      tutorial.userTutorial = userSavedTutorial;
-    }
-    const tutorialEvaluation = _getTutorialEvaluation(tutorialEvaluations, tutorial);
-    if (tutorialEvaluation) {
-      tutorial.tutorialEvaluation = tutorialEvaluation;
-    }
-  };
 }

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -292,8 +292,12 @@ describe('Acceptance | Controller | scorecard-controller', function () {
                 'tube-name': '@web',
                 'tube-practical-description': 'Ceci est une description pratique',
                 'tube-practical-title': 'Ceci est un titre pratique',
+                'skill-id': 'recAcquisWeb1',
               },
               relationships: {
+                'tutorial-evaluation': {
+                  data: null,
+                },
                 'user-tutorial': {
                   data: {
                     id: '10500',
@@ -314,6 +318,15 @@ describe('Acceptance | Controller | scorecard-controller', function () {
                 'tube-name': '@web',
                 'tube-practical-description': 'Ceci est une description pratique',
                 'tube-practical-title': 'Ceci est un titre pratique',
+                'skill-id': 'recAcquisWeb1',
+              },
+              relationships: {
+                'tutorial-evaluation': {
+                  data: null,
+                },
+                'user-tutorial': {
+                  data: null,
+                },
               },
             },
           ],

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -21,6 +21,9 @@ describe('Integration | Repository | tutorial-repository', function () {
           source: 'tuto.fr',
           title: 'tuto0',
           id: 'recTutorial0',
+          skillId: undefined,
+          userTutorial: undefined,
+          tutorialEvaluation: undefined,
         },
         {
           duration: '00:01:54',
@@ -29,6 +32,9 @@ describe('Integration | Repository | tutorial-repository', function () {
           source: 'tuto.com',
           title: 'tuto1',
           id: 'recTutorial1',
+          skillId: undefined,
+          userTutorial: undefined,
+          tutorialEvaluation: undefined,
         },
       ];
       const learningContent = { tutorials: tutorialsList };
@@ -42,7 +48,7 @@ describe('Integration | Repository | tutorial-repository', function () {
 
       // then
       expect(tutorials).to.have.lengthOf(2);
-      expect(tutorials[0]).to.be.instanceof(Tutorial);
+      expect(tutorials[0]).to.be.instanceof(TutorialForUser);
       expect(tutorials).to.deep.include.members(tutorialsList);
     });
 

--- a/api/tests/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-tutorials_test.js
@@ -77,6 +77,7 @@ describe('Unit | UseCase | find-tutorials', function () {
               tubeName: '@wikipédia',
               tubePracticalTitle: 'Practical Title wikipédia',
               tubePracticalDescription: 'Practical Description wikipédia',
+              skillId: 'rec2',
             };
 
             const expectedTutorial2 = {
@@ -85,6 +86,7 @@ describe('Unit | UseCase | find-tutorials', function () {
               tubePracticalTitle: 'Practical Title wikipédia',
               tubePracticalDescription: 'Practical Description wikipédia',
               userTutorial: userSavedTutorial,
+              skillId: 'rec2',
             };
 
             const expectedTutorial3 = {
@@ -92,6 +94,7 @@ describe('Unit | UseCase | find-tutorials', function () {
               tubeName: '@recherche',
               tubePracticalTitle: 'Practical Title recherche',
               tubePracticalDescription: 'Practical Description recherche',
+              skillId: 'rec8',
             };
 
             expectedTutorialList = [expectedTutorial3, expectedTutorial1, expectedTutorial2];


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons enregistrer le contexte dans lequel un tutoriel a été proposé. Le contexte correspond au `skillId` qui contenait le tutoriel. Ce contexte nous permettra à l'avenir de pouvoir filtrer sur nos tutoriels enregistrés et recommandés.

Actuellement, dans le cadre des tutoriels proposé dans la page de détail d'une compétence sur Pix APP le` skillId` n'est pas remonté au front.

## :robot: Solution
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
Remonter le skillId.

## :100: Pour tester
- Se connecter sur Pix App
- Cliquer sur le détail d'une compétence
- Constater dans l'extension ember que les tutoriels ramenés contiennent bien un skillId.
