### PR TITLE
[FEATURE] Restreindre l'accès aux campagnes de l'organisation CNAV sur Pix App(PIX-5114).

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -5,6 +5,7 @@ const {
   TARGET_PROFILE_SIMPLIFIED_ACCESS_ID,
   TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
   TARGET_PROFILE_PIX_DROIT_ID,
+  TARGET_PROFILE_CNAV_ID,
 } = require('./target-profiles-builder');
 const {
   CERTIF_REGULAR_USER1_ID,
@@ -14,7 +15,7 @@ const {
   CERTIF_REGULAR_USER5_ID,
 } = require('./certification/users');
 const { PRO_BASICS_BADGE_ID, PRO_TOOLS_BADGE_ID } = require('./badges-builder');
-const { PRO_COMPANY_ID, PRO_POLE_EMPLOI_ID, PRO_MED_NUM_ID } = require('./organizations-pro-builder');
+const { PRO_COMPANY_ID, PRO_POLE_EMPLOI_ID, PRO_MED_NUM_ID, PRO_CNAV_ID } = require('./organizations-pro-builder');
 const { DEFAULT_PASSWORD } = require('./users-builder');
 const {
   participateToAssessmentCampaign,
@@ -97,6 +98,23 @@ __Plus d'infos :)__
     customLandingPageText: null,
     idPixLabel: null,
     createdAt: new Date('2020-01-11'),
+    multipleSendings: true,
+  });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 27,
+    name: 'Pro - Campagne Pix CNAV',
+    code: 'PIXCNAV01',
+    organizationId: PRO_CNAV_ID,
+    creatorId: 2,
+    ownerId: 2,
+    targetProfileId: TARGET_PROFILE_CNAV_ID,
+    assessmentMethod: 'SMART_RANDOM',
+    createdAt: new Date('2020-01-11'),
+    type: 'ASSESSMENT',
+    title: null,
+    customLandingPageText: null,
+    idPixLabel: null,
     multipleSendings: true,
   });
 

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -4,6 +4,7 @@ const OrganizationInvitation = require('../../../lib/domain/models/OrganizationI
 const { DEFAULT_PASSWORD } = require('./users-builder');
 const PRO_COMPANY_ID = 1;
 const PRO_POLE_EMPLOI_ID = 4;
+const PRO_CNAV_ID = 17;
 const PRO_MED_NUM_ID = 5;
 const PRO_ARCHIVED_ID = 15;
 
@@ -87,6 +88,23 @@ function organizationsProBuilder({ databaseBuilder }) {
     organizationRole: Membership.roles.ADMIN,
   });
 
