### PR TITLE
[FEATURE] Permettre la suppression d'une participation pour un prescrit depuis la page utilisateurs de Pix Admin (PIX-5369).

### DIFF
--- a/admin/app/adapters/user-participation.js
+++ b/admin/app/adapters/user-participation.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class UserParticipations extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForDeleteRecord(id) {
+    const baseUrl = this.buildURL();
+    return `${baseUrl}/campaign-participations/${id}`;
+  }
+}

--- a/admin/app/components/users/user-detail-personal-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information.hbs
@@ -26,7 +26,10 @@
 </section>
 
 <section class="page-section">
-  <Users::UserDetailPersonalInformation::CampaignParticipations @participations={{@user.participations}} />
+  <Users::UserDetailPersonalInformation::CampaignParticipations
+    @participations={{@user.participations}}
+    @removeParticipation={{@removeParticipation}}
+  />
 </section>
 
 <ConfirmPopup

--- a/admin/app/components/users/user-detail-personal-information/campaign-participations.hbs
+++ b/admin/app/components/users/user-detail-personal-information/campaign-participations.hbs
@@ -13,6 +13,9 @@
         <th>Statut</th>
         <th>Date d'envoi</th>
         <th>Supprimé le</th>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          <th>Actions</th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
@@ -45,6 +48,19 @@
           {{else}}
             <td>-</td>
           {{/if}}
