### PR TITLE
[FEATURE] Pouvoir mettre plusieurs langues dans le bandeau de communication (PIX-5395).

### DIFF
--- a/mon-pix/app/components/communication-banner.hbs
+++ b/mon-pix/app/components/communication-banner.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEnabled}}
   <PixBanner @type={{this.bannerType}}>
-    {{this.bannerContent}}
+    {{text-with-multiple-lang this.bannerContent}}
   </PixBanner>
 {{/if}}

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -1,20 +1,24 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
+import { htmlSafe, isHTMLSafe } from '@ember/string';
 
 export default class textWithMultipleLang extends Helper {
   @service intl;
 
   compute(params) {
-    const text = params[0];
+    let text = params[0];
+    if (isHTMLSafe(text)) {
+      text = text.toString();
+    }
     const lang = this.intl.t('current-lang');
     const listOfLocales = this.intl.locales;
+    let outputText = _clean(text, listOfLocales);
     if (text && listOfLocales.includes(lang)) {
       const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
       const textForLang = text.match(regex);
-      return textForLang ? _clean(textForLang[0], listOfLocales) : _clean(text, listOfLocales);
-    } else {
-      return _clean(text, listOfLocales);
+      outputText = textForLang ? _clean(textForLang[0], listOfLocales) : outputText;
     }
+    return htmlSafe(outputText);
   }
 }
 

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import textWithMultipleLang from 'mon-pix/helpers/text-with-multiple-lang';
+import { htmlSafe } from '@ember/string';
 
 describe('Unit | Helper | text with multiple lang', function () {
   let textWithMultipleLangHelper;
@@ -12,16 +13,24 @@ describe('Unit | Helper | text with multiple lang', function () {
   [
     { text: 'des mots', lang: 'fr', outputText: 'des mots' },
     { text: 'des mots', lang: null, outputText: 'des mots' },
-    { text: null, lang: 'fr', outputText: null },
+    { text: null, lang: 'fr', outputText: '' },
     { text: '[fr]des mots', lang: 'fr', outputText: 'des mots' },
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'notexist', outputText: 'des motssome words' },
+    { text: htmlSafe('<div>une phrase</div>'), lang: 'fr', outputText: '<div>une phrase</div>' },
+    {
+      text: htmlSafe('[fr]<div>une phrase</div>[/fr][en]<div>one string</div>[/en]'),
+      lang: 'en',
+      outputText: '<div>one string</div>',
+    },
   ].forEach((expected) => {
     it(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function () {
       textWithMultipleLangHelper.intl.t = () => expected.lang;
 
-      expect(textWithMultipleLangHelper.compute([expected.text, expected.lang])).to.equal(expected.outputText);
+      expect(textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString()).to.equal(
+        expected.outputText
+      );
     });
   });
 });

--- a/orga/app/components/banner/communication.hbs
+++ b/orga/app/components/banner/communication.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEnabled}}
   <PixBanner @type={{this.bannerType}}>
-    {{this.bannerContent}}
+    {{text-with-multiple-lang this.bannerContent}}
   </PixBanner>
 {{/if}}

--- a/orga/app/helpers/display-campaign-errors.js
+++ b/orga/app/helpers/display-campaign-errors.js
@@ -5,7 +5,7 @@ export default class extends Helper {
   @service errorMessages;
 
   compute([errors]) {
-    if (!errors.length) return;
+    if (!errors.length) return null;
     return this.errorMessages.getErrorMessage(errors[0].message);
   }
 }

--- a/orga/app/helpers/text-with-multiple-lang.js
+++ b/orga/app/helpers/text-with-multiple-lang.js
@@ -1,0 +1,29 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { htmlSafe, isHTMLSafe } from '@ember/string';
+
+export default class textWithMultipleLang extends Helper {
+  @service intl;
+
+  compute(params) {
+    let text = params[0];
+    if (isHTMLSafe(text)) {
+      text = text.toString();
+    }
+    const lang = this.intl.t('current-lang');
+    const listOfLocales = this.intl.locales;
+    let outputText = _clean(text, listOfLocales);
+
+    if (text && listOfLocales.includes(lang)) {
+      const multipleLangRegExp = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
+      const textForLang = text.match(multipleLangRegExp);
+      outputText = textForLang ? _clean(textForLang[0], listOfLocales) : outputText;
+    }
+    return htmlSafe(outputText);
+  }
+}
+
+function _clean(text, listOfLocales) {
+  const regex = new RegExp(`\\[(\\/)?(${listOfLocales.join('|')})\\]`, 'g');
+  return text ? text.replace(regex, '') : text;
+}

