### PR TITLE
[TECH] Utiliser la version de redis de Scalingo en local

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -29,7 +29,7 @@
 # presence: optional
 # type: Url
 # default: none
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://:secret@localhost:6379
 
 # Cache reload schedule
 #
@@ -629,7 +629,7 @@ TEST_LOG_ENABLED=false
 # presence: required
 # type: Url
 # default: none
-TEST_REDIS_URL=redis://localhost:6379
+TEST_REDIS_URL=redis://:secret@localhost:6379
 
 # ========
 # RATE LIMITING

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,10 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
-    image: redis:5.0.7-alpine
+    image: scalingo/redis:6.2.5-1
     container_name: pix-api-redis
+    command: /redis
     ports:
       - '${PIX_CACHE_PORT:-6379}:6379'
+    environment:
+      DB_PASSWORD: secret


### PR DESCRIPTION
## :unicorn: Problème
L'image utilisée pour instancier le serveur redis local n'est pas celle de Scalingo.
Des écarts de comportement peuvent apparaître.

## :robot: Solution
Utiliser l'image Scalingo
https://hub.docker.com/r/scalingo/redis

## :rainbow: Remarques
Elle à peine plus lourde (14Mo) que la version alpine (10Mo).
Est-ce qu'on l'utilise sur la CI ?

## :100: Pour tester
Mettre à jour le `.env`
Exécuter les tests en local

Se connecter à redis avec
```
redis-cli
AUTH secret
KEYS *
```
