### PR TITLE
[TECH] Mettre à jour le serveur redis de test de 5.0.7 à 6.2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:5.0.7-alpine
+      - image: redis:6.2.7-alpine
     resource_class: small
     working_directory: ~/pix/api
     steps:
@@ -241,7 +241,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:5.0.7-alpine
+      - image: redis:6.2.7-alpine
     resource_class: medium+
     parallelism: 5
     working_directory: ~/pix/high-level-tests/e2e

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
-    image: redis:5.0.7-alpine
+    image: redis:6.2.7-alpine
     container_name: pix-api-redis
     ports:
       - '${PIX_CACHE_PORT:-6379}:6379'

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
 
   redis:
     container_name: pix-e2e-redis
-    image: redis:5.0.7-alpine
+    image: redis:6.2.7-alpine
 
   cypress:
     container_name: pix-e2e-cypress


### PR DESCRIPTION
## :unicorn: Problème
Le PaaS Scalingo utilise par défaut la version `6.2.5` dans les review app

## :robot: Solution
Utiliser la même version en local
L'image `6.2.5`  n'existe pas sur DockerHub.
Utilisation de la version `6.2.7` en lieu et place.

## :rainbow: Remarques
Pour avoir la même version que sur Scalingo, voir la PR https://github.com/1024pix/pix/pull/4701

Des mises à jour intermédiaires sont nécessaires pour les environnements Scalingo:
- 5.0.13.1;
- 6.0.10-1;
- 6.2.5.

L'action de mise à jour à chaud a été testée sur https://dashboard.scalingo.com/apps/osc-fr1/pix-api-integration.

## :100: Pour tester
Vérifier qu'on peut se connecter via le client redis en local.
Vérifier que la CI passe.