--- a/orga/tests/acceptance/campaign-assessment-results_test.js
+++ b/orga/tests/acceptance/campaign-assessment-results_test.js
@@ -69,9 +69,7 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       await clickByName('AAAAAAAA_IAM_FIRST');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');
+      assert.strictEqual(currentURL(), '/campagnes/1/evaluations/1/resultats');
     });
   });
 

--- a/orga/tests/acceptance/campaign-details_test.js
+++ b/orga/tests/acceptance/campaign-details_test.js
@@ -20,9 +20,7 @@ module('Acceptance | Campaign Details', function (hooks) {
       await visit('/campagnes/1');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -42,9 +40,7 @@ module('Acceptance | Campaign Details', function (hooks) {
       await clickByName('Retour');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/campagnes/les-miennes');
+      assert.strictEqual(currentURL(), '/campagnes/les-miennes');
     });
 
     test('[A11Y] it should contain accessibility aria-label nav', async function (assert) {

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -40,9 +40,7 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+      assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
 
@@ -51,9 +49,7 @@ module('Acceptance | join', function (hooks) {
       await visit('rejoindre?invitationId=123456&code=FAKE999');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
     });
 
@@ -73,9 +69,7 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       assert.dom('.login-form__invitation-error').exists();
       assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);
@@ -96,9 +90,7 @@ module('Acceptance | join', function (hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
       assert.contains(this.intl.t('pages.login-form.invitation-was-cancelled'));
     });
@@ -144,9 +136,8 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/cgu');
+
+        assert.strictEqual(currentURL(), '/cgu');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
 
@@ -201,9 +192,8 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/campagnes/les-miennes');
+
+        assert.strictEqual(currentURL(), '/campagnes/les-miennes');
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
 
@@ -266,9 +256,8 @@ module('Acceptance | join', function (hooks) {
         await clickByName(loginButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+
+        assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
         assert.contains(expectedErrorMessage);
       });
@@ -319,9 +308,7 @@ module('Acceptance | join', function (hooks) {
           await clickByName(loginButton);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/cgu');
+          assert.strictEqual(currentURL(), '/cgu');
           assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
         });
       }
@@ -374,14 +361,10 @@ module('Acceptance | join', function (hooks) {
           await clickByName(registerButtonLabel);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/cgu');
+          assert.strictEqual(currentURL(), '/cgu');
           assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
           const organizationInvitation = server.db.organizationInvitations[0];
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(organizationInvitation.status, 'accepted');
+          assert.strictEqual(organizationInvitation.status, 'accepted');
         });
       });
 
@@ -427,9 +410,7 @@ module('Acceptance | join', function (hooks) {
           await clickByName(registerButtonLabel);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+          assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
           assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
         });
       });

--- a/orga/tests/acceptance/profile_test.js
+++ b/orga/tests/acceptance/profile_test.js
@@ -27,9 +27,7 @@ module('Acceptance | Campaign Profile', function (hooks) {
     await clickByName('Retour');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/campagnes/1');
+    assert.strictEqual(currentURL(), '/campagnes/1');
   });
 
   test('it display profile information', async function (assert) {

--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -24,9 +24,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
       await visit('/eleves');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -51,9 +49,8 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
         await visit('/eleves');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/campagnes/les-miennes');
+
+        assert.strictEqual(currentURL(), '/campagnes/les-miennes');
       });
     });
 
@@ -70,9 +67,8 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
         await visit('/eleves');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/eleves');
+
+        assert.strictEqual(currentURL(), '/eleves');
       });
 
       module('when admin uploads a file', function (hooks) {
@@ -137,9 +133,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
           await visit('/eleves');
           await fillByLabel('Entrer un nom', 'ambo');
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/eleves?lastName=ambo');
+          assert.strictEqual(currentURL(), '/eleves?lastName=ambo');
           assert.contains('Rambo');
           assert.notContains('Norris');
         });
@@ -150,9 +144,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
           await fillByLabel('Entrer un prénom', 'Jo');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/eleves?firstName=Jo');
+          assert.strictEqual(currentURL(), '/eleves?firstName=Jo');
           assert.contains('Rambo');
           assert.notContains('Norris');
         });
@@ -163,9 +155,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
           await fillByLabel('Rechercher par méthode de connexion', 'email');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/eleves?connexionType=email');
+          assert.strictEqual(currentURL(), '/eleves?connexionType=email');
           assert.contains('Rambo');
           assert.notContains('Norris');
         });

--- a/orga/tests/acceptance/sup-organization-participants-import_test.js
+++ b/orga/tests/acceptance/sup-organization-participants-import_test.js
@@ -96,9 +96,7 @@ module('Acceptance | Sup Student Import', function (hooks) {
       await visit('/etudiants/import');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/campagnes/les-miennes');
+      assert.strictEqual(currentURL(), '/campagnes/les-miennes');
     });
   });
 });

