### PR TITLE
[TECH] Ne plus récupérer de propriété id ignorée dans les tests

### DIFF
--- a/api/tests/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-issue-report-controller_test.js
@@ -14,7 +14,7 @@ describe('Acceptance | Controller | certification-issue-report-controller', func
       const server = await createServer();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
       const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
       const certificationIssueReportId = databaseBuilder.factory.buildCertificationIssueReport({

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -866,8 +866,8 @@ describe('Acceptance | Application | organization-controller', function () {
       const member2 = databaseBuilder.factory.buildUser();
       const otherOrganizationMember = databaseBuilder.factory.buildUser();
 
-      databaseBuilder.factory.buildMembership({ userId: member1.id, organizationId }).id;
-      databaseBuilder.factory.buildMembership({ userId: member2.id, organizationId }).id;
+      databaseBuilder.factory.buildMembership({ userId: member1.id, organizationId });
+      databaseBuilder.factory.buildMembership({ userId: member2.id, organizationId });
       databaseBuilder.factory.buildMembership({
         userId: otherOrganizationMember.id,
         organizationId: otherOrganizationId,

--- a/api/tests/acceptance/application/progression-controller_test.js
+++ b/api/tests/acceptance/application/progression-controller_test.js
@@ -46,7 +46,7 @@ describe('Acceptance | API | Progressions', function () {
 
       userId = databaseBuilder.factory.buildUser({}).id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId }).id;
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId });
       const campaignId = databaseBuilder.factory.buildCampaign({
         name: 'Campaign',
         targetProfileId,

--- a/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
@@ -39,7 +39,7 @@ describe('POST /api/admin/sessions/publish-in-batch', function () {
         sessionId = databaseBuilder.factory.buildSession({ publishedAt: null }).id;
         databaseBuilder.factory.buildFinalizedSession({ sessionId });
         options.payload = { data: { attributes: { ids: [sessionId] } } };
-        databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false }).id;
+        databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false });
         return databaseBuilder.commit();
       });
 

--- a/api/tests/integration/domain/event/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/event/handle-badge-acquisition_test.js
@@ -95,7 +95,7 @@ describe('Integration | Event | Handle Badge Acquisition Service', function () {
         targetProfileId,
         badgeCriteria: [],
         key: 'Badge3',
-      }).id;
+      });
 
       event = new AsessmentCompletedEvent();
       event.userId = userId;

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -64,10 +64,10 @@ describe('Integration | Service | Certification-Badges Service', function () {
         badgeId: badge.id,
         threshold: 40,
       });
-      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' }).id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' }).id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' }).id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' }).id;
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
       const skillSet = databaseBuilder.factory.buildSkillSet({
         badgeId: badge.id,
         skillIds: ['web1', 'web2', 'web3', 'web4'],

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -253,7 +253,7 @@ describe('Integration | Repository | Badge', function () {
     it('should not return a badge from another campaign', async function () {
       // given
       const targetProfileId = targetProfileWithSeveralBadges.id;
-      databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      databaseBuilder.factory.buildCampaign({ targetProfileId });
       const anotherCampaignId = databaseBuilder.factory.buildCampaign().id;
       await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -103,13 +103,13 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
           userId,
           createdAt: new Date('2020-10-10'),
           state: Assessment.states.COMPLETED,
-        }).id;
+        });
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId,
           userId,
           createdAt: new Date('2020-11-11'),
           state: Assessment.states.STARTED,
-        }).id;
+        });
 
         databaseBuilder.factory.buildKnowledgeElement({
           userId,

--- a/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -351,9 +351,9 @@ describe('Integration | Repository | Campaign-Management', function () {
 
       it('should sort campaigns by descending creation date', async function () {
         // given
-        databaseBuilder.factory.buildCampaign({ organizationId, name: 'May', createdAt: new Date('2020-05-01') }).id;
-        databaseBuilder.factory.buildCampaign({ organizationId, name: 'June', createdAt: new Date('2020-06-01') }).id;
-        databaseBuilder.factory.buildCampaign({ organizationId, name: 'July', createdAt: new Date('2020-07-01') }).id;
+        databaseBuilder.factory.buildCampaign({ organizationId, name: 'May', createdAt: new Date('2020-05-01') });
+        databaseBuilder.factory.buildCampaign({ organizationId, name: 'June', createdAt: new Date('2020-06-01') });
+        databaseBuilder.factory.buildCampaign({ organizationId, name: 'July', createdAt: new Date('2020-07-01') });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -470,15 +470,15 @@ describe('Integration | Repository | Campaign Participation', function () {
           organizationId: otherOrganizationId,
           division: '2nd',
         }).id;
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, organizationLearnerId }).id;
+        databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, organizationLearnerId });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaign.id,
           organizationLearnerId,
-        }).id;
+        });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: otherCampaign.id,
           organizationLearnerId: otherOrganizationLearnerId,
