### PR TITLE
[FEATURE] Utilise la `PixBanner` pour le bandeau de communication sur Pix App (PIX-5361)

### DIFF
--- a/mon-pix/app/components/communication-banner.hbs
+++ b/mon-pix/app/components/communication-banner.hbs
@@ -1,14 +1,5 @@
 {{#if this.isEnabled}}
-  <div class="communication-banner communication-banner--{{this.bannerType}}">
-    <span class="communication-banner__icon">
-      {{#if this.isError}}
-        <FaIcon @icon="triangle-exclamation" />
-      {{else if this.isWarning}}
-        <FaIcon @icon="circle-exclamation" />
-      {{else}}
-        <FaIcon @icon="circle-info" />
-      {{/if}}
-    </span>
+  <PixBanner @type={{this.bannerType}}>
     {{this.bannerContent}}
-  </div>
+  </PixBanner>
 {{/if}}

--- a/mon-pix/app/components/communication-banner.js
+++ b/mon-pix/app/components/communication-banner.js
@@ -7,11 +7,6 @@ export default class CommunicationBanner extends Component {
   bannerType = ENV.APP.BANNER_TYPE;
 
   _rawBannerContent = ENV.APP.BANNER_CONTENT;
-  _bannerTypes = {
-    info: 'info',
-    warning: 'warning',
-    error: 'error',
-  };
 
   get isEnabled() {
     return !isEmpty(this._rawBannerContent) && !isEmpty(this.bannerType);
@@ -19,13 +14,5 @@ export default class CommunicationBanner extends Component {
 
   get bannerContent() {
     return htmlSafe(this._rawBannerContent);
-  }
-
-  get isWarning() {
-    return this.bannerType === this._bannerTypes.warning;
-  }
-
-  get isError() {
-    return this.bannerType === this._bannerTypes.error;
   }
 }

--- a/mon-pix/tests/integration/components/communication-banner_test.js
+++ b/mon-pix/tests/integration/components/communication-banner_test.js
@@ -25,25 +25,19 @@ describe('Integration | Component | communication-banner', function () {
     await render(hbs`<CommunicationBanner />`);
 
     // then
-    expect(find('.warning-banner')).to.not.exist;
+    expect(find('.pix-banner')).to.not.exist;
   });
 
-  [
-    { bannerContent: 'info banner text ...', bannerType: 'info', bannerClass: '.communication-banner--info' },
-    { bannerContent: 'warning banner text ...', bannerType: 'warning', bannerClass: '.communication-banner--warning' },
-    { bannerContent: 'error banner text ...', bannerType: 'error', bannerClass: '.communication-banner--error' },
-  ].forEach((testCase) => {
-    it(`should display the ${testCase.bannerType} banner`, async function () {
-      // given
-      ENV.APP.BANNER_CONTENT = testCase.bannerContent;
-      ENV.APP.BANNER_TYPE = testCase.bannerType;
+  it('should display the information banner', async function () {
+    // given
+    ENV.APP.BANNER_CONTENT = 'information banner text ...';
+    ENV.APP.BANNER_TYPE = 'information';
 
-      // when
-      await render(hbs`<CommunicationBanner />`);
+    // when
+    await render(hbs`<CommunicationBanner />`);
 
-      // then
-      expect(find(testCase.bannerClass)).to.exist;
-      expect(find(testCase.bannerClass).textContent).to.contain(testCase.bannerType);
-    });
+    // then
+    expect(find('.pix-banner--information')).to.exist;
+    expect(find('.pix-banner--information').textContent).to.contain('information banner text ...');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le bandeau de comm Pix App n'est pas joli.

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/5855339/179490712-6de0f68d-deef-4f10-b7e8-4eac7835aec1.png">

## :robot: Solution
Uniformiser l'utilisation du composant `<PixBanner>` comme sur Certif et Orga.

## :rainbow: Remarques
L'utilisation de la valeur `info` est dépréciée en faveur de `information` pour être iso avec le paramètre d'entrée du composant. [La doc](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/3476783107/Bandeaux+d+info+sur+les+applis+fronts) est à mettre à jour en conséquence.

On sécurise un peu plus le type de bannière en ajoutant un `.toLowerCase()`.

Les couleurs seront mises à jour par Quentin plus tard pour une meilleure accessibilité.

## :100: Pour tester
Vérifier que le bandeau sur la RA est similaire aux autres applis.

Ex : certif
<img width="1294" alt="image" src="https://user-images.githubusercontent.com/5855339/179490760-c9aa8f07-f754-414b-b819-6d54dad38dee.png">
