### PR TITLE
[FEATURE] Ne plus centrer la `PixBanner` de comm' sur Certif (PIX-5391)

### DIFF
--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -24,7 +24,6 @@
 @import "pages/terms-of-service";
 @import "components/add-student-list";
 @import "components/certif-checkbox";
-@import "components/communication-banner";
 @import "components/ember-cli-notifications-ie-fallback";
 @import "components/add-issue-report-modal";
 @import "components/certification-candidate-details-modal";

--- a/certif/app/styles/components/communication-banner.scss
+++ b/certif/app/styles/components/communication-banner.scss
@@ -1,3 +1,0 @@
-.pix-banner {
-  justify-content: center;
-}


### PR DESCRIPTION
## :unicorn: Problème
Pour respecter le Design System, il ne faut pas centrer les PixBanner : https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=379%3A5239

## :robot: Solution
Supprimer le CSS custom sur la communication banner pour qu'elle soit alignée à gauche.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la PixBanner sur la RA est bien alignée à gauche.
