### PR TITLE
[BUGFIX] Affichage bannière informative Pix App (PIX-5361)

### DIFF
--- a/mon-pix/app/components/communication-banner.hbs
+++ b/mon-pix/app/components/communication-banner.hbs
@@ -9,6 +9,9 @@
         <FaIcon @icon="circle-info" />
       {{/if}}
     </span>
-    {{this.bannerContent}}
+
+    <div class="communication-banner_content">
+      {{this.bannerContent}}
+    </div>
   </div>
 {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’on affiche plusieurs phrases avec du code, le bandeau rend moche. C’est dû au flexbox qui espace les contenus.

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/5855339/179490712-6de0f68d-deef-4f10-b7e8-4eac7835aec1.png">

Exemple sur Certif

<img width="1294" alt="image" src="https://user-images.githubusercontent.com/5855339/179490760-c9aa8f07-f754-414b-b819-6d54dad38dee.png">

## :robot: Solution
Wrapper le contenu pour éviter que flexbox considère plusieurs blocs quand ça n'a pas lieu d'être.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA que le bandeau est plus joli que sur la recette.
