### PR TITLE
[FEATURE] Pix admin - Profil cible : Retirer la description du sujet dans l'affichage de ce dernier (PIX-5312)

### DIFF
--- a/admin/app/components/target-profiles/tubes-selection/tube.hbs
+++ b/admin/app/components/target-profiles/tubes-selection/tube.hbs
@@ -5,9 +5,9 @@
       @state={{this.state}}
       {{on "change" this.onChange}}
     />
-    {{@tube.practicalTitle}}
+    {{@tube.name}}
     :
-    {{@tube.practicalDescription}}
+    {{@tube.practicalTitle}}
   </label>
 </td>
 <td class="table__column--center">

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/details.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/details.js
@@ -26,7 +26,7 @@ export default class TargetProfileDetailsController extends Controller {
 
   buildTubeViewModel(tube) {
     return {
-      title: `${tube.practicalTitle} : ${tube.practicalDescription}`,
+      title: `${tube.name} : ${tube.practicalTitle}`,
       level: tube.level,
       mobile: tube.mobile,
       tablet: tube.tablet,

--- a/admin/app/models/tube.js
+++ b/admin/app/models/tube.js
@@ -1,6 +1,7 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Tube extends Model {
+  @attr('string') name;
   @attr('string') practicalTitle;
   @attr('string') practicalDescription;
   @attr('string') competenceId;

--- a/admin/tests/integration/components/target-profiles/tubes-selection_test.js
+++ b/admin/tests/integration/components/target-profiles/tubes-selection_test.js
@@ -12,14 +12,14 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     const tubes1 = [
       {
         id: 'tubeId1',
+        name: '@tubeName1',
         practicalTitle: 'Tube 1',
-        practicalDescription: 'Description 1',
         skills: [],
       },
       {
         id: 'tubeId2',
+        name: '@tubeName2',
         practicalTitle: 'Tube 2',
-        practicalDescription: 'Description 2',
         skills: [],
       },
     ];
@@ -27,8 +27,8 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     const tubes2 = [
       {
         id: 'tubeId3',
+        name: '@tubeName3',
         practicalTitle: 'Tube 3',
-        practicalDescription: 'Description 3',
         skills: [],
       },
     ];
@@ -78,19 +78,19 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     await clickByName('1 Titre competence');
 
     // then
-    assert.dom(screen.getByText('Tube 1 : Description 1')).exists();
-    assert.dom(screen.getByText('Tube 2 : Description 2')).exists();
-    assert.dom(screen.getByText('Tube 3 : Description 3')).exists();
+    assert.dom(screen.getByText('@tubeName1 : Tube 1')).exists();
+    assert.dom(screen.getByText('@tubeName2 : Tube 2')).exists();
+    assert.dom(screen.getByText('@tubeName3 : Tube 3')).exists();
   });
 
   test('it should check the tubes if selected', async function (assert) {
     // when
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
-    await clickByName('Tube 1 : Description 1');
+    await clickByName('@tubeName1 : Tube 1');
 
     // then
-    assert.dom(screen.getByLabelText('Tube 1 : Description 1')).isChecked();
+    assert.dom(screen.getByLabelText('@tubeName1 : Tube 1')).isChecked();
   });
 
   test('it should check all tubes corresponding to the thematics if a thematic is selected', async function (assert) {
@@ -100,8 +100,8 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     await clickByName('Thématique 1');
 
     // then
-    assert.dom(screen.getByLabelText('Tube 1 : Description 1')).isChecked();
-    assert.dom(screen.getByLabelText('Tube 2 : Description 2')).isChecked();
+    assert.dom(screen.getByLabelText('@tubeName1 : Tube 1')).isChecked();
+    assert.dom(screen.getByLabelText('@tubeName2 : Tube 2')).isChecked();
     assert.dom(screen.getByLabelText('Thématiques')).isNotChecked();
     assert.dom(screen.getByLabelText('Thématiques')).hasProperty('indeterminate', true);
   });
@@ -110,8 +110,8 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     // when
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
-    await clickByName('Tube 1 : Description 1');
-    await clickByName('Tube 2 : Description 2');
+    await clickByName('@tubeName1 : Tube 1');
+    await clickByName('@tubeName2 : Tube 2');
 
     // then
     assert.dom(screen.getByLabelText('Thématique 1')).isChecked();
@@ -123,7 +123,7 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     // when
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
-    await clickByName('Tube 1 : Description 1');
+    await clickByName('@tubeName1 : Tube 1');
 
     // then
     assert.dom(screen.getByLabelText('Thématique 1')).isNotChecked();
@@ -156,9 +156,9 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     assert.dom(screen.getByLabelText('Thématique 2')).isChecked();
     assert.dom(screen.getByLabelText('Thématique 2')).hasProperty('indeterminate', false);
 
-    assert.dom(screen.getByLabelText('Tube 1 : Description 1')).isChecked();
-    assert.dom(screen.getByLabelText('Tube 2 : Description 2')).isChecked();
-    assert.dom(screen.getByLabelText('Tube 3 : Description 3')).isChecked();
+    assert.dom(screen.getByLabelText('@tubeName1 : Tube 1')).isChecked();
+    assert.dom(screen.getByLabelText('@tubeName2 : Tube 2')).isChecked();
+    assert.dom(screen.getByLabelText('@tubeName3 : Tube 3')).isChecked();
   });
 
   module('#import tubes preselection', function () {
@@ -172,7 +172,7 @@ module('Integration | Component | TargetProfiles::TubesSelection', function (hoo
     // when
     await clickByName('1 · Titre domaine');
     await clickByName('1 Titre competence');
-    await clickByName('Tube 1 : Description 1');
+    await clickByName('@tubeName1 : Tube 1');
 
     // then
     assert.dom(screen.getByText('1/3')).exists();

--- a/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
@@ -19,7 +19,7 @@ module.exports = {
           tubes: {
             include: true,
             ref: 'id',
-            attributes: ['practicalTitle', 'practicalDescription', 'mobile', 'tablet', 'skills'],
+            attributes: ['name', 'practicalTitle', 'practicalDescription', 'mobile', 'tablet', 'skills'],
             skills: {
               ref: true,
               ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
+++ b/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Controller | frameworks-controller', function () {
     tubes: [
       {
         id: 'tubeId',
-        title: '@tube',
+        name: '@tube',
         description: 'Description tube',
         practicalTitleFrFr: 'Titre pratique',
         practicalDescriptionFrFr: 'description pratique',
@@ -126,6 +126,7 @@ describe('Acceptance | Controller | frameworks-controller', function () {
               id: 'tubeId',
               type: 'tubes',
               attributes: {
+                name: '@tube',
                 'practical-title': 'Titre pratique',
                 'practical-description': 'description pratique',
                 mobile: false,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
@@ -50,6 +50,7 @@ describe('Unit | Serializer | JSONAPI | pix-framework-serializer', function () {
             type: 'tubes',
             id: 'tubeId',
             attributes: {
+              name: '@tubeName',
               'practical-title': 'titre pratique',
               'practical-description': 'description pratique',
             },


### PR DESCRIPTION
## :unicorn: Problème

L'affichage des sujets n'est pas très lisible.

## :robot: Solution

Retirer la description du sujet et ajouter son nom en préfixe.

## :rainbow: Remarques

On garde la `practicalDescription` en sortie de l'API pour PixOrga.

## :100: Pour tester

Sur la RA, créer un profil et visualiser son onglet détail.