### PR TITLE
[TECH] Utiliser le niveau du badge en BDD afin de déterminer le badge à certifier (PIX-5206).

### DIFF
--- a/api/db/database-builder/factory/build-badge.js
+++ b/api/db/database-builder/factory/build-badge.js
@@ -1,7 +1,7 @@
 const databaseBuffer = require('../database-buffer');
 const buildTargetProfile = require('./build-target-profile');
 
-module.exports = function buildBadge({
+function buildBadge({
   id = databaseBuffer.getNextId(),
   altMessage = 'alt message',
   imageUrl = '/img_funny.svg',
@@ -29,4 +29,52 @@ module.exports = function buildBadge({
     tableName: 'badges',
     values,
   });
+}
+
+buildBadge.certifiable = function ({
+  id = databaseBuffer.getNextId(),
+  altMessage = 'alt message',
+  imageUrl = '/img_funny.svg',
+  message = 'message',
+  title = 'title',
+  key = 'key',
+  targetProfileId,
+  isAlwaysVisible = false,
+}) {
+  return buildBadge({
+    id,
+    altMessage,
+    imageUrl,
+    message,
+    title,
+    key,
+    isCertifiable: true,
+    targetProfileId,
+    isAlwaysVisible,
+  });
 };
+
+buildBadge.notCertifiable = function ({
+  id = databaseBuffer.getNextId(),
+  altMessage = 'alt message',
+  imageUrl = '/img_funny.svg',
+  message = 'message',
+  title = 'title',
+  key = 'key',
+  targetProfileId,
+  isAlwaysVisible = false,
+}) {
+  return buildBadge({
+    id,
+    altMessage,
+    imageUrl,
+    message,
+    title,
+    key,
+    isCertifiable: false,
+    targetProfileId,
+    isAlwaysVisible,
+  });
+};
+
+module.exports = buildBadge;

--- a/api/lib/domain/services/certification-badges-service.js
+++ b/api/lib/domain/services/certification-badges-service.js
@@ -9,7 +9,7 @@ const { PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3 } = require('
 
 module.exports = {
   async findStillValidBadgeAcquisitions({ userId, domainTransaction }) {
-    const highestCertifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({
+    const highestCertifiableBadgeAcquisitions = await badgeAcquisitionRepository.findHighestCertifiable({
       userId,
       domainTransaction,
     });

--- a/api/lib/domain/services/certification-badges-service.js
+++ b/api/lib/domain/services/certification-badges-service.js
@@ -5,18 +5,15 @@ const badgeRepository = require('../../infrastructure/repositories/badge-reposit
 const knowledgeElementRepository = require('../../infrastructure/repositories/knowledge-element-repository');
 const targetProfileRepository = require('../../infrastructure/repositories/target-profile-repository');
 const badgeCriteriaService = require('../../domain/services/badge-criteria-service');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF, PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3 } =
-  require('../../domain/models/Badge').keys;
-const PixEdu2ndDegreBadgeAcquisitionOrderer = require('../models/PixEdu2ndDegreBadgeAcquisitionOrderer');
-const PixEdu1erDegreBadgeAcquisitionOrderer = require('../models/PixEdu1erDegreBadgeAcquisitionOrderer');
+const { PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3 } = require('../../domain/models/Badge').keys;
 
 module.exports = {
   async findStillValidBadgeAcquisitions({ userId, domainTransaction }) {
-    const certifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({
+    const highestCertifiableBadgeAcquisitions = await badgeAcquisitionRepository.findCertifiable({
       userId,
       domainTransaction,
     });
-    const highestCertifiableBadgeAcquisitions = _keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions);
+
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, domainTransaction });
 
     const badgeAcquisitions = await bluebird.mapSeries(
@@ -72,44 +69,3 @@ module.exports = {
     });
   },
 };
-
-function _keepHighestBadgeWithinPlusCertifications(certifiableBadgeAcquisitions) {
-  let highestBadges = _keepHighestBadgeWithinDroitCertification(certifiableBadgeAcquisitions);
-  highestBadges = _keepHighestBadgeWithinEdu2ndDegreCertification(highestBadges);
-  return _keepHighestBadgeWithinEdu1erDegreCertification(highestBadges);
-}
-
-function _keepHighestBadgeWithinDroitCertification(certifiableBadgeAcquisitions) {
-  const [pixDroitBadgeAcquisitions, nonPixDroitBadgeAcquisitions] = _.partition(
-    certifiableBadgeAcquisitions,
-    (badgeAcquisition) => badgeAcquisition.isPixDroit()
-  );
-  if (pixDroitBadgeAcquisitions.length === 0) return nonPixDroitBadgeAcquisitions;
-  const expertBadgeAcquisition = _.find(certifiableBadgeAcquisitions, { badgeKey: PIX_DROIT_EXPERT_CERTIF });
-  const maitreBadgeAcquisition = _.find(certifiableBadgeAcquisitions, { badgeKey: PIX_DROIT_MAITRE_CERTIF });
-  return [...nonPixDroitBadgeAcquisitions, expertBadgeAcquisition || maitreBadgeAcquisition];
-}
-
-function _keepHighestBadgeWithinEdu2ndDegreCertification(certifiableBadgeAcquisitions) {
-  const [pixEdu2ndDegreBadgeAcquisitions, nonPixEdu2ndDegreBadgeAcquisitions] = _.partition(
-    certifiableBadgeAcquisitions,
-    (badgeAcquisition) => badgeAcquisition.isPixEdu2ndDegre()
-  );
-  if (pixEdu2ndDegreBadgeAcquisitions.length === 0) return nonPixEdu2ndDegreBadgeAcquisitions;
-  const pixEduBadgeAcquisitionOrderer = new PixEdu2ndDegreBadgeAcquisitionOrderer({
-    badgesAcquisitions: pixEdu2ndDegreBadgeAcquisitions,
-  });
-  return [...nonPixEdu2ndDegreBadgeAcquisitions, pixEduBadgeAcquisitionOrderer.getHighestBadge()];
-}
-
-function _keepHighestBadgeWithinEdu1erDegreCertification(certifiableBadgeAcquisitions) {
-  const [pixEdu1erDegreBadgeAcquisitions, nonPixEdu1erDegreBadgeAcquisitions] = _.partition(
-    certifiableBadgeAcquisitions,
-    (badgeAcquisition) => badgeAcquisition.isPixEdu1erDegre()
-  );
-  if (pixEdu1erDegreBadgeAcquisitions.length === 0) return nonPixEdu1erDegreBadgeAcquisitions;
-  const pixEduBadgeAcquisitionOrderer = new PixEdu1erDegreBadgeAcquisitionOrderer({
-    badgesAcquisitions: pixEdu1erDegreBadgeAcquisitions,
-  });
-  return [...nonPixEdu1erDegreBadgeAcquisitions, pixEduBadgeAcquisitionOrderer.getHighestBadge()];
-}

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -89,7 +89,7 @@ module.exports = {
     return acquiredBadgesByUsers;
   },
 
-  async findCertifiable({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  async findHighestCertifiable({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction.knexTransaction || knex;
     const certifiableBadgeAcquisitions = await knexConn('badge-acquisitions')
       .join('badges', 'badges.id', 'badge-acquisitions.badgeId')

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -55,22 +55,36 @@ describe('Integration | Service | Certification-Badges Service', function () {
     it('should return one badgeAcquisition', async function () {
       // given
       const { id: userId } = databaseBuilder.factory.buildUser();
+
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+
       listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
-      const badge = databaseBuilder.factory.buildBadge({ isCertifiable: true, targetProfileId: targetProfileId });
+
+      const badge = databaseBuilder.factory.buildBadge.certifiable({ targetProfileId: targetProfileId });
+
       databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge.id });
-      const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
-        scope: 'CampaignParticipation',
+      const { id: complementaryCertificationId } = databaseBuilder.factory.buildComplementaryCertification();
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        userId,
         badgeId: badge.id,
-        threshold: 40,
+        complementaryCertificationId,
+        level: 2,
       });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
+
       const skillSet = databaseBuilder.factory.buildSkillSet({
         badgeId: badge.id,
         skillIds: ['web1', 'web2', 'web3', 'web4'],
+      });
+
+      const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
+        scope: 'CampaignParticipation',
+        badgeId: badge.id,
+        threshold: 40,
+        skillSetIds: [skillSet.id],
       });
 
       await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-helper');
 const _ = require('lodash');
 const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
@@ -338,69 +338,162 @@ describe('Integration | Repository | Badge Acquisition', function () {
   });
 
   describe('#findCertifiable', function () {
-    let badgeCertifiable, badgeNonCertifiable, skillSet, badgePartnerCriterion, user, userWithoutBadge;
-    beforeEach(async function () {
-      const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      badgeCertifiable = databaseBuilder.factory.buildBadge({
-        key: 'key1',
-        targetProfileId: targetProfile.id,
-        isCertifiable: true,
+    describe('when the user has a certifiable acquired badge', function () {
+      it('should return the highest level certifiable acquired badge', async function () {
+        //given
+        const user = databaseBuilder.factory.buildUser();
+        const acquiredBadge = databaseBuilder.factory.buildBadge.certifiable({
+          key: 'PIX_DROIT_MAITRE_CERTIF',
+        });
+
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: acquiredBadge.id, userId: user.id });
+
+        const { id: complementaryCertificationId } = databaseBuilder.factory.buildComplementaryCertification();
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId: acquiredBadge.id,
+          complementaryCertificationId,
+          level: 2,
+        });
+
+        const skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: acquiredBadge.id });
+
+        const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
+          badgeId: acquiredBadge.id,
+          skillSetIds: [skillSet.id],
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
+          userId: user.id,
+        });
+
+        // then
+        const expectedSkillSetsForCertifiableBadge = [
+          {
+            id: skillSet.id,
+            badgeId: acquiredBadge.id,
+            name: skillSet.name,
+            skillIds: skillSet.skillIds,
+          },
+        ];
+
+        const expectedBadgeCriteria = [
+          {
+            id: badgeCriterion.id,
+            scope: badgeCriterion.scope,
+            threshold: badgeCriterion.threshold,
+            skillSetIds: badgeCriterion.skillSetIds,
+            badgeId: acquiredBadge.id,
+          },
+        ];
+
+        expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
+        expect(certifiableBadgesAcquiredByUser[0]).to.deepEqualInstanceOmitting(
+          domainBuilder.buildBadgeAcquisition({
+            badge: domainBuilder.buildBadge({
+              ...acquiredBadge,
+              skillSets: expectedSkillSetsForCertifiableBadge,
+              badgeCriteria: expectedBadgeCriteria,
+            }),
+            userId: user.id,
+            badgeId: acquiredBadge.id,
+            campaignParticipationId: null,
+          }),
+          ['id']
+        );
       });
-      databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id, isCertifiable: true });
-      badgeNonCertifiable = databaseBuilder.factory.buildBadge({
-        key: 'key2',
-        targetProfileId: targetProfile.id,
-        isCertifiable: false,
-      });
-      user = databaseBuilder.factory.buildUser();
-      userWithoutBadge = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeCertifiable.id, userId: user.id });
-      databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeNonCertifiable.id, userId: user.id });
-      skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeCertifiable.id });
-      badgePartnerCriterion = databaseBuilder.factory.buildBadgeCriterion({ badgeId: badgeCertifiable.id });
-      await databaseBuilder.commit();
     });
 