--- a/orga/tests/acceptance/switch-organization_test.js
+++ b/orga/tests/acceptance/switch-organization_test.js
@@ -94,9 +94,7 @@ module('Acceptance | Switch Organization', function (hooks) {
           await clickByName('My Heaven Company (HEAVEN)');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/campagnes/les-miennes');
+          assert.strictEqual(currentURL(), '/campagnes/les-miennes');
         });
       });
 

--- a/orga/tests/acceptance/team-creation_test.js
+++ b/orga/tests/acceptance/team-creation_test.js
@@ -21,9 +21,7 @@ module('Acceptance | Team Creation', function (hooks) {
     await visit('/equipe/creation');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/connexion');
+    assert.strictEqual(currentURL(), '/connexion');
   });
 
   module('When prescriber is logged in', function (hooks) {
@@ -48,9 +46,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await visit('/equipe/creation');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/campagnes/les-miennes');
+
+        assert.strictEqual(currentURL(), '/campagnes/les-miennes');
       });
     });
 
@@ -77,9 +74,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await visit('/equipe/creation');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/creation');
+
+        assert.strictEqual(currentURL(), '/equipe/creation');
       });
 
       test('it should allow to invite a prescriber, redirect to invitations list and display confirmation invitation message', async function (assert) {
@@ -100,18 +96,14 @@ module('Acceptance | Team Creation', function (hooks) {
 
         // then
         const organizationInvitation = server.db.organizationInvitations[server.db.organizationInvitations.length - 1];
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(organizationInvitation.email, email);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(organizationInvitation.status, 'PENDING');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(organizationInvitation.code, code);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/invitations');
+
+        assert.strictEqual(organizationInvitation.email, email);
+
+        assert.strictEqual(organizationInvitation.status, 'PENDING');
+
+        assert.strictEqual(organizationInvitation.code, code);
+
+        assert.strictEqual(currentURL(), '/equipe/invitations');
         assert.contains(email);
         assert.contains(this.intl.t('pages.team-new.success.invitation', { email }));
       });
@@ -139,9 +131,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/creation');
+
+        assert.strictEqual(currentURL(), '/equipe/creation');
       });
 
       test('should display an empty input field after cancel and before add a team member', async function (assert) {
@@ -165,9 +156,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(cancelButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/invitations');
+
+        assert.strictEqual(currentURL(), '/equipe/invitations');
       });
 
       test('it should display error on global form when error 500 is returned from backend', async function (assert) {
@@ -194,9 +184,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/creation');
+
+        assert.strictEqual(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
 
@@ -224,9 +213,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/creation');
+
+        assert.strictEqual(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
 
@@ -254,9 +242,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/creation');
+
+        assert.strictEqual(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
 
@@ -284,9 +271,8 @@ module('Acceptance | Team Creation', function (hooks) {
         await clickByName(inviteButton);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/creation');
+
+        assert.strictEqual(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
     });

--- a/orga/tests/acceptance/team-list_test.js
+++ b/orga/tests/acceptance/team-list_test.js
@@ -23,9 +23,7 @@ module('Acceptance | Team List', function (hooks) {
       await visit('/equipe');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -71,9 +69,7 @@ module('Acceptance | Team List', function (hooks) {
         const screen = await visitScreen('/equipe');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/membres');
+        assert.strictEqual(currentURL(), '/equipe/membres');
         assert.dom(screen.queryByLabelText('Membres')).isNotVisible();
         assert.dom(screen.queryByLabelText('Invitations')).isNotVisible();
         assert.dom(screen.queryByLabelText('Inviter un membre')).isNotVisible();
@@ -93,9 +89,7 @@ module('Acceptance | Team List', function (hooks) {
         await visit('/equipe/membres');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/equipe/membres');
+        assert.strictEqual(currentURL(), '/equipe/membres');
       });
 
       test('it should show title of team page', async function (assert) {
@@ -151,9 +145,7 @@ module('Acceptance | Team List', function (hooks) {
       await clickByName('Équipe');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/equipe/membres');
+      assert.strictEqual(currentURL(), '/equipe/membres');
     });
   });
 });

--- a/orga/tests/acceptance/terms-of-service_test.js
+++ b/orga/tests/acceptance/terms-of-service_test.js
@@ -19,9 +19,7 @@ module('Acceptance | terms-of-service', function (hooks) {
     await visit('/cgu');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/connexion');
+    assert.strictEqual(currentURL(), '/connexion');
     assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
   });
 
@@ -40,9 +38,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await clickByName('J’accepte les conditions d’utilisation');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/campagnes/les-miennes');
+      assert.strictEqual(currentURL(), '/campagnes/les-miennes');
     });
 
     test('it should not be possible to visit another page if cgu are not accepted', async function (assert) {
@@ -53,9 +49,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await visit('/campagnes');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/cgu');
+      assert.strictEqual(currentURL(), '/cgu');
     });
   });
 
@@ -71,9 +65,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await visit('/cgu');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/campagnes/les-miennes');
+      assert.strictEqual(currentURL(), '/campagnes/les-miennes');
     });
   });
 });

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -75,18 +75,10 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.email, 'pix@example.net');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.password, 'JeMeLoggue1024');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.scope, 'pix-orga');
+      assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+      assert.strictEqual(sessionServiceObserver.email, 'pix@example.net');
+      assert.strictEqual(sessionServiceObserver.password, 'JeMeLoggue1024');
+      assert.strictEqual(sessionServiceObserver.scope, 'pix-orga');
     });
   });
 
