### PR TITLE
[FEATURE] Ajout d'un id sur le message d'erreur sur la page de connexion de Pix App (PIX-5357)

### DIFF
--- a/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
+++ b/mon-pix/app/components/account-recovery/backup-email-confirmation-form.hbs
@@ -4,17 +4,19 @@
 
 <div class="account-recovery__content--step--content">
   {{#if @existingEmail}}
-    <p class="account-recovery__content--information-text">
-      {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-already-exist-for-account-message"}}
-      <strong>{{@existingEmail}}</strong>
-    </p>
-    <p class="account-recovery__content--information-text--details">
-      {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-valid-message"}}
-      <LinkTo @route="password-reset-demand">
-        {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-reset-message"}}
-      </LinkTo>
-      {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.ask-for-new-email-message"}}
-    </p>
+    <div id="backup-email-confirmation-already-associated-error-message">
+      <p class="account-recovery__content--information-text">
+        {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-already-exist-for-account-message"}}
+        <strong>{{@existingEmail}}</strong>
+      </p>
+      <p class="account-recovery__content--information-text--details">
+        {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-valid-message"}}
+        <LinkTo @route="password-reset-demand">
+          {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-reset-message"}}
+        </LinkTo>
+        {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.ask-for-new-email-message"}}
+      </p>
+    </div>
   {{else}}
     <p class="account-recovery__content--information-text">
       {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.email-sent-to-choose-password-message"}}
@@ -32,10 +34,15 @@
       @autocomplete="off"
       @require={{true}}
       @hideRequired={{true}}
+      @aria-describedby="backup-email-confirmation-already-use-error-message backup-email-confirmation-already-associated-error-message"
     />
 
     {{#if @showAlreadyRegisteredEmailError}}
-      <PixMessage @type="alert" class="account-recovery__content--not-found-error">
+      <PixMessage
+        @type="alert"
+        class="account-recovery__content--not-found-error"
+        id="backup-email-confirmation-already-use-error-message"
+      >
         {{t "pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.new-email-already-exist"}}
       </PixMessage>
     {{/if}}

--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -43,6 +43,7 @@
         @require={{true}}
         @hideRequired="true"
         @placeholder="123456789XX"
+        @aria-describedby="student-information-error-message"
       />
 
       <FormTextfield
@@ -55,6 +56,7 @@
         @autocomplete="off"
         @require={{true}}
         @hideRequired="true"
+        @aria-describedby="student-information-error-message"
       />
 
       <FormTextfield
@@ -67,6 +69,7 @@
         @autocomplete="off"
         @require={{true}}
         @hideRequired="true"
+        @aria-describedby="student-information-error-message"
       />
 
       <div>
@@ -118,7 +121,11 @@
     </div>
 
     {{#if @showAccountNotFoundError}}
-      <PixMessage @type="alert" class="account-recovery__content--not-found-error">
+      <PixMessage
+        @type="alert"
+        class="account-recovery__content--not-found-error"
+        id="student-information-error-message"
+      >
         {{t "pages.account-recovery.find-sco-record.student-information.errors.not-found"}}
         <a
           href="{{t "pages.account-recovery.find-sco-record.contact-support.link-url"}}"

--- a/mon-pix/app/components/form-textfield-date.hbs
+++ b/mon-pix/app/components/form-textfield-date.hbs
@@ -18,7 +18,7 @@
         name={{@dayTextfieldName}}
         {{on "focusout" (fn @onValidateDay @dayTextfieldName @dayInputBindingValue)}}
         class="form-textfield__input {{this.dayInputValidationStatus}}"
-        ariaDescribedBy={{@dayValidationMessage}}
+        aria-describedby={{@aria-describedby @dayValidationMessage}}
         required={{@require}}
         disabled={{@disabled}}
         placeholder="JJ"

--- a/mon-pix/app/components/form-textfield.hbs
+++ b/mon-pix/app/components/form-textfield.hbs
@@ -20,7 +20,7 @@
       {{on "focusout" (fn this.onValidate @textfieldName @inputBindingValue)}}
       class="form-textfield__input {{this.inputValidationStatus}}"
       autocomplete={{@autocomplete}}
-      aria-describedby="validationMessage-{{@textfieldName}}"
+      aria-describedby="{{@aria-describedby}} validationMessage-{{@textfieldName}}"
       required={{@require}}
       disabled={{@disabled}}
       placeholder={{@placeholder}}

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -14,13 +14,20 @@
   </div>
 
   {{#if this.hasFailed}}
-    <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
+    <div
+      class="sign-form__notification-message sign-form__notification-message--error"
+      aria-live="polite"
+      id="password-reset-demand-failed-message"
+    >
       {{t "pages.password-reset-demand.error.message"}}
     </div>
   {{/if}}
 
   {{#if this.hasErrors}}
-    <h2 class="sign-form__notification-message sign-form__notification-message--error">
+    <h2
+      class="sign-form__notification-message sign-form__notification-message--error"
+      id="password-reset-demand-error-message"
+    >
       {{this.error}}
     </h2>
   {{/if}}
@@ -53,6 +60,7 @@
           @validationStatus="default"
           @inputBindingValue={{this.email}}
           @require={{true}}
+          @aria-describedby="password-reset-demand-error-message password-reset-demand-failed-message"
         />
       </div>
 

--- a/mon-pix/app/components/routes/login-form.hbs
+++ b/mon-pix/app/components/routes/login-form.hbs
@@ -2,7 +2,7 @@
 
 <div class="login-form">
   {{#if this.isErrorMessagePresent}}
-    <div id="login-form-error-message" class="login-form__error-message error-message">{{t
+    <div id="login-error-message" class="login-form__error-message error-message">{{t
         "pages.login-or-register.login-form.error"
       }}</div>
   {{/if}}
@@ -23,6 +23,7 @@
         @validationStatus="default"
         @inputBindingValue={{this.login}}
         @autocomplete="username"
+        @aria-describedby="login-error-message update-form-error-message"
       />
     </div>
 
@@ -33,6 +34,7 @@
         @validationStatus="default"
         @inputBindingValue={{this.password}}
         @autocomplete="current-password"
+        @aria-describedby="login-error-message update-form-error-message"
       />
     </div>
 

--- a/mon-pix/app/components/routes/register-form.hbs
+++ b/mon-pix/app/components/routes/register-form.hbs
@@ -14,6 +14,7 @@
         @autocomplete="firstname"
         @disabled={{this.matchingStudentFound}}
         @require={{true}}
+        @aria-describedby="register-error-message register-display-error-message"
       />
     </div>
 
@@ -28,6 +29,7 @@
         @autocomplete="lastname"
         @disabled={{this.matchingStudentFound}}
         @require={{true}}
+        @aria-describedby="register-error-message register-display-error-message"
       />
     </div>
 
@@ -51,11 +53,12 @@
         @yearValidationMessage={{this.validation.yearOfBirth.message}}
         @disabled={{this.matchingStudentFound}}
         @require={{true}}
+        @aria-describedby="register-error-message register-display-error-message"
       />
     </div>
 
     {{#if this.errorMessage}}
-      <div class="register-form__error" aria-live="polite">{{{this.errorMessage}}}</div>
+      <div class="register-form__error" aria-live="polite" id="register-error-message">{{{this.errorMessage}}}</div>
     {{/if}}
 
     {{#unless this.matchingStudentFound}}
@@ -104,6 +107,7 @@
             @validationStatus={{this.validation.email.status}}
             @validationMessage={{this.validation.email.message}}
             @require={{true}}
+            @aria-describedby="register-error-message register-display-error-message"
           />
         </div>
       {{/if}}
@@ -117,11 +121,15 @@
           @validationStatus={{this.validation.password.status}}
           @validationMessage={{this.validation.password.message}}
           @require={{true}}
+          @aria-describedby="register-error-message register-display-error-message"
         />
       </div>
 
       {{#if this.displayRegisterErrorMessage}}
-        <div class="register-form__error" aria-live="polite">{{t "pages.login-or-register.register-form.error"}}</div>
+        <div class="register-form__error" aria-live="polite" id="register-display-error-message">{{t
+            "pages.login-or-register.register-form.error"
+          }}
+        </div>
       {{/if}}
 
       <div class="register-button-container">

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -14,7 +14,11 @@
   </div>
 
   {{#if this.hasFailed}}
-    <div class="sign-form__notification-message sign-form__notification-message--error" role="alert">
+    <div
+      class="sign-form__notification-message sign-form__notification-message--error"
+      role="alert"
+      id="sign-in-error-message"
+    >
       {{this.errorMessage}}
     </div>
   {{/if}}
@@ -33,6 +37,7 @@
           @autocomplete="username"
           @hideRequired={{true}}
           @require={{true}}
+          @aria-describedby="sign-in-error-message"
         />
       </div>
 
@@ -45,6 +50,7 @@
           @autocomplete="current-password"
           @hideRequired={{true}}
           @require={{true}}
+          @aria-describedby="sign-in-error-message"
         />
       </div>
     </fieldset>

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -12,7 +12,11 @@
   </div>
 
   {{#if this.errorMessage}}
-    <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
+    <div
+      class="sign-form__notification-message sign-form__notification-message--error"
+      aria-live="polite"
+      id="sign-up-error-message"
+    >
       {{this.errorMessage}}
     </div>
   {{/if}}
@@ -39,6 +43,7 @@
           @autocomplete="given-name"
           @hideRequired={{true}}
           @require={{true}}
+          @aria-describedby="sign-up-error-message"
         />
       </div>
 
@@ -53,6 +58,7 @@
           @autocomplete="family-name"
           @hideRequired={{true}}
           @require={{true}}
+          @aria-describedby="sign-up-error-message"
         />
       </div>
 
@@ -68,6 +74,7 @@
           @autocomplete="email"
           @hideRequired={{true}}
           @require={{true}}
+          @aria-describedby="sign-up-error-message"
         />
       </div>
 
@@ -83,6 +90,7 @@
           @autocomplete="new-password"
           @hideRequired={{true}}
           @require={{true}}
+          @aria-describedby="sign-up-error-message"
         />
       </div>
 
@@ -98,7 +106,7 @@
           </a>
           {{t "pages.sign-up.fields.cgu.pix"}}
           {{#if @user.errors.cgu}}
-            <div id="validationMessage-cgu" class="sign-form__validation-error" aria-live="polite">
+            <div class="sign-form__validation-error" aria-live="polite" id="sign-up-cgu-error-message">
               {{t "pages.sign-up.fields.cgu.error"}}
             </div>
           {{/if}}
@@ -108,6 +116,7 @@
           class="signup-form__cgu"
           @checked={{@user.cgu}}
           aria-label={{t "pages.sign-up.fields.cgu.label"}}
+          aria-describedby="sign-up-cgu-error-message"
         />
       </div>
 

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -8,7 +8,10 @@
     <h1 class="update-expired-password-form-title">{{t "pages.update-expired-password.first-title"}}</h1>
 
     {{#unless this.authenticationHasFailed}}
-      <div class="update-expired-password-form-header__instruction update-expired-password-form-subtitle">
+      <div
+        class="update-expired-password-form-header__instruction update-expired-password-form-subtitle"
+        id="update-expired-password-authentication-failed-message"
+      >
         {{t "pages.update-expired-password.subtitle"}}
       </div>
     {{/unless}}
@@ -18,6 +21,7 @@
     <div
       class="update-expired-password-form__notification-message update-expired-password-form__notification-message--error"
       aria-live="polite"
+      id="update-expired-password-error-message"
     >
       {{this.errorMessage}}
     </div>
@@ -36,6 +40,7 @@
           @validationStatus={{this.validation.status}}
           @validationMessage={{this.validationMessage}}
           @require={{true}}
+          @aria-describedby="update-expired-password-error-message update-expired-password-authentication-failed-message"
         />
       </div>
 

--- a/mon-pix/tests/integration/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form_test.js
@@ -53,7 +53,7 @@ describe('Integration | Component | password reset demand form', function () {
     await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
     // then
-    expect(find('.sign-form__notification-message--error')).to.exist;
+    expect(find('div[id="password-reset-demand-failed-message"]')).to.exist;
   });
 
   it('should display success message when there is no error on password reset demand', async function () {
@@ -76,6 +76,7 @@ describe('Integration | Component | password reset demand form', function () {
     await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
     // then
+    expect(find('div[id="password-reset-demand-failed-message"]')).to.not.exist;
     expect(find('.password-reset-demand-form__body')).to.exist;
   });
 

--- a/mon-pix/tests/integration/components/routes/login-form_test.js
+++ b/mon-pix/tests/integration/components/routes/login-form_test.js
@@ -26,7 +26,7 @@ describe('Integration | Component | routes/login-form', function () {
     await render(hbs`<Routes::LoginForm/>`);
 
     // then
-    expect(find('#login-form-error-message')).to.not.exist;
+    expect(find('div[id="error-message"]')).to.not.exist;
   });
 
   it('should display an error message when authentication fails', async function () {
@@ -43,8 +43,8 @@ describe('Integration | Component | routes/login-form', function () {
     await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
     // then
-    expect(find('#login-form-error-message')).to.exist;
-    expect(find('#login-form-error-message').textContent).to.equal(
+    expect(find('div[id="login-error-message"]')).to.exist;
+    expect(find('#login-error-message').textContent).to.equal(
       "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects"
     );
   });

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -128,7 +128,6 @@ describe('Integration | Component | routes/register-form', function () {
         // given
         const expectedRegisterErrorMessage = this.intl.t('pages.login-or-register.register-form.error');
         saveDependentUserStub.rejects({ errors: [{ status: '400' }] });
-
         // when
         await render(hbs`<Routes::RegisterForm />`);
 
@@ -141,12 +140,10 @@ describe('Integration | Component | routes/register-form', function () {
         await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         await fillIn('#password', 'Mypassword1');
-
         await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
-
         // then
-        expect(find('.register-form__error')).to.exist;
-        expect(find('.register-form__error').innerHTML).to.equal(expectedRegisterErrorMessage);
+        expect(find('div[id="register-display-error-message"')).to.exist;
+        expect(find('div[id="register-display-error-message"').innerHTML).to.contains(expectedRegisterErrorMessage);
       });
     });
 
@@ -367,7 +364,7 @@ describe('Integration | Component | routes/register-form', function () {
         await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // then
-        expect(find('.register-form__error').innerHTML).to.equal(errorMessage);
+        expect(find('div[id="register-error-message"').innerHTML).to.equal(errorMessage);
       });
     });
 
@@ -395,7 +392,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -422,7 +419,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -449,7 +446,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -476,7 +473,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -503,7 +500,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -530,7 +527,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -557,7 +554,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
     });
@@ -586,7 +583,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -613,7 +610,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -640,7 +637,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -667,7 +664,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -694,7 +691,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -721,7 +718,7 @@ describe('Integration | Component | routes/register-form', function () {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
 
@@ -747,7 +744,7 @@ describe('Integration | Component | routes/register-form', function () {
           // when
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
           // then
-          expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
+          expect(find('div[id="register-error-message"').innerHTML).to.equal(expectedErrorMessage);
         });
       });
     });

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -73,9 +73,7 @@ describe('Integration | Component | signin form', function () {
         await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-          this.intl.t(expectedErrorMessage)
-        );
+        expect(find('div[id="sign-in-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
       });
 
       it('should display related error message if bad request error', async function () {
@@ -90,9 +88,7 @@ describe('Integration | Component | signin form', function () {
         await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-          this.intl.t(expectedErrorMessage)
-        );
+        expect(find('div[id="sign-in-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
       });
 
       it('should display an error if api cannot be reached', async function () {
@@ -108,7 +104,7 @@ describe('Integration | Component | signin form', function () {
 
         // then
         expect(document.querySelector('div.sign-form__notification-message--error')).to.exist;
-        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
+        expect(find('div[id="sign-in-error-message"]').textContent.trim()).to.equal(
           this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE)
         );
       });

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -136,10 +136,8 @@ describe('Integration | Component | SignupForm', function () {
       await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      expect(find('.sign-form__notification-message--error')).to.exist;
-      expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-        this.intl.t(expectedErrorMessage)
-      );
+      expect(find('div[id="sign-up-error-message"]')).to.exist;
+      expect(find('div[id="sign-up-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
     });
 
     it('should display related error message if internal server error', async function () {
@@ -169,10 +167,8 @@ describe('Integration | Component | SignupForm', function () {
       await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      expect(find('.sign-form__notification-message--error')).to.exist;
-      expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-        this.intl.t(expectedErrorMessage)
-      );
+      expect(find('div[id="sign-up-error-message"]')).to.exist;
+      expect(find('div[id="sign-up-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
     });
 
     it('should display related error message if bad gateway error', async function () {
@@ -201,10 +197,8 @@ describe('Integration | Component | SignupForm', function () {
       await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      expect(find('.sign-form__notification-message--error')).to.exist;
-      expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-        this.intl.t(expectedErrorMessage)
-      );
+      expect(find('div[id="sign-up-error-message"]')).to.exist;
+      expect(find('div[id="sign-up-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
     });
 
     it('should display related error message if gateway timeout error', async function () {
@@ -233,10 +227,8 @@ describe('Integration | Component | SignupForm', function () {
       await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      expect(find('.sign-form__notification-message--error')).to.exist;
-      expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-        this.intl.t(expectedErrorMessage)
-      );
+      expect(find('div[id="sign-up-error-message"]')).to.exist;
+      expect(find('div[id="sign-up-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
     });
 
     it('should display related error message if not implemented error', async function () {
@@ -265,10 +257,8 @@ describe('Integration | Component | SignupForm', function () {
       await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      expect(find('.sign-form__notification-message--error')).to.exist;
-      expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(
-        this.intl.t(expectedErrorMessage)
-      );
+      expect(find('div[id="sign-up-error-message"]')).to.exist;
+      expect(find('div[id="sign-up-error-message"]').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le message d'erreur n'est pas à proximité du champ du formulaire, ce qui rend plus difficile l'accès à l'information.

## :robot: Solution
Ajouter un `id` sur les messages d'erreurs correspondant au `aria-describedby` des champs du formulaire afin de les associer directement.

## :100: Pour tester
Vérifier qu'un `aria-describedby` existe bien sur les champs du formulaires et qu'un attribut `id` est présent sur le message d'erreur.
