### PR TITLE
[TECH] Corrige le format du fichier package-lock.json

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -36219,15 +36219,9 @@
       }
     },
     "@1024pix/pix-ui": {
-<<<<<<< HEAD
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.5.0.tgz",
-      "integrity": "sha512-OjIXh7kcNDpO0fgrT97wqICoCEQ69u+5K2RhYz1uxP+BDSQmFRMKiyNt0ayEkcirytIPJAojPevxTb83Ff6LNg==",
-=======
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-15.0.2.tgz",
       "integrity": "sha512-D8u3E5oBqMt/uwzvF7KKngRX1FBWJ49USaQ39RIBJzjVDoNbC5Nvbu3qaQyWHHCiefvuJdIF4sVEyPJkZEkFdQ==",
->>>>>>> ced6d3039a (chore(orga) Update pix-ui to v15.0.2)
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",


### PR DESCRIPTION
## :unicorn: Problème
Le package lock contient des lignes de texte relative à un merge git

## :robot: Solution
Appliquer l'un des deux patchs et restaurer le bon format de package-lock.json

## :100: Pour tester
Vérifier que Orga se déploie