+          {{#if this.accessControl.hasAccessToUsersActionsScope}}
+            <td>
+              {{#unless participation.deletedAt}}
+                <PixButton
+                  @triggerAction={{fn this.toggleDisplayRemoveParticipationModal participation}}
+                  @size="small"
+                  @backgroundColor="red"
+                >
+                  Supprimer
+                </PixButton>
+              {{/unless}}
+            </td>
+          {{/if}}
         </tr>
       {{/each}}
     </tbody>
@@ -53,3 +69,13 @@
     <div class="table__empty">Aucune participation</div>
   {{/unless}}
 </div>
+
+<ConfirmPopup
+  @message="Vous êtes sur le point de supprimer la ou les participation(s) de {{this.participationToDelete.organizationLearnerFullName}} (y compris celles améliorées), celle-ci ne sera plus visible ni comprise dans les statistiques de la campagne de Pix Orga. Le participant pourra terminer son parcours mais ne pourra plus envoyer ses résultats. Il ne pourra pas non plus participer de nouveau à cette campagne."
+  @title="Supprimer cette participation ?"
+  @submitTitle="Oui, je supprime"
+  @submitButtonType="danger"
+  @confirm={{this.removeParticipation}}
+  @cancel={{this.toggleDisplayRemoveParticipationModal}}
+  @show={{this.displayRemoveParticipationModal}}
+/>

--- a/admin/app/components/users/user-detail-personal-information/campaign-participations.js
+++ b/admin/app/components/users/user-detail-personal-information/campaign-participations.js
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class CampaignParticipation extends Component {
+  @service accessControl;
+  @service notifications;
+
+  @tracked displayRemoveParticipationModal = false;
+  @tracked participationToDelete = null;
+
+  @action
+  toggleDisplayRemoveParticipationModal(participation) {
+    this.participationToDelete = participation;
+    this.displayRemoveParticipationModal = !this.displayRemoveParticipationModal;
+  }
+
+  @action
+  async removeParticipation() {
+    try {
+      await this.args.removeParticipation(this.participationToDelete);
+    } finally {
+      this.toggleDisplayRemoveParticipationModal();
+    }
+  }
+}

--- a/admin/app/controllers/authenticated/users/get.js
+++ b/admin/app/controllers/authenticated/users/get.js
@@ -53,6 +53,18 @@ export default class GetController extends Controller {
     }
   }
 
+  @action
+  async removeParticipation(campaignParticipation) {
+    try {
+      await campaignParticipation.deleteRecord();
+      await campaignParticipation.save();
+      await this.model.participations.reload();
+      this.notifications.success('La participation du prescrit a été supprimée avec succès.');
+    } catch (e) {
+      this.notifications.error('Une erreur est survenue lors de la suppression de la participation.');
+    }
+  }
+
   _handleResponseError(errorResponse, identityProvider) {
     const { errors } = errorResponse;
 

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -13,5 +13,6 @@
     @removeAuthenticationMethod={{this.removeAuthenticationMethod}}
     @addPixAuthenticationMethod={{this.addPixAuthenticationMethod}}
     @reassignAuthenticationMethod={{this.reassignAuthenticationMethod}}
+    @removeParticipation={{this.removeParticipation}}
   />
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -205,6 +205,20 @@ export default function () {
   this.patch('/admin/organizations/:id');
 
   this.get('/admin/users/:id');
+  this.get('/admin/users/:id/participations', (schema) => {
+    return schema.userParticipations.all();
+  });
+
+  this.delete('/admin/campaign-participations/:id', (schema, request) => {
+    const participationId = request.params.id;
+    const participation = schema.userParticipations.find(participationId);
+    participation.update({
+      deletedAt: new Date('2012-12-12'),
+      deletedByFullName: 'Terry Dicule',
+    });
+
+    return new Response(204);
+  });
 
   this.patch('/admin/users/:id', (schema, request) => {
     const userId = request.params.id;

--- a/admin/mirage/serializers/user.js
+++ b/admin/mirage/serializers/user.js
@@ -4,4 +4,12 @@ const _includes = ['schoolingRegistrations', 'authenticationMethods'];
 
 export default ApplicationSerializer.extend({
   include: _includes,
+
+  links(user) {
+    return {
+      participations: {
+        related: `/api/admin/users/${user.id}/participations`,
+      },
+    };
+  },
 });

--- a/admin/tests/acceptance/user-details-personal-information_test.js
+++ b/admin/tests/acceptance/user-details-personal-information_test.js
@@ -158,4 +158,30 @@ module('Acceptance | User details personal information', function (hooks) {
       assert.dom(screen.queryByText('Supprimer')).doesNotExist();
     });
   });
+
+  module('when administrator click on delete participation button', function () {
+    test('should mark participation as deleted', async function (assert) {
+      // given
+      const userParticipation = this.server.create('user-participation', { deletedAt: null });
+      const user = server.create('user');
+      user.participations = [userParticipation];
+      user.save();
+      this.server.create('admin-member', {
+        userId: user.id,
+        isSuperAdmin: true,
+      });
+      await createAuthenticateSession({ userId: user.id });
+
+      const screen = await visit(`/users/${user.id}`);
+
+      // when
+      await click(screen.getByRole('button', { name: 'Supprimer' }));
+      await clickByName('Oui, je supprime');
+
+      // then
+      assert.dom(screen.getByText('La participation du prescrit a été supprimée avec succès.')).exists();
+      assert.dom(screen.getByText('12/12/2012 par')).exists();
+      assert.dom(screen.getByRole('link', { name: 'Terry Dicule' })).exists();
+    });
+  });
 });

--- a/admin/tests/integration/components/users/user-detail-personal-information/campaign-participations_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/campaign-participations_test.js
@@ -1,131 +1,230 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import sinon from 'sinon';
 
 module('Integration | Component | users | user-detail-personal-information/campaign-participation', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display a list of participations', async function (assert) {
-    // given
-    const participation1 = EmberObject.create({
-      campaignCode: 'SOMECODE',
+  module('When the admin member does not have access to users actions scope', function (hooks) {
+    class AccessControlStub extends Service {
+      hasAccessToUsersActionsScope = false;
+    }
+    hooks.beforeEach(function () {
+      this.owner.register('service:access-control', AccessControlStub);
     });
-    const participation2 = EmberObject.create({
-      campaignCode: 'SOMEOTHERCODE',
+
+    test('it should display a list of participations', async function (assert) {
+      // given
+      const participation1 = EmberObject.create({
+        campaignCode: 'SOMECODE',
+      });
+      const participation2 = EmberObject.create({
+        campaignCode: 'SOMEOTHERCODE',
+      });
+      const participations = [participation1, participation2];
+      this.set('participations', participations);
+
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByLabelText('Participation').length, 2);
     });
-    const participations = [participation1, participation2];
-    this.set('participations', participations);
 
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
+    test('it should display an empty table when no participations', async function (assert) {
+      // given
+      const participations = [];
+      this.set('participations', participations);
 
-    // then
-    assert.strictEqual(screen.getAllByLabelText('Participation').length, 2);
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByText('Aucune participation')).exists();
+    });
+
+    test('it should display campaign information', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        campaignCode: 'SOMECODE',
+        campaignId: 1,
+      });
+      this.set('participations', [participation]);
+
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByText('SOMECODE')).exists();
+      assert.dom(screen.getByRole('link', { name: 'SOMECODE' })).exists();
+    });
+
+    test('it should display orgnaization learner information', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        organizationLearnerFullName: 'Un nom bien long',
+      });
+      this.set('participations', [participation]);
+
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByText('Un nom bien long')).exists();
+    });
+
+    test('it should display participation information', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        participantExternalId: 'Some external id',
+        createdAt: new Date('2020-01-01'),
+        displayedStatus: 'Envoyé',
+      });
+      this.set('participations', [participation]);
+
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByText('Some external id')).exists();
+      assert.dom(screen.getByText('01/01/2020')).exists();
+      assert.dom(screen.getByText('Envoyé')).exists();
+    });
+
+    test('it should display shared date if participation is shared', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        sharedAt: new Date('2020-01-01'),
+      });
+      this.set('participations', [participation]);
+
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByText('01/01/2020')).exists();
+    });
+
+    test('it should display deletedByFullName and deletedAt if participation is deleted', async function (assert) {
+      // given
+      const participation = EmberObject.create({
+        deletedAt: new Date('2022-01-01'),
+        deletedByFullName: 'le coupable',
+      });
+      this.set('participations', [participation]);
+
+      // when
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // then
+      assert.dom(screen.getByText('01/01/2022 par')).exists();
+      assert.dom(screen.getByRole('link', { name: 'le coupable' })).exists();
+    });
+
+    test('it should not be able to see action button "Supprimer"', async function (assert) {
+      // Given
+      const participation = EmberObject.create({
+        deletedAt: null,
+      });
+
+      this.set('participations', [participation]);
+
+      // When
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // Then
+      assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
+    });
   });
 