-    it('should return certifiable badges acquired by the user', async function () {
-      // when
-      const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
-        userId: user.id,
+    describe('when the user has several acquired badges', function () {
+      it('should return the highest level certifiable badge acquired for each complementary certification', async function () {
+        //given
+        const user = databaseBuilder.factory.buildUser();
+        const badgeLevel1 = databaseBuilder.factory.buildBadge.certifiable({
+          key: 'level-1',
+        });
+        const badgeLevel2 = databaseBuilder.factory.buildBadge.certifiable({
+          key: 'level-2',
+        });
+        const badgeLevel3 = databaseBuilder.factory.buildBadge.certifiable({
+          key: 'level-3',
+        });
+
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeLevel1.id, userId: user.id });
+        databaseBuilder.factory.buildBadgeAcquisition({ badgeId: badgeLevel2.id, userId: user.id });
+
+        const { id: complementaryCertificationId } = databaseBuilder.factory.buildComplementaryCertification();
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId: badgeLevel2.id,
+          complementaryCertificationId,
+          level: 2,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId: badgeLevel1.id,
+          complementaryCertificationId,
+          level: 1,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId: badgeLevel3.id,
+          complementaryCertificationId,
+          level: 3,
+        });
+
+        const badgeLevel1skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeLevel1.id });
+        const badgeLevel2skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeLevel2.id });
+        const badgeLevel3SkillSet = databaseBuilder.factory.buildSkillSet({
+          badgeId: badgeLevel3.id,
+        });
+
+        databaseBuilder.factory.buildBadgeCriterion({
+          badgeId: badgeLevel1.id,
+          skillSetIds: [badgeLevel1skillSet.id],
+        });
+        databaseBuilder.factory.buildBadgeCriterion({
+          badgeId: badgeLevel2.id,
+          skillSetIds: [badgeLevel2skillSet.id],
+        });
+        databaseBuilder.factory.buildBadgeCriterion({
+          badgeId: badgeLevel3.id,
+          skillSetIds: [badgeLevel3SkillSet.id],
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
+          userId: user.id,
+        });
+
+        // then
+        expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
+        expect(certifiableBadgesAcquiredByUser.map(({ badgeId }) => badgeId)).to.deep.equal([badgeLevel2.id]);
       });
