### PR TITLE
[FEATURE] Ajouter la colonne 'Dernière participation' au tableau des Participants(PIX-5124)

### DIFF
--- a/api/lib/domain/read-models/OrganizationParticipant.js
+++ b/api/lib/domain/read-models/OrganizationParticipant.js
@@ -1,9 +1,10 @@
 class OrganizationParticipant {
-  constructor({ id, firstName, lastName, participationCount } = {}) {
+  constructor({ id, firstName, lastName, participationCount, lastParticipationDate } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.participationCount = participationCount;
+    this.lastParticipationDate = lastParticipationDate;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/organization-participant-repository.js
@@ -11,6 +11,9 @@ async function getParticipantsByOrganizationId({ organizationId, page }) {
       knex.raw(
         'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organizationLearnerId") AS "participationCount"'
       ),
+      knex.raw(
+        'max("campaign-participations"."createdAt") OVER(PARTITION BY "organizationLearnerId") AS "lastParticipationDate"'
+      ),
     ])
     .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
     .leftJoin('users', 'organization-learners.userId', 'users.id')

--- a/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize({ organizationParticipants, pagination }) {
     return new Serializer('organization-participants', {
       id: 'id',
-      attributes: ['firstName', 'lastName', 'participationCount'],
+      attributes: ['firstName', 'lastName', 'participationCount', 'lastParticipationDate'],
       meta: pagination,
     }).serialize(organizationParticipants);
   },

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2641,7 +2641,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
           organizationLearnerId,
           deletedAt: null,
           deletedBy: null,
-          createdAt: new Date('2021-01-01'),
+          createdAt: new Date('2021-02-01'),
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaignId,

--- a/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -78,6 +78,28 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
       expect(organizationParticipants[0].participationCount).to.equal(1);
     });
 
+    it('should return the date of the last participation ', async function () {
+      const organizationLearnerId = buildLearnerWithParticipation(
+        organizationId,
+        {},
+        { createdAt: new Date('2021-03-17') }
+      ).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+      const lastParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId,
+        campaignId,
+        createdAt: new Date('2022-03-17'),
+      });
+      await databaseBuilder.commit();
+      // when
+      const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+        organizationId,
+      });
+
+      // // then
+      expect(organizationParticipants[0].lastParticipationDate).to.deep.equal(lastParticipation.createdAt);
+    });
+
     it('should return only 1 result even when the participant has participated to several campaigns of the organization', async function () {
       const organizationLearnerId = buildLearnerWithParticipation(organizationId).id;
       const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
@@ -12,12 +12,14 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
           firstName: 'Alex',
           lastName: 'Vasquez',
           participationCount: 4,
+          lastParticipationDate: '2021-03-05',
         }),
         new OrganizationParticipant({
           id: 778,
           firstName: 'Sam',
           lastName: 'Simpson',
           participationCount: 3,
+          lastParticipationDate: '2021-03-05',
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -31,6 +33,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
               'first-name': organizationParticipants[0].firstName,
               'last-name': organizationParticipants[0].lastName,
               'participation-count': organizationParticipants[0].participationCount,
+              'last-participation-date': organizationParticipants[0].lastParticipationDate,
             },
           },
           {
@@ -40,6 +43,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
               'first-name': organizationParticipants[1].firstName,
               'last-name': organizationParticipants[1].lastName,
               'participation-count': organizationParticipants[1].participationCount,
+              'last-participation-date': organizationParticipants[1].lastParticipationDate,
             },
           },
         ],

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -7,6 +7,9 @@
         <Table::Header @align="right">{{t
             "pages.organization-participants.table.column.participation-count"
           }}</Table::Header>
+        <Table::Header @size="medium">{{t
+            "pages.organization-participants.table.column.lastest-participation"
+          }}</Table::Header>
       </tr>
     </thead>
 
@@ -17,6 +20,7 @@
             <td class="ellipsis" title={{participant.lastName}}>{{participant.lastName}}</td>
             <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
             <td class="table__column--right">{{participant.participationCount}}</td>
+            <td class="table__column--center">{{moment-format participant.lastParticipationDate "DD/MM/YYYY"}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/orga/app/models/organization-participant.js
+++ b/orga/app/models/organization-participant.js
@@ -4,4 +4,5 @@ export default class OrganizationParticipant extends Model {
   @attr('string') lastName;
   @attr('string') firstName;
   @attr('number') participationCount;
+  @attr('date') lastParticipationDate;
 }

--- a/orga/tests/integration/components/organization-participants/list_test.js
+++ b/orga/tests/integration/components/organization-participants/list_test.js
@@ -26,6 +26,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     assert.contains('Nom');
     assert.contains('Prénom');
     assert.contains('Nombre de participations');
+    assert.contains('Dernière participation');
   });
 
   test('it should display a list of participants', async function (assert) {
@@ -79,5 +80,22 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // then
     assert.dom(allRows[0]).containsText(4);
     assert.dom(allRows[1]).containsText(1);
+  });
+  test('it should display the date of the last participation for each participant', async function (assert) {
+    // given
+    const participants = [
+      { lastName: 'La Terreur', firstName: 'Gigi', id: 34, lastParticipationDate: new Date('2022-05-15') },
+      { lastName: "L'asticot", firstName: 'Gogo', id: 56, lastParticipationDate: new Date('2022-01-07') },
+    ];
+
+    this.set('participants', participants);
+
+    // when
+    const screen = await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    const allRows = screen.getAllByLabelText(this.intl.t('pages.organization-participants.table.row-title'));
+
+    // then
+    assert.dom(allRows[0]).containsText('15/05/2022');
+    assert.dom(allRows[1]).containsText('07/01/2022');
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -657,6 +657,7 @@
         "column": {
           "first-name": "First name",
           "last-name": "Last name",
+          "lastest-participation": "Lastest participation",
           "participation-count": "Number of participations"
         },
         "empty": "No participants",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -656,6 +656,7 @@
         "column": {
           "first-name": "Prénom",
           "last-name": "Nom",
+          "lastest-participation": "Dernière participation",
           "participation-count": "Nombre de participations"
         },
         "empty": "Aucun participant",


### PR DESCRIPTION
## :unicorn: Problème
Dans la continuité de l'amélioration de l'onglet "Participants", on souhaite donner des infos intéressantes notamment la date de la dernière participation.

## :robot: Solution
Ajouter une colonne dans le tableau pour donner l'info

## :rainbow: Remarques


## :100: Pour tester
- Aller sur Pix Orga et se connecter avec un compte PRO
- Aller dans l'onglet "Participants"
- Constater la présence de la colonne "Dernière participation"
