### PR TITLE
[FEATURE] Afficher la liste des participations aux campagne pour un utilisateur dans Pix Admin (PIX-5365).

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -5,7 +5,7 @@
 </header>
 
 <main class="page-body">
-  <section class="page-section mb_10">
+  <section class="page-section">
     <div class="page-section__header">
       <h1 class="page-section__title">{{@badge.name}}</h1>
     </div>

--- a/admin/app/components/campaigns/participations-section.hbs
+++ b/admin/app/components/campaigns/participations-section.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <header>
     <h2 class="participations-section__title">Liste des participations</h2>
   </header>

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <div class="certification-center-information">
 
     {{#if this.isEditMode}}

--- a/admin/app/components/certification-centers/memberships-section.hbs
+++ b/admin/app/components/certification-centers/memberships-section.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
 
   <header class="page-section__header">
     <h2 class="page-section__title">Membres</h2>

--- a/admin/app/components/certifications/certified-profile.hbs
+++ b/admin/app/components/certifications/certified-profile.hbs
@@ -1,5 +1,5 @@
 {{#each this.certifiedCompetenceList as |certifiedCompetence|}}
-  <section class="page-section mb_10 competence">
+  <section class="page-section competence">
     <span class="competence__border competence__border--{{certifiedCompetence.certifiedArea.color}}"></span>
     <div>
       <header class="competence__header">
@@ -51,7 +51,7 @@
     </div>
   </section>
 {{else}}
-  <section class="page-section mb_10">
+  <section class="page-section">
     <div class="table__empty">Profil certifié vide.</div>
   </section>
 {{/each}}

--- a/admin/app/components/organizations/all-tags.hbs
+++ b/admin/app/components/organizations/all-tags.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
 
   {{#if this.allTags}}
     <ul class="organization-all-tags-list">

--- a/admin/app/components/organizations/campaigns-section.hbs
+++ b/admin/app/components/organizations/campaigns-section.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">Liste des campagnes</h2>
   </header>

--- a/admin/app/components/organizations/information-section.hbs
+++ b/admin/app/components/organizations/information-section.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <div class="organization__information">
     <div class="organization__logo">
       <figure class="organization__logo-figure">

--- a/admin/app/components/organizations/invitations-action.hbs
+++ b/admin/app/components/organizations/invitations-action.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10 organization-invitations">
+<section class="page-section organization-invitations">
   <div class="organization__forms-section">
     <form>
       <h2>Inviter un membre</h2>

--- a/admin/app/components/organizations/invitations.hbs
+++ b/admin/app/components/organizations/invitations.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">Invitations</h2>
   </header>

--- a/admin/app/components/organizations/target-profiles-section.hbs
+++ b/admin/app/components/organizations/target-profiles-section.hbs
@@ -1,5 +1,5 @@
 {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
-  <section class="page-section mb_10">
+  <section class="page-section">
     <header class="page-section__header">
       <h2 class="page-section__title">Rattacher un ou plusieurs profil(s) cible(s)</h2>
     </header>
@@ -17,7 +17,7 @@
   </section>
 {{/if}}
 
-<section class="page-section mb_10">
+<section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">Profils cibles</h2>
   </header>

--- a/admin/app/components/organizations/team-actions-section.hbs
+++ b/admin/app/components/organizations/team-actions-section.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10 organization-team-section">
+<section class="page-section organization-team-section">
   <div class="organization__forms-section">
     <form>
       <h2>Ajouter un membre</h2>

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable require-input-label }}
-<section class="page-section mb_10">
+<section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">Membres</h2>
   </header>

--- a/admin/app/components/stages/stage.hbs
+++ b/admin/app/components/stages/stage.hbs
@@ -10,7 +10,7 @@
     <Stages::update-stage @model={{@model}} @toggleEditMode={{@toggleEditMode}} />
 
   {{else}}
-    <section class="page-section mb_10">
+    <section class="page-section">
       <div class="page-section__header">
         <h1 class="page-section__title">{{@model.name}}</h1>
       </div>

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <form class="form stage-form" {{on "submit" this.updateStage}}>
     <div class="form-field">
       <label for="threshold" class="form-field__label">

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10 target-profile-organizations">
+<section class="page-section target-profile-organizations">
   <div class="organization__forms-section">
     <form class="organization__form" {{on "submit" this.attachOrganizations}}>
       <label for="attach-organizations">Rattacher une ou plusieurs organisation(s)</label>
@@ -46,7 +46,7 @@
     </form>
   </div>
 </section>
-<section class="page-section mb_10">
+<section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">Organisations</h2>
   </header>

--- a/admin/app/components/users/user-detail-personal-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information.hbs
@@ -1,11 +1,11 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <Users::UserDetailPersonalInformation::UserOverview
     @user={{@user}}
     @toggleDisplayAnonymizeModal={{this.toggleDisplayAnonymizeModal}}
   />
 </section>
 
-<section class="page-section mb_10 user-authentication-method">
+<section class="page-section user-authentication-method">
   <Users::UserDetailPersonalInformation::AuthenticationMethod
     @user={{@user}}
     @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
@@ -14,18 +14,18 @@
   />
 </section>
 
-<section class="page-section mb_10">
+<section class="page-section">
   <Users::UserDetailPersonalInformation::SchoolingRegistrationInformation
     @user={{@user}}
     @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}}
   />
 </section>
 
-<section class="page-section mb_10">
+<section class="page-section">
   <Users::UserDetailPersonalInformation::UserProfile @profile={{@user.profile}} />
 </section>
 
-<section class="page-section mb_10">
+<section class="page-section">
   <Users::UserDetailPersonalInformation::CampaignParticipations @participations={{@user.participations}} />
 </section>
 

--- a/admin/app/components/users/user-detail-personal-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information.hbs
@@ -25,6 +25,10 @@
   <Users::UserDetailPersonalInformation::UserProfile @profile={{@user.profile}} />
 </section>
 
+<section class="page-section mb_10">
+  <Users::UserDetailPersonalInformation::CampaignParticipations @participations={{@user.participations}} />
+</section>
+
 <ConfirmPopup
   @message="Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible."
   @confirm={{this.anonymizeUser}}

--- a/admin/app/components/users/user-detail-personal-information/campaign-participations.hbs
+++ b/admin/app/components/users/user-detail-personal-information/campaign-participations.hbs
@@ -1,0 +1,55 @@
+<header class="page-section__header">
+  <h2 class="page-section__title">Participations à des campagnes</h2>
+</header>
+
+<div class="campaign-participations-table content-text content-text--small">
+  <table class="table-admin">
+    <thead>
+      <tr>
+        <th>Prescrit</th>
+        <th>Campagne</th>
+        <th>Identifiant externe</th>
+        <th>Date de début</th>
+        <th>Statut</th>
+        <th>Date d'envoi</th>
+        <th>Supprimé le</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @participations as |participation|}}
+        <tr aria-label="Participation">
+          <td>{{participation.organizationLearnerFullName}}</td>
+          <td>
+            <LinkTo @route="authenticated.campaigns.campaign" @model={{participation.campaignId}}>
+              {{participation.campaignCode}}
+            </LinkTo>
+          </td>
+          {{#if participation.participantExternalId}}
+            <td>{{participation.participantExternalId}}</td>
+          {{else}}
+            <td>-</td>
+          {{/if}}
+          <td>{{dayjs-format participation.createdAt "DD/MM/YYYY"}}</td>
+          <td>{{participation.displayedStatus}}</td>
+          <td>
+            {{if participation.sharedAt (dayjs-format participation.sharedAt "DD/MM/YYYY") "-"}}
+          </td>
+          {{#if participation.deletedAt}}
+            <td>
+              {{dayjs-format participation.deletedAt "DD/MM/YYYY"}}
+              par
+              <LinkTo @route="authenticated.users.get" @model={{participation.deletedBy}}>
+                {{participation.deletedByFullName}}
+              </LinkTo>
+            </td>
+          {{else}}
+            <td>-</td>
+          {{/if}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{#unless @participations}}
+    <div class="table__empty">Aucune participation</div>
+  {{/unless}}
+</div>

--- a/admin/app/components/users/user-detail-personal-information/user-overview.hbs
+++ b/admin/app/components/users/user-detail-personal-information/user-overview.hbs
@@ -89,7 +89,7 @@
   </form>
 {{else}}
   <form class="form">
-    <section class="page-section mb_10">
+    <section class="page-section">
       <div class="user-detail-personal-information-section__content">
         <div>
           <div>

--- a/admin/app/models/user-participation.js
+++ b/admin/app/models/user-participation.js
@@ -1,0 +1,24 @@
+import Model, { attr } from '@ember-data/model';
+
+export const campaignParticipationStatuses = {
+  STARTED: 'En cours',
+  TO_SHARE: 'En attente d’envoi',
+  SHARED: 'Envoyé',
+};
+
+export default class UserParticipation extends Model {
+  @attr campaignId;
+  @attr('string') campaignCode;
+  @attr('string') participantExternalId;
+  @attr('string') status;
+  @attr('date') createdAt;
+  @attr('date') sharedAt;
+  @attr('date') deletedAt;
+  @attr deletedBy;
+  @attr('string') deletedByFullName;
+  @attr('string') organizationLearnerFullName;
+
+  get displayedStatus() {
+    return campaignParticipationStatuses[this.status];
+  }
+}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -25,6 +25,7 @@ export default class User extends Model {
   @hasMany('certification-center-membership') certificationCenterMemberships;
   @hasMany('schooling-registration') schoolingRegistrations;
   @hasMany('authentication-method') authenticationMethods;
+  @hasMany('user-participation') participations;
 
   @computed('firstName', 'lastName')
   get fullName() {

--- a/admin/app/routes/authenticated/users/get.js
+++ b/admin/app/routes/authenticated/users/get.js
@@ -10,6 +10,7 @@ export default class AuthenticatedUsersGetRoute extends Route {
       include: 'schoolingRegistrations,authenticationMethods',
     });
     await user.belongsTo('profile').reload();
+    await user.hasMany('participations').reload();
     return user;
   }
 

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -45,6 +45,7 @@
       background: $pix-neutral-0;
       border-radius: 5px;
       padding: 32px;
+      margin-bottom: 10px;
 
       &__header {
         display: flex;

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -16,7 +16,7 @@
     @updateCertificationCenter={{this.updateCertificationCenter}}
   />
 
-  <section class="page-section mb_10">
+  <section class="page-section">
     <header class="page-section__header">
       <h2 class="page-section__title">Ajouter un membre</h2>
     </header>

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -1,4 +1,4 @@
-<section class="page-section mb_10">
+<section class="page-section">
   <div class="session-info">
 
     <div class="session-info__certification-officer-assigned">

--- a/admin/tests/integration/components/users/user-detail-personal-information/campaign-participations_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/campaign-participations_test.js
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | users | user-detail-personal-information/campaign-participation', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display a list of participations', async function (assert) {
+    // given
+    const participation1 = EmberObject.create({
+      campaignCode: 'SOMECODE',
+    });
+    const participation2 = EmberObject.create({
+      campaignCode: 'SOMEOTHERCODE',
+    });
+    const participations = [participation1, participation2];
+    this.set('participations', participations);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.strictEqual(screen.getAllByLabelText('Participation').length, 2);
+  });
+
+  test('it should display an empty table when no participations', async function (assert) {
+    // given
+    const participations = [];
+    this.set('participations', participations);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('Aucune participation')).exists();
+  });
+
+  test('it should display campaign information', async function (assert) {
+    // given
+    const participation = EmberObject.create({
+      campaignCode: 'SOMECODE',
+      campaignId: 1,
+    });
+    this.set('participations', [participation]);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('SOMECODE')).exists();
+    assert.dom(screen.getByRole('link', { name: 'SOMECODE' })).exists();
+  });
+
+  test('it should display orgnaization learner information', async function (assert) {
+    // given
+    const participation = EmberObject.create({
+      organizationLearnerFullName: 'Un nom bien long',
+    });
+    this.set('participations', [participation]);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('Un nom bien long')).exists();
+  });
+
+  test('it should display participation information', async function (assert) {
+    // given
+    const participation = EmberObject.create({
+      participantExternalId: 'Some external id',
+      createdAt: new Date('2020-01-01'),
+      displayedStatus: 'Envoyé',
+    });
+    this.set('participations', [participation]);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('Some external id')).exists();
+    assert.dom(screen.getByText('01/01/2020')).exists();
+    assert.dom(screen.getByText('Envoyé')).exists();
+  });
+
+  test('it should display shared date if participation is shared', async function (assert) {
+    // given
+    const participation = EmberObject.create({
+      sharedAt: new Date('2020-01-01'),
+    });
+    this.set('participations', [participation]);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('01/01/2020')).exists();
+  });
+
+  test('it should display deletedByFullName and deletedAt if participation is deleted', async function (assert) {
+    // given
+    const participation = EmberObject.create({
+      deletedAt: new Date('2022-01-01'),
+      deletedByFullName: 'le coupable',
+    });
+    this.set('participations', [participation]);
+
+    // when
+    const screen = await render(
+      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+    );
+
+    // then
+    assert.dom(screen.getByText('01/01/2022 par')).exists();
+    assert.dom(screen.getByRole('link', { name: 'le coupable' })).exists();
+  });
+});

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -263,6 +263,31 @@ exports.register = async function (server) {
         tags: ['api', 'user', 'profile'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/users/{id}/participations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.findCampaignParticipationsForUserManagement,
+        notes: ["- Permet à un administrateur de lister les participations d'un utilisateur à une campagne"],
+        tags: ['api', 'user', 'campaign-participations'],
+      },
+    },
   ];
 
   server.route([

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -14,6 +14,7 @@ const userDetailsForAdminSerializer = require('../../infrastructure/serializers/
 const userAnonymizedDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer');
 const updateEmailSerializer = require('../../infrastructure/serializers/jsonapi/update-email-serializer');
 const authenticationMethodsSerializer = require('../../infrastructure/serializers/jsonapi/authentication-methods-serializer');
+const campaignParticipationForUserManagementSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
@@ -315,5 +316,11 @@ module.exports = {
     return h.response().code(204);
   },
 
-  async findCampaignParticipationsForUserManagement() {},
+  async findCampaignParticipationsForUserManagement(request, h) {
+    const userId = request.params.id;
+    const campaignParticipations = await usecases.findCampaignParticipationsForUserManagement({
+      userId,
+    });
+    return h.response(campaignParticipationForUserManagementSerializer.serialize(campaignParticipations));
+  },
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -314,4 +314,6 @@ module.exports = {
     });
     return h.response().code(204);
   },
+
+  async findCampaignParticipationsForUserManagement() {},
 };

