### PR TITLE
[TECH] Utiliser la version de base de données de Scalingo en local

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -108,8 +108,10 @@ LCMS_API_URL=<SOME_URL>
 
 Vérifier les connexions à la base de donnée :
 
-- de test manuel (présence de table et de données) `docker exec -it pix-api-postgres psql -U postgres pix`;
-- de test automatique (présence de tables) `docker exec -it pix-api-postgres psql -U postgres pix_test`.
+- de test manuel (présence de table et de
+  données) `docker exec -it pix-api-postgres psql postgres://postgresql:secret@localhost:5432/pix`;
+- de test automatique (présence de
+  tables) `docker exec -it pix-api-postgres psql postgres://postgresql:secret@localhost:5432/pix_test`.
 
 ### 4. Démarrer les applications.
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -63,7 +63,7 @@ REDIS_URL=redis://localhost:6379
 # presence: required
 # type: Url
 # default: none
-DATABASE_URL=postgresql://postgres@localhost/pix
+DATABASE_URL=postgres://postgresql:secret@localhost:5432/pix
 
 # URL of the PostgreSQL database used for API local testing.
 #
@@ -72,7 +72,7 @@ DATABASE_URL=postgresql://postgres@localhost/pix
 # presence: required
 # type: Url
 # default: none
-TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
+DATABASE_URL=postgres://postgresql:secret@localhost:5432/pix_test
 
 # Maximum connection pool size
 # https://knexjs.org/#Installation-pooling

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,12 +2,11 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:13.7-alpine
+    image: scalingo/postgresql:13.7.0-1
     container_name: pix-api-postgres
+    command: /postgresql
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
     image: redis:5.0.7-alpine


### PR DESCRIPTION
## :unicorn: Problème
L'image utilisée pour instancier la BDD locale n'est pas celle de Scalingo.
Des écarts de comportement peuvent apparaître.

## :robot: Solution
Utiliser l'image Scalingo
https://hub.docker.com/r/scalingo/postgresql/tags

## :rainbow: Remarques
Elle plus lourde (700Mo) que la version alpine (70Mo), mais n'est téléchargée qu'une seule fois en local.
On garde la version alpine dans la CI.

## :100: Pour tester
Exécuter les tests en local
Se connecter à la base de données avec `psql postgres://postgresql:secret@localhost:5432/pix`