-        }).id;
+        });
 
         await databaseBuilder.commit();
       });

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -192,7 +192,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       });
 
       it('return the number of competences certifiable', async function () {
-        databaseBuilder.factory.buildCampaign().id;
+        databaseBuilder.factory.buildCampaign();
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const user = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Shaft' });
@@ -220,7 +220,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       });
 
       it('return the total pix score', async function () {
-        databaseBuilder.factory.buildCampaign().id;
+        databaseBuilder.factory.buildCampaign();
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const user = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Shaft' });
@@ -257,7 +257,7 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       });
 
       it('computes certifiable competences acquired before the sharing date of the campaign participation', async function () {
-        databaseBuilder.factory.buildCampaign().id;
+        databaseBuilder.factory.buildCampaign();
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const user = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Shaft' });

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -192,7 +192,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       });
 
       it('return the number of competences certifiable', async function () {
-        databaseBuilder.factory.buildCampaign();
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const user = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Shaft' });
@@ -220,7 +219,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       });
 
       it('return the total pix score', async function () {
-        databaseBuilder.factory.buildCampaign();
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const user = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Shaft' });
@@ -257,7 +255,6 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       });
 
       it('computes certifiable competences acquired before the sharing date of the campaign participation', async function () {
-        databaseBuilder.factory.buildCampaign();
         const campaignId = databaseBuilder.factory.buildCampaign().id;
 
         const user = databaseBuilder.factory.buildUser({ firstName: 'John', lastName: 'Shaft' });

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -471,7 +471,7 @@ describe('Integration | Repository | Campaign', function () {
       const otherCampaignId = databaseBuilder.factory.buildCampaign().id;
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: otherCampaignId,
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -187,7 +187,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
           assessmentId: expectedCertificationAssessmentId,
           createdAt: new Date('2020-06-25T00:00:01Z'),
           challengeId: 'recChalA',
-        }).id;
+        });
         dbf.buildCertificationChallenge({ challengeId: 'recChalA', courseId: certificationCourseId, id: 123 });
         dbf.buildCertificationChallenge({ challengeId: 'recChalB', courseId: certificationCourseId, id: 456 });
 

--- a/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-attestation-repository_test.js
@@ -1087,7 +1087,7 @@ async function _buildIncomplete(certificationAttestationData) {
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
-  }).id;
+  });
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1101,8 +1101,8 @@ async function _buildIncomplete(certificationAttestationData) {
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
-  }).id;
-  databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id }).id;
+  });
+  databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id });
   await databaseBuilder.commit();
 }
 
@@ -1114,7 +1114,7 @@ async function _buildRejected(certificationAttestationData) {
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
-  }).id;
+  });
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1128,7 +1128,7 @@ async function _buildRejected(certificationAttestationData) {
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
-  }).id;
+  });
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationAttestationData.id,
   }).id;
