### PR TITLE
[FEATURE] Ne plus centrer la PixBanner de comm' sur Orga (PIX-5390)

### DIFF
--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -24,7 +24,6 @@
 // components
 @import 'components/ui';
 @import 'components/ui/last-participation-date-tooltip.scss';
-@import 'components/banner/communication';
 @import 'components/login-form';
 @import 'components/campaign';
 @import 'components/current-organization';

--- a/orga/app/styles/components/banner/communication.scss
+++ b/orga/app/styles/components/banner/communication.scss
@@ -1,3 +1,0 @@
-.pix-banner {
-  justify-content: center;
-}


### PR DESCRIPTION
## :unicorn: Problème
Pour respecter le Design System, il ne faut pas centrer les PixBanner : [figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=379%3A5239](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=379%3A5239)

## :robot: Solution
Supprimer le CSS custom sur la communication banner pour qu'elle soit alignée à gauche.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la PixBanner sur la RA est bien alignée à gauche.
