### PR TITLE
[TECH] Corriger les sinon.stub().withArgs() qui ne fonctionnent pas

### DIFF
--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -170,6 +170,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       estimatedLevel;
 
     beforeEach(async function () {
+      // given
       userId = 'dummyUserId';
       assessmentId = 21;
       campaignParticipationId = 456;
@@ -216,6 +217,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
         possibleChallenges,
       });
 
+      // when
       actualNextChallenge = await getNextChallengeForCampaignAssessment({
         assessment,
         answerRepository,
@@ -228,14 +230,17 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
     });
 
     it('should have fetched the answers', function () {
+      // then
       expect(answerRepository.findByAssessment).to.have.been.calledWithExactly(assessmentId);
     });
 
     it('should have fetched the challenges', function () {
+      // then
       expect(challengeRepository.findFlashCompatible).to.have.been.called;
     });
 
     it('should have fetched the next challenge with only most recent knowledge elements', function () {
+      // then
       const allAnswers = [lastAnswer];
       expect(flash.getPossibleNextChallenges).to.have.been.calledWithExactly({
         allAnswers,
@@ -245,6 +250,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
     });
 
     it('should have returned the next challenge', function () {
+      // then
       expect(actualNextChallenge.id).to.equal(challengeWeb22.id);
     });
   });

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -191,8 +191,9 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
 
       estimatedLevel = Symbol('estimatedLevel');
       flashAssessmentResultRepository = {
-        getLatestByAssessmentId: sinon.stub().withArgs(assessmentId).resolves({ estimatedLevel }),
+        getLatestByAssessmentId: sinon.stub(),
       };
+      flashAssessmentResultRepository.getLatestByAssessmentId.withArgs(assessmentId).resolves({ estimatedLevel });
 
       const web2 = domainBuilder.buildSkill({ name: '@web2' });
       challengeWeb21 = domainBuilder.buildChallenge({ id: 'challenge_web2_1' });