-
-      // then
-      const expectedSkillSets = [
-        {
-          id: skillSet.id,
-          badgeId: badgeCertifiable.id,
-          name: skillSet.name,
-          skillIds: skillSet.skillIds,
-        },
-      ];
-
-      const expectedBadgeCriteria = [
-        {
-          id: badgePartnerCriterion.id,
-          scope: badgePartnerCriterion.scope,
-          threshold: badgePartnerCriterion.threshold,
-          skillSetIds: badgePartnerCriterion.skillSetIds,
-          badgeId: badgeCertifiable.id,
-        },
-      ];
-
-      expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
-      expect(certifiableBadgesAcquiredByUser[0].badge).to.includes(badgeCertifiable);
-      expect(certifiableBadgesAcquiredByUser[0].badge.skillSets).to.deep.equal(expectedSkillSets);
-      expect(certifiableBadgesAcquiredByUser[0].badge.badgeCriteria).to.deep.equal(expectedBadgeCriteria);
     });
+    describe('when the user has no certifiable acquired badge', function () {
+      it('should return an empty array', async function () {
+        // given
+        const userWithoutCertifiableBadge = databaseBuilder.factory.buildUser();
+        const badgeNonCertifiable = databaseBuilder.factory.buildBadge.notCertifiable({
+          key: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+        });
 
-    it('should return an empty array when user has no certifiable acquired badge', async function () {
-      // when
-      const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
-        userId: userWithoutBadge.id,
+        databaseBuilder.factory.buildBadgeAcquisition({
+          badgeId: badgeNonCertifiable.id,
+          userId: userWithoutCertifiableBadge.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
+          userId: userWithoutCertifiableBadge.id,
+        });
+
+        // then
+        expect(certifiableBadgesAcquiredByUser).to.be.empty;
       });
-
-      // then
-      expect(certifiableBadgesAcquiredByUser).to.deep.equal([]);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -337,7 +337,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
     });
   });
 
