### PR TITLE
[FEATURE] Pix admin - Page détail d'un nouveau PC : reprendre les CTA (PIX-5313)

### DIFF
--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -22,6 +22,10 @@ export default class TargetProfileController extends Controller {
     return this.model.isSimplifiedAccess ? 'Oui' : 'Non';
   }
 
+  get displayActionsSeparator() {
+    return !this.model.isSimplifiedAccess || this.model.tubesSelection;
+  }
+
   @action
   toggleEditMode() {
     this.isEditMode = !this.isEditMode;

--- a/admin/app/styles/components/target-profiles/target-profile.scss
+++ b/admin/app/styles/components/target-profiles/target-profile.scss
@@ -20,6 +20,23 @@
   }
 }
 
-.target-profile_title {
-  margin-right: 8px;
+.target-profile {
+
+  &__title {
+    margin-right: 8px;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 16px;
+
+    &-separator {
+      background-color: $pix-neutral-22;
+      width: 1px;
+    }
+
+    &-spacer {
+      flex-grow: 1;
+    }
+  }
 }

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -15,7 +15,7 @@
   {{else}}
     <section class="page-section">
       <div class="page-section__header">
-        <h1 class="page-section__title target-profile_title">{{@model.name}}</h1>
+        <h1 class="page-section__title target-profile__title">{{@model.name}}</h1>
         <TargetProfiles::Category @category={{@model.category}} />
       </div>
       <div class="page-section__container">
@@ -46,22 +46,23 @@
           {{/if}}
         </div>
       </div>
-      <div class="form-actions">
+      <div class="target-profile__actions">
         <PixButton
           @size="small"
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
           @triggerAction={{this.toggleEditMode}}
-        >Editer</PixButton>
-        {{#unless @model.outdated}}
-          <PixButton @size="small" @backgroundColor="red" @triggerAction={{this.toggleDisplayConfirm}}>
-            Marquer comme obsolète
-          </PixButton>
-        {{/unless}}
+        >
+          Éditer
+        </PixButton>
+        {{#if this.displayActionsSeparator}}
+          <div class="target-profile__actions-separator"></div>
+        {{/if}}
         {{#unless @model.isSimplifiedAccess}}
           <PixButton
             @size="small"
-            @backgroundColor="yellow"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
             @triggerAction={{this.toggleDisplaySimplifiedAccessPopupConfirm}}
           >
             Marquer comme accès simplifié
@@ -72,6 +73,12 @@
             Télécharger le profil cible (JSON)
           </PixButton>
         {{/if}}
+        {{#unless @model.outdated}}
+          <div class="target-profile__actions-spacer"></div>
+          <PixButton @size="small" @backgroundColor="red" @triggerAction={{this.toggleDisplayConfirm}}>
+            Marquer comme obsolète
+          </PixButton>
+        {{/unless}}
       </div>
     </section>
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/details_test.js
@@ -132,10 +132,10 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
         // when
         const screen = await visit('/target-profiles/1');
-        await clickByName('Editer');
+        await clickByName('Éditer');
 
         // then
-        assert.dom(screen.queryByLabelText('Editer')).doesNotExist();
+        assert.dom(screen.queryByLabelText('Éditer')).doesNotExist();
       });
 
       test('it should outdate target profile', async function (assert) {
@@ -191,7 +191,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
         // when
         const screen = await visit('/target-profiles/1');
-        await clickByName('Editer');
+        await clickByName('Éditer');
         await fillByLabel('* Nom', 'Profil Cible Fantastix Edited');
         await clickByName('Enregistrer');
 
@@ -213,7 +213,7 @@ module('Acceptance | Target Profiles | Target Profile | Details', function (hook
 
         // when
         const screen = await visit('/target-profiles/1');
-        await clickByName('Editer');
+        await clickByName('Éditer');
         await fillByLabel('Catégorie :', 'CUSTOM');
         await clickByName('Enregistrer');
 


### PR DESCRIPTION
## :unicorn: Problème

Les boutons CTA sont un peu laids.

## :robot: Solution

Reprendre les boutons CTA pour colle à la nouvelle maquette : https://www.figma.com/file/0bksLNTrEC1IBgTXu16z77/Pix-admin?node-id=711%3A7648

## :rainbow: Remarques

N/A

## :100: Pour tester

Aller admirer l'affichage de l'onglet détail d'un profil cible avec différentes configurations (ancien/nouveau PC, accès simplifié ou non, obsolète ou non...).