### PR TITLE
[TECH] Rétablir la preview des challenges focus en local (PIX-5353).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -95,8 +95,7 @@ export default class ChallengeController extends Controller {
   }
 
   get hasConfirmedFocusChallengeWarningScreen() {
-    const hasUserConfirmedFocusChallenge = this.focusedCertificationChallengeWarningManager.hasConfirmed();
-    return hasUserConfirmedFocusChallenge;
+    return this.focusedCertificationChallengeWarningManager.hasConfirmed;
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -94,13 +94,6 @@ export default class ChallengeController extends Controller {
     return this._isFocusedCertificationChallenge && !this.model.answer;
   }
 
-  get hasConfirmedFocusScreenForCurrentChallenge() {
-    const challengeId = this.model.challenge.id;
-    const hasUserConfirmedFocusChallenge = this.focusedCertificationChallengesManager.has(challengeId);
-
-    return hasUserConfirmedFocusChallenge;
-  }
-
   get hasConfirmedFocusChallengeWarningScreen() {
     const hasUserConfirmedFocusChallenge = this.focusedCertificationChallengeWarningManager.hasConfirmed();
     return hasUserConfirmedFocusChallenge;

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -127,10 +127,6 @@ export default class ChallengeController extends Controller {
   }
 
   get displayChallenge() {
-    if (!this._isFocusedCertificationChallenge) {
-      this.focusedCertificationChallengeWarningManager.reset();
-    }
-
     if (this._hasAlreadyAnswered()) {
       return true;
     }

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -7,6 +7,7 @@ export default class ChallengeRoute extends Route {
   @service currentUser;
   @service router;
   @service store;
+  @service focusedCertificationChallengeWarningManager;
 
   async model(params) {
     const assessment = await this.modelFor('assessments');
@@ -37,6 +38,10 @@ export default class ChallengeRoute extends Route {
 
     // WORKAROUND for PIX-4471 (wrongly displayed focusedout message)
     if (assessment.lastQuestionState === 'focusedout') await assessment.reload();
+
+    if (assessment.isCertification && challenge.focused) {
+      this.focusedCertificationChallengeWarningManager.reset();
+    }
 
     return RSVP.hash({
       assessment,

--- a/mon-pix/app/services/focused-certification-challenge-warning-manager.js
+++ b/mon-pix/app/services/focused-certification-challenge-warning-manager.js
@@ -6,12 +6,7 @@ const LOCAL_STORAGE_KEY = 'hasConfirmedFocusChallengeScreen';
 export default class FocusedCertificationChallengeWarningManager extends Service {
   _localStorage = window.localStorage;
 
-  @tracked _hasConfirmedFocusChallengeScreen;
-
-  constructor() {
-    super(...arguments);
-    this._hasConfirmedFocusChallengeScreen = JSON.parse(this._localStorage.getItem(LOCAL_STORAGE_KEY)) || false;
-  }
+  @tracked _hasConfirmedFocusChallengeScreen = JSON.parse(this._localStorage.getItem(LOCAL_STORAGE_KEY)) || false;
 
   reset() {
     this._hasConfirmedFocusChallengeScreen = false;

--- a/mon-pix/app/services/focused-certification-challenge-warning-manager.js
+++ b/mon-pix/app/services/focused-certification-challenge-warning-manager.js
@@ -18,7 +18,7 @@ export default class FocusedCertificationChallengeWarningManager extends Service
     this._localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(this._hasConfirmedFocusChallengeScreen));
   }
 
-  hasConfirmed() {
+  get hasConfirmed() {
     return this._hasConfirmedFocusChallengeScreen;
   }
 }

--- a/mon-pix/tests/unit/controllers/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge_test.js
@@ -139,9 +139,8 @@ describe('Unit | Controller | Assessments | Challenge', function () {
           const focusedCertificationChallengeWarningManager = this.owner.lookup(
             'service:focused-certification-challenge-warning-manager'
           );
-          sinon
-            .stub(focusedCertificationChallengeWarningManager, 'hasConfirmed')
-            .returns(data.hasUserConfirmedCertificationFocusWarning);
+          focusedCertificationChallengeWarningManager._hasConfirmedFocusChallengeScreen =
+            data.hasUserConfirmedCertificationFocusWarning;
 
           const challenge = {
             id: 'rec_123',
@@ -154,7 +153,6 @@ describe('Unit | Controller | Assessments | Challenge', function () {
           const assessment = { isCertification: true };
 
           controller.model = { challenge, answer, assessment };
-          controller.hasUserConfirmedCertificationFocusWarning = data.hasUserConfirmedCertificationFocusWarning;
 
           // when
           const result = controller.displayChallenge;

--- a/mon-pix/tests/unit/services/focused-certification-challenge-warning-manager_test.js
+++ b/mon-pix/tests/unit/services/focused-certification-challenge-warning-manager_test.js
@@ -32,7 +32,7 @@ describe('Unit | Service | focused-certification-challenge-warning-manager', fun
       service.setToConfirmed();
 
       // then
-      expect(service.hasConfirmed()).to.be.true;
+      expect(service.hasConfirmed).to.be.true;
     });
   });
 
@@ -43,7 +43,7 @@ describe('Unit | Service | focused-certification-challenge-warning-manager', fun
       const service = this.owner.lookup('service:focused-certification-challenge-warning-manager');
 
       // when // then
-      expect(service.hasConfirmed()).to.be.true;
+      expect(service.hasConfirmed).to.be.true;
     });
 
     it('should return false when when hasConfirmedFocusChallengeScreen is false in localstorage', function () {
@@ -52,7 +52,7 @@ describe('Unit | Service | focused-certification-challenge-warning-manager', fun
       const service = this.owner.lookup('service:focused-certification-challenge-warning-manager');
 
       // when // then
-      expect(service.hasConfirmed()).to.be.false;
+      expect(service.hasConfirmed).to.be.false;
     });
 
     it('should return false when hasConfirmedFocusChallengeScreen does not exist in local storage', function () {
@@ -61,7 +61,7 @@ describe('Unit | Service | focused-certification-challenge-warning-manager', fun
       const service = this.owner.lookup('service:focused-certification-challenge-warning-manager');
 
       // when // then
-      expect(service.hasConfirmed()).to.be.false;
+      expect(service.hasConfirmed).to.be.false;
     });
   });
 
@@ -75,7 +75,7 @@ describe('Unit | Service | focused-certification-challenge-warning-manager', fun
       service.reset();
 
       // when // then
-      expect(service.hasConfirmed()).to.be.false;
+      expect(service.hasConfirmed).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix APP, il n'est pas possible de prévisualiser un challenge en local. 

## :robot: Solution
Dans le controller `challenge` plusieurs `getter` utilisaient la valeur de `_hasConfirmedFocusChallengeScreen`. 
Cependant le getter `displayChallenge` changeait la valeur de ce dernier, ce qui provoquait à nouveau le déclenchement des getters, comme la propriété est trackée. Cela provoque une boucle qu'Ember évite. 

Pour éviter cela, le reset du service est fait au niveau du controller comme ça la propriété à directement la bonne valeur dans le controller. 

## :rainbow: Remarques
Je ne sais pas pourquoi le bug ne se produit pas sur les autres environnement.

La fonction `hasConfirmed` a été remplacé en getter pour bénéficier de la propriété trackée. 

## :100: Pour tester

### Vérifier le bon fonctionnement des previews en local
- [Un challenge focus](http://localhost:4200/challenges/challenge2A5Aq56bLL5C8I/preview)
- [Un challenge non-focus](http://localhost:4200/challenges/recLt9uwa2dR3IYpi/preview
)
### Vérifier le bon fonctionnement sur la RA
- [Un challenge focus](https://app-pr4656.review.pix.fr/challenges/challenge2A5Aq56bLL5C8I/preview)
- [Un challenge non-focus](https://app-pr4656.review.pix.fr//challenges/recLt9uwa2dR3IYpi/preview)

### Vérifier le bon fonctionnement de l'écran de focus en certif 
- Passer une certification avec le compte : [certif1@example.net](mailto:certif1@example.net)
- Constater avant chaque train de question focus l'affichage de l'écran spécifique