### PR TITLE
[TECH] Ajout d'un feature toggle pour la réconciliation de compte SSO sur Pix App (PIX-5351).

### DIFF
--- a/api/lib/application/preHandlers/feature-toggles.js
+++ b/api/lib/application/preHandlers/feature-toggles.js
@@ -1,1 +1,11 @@
-module.exports = {};
+const config = require('../../config');
+const { NotFoundError } = require('../../application/http-errors');
+
+module.exports = {
+  async checkIfSSOAccountReconciliationIsEnabled() {
+    if (!config.featureToggles.isSSOAccountReconciliationEnabled) {
+      throw new NotFoundError('Cette route est désactivée');
+    }
+    return true;
+  },
+};

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -188,6 +188,7 @@ module.exports = (function () {
 
     featureToggles: {
       isPixAppTutoFiltersEnabled: isFeatureEnabled(process.env.FT_TUTOS_V2_1_FILTERS),
+      isSSOAccountReconciliationEnabled: isFeatureEnabled(process.env.FT_SSO_ACCOUNT_RECONCILIATION),
     },
 
     infra: {
@@ -308,6 +309,7 @@ module.exports = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.isPixAppTutoFiltersEnabled = false;
+    config.featureToggles.isSSOAccountReconciliationEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -26,6 +26,7 @@ const schema = Joi.object({
   LOG_OPS_METRICS: Joi.string().optional().valid('true', 'false'),
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
+  FT_SSO_ACCOUNT_RECONCILIATION: Joi.string().optional().valid('true', 'false'),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -671,6 +671,13 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 # default: false
 # FT_TUTOS_V2_1_FILTERS=true
 
+# Prevent user from seeing the new sso account reconciliation
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_SSO_ACCOUNT_RECONCILIATION=true
+
 # =====
 # CPF
 # =====

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,6 +23,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           type: 'feature-toggles',
           attributes: {
             'is-pix-app-tuto-filters-enabled': false,
+            'is-sso-account-reconciliation-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isPixAppTutoFiltersEnabled;
+  @attr('boolean') isSSOAccountReconciliationEnabled;
 }

--- a/mon-pix/tests/unit/services/feature-toggles_test.js
+++ b/mon-pix/tests/unit/services/feature-toggles_test.js
@@ -10,7 +10,9 @@ describe('Unit | Service | feature-toggles', function () {
   setupTest();
 
   describe('feature toggles are loaded', function () {
-    const featureToggles = Object.create({});
+    const featureToggles = Object.create({
+      isSSOAccountReconciliationEnabled: false,
+    });
 
     let storeStub;
 


### PR DESCRIPTION
## :unicorn: Problème
Avec l'interconnexion de notre nouveau partenaire CNAV, nous avons repensé le parcours utilisateur dans Pix App et notamment la partie concernant la pérennité des comptes. 
Cette nouvelle réconciliation de compte va concerner nos deux partenaires CNAV et Pôle Emploi. 
Or Pôle Emploi dispose déjà d'un scénario de réconciliation. Il ne faut donc pas que cette nouvelle implémentation impacte l'existant.

## :robot: Solution
Mettre en place un feature toggle pour cette nouvelle réconciliation de compte SSO

## :rainbow: Remarques
On applique ce feature toggle à la fois dans le front et le back.

## :100: Pour tester
Vérifier que les tests et la CI passent.
