### PR TITLE
[FEATURE] Mise à jour du niveau d'accessibilité de Pix-Certif (PIX-5356).

### DIFF
--- a/certif/app/components/layout/footer.hbs
+++ b/certif/app/components/layout/footer.hbs
@@ -19,7 +19,7 @@
           class="footer-navigation__item"
           rel="noopener noreferrer"
         >
-          Accessibilité : non conforme
+          {{t "navigation.footer.a11y"}}
         </a>
       </li>
     </ul>

--- a/certif/app/components/layout/footer.hbs
+++ b/certif/app/components/layout/footer.hbs
@@ -26,6 +26,6 @@
   </nav>
 
   <div class="footer__copyright">
-    <span>© {{this.currentYear}} Pix</span>
+    <span>{{this.currentYear}}</span>
   </div>
 </footer>

--- a/certif/app/components/layout/footer.hbs
+++ b/certif/app/components/layout/footer.hbs
@@ -8,7 +8,7 @@
           class="footer-navigation__item"
           rel="noopener noreferrer"
         >
-          Mentions légales
+          {{t "navigation.footer.legal-notice"}}
         </a>
       </li>
 

--- a/certif/app/components/layout/footer.js
+++ b/certif/app/components/layout/footer.js
@@ -1,8 +1,11 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class Footer extends Component {
+  @service intl;
+
   get currentYear() {
-    const date = new Date();
-    return date.getFullYear().toString();
+    const currentYear = new Date().getFullYear();
+    return this.intl.t('navigation.footer.current-year', { currentYear });
   }
 }

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -20,10 +20,10 @@ module('Integration | Component | Layout::Footer', function (hooks) {
 
   test('should display legal notice link', async function (assert) {
     // when
-    await renderScreen(hbs`<Layout::Footer />}`);
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.contains('Mentions légales');
+    assert.dom(screen.getByText(this.intl.t('navigation.footer.legal-notice'))).exists();
     assert.dom('a[href="https://pix.fr/mentions-legales/"]').exists();
   });
 

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -32,7 +32,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.contains('Accessibilité : non conforme');
+    assert.dom(screen.getByText(this.intl.t('navigation.footer.a11y'))).exists();
     assert.dom('a[href="https://pix.fr/accessibilite-pix-certif/"]').exists();
   });
 });

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
+import setupRenderingIntlTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Layout::Footer', function (hooks) {
-  setupRenderingTest(hooks);
+  setupRenderingIntlTest(hooks);
 
   test('should display copyright with current year', async function (assert) {
     //given
@@ -12,7 +12,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     const expectedYear = date.getFullYear().toString();
 
     // when
-    await render(hbs`<Layout::Footer />}`);
+    await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
     assert.contains(`© ${expectedYear} Pix`);
@@ -20,7 +20,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
 
   test('should display legal notice link', async function (assert) {
     // when
-    await render(hbs`<Layout::Footer />}`);
+    await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
     assert.contains('Mentions légales');
@@ -29,7 +29,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
 
   test('should display accessibility link', async function (assert) {
     // when
-    await render(hbs`<Layout::Footer />}`);
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
     assert.contains('Accessibilité : non conforme');

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -9,13 +9,13 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   test('should display copyright with current year', async function (assert) {
     //given
     const date = new Date();
-    const expectedYear = date.getFullYear().toString();
+    const expectedYear = date.getFullYear();
 
     // when
-    await renderScreen(hbs`<Layout::Footer />}`);
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.contains(`© ${expectedYear} Pix`);
+    assert.dom(screen.getByText(this.intl.t('navigation.footer.current-year', { currentYear: expectedYear }))).exists();
   });
 
   test('should display legal notice link', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,5 +1,10 @@
 {
   "current-lang": "en",
+  "navigation": {
+    "footer": {
+      "a11y": "Accessibilité : partiellement conforme"
+    }
+  },
   "pages": {
     "login": {
       "title": "Login"

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -3,7 +3,8 @@
   "navigation": {
     "footer": {
       "a11y": "Accessibilité : partiellement conforme",
-      "legal-notice": "Mentions légales"
+      "legal-notice": "Mentions légales",
+      "current-year": "© {currentYear} Pix"
     }
   },
   "pages": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -2,7 +2,8 @@
   "current-lang": "en",
   "navigation": {
     "footer": {
-      "a11y": "Accessibilité : partiellement conforme"
+      "a11y": "Accessibilité : partiellement conforme",
+      "legal-notice": "Mentions légales"
     }
   },
   "pages": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,5 +1,10 @@
 {
   "current-lang": "fr",
+  "navigation": {
+    "footer": {
+      "a11y": "Accessibilité : partiellement conforme"
+    }
+  },
   "pages": {
     "login": {
       "title": "Connectez-vous"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -3,7 +3,8 @@
   "navigation": {
     "footer": {
       "a11y": "Accessibilité : partiellement conforme",
-      "legal-notice": "Mentions légales"
+      "legal-notice": "Mentions légales",
+      "current-year": "© {currentYear} Pix"
     }
   },
   "pages": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -2,7 +2,8 @@
   "current-lang": "fr",
   "navigation": {
     "footer": {
-      "a11y": "Accessibilité : partiellement conforme"
+      "a11y": "Accessibilité : partiellement conforme",
+      "legal-notice": "Mentions légales"
     }
   },
   "pages": {


### PR DESCRIPTION
## :unicorn: Problème

Le niveau d'accessibilité indiqué dans le footer de Certif ne reflète pas l'état actuel des choses.
L'application vient en effet d’atteindre les 50% de conformité en terme d’accessibilité.

## :robot: Solution

Modification du statut pour passer de `Accessibilité : non conforme` à `Accessibilité : partiellement conforme`

## :rainbow: Remarques

Nous profitons de cette PR pour traduire les données du footer.

## :100: Pour tester

Dans le footer de Certif, vérifier que le niveau d'accessibilité a évolué.