@@ -121,18 +113,10 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
       await clickByName(loginLabel);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.email, 'pix@example.net');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.password, 'JeMeLoggue1024');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionServiceObserver.scope, 'pix-orga');
+      assert.strictEqual(sessionServiceObserver.authenticator, 'authenticator:oauth2');
+      assert.strictEqual(sessionServiceObserver.email, 'pix@example.net');
+      assert.strictEqual(sessionServiceObserver.password, 'JeMeLoggue1024');
+      assert.strictEqual(sessionServiceObserver.scope, 'pix-orga');
     });
   });
 

--- a/orga/tests/integration/components/campaign/badges_test.js
+++ b/orga/tests/integration/components/campaign/badges_test.js
@@ -18,15 +18,9 @@ module('Integration | Component | Campaign::Badges', function (hooks) {
 
     // then
     const badgeImages = this.element.querySelectorAll('img');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(badgeImages.length, 2);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(badgeImages[0].getAttribute('src'), 'img1');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(badgeImages[0].getAttribute('alt'), 'alt-img1');
+    assert.strictEqual(badgeImages.length, 2);
+    assert.strictEqual(badgeImages[0].getAttribute('src'), 'img1');
+    assert.strictEqual(badgeImages[0].getAttribute('alt'), 'alt-img1');
   });
 
   test('should render the title', async function (assert) {

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -132,9 +132,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         await clickByName('Annuler');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(memberMembership.organizationRole, 'MEMBER');
+
+        assert.strictEqual(memberMembership.organizationRole, 'MEMBER');
         sinon.assert.notCalled(memberMembership.save);
       });
 
@@ -152,9 +151,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         await clickByText('Enregistrer');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(memberMembership.organizationRole, 'ADMIN');
+
+        assert.strictEqual(memberMembership.organizationRole, 'ADMIN');
         sinon.assert.called(memberMembership.save);
       });
 
@@ -172,9 +170,8 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         await clickByText('Enregistrer');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(adminMembership.organizationRole, 'MEMBER');
+
+        assert.strictEqual(adminMembership.organizationRole, 'MEMBER');
         sinon.assert.called(adminMembership.save);
       });
 

--- a/orga/tests/unit/adapters/application_test.js
+++ b/orga/tests/unit/adapters/application_test.js
@@ -10,9 +10,7 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(applicationAdapter.namespace, 'api');
+    assert.strictEqual(applicationAdapter.namespace, 'api');
   });
 
   module('get headers()', function () {
@@ -25,9 +23,7 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
+      assert.strictEqual(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
     });
 
     test('should not add header authentication token when the session is not authenticated', function (assert) {
@@ -54,9 +50,7 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       });
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(applicationAdapter.headers['Accept-Language'], 'fr-fr');
+      assert.strictEqual(applicationAdapter.headers['Accept-Language'], 'fr-fr');
     });
 
     test('should add Accept-Language header set to fr when the current domain contains pix.org and locale is "fr"', function (assert) {
@@ -72,9 +66,7 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       });
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(applicationAdapter.headers['Accept-Language'], 'fr');
+      assert.strictEqual(applicationAdapter.headers['Accept-Language'], 'fr');
     });
 
     test('should add Accept-Language header set to en when locale is "en"', function (assert) {
@@ -85,9 +77,7 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
       applicationAdapter.intl = { get: () => ['en'] };
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(applicationAdapter.headers['Accept-Language'], 'en');
+      assert.strictEqual(applicationAdapter.headers['Accept-Language'], 'en');
     });
   });
 

--- a/orga/tests/unit/adapters/campaign-profile_test.js
+++ b/orga/tests/unit/adapters/campaign-profile_test.js
@@ -18,12 +18,8 @@ module('Unit | Adapters | campaign-profile', function (hooks) {
       const url = await adapter.urlForQueryRecord(query);
 
       assert.ok(url.endsWith('/api/campaigns/campaignId1/profiles-collection-participations/campaignParticipationId1'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(query.campaignId, undefined);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(query.campaignParticipationId, undefined);
+      assert.strictEqual(query.campaignId, undefined);
+      assert.strictEqual(query.campaignParticipationId, undefined);
     });
   });
 });

