### PR TITLE
[FEATURE] Afficher les candidat inscrits lors de la suppression d'une session (PIX-5337)

### DIFF
--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -1,13 +1,20 @@
 {{#if @show}}
-  <PixModal @title="Supprimer la session" @onCloseButtonClick={{@close}}>
+  <PixModal @title={{t "pages.sessions.list.delete-modal.title"}} @onCloseButtonClick={{@close}}>
     <:content>
-      <p class="session-delete-confirmation-modal">Souhaitez-vous supprimer la session <span>{{@sessionId}}</span> ?</p>
+      <p class="session-delete-confirmation-modal">{{t
+          "pages.sessions.list.delete-modal.label"
+          sessionId=@sessionId
+          htmlSafe=true
+        }}</p>
       {{#if (gt @enrolledCandidatesCount 0)}}
-        <p class="session-delete-confirmation-modal"><span>{{@enrolledCandidatesCount}} candidats</span>
-          sont inscrits à cette session</p>
+        <p class="session-delete-confirmation-modal">{{t
+            "pages.sessions.list.delete-modal.enrolled-candidates"
+            enrolledCandidatesCount=@enrolledCandidatesCount
+            htmlSafe=true
+          }}</p>
       {{/if}}
       <PixMessage @type="warning" @withIcon={{true}}>
-        Attention, cette action est irréversible.
+        {{t "pages.sessions.list.delete-modal.disclaimer"}}
       </PixMessage>
     </:content>
     <:footer>
@@ -17,7 +24,7 @@
         @isBorderVisible={{true}}
         @triggerAction={{@close}}
       >
-        Annuler
+        {{t "common.actions.cancel"}}
       </PixButton>
 
       <PixButton
@@ -26,7 +33,7 @@
         @loadingColor="white"
         @backgroundColor="blue"
       >
-        Supprimer
+        {{t "common.actions.delete"}}
       </PixButton>
     </:footer>
   </PixModal>

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -1,7 +1,11 @@
 {{#if @show}}
   <PixModal @title="Supprimer la session" @onCloseButtonClick={{@close}}>
     <:content>
-      <p>Souhaitez-vous supprimer la session <span>{{@sessionId}}</span> ?</p>
+      <p class="session-delete-confirmation-modal">Souhaitez-vous supprimer la session <span>{{@sessionId}}</span> ?</p>
+      {{#if (gt @enrolledCandidatesCount 0)}}
+        <p class="session-delete-confirmation-modal"><span>{{@enrolledCandidatesCount}} candidats</span>
+          sont inscrits à cette session</p>
+      {{/if}}
       <PixMessage @type="warning" @withIcon={{true}}>
         Attention, cette action est irréversible.
       </PixMessage>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -71,7 +71,6 @@
                           disabled={{true}}
                           aria-describedby="tooltip-delete-session-button"
                           @withBackground={{true}}
-                          @triggerAction={{fn this.openSessionDeletionConfirmModal sessionSummary.id}}
                         />
                       </:triggerElement>
                       <:tooltip
@@ -84,7 +83,11 @@
                       disabled={{false}}
                       aria-describedby="tooltip-delete-session-button"
                       @withBackground={{true}}
-                      @triggerAction={{fn this.openSessionDeletionConfirmModal sessionSummary.id}}
+                      @triggerAction={{fn
+                        this.openSessionDeletionConfirmModal
+                        sessionSummary.id
+                        sessionSummary.enrolledCandidatesCount
+                      }}
                     />
                   {{/if}}
                 </div>
@@ -108,5 +111,6 @@
   @show={{this.shouldDisplaySessionDeletionModal}}
   @close={{this.closeSessionDeletionConfirmModal}}
   @sessionId={{this.currentSessionToBeDeletedId}}
+  @enrolledCandidatesCount="{{this.currentEnrolledCandidatesCount}}"
   @confirm={{this.deleteSession}}
 />

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -7,13 +7,15 @@ import get from 'lodash/get';
 export default class SessionSummaryList extends Component {
   @tracked shouldDisplaySessionDeletionModal = false;
   @tracked currentSessionToBeDeletedId = null;
+  @tracked currentEnrolledCandidatesCount = null;
   @service store;
   @service notifications;
 
   @action
-  openSessionDeletionConfirmModal(sessionId, event) {
+  openSessionDeletionConfirmModal(sessionId, enrolledCandidatesCount, event) {
     event.stopPropagation();
     this.currentSessionToBeDeletedId = sessionId;
+    this.currentEnrolledCandidatesCount = enrolledCandidatesCount;
     this.shouldDisplaySessionDeletionModal = true;
   }
 

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -35,6 +35,7 @@
 @import "components/finalize";
 @import "components/new-certification-candidate-modal";
 @import "components/finalization-confirmation-modal";
+@import "components/session-delete-confirm-modal";
 @import "components/session-finalization-step-container";
 @import "components/session-finalization/reports-information-step";
 @import "components/session-finalization/complementary-information-step";

--- a/certif/app/styles/components/session-delete-confirm-modal.scss
+++ b/certif/app/styles/components/session-delete-confirm-modal.scss
@@ -1,0 +1,3 @@
+.session-delete-confirmation-modal span {
+  font-weight: bold;
+}

--- a/certif/tests/integration/components/session-delete-confirm-modal_test.js
+++ b/certif/tests/integration/components/session-delete-confirm-modal_test.js
@@ -3,10 +3,10 @@ import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | session-delete-confirm-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when shouldDisplaySessionDeletionModal is true', function () {
     test('it should render the modal', async function (assert) {
@@ -23,8 +23,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
     />`);
 
       // then
-      assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
-      assert.dom(screen.getByText('Attention, cette action est irréversible.')).exists();
+      assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') })).exists();
       assert
         .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
         .hasText('Souhaitez-vous supprimer la session 123 ?');
@@ -46,7 +45,9 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
     />`);
 
       // then
-      assert.dom(screen.queryByText('Supprimer la session')).doesNotExist();
+      assert
+        .dom(screen.queryByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
+        .doesNotExist();
     });
   });
 

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -236,6 +236,62 @@ module('Integration | Component | session-summary-list', function (hooks) {
             .hasText('Souhaitez-vous supprimer la session 123 ?');
         });
 
+        module('when there are enrolled candidates', function () {
+          test('it should open the modal with the number of enrolled candidates', async function (assert) {
+            // given
+            this.goToSessionDetailsSpy = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const sessionSummary = store.createRecord('session-summary', {
+              id: 123,
+              enrolledCandidatesCount: 5,
+              meta: {
+                rowCount: 1,
+              },
+            });
+            this.sessionSummaries = [sessionSummary];
+
+            const screen = await renderScreen(hbs`<SessionSummaryList
+                    @sessionSummaries={{this.sessionSummaries}}
+                    @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
+
+            // when
+            await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+
+            // then
+            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+            assert
+              .dom(screen.getByText('sont inscrits à cette session', { exact: false }))
+              .hasText('5 candidats sont inscrits à cette session');
+          });
+        });
+
+        module('when there are no enrolled candidates', function () {
+          test('it should open the modal without the number of enrolled candidates', async function (assert) {
+            // given
+            this.goToSessionDetailsSpy = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const sessionSummary = store.createRecord('session-summary', {
+              id: 123,
+              enrolledCandidatesCount: 0,
+              meta: {
+                rowCount: 1,
+              },
+            });
+            this.sessionSummaries = [sessionSummary];
+
+            const screen = await renderScreen(hbs`<SessionSummaryList
+                      @sessionSummaries={{this.sessionSummaries}}
+                      @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
+
+            // when
+            await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+
+            // then
+            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+            assert.dom(screen.queryByText('sont inscrits à cette session', { exact: false })).doesNotExist();
+          });
+        });
+
         module('when clicking on modal delete button', function () {
           test('it should close the modal', async function (assert) {
             // given

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -3,10 +3,10 @@ import sinon from 'sinon';
 import { render, click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | session-summary-list', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
     this.set('goToSessionDetailsSpy', () => {});
@@ -68,13 +68,13 @@ module('Integration | Component | session-summary-list', function (hooks) {
       this.sessionSummaries = sessionSummaries;
 
       // when
-      await render(hbs`<SessionSummaryList
+      const screen = await renderScreen(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
       // then
       assert.notContains('Aucune session trouvée');
-      assert.dom('[aria-label="Session de certification"]').exists({ count: 2 });
+      assert.strictEqual(screen.getAllByRole('row', { name: 'Session de certification' }).length, 2);
     });
 
     test('it should display all the attributes of the session summary in the row', async function (assert) {
@@ -126,12 +126,12 @@ module('Integration | Component | session-summary-list', function (hooks) {
         rowCount: 1,
       };
       this.sessionSummaries = sessionSummaries;
-      await render(hbs`<SessionSummaryList
+      const screen = await renderScreen(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
       // when
-      await click('[aria-label="Session de certification"]');
+      await click(screen.getByRole('row', { name: 'Session de certification' }));
 
       // then
       sinon.assert.calledWith(this.goToSessionDetailsSpy, '123');
@@ -152,12 +152,12 @@ module('Integration | Component | session-summary-list', function (hooks) {
       this.sessionSummaries = sessionSummaries;
 
       // when
-      await render(hbs`<SessionSummaryList
+      const screen = await renderScreen(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
       // then
-      assert.dom('a[href="/sessions/123"]').exists();
+      assert.dom(screen.getByRole('link', { name: 'Session 123' })).exists();
     });
 
     module('when there is at least one effective candidate', function () {
@@ -230,14 +230,16 @@ module('Integration | Component | session-summary-list', function (hooks) {
           await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
           // then
-          assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+          assert
+            .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
+            .exists();
           assert
             .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
             .hasText('Souhaitez-vous supprimer la session 123 ?');
         });
 
         module('when there are enrolled candidates', function () {
-          test('it should open the modal with the number of enrolled candidates', async function (assert) {
+          test('it should open the modal with the number of enrolled candidates (plural)', async function (assert) {
             // given
             this.goToSessionDetailsSpy = sinon.stub();
             const store = this.owner.lookup('service:store');
@@ -258,10 +260,41 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
             // then
-            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+            assert
+              .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
+              .exists();
             assert
               .dom(screen.getByText('sont inscrits à cette session', { exact: false }))
               .hasText('5 candidats sont inscrits à cette session');
+          });
+
+          test('it should open the modal with the number of enrolled candidates (singular)', async function (assert) {
+            // given
+            this.goToSessionDetailsSpy = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const sessionSummary = store.createRecord('session-summary', {
+              id: 123,
+              enrolledCandidatesCount: 1,
+              meta: {
+                rowCount: 1,
+              },
+            });
+            this.sessionSummaries = [sessionSummary];
+
+            const screen = await renderScreen(hbs`<SessionSummaryList
+                    @sessionSummaries={{this.sessionSummaries}}
+                    @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
+
+            // when
+            await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+
+            // then
+            assert
+              .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
+              .exists();
+            assert
+              .dom(screen.getByText('est inscrit à cette session', { exact: false }))
+              .hasText('1 candidat est inscrit à cette session');
           });
         });
 
@@ -287,7 +320,9 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
             // then
-            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
+            assert
+              .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
+              .exists();
             assert.dom(screen.queryByText('sont inscrits à cette session', { exact: false })).doesNotExist();
           });
         });
@@ -315,7 +350,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await click(screen.getByRole('button', { name: 'Fermer' }));
 
             // then
-            assert.dom(screen.queryByText('Supprimer la session')).doesNotExist();
+            assert.dom(screen.queryByText(this.intl.t('pages.sessions.list.delete-modal.title'))).doesNotExist();
           });
         });
       });

--- a/certif/tests/unit/components/session-summary-list_test.js
+++ b/certif/tests/unit/components/session-summary-list_test.js
@@ -22,7 +22,7 @@ module('Unit | Component | session-summary', function (hooks) {
       };
 
       // when
-      await component.openSessionDeletionConfirmModal(sessionId, event);
+      await component.openSessionDeletionConfirmModal(sessionId, 1, event);
 
       // then
       assert.true(component.shouldDisplaySessionDeletionModal);
@@ -37,11 +37,26 @@ module('Unit | Component | session-summary', function (hooks) {
       };
 
       // when
-      await component.openSessionDeletionConfirmModal(sessionId, event);
+      await component.openSessionDeletionConfirmModal(sessionId, 1, event);
 
       // then
       sinon.assert.calledOnce(event.stopPropagation);
       assert.ok(true);
+    });
+
+    test('should set the currentEnrolledCandidatesCount value', async function (assert) {
+      // given
+      const sessionId = null;
+      component.shouldDisplaySessionDeletionModal = false;
+      const event = {
+        stopPropagation: sinon.stub(),
+      };
+
+      // when
+      await component.openSessionDeletionConfirmModal(sessionId, 99, event);
+
+      // then
+      assert.strictEqual(component.currentEnrolledCandidatesCount, 99);
     });
   });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,4 +1,10 @@
 {
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "delete": "Supprimer"
+    }
+  },
   "current-lang": "en",
   "navigation": {
     "footer": {
@@ -19,6 +25,14 @@
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
+      },
+      "list": {
+        "delete-modal": {
+          "title": "Supprimer la session",
+          "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
+          "enrolled-candidates": "<span>{enrolledCandidatesCount} candidats</span> sont inscrits à cette session",
+          "disclaimer": "Attention, cette action est irréversible."
+        }
       }
     }
   }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,4 +1,10 @@
 {
+  "common": {
+    "actions": {
+      "cancel": "Annuler",
+      "delete": "Supprimer"
+    }
+  },
   "current-lang": "fr",
   "navigation": {
     "footer": {
@@ -19,6 +25,14 @@
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
+      },
+      "list": {
+        "delete-modal": {
+          "title": "Supprimer la session",
+          "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
+          "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
+          "disclaimer": "Attention, cette action est irréversible."
+        }
       }
     }
   }


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une session à supprimer  a des candidats inscrits  on n'affiche pas cette information

## :robot: Solution
le nombre de candidat inscrits à la session devrait s’afficher sur la pop-up de confirmation de suppression, comme prévu initialement

## :rainbow: Remarques
le numéro de session et le nombre de candidats inscrits devraient être en bold comme sur la maquette

## :100: Pour tester
Aller sur la liste des certifications:
https://certif-pr4654.review.pix.fr/sessions/liste
Cliquer sur la suppression d'une session qui contient des candidats inscrits (session #2)
- Verifier que le nombre de candidat inscrit s'affiche
- Verifier que ce nombre et l'id de la session est en gras