@@ -1148,7 +1148,7 @@ async function _buildCancelled(certificationAttestationData) {
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
-  }).id;
+  });
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1162,7 +1162,7 @@ async function _buildCancelled(certificationAttestationData) {
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
-  }).id;
+  });
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationAttestationData.id,
   }).id;
@@ -1182,7 +1182,7 @@ async function _buildValidCertificationAttestation(certificationAttestationData,
     publishedAt: certificationAttestationData.deliveredAt,
     certificationCenter: certificationAttestationData.certificationCenter,
     certificationCenterId,
-  }).id;
+  });
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1196,7 +1196,7 @@ async function _buildValidCertificationAttestation(certificationAttestationData,
     maxReachableLevelOnCertificationDate: certificationAttestationData.maxReachableLevelOnCertificationDate,
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
-  }).id;
+  });
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationAttestationData.id,
   }).id;

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -69,7 +69,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         pixScore: 0,
         status: CertificationResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
-      }).id;
+      });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,
@@ -413,7 +413,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         pixScore: 0,
         status: CertificationResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
-      }).id;
+      });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -20,7 +20,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthPostalCode: null,
         isPublished: true,
         sessionId: firstPublishedSessionId,
-      }).id;
+      });
       databaseBuilder.factory.buildAssessmentResult({
         id: 2244,
         pixScore: 132,
@@ -190,7 +190,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           birthPostalCode: null,
           isPublished: false,
           sessionId: publishedSessionId,
-        }).id;
+        });
         await databaseBuilder.commit();
 
         // when
@@ -222,7 +222,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           isPublished: true,
           isCancelled: true,
           sessionId: publishedSessionId,
-        }).id;
+        });
         await databaseBuilder.commit();
 
         // when
@@ -302,7 +302,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           birthPostalCode: null,
           isPublished: true,
           sessionId: publishedSessionId,
-        }).id;
+        });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/end-test-screen-removal-repository_test.js
@@ -161,10 +161,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
         //given
         databaseBuilder.factory.buildCertificationCenter({
           isSupervisorAccessEnabled: true,
-        }).id;
+        });
         databaseBuilder.factory.buildCertificationCenter({
           isSupervisorAccessEnabled: true,
-        }).id;
+        });
         await databaseBuilder.commit();
 
         //when
@@ -180,10 +180,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
         // given
         databaseBuilder.factory.buildCertificationCenter({
           isSupervisorAccessEnabled: true,
-        }).id;
+        });
         databaseBuilder.factory.buildCertificationCenter({
           isSupervisorAccessEnabled: false,
-        }).id;
+        });
         await databaseBuilder.commit();
 
         // when
@@ -199,10 +199,10 @@ describe('Integration | Repository | EndTestScreenRemovalRepository', function (
         // given
         databaseBuilder.factory.buildCertificationCenter({
           isSupervisorAccessEnabled: false,
-        }).id;
+        });
         databaseBuilder.factory.buildCertificationCenter({
           isSupervisorAccessEnabled: false,
-        }).id;
+        });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -513,7 +513,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', fu
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildOrganizationTag({ organizationId }).id;
+        databaseBuilder.factory.buildOrganizationTag({ organizationId });
         databaseBuilder.factory.buildMembership({ userId, organizationId });
 
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -2429,7 +2429,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId }).id;
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
         await databaseBuilder.commit();
 
         // when
@@ -2494,7 +2494,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId }).id;
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
         await databaseBuilder.commit();
 
         // when
@@ -2584,7 +2584,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       it('should count 0 participation when organizationLearner has no participation', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId });
         await databaseBuilder.commit();
 
         // when