--- a/orga/tests/unit/adapters/campaign-stats_test.js
+++ b/orga/tests/unit/adapters/campaign-stats_test.js
@@ -23,9 +23,7 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByStage(campaignId);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(stats, expectedStats);
+      assert.strictEqual(stats, expectedStats);
     });
   });
 
@@ -37,9 +35,7 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByStatus(campaignId);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(stats, expectedStats);
+      assert.strictEqual(stats, expectedStats);
     });
   });
 
@@ -51,9 +47,7 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByDay(campaignId);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(stats, expectedStats);
+      assert.strictEqual(stats, expectedStats);
     });
   });
 
@@ -65,9 +59,7 @@ module('Unit | Adapter | campaign-stats', function (hooks) {
       ajaxStub.withArgs(url, 'GET').resolves(expectedStats);
       const stats = await adapter.getParticipationsByMasteryRate(campaignId);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(stats, expectedStats);
+      assert.strictEqual(stats, expectedStats);
     });
   });
 });

--- a/orga/tests/unit/adapters/membership_test.js
+++ b/orga/tests/unit/adapters/membership_test.js
@@ -22,9 +22,7 @@ module('Unit | Adapter | membership', function (hooks) {
       const url = await adapter.urlForQuery(query);
 
       assert.ok(url.endsWith('/api/organizations/1/memberships'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(query.filter.organizationId, undefined);
+      assert.strictEqual(query.filter.organizationId, undefined);
     });
   });
 

--- a/orga/tests/unit/components/tube/list_test.js
+++ b/orga/tests/unit/components/tube/list_test.js
@@ -15,8 +15,6 @@ module('Unit | Component | Tube::List', function (hooks) {
 
     // then
     const text = await component.file.text();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(text, expectedFile);
+    assert.strictEqual(text, expectedFile);
   });
 });

--- a/orga/tests/unit/components/user-logged-menu_test.js
+++ b/orga/tests/unit/components/user-logged-menu_test.js
@@ -43,9 +43,7 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       // when
       const computedOrganizationName = component.organizationNameAndExternalId;
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(computedOrganizationName, expectedOrganizationName);
+      assert.strictEqual(computedOrganizationName, expectedOrganizationName);
     });
 
     test('should return the organization name and externalId if the externalId is defined', function (assert) {
@@ -58,9 +56,7 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       // when
       const computedOrganizationName = component.organizationNameAndExternalId;
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(computedOrganizationName, `${expectedOrganizationName} (${expectedExternalId})`);
+      assert.strictEqual(computedOrganizationName, `${expectedOrganizationName} (${expectedExternalId})`);
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/assessment/analysis_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/assessment/analysis_test.js
@@ -11,8 +11,6 @@ module('Unit | Controller | authenticated/campaigns/assessment/analysis', functi
       lastName: 'attends',
     };
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(controller.pageTitle, 'Analyse pour Jaune attends');
+    assert.strictEqual(controller.pageTitle, 'Analyse pour Jaune attends');
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/assessment/results_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/assessment/results_test.js
@@ -11,8 +11,6 @@ module('Unit | Controller | authenticated/campaigns/assessment/results', functio
       lastName: 'attends',
     };
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(controller.pageTitle, 'Résultats de Jaune attends');
+    assert.strictEqual(controller.pageTitle, 'Résultats de Jaune attends');
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/profile_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/profile_test.js
@@ -13,8 +13,6 @@ module('Unit | Controller | authenticated/campaigns/participant-profile', functi
       },
     };
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(controller.pageTitle, 'Profil de Jaune attends');
+    assert.strictEqual(controller.pageTitle, 'Profil de Jaune attends');
   });
 });

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -59,9 +59,7 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
       await controller.onSelectDivision(event);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.selectedDivision, event.target.value);
+      assert.strictEqual(controller.selectedDivision, event.target.value);
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
@@ -54,9 +54,8 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a>.</div>'
         );
@@ -70,9 +69,8 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
         );
@@ -86,9 +84,8 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
         );
@@ -102,9 +99,8 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>'
         );

--- a/orga/tests/unit/controllers/authenticated/sup-organization-participants/import_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-organization-participants/import_test.js
@@ -43,9 +43,8 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a></div>'
         );
@@ -59,9 +58,8 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
         );
@@ -75,9 +73,8 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
         );
@@ -105,9 +102,8 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a></div>'
         );
@@ -121,9 +117,8 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
         );