-  describe('#findCertifiable', function () {
+  describe('#findHighestCertifiable', function () {
     describe('when the user has a certifiable acquired badge', function () {
       it('should return the highest level certifiable acquired badge', async function () {
         //given
@@ -365,7 +365,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
         await databaseBuilder.commit();
 
         // when
-        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
+        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findHighestCertifiable({
           userId: user.id,
         });
 
@@ -463,7 +463,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
         await databaseBuilder.commit();
 
         // when
-        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
+        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findHighestCertifiable({
           userId: user.id,
         });
 
@@ -487,7 +487,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
         await databaseBuilder.commit();
 
         // when
-        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findCertifiable({
+        const certifiableBadgesAcquiredByUser = await badgeAcquisitionRepository.findHighestCertifiable({
           userId: userWithoutCertifiableBadge.id,
         });
 

--- a/api/tests/unit/domain/services/certification-badges-service-test.js
+++ b/api/tests/unit/domain/services/certification-badges-service-test.js
@@ -11,7 +11,7 @@ const { PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3 } =
 describe('Unit | Service | Certification Badges Service', function () {
   describe('#findStillValidBadgeAcquisitions', function () {
     beforeEach(function () {
-      sinon.stub(badgeAcquisitionRepository, 'findCertifiable');
+      sinon.stub(badgeAcquisitionRepository, 'findHighestCertifiable');
       sinon.stub(badgeCriteriaService, 'areBadgeCriteriaFulfilled');
       sinon.stub(targetProfileRepository, 'get');
       sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
@@ -22,7 +22,7 @@ describe('Unit | Service | Certification Badges Service', function () {
         // given
         const userId = 12;
         const domainTransaction = Symbol('someDomainTransaction');
-        badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([]);
+        badgeAcquisitionRepository.findHighestCertifiable.withArgs({ userId, domainTransaction }).resolves([]);
 
         // when
         const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
@@ -45,7 +45,9 @@ describe('Unit | Service | Certification Badges Service', function () {
         targetProfile = { id: 12 };
         badge = domainBuilder.buildBadge({ targetProfileId: targetProfile.id });
         badgeAcquisition = domainBuilder.buildBadgeAcquisition({ id: 'badgeId', userId, badge });
-        badgeAcquisitionRepository.findCertifiable.withArgs({ userId, domainTransaction }).resolves([badgeAcquisition]);
+        badgeAcquisitionRepository.findHighestCertifiable
+          .withArgs({ userId, domainTransaction })
+          .resolves([badgeAcquisition]);
         knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
         targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
       });
@@ -110,7 +112,7 @@ describe('Unit | Service | Certification Badges Service', function () {
             userId,
             badge: badgeLevel1,
           });
-          badgeAcquisitionRepository.findCertifiable
+          badgeAcquisitionRepository.findHighestCertifiable
             .withArgs({ userId, domainTransaction })
             .resolves([badgeAcquisitionLevel1]);
           knowledgeElementRepository.findUniqByUserId
@@ -155,7 +157,7 @@ describe('Unit | Service | Certification Badges Service', function () {
             userId,
             badge: badgeLevel2,
           });
-          badgeAcquisitionRepository.findCertifiable
+          badgeAcquisitionRepository.findHighestCertifiable
             .withArgs({ userId, domainTransaction })
             .resolves([badgeAcquisitionLevel2]);
           knowledgeElementRepository.findUniqByUserId
@@ -197,7 +199,7 @@ describe('Unit | Service | Certification Badges Service', function () {
         const pixDroitMaitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition.forPixDroitMaitre();
         const pixDroitExpertBadgeAcquisition = domainBuilder.buildBadgeAcquisition.forPixDroitExpert();
 
-        badgeAcquisitionRepository.findCertifiable
+        badgeAcquisitionRepository.findHighestCertifiable
           .withArgs({ userId, domainTransaction })
           .resolves([
             pixEduFormationContinue1erDegreExpertBadgeAcquisition,

--- a/api/tests/unit/domain/services/certification-badges-service-test.js
+++ b/api/tests/unit/domain/services/certification-badges-service-test.js
@@ -5,7 +5,7 @@ const badgeRepository = require('../../../../lib/infrastructure/repositories/bad
 const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
 const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
 const badgeCriteriaService = require('../../../../lib/domain/services/badge-criteria-service');
-const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF, PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3 } =
+const { PIX_EMPLOI_CLEA_V1, PIX_EMPLOI_CLEA_V2, PIX_EMPLOI_CLEA_V3 } =
   require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Service | Certification Badges Service', function () {
@@ -97,37 +97,28 @@ describe('Unit | Service | Certification Badges Service', function () {
         targetProfile = { id: 12 };
       });
 
-      context('has maitreBadgeAcquisition', function () {
-        it('should return badge-acquisitions with maitreBadgeAcquisition', async function () {
+      context('has one badge acquisition', function () {
+        it('should return badge-acquisition with highest level', async function () {
           // given
-          const maitreBadge = domainBuilder.buildBadge({
+          const badgeLevel1 = domainBuilder.buildBadge({
             id: 'maitre',
             targetProfileId: targetProfile.id,
-            key: PIX_DROIT_MAITRE_CERTIF,
+            key: 'LEVEL_1',
           });
-          const otherBadge = domainBuilder.buildBadge({ id: 'other', targetProfileId: targetProfile.id });
-          const maitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
+          const badgeAcquisitionLevel1 = domainBuilder.buildBadgeAcquisition({
             id: 'badgeId1',
             userId,
-            badge: maitreBadge,
-          });
-          const otherBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
-            id: 'badgeId2',
-            userId,
-            badge: otherBadge,
+            badge: badgeLevel1,
           });
           badgeAcquisitionRepository.findCertifiable
             .withArgs({ userId, domainTransaction })
-            .resolves([maitreBadgeAcquisition, otherBadgeAcquisition]);
+            .resolves([badgeAcquisitionLevel1]);
           knowledgeElementRepository.findUniqByUserId
             .withArgs({ userId, domainTransaction })
             .resolves(knowledgeElements);
           targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
           badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ targetProfile, badge: maitreBadge, knowledgeElements })
-            .returns(true);
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ targetProfile, badge: otherBadge, knowledgeElements })
+            .withArgs({ targetProfile, badge: badgeLevel1, knowledgeElements })
             .returns(true);
 
           // when
@@ -137,45 +128,42 @@ describe('Unit | Service | Certification Badges Service', function () {
           });
 
           // then
-          expect(badgesAcquisitions).to.deep.equal([otherBadgeAcquisition, maitreBadgeAcquisition]);
+          expect(badgesAcquisitions).to.deep.equal([badgeAcquisitionLevel1]);
         });
       });
 
-      context('has maitreBadgeAcquisition and expertBadgeAcquisition', function () {
-        it('should return badge-acquisitions with expertBadgeAcquisition', async function () {
+      context('has several badge acquisition', function () {
+        it('should return the badge-acquisition with the highest level', async function () {
           // given
-          const maitreBadge = domainBuilder.buildBadge({
+          const badgeLevel1 = domainBuilder.buildBadge({
             id: 'maitre',
             targetProfileId: targetProfile.id,
-            key: PIX_DROIT_MAITRE_CERTIF,
+            key: 'LEVEL_1',
           });
-          const expertBadge = domainBuilder.buildBadge({
+          const badgeLevel2 = domainBuilder.buildBadge({
             id: 'expert',
             targetProfileId: targetProfile.id,
-            key: PIX_DROIT_EXPERT_CERTIF,
+            key: 'LEVEL_2',
           });
-          const maitreBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
+          domainBuilder.buildBadgeAcquisition({
             id: 'badgeId1',
             userId,
-            badge: maitreBadge,
+            badge: badgeLevel1,
           });
-          const expertBadgeAcquisition = domainBuilder.buildBadgeAcquisition({
+          const badgeAcquisitionLevel2 = domainBuilder.buildBadgeAcquisition({
             id: 'badgeId2',
             userId,
-            badge: expertBadge,
+            badge: badgeLevel2,
           });
           badgeAcquisitionRepository.findCertifiable
             .withArgs({ userId, domainTransaction })
-            .resolves([maitreBadgeAcquisition, expertBadgeAcquisition]);
+            .resolves([badgeAcquisitionLevel2]);
           knowledgeElementRepository.findUniqByUserId
             .withArgs({ userId, domainTransaction })
             .resolves(knowledgeElements);
           targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
           badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ targetProfile, badge: maitreBadge, knowledgeElements })
-            .returns(true);
-          badgeCriteriaService.areBadgeCriteriaFulfilled
-            .withArgs({ targetProfile, badge: expertBadge, knowledgeElements })
+            .withArgs({ targetProfile, badge: badgeLevel2, knowledgeElements })
             .returns(true);
 
           // when
@@ -185,107 +173,13 @@ describe('Unit | Service | Certification Badges Service', function () {
           });
 
           // then
-          expect(badgesAcquisitions).to.deep.equal([expertBadgeAcquisition]);
+          expect(badgesAcquisitions).to.deep.equal([badgeAcquisitionLevel2]);
         });
       });
     });
 
-    context('has certifiable badges including Pix+ Édu 2nd degre', function () {
-      it('should return badge-acquisitions with highest Pix+ Édu badge and other badge acquisitions', async function () {
-        // given
-        const userId = 12;
-        const domainTransaction = Symbol('someDomainTransaction');
-        const knowledgeElements = [];
-        const targetProfile = { id: 456 };
-
-        const pixEduFormationContinueAvanceBadgeAcquisition =
-          domainBuilder.buildBadgeAcquisition.forPixEduFormationContinue2ndDegreAvance();
-        const pixEduFormationContinueConfirmeBadgeAcquisition =
-          domainBuilder.buildBadgeAcquisition.forPixEduFormationContinue2ndDegreConfirme();
-        const otherBadgeAcquisition = domainBuilder.buildBadgeAcquisition();
-
-        badgeAcquisitionRepository.findCertifiable
-          .withArgs({ userId, domainTransaction })
-          .resolves([
-            pixEduFormationContinueConfirmeBadgeAcquisition,
-            pixEduFormationContinueAvanceBadgeAcquisition,
-            otherBadgeAcquisition,
-          ]);
-        knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
-        targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
-        badgeCriteriaService.areBadgeCriteriaFulfilled
-          .withArgs({ targetProfile, badge: pixEduFormationContinueAvanceBadgeAcquisition.badge, knowledgeElements })
-          .returns(true);
-        badgeCriteriaService.areBadgeCriteriaFulfilled
-          .withArgs({ targetProfile, badge: pixEduFormationContinueConfirmeBadgeAcquisition.badge, knowledgeElements })
-          .returns(true);
-        badgeCriteriaService.areBadgeCriteriaFulfilled
-          .withArgs({ targetProfile, badge: otherBadgeAcquisition.badge, knowledgeElements })
-          .returns(true);
-
-        // when
-        const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
-          userId,
-          domainTransaction,
-        });
-
-        // then
-        expect(badgesAcquisitions).to.deep.equal([
-          otherBadgeAcquisition,
-          pixEduFormationContinueAvanceBadgeAcquisition,
-        ]);
-      });
-    });
-
-    context('has certifiable badges including Pix+ Édu 1er degre', function () {
-      it('should return badge-acquisitions with highest Pix+ Édu badge and other badge acquisitions', async function () {
-        // given
-        const userId = 12;
-        const domainTransaction = Symbol('someDomainTransaction');
-        const knowledgeElements = [];
-        const targetProfile = { id: 456 };
-
-        const pixEduFormationContinueAvanceBadgeAcquisition =
-          domainBuilder.buildBadgeAcquisition.forPixEduFormationContinue1erDegreAvance();
-        const pixEduFormationContinueConfirmeBadgeAcquisition =
-          domainBuilder.buildBadgeAcquisition.forPixEduFormationContinue1erDegreConfirme();
-        const otherBadgeAcquisition = domainBuilder.buildBadgeAcquisition();
-
-        badgeAcquisitionRepository.findCertifiable
-          .withArgs({ userId, domainTransaction })
-          .resolves([
-            pixEduFormationContinueConfirmeBadgeAcquisition,
-            pixEduFormationContinueAvanceBadgeAcquisition,
-            otherBadgeAcquisition,
-          ]);
-        knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
-        targetProfileRepository.get.withArgs(targetProfile.id, domainTransaction).resolves(targetProfile);
-        badgeCriteriaService.areBadgeCriteriaFulfilled
-          .withArgs({ targetProfile, badge: pixEduFormationContinueAvanceBadgeAcquisition.badge, knowledgeElements })
-          .returns(true);
-        badgeCriteriaService.areBadgeCriteriaFulfilled
-          .withArgs({ targetProfile, badge: pixEduFormationContinueConfirmeBadgeAcquisition.badge, knowledgeElements })
-          .returns(true);
-        badgeCriteriaService.areBadgeCriteriaFulfilled
-          .withArgs({ targetProfile, badge: otherBadgeAcquisition.badge, knowledgeElements })
-          .returns(true);
-
-        // when
-        const badgesAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
-          userId,
-          domainTransaction,
-        });
-
-        // then
-        expect(badgesAcquisitions).to.deep.equal([
-          otherBadgeAcquisition,
-          pixEduFormationContinueAvanceBadgeAcquisition,
-        ]);
-      });
-    });
-
-    context('has certifiable badges including Pix+ Édu and Pix+ Droit', function () {
-      it('should return badge-acquisitions with highest Pix+ Édu badge and highest Pix+ Droit badge', async function () {
+    context('has different types of certifiable badges', function () {
+      it('should return badge-acquisitions with highest level for each type of certifiable badge', async function () {
         // given
         const userId = 12;
         const domainTransaction = Symbol('someDomainTransaction');
@@ -306,11 +200,8 @@ describe('Unit | Service | Certification Badges Service', function () {
         badgeAcquisitionRepository.findCertifiable
           .withArgs({ userId, domainTransaction })
           .resolves([
-            pixEduFormationContinue1erAvanceBadgeAcquisition,
             pixEduFormationContinue1erDegreExpertBadgeAcquisition,
-            pixEduFormationContinue2ndAvanceBadgeAcquisition,
             pixEduFormationContinue2ndDegreExpertBadgeAcquisition,
-            pixDroitMaitreBadgeAcquisition,
             pixDroitExpertBadgeAcquisition,
           ]);
         knowledgeElementRepository.findUniqByUserId.withArgs({ userId, domainTransaction }).resolves(knowledgeElements);
@@ -337,9 +228,9 @@ describe('Unit | Service | Certification Badges Service', function () {
 
         // then
         expect(badgesAcquisitions).to.deep.equal([
-          pixDroitExpertBadgeAcquisition,
-          pixEduFormationContinue2ndDegreExpertBadgeAcquisition,
           pixEduFormationContinue1erDegreExpertBadgeAcquisition,
+          pixEduFormationContinue2ndDegreExpertBadgeAcquisition,
+          pixDroitExpertBadgeAcquisition,
         ]);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, lorsqu’un utilisateur passe un parcours basé sur un profil cible permettant d’obtenir un badge certifiable, ce dernier obtient un badge à chaque fois qu’un palier d’acquis est atteint. Par exemple, pour une campagne Pix+ Droit, l’utilisateur obtiendra le badge Pix+ Droit Maître à un certain moment puis Pix+ Droit Expert s’il continue à bien répondre aux épreuves. Cependant, bien qu’il ait obtenu deux badges, nous souhaitons le certifier uniquement sur le badge de plus haut niveau (en l'occurrence Pix+ Droit Expert).

L’objectif de ce ticket et d’utiliser le niveau inscrit dans la table complementary-certification-badges plutôt que d’utiliser une valeur en dure dans le code.

## :robot: Solution

Nous remplaçons le système de filtres utilisés pour récupérer chaque badge certifiable de plus haut niveau en dur dans le code dans `certification-badges-services.js` par des requêtes SQL.

## :rainbow: Remarques

- Nous en profitons pour remplacer Bookshelf dans l'ancienne implémentation.

- Le cléA n'est pas (encore) impacté par ce changement

## :100: Pour tester

• Obtenir un compte certifiable Pix+ Droit au niveau expert (soit en passant une campagne Droit, soit en faisant en sorte que le compte certifdroit@example.net soit au niveau expert)
• Créer une session et y ajouter un candidat pour chaque certification complémentaire (4 candidats)
• Se connecter à Pix App avec le compte éligible au badge Pix+ Droit Expert 
• Vérifier que, depuis la page d’accès à une certification, le candidat est bien éligible à la certification Pix+ Droit Expert.
• Rentrer les informations de connexion à la session.
• Vérifier que le candidat est bien éligible et inscrit à la certification complémentaire Pix+ Droit Expert.
• Commencer la certification.
• Vérifier que, dans la table `complementary-certification-courses` la partnerKey correspond bien au badge Pix+ Droit de niveau Expert.

Répéter ce procédé avec les comptes suivants:

`certifedu.1er.initiale@example.net` (niveau Pix+ Édu 1er degré Confirmé, hors inscription). `certifedu.1er.continue@example.net` (niveau Pix+ Édu 1er degré Avancé, hors inscription). 
`certifedu.2nd.initiale@example.net` (niveau Pix+ Édu 2nd degré Confirmé, hors inscription).
`certifedu.2nd.continue@example.net` (niveau Pix+ Édu 2nd degré Avancé, hors inscription). 