--- a/api/tests/unit/domain/events/compute-campaign-participation-results_test.js
+++ b/api/tests/unit/domain/events/compute-campaign-participation-results_test.js
@@ -22,7 +22,8 @@ describe('Unit | Domain | Events | compute-campaign-participation-results', func
     // given
     const participationResultsShared = Symbol('participation results shared');
     const event = new CampaignParticipationResultsShared({ campaignParticipationId: 1 });
-    const participantResultsSharedRepository = { get: sinon.stub().withArgs(1).resolves(participationResultsShared) };
+    const participantResultsSharedRepository = { get: sinon.stub() };
+    participantResultsSharedRepository.get.withArgs(1).resolves(participationResultsShared);
     const campaignParticipationRepository = { update: sinon.stub() };
 
     // when

--- a/api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js
+++ b/api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js
@@ -58,8 +58,9 @@ describe('Unit | UseCase | generate-username-with-temporary-password', function 
       updateUsernameAndPassword: sinon.stub().resolves(),
     };
     organizationLearnerRepository = {
-      get: sinon.stub().withArgs(organizationLearnerId).resolves(organizationLearner),
+      get: sinon.stub(),
     };
+    organizationLearnerRepository.get.withArgs(organizationLearnerId).resolves(organizationLearner);
   });
 
   it('should generate username and temporary password', async function () {

--- a/api/tests/unit/domain/usecases/save-admin-member_test.js
+++ b/api/tests/unit/domain/usecases/save-admin-member_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | save-admin-member', function () {
       // given
       const attributes = { email: 'ice.bot@example.net', role: ROLES.SUPER_ADMIN };
       const adminMemberRepository = {};
-      const userRepository = { getByEmail: sinon.stub().withArgs(attributes.email).rejects(new UserNotFoundError()) };
+      const userRepository = { getByEmail: sinon.stub().rejects(new UserNotFoundError()) };
 
       // when
       const error = await catchErr(saveAdminMember)({ ...attributes, adminMemberRepository, userRepository });
@@ -33,11 +33,13 @@ describe('Unit | UseCase | save-admin-member', function () {
         role: ROLES.SUPER_ADMIN,
         createdAt: new Date(),
       });
-      const userRepository = { getByEmail: sinon.stub().withArgs(attributes.email).resolves(user) };
+      const userRepository = { getByEmail: sinon.stub() };
+      userRepository.getByEmail.withArgs(attributes.email).resolves(user);
       const adminMemberRepository = {
-        get: sinon.stub().withArgs({ userId: user.id }).resolves(undefined),
-        save: sinon.stub().withArgs({ userId: user.id, role: ROLES.SUPER_ADMIN }).resolves(savedAdminMember),
+        get: sinon.stub().resolves(undefined),
+        save: sinon.stub(),
       };
+      adminMemberRepository.save.withArgs({ userId: user.id, role: ROLES.SUPER_ADMIN }).resolves(savedAdminMember);
 
       // when
       const result = await saveAdminMember({ ...attributes, adminMemberRepository, userRepository });
@@ -59,8 +61,10 @@ describe('Unit | UseCase | save-admin-member', function () {
         email: user.email,
         role: ROLES.SUPER_ADMIN,
       });
-      const userRepository = { getByEmail: sinon.stub().withArgs(attributes.email).resolves(user) };
-      const adminMemberRepository = { get: sinon.stub().withArgs({ userId: user.id }).resolves(adminMember) };
+      const userRepository = { getByEmail: sinon.stub() };
+      userRepository.getByEmail.withArgs(attributes.email).resolves(user);
+      const adminMemberRepository = { get: sinon.stub() };
+      adminMemberRepository.get.withArgs({ userId: user.id }).resolves(adminMember);
 
       // when
       const error = await catchErr(saveAdminMember)({ ...attributes, adminMemberRepository, userRepository });

--- a/certif/tests/unit/routes/authenticated/sessions/update_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/update_test.js
@@ -10,19 +10,17 @@ module('Unit | Route | authenticated/sessions/update', function (hooks) {
     route = this.owner.lookup('route:authenticated/sessions/update');
   });
 
-  module('#model', function (hooks) {
-    const session_id = 1;
-
-    hooks.beforeEach(function () {
-      route.store.findRecord = sinon.stub().withArgs('session', session_id).resolves({});
-    });
-
+  module('#model', function () {
     test('it should return session with time', async function (assert) {
+      // given
+      const session_id = 1;
+      route.store.findRecord = sinon.stub().resolves({});
+
       // when
       const actualSession = await route.model({ session_id });
 
       // then
-      sinon.assert.calledOnce(route.store.findRecord);
+      sinon.assert.calledOnceWithExactly(route.store.findRecord, 'session', session_id);
       assert.ok(actualSession.time);
     });
   });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -206,8 +206,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           function () {
             beforeEach(async function () {
               const reachedStage = {
-                get: sinon.stub().withArgs('threshold').returns([75]),
+                get: sinon.stub(),
               };
+              reachedStage.get.withArgs('threshold').returns([75]);
               campaign = {
                 customResultPageButtonUrl: 'http://www.my-url.net/resultats',
                 customResultPageButtonText: 'Next step',

--- a/mon-pix/tests/unit/services/file-saver_test.js
+++ b/mon-pix/tests/unit/services/file-saver_test.js
@@ -34,8 +34,9 @@ describe('Unit | Service | file-saver', function () {
       it('should give fileName from response', async function () {
         // given
         const headers = {
-          get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`),
+          get: sinon.stub(),
         };
+        headers.get.withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`);
         const response = { headers, blob: blobStub };
         fetchStub = sinon.stub().resolves(response);
 

--- a/orga/tests/unit/services/file-saver_test.js
+++ b/orga/tests/unit/services/file-saver_test.js
@@ -33,8 +33,9 @@ module('Unit | Service | file-saver', function (hooks) {
       test('should use fileName and fileContent from response', async function (assert) {
         // given
         const headers = {
-          get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`),
+          get: sinon.stub(),
         };
+        headers.get.withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`);
         const jsonStub = sinon.stub().resolves('a json');
 
         const response = { headers, blob: blobStub, status: 200, json: jsonStub };
@@ -59,8 +60,9 @@ module('Unit | Service | file-saver', function (hooks) {
       test('should throw', async function (assert) {
         // given
         const headers = {
-          get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`),
+          get: sinon.stub(),
         };
+        headers.get.withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`);
         const jsonStub = sinon.stub().resolves({ errors: [] });
         const response = { headers, blob: blobStub, status: 403, json: jsonStub };
         fetchStub = sinon.stub().resolves(response);

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -46,8 +46,9 @@ module('Unit | Service | session', function (hooks) {
           };
           service.intl = {
             setLocale: sinon.stub(),
-            get: sinon.stub().withArgs('locales').returns(['fr', 'en']),
+            get: sinon.stub(),
           };
+          service.intl.get.withArgs('locales').returns(['fr', 'en']);
           service.moment = {
             setLocale: sinon.stub(),
           };


### PR DESCRIPTION
## :unicorn: Problème
Le `sinon.stub().withArgs(...).returns('blabla')` ne fonctionne pas. En effet avec ça le contenu de `withArgs` est totalement ignoré et retourne ou résous directement 'blabla'.

Pour le tester il suffit d'aller dans l'implémentation, d'enlever les paramètres ciblés par le `withArgs` et constater que le test passe bien (alors qu'il aurait dû planter !).


## :robot: Solution
Pour stubber correctement avec le `withArgs` de `sinon` il y a 2 manières : 
**1- Stub withArgs d'une dépendance injectée**
```js
const monRepository = { get: sinon.stub() };
monRepository.get.withArgs(arg1, arg2).resolves(qlqch); // en 2 étapes !!
```

**2- Stub withArgs d'une dépendance importée directement dans le fichier de test**
```js
sinon.stub(monModule, 'maFonctionAStub').withArgs(arg1, arg2).resolves(qlqch)
```


## :rainbow: Remarques

Pour plus d'info voir cet article qui explique très bien la problématique : https://nikas.praninskas.com/javascript/2015/07/28/quickie-sinon-withargs-not-working/ 


## :100: Pour tester

### Couac 1
#### Se mettre sur dev : 
- Dans `api/lib/domain/services/algorithm-methods/data-fetcher.js` : supprimer le paramètre `assessement.id` de l'appel `flashAssessmentResultRepository.getLatestByAssessmentId` (ligne 87)
- Lancer le test d'intégration `api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js` qui concerne la méthode `#getNextChallengeForCampaignAssessment`
- Constater qu'aucun des tests ne plantent alors qu'ils devraient

#### Se mettre sur la branche :
- Dans `api/lib/domain/services/algorithm-methods/data-fetcher.js` : supprimer le paramètre `assessement.id` de l'appel `flashAssessmentResultRepository.getLatestByAssessmentId` (ligne 87)
- Lancer le test d'intégration `api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js` qui concerne la méthode `#getNextChallengeForCampaignAssessment`
- Constater qu'un test plante

### Couac 2
#### Se mettre sur dev : 
- Dans `api/lib/domain/events/compute-campaign-participation-results.js` supprimer `campaignParticipationId` de l'appel à `participantResultsSharedRepository.get`
- Lancer les tests unitaire de `api/tests/unit/domain/events/compute-campaign-participation-results_test.js` 
- Constater qu'aucun tests ne plantent 

#### Se mettre sur la branche :
- Enlever le paramètre
- Lancer les tests unitaires
- Constater qu'au moins un test plante

### Couac 3
Idem pour tous les autres couacs : 
-`api/lib/domain/usecases/generate-username-with-temporary-password.js` 
- `api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js`
- `await organizationLearnerRepository.get(organizationLearnerId);` n'est pas protégé par le withArgs

### Couac 4
- `api/lib/domain/usecases/save-admin-member.js`
- `api/tests/unit/domain/usecases/save-admin-member_test.js` 
- `await userRepository.getByEmail(email);` + `await adminMemberRepository.get({ userId });` + `await adminMemberRepository.save({ userId, role });` 

### Couac 5
- `certif/app/routes/authenticated/sessions/update.js` 
- `certif/tests/unit/routes/authenticated/sessions/update_test.js`
- `await this.store.findRecord('session', session_id);` 

### Couac 6
- `mon-pix/app/components/routes/campaigns/assessment/skill-review.js`
- `mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js`
- `this.reachedStage.get('threshold');`

### Couac 7
- `mon-pix/app/services/file-saver.js` 
- `mon-pix/tests/unit/services/file-saver_test.js` 
- `headers.get('Content-Disposition')`

### Couac 8
- `orga/app/services/file-saver.js` 
- `orga/tests/unit/services/file-saver_test.js` 
- `headers.get('Content-Disposition')`

### Couac 9
- `orga/app/services/session.js`
- `orga/tests/unit/services/session_test.js`
- `this.intl.get('locales')`