### PR TITLE
[FEATURE] Mettre à jour le message de fin de campagne (PIX-5320)

### DIFF
--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -97,7 +97,6 @@
     font-size: 2.625rem;
     line-height: 3rem;
     font-weight: $font-light;
-    margin-bottom: 60px;
   }
 
   &__info {
@@ -105,7 +104,9 @@
     font-size: 1.5rem;
     line-height: 2.063rem;
     font-weight: $font-light;
-    margin-bottom: 60px;
+    margin-top: 0;
+    margin-bottom: 40px;
     max-width: 100%;
+    white-space: pre-line;
   }
 }

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -53,12 +53,12 @@
         />
       {{else}}
         <div class="checkpoint-no-answer">
-          <div class="checkpoint-no-answer__header">
+          <h1 class="checkpoint-no-answer__header">
             {{t "pages.checkpoint.answers.already-finished.info"}}
-          </div>
-          <div class="checkpoint-no-answer__info">
+          </h1>
+          <p class="checkpoint-no-answer__info">
             {{t "pages.checkpoint.answers.already-finished.explanation"}}
-          </div>
+          </p>
           <CheckpointContinue
             @assessmentId={{@model.id}}
             @nextPageButtonText={{this.nextPageButtonText}}

--- a/mon-pix/tests/acceptance/checkpoint_test.js
+++ b/mon-pix/tests/acceptance/checkpoint_test.js
@@ -55,7 +55,7 @@ describe('Acceptance | Checkpoint', () => {
       expect(find('.checkpoint__continue')).to.exist;
       expect(find('.checkpoint__continue').textContent).to.contain('Voir mes résultats');
       expect(find('.checkpoint-no-answer__info').textContent).to.contain(
-        'Vous avez déjà répondu aux questions, lors de vos parcours précédents. Vous pouvez directement accéder à vos résultats.'
+        'Vous avez déjà répondu à ces questions lors de vos tests précédents : vous pouvez directement accéder à vos résultats.\n\nVous souhaitez améliorer votre score ? En cliquant sur  “Voir mes résultats”, vous aurez la possibilité de retenter le parcours.'
       );
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -584,8 +584,8 @@
       },
       "answers": {
         "already-finished": {
-          "explanation": "You have already answered the questions in your previous customised tests. You can go straight to your results.",
-          "info": "Don’t be surprised, it’s over already!"
+          "explanation": "You have already answered these questions in previous test. You can jump straight to your results.\n \n Want to improve your score? Click on \"See my results\" and you will be able to retake the test.",
+          "info": "You have already answered !"
         },
         "header": "your answers"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -584,8 +584,8 @@
       },
       "answers": {
         "already-finished": {
-          "explanation": "Vous avez déjà répondu aux questions, lors de vos parcours précédents. Vous pouvez directement accéder à vos résultats.",
-          "info": "C’est déjà fini, ne soyez pas surpris !"
+          "explanation": "Vous avez déjà répondu à ces questions lors de vos tests précédents : vous pouvez directement accéder à vos résultats.\n\nVous souhaitez améliorer votre score ? En cliquant sur  “Voir mes résultats”, vous aurez la possibilité de retenter le parcours.",
+          "info": "Vous avez déjà répondu !"
         },
         "header": "vos réponses"
       },


### PR DESCRIPTION
## :unicorn: Problème
Le message actuel de fin de parcours n'est pas parlant pour les utilisateurs.

## :robot: Solution
Mettre à jour le message.

## :rainbow: Remarques


## :100: Pour tester
- Se rendre sur le page d'accueil de pix App
- Commencer une première campagne (cliquer en haut à droite sur "J'ai un code")
- Rentrer le code `PROCUSTOM`
- Terminer la campagne en répondant aux questions 
- Retourner sur la page d'accueil de pix App
- Commencer une nouvelle campagne avec le code `PROPIC123`
- Le message apparait
- Constater que le wording est correct en français
