### PR TITLE
[FEATURE] Ajouter des roles WAI-ARIA structurant la page (PIX-5364)

### DIFF
--- a/mon-pix/.template-lintrc.js
+++ b/mon-pix/.template-lintrc.js
@@ -7,6 +7,7 @@ module.exports = {
 
   rules: {
     'no-duplicate-landmark-elements': false,
+    'no-redundant-landmark-role': false,
     'no-html-comments': false,
     'no-bare-strings': ['Pix', '&nbsp;', '&#8226;', '.', '*', '1024', '/', '•', '-', '%'],
   },

--- a/mon-pix/app/components/assessment-banner.hbs
+++ b/mon-pix/app/components/assessment-banner.hbs
@@ -1,5 +1,5 @@
 <div class="background-banner assessment-banner">
-  <header class="assessment-banner-container">
+  <header class="assessment-banner-container" role="banner">
     <div class="assessment-banner__pix-logo">
       <img src="/images/pix-logo-blanc.svg" alt="{{t "common.pix"}}" />
     </div>

--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -1,5 +1,5 @@
-<article class="campaign-participation-overview-card">
-  <header class="campaign-participation-overview-card__header">
+<article class="campaign-participation-overview-card" role="article">
+  <header class="campaign-participation-overview-card__header" role="banner">
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.disabled"}}
     </PixTag>

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
@@ -1,5 +1,5 @@
-<article class="campaign-participation-overview-card">
-  <header class="campaign-participation-overview-card__header">
+<article class="campaign-participation-overview-card" role="article">
+  <header class="campaign-participation-overview-card__header" role="banner">
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.finished"}}
     </PixTag>

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
@@ -1,5 +1,5 @@
-<article class="campaign-participation-overview-card">
-  <header class="campaign-participation-overview-card__header">
+<article class="campaign-participation-overview-card" role="article">
+  <header class="campaign-participation-overview-card__header" role="banner">
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="green-light">
       {{t "pages.campaign-participation-overview.card.tag.started"}}
     </PixTag>

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
@@ -1,5 +1,5 @@
-<article class="campaign-participation-overview-card">
-  <header class="campaign-participation-overview-card__header">
+<article class="campaign-participation-overview-card" role="article">
+  <header class="campaign-participation-overview-card__header" role="banner">
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="yellow-light">
       {{t "pages.campaign-participation-overview.card.tag.completed"}}
     </PixTag>

--- a/mon-pix/app/components/campaign-start-block.hbs
+++ b/mon-pix/app/components/campaign-start-block.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-implicit-this no-action no-triple-curlies }}
-<main class="rounded-panel campaign-landing-page__container__start">
+<div class="rounded-panel campaign-landing-page__container__start">
   <div class="campaign-landing-page__start__image__container">
     <div class="campaign-landing-page__pix-logo">
       <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix" />
@@ -42,4 +42,4 @@
       <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} />
     </div>
   {{/if}}
-</main>
+</div>

--- a/mon-pix/app/components/certification-banner.hbs
+++ b/mon-pix/app/components/certification-banner.hbs
@@ -1,4 +1,4 @@
-<div class="assessment-banner--certification {{if @shouldBlurBanner "blur-banner"}}">
+<div class="assessment-banner--certification {{if @shouldBlurBanner "blur-banner"}}" role="banner">
   <div class="assessment-banner-container">
     <div class="assessment-banner__pix-logo">
       <img src="/images/pix-logo-blanc.svg" role="none" alt="" />

--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -5,6 +5,7 @@
   {{on "mouseenter" this.hideOutOfFocusBorder}}
   {{on "mouseleave" this.showOutOfFocusBorder}}
   {{will-destroy this.clearFocusOutEventListener}}
+  role="article"
 >
   <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 

--- a/mon-pix/app/components/competence-card-default.hbs
+++ b/mon-pix/app/components/competence-card-default.hbs
@@ -1,4 +1,4 @@
-<article class="competence-card {{if @interactive "competence-card--interactive"}}">
+<article class="competence-card {{if @interactive "competence-card--interactive"}}" role="article">
   <LinkTo @route="competences.details" @model={{@scorecard.competenceId}}>
     <div class="competence-card__title">
       <div class="competence-card__wrapper competence-card__wrapper--{{@scorecard.area.color}}">