@@ -137,9 +132,8 @@ module('Unit | Controller | authenticated/sup-organization-participants/import',
 
         // then
         const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+
+        assert.strictEqual(
           notificationMessage,
           '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'
         );

--- a/orga/tests/unit/controllers/authenticated/team/list/members_test.js
+++ b/orga/tests/unit/controllers/authenticated/team/list/members_test.js
@@ -25,9 +25,7 @@ module('Unit | Controller | authenticated/team/list/members', function (hooks) {
       await controller.removeMembership(membership);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(membership.organization, currentUser.organization);
+      assert.strictEqual(membership.organization, currentUser.organization);
     });
 
     test('should call disable membership endpoint', async function (assert) {

--- a/orga/tests/unit/helpers/display-campaign-errors_test.js
+++ b/orga/tests/unit/helpers/display-campaign-errors_test.js
@@ -12,18 +12,14 @@ module('Unit | Helper | display-campaign-errors', function (hooks) {
   module('when there is an error', function () {
     test('it returns the intlKey corresponding to the name error message', function (assert) {
       const nameErrors = [{ attribute: 'name', message: 'CAMPAIGN_NAME_IS_REQUIRED' }];
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(helper.compute([nameErrors]), 'Veuillez donner un nom à votre campagne.');
+      assert.strictEqual(helper.compute([nameErrors]), 'Veuillez donner un nom à votre campagne.');
     });
   });
 
   module('when there is no error', function () {
     test('it returns the intlKey corresponding to the type error message', function (assert) {
       const noError = [];
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(helper.compute([noError]), null);
+      assert.strictEqual(helper.compute([noError]), null);
     });
   });
 });

--- a/orga/tests/unit/helpers/join_test.js
+++ b/orga/tests/unit/helpers/join_test.js
@@ -8,16 +8,12 @@ module('Unit | Helper | join', function (hooks) {
   module('join', () => {
     module('when there are several values', () => {
       test('it joins all values using the seperator', function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(join([['Un', 'Deux'], ', ']), 'Un, Deux');
+        assert.strictEqual(join([['Un', 'Deux'], ', ']), 'Un, Deux');
       });
     });
     module('when there is only one value', () => {
       test('it returns the value', function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(join([['Un'], ', ']), 'Un');
+        assert.strictEqual(join([['Un'], ', ']), 'Un');
       });
     });
   });

--- a/orga/tests/unit/helpers/multiply_test.js
+++ b/orga/tests/unit/helpers/multiply_test.js
@@ -7,15 +7,11 @@ module('Unit | Helper | multiply', function (hooks) {
 
   module('multiply', () => {
     test('it multiply 10 by 2', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(multiply([10, 2]), 20);
+      assert.strictEqual(multiply([10, 2]), 20);
     });
 
     test('it multiply 10 by 2 by 20', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(multiply([10, 2, 20]), 400);
+      assert.strictEqual(multiply([10, 2, 20]), 400);
     });
   });
 });

--- a/orga/tests/unit/helpers/percentage_test.js
+++ b/orga/tests/unit/helpers/percentage_test.js
@@ -7,15 +7,11 @@ module('Unit | Helper | percentage', function (hooks) {
 
   module('percentage', () => {
     test('it multiply by 100 the given value', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(percentage([1]), 100);
+      assert.strictEqual(percentage([1]), 100);
     });
 
     test('it rounds the given value with one digit', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(percentage([0.088]), 8.8);
+      assert.strictEqual(percentage([0.088]), 8.8);
     });
   });
 });

--- a/orga/tests/unit/helpers/sum_test.js
+++ b/orga/tests/unit/helpers/sum_test.js
@@ -7,15 +7,11 @@ module('Unit | Helper | sum', function (hooks) {
 
   module('sum', () => {
     test('it sum 10 and 2', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sum([10, 2]), 12);
+      assert.strictEqual(sum([10, 2]), 12);
     });
 
     test('it sum 10 and 2 and 20', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sum([10, 2, 20]), 32);
+      assert.strictEqual(sum([10, 2, 20]), 32);
     });
   });
 });

--- a/orga/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/orga/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -1,0 +1,38 @@
+import { htmlSafe } from '@ember/string';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Helper | TextWithMultipleLang', function (hooks) {
+  setupTest(hooks);
+  let helper;
+  hooks.beforeEach(function () {
+    helper = this.owner.factoryFor('helper:text-with-multiple-lang').create();
+  });
+
+  [
+    { text: 'des mots', lang: 'fr', outputText: 'des mots' },
+    { text: 'des mots', lang: null, outputText: 'des mots' },
+    { text: null, lang: 'fr', outputText: '' },
+    { text: '[fr]des mots', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'notexist', outputText: 'des motssome words' },
+    { text: htmlSafe('<div>une phrase</div>'), lang: 'fr', outputText: '<div>une phrase</div>' },
+    {
+      text: htmlSafe('[fr]<div>une phrase</div>[/fr][en]<div>one string</div>[/en]'),
+      lang: 'en',
+      outputText: '<div>one string</div>',
+    },
+  ].forEach((expected) => {
+    test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
+      // given
+      this.owner.lookup('service:intl').setLocale(expected.lang);
+
+      // when
+      const computedText = helper.compute([expected.text]).toString();
+
+      // then
+      assert.strictEqual(computedText, expected.outputText);
+    });
+  });
+});

