### PR TITLE
[TECH] Prévenir une résolution de nom réseau dans les tests unitaires.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -143,7 +143,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
-    "test:api:unit": "TEST_DATABASE_URL=postgres://SHOULD_NOT_REACH_DB_IN_UNIT_TESTS REDIS_URL= npm run test:api:path -- tests/unit",
+    "test:api:unit": "TEST_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests REDIS_URL= npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",


### PR DESCRIPTION
## :unicorn: Problème
Les tests unitaires mentionnent une URL de connexion `TEST_DATABASE_URL` à la base de données invalides pour prévenir les tests qui ne seraient pas unitaires. Si seul un nom de machine est mentionné (cas présent) `postgres://SHOULD_NOT_REACH_DB_IN_UNIT_TESTS`, alors une résolution de nom est lancée.
Cette résolution va échouer, et le temps du timeout est gâché.

## :robot: Solution
Empêcher la résolution en mentionnant un domaine inexistant, ce qui donne l'URL `postgres://should.not.reach.db.in.unit.tests`

## :rainbow: Remarques
Cela ne se produit que sur certaines machines, voir https://1024pix.slack.com/archives/C658LDBAQ/p1644513138393319?thread_ts=1644501725.012859&cid=C658LDBAQ

## :100: Pour tester
Vérifier que la CI passe
