### PR TITLE
[TECH] Prévenir les faux négatifs dans les tests (PIX-5485)

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -3,6 +3,7 @@ extends:
   - 'plugin:i18n-json/recommended'
   - 'plugin:mocha/recommended'
   - 'plugin:prettier/recommended'
+  - 'plugin:chai-expect/recommended'
 parserOptions:
   ecmaVersion: 2020
   requireConfigFile: false

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -87,6 +87,7 @@
         "depcheck": "^1.4.3",
         "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-i18n-json": "^3.1.0",
         "eslint-plugin-knex": "^0.2.1",
         "eslint-plugin-mocha": "^10.0.5",
@@ -5512,6 +5513,18 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-chai-expect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-3.0.0.tgz",
+      "integrity": "sha512-NS0YBcToJl+BRKBSMCwRs/oHJIX67fG5Gvb4tGked+9Wnd1/PzKijd82B2QVKcSSOwRe+pp4RAJ2AULeck4eQw==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || 12.* || >= 14.*"
+      },
+      "peerDependencies": {
+        "eslint": ">=2.0.0 <= 8.x"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -18146,6 +18159,13 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-chai-expect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-3.0.0.tgz",
+      "integrity": "sha512-NS0YBcToJl+BRKBSMCwRs/oHJIX67fG5Gvb4tGked+9Wnd1/PzKijd82B2QVKcSSOwRe+pp4RAJ2AULeck4eQw==",
       "dev": true,
       "requires": {}
     },

--- a/api/package.json
+++ b/api/package.json
@@ -93,6 +93,7 @@
     "depcheck": "^1.4.3",
     "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-i18n-json": "^3.1.0",
     "eslint-plugin-knex": "^0.2.1",
     "eslint-plugin-mocha": "^10.0.5",

--- a/api/tests/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/integration/domain/usecases/create-campaign_test.js
@@ -65,9 +65,6 @@ describe('Integration | UseCases | create-campaign', function () {
     expect(result).to.be.an.instanceOf(Campaign);
 
     expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
-
-    expect('code').to.be.ok;
-    expect('id').to.be.ok;
   });
 
   it('should save a new campaign of type PROFILES_COLLECTION', async function () {
@@ -93,10 +90,7 @@ describe('Integration | UseCases | create-campaign', function () {
 
     // then
     expect(result).to.be.an.instanceOf(Campaign);
-
     expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
-
-    expect('code').to.be.ok;
-    expect('id').to.be.ok;
+    expect(result.code).to.have.lengthOf.above(0);
   });
 });

--- a/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
@@ -191,13 +191,15 @@ describe('Integration | Infrastructure | Utils | Ods | read-ods-utils', function
         odsBuffer = await readFile(DEFAULT_ODS_FILE_PATH);
 
         // when
-        await validateOdsHeaders({
-          odsBuffer,
-          headers: VALID_HEADERS,
-        });
+        const call = async () => {
+          await validateOdsHeaders({
+            odsBuffer,
+            headers: VALID_HEADERS,
+          });
+        };
 
         // then
-        expect(true).to.be.true;
+        expect(call).to.not.throw();
       });
     });
 
@@ -218,18 +220,19 @@ describe('Integration | Infrastructure | Utils | Ods | read-ods-utils', function
     });
 
     context('when newlines are present in file headers', function () {
-      it('should not throw a UnprocessableEntityError', async function () {
+      it('should not throw', async function () {
         // given
         odsBuffer = await readFile(NEW_LINE_ODS_FILE_PATH);
 
         // when
-        await validateOdsHeaders({
-          odsBuffer,
-          headers: VALID_HEADERS,
-        });
-
+        const call = () => {
+          validateOdsHeaders({
+            odsBuffer,
+            headers: VALID_HEADERS,
+          });
+        };
         // then
-        expect(true).to.be.true;
+        expect(call).to.not.throw();
       });
     });
   });

--- a/api/tests/integration/scripts/add-tags-to-organizations_test.js
+++ b/api/tests/integration/scripts/add-tags-to-organizations_test.js
@@ -106,10 +106,8 @@ describe('Integration | Scripts | add-tags-to-organizations.js', function () {
         const checkedData = [{ organizationId: firstOrganizationId, tagName: firstTag.name }];
 
         // when
-        await addTagsToOrganizations({ tagsByName, checkedData });
-
         // then
-        expect(true).to.be.true;
+        await addTagsToOrganizations({ tagsByName, checkedData });
       });
     });
   });

