### PR TITLE
[TECH] Intégrer le composant PixMessage dans Pix-App (PIX-5322)

### DIFF
--- a/mon-pix/app/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item-qcm.hbs
@@ -31,9 +31,9 @@
   </div>
 
   {{#if this.errorMessage}}
-    <div class="alert alert--danger" role="alert">
+    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
-    </div>
+    </PixMessage>
   {{/if}}
 
   {{#if @assessment}}

--- a/mon-pix/app/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item-qcu.hbs
@@ -31,9 +31,9 @@
   </div>
 
   {{#if this.errorMessage}}
-    <div class="alert alert--danger" role="alert">
+    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
-    </div>
+    </PixMessage>
   {{/if}}
 
   {{#if @assessment}}

--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -115,9 +115,9 @@
   {{/if}}
 
   {{#if this.errorMessage}}
-    <div class="alert alert--danger" role="alert">
+    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
-    </div>
+    </PixMessage>
   {{/if}}
 
   {{#if @assessment}}

--- a/mon-pix/app/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/components/challenge-item-qrocm.hbs
@@ -31,9 +31,9 @@
   </div>
 
   {{#if this.errorMessage}}
-    <div class="alert alert--danger" role="alert">
+    <PixMessage class="challenge-response__alert" @type="error" @withIcon={{true}}>
       {{this.errorMessage}}
-    </div>
+    </PixMessage>
   {{/if}}
 
   {{#if @assessment}}

--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -80,9 +80,9 @@
                   />
                 </div>
                 {{#if this.emptyTextBoxMessageError}}
-                  <div class="alert alert--danger" role="alert">
+                  <PixMessage class="feedback-panel__alert" @type="error" @withIcon={{true}}>
                     {{this.emptyTextBoxMessageError}}
-                  </div>
+                  </PixMessage>
                 {{/if}}
                 <PixButton @type="submit" @backgroundColor="grey" @isDisabled={{this.isSendButtonDisabled}}>
                   {{t "pages.challenge.feedback-panel.form.actions.submit"}}

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -76,6 +76,10 @@
     font-weight: $font-normal;
     width: 100%;
   }
+
+  &__alert {
+    margin: 4px;
+  }
 }
 
 .proposal-text {

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -161,3 +161,7 @@
   padding-top: 20px;
   padding-bottom: 10px;
 }
+
+.feedback-panel__alert {
+  margin: 4px 0;
+}

--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -1,28 +1,3 @@
-.alert {
-  outline: none;
-  border-radius: 0.195em;
-  padding: 9px;
-  margin-bottom: 11px;
-  color: $pix-neutral-110;
-  text-shadow: none;
-  font-size: 0.875rem;
-  font-weight: $font-normal;
-  letter-spacing: 0.009rem;
-  line-height: 1.375rem;
-  display: flex;
-  align-items: center;
-
-  &--danger {
-    border: 1px solid $pix-error-70;
-    background-color: $pix-error-10;
-    color: $pix-error-70;
-  }
-}
-
-.challenge-response + .alert {
-  margin: 0 5px;
-}
-
 abbr.mandatory-mark {
   cursor: help;
   color: $pix-error-70;

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -97,7 +97,3 @@
     margin: 0;
   }
 }
-
-.challenge .alert {
-  margin: 6px;
-}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "3.227.0",
+      "version": "3.230.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^14.8.1",
+        "@1024pix/pix-ui": "^16.0.0",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -102,7 +102,7 @@
       },
       "engines": {
         "node": "16.14.0",
-        "npm": "^8.3.1"
+        "npm": ">=8.3.1 <=8.13.2"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {
@@ -457,10 +457,11 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "14.8.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.8.1.tgz",
-      "integrity": "sha512-ssxER96IMoxhy0AYQsgqdSwQxIHEC3FJ/mKxWI/ghpH315gqMLFJbIs5dP9Ovv2+6nC5L5eJFSuwkWxPubKyhQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.0.0.tgz",
+      "integrity": "sha512-5sxRCkQUA4+R9bNa1wjwIN6YElFsOhG1QAdb2vYb/+Fj0JrV7b65KSLXh9XPA5zNKIGASi6UtvCNcl6SnHPSeA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.6.2",
@@ -471,7 +472,8 @@
         "ember-truth-helpers": "^3.0.0"
       },
       "engines": {
-        "node": "^16.13.0"
+        "node": "16.14.0",
+        "npm": ">=8.3.1 <=8.13.2"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/async-disk-cache": {
@@ -39526,9 +39528,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "14.8.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.8.1.tgz",
-      "integrity": "sha512-ssxER96IMoxhy0AYQsgqdSwQxIHEC3FJ/mKxWI/ghpH315gqMLFJbIs5dP9Ovv2+6nC5L5eJFSuwkWxPubKyhQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.0.0.tgz",
+      "integrity": "sha512-5sxRCkQUA4+R9bNa1wjwIN6YElFsOhG1QAdb2vYb/+Fj0JrV7b65KSLXh9XPA5zNKIGASi6UtvCNcl6SnHPSeA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^14.8.1",
+    "@1024pix/pix-ui": "^16.0.0",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -39,7 +39,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       );
       expect(proposalsText[3].textContent.trim()).to.equal('possibilite 4');
 
-      expect(find('.alert')).to.not.exist;
+      expect(find('.challenge-response__alert')).to.not.exist;
     });
 
     it('should display the alert box if user validates without checking a checkbox', async () => {
@@ -47,8 +47,8 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await click('.challenge-actions__action-validate');
 
       // then
-      expect(find('.alert')).to.exist;
-      expect(find('.alert').textContent.trim()).to.equal(
+      expect(find('.challenge-response__alert')).to.exist;
+      expect(find('.challenge-response__alert').textContent.trim()).to.equal(
         'Pour valider, sélectionnez au moins une réponse. Sinon, passez.'
       );
     });
@@ -61,7 +61,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await click(findAll('.proposal-text')[1]);
 
       // then
-      expect(find('.alert')).to.not.exist;
+      expect(find('.challenge-response__alert')).to.not.exist;
     });
 
     it('should go to checkpoint when user validated', async () => {

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -38,7 +38,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       );
       expect(findAll('.proposal-text')[3].textContent.trim()).to.equal('4eme possibilite');
 
-      expect(find('.alert')).to.not.exist;
+      expect(find('.challenge-reponse__alert')).to.not.exist;
     });
 
     it('should display the alert box if user validates without checking a radio button', async () => {
@@ -46,8 +46,10 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await click('.challenge-actions__action-validate');
 
       // then
-      expect(find('.alert')).to.exist;
-      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionnez une réponse. Sinon, passez.');
+      expect(find('.challenge-response__alert')).to.exist;
+      expect(find('.challenge-response__alert').textContent.trim()).to.equal(
+        'Pour valider, sélectionnez une réponse. Sinon, passez.'
+      );
     });
 
     it('should hide the alert error after the user interact with radio button', async () => {
@@ -58,7 +60,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await click(findAll('.proposal-text')[1]);
 
       // then
-      expect(find('.alert')).to.not.exist;
+      expect(find('.challenge-response__alert')).to.not.exist;
     });
 
     it('should go to checkpoint when user selects an answer and validates', async () => {

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -34,12 +34,12 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
       it('should display the alert box when user validates without successfully finishing the embed', async () => {
         // when
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal(
+        expect(find('.challenge-response__alert')).to.exist;
+        expect(find('.challenge-response__alert').textContent.trim()).to.equal(
           '“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.'
         );
       });
@@ -78,7 +78,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         await click('.challenge-actions__action-validate');
-        expect(find('.alert').textContent.trim()).to.equal(
+        expect(find('.challenge-response__alert').textContent.trim()).to.equal(
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.'
         );
       });
@@ -99,18 +99,18 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('Entrez le <em>prénom</em> de B. Gates :');
 
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should display the alert box if user validates without write an answer in input', async () => {
         // when
         await fillIn('input[data-uid="qroc-proposal-uid"]', '');
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal(
+        expect(find('.challenge-response__alert')).to.exist;
+        expect(find('.challenge-response__alert').textContent.trim()).to.equal(
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.'
         );
       });
@@ -124,7 +124,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await fillIn('input[data-uid="qroc-proposal-uid"]', 'Test');
 
         // then
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should go to checkpoint when user validated', async () => {
@@ -277,18 +277,18 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__proposal').disabled).to.be.false;
         expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('Entrez le <em>prénom</em> de B. Gates :');
 
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should display the alert box if user validates without write an answer in input', async () => {
         // when
         await fillIn('textarea[data-uid="qroc-proposal-uid"]', '');
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal(
+        expect(find('.challenge-response__alert')).to.exist;
+        expect(find('.challenge-response__alert').textContent.trim()).to.equal(
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.'
         );
       });
@@ -302,7 +302,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await fillIn('textarea[data-uid="qroc-proposal-uid"]', 'Test');
 
         // then
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should go to checkpoint when user validated', async () => {
@@ -394,13 +394,13 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('[data-test="challenge-response-proposal-selector"]').disabled).to.be.false;
         expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('Select: ');
 
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should hide the alert error after the user interact with input text', async () => {
         // given
         await click('.challenge-actions__action-validate');
-        expect(find('.alert')).to.exist;
+        expect(find('.challenge-response__alert')).to.exist;
         const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
         const optionToFillIn = selectOptions[1];
 
@@ -408,7 +408,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await fillIn('select[data-test="challenge-response-proposal-selector"]', optionToFillIn.value);
 
         // then
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should go to checkpoint when user validated', async () => {

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -34,7 +34,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
         expect(find('div[data-test="qrocm-label-1"]').innerHTML).to.contains('Station <em>2</em> :');
 
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should display the alert box if user validates without write an answer for each input', async () => {
@@ -44,8 +44,8 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
 
         await click(find('.challenge-actions__action-validate'));
 
-        expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal(
+        expect(find('.challenge-response__alert')).to.exist;
+        expect(find('.challenge-response__alert').textContent.trim()).to.equal(
           'Pour valider, veuillez remplir tous les champs réponse. Sinon, passez.'
         );
       });
@@ -60,7 +60,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await fillIn(findAll('input')[1], 'ANSWER');
 
         // then
-        expect(find('.alert')).to.not.exist;
+        expect(find('.challenge-response__alert')).to.not.exist;
       });
 
       it('should go to checkpoint when user validated', async () => {
@@ -86,7 +86,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        expect(find('.alert--danger')).to.exist;
+        expect(find('.challenge-response__alert')).to.exist;
         expect(currentURL()).to.contains(`/assessments/${assessment.id}/challenges/0`);
       });
 
@@ -100,7 +100,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await click(find('.challenge-actions__action-validate'));
 
         // then
-        expect(find('.alert--danger')).to.exist;
+        expect(find('.challenge-response__alert')).to.exist;
         expect(currentURL()).to.contains(`/assessments/${assessment.id}/challenges/0`);
       });
 

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -253,7 +253,7 @@ describe('Integration | Component | feedback-panel', function () {
       await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
 
       // then
-      expect(find('.alert')).to.exist;
+      expect(find('.feedback-panel__alert')).to.exist;
     });
 
     it('should display error if "content" is blank', async function () {
@@ -264,7 +264,7 @@ describe('Integration | Component | feedback-panel', function () {
       await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
 
       // then
-      expect(find('.alert')).to.exist;
+      expect(find('.feedback-panel__alert')).to.exist;
     });
 
     it('should not display error if "form" view (with error) was closed and re-opened', async function () {
@@ -277,7 +277,7 @@ describe('Integration | Component | feedback-panel', function () {
       await click(OPEN_FEEDBACK_BUTTON);
 
       // then
-      expect(find('.alert')).to.not.exist;
+      expect(find('.feedback-panel__alert')).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous utilisions des composants custom pour les bannière d'erreur alors qu'il existe un composant PixMessage dans le Design System.

## :robot: Solution
Remplacer le composant custom par PixMessage sur les pages épreuves lors de la validation et sur les panneau de signalement d'un problème.

## :rainbow: Remarques
Cette PR a nécessité le fait de monter de version Pix-ui car la version de fontawesome n'était pas à jour ce qui impliquait que des icônes ne s'affichaient plus.

## :100: Pour tester
Vérifier que le composant s'affiche bien.