-  test('it should display an empty table when no participations', async function (assert) {
-    // given
-    const participations = [];
-    this.set('participations', participations);
+  module('When the admin member has access to users actions scope', function () {
+    test('it should be able to see action button "Supprimer"', async function (assert) {
+      // Given
+      const participation = EmberObject.create({
+        deletedAt: null,
+      });
 
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
+      class AccessControlStub extends Service {
+        hasAccessToUsersActionsScope = true;
+      }
+      this.set('participations', [participation]);
+      this.owner.register('service:access-control', AccessControlStub);
 
-    // then
-    assert.dom(screen.getByText('Aucune participation')).exists();
-  });
+      // When
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
 
-  test('it should display campaign information', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      campaignCode: 'SOMECODE',
-      campaignId: 1,
+      // Then
+      assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).exists();
     });
-    this.set('participations', [participation]);
 
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
+    test('it should hide button "Supprimer" if participation is already deleted', async function (assert) {
+      // Given
+      const participation = EmberObject.create({
+        deletedAt: new Date('2022-01-01'),
+        deletedByFullName: 'le coupable',
+      });
 
-    // then
-    assert.dom(screen.getByText('SOMECODE')).exists();
-    assert.dom(screen.getByRole('link', { name: 'SOMECODE' })).exists();
-  });
+      class AccessControlStub extends Service {
+        hasAccessToUsersActionsScope = true;
+      }
+      this.set('participations', [participation]);
+      this.owner.register('service:access-control', AccessControlStub);
 
-  test('it should display orgnaization learner information', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      organizationLearnerFullName: 'Un nom bien long',
+      // When
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
+      );
+
+      // Then
+      assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
     });