--- a/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
+++ b/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
@@ -31,8 +31,9 @@ describe('Integration | Scripts | create-assessment-campaigns', function () {
       const campaigns = await prepareCampaigns([campaignData]);
 
       // then
-      expect(typeof campaigns[0].code === 'string').to.be.true;
-      expect(campaigns[0].code.length).to.equal(9);
+      const code = campaigns[0].code;
+      expect(code).to.be.a('string');
+      expect(code).to.have.lengthOf(9);
     });
 
     it('should create campaigns for each target profile', async function () {

--- a/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
@@ -30,8 +30,9 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
       const campaigns = await prepareCampaigns([campaignData]);
 
       // then
-      expect(typeof campaigns[0].code === 'string').to.be.true;
-      expect(campaigns[0].code.length).to.equal(9);
+      const code = campaigns[0].code;
+      expect(code).to.be.a('string');
+      expect(code).to.have.lengthOf(9);
     });
 
     it('should be a profile collection type for the campaign model', async function () {

--- a/api/tests/tooling/i18n/i18n_test.js
+++ b/api/tests/tooling/i18n/i18n_test.js
@@ -3,7 +3,7 @@ const { getI18n } = require('./i18n');
 
 describe('Unit | Tooling | i18n', function () {
   it('should translate by default to fr', function () {
-    const i18n = getI18n();
-    expect(i18n.__('current-lang'), 'fr');
+    const currentLang = getI18n().__('current-lang');
+    expect(currentLang).to.equal('fr');
   });
 });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -309,10 +309,8 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
 
       // when
-      certificationCandidate.validateParticipation();
-
       // then
-      expect(true).to.be.true;
+      certificationCandidate.validateParticipation();
     });
 
     it('should return an error if firstName is not defined', function () {

--- a/api/tests/unit/domain/models/CertificationReport_test.js
+++ b/api/tests/unit/domain/models/CertificationReport_test.js
@@ -30,10 +30,8 @@ describe('Unit | Domain | Models | CertificationReport', function () {
       });
 
       // when
-      certificationReport.validateForFinalization();
-
       // then
-      expect(true).to.be.true;
+      certificationReport.validateForFinalization();
     });
 
     // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/unit/tooling/chai-custom-helpers/deep-equal-array_test.js
+++ b/api/tests/unit/tooling/chai-custom-helpers/deep-equal-array_test.js
@@ -6,7 +6,8 @@ describe('Unit | chai-custom-helpers | deepEqualArray', function () {
       expect([]).to.deepEqualArray('coucou');
     }, "expected 'String' to equal 'Array'");
     global.chaiErr(function () {
-      expect('coucou').to.deepEqualArray([]);
+      const foo = 'bar';
+      expect(foo).to.deepEqualArray([]);
     }, "expected 'String' to equal 'Array'");
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Certaines assertions chai sont toujours vraies, car leur syntaxe est incorrecte.

Cela peut entraîner des faux négatifs: 
- une régression est introduite dans l'implémentation:
- le test passe toujours.

## :robot: Solution
Utiliser le plugin [chai-expect](https://github.com/Turbo87/eslint-plugin-chai-expect)

## :rainbow: Remarques

### Levée d'erreur
La vérification qu'une fonction (SUT) ne lance pas d'erreur est effectuée automatiquement par Mocha.
Si le `catchErr` est utilisé, une erreur est lancée par `catchErr` si le SUT ne lance pas d'erreur.

Il est probablement possible d'utiliser le matcher [throw](https://www.chaijs.com/api/bdd/#method_throw), mais lorsque le SUT renvoie une promesse, je n'ai pas réussi à le faire fonctionner.

### Cas à résoudre
Le custom matcher `deepEqualArray` comporte un test que je ne comprend pas, aussi j'ai ajouté une exception

## :100: Pour tester
Muter l'implémentation et vérifier que le test ne passe plus.
Ajouter un `expect(true).to.be.true` et vérifier qu'une erreur de lint apparaît.