+  /* CNAV */
+  databaseBuilder.factory.buildOrganization({
+    id: PRO_CNAV_ID,
+    type: 'PRO',
+    name: 'CNAV',
+    externalId: null,
+    provinceCode: null,
+    email: null,
+    identityProviderForCampaigns: 'CNAV',
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: proUser1.id,
+    organizationId: PRO_CNAV_ID,
+    organizationRole: Membership.roles.ADMIN,
+  });
+
   /* MEDIATION NUMERIQUE */
   databaseBuilder.factory.buildOrganization({
     id: PRO_MED_NUM_ID,
@@ -152,5 +170,6 @@ module.exports = {
   organizationsProBuilder,
   PRO_COMPANY_ID,
   PRO_POLE_EMPLOI_ID,
+  PRO_CNAV_ID,
   PRO_MED_NUM_ID,
 };

--- a/api/db/seeds/data/target-profiles-builder.js
+++ b/api/db/seeds/data/target-profiles-builder.js
@@ -181,6 +181,7 @@ const TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE = 9;
 const TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE = 10;
 const TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE = 11;
 const TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3 = 12;
+const TARGET_PROFILE_CNAV_ID = 13;
 
 function targetProfilesBuilder({ databaseBuilder }) {
   _buildTargetProfilePICDiagnosticInitial(databaseBuilder);
@@ -195,6 +196,7 @@ function targetProfilesBuilder({ databaseBuilder }) {
   _buildTargetProfilePixEduFormationInitiale1erDegre(databaseBuilder);
   _buildTargetProfilePixEduFormationContinue2ndDegre(databaseBuilder);
   _buildTargetProfilePixEduFormationContinue1erDegre(databaseBuilder);
+  _buildTargetProfileCnav(databaseBuilder);
 }
 
 function _buildTargetProfilePICDiagnosticInitial(databaseBuilder) {
@@ -843,6 +845,18 @@ function _buildTargetProfilePixEduFormationContinue1erDegre(databaseBuilder) {
   });
 }
 
+function _buildTargetProfileCnav(databaseBuilder) {
+  databaseBuilder.factory.buildTargetProfile({
+    id: TARGET_PROFILE_CNAV_ID,
+    name: 'Parcours Cnav',
+    isPublic: false,
+  });
+
+  ['recAzV1ljhCdjrasn', 'recx7WnZJCXVgCvN4'].forEach((skillId) => {
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: TARGET_PROFILE_CNAV_ID, skillId });
+  });
+}
+
 module.exports = {
   targetProfilesBuilder,
   TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
@@ -857,6 +871,7 @@ module.exports = {
   TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
   TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE,
   TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE,
+  TARGET_PROFILE_CNAV_ID,
   targetProfileSkillIdsForCleaBadgeV1,
   targetProfileSkillIdsForCleaBadgeV2,
   targetProfileSkillIdsForCleaBadgeV3,

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -2,6 +2,7 @@ const get = require('lodash/get');
 const { UnauthorizedError, BadRequestError } = require('../http-errors');
 const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
+const PoleEmploiOidcAuthenticationService = require('../../domain/services/authentication/pole-emploi-oidc-authentication-service');
 
 module.exports = {
   /**
@@ -91,6 +92,7 @@ module.exports = {
   async authenticatePoleEmploiUser(request) {
     const authenticatedUserId = get(request.auth, 'credentials.userId');
     const { code, redirect_uri: redirectUri, state_sent: stateSent, state_received: stateReceived } = request.payload;
+    const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
 
     const result = await usecases.authenticatePoleEmploiUser({
       authenticatedUserId,
@@ -98,6 +100,7 @@ module.exports = {
       redirectUri,
       stateReceived,
       stateSent,
+      poleEmploiOidcAuthenticationService,
     });
 
     if (result.pixAccessToken && result.poleEmploiAuthenticationSessionContent) {

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -46,12 +46,16 @@ module.exports = {
 
   async authenticateCnavUser(request) {
     const { code, redirect_uri: redirectUri, state_sent: stateSent, state_received: stateReceived } = request.payload;
+    const { oidcAuthenticationService } = authenticationRegistry.lookupAuthenticationService(
+      AuthenticationMethod.identityProviders.CNAV
+    );
 
     const result = await usecases.authenticateCnavUser({
       code,
       redirectUri,
       stateReceived,
       stateSent,
+      oidcAuthenticationService,
     });
 
     if (result.isAuthenticationComplete) {

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -2,7 +2,8 @@ const get = require('lodash/get');
 const { UnauthorizedError, BadRequestError } = require('../http-errors');
 const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
-const PoleEmploiOidcAuthenticationService = require('../../domain/services/authentication/pole-emploi-oidc-authentication-service');
+const authenticationRegistry = require('../../domain/services/authentication/authentication-service-registry');
+const AuthenticationMethod = require('../../domain/models/AuthenticationMethod');
 
 module.exports = {
   /**
@@ -92,7 +93,9 @@ module.exports = {
   async authenticatePoleEmploiUser(request) {
     const authenticatedUserId = get(request.auth, 'credentials.userId');
     const { code, redirect_uri: redirectUri, state_sent: stateSent, state_received: stateReceived } = request.payload;
-    const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+    const { oidcAuthenticationService } = authenticationRegistry.lookupAuthenticationService(
+      AuthenticationMethod.identityProviders.POLE_EMPLOI
+    );
 
     const result = await usecases.authenticatePoleEmploiUser({
       authenticatedUserId,
@@ -100,7 +103,7 @@ module.exports = {
       redirectUri,
       stateReceived,
       stateSent,
-      poleEmploiOidcAuthenticationService,
+      oidcAuthenticationService,
     });
 
     if (result.pixAccessToken && result.poleEmploiAuthenticationSessionContent) {

--- a/api/lib/application/cnav/cnav-controller.js
+++ b/api/lib/application/cnav/cnav-controller.js
@@ -2,6 +2,7 @@ const cnavAuthenticationService = require('../../../lib/domain/services/authenti
 const usecases = require('../../domain/usecases');
 const userRepository = require('../../infrastructure/repositories/user-repository');
 const AuthenticationMethod = require('../../domain/models/AuthenticationMethod');
+const authenticationRegistry = require('../../domain/services/authentication/authentication-service-registry');
 
 module.exports = {
   async createUser(request, h) {
@@ -12,7 +13,10 @@ module.exports = {
       identityProvider: AuthenticationMethod.identityProviders.CNAV,
     });
 
-    const accessToken = cnavAuthenticationService.createAccessToken(userId);
+    const { oidcAuthenticationService } = authenticationRegistry.lookupAuthenticationService(
+      AuthenticationMethod.identityProviders.CNAV
+    );
+    const accessToken = oidcAuthenticationService.createAccessToken(userId);
     await userRepository.updateLastLoggedAt({ userId });
 
     const response = { access_token: accessToken };

--- a/api/lib/application/pole-emploi/pole-emploi-controller.js
+++ b/api/lib/application/pole-emploi/pole-emploi-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 const userRepository = require('../../infrastructure/repositories/user-repository');
-const poleEmploiAuthenticationService = require('../../../lib/domain/services/authentication/pole-emploi-authentication-service');
+const authenticationService = require('../../../lib/domain/services/authentication/pole-emploi-authentication-service');
+const PoleEmploiOidcAuthenticationService = require('../../../lib/domain/services/authentication/pole-emploi-oidc-authentication-service');
 const AuthenticationMethod = require('../../domain/models/AuthenticationMethod');
 
 module.exports = {
@@ -12,7 +13,8 @@ module.exports = {
       identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
     });
 
-    const accessToken = poleEmploiAuthenticationService.createAccessToken(userId);
+    const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+    const accessToken = poleEmploiOidcAuthenticationService.createAccessToken(userId);
     await userRepository.updateLastLoggedAt({ userId });
 
     const response = {
@@ -30,7 +32,7 @@ module.exports = {
   },
 
   async getAuthUrl(request, h) {
-    const result = poleEmploiAuthenticationService.getAuthUrl({
+    const result = authenticationService.getAuthUrl({
       redirectUri: request.query['redirect_uri'],
     });
     return h.response(result).code(200);

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -53,7 +53,6 @@ module.exports = {
 
   SOURCE: {
     CNAV: 'cnav',
-    POLE_EMPLOI: 'pole_emploi_connect',
   },
 
   IDENTITY_PROVIDER: {

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -51,10 +51,6 @@ module.exports = {
     FRENCH_SPOKEN: 'fr',
   },
 
-  SOURCE: {
-    CNAV: 'cnav',
-  },
-
   IDENTITY_PROVIDER: {
     POLE_EMPLOI: 'POLE_EMPLOI',
   },

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -2,8 +2,10 @@ const AuthenticationMethod = require('../../models/AuthenticationMethod');
 const poleEmploiAuthenticationService = require('./pole-emploi-authentication-service');
 const cnavAuthenticationService = require('./cnav-authentication-service');
 const PoleEmploiOidcAuthenticationService = require('./pole-emploi-oidc-authentication-service');
+const CnavOidcAuthenticationService = require('./cnav-oidc-authentication-service');
 
 const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+const cnavOidcAuthenticationService = new CnavOidcAuthenticationService();
 
 function lookupAuthenticationService(identityProvider) {
   switch (identityProvider) {
@@ -13,7 +15,10 @@ function lookupAuthenticationService(identityProvider) {
         oidcAuthenticationService: poleEmploiOidcAuthenticationService,
       };
     case AuthenticationMethod.identityProviders.CNAV:
-      return { authenticationService: cnavAuthenticationService };
+      return {
+        authenticationService: cnavAuthenticationService,
+        oidcAuthenticationService: cnavOidcAuthenticationService,
+      };
     default:
       throw new Error();
   }

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -1,13 +1,19 @@
 const AuthenticationMethod = require('../../models/AuthenticationMethod');
 const poleEmploiAuthenticationService = require('./pole-emploi-authentication-service');
 const cnavAuthenticationService = require('./cnav-authentication-service');
+const PoleEmploiOidcAuthenticationService = require('./pole-emploi-oidc-authentication-service');
+
+const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
 
 function lookupAuthenticationService(identityProvider) {
   switch (identityProvider) {
     case AuthenticationMethod.identityProviders.POLE_EMPLOI:
-      return poleEmploiAuthenticationService;
+      return {
+        authenticationService: poleEmploiAuthenticationService,
+        oidcAuthenticationService: poleEmploiOidcAuthenticationService,
+      };
     case AuthenticationMethod.identityProviders.CNAV:
-      return cnavAuthenticationService;
+      return { authenticationService: cnavAuthenticationService };
     default:
       throw new Error();
   }

--- a/api/lib/domain/services/authentication/cnav-authentication-service.js
+++ b/api/lib/domain/services/authentication/cnav-authentication-service.js
@@ -4,16 +4,8 @@ const httpAgent = require('../../../infrastructure/http/http-agent');
 const querystring = require('querystring');
 const { AuthenticationTokenRetrievalError } = require('../../errors');
 const jsonwebtoken = require('jsonwebtoken');
-const { CNAV } = require('../../constants').SOURCE;
 const DomainTransaction = require('../../../infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../models/AuthenticationMethod');
-
-function createAccessToken(userId) {
-  const expirationDelaySeconds = settings.cnav.accessTokenLifespanMs / 1000;
-  return jsonwebtoken.sign({ user_id: userId, source: CNAV }, settings.authentication.secret, {
-    expiresIn: expirationDelaySeconds,
-  });
-}
 
 async function exchangeCodeForIdToken({ code, redirectUri }) {
   const data = {
@@ -92,7 +84,6 @@ async function createUserAccount({ user, externalIdentityId, userToCreateReposit
 }
 
 module.exports = {
-  createAccessToken,
   exchangeCodeForIdToken,
   getAuthUrl,
   getUserInfo,

--- a/api/lib/domain/services/authentication/cnav-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/cnav-oidc-authentication-service.js
@@ -1,0 +1,15 @@
+const settings = require('../../../config');
+const OidcAuthenticationService = require('./oidc-authentication-service');
+
+class CnavOidcAuthenticationService extends OidcAuthenticationService {
+  constructor() {
+    const source = 'cnav';
+    const identityProvider = 'CNAV';
+    const expirationDelaySeconds = settings.cnav.accessTokenLifespanMs / 1000;
+    const jwtOptions = { expiresIn: expirationDelaySeconds };
+
+    super({ source, identityProvider, jwtOptions });
+  }
+}
+
+module.exports = CnavOidcAuthenticationService;

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -1,0 +1,24 @@
+const jsonwebtoken = require('jsonwebtoken');
+const settings = require('../../../config');
+
+class OidcAuthenticationService {
+  constructor({ source, identityProvider, jwtOptions }) {
+    this.source = source;
+    this.identityProvider = identityProvider;
+    this.jwtOptions = jwtOptions;
+  }
+
+  createAccessToken(userId) {
+    return jsonwebtoken.sign(
+      {
+        user_id: userId,
+        source: this.source,
+        identity_provider: this.identityProvider,
+      },
+      settings.authentication.secret,
+      this.jwtOptions
+    );
+  }
+}
+
+module.exports = OidcAuthenticationService;

--- a/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
@@ -11,21 +11,6 @@ const DomainTransaction = require('../../../infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../models/AuthenticationMethod');
 const moment = require('moment');
 
-function createAccessToken(userId) {
-  const expirationDelaySeconds = settings.poleEmploi.accessTokenLifespanMs / 1000;
-  return jsonwebtoken.sign(
-    {
-      user_id: userId,
-      source: constants.SOURCE.POLE_EMPLOI,
-      identity_provider: constants.IDENTITY_PROVIDER.POLE_EMPLOI,
-    },
-    settings.authentication.secret,
-    {
-      expiresIn: expirationDelaySeconds,
-    }
-  );
-}
-
 async function exchangeCodeForTokens({ code, redirectUri }) {
   const data = {
     client_secret: settings.poleEmploi.clientSecret,
@@ -123,7 +108,6 @@ async function createUserAccount({
 }
 
 module.exports = {
-  createAccessToken,
   exchangeCodeForTokens,
   getAuthUrl,
   getUserInfo,

--- a/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
@@ -5,7 +5,6 @@ const querystring = require('querystring');
 const { AuthenticationTokenRetrievalError } = require('../../errors');
 const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
 const jsonwebtoken = require('jsonwebtoken');
-const constants = require('../../constants');
 
 const DomainTransaction = require('../../../infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../models/AuthenticationMethod');

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -1,0 +1,17 @@
+const settings = require('../../../config');
+const constants = require('../../constants');
+const OidcAuthenticationService = require('./oidc-authentication-service');
+
+class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
+  constructor() {
+    // todo : remove constants from constants file (enter value directly here)
+    const source = constants.SOURCE.POLE_EMPLOI;
+    const identityProvider = constants.IDENTITY_PROVIDER.POLE_EMPLOI;
+    const expirationDelaySeconds = settings.poleEmploi.accessTokenLifespanMs / 1000;
+    const jwtOptions = { expiresIn: expirationDelaySeconds };
+
+    super({ source, identityProvider, jwtOptions });
+  }
+}
+
+module.exports = PoleEmploiOidcAuthenticationService;

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -4,8 +4,7 @@ const OidcAuthenticationService = require('./oidc-authentication-service');
 
 class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   constructor() {
-    // todo : remove constants from constants file (enter value directly here)
-    const source = constants.SOURCE.POLE_EMPLOI;
+    const source = 'pole_emploi_connect';
     const identityProvider = constants.IDENTITY_PROVIDER.POLE_EMPLOI;
     const expirationDelaySeconds = settings.poleEmploi.accessTokenLifespanMs / 1000;
     const jwtOptions = { expiresIn: expirationDelaySeconds };

--- a/api/lib/domain/usecases/authentication/authenticate-cnav-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-cnav-user.js
@@ -8,6 +8,7 @@ module.exports = async function authenticateCnavUser({
   stateReceived,
   stateSent,
   cnavAuthenticationService,
+  oidcAuthenticationService,
   authenticationSessionService,
   userRepository,
 }) {
@@ -25,7 +26,7 @@ module.exports = async function authenticateCnavUser({
   });
 
   if (user) {
-    const pixAccessToken = cnavAuthenticationService.createAccessToken(user.id);
+    const pixAccessToken = oidcAuthenticationService.createAccessToken(user.id);
 
     await userRepository.updateLastLoggedAt({ userId: user.id });
 

--- a/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
@@ -12,7 +12,7 @@ module.exports = async function authenticatePoleEmploiUser({
   stateSent,
   authenticationSessionService,
   poleEmploiAuthenticationService,
-  poleEmploiOidcAuthenticationService,
+  oidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -44,7 +44,7 @@ module.exports = async function authenticatePoleEmploiUser({
       authenticatedUserId,
       authenticationComplement,
       poleEmploiAuthenticationService,
-      poleEmploiOidcAuthenticationService,
+      oidcAuthenticationService,
       authenticationMethodRepository,
       userRepository,
     });
@@ -62,7 +62,7 @@ module.exports = async function authenticatePoleEmploiUser({
         user,
         authenticationComplement,
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationMethodRepository,
         userRepository,
       });
@@ -88,7 +88,7 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
   userInfo,
   authenticatedUserId,
   authenticationComplement,
-  poleEmploiOidcAuthenticationService,
+  oidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -115,7 +115,7 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
     await authenticationMethodRepository.create({ authenticationMethod });
   }
 
-  const pixAccessToken = poleEmploiOidcAuthenticationService.createAccessToken(authenticatedUserId);
+  const pixAccessToken = oidcAuthenticationService.createAccessToken(authenticatedUserId);
   await userRepository.updateLastLoggedAt({ userId: authenticatedUserId });
   return pixAccessToken;
 }
@@ -123,7 +123,7 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
 async function _getPixAccessTokenFromPoleEmploiUser({
   user,
   authenticationComplement,
-  poleEmploiOidcAuthenticationService,
+  oidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -132,7 +132,7 @@ async function _getPixAccessTokenFromPoleEmploiUser({
     userId: user.id,
   });
 
-  const pixAccessToken = poleEmploiOidcAuthenticationService.createAccessToken(user.id);
+  const pixAccessToken = oidcAuthenticationService.createAccessToken(user.id);
 
   await userRepository.updateLastLoggedAt({ userId: user.id });
   return pixAccessToken;

--- a/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
@@ -12,6 +12,7 @@ module.exports = async function authenticatePoleEmploiUser({
   stateSent,
   authenticationSessionService,
   poleEmploiAuthenticationService,
+  poleEmploiOidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -43,6 +44,7 @@ module.exports = async function authenticatePoleEmploiUser({
       authenticatedUserId,
       authenticationComplement,
       poleEmploiAuthenticationService,
+      poleEmploiOidcAuthenticationService,
       authenticationMethodRepository,
       userRepository,
     });
@@ -60,6 +62,7 @@ module.exports = async function authenticatePoleEmploiUser({
         user,
         authenticationComplement,
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationMethodRepository,
         userRepository,
       });
@@ -85,7 +88,7 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
   userInfo,
   authenticatedUserId,
   authenticationComplement,
-  poleEmploiAuthenticationService,
+  poleEmploiOidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -111,7 +114,8 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
     });
     await authenticationMethodRepository.create({ authenticationMethod });
   }
-  const pixAccessToken = poleEmploiAuthenticationService.createAccessToken(authenticatedUserId);
+
+  const pixAccessToken = poleEmploiOidcAuthenticationService.createAccessToken(authenticatedUserId);
   await userRepository.updateLastLoggedAt({ userId: authenticatedUserId });
   return pixAccessToken;
 }
@@ -119,7 +123,7 @@ async function _getPixAccessTokenFromAlreadyAuthenticatedPixUser({
 async function _getPixAccessTokenFromPoleEmploiUser({
   user,
   authenticationComplement,
-  poleEmploiAuthenticationService,
+  poleEmploiOidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -127,7 +131,8 @@ async function _getPixAccessTokenFromPoleEmploiUser({
     authenticationComplement,
     userId: user.id,
   });
-  const pixAccessToken = poleEmploiAuthenticationService.createAccessToken(user.id);
+
+  const pixAccessToken = poleEmploiOidcAuthenticationService.createAccessToken(user.id);
 
   await userRepository.updateLastLoggedAt({ userId: user.id });
   return pixAccessToken;

--- a/api/lib/domain/usecases/create-user-from-external-identity-provider.js
+++ b/api/lib/domain/usecases/create-user-from-external-identity-provider.js
@@ -18,10 +18,8 @@ module.exports = async function createUserFromExternalIdentityProvider({
   if (!sessionContent) {
     throw new AuthenticationKeyExpired();
   }
-  const selectedAuthenticationService = await authenticationServiceRegistry.lookupAuthenticationService(
-    identityProvider
-  );
-  const userInfo = await selectedAuthenticationService.getUserInfo(sessionContent);
+  const { authenticationService } = await authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
+  const userInfo = await authenticationService.getUserInfo(sessionContent);
 
   if (!userInfo.firstName || !userInfo.lastName || !userInfo.externalIdentityId) {
     logger.error(`Un des champs obligatoires n'a pas été renvoyé : ${JSON.stringify(userInfo)}.`);
@@ -44,7 +42,7 @@ module.exports = async function createUserFromExternalIdentityProvider({
     lastName: userInfo.lastName,
   });
 
-  return await selectedAuthenticationService.createUserAccount({
+  return await authenticationService.createUserAccount({
     user,
     sessionContent,
     externalIdentityId: userInfo.externalIdentityId,

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -224,7 +224,7 @@ describe('Unit | Application | Controller | Authentication', function () {
       await authenticationController.authenticatePoleEmploiUser(request, hFake);
 
       // then
-      expect(usecases.authenticatePoleEmploiUser).to.have.been.calledWith(expectedParameters);
+      expect(usecases.authenticatePoleEmploiUser).to.have.been.calledWithMatch(expectedParameters);
     });
 
     it('should return PIX access token and Pole emploi ID token', async function () {

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -76,6 +76,11 @@ describe('Unit | Application | Controller | Authentication', function () {
       };
       const pixAccessToken = 'pixAccessToken';
       sinon.stub(usecases, 'authenticateCnavUser').resolves({ pixAccessToken, isAuthenticationComplete: true });
+      const oidcAuthenticationService = {};
+      sinon
+        .stub(authenticationRegistry, 'lookupAuthenticationService')
+        .withArgs('CNAV')
+        .returns({ oidcAuthenticationService });
 
       // when
       await authenticationController.authenticateCnavUser(request, hFake);
@@ -86,6 +91,7 @@ describe('Unit | Application | Controller | Authentication', function () {
         redirectUri: 'http://redirectUri.fr',
         stateReceived: 'state',
         stateSent: 'state',
+        oidcAuthenticationService,
       });
     });
 

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -4,6 +4,7 @@ const poleEmploiController = require('../../../../lib/application/pole-emploi/po
 const usecases = require('../../../../lib/domain/usecases');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const poleEmploiAuthenticationService = require('../../../../lib/domain/services/authentication/pole-emploi-authentication-service');
+const PoleEmploiOidcAuthenticationService = require('../../../../lib/domain/services/authentication/pole-emploi-oidc-authentication-service');
 
 describe('Unit | Controller | pole-emploi-controller', function () {
   describe('#getSendings', function () {
@@ -65,7 +66,7 @@ describe('Unit | Controller | pole-emploi-controller', function () {
       const request = { query: { 'authentication-key': 'abcde' } };
       const userId = 7;
       sinon.stub(usecases, 'createUserFromExternalIdentityProvider').resolves({ userId, idToken: 1 });
-      sinon.stub(poleEmploiAuthenticationService, 'createAccessToken').resolves('an access token');
+      sinon.stub(PoleEmploiOidcAuthenticationService.prototype, 'createAccessToken');
       sinon.stub(userRepository, 'updateLastLoggedAt');
 
       // when
@@ -86,12 +87,15 @@ describe('Unit | Controller | pole-emploi-controller', function () {
         .withArgs({ authenticationKey: 'abcde', identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
         .resolves({ userId, idToken });
       sinon.stub(userRepository, 'updateLastLoggedAt');
-      sinon.stub(poleEmploiAuthenticationService, 'createAccessToken').withArgs(userId).returns(accessToken);
+      sinon
+        .stub(PoleEmploiOidcAuthenticationService.prototype, 'createAccessToken')
+        .withArgs(userId)
+        .returns(accessToken);
 
       // when
       const result = await poleEmploiController.createUser(request, hFake);
 
-      //then
+      // then
       expect(result.source.access_token).to.equal(accessToken);
       expect(result.source.id_token).to.equal(idToken);
     });

--- a/api/tests/unit/domain/services/authentication/cnav-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/cnav-authentication-service_test.js
@@ -3,8 +3,6 @@ const { AuthenticationTokenRetrievalError } = require('../../../../../lib/domain
 const settings = require('../../../../../lib/config');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const jsonwebtoken = require('jsonwebtoken');
-const { CNAV } = require('../../../../../lib/domain/constants').SOURCE;
-
 const cnavAuthenticationService = require('../../../../../lib/domain/services/authentication/cnav-authentication-service');
 const UserToCreate = require('../../../../../lib/domain/models/UserToCreate');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
@@ -26,26 +24,6 @@ describe('Unit | Domain | Services | cnav-authentication-service', function () {
     authenticationMethodRepository = {
       create: sinon.stub(),
     };
-  });
-
-  describe('#createAccessToken', function () {
-    it('should create access token with user id and source', function () {
-      // given
-      const userId = 123;
-      settings.authentication.secret = 'a secret';
-      settings.cnav.accessTokenLifespanMs = 1000;
-      const accessToken = 'valid access token';
-      const firstParameter = { user_id: userId, source: CNAV };
-      const secondParameter = 'a secret';
-      const thirdParameter = { expiresIn: 1 };
-      sinon.stub(jsonwebtoken, 'sign').withArgs(firstParameter, secondParameter, thirdParameter).returns(accessToken);
-
-      // when
-      const result = cnavAuthenticationService.createAccessToken(userId);
-
-      // then
-      expect(result).to.equal(accessToken);
-    });
   });
 
   describe('#exchangeCodeForIdToken', function () {

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -1,0 +1,34 @@
+const { expect, sinon } = require('../../../../test-helper');
+const settings = require('../../../../../lib/config');
+
+const OidcAuthenticationService = require('../../../../../lib/domain/services/authentication/oidc-authentication-service');
+const jsonwebtoken = require('jsonwebtoken');
+
+describe('Unit | Domain | Services | oidc-authentication-service', function () {
+  describe('#createAccessToken', function () {
+    it('should create access token with user id, source and identityProvider', function () {
+      // given
+      const userId = 42;
+      const accessToken = Symbol('valid access token');
+      const source = Symbol('an oidc source');
+      const identityProvider = Symbol('name of identityProvider');
+      settings.authentication.secret = 'a secret';
+      const payload = {
+        user_id: userId,
+        source,
+        identity_provider: identityProvider,
+      };
+      const secret = 'a secret';
+      const jwtOptions = { expiresIn: 1 };
+      sinon.stub(jsonwebtoken, 'sign').withArgs(payload, secret, jwtOptions).returns(accessToken);
+
+      const oidcAuthenticationService = new OidcAuthenticationService({ source, identityProvider, jwtOptions });
+
+      // when
+      const result = oidcAuthenticationService.createAccessToken(userId);
+
+      // then
+      expect(result).to.equal(accessToken);
+    });
+  });
+});

--- a/api/tests/unit/domain/services/authentication/pole-emploi-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-authentication-service_test.js
@@ -7,7 +7,6 @@ const poleEmploiAuthenticationService = require('../../../../../lib/domain/servi
 const AuthenticationSessionContent = require('../../../../../lib/domain/models/AuthenticationSessionContent');
 const UserToCreate = require('../../../../../lib/domain/models/UserToCreate');
 const jsonwebtoken = require('jsonwebtoken');
-const constants = require('../../../../../lib/domain/constants');
 const DomainTransaction = require('../../../../../lib/infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
 const moment = require('moment');
@@ -36,30 +35,6 @@ describe('Unit | Domain | Services | pole-emploi-authentication-service', functi
 
   afterEach(function () {
     clock.restore();
-  });
-
-  describe('#createAccessToken', function () {
-    it('should create access token with user id, source and identityProvider', function () {
-      // given
-      const userId = 123;
-      settings.authentication.secret = 'a secret';
-      settings.poleEmploi.accessTokenLifespanMs = 1000;
-      const accessToken = 'valid access token';
-      const firstParameter = {
-        user_id: userId,
-        source: constants.SOURCE.POLE_EMPLOI,
-        identity_provider: constants.IDENTITY_PROVIDER.POLE_EMPLOI,
-      };
-      const secondParameter = 'a secret';
-      const thirdParameter = { expiresIn: 1 };
-      sinon.stub(jsonwebtoken, 'sign').withArgs(firstParameter, secondParameter, thirdParameter).returns(accessToken);
-
-      // when
-      const result = poleEmploiAuthenticationService.createAccessToken(userId);
-
-      // then
-      expect(result).to.equal(accessToken);
-    });
   });
 
   describe('#exchangeCodeForTokens', function () {

--- a/api/tests/unit/domain/usecases/authentication/authenticate-cnav-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-cnav-user_test.js
@@ -6,6 +6,7 @@ const authenticateCnavUser = require('../../../../../lib/domain/usecases/authent
 
 describe('Unit | UseCase | authenticate-cnav-user', function () {
   let cnavAuthenticationService;
+  let oidcAuthenticationService;
   let authenticationSessionService;
   let userRepository;
 
@@ -13,7 +14,10 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
     cnavAuthenticationService = {
       exchangeCodeForIdToken: sinon.stub(),
       getUserInfo: sinon.stub(),
-      createAccessToken: sinon.stub().returns(),
+    };
+
+    oidcAuthenticationService = {
+      createAccessToken: sinon.stub(),
     };
 
     authenticationSessionService = {
@@ -69,12 +73,13 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         cnavAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         userRepository,
       });
 
       // then
-      expect(cnavAuthenticationService.createAccessToken).to.have.been.calledWith(user.id);
+      expect(oidcAuthenticationService.createAccessToken).to.have.been.calledWith(user.id);
     });
 
     it('should save last logged at date', async function () {
@@ -85,7 +90,7 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
       });
       _fakeCnavAPI({ cnavAuthenticationService });
       userRepository.findByExternalIdentifier.resolves(user);
-      cnavAuthenticationService.createAccessToken.returns('access-token');
+      oidcAuthenticationService.createAccessToken.returns('access-token');
 
       // when
       await authenticateCnavUser({
@@ -94,6 +99,7 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         cnavAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         userRepository,
       });
@@ -112,7 +118,7 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
 
       _fakeCnavAPI({ cnavAuthenticationService });
       userRepository.findByExternalIdentifier.resolves(user);
-      cnavAuthenticationService.createAccessToken.returns(pixAccessToken);
+      oidcAuthenticationService.createAccessToken.returns(pixAccessToken);
 
       // when
       const result = await authenticateCnavUser({
@@ -121,6 +127,7 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         cnavAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         userRepository,
       });

--- a/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
@@ -84,7 +84,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should call authenticate pole emploi user with code and redirectUri parameters', async function () {
       // given
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      const poleEmploiOidcAuthenticationService = {
+      const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
       };
 
@@ -97,7 +97,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -113,7 +113,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should call get pole emploi user info with id token parameter', async function () {
       // given
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      const poleEmploiOidcAuthenticationService = {
+      const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
       };
 
@@ -126,7 +126,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -140,10 +140,10 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       // given
       const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
       const authenticatedUserId = 1;
-      const poleEmploiOidcAuthenticationService = {
+      const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
       };
-      poleEmploiOidcAuthenticationService.createAccessToken.withArgs(1).resolves('access-token');
+      oidcAuthenticationService.createAccessToken.withArgs(1).resolves('access-token');
 
       // when
       const result = await authenticatePoleEmploiUser({
@@ -154,7 +154,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -171,7 +171,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should save last logged at date', async function () {
       // given
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      const poleEmploiOidcAuthenticationService = {
+      const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
       };
 
@@ -184,7 +184,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -199,7 +199,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         // given
         userRepository.findByExternalIdentifier.resolves({ id: 1 });
         const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-        const poleEmploiOidcAuthenticationService = {
+        const oidcAuthenticationService = {
           createAccessToken: sinon.stub(),
         };
 
@@ -212,7 +212,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           stateReceived: 'state',
           stateSent: 'state',
           poleEmploiAuthenticationService,
-          poleEmploiOidcAuthenticationService,
+          oidcAuthenticationService,
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
@@ -236,7 +236,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         // given
         userRepository.findByExternalIdentifier.resolves({ id: 123 });
         _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-        const poleEmploiOidcAuthenticationService = {
+        const oidcAuthenticationService = {
           createAccessToken: sinon.stub(),
         };
 
@@ -249,7 +249,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           stateReceived: 'state',
           stateSent: 'state',
           poleEmploiAuthenticationService,
-          poleEmploiOidcAuthenticationService,
+          oidcAuthenticationService,
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
@@ -266,7 +266,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           // given
           const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
           userRepository.findByExternalIdentifier.resolves(null);
-          const poleEmploiOidcAuthenticationService = {
+          const oidcAuthenticationService = {
             createAccessToken: sinon.stub(),
           };
 
@@ -279,7 +279,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
             stateReceived: 'state',
             stateSent: 'state',
             poleEmploiAuthenticationService,
-            poleEmploiOidcAuthenticationService,
+            oidcAuthenticationService,
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
@@ -311,7 +311,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
               externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
             })
           );
-          const poleEmploiOidcAuthenticationService = {
+          const oidcAuthenticationService = {
             createAccessToken: sinon.stub(),
           };
 
@@ -324,7 +324,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
             stateReceived: 'state',
             stateSent: 'state',
             poleEmploiAuthenticationService,
-            poleEmploiOidcAuthenticationService,
+            oidcAuthenticationService,
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
@@ -353,7 +353,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
               externalIdentifier: 'other_external_identifier',
             })
           );
-          const poleEmploiOidcAuthenticationService = {
+          const oidcAuthenticationService = {
             createAccessToken: sinon.stub(),
           };
 
@@ -366,7 +366,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
             stateReceived: 'state',
             stateSent: 'state',
             poleEmploiAuthenticationService,
-            poleEmploiOidcAuthenticationService,
+            oidcAuthenticationService,
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
@@ -386,7 +386,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       const key = 'aaa-bbb-ccc';
       authenticationSessionService.save.resolves(key);
       userRepository.findByExternalIdentifier.resolves(null);
-      const poleEmploiOidcAuthenticationService = {
+      const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
       };
 
@@ -399,7 +399,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -415,7 +415,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
       authenticationSessionService.save.resolves(key);
       userRepository.findByExternalIdentifier.resolves(null);
-      const poleEmploiOidcAuthenticationService = {
+      const oidcAuthenticationService = {
         createAccessToken: sinon.stub(),
       };
 
@@ -428,7 +428,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
-        poleEmploiOidcAuthenticationService,
+        oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,

--- a/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
@@ -4,7 +4,6 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../../test-hel
 
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
 const AuthenticationSessionContent = require('../../../../../lib/domain/models/AuthenticationSessionContent');
-const User = require('../../../../../lib/domain/models/User');
 
 const { UnexpectedOidcStateError, UnexpectedUserAccountError } = require('../../../../../lib/domain/errors');
 const DomainTransaction = require('../../../../../lib/infrastructure/DomainTransaction');
@@ -15,7 +14,6 @@ const authenticatePoleEmploiUser = require('../../../../../lib/domain/usecases/a
 describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
   let poleEmploiAuthenticationService;
   let authenticationSessionService;
-
   let authenticationMethodRepository;
   let userRepository;
 
@@ -27,7 +25,6 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     poleEmploiAuthenticationService = {
       exchangeCodeForTokens: sinon.stub(),
       getUserInfo: sinon.stub(),
-      createAccessToken: sinon.stub(),
     };
 
     authenticationMethodRepository = {
@@ -87,7 +84,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should call authenticate pole emploi user with code and redirectUri parameters', async function () {
       // given
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+      const poleEmploiOidcAuthenticationService = {
+        createAccessToken: sinon.stub(),
+      };
 
       // when
       await authenticatePoleEmploiUser({
@@ -98,6 +97,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -113,7 +113,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should call get pole emploi user info with id token parameter', async function () {
       // given
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+      const poleEmploiOidcAuthenticationService = {
+        createAccessToken: sinon.stub(),
+      };
 
       // when
       await authenticatePoleEmploiUser({
@@ -124,6 +126,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -133,38 +136,14 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       expect(poleEmploiAuthenticationService.getUserInfo).to.have.been.calledWith({ idToken: 'idToken' });
     });
 
-    it('should call poleEmploiAuthenticationService createAccessToken function with user id', async function () {
-      // given
-      const user = new User({ id: 1, firstName: 'Tuck', lastName: 'Morris' });
-      user.externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
-      poleEmploiAuthenticationService.createAccessToken.returns('access-token');
-
-      _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      userRepository.findByExternalIdentifier.resolves({ id: 1 });
-
-      // when
-      await authenticatePoleEmploiUser({
-        authenticatedUserId: 1,
-        clientId: 'clientId',
-        code: 'code',
-        redirectUri: 'redirectUri',
-        stateReceived: 'state',
-        stateSent: 'state',
-        poleEmploiAuthenticationService,
-        authenticationSessionService,
-        authenticationMethodRepository,
-        userRepository,
-      });
-
-      // then
-      expect(poleEmploiAuthenticationService.createAccessToken).to.have.been.calledWith(1);
-    });
-
     it('should return accessToken and idToken', async function () {
       // given
       const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
       const authenticatedUserId = 1;
-      poleEmploiAuthenticationService.createAccessToken.withArgs(authenticatedUserId).returns('access-token');
+      const poleEmploiOidcAuthenticationService = {
+        createAccessToken: sinon.stub(),
+      };
+      poleEmploiOidcAuthenticationService.createAccessToken.withArgs(1).resolves('access-token');
 
       // when
       const result = await authenticatePoleEmploiUser({
@@ -175,6 +154,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -191,7 +171,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
     it('should save last logged at date', async function () {
       // given
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-      poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+      const poleEmploiOidcAuthenticationService = {
+        createAccessToken: sinon.stub(),
+      };
 
       // when
       await authenticatePoleEmploiUser({
@@ -202,6 +184,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -216,7 +199,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         // given
         userRepository.findByExternalIdentifier.resolves({ id: 1 });
         const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-        poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+        const poleEmploiOidcAuthenticationService = {
+          createAccessToken: sinon.stub(),
+        };
 
         // when
         await authenticatePoleEmploiUser({
@@ -227,6 +212,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           stateReceived: 'state',
           stateSent: 'state',
           poleEmploiAuthenticationService,
+          poleEmploiOidcAuthenticationService,
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
@@ -250,7 +236,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         // given
         userRepository.findByExternalIdentifier.resolves({ id: 123 });
         _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
-        poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+        const poleEmploiOidcAuthenticationService = {
+          createAccessToken: sinon.stub(),
+        };
 
         // when
         await authenticatePoleEmploiUser({
@@ -261,6 +249,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           stateReceived: 'state',
           stateSent: 'state',
           poleEmploiAuthenticationService,
+          poleEmploiOidcAuthenticationService,
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
@@ -277,7 +266,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
           // given
           const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
           userRepository.findByExternalIdentifier.resolves(null);
-          poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+          const poleEmploiOidcAuthenticationService = {
+            createAccessToken: sinon.stub(),
+          };
 
           // when
           await authenticatePoleEmploiUser({
@@ -288,6 +279,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
             stateReceived: 'state',
             stateSent: 'state',
             poleEmploiAuthenticationService,
+            poleEmploiOidcAuthenticationService,
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
@@ -319,7 +311,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
               externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
             })
           );
-          poleEmploiAuthenticationService.createAccessToken.returns('access-token');
+          const poleEmploiOidcAuthenticationService = {
+            createAccessToken: sinon.stub(),
+          };
 
           // when
           await authenticatePoleEmploiUser({
@@ -330,6 +324,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
             stateReceived: 'state',
             stateSent: 'state',
             poleEmploiAuthenticationService,
+            poleEmploiOidcAuthenticationService,
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
@@ -358,6 +353,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
               externalIdentifier: 'other_external_identifier',
             })
           );
+          const poleEmploiOidcAuthenticationService = {
+            createAccessToken: sinon.stub(),
+          };
 
           // when
           const error = await catchErr(authenticatePoleEmploiUser)({
@@ -368,6 +366,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
             stateReceived: 'state',
             stateSent: 'state',
             poleEmploiAuthenticationService,
+            poleEmploiOidcAuthenticationService,
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
@@ -387,6 +386,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       const key = 'aaa-bbb-ccc';
       authenticationSessionService.save.resolves(key);
       userRepository.findByExternalIdentifier.resolves(null);
+      const poleEmploiOidcAuthenticationService = {
+        createAccessToken: sinon.stub(),
+      };
 
       // when
       await authenticatePoleEmploiUser({
@@ -397,6 +399,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
@@ -412,6 +415,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       _fakePoleEmploiAPI({ poleEmploiAuthenticationService });
       authenticationSessionService.save.resolves(key);
       userRepository.findByExternalIdentifier.resolves(null);
+      const poleEmploiOidcAuthenticationService = {
+        createAccessToken: sinon.stub(),
+      };
 
       // when
       const result = await authenticatePoleEmploiUser({
@@ -422,6 +428,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
         stateReceived: 'state',
         stateSent: 'state',
         poleEmploiAuthenticationService,
+        poleEmploiOidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,

--- a/api/tests/unit/domain/usecases/create-user-from-external-identity-provider_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-external-identity-provider_test.js
@@ -65,7 +65,7 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
       authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves('SESSION_CONTENT');
       authenticationServiceRegistry.lookupAuthenticationService
         .withArgs('SOME_IDP')
-        .resolves(externalAuthenticationService);
+        .resolves({ authenticationService: externalAuthenticationService });
       externalAuthenticationService.getUserInfo
         .withArgs('SESSION_CONTENT')
         .resolves({ firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'duGAR' });
@@ -94,7 +94,9 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
       // given
       const authenticationSessionContent = 'SESSION_CONTENT';
       authenticationSessionService.getByKey.resolves(authenticationSessionContent);
-      authenticationServiceRegistry.lookupAuthenticationService.resolves(externalAuthenticationService);
+      authenticationServiceRegistry.lookupAuthenticationService.resolves({
+        authenticationService: externalAuthenticationService,
+      });
       externalAuthenticationService.getUserInfo.resolves({
         firstName: 'Jean',
         lastName: undefined,
@@ -128,7 +130,7 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
     authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves('SESSION_CONTENT');
     authenticationServiceRegistry.lookupAuthenticationService
       .withArgs('SOME_IDP')
-      .resolves(externalAuthenticationService);
+      .resolves({ authenticationService: externalAuthenticationService });
     externalAuthenticationService.getUserInfo
       .withArgs('SESSION_CONTENT')
       .resolves({ firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'duGAR' });

--- a/mon-pix/app/authenticators/cnav.js
+++ b/mon-pix/app/authenticators/cnav.js
@@ -55,6 +55,7 @@ export default class CnavAuthenticator extends BaseAuthenticator {
       access_token: data.access_token,
       source: decodedAccessToken.source,
       user_id: decodedAccessToken.user_id,
+      identity_provider: decodedAccessToken.identity_provider,
     };
   }
 }

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -46,7 +46,7 @@ export default class Campaign extends Model {
     return this.organizationType === 'SUP';
   }
 
-  get isRestrictedByPoleEmploiIdentityProvider() {
-    return this.identityProvider === 'POLE_EMPLOI';
+  isRestrictedByIdentityProvider(identityProvider) {
+    return this.identityProvider === identityProvider;
   }
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -76,7 +76,10 @@ export default class Application extends Route.extend(ApplicationRouteMixin) {
     await this._handleLocale();
 
     const nextURL = this.session.data.nextURL;
-    if (nextURL && get(this.session, 'data.authenticated.source') === 'pole_emploi_connect') {
+    if (
+      this._isFromIdentityProviderLoginPage(nextURL, 'CNAV') ||
+      this._isFromIdentityProviderLoginPage(nextURL, 'POLE_EMPLOI')
+    ) {
       this.session.set('data.nextURL', undefined);
       this.router.replaceWith(nextURL);
     } else {
@@ -141,5 +144,11 @@ export default class Application extends Route.extend(ApplicationRouteMixin) {
     delete this.session.data.expectedUserId;
     delete this.session.data.externalUser;
     return this.session.invalidate();
+  }
+
+  _isFromIdentityProviderLoginPage(nextUrl, identityProvider) {
+    const isUserLoggedInToIdentityProvider =
+      get(this.session, 'data.authenticated.identity_provider') === identityProvider;
+    return nextUrl && isUserLoggedInToIdentityProvider;
   }
 }

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -18,9 +18,12 @@ export default class AccessRoute extends Route.extend(SecuredRouteMixin) {
     this.authenticationRoute = 'inscription';
     const campaign = this.modelFor('campaigns');
 
-    if (this._shouldVisitPoleEmploiLoginPage(campaign)) {
+    if (this._shouldVisitIdentityProviderLoginPage(campaign, 'POLE_EMPLOI')) {
       this.session.set('attemptedTransition', transition);
       return this.router.replaceWith('login-pole-emploi');
+    } else if (this._shouldVisitIdentityProviderLoginPage(campaign, 'CNAV')) {
+      this.session.set('attemptedTransition', transition);
+      return this.router.replaceWith('login-cnav');
     } else if (this._shouldLoginToAccessSCORestrictedCampaign(campaign)) {
       this.authenticationRoute = 'campaigns.join.student-sco';
     } else if (this._shouldJoinFromMediacentre(campaign)) {
@@ -62,9 +65,10 @@ export default class AccessRoute extends Route.extend(SecuredRouteMixin) {
     );
   }
 
-  _shouldVisitPoleEmploiLoginPage(campaign) {
-    const isUserLoggedInPoleEmploi = get(this.session, 'data.authenticated.identity_provider') === 'POLE_EMPLOI';
-    return campaign.isRestrictedByPoleEmploiIdentityProvider && !isUserLoggedInPoleEmploi;
+  _shouldVisitIdentityProviderLoginPage(campaign, identityProvider) {
+    const isUserLoggedInToIdentityProvider =
+      get(this.session, 'data.authenticated.identity_provider') === identityProvider;
+    return campaign.isRestrictedByIdentityProvider(identityProvider) && !isUserLoggedInToIdentityProvider;
   }
 
   _shouldJoinFromMediacentre(campaign) {

--- a/mon-pix/app/routes/login-cnav.js
+++ b/mon-pix/app/routes/login-cnav.js
@@ -61,6 +61,25 @@ export default class LoginCnavRoute extends Route {
   }
 
   async _handleRedirectRequest() {
+    /**
+     * Store the `attemptedTransition` in the localstorage so when the user returns after
+     * the login he can be sent to the initial destination.
+     */
+    if (this.session.get('attemptedTransition')) {
+      /**
+       * There is two types of intent in transition (see: https://github.com/tildeio/router.js/blob/9b3d00eb923e0bbc34c44f08c6de1e05684b907a/ARCHITECTURE.md#transitionintent)
+       * When the route is accessed by url (/campagnes/:code), the url is provided
+       * When the route is accessed by the submit of the campaign code, the route name (campaigns.access) and contexts ([Campaign]) are provided
+       */
+
+      let { url } = this.session.get('attemptedTransition.intent');
+      const { name, contexts } = this.session.get('attemptedTransition.intent');
+      if (!url) {
+        url = this.router.urlFor(name, contexts[0]);
+      }
+      this.session.set('data.nextURL', url);
+    }
+
     const response = await fetch(
       `${ENV.APP.API_HOST}/api/cnav/auth-url?redirect_uri=${encodeURIComponent(this.redirectUri)}`
     );

--- a/mon-pix/tests/unit/routes/application_test.js
+++ b/mon-pix/tests/unit/routes/application_test.js
@@ -30,22 +30,46 @@ describe('Unit | Route | application', function () {
     expect(splashStub.hideCount).to.equal(1);
   });
 
-  it('should load the current user', function () {
-    // given
-    const currentUserStub = {
-      called: false,
-      load() {
-        this.called = true;
-      },
-    };
-    const route = this.owner.lookup('route:application');
-    route.set('currentUser', currentUserStub);
+  describe('#sessionAuthenticated', function () {
+    it('should load the current user', function () {
+      // given
+      const currentUserStub = {
+        called: false,
+        load() {
+          this.called = true;
+        },
+      };
+      const route = this.owner.lookup('route:application');
+      route.set('currentUser', currentUserStub);
 
-    // when
-    route.sessionAuthenticated();
+      // when
+      route.sessionAuthenticated();
 
-    // then
-    expect(currentUserStub.called).to.be.true;
+      // then
+      expect(currentUserStub.called).to.be.true;
+    });
+
+    it('should redirect to campaign after login in external oidc page', async function () {
+      // given
+      const route = this.owner.lookup('route:application');
+      const sessionStub = Service.create({
+        data: {
+          nextURL: '/campagnes/PIXCNAV01/access',
+          authenticated: {
+            identity_provider: 'CNAV',
+          },
+        },
+      });
+      route.set('session', sessionStub);
+      sinon.stub(route.router, 'replaceWith');
+      route.router.replaceWith.resolves();
+
+      // when
+      await route.sessionAuthenticated();
+
+      // then
+      sinon.assert.calledWith(route.router.replaceWith, '/campagnes/PIXCNAV01/access');
+    });
   });
 
   describe('#__handleLocale', function () {


### PR DESCRIPTION
## :unicorn: Problème
Nous ne gérons toujours pas l'accès restreint aux campagnes pour la CNAV sur Pix App.

## :robot: Solution
Restreindre l'accès aux campagnes appartenant à la CNAV. 

## :rainbow: Remarques
Mutualisation du code (back et front) pour nos deux partenaires openId: Pôle Emploi et CNAV.

PR qui supprime l'usage du Tag Pôle Emploi dans la restriction des accès aux campagnes : https://github.com/1024pix/pix/pull/4551/files#diff-2db20c130bafca6e6ba6a5746b898f5a763a86563360859da600de5e5e482eee

## :100: Pour tester
Comme ce ticket touche à du code Pôle Emploi, tester la non régression des scénarios PE : 

`Scénario première connexion`

- Aller sur Pix App
- Cliquer sur le bouton 'Se connecter avec Pole Emploi' ou taper dans l'url /connexion-pole-emploi
- Entrer les seeds Pôle Emploi (vous les trouverez dans le wiki)
- Valider les cgu
- Constater que l'on est connecté
- Se déconnecter

`Scénario deuxième connexion`

Se reconnecter et ne pas passer par les cgu

`Scénario campagne PE`

- Sur Pix App, taper /campagnes
- Entrer le code suivant : PIXEMPLOI
- Cliquer sur commencer
- Entrer les seeds Pôle Emploi (vous les trouverez dans le wiki)
- Constater que l'on revient sur Pix et sur la suite de la campagne

---

Tester le scénario CNAV classique aussi (/connexion-cnav)

Enfin, tester le scénario de la restriction d'accès à la campagne CNAV : 
- Sur Pix App, taper /campagnes
- Entrer le code suivant : PIXCNAV01
- Cliquer sur commencer
- Constater que l'on passe bien dans l'auth CNAV
- Remplir les infos (l'identifiant et mot de passe se trouvent dans le keepass Pix)
- Constater que l'on revient sur Pix et sur la suite de la campagne