--- a/orga/tests/unit/models/campaign-assessment-participation-result_test.js
+++ b/orga/tests/unit/models/campaign-assessment-participation-result_test.js
@@ -25,15 +25,9 @@ module('Unit | Model | campaignAssessmentParticipationResult', function (hooks) 
       const sortedCompetenceResults = model.get('sortedCompetenceResults');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sortedCompetenceResults[0].index, '1.1');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sortedCompetenceResults[1].index, '1.2');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sortedCompetenceResults[2].index, '4.1');
+      assert.strictEqual(sortedCompetenceResults[0].index, '1.1');
+      assert.strictEqual(sortedCompetenceResults[1].index, '1.2');
+      assert.strictEqual(sortedCompetenceResults[2].index, '4.1');
     });
   });
 });

--- a/orga/tests/unit/models/campaign-profile_test.js
+++ b/orga/tests/unit/models/campaign-profile_test.js
@@ -18,17 +18,9 @@ module('Unit | Model | campaign-profile', function (hooks) {
 
     const sortedCompetences = model.get('sortedCompetences');
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(sortedCompetences[0].index, '1.1');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(sortedCompetences[1].index, '1.1.1');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(sortedCompetences[2].index, '1.2');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(sortedCompetences[3].index, '2.1');
+    assert.strictEqual(sortedCompetences[0].index, '1.1');
+    assert.strictEqual(sortedCompetences[1].index, '1.1.1');
+    assert.strictEqual(sortedCompetences[2].index, '1.2');
+    assert.strictEqual(sortedCompetences[3].index, '2.1');
   });
 });

--- a/orga/tests/unit/models/campaign_test.js
+++ b/orga/tests/unit/models/campaign_test.js
@@ -10,12 +10,8 @@ module('Unit | Model | campaign', function (hooks) {
       name: 'Fake name',
       code: 'ABC123',
     });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.name, 'Fake name');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model.code, 'ABC123');
+    assert.strictEqual(model.name, 'Fake name');
+    assert.strictEqual(model.code, 'ABC123');
   });
 
   module('#urlToResult', function () {
@@ -28,9 +24,10 @@ module('Unit | Model | campaign', function (hooks) {
         tokenForCampaignResults: 'token',
         type: 'ASSESSMENT',
       });
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results?accessToken=token');
+      assert.strictEqual(
+        model.urlToResult,
+        'http://localhost:3000/api/campaigns/1/csv-assessment-results?accessToken=token'
+      );
     });
 
     test('it should construct the url to result of the campaign with type profiles collection', function (assert) {
@@ -42,9 +39,7 @@ module('Unit | Model | campaign', function (hooks) {
         tokenForCampaignResults: 'token',
         type: 'PROFILES_COLLECTION',
       });
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         model.urlToResult,
         'http://localhost:3000/api/campaigns/1/csv-profiles-collection-results?accessToken=token'
       );
@@ -63,9 +58,7 @@ module('Unit | Model | campaign', function (hooks) {
       const model = store.createRecord('campaign', { type: 'ASSESSMENT' });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.readableType, 'Évaluation');
+      assert.strictEqual(model.readableType, 'Évaluation');
     });
 
     test('it should compute the readableType property when type is PROFILES_COLLECTION', function (assert) {
@@ -73,9 +66,7 @@ module('Unit | Model | campaign', function (hooks) {
       const model = store.createRecord('campaign', { type: 'PROFILES_COLLECTION' });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.readableType, 'Collecte de profils');
+      assert.strictEqual(model.readableType, 'Collecte de profils');
     });
   });
 
@@ -154,9 +145,7 @@ module('Unit | Model | campaign', function (hooks) {
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('campaign', { ownerFirstName: 'Jean-Baptiste', ownerLastName: 'Poquelin' });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.ownerFullName, 'Jean-Baptiste Poquelin');
+      assert.strictEqual(model.ownerFullName, 'Jean-Baptiste Poquelin');
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profile-results_test.js
@@ -57,9 +57,7 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
 
       const summaries = route.fetchProfileSummaries(params);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(summaries, expectedSummaries);
+      assert.strictEqual(summaries, expectedSummaries);
     });
   });
 
