### PR TITLE
[BUGFIX] Ne pas mettre à jour le rôle d'un agent Pix si aucun nouveau rôle n'est choisi (PIX-5387).

### DIFF
--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -34,6 +34,12 @@ export default class List extends Component {
   @action
   async updateMemberRole(adminMember) {
     const previousRole = adminMember.role;
+
+    if (!this.newRole || this.newRole === previousRole) {
+      adminMember.isInEditionMode = false;
+      return;
+    }
+
     adminMember.role = this.newRole;
     try {
       await adminMember.save();

--- a/admin/app/components/users/user-detail-personal-information/schooling-registration-information.hbs
+++ b/admin/app/components/users/user-detail-personal-information/schooling-registration-information.hbs
@@ -65,7 +65,7 @@
         </tr>
       {{else}}
         <tr>
-          <td colspan="10" class="table-admin-empty">Aucun résultat</td>
+          <td colspan="9" class="table-admin-empty">Aucun résultat</td>
         </tr>
       {{/each}}
     </tbody>

--- a/admin/tests/integration/components/team/list_test.js
+++ b/admin/tests/integration/components/team/list_test.js
@@ -25,10 +25,8 @@ module('Integration | Component | team | list', function (hooks) {
       const screen = await render(hbs`<Team::List @members={{this.members}}/>`);
 
       // then
-      assert.dom(screen.getByText('Marie')).exists();
-      assert.dom(screen.getByText('Tim')).exists();
-      assert.dom(screen.getByText('marie.tim@example.net')).exists();
-      assert.dom(screen.getByText('SUPER_ADMIN')).exists();
+      assert.dom(screen.getByRole('row', { name: 'Marie Tim' })).includesText('marie.tim@example.net');
+      assert.dom(screen.getByRole('row', { name: 'Marie Tim' })).includesText('SUPER_ADMIN');
     });
 
     test('should display action buttons for a member', async function (assert) {

--- a/admin/tests/unit/components/team/list_test.js
+++ b/admin/tests/unit/components/team/list_test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | team | list', function (hooks) {
+  setupTest(hooks);
+
+  module('when super admin change role', function () {
+    test('should save new role', async function (assert) {
+      // given
+      const adminMember = {
+        role: 'SUPER_ADMIN',
+        save: sinon.stub(),
+      };
+      const component = createGlimmerComponent('component:team/list');
+      component.newRole = 'CERTIF';
+
+      // when
+      await component.updateMemberRole(adminMember);
+
+      // then
+      assert.ok(adminMember.save.called);
+    });
+
+    module('when super admin saved without choose new role', function () {
+      test('should not called save method', async function (assert) {
+        // given
+        const adminMember = {
+          role: 'SUPER_ADMIN',
+          save: sinon.stub(),
+        };
+        const component = createGlimmerComponent('component:team/list');
+        component.newRole = undefined;
+
+        // when
+        await component.updateMemberRole(adminMember);
+
+        // then
+        assert.notOk(adminMember.save.called);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur la page équipe de Pix Admin, lorsqu'un agent Pix ayant le rôle SUPER ADMIN souhaite modifier le rôle d'un autre agent mais qu'il ne change pas le rôle qu'il possède déjà et qu'il valide, un appel à l'API est fait et l'erreur suivante apparaît à l'utilisateur : "une erreur est survenue". 

- Si aucun changement n'est fait, on doit empêcher l'appel.
- L'erreur provient d'un 400 de l'api car aucun rôle n'est fournit par le front. Or celui-ci s'assure que le rôle donné fait bien partie de la whitelist existante

<img width="572" alt="Capture d’écran 2022-07-21 à 10 52 39" src="https://user-images.githubusercontent.com/58915422/180173838-955e08c4-3032-46d4-a9f2-5597365d4898.png">


## :robot: Solution
Ne pas mettre à jour le rôle d'un agent Pix si aucun nouveau rôle n'est choisi. Ce qui permet d'empêcher l'appel API.

## :rainbow: Remarques
Fix sur le tableau des informations prescrit

Lorsque le tableau est vide, une colonne supplémentaire apparaît.
<img width="1650" alt="Capture d’écran 2022-07-21 à 11 00 26" src="https://user-images.githubusercontent.com/58915422/180174698-2038b254-bac0-4ba4-9b23-18b6f3267b44.png">

## :100: Pour tester
- Se connecter sur Pix Admin avec superadmin@example.net
- Aller sur Utilisateurs et chercher George
- Aller sur son tableau Information Prescrit et le dissocier
- Constater que le tableau est propre 
<img width="1659" alt="Capture d’écran 2022-07-21 à 11 00 35" src="https://user-images.githubusercontent.com/58915422/180174702-65d97c3c-a762-4eab-8d59-76619ddf656f.png">

- Aller dans Equipe
- Cliquer dans modifier sur le rôle de quelqu'un mais ne pas changer le rôle existant et valider
- Constater que le mode édition disparaît et que rien ne se passe

- Modifier cette fois-ci le rôle de CERTIF en METIER et constater que le rôle est bien mis à jour