--- a/api/lib/domain/read-models/CampaignParticipationForUserManagement.js
+++ b/api/lib/domain/read-models/CampaignParticipationForUserManagement.js
@@ -1,0 +1,33 @@
+class CampaignParticipationForUserManagement {
+  constructor({
+    id,
+    participantExternalId,
+    status,
+    campaignId,
+    campaignCode,
+    createdAt,
+    sharedAt,
+    deletedAt,
+    deletedBy,
+    deletedByFirstName,
+    deletedByLastName,
+    organizationLearnerFirstName,
+    organizationLearnerLastName,
+  } = {}) {
+    this.id = id;
+    this.participantExternalId = participantExternalId;
+    this.status = status;
+    this.campaignId = campaignId;
+    this.campaignCode = campaignCode;
+    this.createdAt = createdAt;
+    this.sharedAt = sharedAt;
+    this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
+    if (this.deletedAt) {
+      this.deletedByFullName = deletedByFirstName + ' ' + deletedByLastName;
+    }
+    this.organizationLearnerFullName = organizationLearnerFirstName + ' ' + organizationLearnerLastName;
+  }
+}
+
+module.exports = CampaignParticipationForUserManagement;

--- a/api/lib/domain/usecases/find-campaign-participations-for-user-management.js
+++ b/api/lib/domain/usecases/find-campaign-participations-for-user-management.js
@@ -1,0 +1,6 @@
+module.exports = async function findCampaignParticipationsForUserManagement({
+  userId,
+  participationsForUserManagementRepository,
+}) {
+  return participationsForUserManagementRepository.findByUserId(userId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -100,6 +100,7 @@ const dependencies = {
   organizationsToAttachToTargetProfileRepository: require('../../infrastructure/repositories/organizations-to-attach-to-target-profile-repository'),
   participantResultRepository: require('../../infrastructure/repositories/participant-result-repository'),
   participationsForCampaignManagementRepository: require('../../infrastructure/repositories/participations-for-campaign-management-repository'),
+  participationsForUserManagementRepository: require('../../infrastructure/repositories/participations-for-user-management-repository'),
   partnerCertificationScoringRepository: require('../../infrastructure/repositories/partner-certification-scoring-repository'),
   passwordGenerator: require('../../domain/services/password-generator'),
   pickChallengeService: require('../services/pick-challenge-service'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -239,6 +239,7 @@ module.exports = injectDependencies(
     findAnswerByChallengeAndAssessment: require('./find-answer-by-challenge-and-assessment'),
     findAssessmentParticipationResultList: require('./find-assessment-participation-result-list'),
     findAssociationBetweenUserAndOrganizationLearner: require('./find-association-between-user-and-organization-learner'),
+    findCampaignParticipationsForUserManagement: require('./find-campaign-participations-for-user-management'),
     findCampaignProfilesCollectionParticipationSummaries: require('./find-campaign-profiles-collection-participation-summaries'),
     findCertificationCenterMembershipsByCertificationCenter: require('./find-certification-center-memberships-by-certification-center'),
     findCountries: require('./find-countries'),

--- a/api/lib/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-user-management-repository.js
@@ -1,0 +1,30 @@
+const { knex } = require('../../../db/knex-database-connection');
+const CampaignParticipationForUserManagement = require('../../domain/read-models/CampaignParticipationForUserManagement');
+
+module.exports = {
+  async findByUserId(userId) {
+    const campaignParticipations = await knex('campaign-participations')
+      .select({
+        id: 'campaign-participations.id',
+        participantExternalId: 'campaign-participations.participantExternalId',
+        status: 'campaign-participations.status',
+        campaignId: 'campaigns.id',
+        campaignCode: 'campaigns.code',
+        createdAt: 'campaign-participations.createdAt',
+        sharedAt: 'campaign-participations.sharedAt',
+        deletedAt: 'campaign-participations.deletedAt',
+        deletedBy: 'deletedByUsers.id',
+        deletedByFirstName: 'deletedByUsers.firstName',
+        deletedByLastName: 'deletedByUsers.lastName',
+        organizationLearnerFirstName: 'organization-learners.firstName',
+        organizationLearnerLastName: 'organization-learners.lastName',
+      })
+      .innerJoin('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .innerJoin('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+      .leftJoin('users as deletedByUsers', 'deletedByUsers.id', 'campaign-participations.deletedBy')
+      .where('campaign-participations.userId', userId)
+      .orderBy('createdAt', 'desc');
+
+    return campaignParticipations.map((attributes) => new CampaignParticipationForUserManagement(attributes));
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer.js
@@ -1,0 +1,20 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(campaignParticipation) {
+    return new Serializer('user-participation', {
+      attributes: [
+        'participantExternalId',
+        'status',
+        'campaignId',
+        'campaignCode',
+        'createdAt',
+        'sharedAt',
+        'deletedAt',
+        'deletedBy',
+        'deletedByFullName',
+        'organizationLearnerFullName',
+      ],
+    }).serialize(campaignParticipation);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -7,6 +7,7 @@ module.exports = {
       transform(record) {
         record.schoolingRegistrations = record.organizationLearners;
         record.profile = null;
+        record.participations = null;
         return record;
       },
       attributes: [
@@ -28,6 +29,7 @@ module.exports = {
         'organizationLearners',
         'authenticationMethods',
         'profile',
+        'participations',
       ],
       schoolingRegistrations: {
         ref: 'id',
@@ -74,6 +76,15 @@ module.exports = {
         relationshipLinks: {
           related: function (record, current, parent) {
             return `/api/admin/users/${parent.id}/profile`;
+          },
+        },
+      },
+      participations: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/admin/users/${parent.id}/participations`;
           },
         },
       },

--- a/api/tests/acceptance/application/users/find-campaign-participations-for-user-management_test.js
+++ b/api/tests/acceptance/application/users/find-campaign-participations-for-user-management_test.js
@@ -1,0 +1,53 @@
+const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | GET /api/admin/users/{id}/participations', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  it('should return participations', async function () {
+    // given
+    const user = databaseBuilder.factory.buildUser();
+    const campaign = databaseBuilder.factory.buildCampaign();
+    const organizationLearner = databaseBuilder.factory.buildOrganizationLearner();
+    const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+      userId: user.id,
+      campaignId: campaign.id,
+      organizationLearnerId: organizationLearner.id,
+    });
+    const admin = databaseBuilder.factory.buildUser.withRole();
+    await databaseBuilder.commit();
+
+    // when
+    const response = await server.inject({
+      method: 'GET',
+      url: `/api/admin/users/${user.id}/participations`,
+      headers: { authorization: generateValidRequestAuthorizationHeader(admin.id) },
+    });
+
+    // then
+    expect(response.statusCode).to.equal(200);
+    expect(response.result).to.deep.equal({
+      data: [
+        {
+          id: campaignParticipation.id.toString(),
+          type: 'user-participations',
+          attributes: {
+            'campaign-code': campaign.code,
+            'campaign-id': campaign.id,
+            'created-at': campaignParticipation.createdAt,
+            'deleted-at': null,
+            'deleted-by': null,
+            'participant-external-id': campaignParticipation.participantExternalId,
+            'shared-at': campaignParticipation.sharedAt,
+            status: campaignParticipation.status,
+            'organization-learner-full-name': `${organizationLearner.firstName} ${organizationLearner.lastName}`,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -8,7 +8,7 @@ const {
 
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | users-controller-get-user-profile', function () {
+describe('Acceptance | Controller | users-controller-get-user-details-for-admin', function () {
   let options;
   let server;
   let user;
@@ -101,6 +101,11 @@ describe('Acceptance | Controller | users-controller-get-user-profile', function
               profile: {
                 links: {
                   related: `/api/admin/users/${user.id}/profile`,
+                },
+              },
+              participations: {
+                links: {
+                  related: `/api/admin/users/${user.id}/participations`,
                 },
               },
             },

--- a/api/tests/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
@@ -1,0 +1,147 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const participationsForUserManagementRepository = require('../../../../lib/infrastructure/repositories/participations-for-user-management-repository');
+const _ = require('lodash');
+const CampaignParticipationForUserManagement = require('../../../../lib/domain/read-models/CampaignParticipationForUserManagement');
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+
+const { SHARED } = CampaignParticipationStatuses;
+
+describe('Integration | Repository | Participations-For-User-Management', function () {
+  describe('#findByUserId', function () {
+    let userId;
+
+    beforeEach(async function () {
+      userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+    });
+
+    context('when the given user has no participations', function () {
+      it('should return an empty array', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation();
+        await databaseBuilder.commit();
+
+        // when
+        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+
+        // then
+        expect(participationsForUserManagement).to.be.empty;
+      });
+    });
+
+    context('when the given user has participations', function () {
+      it('should return only participations for given user', async function () {
+        // given
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          participantExternalId: 'special',
+        });
+        const otherUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId: otherUserId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+
+        // then
+        expect(participationsForUserManagement).to.have.lengthOf(1);
+        expect(participationsForUserManagement[0].participantExternalId).to.equal(
+          campaignParticipation.participantExternalId
+        );
+      });
+
+      it('should return participations with all attributes', async function () {
+        // given
+        const campaign = databaseBuilder.factory.buildCampaign({ code: 'FUNCODE' });
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          firstName: 'Blanche',
+          lastName: 'Isserie',
+        });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          organizationLearnerId: organizationLearner.id,
+          campaignId: campaign.id,
+          participantExternalId: '123',
+          status: SHARED,
+          createdAt: new Date('2010-10-10'),
+          sharedAt: new Date('2010-10-11'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+
+        // then
+        expect(participationsForUserManagement[0]).to.be.instanceOf(CampaignParticipationForUserManagement);
+        expect(participationsForUserManagement[0]).to.deep.includes({
+          id: campaignParticipation.id,
+          participantExternalId: campaignParticipation.participantExternalId,
+          status: campaignParticipation.status,
+          createdAt: campaignParticipation.createdAt,
+          sharedAt: campaignParticipation.sharedAt,
+          campaignId: campaign.id,
+          campaignCode: campaign.code,
+          organizationLearnerFullName: `${organizationLearner.firstName} ${organizationLearner.lastName}`,
+        });
+      });
+
+      context('When a participation is deleted', function () {
+        it('should return participation with deletion attributes', async function () {
+          // given
+          const deletingUser = databaseBuilder.factory.buildUser({ id: 666, firstName: 'The', lastName: 'Terminator' });
+          const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+            userId,
+            deletedAt: new Date('2010-10-12'),
+            deletedBy: deletingUser.id,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+
+          // then
+          expect(participationsForUserManagement[0]).to.deep.includes({
+            deletedAt: campaignParticipation.deletedAt,
+            deletedBy: campaignParticipation.deletedBy,
+            deletedByFullName: 'The Terminator',
+          });
+        });
+      });
+
+      it('should sort participations by descending createdAt', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          participantExternalId: '2',
+          createdAt: new Date('2020-01-02'),
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          participantExternalId: '3',
+          createdAt: new Date('2020-01-01'),
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          participantExternalId: '1',
+          createdAt: new Date('2020-01-03'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const participationsForUserManagement = await participationsForUserManagementRepository.findByUserId(userId);
+
+        // then
+        expect(_.map(participationsForUserManagement, 'participantExternalId')).to.exactlyContainInOrder([
+          '1',
+          '2',
+          '3',
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-for-user-management.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-for-user-management.js
@@ -1,0 +1,34 @@
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+const CampaignParticipationForUserManagement = require('../../../../lib/domain/read-models/CampaignParticipationForUserManagement');
+
+module.exports = function buildCampaignParticipationForUserManagement({
+  id = 1,
+  participantExternalId = 'un identifiant externe',
+  status = CampaignParticipationStatuses.TO_SHARE,
+  campaignId = 2,
+  campaignCode = 'SOMECODE0',
+  createdAt = new Date(),
+  sharedAt = null,
+  deletedAt = null,
+  deletedBy = null,
+  deletedByFirstName = null,
+  deletedByLastName = null,
+  organizationLearnerFirstName = null,
+  organizationLearnerLastName = null,
+} = {}) {
+  return new CampaignParticipationForUserManagement({
+    id,
+    campaignId,
+    campaignCode,
+    participantExternalId,
+    status,
+    createdAt,
+    sharedAt,
+    deletedAt,
+    deletedBy,
+    deletedByFirstName,
+    deletedByLastName,
+    organizationLearnerFirstName,
+    organizationLearnerLastName,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -16,6 +16,7 @@ module.exports = {
   buildCampaignCollectiveResult: require('./build-campaign-collective-result'),
   buildCampaignParticipation: require('./build-campaign-participation'),
   buildCampaignParticipationBadge: require('./build-campaign-participation-badge'),
+  buildCampaignParticipationForUserManagement: require('./build-campaign-participation-for-user-management'),
   buildCampaignParticipationResult: require('./build-campaign-participation-result'),
   buildCampaignParticipationInfo: require('./build-campaign-participation-info'),
   buildCampaignManagement: require('./build-campaign-management'),

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1178,5 +1178,42 @@ describe('Unit | Router | user-router', function () {
         expect(result.statusCode).to.equal(403);
       });
     });
+
+    describe('GET /api/admin/users/{id}/participations', function () {
+      it('should return an HTTP status code 200', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(userController, 'findCampaignParticipationsForUserManagement').resolves('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/users/8/participations');
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(userController.findCampaignParticipationsForUserManagement);
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return an HTTP status code 403', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+          h
+            .response({ errors: new Error('') })
+            .code(403)
+            .takeover()
+        );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/users/8/participations');
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        expect(response.statusCode).to.equal(403);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/find-campaign-participations-for-user-management_test.js
+++ b/api/tests/unit/domain/usecases/find-campaign-participations-for-user-management_test.js
@@ -1,0 +1,31 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const findCampaignParticipationsForUserManagement = require('../../../../lib/domain/usecases/find-campaign-participations-for-user-management');
+
+describe('Unit | UseCase | findCampaignParticipationsForUserManagement', function () {
+  const userId = 1;
+  let expectedParticipationsForUserManagement;
+
+  beforeEach(function () {
+    expectedParticipationsForUserManagement = [
+      domainBuilder.buildParticipationForCampaignManagement(),
+      domainBuilder.buildParticipationForCampaignManagement(),
+      domainBuilder.buildParticipationForCampaignManagement(),
+    ];
+  });
+
+  it('should fetch campaign participations matching campaign', async function () {
+    const participationsForUserManagementRepository = {
+      findByUserId: sinon.stub(),
+    };
+    participationsForUserManagementRepository.findByUserId
+      .withArgs(userId)
+      .resolves(expectedParticipationsForUserManagement);
+
+    const foundParticipationsForUserManagement = await findCampaignParticipationsForUserManagement({
+      userId,
+      participationsForUserManagementRepository,
+    });
+
+    expect(foundParticipationsForUserManagement).to.deep.equal(expectedParticipationsForUserManagement);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer_test.js
@@ -1,0 +1,49 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer');
+
+describe('Unit | Serializer | JSONAPI | campaign-participation-for-user-management-serializer', function () {
+  describe('#serialize()', function () {
+    it('should convert a participation model object into JSON API data', function () {
+      // given
+      const participationForUserManagement = domainBuilder.buildCampaignParticipationForUserManagement({
+        id: 123,
+        status: 'SHARED',
+        campaignId: 456,
+        campaignCode: 'AZERTY123',
+        createdAt: new Date('2020-10-10'),
+        sharedAt: new Date('2020-10-11'),
+        deletedAt: new Date('2020-10-12'),
+        deletedBy: 666,
+        deletedByFirstName: 'King',
+        deletedByLastName: 'Cong',
+        organizationLearnerFirstName: 'Some',
+        organizationLearnerLastName: 'Learner',
+      });
+
+      // when
+      const json = serializer.serialize([participationForUserManagement]);
+
+      // then
+      expect(json).to.deep.equal({
+        data: [
+          {
+            type: 'user-participations',
+            id: participationForUserManagement.id.toString(),
+            attributes: {
+              'participant-external-id': participationForUserManagement.participantExternalId,
+              status: participationForUserManagement.status,
+              'campaign-id': participationForUserManagement.campaignId,
+              'campaign-code': participationForUserManagement.campaignCode,
+              'created-at': participationForUserManagement.createdAt,
+              'shared-at': participationForUserManagement.sharedAt,
+              'deleted-at': participationForUserManagement.deletedAt,
+              'deleted-by': participationForUserManagement.deletedBy,
+              'deleted-by-full-name': participationForUserManagement.deletedByFullName,
+              'organization-learner-full-name': participationForUserManagement.organizationLearnerFullName,
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -70,6 +70,11 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
                 related: `/api/admin/users/${userDetailsForAdmin.id}/profile`,
               },
             },
+            participations: {
+              links: {
+                related: `/api/admin/users/${userDetailsForAdmin.id}/participations`,
+              },
+            },
           },
           id: `${userDetailsForAdmin.id}`,
           type: 'users',


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui on a aucun moyen de voir les différentes participations à des campagnes d'un utilisateur.

## :robot: Solution
Afficher cette liste de participations dans le détail d'un utilisateur.

## :rainbow: Remarques
Tout est sur la même page pour l'instant, mettre tout sur des pages différentes nécessite un peu de refacto, cela pourra être fait dans une PR ultérieure.

## :100: Pour tester
Aller sur le détail de jaune attend, voir qu'il y plein de participations. Aller sur le détail de sup admin, voir qu'il n'y a aucune participation.