@@ -89,18 +87,16 @@ module('Unit | Route | authenticated/campaigns/campaign/profile-results', functi
     module('when the transition comes from somewhere else', function () {
       test('if returns undefined', function (assert) {
         const transition = { from: { name: 'authenticated.campaigns.campaign' } };
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(route.loading(transition), undefined);
+
+        assert.strictEqual(route.loading(transition), undefined);
       });
     });
 
     module('when the transition has no from attribute', function () {
       test('if keeps loading page', function (assert) {
         const transition = {};
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(route.loading(transition), undefined);
+
+        assert.strictEqual(route.loading(transition), undefined);
       });
     });
   });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign_test.js
@@ -22,9 +22,11 @@ module('Unit | Route | authenticated/campaigns/campaign', function (hooks) {
     // then
     const expectedRedirection = 'not-found';
     route.replaceWith = (redirection) => {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(redirection, expectedRedirection, `expect transition to ${expectedRedirection}, got ${redirection}`);
+      assert.strictEqual(
+        redirection,
+        expectedRedirection,
+        `expect transition to ${expectedRedirection}, got ${redirection}`
+      );
     };
 
     // when

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -45,9 +45,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUserService.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUserService.prescriber, connectedUser);
+      assert.strictEqual(currentUserService.prescriber, connectedUser);
     });
 
     test('should load the memberships', async function (assert) {
@@ -66,9 +64,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUserService.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUserService.memberships, memberships);
+      assert.strictEqual(currentUserService.memberships, memberships);
     });
 
     test('should load the organization', async function (assert) {
@@ -81,9 +77,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUserService.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUserService.organization, organization);
+      assert.strictEqual(currentUserService.organization, organization);
     });
 
     module('When member is not ADMIN', function () {
@@ -253,9 +247,7 @@ module('Unit | Service | current-user', function (hooks) {
         await currentUserService.load();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentUserService.organization.id, organization2.id);
+        assert.strictEqual(currentUserService.organization.id, organization2.id);
       });
     });
   });
@@ -273,9 +265,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.prescriber, null);
+      assert.strictEqual(currentUser.prescriber, undefined);
     });
   });
 
@@ -299,9 +289,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.prescriber, null);
+      assert.strictEqual(currentUser.prescriber, null);
     });
   });
 
@@ -325,9 +313,7 @@ module('Unit | Service | current-user', function (hooks) {
       const result = await currentUser.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'invalidate');
+      assert.strictEqual(result, 'invalidate');
     });
   });
 });

--- a/orga/tests/unit/services/error-messages_test.js
+++ b/orga/tests/unit/services/error-messages_test.js
@@ -12,9 +12,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage(undefined);
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(message, undefined);
+    assert.strictEqual(message, undefined);
   });
 
   test('should return undefined when no error code not found in mapping', function (assert) {
@@ -23,9 +21,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('UNKNOWN_ERROR_CODE');
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(message, undefined);
+    assert.strictEqual(message, undefined);
   });
 
   test('should return the message when error code is found', function (assert) {
@@ -34,9 +30,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(message, t('api-errors-messages.campaign-creation.name-required'));
+    assert.strictEqual(message, t('api-errors-messages.campaign-creation.name-required'));
   });
 
   test('should return the message with parameters', function (assert) {
@@ -45,9 +39,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('FIELD_MIN_LENGTH', { line: 1, field: 'Boo', limit: 2 });
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       message,
       t('api-errors-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 })
     );
@@ -59,9 +51,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('FIELD_BAD_VALUES', { line: 1, field: 'Boo', valids: ['A', 'B'] });
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       message,
       t('api-errors-messages.student-csv-import.field-bad-values', {
         line: 1,

--- a/orga/tests/unit/utils/input-validator_test.js
+++ b/orga/tests/unit/utils/input-validator_test.js
@@ -24,9 +24,7 @@ module('Unit | Utils | input validator', function (hooks) {
     // when
     validator.validate({ value: false, resetServerMessage: true });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(validator.serverMessage, null);
+    assert.strictEqual(validator.serverMessage, null);
   });
 
   test('should return server message rather than default message if it exists', function (assert) {
@@ -37,8 +35,6 @@ module('Unit | Utils | input validator', function (hooks) {
     validator.serverMessage = 'serverMessage';
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(validator.message, 'serverMessage');
+    assert.strictEqual(validator.message, 'serverMessage');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le bandeau de communication n'accepte qu'une langue actuellement sur App et Orga

## :robot: Solution
Utiliser le helper TextWithMultipleLanguage, qui prend du texte de la forme `[fr]test[/fr][en]test[/en]`.

## :rainbow: Remarques
- TextWithMultipleLanguage évolue pour pouvoir prendre du html safe

## :100: Pour tester
- Voir le bandeau sur la version EN et FR d'app et d'orga
- Voir si le texte de fin d'une campagne avec un texte fr/en fonctionne bien.