-    this.set('participations', [participation]);
 
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
+    test('it should be able to delete participation', async function (assert) {
+      // Given
+      this.removeParticipation = sinon.stub();
+      const participation = EmberObject.create({
+        deletedAt: null,
+      });
 
-    // then
-    assert.dom(screen.getByText('Un nom bien long')).exists();
-  });
+      class AccessControlStub extends Service {
+        hasAccessToUsersActionsScope = true;
+      }
+      this.set('participations', [participation]);
+      this.owner.register('service:access-control', AccessControlStub);
 
-  test('it should display participation information', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      participantExternalId: 'Some external id',
-      createdAt: new Date('2020-01-01'),
-      displayedStatus: 'Envoyé',
+      // When
+      const screen = await render(
+        hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}} @removeParticipation={{this.removeParticipation}}/>`
+      );
+      await clickByName('Supprimer');
+
+      // Then
+      assert.dom(screen.getByText('Supprimer cette participation ?')).exists();
+      await clickByName('Oui, je supprime');
+
+      sinon.assert.calledWith(this.removeParticipation, participation);
     });
-    this.set('participations', [participation]);
-
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
-
-    // then
-    assert.dom(screen.getByText('Some external id')).exists();
-    assert.dom(screen.getByText('01/01/2020')).exists();
-    assert.dom(screen.getByText('Envoyé')).exists();
-  });
-
-  test('it should display shared date if participation is shared', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      sharedAt: new Date('2020-01-01'),
-    });
-    this.set('participations', [participation]);
-
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
-
-    // then
-    assert.dom(screen.getByText('01/01/2020')).exists();
-  });
-
-  test('it should display deletedByFullName and deletedAt if participation is deleted', async function (assert) {
-    // given
-    const participation = EmberObject.create({
-      deletedAt: new Date('2022-01-01'),
-      deletedByFullName: 'le coupable',
-    });
-    this.set('participations', [participation]);
-
-    // when
-    const screen = await render(
-      hbs`<Users::UserDetailPersonalInformation::CampaignParticipations @participations={{participations}}/>`
-    );
-
-    // then
-    assert.dom(screen.getByText('01/01/2022 par')).exists();
-    assert.dom(screen.getByRole('link', { name: 'le coupable' })).exists();
   });
 });

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -158,5 +158,16 @@ module.exports = {
     return h.response({}).code(204);
   },
 
-  deleteCampaignParticipationForAdmin() {},
+  async deleteCampaignParticipationForAdmin(request, h) {
+    const { userId } = request.auth.credentials;
+    const { id: campaignParticipationId } = request.params;
+    await DomainTransaction.execute(async (domainTransaction) => {
+      await usecases.deleteCampaignParticipationForAdmin({
+        userId,
+        campaignParticipationId,
+        domainTransaction,
+      });
+    });
+    return h.response({}).code(204);
+  },
 };

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -157,4 +157,6 @@ module.exports = {
     await usecases.updateParticipantExternalId({ campaignParticipationId, participantExternalId });
     return h.response({}).code(204);
   },
+
+  deleteCampaignParticipationForAdmin() {},
 };

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -213,6 +213,29 @@ exports.register = async function (server) {
         ],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/admin/campaign-participations/{id}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignParticipationId,
+          }),
+        },
+        handler: campaignParticipationController.deleteCampaignParticipationForAdmin,
+        notes: ['- Permet à un administrateur de supprimer une participation à une campagne'],
+        tags: ['api', 'campaign-participations'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/usecases/delete-campaign-participation-for-admin.js
+++ b/api/lib/domain/usecases/delete-campaign-participation-for-admin.js
@@ -1,0 +1,24 @@
+const bluebird = require('bluebird');
+
+module.exports = async function deleteCampaignParticipationForAdmin({
+  userId,
+  campaignParticipationId,
+  domainTransaction,
+  campaignRepository,
+  campaignParticipationRepository,
+}) {
+  const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
+
+  const campaignParticipations =
+    await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
+      campaignId,
+      campaignParticipationId,
+      domainTransaction,
+    });
+
+  await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
+    campaignParticipation.delete(userId);
+    const { id, deletedAt, deletedBy } = campaignParticipation;
+    await campaignParticipationRepository.delete({ id, deletedAt, deletedBy, domainTransaction });
+  });
+};

--- a/api/lib/domain/usecases/delete-campaign-participation.js
+++ b/api/lib/domain/usecases/delete-campaign-participation.js
@@ -7,11 +7,12 @@ module.exports = async function deleteCampaignParticipation({
   campaignParticipationId,
   campaignParticipationRepository,
 }) {
-  const campaignParticipations = await campaignParticipationRepository.getAllCampaignParticipationsForAUser({
-    campaignId,
-    campaignParticipationId,
-    domainTransaction,
-  });
+  const campaignParticipations =
+    await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
+      campaignId,
+      campaignParticipationId,
+      domainTransaction,
+    });
 
   await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
     campaignParticipation.delete(userId);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -222,6 +222,7 @@ module.exports = injectDependencies(
     createUserAndReconcileToOrganizationLearnerFromExternalUser: require('./create-user-and-reconcile-to-organization-learner-from-external-user'),
     createUserFromExternalIdentityProvider: require('./create-user-from-external-identity-provider'),
     deleteCampaignParticipation: require('./delete-campaign-participation'),
+    deleteCampaignParticipationForAdmin: require('./delete-campaign-participation-for-admin'),
     deleteCertificationIssueReport: require('./delete-certification-issue-report'),
     deleteSessionJuryComment: require('./delete-session-jury-comment'),
     deleteSession: require('./delete-session'),

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -164,11 +164,15 @@ module.exports = {
     return mapToParticipationByStatus(row, campaignType);
   },
 
-  async getAllCampaignParticipationsForAUser({ campaignId, campaignParticipationId, domainTransaction }) {
+  async getAllCampaignParticipationsInCampaignForASameLearner({
+    campaignId,
+    campaignParticipationId,
+    domainTransaction,
+  }) {
     const knexConn = domainTransaction.knexTransaction;
     const result = await knexConn('campaign-participations')
       .select('organizationLearnerId')
-      .where({ id: campaignParticipationId, campaignId: campaignId })
+      .where({ id: campaignParticipationId, campaignId })
       .first();
 
     if (!result) {

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -105,4 +105,15 @@ module.exports = {
     if (!campaign) return null;
     return campaign.code;
   },
+
+  async getCampaignIdByCampaignParticipationId(campaignParticipationId) {
+    const campaign = await knex('campaigns')
+      .select('campaigns.id')
+      .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+      .where({ 'campaign-participations.id': campaignParticipationId })
+      .first();
+
+    if (!campaign) return null;
+    return campaign.id;
+  },
 };

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -8,6 +8,7 @@ const {
   learningContentBuilder,
   generateValidRequestAuthorizationHeader,
   knex,
+  insertUserWithRoleSuperAdmin,
 } = require('../../test-helper');
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;
@@ -339,6 +340,27 @@ describe('Acceptance | API | Campaign Participations', function () {
       expect(response.statusCode).to.equal(200);
       const campaignProfile = response.result.data.attributes;
       expect(campaignProfile['external-id']).to.equal('Die Hard');
+    });
+  });
+
+  describe('DELETE /api/admin/campaign-participations/{id}', function () {
+    it('should return 204 HTTP status code', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'DELETE',
+        url: `/api/admin/campaign-participations/${campaignParticipationId}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(superAdmin.id) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/integration/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/integration/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -1,0 +1,47 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+
+const deleteCampaignParticipationForAdmin = require('../../../../lib/domain/usecases/delete-campaign-participation-for-admin');
+
+describe('Integration | UseCases | delete-campaign-participation-for-admin', function () {
+  it('should delete all campaignParticipations', async function () {
+    // given
+    const adminUserId = databaseBuilder.factory.buildUser().id;
+    const campaignId = databaseBuilder.factory.buildCampaign().id;
+    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+    databaseBuilder.factory.buildCampaignParticipation({
+      isImproved: true,
+      organizationLearnerId,
+      campaignId,
+    });
+    const campaignParticipationToDelete = databaseBuilder.factory.buildCampaignParticipation({
+      isImproved: false,
+      organizationLearnerId,
+      campaignId,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await DomainTransaction.execute((domainTransaction) => {
+      return deleteCampaignParticipationForAdmin({
+        userId: adminUserId,
+        campaignParticipationId: campaignParticipationToDelete.id,
+        domainTransaction,
+        campaignRepository,
+        campaignParticipationRepository,
+      });
+    });
+
+    // then
+    const results = await knex('campaign-participations').where({ organizationLearnerId });
+
+    expect(results.length).to.equal(2);
+    results.forEach((campaignParticipaton) => {
+      expect(campaignParticipaton.deletedAt).not.to.equal(null);
+      expect(campaignParticipaton.deletedBy).to.equal(adminUserId);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1193,7 +1193,7 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
   });
 
-  describe('#getAllCampaignParticipationsForAUser', function () {
+  describe('#getAllCampaignParticipationsInCampaignForASameLearner', function () {
     let campaignId;
     let organizationLearnerId;
     let organizationId;
@@ -1218,7 +1218,7 @@ describe('Integration | Repository | Campaign Participation', function () {
 
         const error = await catchErr(async function () {
           await DomainTransaction.execute(async (domainTransaction) => {
-            await campaignParticipationRepository.getAllCampaignParticipationsForAUser({
+            await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
               campaignId,
               campaignParticipationId: campaignParticipationToDelete.id,
               domainTransaction,
@@ -1248,7 +1248,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         const participations = await DomainTransaction.execute((domainTransaction) => {
-          return campaignParticipationRepository.getAllCampaignParticipationsForAUser({
+          return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
             campaignId,
             campaignParticipationId: campaignParticipationToDelete.id,
             domainTransaction,
@@ -1281,7 +1281,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         const participations = await DomainTransaction.execute((domainTransaction) => {
-          return campaignParticipationRepository.getAllCampaignParticipationsForAUser({
+          return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
             campaignId,
             campaignParticipationId: campaignParticipationToDelete.id,
             domainTransaction,
@@ -1315,7 +1315,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         await databaseBuilder.commit();
 
         const participations = await DomainTransaction.execute((domainTransaction) => {
-          return campaignParticipationRepository.getAllCampaignParticipationsForAUser({
+          return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
             campaignId,
             campaignParticipationId: campaignParticipationToDelete.id,
             domainTransaction,

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -436,4 +436,49 @@ describe('Integration | Repository | Campaign', function () {
       expect(code).to.equal('CAMPAIGN2');
     });
   });
+
+  describe('#getCampaignIdByCampaignParticipationId', function () {
+    it('should return campaign id', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(campaignId).to.equal(campaign.id);
+    });
+
+    it('should return null when campaignParticipationId does not exist', async function () {
+      // when
+      const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(123);
+
+      // then
+      expect(campaignId).to.be.null;
+    });
+
+    it('should return the campaign id from the given campaignParticipationId', async function () {
+      // given
+      const campaign = databaseBuilder.factory.buildCampaign();
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+      }).id;
+
+      const otherCampaignId = databaseBuilder.factory.buildCampaign().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(campaignId).to.equal(campaign.id);
+    });
+  });
 });

--- a/api/tests/unit/application/campaign-participations/index_test.js
+++ b/api/tests/unit/application/campaign-participations/index_test.js
@@ -187,4 +187,41 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       });
     });
   });
+
+  describe('DELETE /api/admin/campaign-participations/{id}', function () {
+    it('should return an HTTP status code 200', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(campaignParticipationController, 'deleteCampaignParticipationForAdmin').resolves('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/admin/campaign-participations/2');
+
+      // then
+      sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+      sinon.assert.calledOnce(campaignParticipationController.deleteCampaignParticipationForAdmin);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return an HTTP status code 403', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+        h
+          .response({ errors: new Error('') })
+          .code(403)
+          .takeover()
+      );
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('DELETE', '/api/admin/campaign-participations/2');
+
+      // then
+      sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -1,0 +1,82 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { deleteCampaignParticipationForAdmin } = require('../../../../lib/domain/usecases');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+describe('Unit | UseCase | delete-campaign-participation-for-admin', function () {
+  //given
+  let clock;
+  const now = new Date('2021-09-25');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(now.getTime());
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('should call repository method to delete a campaign participation', async function () {
+    const campaignRepository = {
+      getCampaignIdByCampaignParticipationId: sinon.stub(),
+    };
+    const campaignParticipationRepository = {
+      getAllCampaignParticipationsInCampaignForASameLearner: sinon.stub(),
+      delete: sinon.stub(),
+    };
+    const campaignParticipationId = 1234;
+    const domainTransaction = Symbol('domainTransaction');
+    const campaignId = domainBuilder.buildCampaign().id;
+    const ownerId = domainBuilder.buildUser().id;
+    const organizationLearnerId = domainBuilder.buildOrganizationLearner().id;
+
+    const campaignParticipation1 = new CampaignParticipation({
+      id: campaignParticipationId,
+      organizationLearnerId,
+      deletedAt: null,
+      deletedBy: null,
+      campaignId,
+    });
+
+    const campaignParticipation2 = new CampaignParticipation({
+      id: 1235,
+      deletedAt: null,
+      deletedBy: null,
+    });
+
+    const campaignParticipations = [campaignParticipation1, campaignParticipation2];
+
+    campaignRepository.getCampaignIdByCampaignParticipationId.withArgs(campaignParticipationId).resolves(campaignId);
+    campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner
+      .withArgs({
+        campaignId,
+        campaignParticipationId,
+        domainTransaction,
+      })
+      .resolves(campaignParticipations);
+
+    //when
+    await deleteCampaignParticipationForAdmin({
+      userId: ownerId,
+      campaignParticipationId,
+      domainTransaction,
+      campaignRepository,
+      campaignParticipationRepository,
+    });
+
+    //then
+    expect(campaignParticipationRepository.delete).to.have.been.calledTwice;
+    campaignParticipations.forEach((campaignParticipation) => {
+      const deletedCampaignParticipation = new CampaignParticipation({
+        ...campaignParticipation,
+        deletedAt: now,
+        deletedBy: ownerId,
+      });
+      expect(campaignParticipationRepository.delete).to.have.been.calledWithExactly({
+        id: deletedCampaignParticipation.id,
+        deletedAt: deletedCampaignParticipation.deletedAt,
+        deletedBy: deletedCampaignParticipation.deletedBy,
+        domainTransaction,
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/delete-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/delete-campaign-participation_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
 
   it('should call repository method to delete a campaign participation', async function () {
     const campaignParticipationRepository = {
-      getAllCampaignParticipationsForAUser: sinon.stub(),
+      getAllCampaignParticipationsInCampaignForASameLearner: sinon.stub(),
       delete: sinon.stub(),
     };
     const campaignParticipationId = 1234;
@@ -42,7 +42,7 @@ describe('Unit | UseCase | delete-campaign-participation', function () {
 
     const campaignParticipations = [campaignParticipation1, campaignParticipation2];
 
-    await campaignParticipationRepository.getAllCampaignParticipationsForAUser
+    await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner
       .withArgs({
         campaignId,
         campaignParticipationId,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement le support ne peut pas (après accord du prescripteur) supprimer une participation. Exemple avec Pôle emploi qui n'a pas accès à Pix Orga.

## :robot: Solution
Permettre cette suppression depuis Pix Admin, avec les droits au SUPERADMIN ainsi qu'au SUPPORT.

## :rainbow: Remarques
La page d'un user est chargée, le split en plusieurs onglets pourra se faire dans un second temps.

## :100: Pour tester
Supprimer une participation depuis la page d'un user, ainsi qu'une participation multiples, cela doit bien supprimer les 2 et recharger la page.