@@ -2695,7 +2695,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
       it('should be null when organizationLearner has no participation', async function () {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -24,7 +24,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
     });
 
     it('should return no participants', async function () {
-      databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/prescriber-role-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-role-repository_test.js
@@ -78,7 +78,7 @@ describe('Integration | Repository | Campaign', function () {
         const otherUserId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        databaseBuilder.factory.buildMembership({ userId: otherUserId, organizationId }).id;
+        databaseBuilder.factory.buildMembership({ userId: otherUserId, organizationId });
         await databaseBuilder.commit();
 
         // when
@@ -93,7 +93,7 @@ describe('Integration | Repository | Campaign', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign().id;
-        databaseBuilder.factory.buildMembership({ userId: userId, organizationId: otherOrganizationId }).id;
+        databaseBuilder.factory.buildMembership({ userId: userId, organizationId: otherOrganizationId });
         await databaseBuilder.commit();
 
         // when
@@ -108,7 +108,7 @@ describe('Integration | Repository | Campaign', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() }).id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-certification-candidate-repository_test.js
@@ -141,7 +141,7 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
       databaseBuilder.factory.buildCertificationCandidate({
         sessionId,
         organizationLearnerId: disabledOrganizationLearnerId,
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when
@@ -173,7 +173,7 @@ describe('Integration | Repository | SCOCertificationCandidate', function () {
       databaseBuilder.factory.buildCertificationCandidate({
         sessionId,
         organizationLearnerId: anotherOrganizationLearnerId,
-      }).id;
+      });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/sessions/session-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-summary-repository_test.js
@@ -85,10 +85,10 @@ describe('Integration | Repository | Session Summary', function () {
 
       it('should sort sessions by descending date and time, and finally by ID ascending', async function () {
         // given
-        databaseBuilder.factory.buildSession({ id: 1, certificationCenterId, date: '2020-01-01', time: '18:00:00' }).id;
-        databaseBuilder.factory.buildSession({ id: 2, certificationCenterId, date: '2020-01-01', time: '15:00:00' }).id;
-        databaseBuilder.factory.buildSession({ id: 3, certificationCenterId, date: '2021-01-01' }).id;
-        databaseBuilder.factory.buildSession({ id: 4, certificationCenterId, date: '2020-01-01', time: '15:00:00' }).id;
+        databaseBuilder.factory.buildSession({ id: 1, certificationCenterId, date: '2020-01-01', time: '18:00:00' });
+        databaseBuilder.factory.buildSession({ id: 2, certificationCenterId, date: '2020-01-01', time: '15:00:00' });
+        databaseBuilder.factory.buildSession({ id: 3, certificationCenterId, date: '2021-01-01' });
+        databaseBuilder.factory.buildSession({ id: 4, certificationCenterId, date: '2020-01-01', time: '15:00:00' });
         await databaseBuilder.commit();
 
         // when

--- a/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/shareable-certificate-repository_test.js
@@ -79,7 +79,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         sessionId,
         userId,
       }).id;
-      databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -94,7 +94,7 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
     it('should return an empty array if organization has no admin membership', async function () {
       // given
       const externalId = '1212121A';
-      databaseBuilder.factory.buildOrganization({ externalId }).id;
+      databaseBuilder.factory.buildOrganization({ externalId });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -168,7 +168,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
         targetProfileId,
         badgeCriteria: [],
         key: 'Badge3',
-      }).id;
+      });
 
       const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
       mockLearningContent(learningContentObjects);


### PR DESCRIPTION
## :unicorn: Problème
Dans les tests, nous appellons les database builders qui créent des données de test en base de donnée.
Ceux-ci retournent par défaut l'objet créé.
Lorsque cet objet est ignoré, il n'y a pas d'utilité de sélectionner son identifiant.
Exemple: `databaseBuilder.factory.buildUser().id`

## :robot: Solution
Retirer la mention à l'identifiant.

## :rainbow: Remarques
- Ce problème est relié à la règle de linter `no-unused-expressions` qui est aussi activé par les tests avec Chai (exemple : `expect(certificationCourseRepository.save).not.to.have.been.called`). Cette règle n'a donc pas été ajouté. 
- Suppression aussi dans des tests de création en doublon de campagne sans raison

## :100: Pour tester
Tests OK