--- a/mon-pix/app/components/competence-card-mobile.hbs
+++ b/mon-pix/app/components/competence-card-mobile.hbs
@@ -1,4 +1,4 @@
-<article class="competence-card {{if @interactive "competence-card--interactive"}}">
+<article class="competence-card {{if @interactive "competence-card--interactive"}}" role="article">
   <LinkTo @route="competences.details" @model={{@scorecard.competenceId}} class="competence-card__link">
     <span class="competence-card__wrapper competence-card__wrapper--{{@scorecard.area.color}}"></span>
     <div class="competence-card__title">

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -1,4 +1,4 @@
-<main id="main" class="page-container dashboard-content">
+<main id="main" class="page-container dashboard-content" role="main">
   <h1 class="sr-only">{{t "pages.dashboard.title"}}</h1>
 
   {{! This banner is displayed on tablet }}

--- a/mon-pix/app/components/footer.hbs
+++ b/mon-pix/app/components/footer.hbs
@@ -1,4 +1,4 @@
-<footer id="footer" class="footer">
+<footer id="footer" class="footer" role="contentinfo">
   <div class="footer__container">
     <div class="footer-container__logos">
       {{#if this.shouldShowTheMarianneLogo}}
@@ -14,7 +14,7 @@
     </div>
 
     <div class="footer-container__content">
-      <nav class="footer-container-content__navigation">
+      <nav class="footer-container-content__navigation" role="navigation">
         <ul class="footer-container-content__navigation-list">
           <li>
             <a href="{{this.supportHomeUrl}}" target="_blank" class="footer-navigation__item" rel="noopener noreferrer">

--- a/mon-pix/app/components/inaccessible-campaign.hbs
+++ b/mon-pix/app/components/inaccessible-campaign.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-implicit-this  }}
-<div class="background-banner-wrapper">
+<div class="background-banner-wrapper" role="banner">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
     <div class="campaign-landing-page__start__image__container">

--- a/mon-pix/app/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/components/navbar-burger-menu.hbs
@@ -1,4 +1,4 @@
-<nav class="navbar-burger-menu">
+<nav class="navbar-burger-menu" role="navigation">
   <div class="navbar-burger-menu__navigation">
 
     {{#if this.currentUser.user}}

--- a/mon-pix/app/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/components/navbar-desktop-header.hbs
@@ -13,7 +13,7 @@
     </div>
 
     {{#if this.showHeaderMenuItem}}
-      <nav class="navbar-desktop-header-container__menu">
+      <nav class="navbar-desktop-header-container__menu" role="navigation">
         <ul class="navbar-desktop-header-menu__list">
           <li class="navbar-desktop-header-menu__item">
             <LinkTo @route="user-dashboard" class="navbar-desktop-header-menu__link">

--- a/mon-pix/app/components/navbar-header.hbs
+++ b/mon-pix/app/components/navbar-header.hbs
@@ -1,7 +1,7 @@
 <Skiplink @href="#main" @label={{t "common.skip-links.skip-to-content"}} />
 <Skiplink @href="#footer" @label={{t "common.skip-links.skip-to-footer"}} />
 
-<nav class="navbar-header">
+<nav class="navbar-header" role="navigation">
   {{#if (media "isDesktop")}}
     <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}} />
   {{else}}

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -1,4 +1,4 @@
-<main class="sign-form__container">
+<main class="sign-form__container" role="main">
 
   <a href={{this.homeUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t "navigation.homepage"}}" />

--- a/mon-pix/app/components/profile-content.hbs
+++ b/mon-pix/app/components/profile-content.hbs
@@ -1,4 +1,4 @@
-<main id="main" class="background-banner-wrapper">
+<main id="main" class="background-banner-wrapper" role="main">
   <div class="background-banner"></div>
 
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner profile__panel">

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -197,7 +197,7 @@
 
     {{#unless @model.campaign.isForAbsoluteNovice}}
 
-      <main class="skill-review-result-detail__content">
+      <main class="skill-review-result-detail__content" role="main">
         <div class="skill-review-result-detail__table-header">
           <h2 class="skill-review-result-detail__subtitle">
             {{t "pages.skill-review.details.title"}}

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
@@ -1,6 +1,7 @@
 {{! template-lint-disable no-action require-input-label no-unknown-arguments-for-builtin-components }}
 <main
   class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-participant-external-id__container"
+  role="main"
 >
   <h1 class="fill-in-participant-external-id-text fill-in-participant-external-id-text__title">{{t
       "pages.fill-in-participant-external-id.first-title"

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -1,4 +1,4 @@
-<main class="sign-form__container">
+<main class="sign-form__container" role="main">
 
   <a href={{this.homeUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t "navigation.homepage"}}" />

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,4 +1,4 @@
-<main class="sign-form__container">
+<main class="sign-form__container" role="main">
   <a href={{this.homeUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t "navigation.homepage"}}" />
   </a>

--- a/mon-pix/app/components/sitemap/content.hbs
+++ b/mon-pix/app/components/sitemap/content.hbs
@@ -1,4 +1,4 @@
-<main class="sitemap">
+<main class="sitemap" role="main">
   <div class="sitemap__content">
     <h1 class="sitemap-content__title">{{t "pages.sitemap.title"}}</h1>
 

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,4 +1,4 @@
-<article class="tutorial-card-v2">
+<article class="tutorial-card-v2" role="article">
   <div class="tutorial-card-v2__content">
     <a
       target="_blank"

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -1,4 +1,4 @@
-<header class="background-banner-v2">
+<div class="background-banner-v2">
   <div class="user-tutorials-banner-v2">
     <h1 class="user-tutorials-banner-v2__title">{{t "pages.user-tutorials.title"}}</h1>
     <p class="user-tutorials-banner-v2__description">
@@ -19,4 +19,4 @@
       </ChoiceChip>
     </div>
   </div>
-</header>
+</div>

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -34,7 +34,7 @@
     {{/if}}
   </div>
 
-  <main class="challenge__content rounded-panel--over-background-banner">
+  <main class="challenge__content rounded-panel--over-background-banner" role="main">
     <ProgressBar
       @assessment={{@model.assessment}}
       @currentChallengeNumber={{@model.currentChallengeNumber}}

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -33,7 +33,7 @@
       {{/if}}
     </div>
 
-    <main class="rounded-panel rounded-panel--strong checkpoint__content">
+    <main class="rounded-panel rounded-panel--strong checkpoint__content" role="main">
       {{#if this.shouldDisplayAnswers}}
         <div class="rounded-panel-one-line-header">
           <h2 class="rounded-panel-header-text__content rounded-panel-title rounded-panel-title--all-small-caps">

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -2,7 +2,7 @@
 {{page-title "Didacticiel"}}
 
 <div class="campaign-tutorial">
-  <main id="main" class="rounded-panel rounded-panel--strong campaign-tutorial__container">
+  <main id="main" class="rounded-panel rounded-panel--strong campaign-tutorial__container" role="main">
 
     <h1 class="sr-only">{{t "pages.tutorial.title"}}</h1>
 

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -2,7 +2,7 @@
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
-  <div class="campaign-landing-page__container rounded-panel--over-background-banner">
+  <main class="campaign-landing-page__container rounded-panel--over-background-banner" role="main">
     <CampaignStartBlock @campaign={{@model}} @startCampaignParticipation={{this.startCampaignParticipation}} />
 
     {{#if @model.isAssessment}}
@@ -65,5 +65,5 @@
         </div>
       </div>
     {{/if}}
-  </div>
+  </main>
 </div>

--- a/mon-pix/app/templates/campaigns/invited/student-sco.hbs
+++ b/mon-pix/app/templates/campaigns/invited/student-sco.hbs
@@ -2,8 +2,9 @@
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
-  <div
+  <main
     class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container"
+    role="main"
   >
     <div class="join-restricted-campaign">
       <Routes::Campaigns::Invited::AssociateScoStudentForm
@@ -12,5 +13,5 @@
         @onSubmit={{this.reconcile}}
       />
     </div>
-  </div>
+  </main>
 </div>

--- a/mon-pix/app/templates/campaigns/invited/student-sup.hbs
+++ b/mon-pix/app/templates/campaigns/invited/student-sup.hbs
@@ -2,8 +2,9 @@
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
-  <div
+  <main
     class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container"
+    role="main"
   >
     <div class="join-restricted-campaign">
       <Routes::Campaigns::Invited::AssociateSupStudentForm
@@ -11,5 +12,5 @@
         @campaignCode={{@model.code}}
       />
     </div>
-  </div>
+  </main>
 </div>

--- a/mon-pix/app/templates/campaigns/join/sco-mediacentre.hbs
+++ b/mon-pix/app/templates/campaigns/join/sco-mediacentre.hbs
@@ -2,8 +2,9 @@
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
-  <div
+  <main
     class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container"
+    role="main"
   >
     <div class="join-restricted-campaign">
       <Routes::Campaigns::Join::AssociateScoStudentWithMediacentreForm
@@ -12,5 +13,5 @@
         @onSubmit={{this.createAndReconcile}}
       />
     </div>
-  </div>
+  </main>
 </div>

--- a/mon-pix/app/templates/certifications/join.hbs
+++ b/mon-pix/app/templates/certifications/join.hbs
@@ -2,8 +2,11 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
-    <main class="main">
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
+    <main class="main" role="main">
       <PixBackgroundHeader id="main">
 
         {{#if this.model.isCertifiable}}

--- a/mon-pix/app/templates/certifications/start-loading.hbs
+++ b/mon-pix/app/templates/certifications/start-loading.hbs
@@ -1,7 +1,10 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>
 

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -2,8 +2,11 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
-    <main class="main">
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
+    <main class="main" role="main">
       <PixBackgroundHeader id="main">
         <PixBlock @shadow="heavy" class="certification-start-page__block">
           <CertificationStarter @certificationCandidateSubscription={{@model}} />

--- a/mon-pix/app/templates/competences/details.hbs
+++ b/mon-pix/app/templates/competences/details.hbs
@@ -3,8 +3,11 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
-    <main id="main" class="main background-banner-wrapper competence-details">
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
+    <main id="main" class="main background-banner-wrapper competence-details" role="main">
       <div class="background-banner"></div>
 
       <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">

--- a/mon-pix/app/templates/competences/results.hbs
+++ b/mon-pix/app/templates/competences/results.hbs
@@ -3,9 +3,11 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
 
-    <main id="main" class="background-banner-wrapper">
+    <main id="main" class="background-banner-wrapper" role="main">
       <div class="background-banner"></div>
 
       <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -2,7 +2,9 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
 
     <div class="error-page">
       <div class="rounded-panel rounded-panel--strong error-page__body-section">

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -2,9 +2,12 @@
 {{page-title (t "pages.fill-in-campaign-code.title")}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @burger={{burger}} />
 
-    <main class="main">
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
+    <main class="main" role="main">
       <PixBackgroundHeader>
         <PixBlock class="fill-in-campaign-code__container">
           <h1 class="fill-in-campaign-code__title rounded-panel-title">

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -3,8 +3,12 @@
 
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @burger={{burger}} />
-    <main>
+
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
+    <main role="main">
       <PixBackgroundHeader id="main">
         <PixBlock class="fill-in-certificate-verification-code">
           <form class="fill-in-certificate-verification-code__form" autocomplete="off">

--- a/mon-pix/app/templates/not-connected.hbs
+++ b/mon-pix/app/templates/not-connected.hbs
@@ -1,5 +1,5 @@
 {{page-title (t "pages.not-connected.title")}}
-<main class="not-connected">
+<main class="not-connected" role="main">
   <div class="rounded-panel not-connected__container">
     <img class="pix-logo__image not-connected__logo" src="/images/pix-logo.svg" alt="Pix" />
     <h1 class="sr-only">{{t "pages.not-connected.title"}}</h1>

--- a/mon-pix/app/templates/profile.hbs
+++ b/mon-pix/app/templates/profile.hbs
@@ -3,7 +3,9 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
 
     <ProfileContent @model={{@model}} />
 

--- a/mon-pix/app/templates/sitemap.hbs
+++ b/mon-pix/app/templates/sitemap.hbs
@@ -1,7 +1,10 @@
 {{page-title (t "pages.sitemap.title")}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @burger={{burger}} />
+
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
 
     <Sitemap::Content @model={{@model}} />
 

--- a/mon-pix/app/templates/user-account.hbs
+++ b/mon-pix/app/templates/user-account.hbs
@@ -3,15 +3,17 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} @campaignParticipations={{@model.campaignParticipations}} />
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} @campaignParticipations={{@model.campaignParticipations}} />
+    </header>
 
-    <main id="main" class="main">
+    <main id="main" class="main" role="main">
       <PixBackgroundHeader>
 
         <h1 class="user-account__title">{{t "pages.user-account.title"}}</h1>
         <div class="user-account__menu-and-content">
           <PixBlock class="user-account__menu-block">
-            <nav class="user-account-menu">
+            <nav class="user-account-menu" role="navigation">
               <ul>
                 <li>
                   <LinkTo @route="user-account.personal-information" class="user-account-menu__link">

--- a/mon-pix/app/templates/user-certifications.hbs
+++ b/mon-pix/app/templates/user-certifications.hbs
@@ -1,7 +1,10 @@
 {{page-title (t "pages.certifications-list.title")}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @burger={{burger}} />
+
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
 
     {{outlet}}
 

--- a/mon-pix/app/templates/user-certifications/index.hbs
+++ b/mon-pix/app/templates/user-certifications/index.hbs
@@ -1,4 +1,4 @@
-<main id="main" class="main page-container user-certifications-page__container">
+<main id="main" class="main page-container user-certifications-page__container" role="main">
   <h1 class="user-certifications-page__title">{{t "pages.certifications-list.title"}}</h1>
 
   <UserCertificationsPanel @certifications={{@model}} />

--- a/mon-pix/app/templates/user-dashboard.hbs
+++ b/mon-pix/app/templates/user-dashboard.hbs
@@ -2,7 +2,10 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @burger={{burger}} />
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
     <Dashboard::Content @model={{this.model}} />
 
     <Footer />

--- a/mon-pix/app/templates/user-tests.hbs
+++ b/mon-pix/app/templates/user-tests.hbs
@@ -1,8 +1,12 @@
 {{page-title (t "pages.user-tests.title")}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @burger={{burger}} />
-    <main id="main">
+
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+    </header>
+
+    <main id="main" role="main">
       <PixBackgroundHeader>
         <div class="user-tests-banner">
           <img

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -1,9 +1,13 @@
 {{page-title (t "pages.user-tutorials.title")}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @burger={{burger}} />
-    <Tutorials::Header />
-    <main id="main" class="main">
+
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+      <Tutorials::Header />
+    </header>
+
+    <main id="main" class="main" role="main">
       <div class="user-tutorials-content-v2">
         {{outlet}}
       </div>


### PR DESCRIPTION
## :unicorn: Problème
WAI-ARIA propose des rôles permettant d’indiquer les zones principales (régions) du document. Ces rôles sont très profitables aux utilisateurs de lecteurs d’écran notamment, mais également aux utilisateurs de la navigation au clavier qui peuvent ainsi bénéficier de fonctionnalités de navigation rapide dans la [structure du document](https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/glossaire/#structure-du-document).
Ces rôles ne sont pas existants sur nos pages.

## :robot: Solution
Les rajouter.

## :rainbow: Remarques
Les rôles `"banner"`, `"main"`, `"contentinfo"` ne doit être présent qu'une seule fois dans la page.
La règle eslint  'no-redundant-landmark-role' a été désactivé car il contredit les règles du [RGAA](https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/glossaire/#landmarks). 


## :100: Pour tester
Aller sur les pages et vérifier que les rôles sont bien présents. Utiliser le lecteur d'écran en navigation rapide pour parcourir les différentes sections.
