### PR TITLE
[BUGFIX] Passer l'adresse e-mail en minuscule lors de l'ajout de membre à une organisation dans Pix Admin (PIX-1772).

### DIFF
--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -45,10 +45,10 @@ export default class GetTeamController extends Controller {
   }
 
   async _getUser(email) {
-    const matchingUsers = await this.store.query('user', { filter: { email } });
-
+    const emailInLowerCase = email.toLowerCase();
+    const matchingUsers = await this.store.query('user', { filter: { email: emailInLowerCase } });
     // GET /users?filter[email] makes an approximative request ("LIKE %email%") and not a strict request
-    return matchingUsers.find((user) => user.email.toLowerCase() == email.toLowerCase());
+    return matchingUsers.findBy('email', emailInLowerCase);
   }
 
   @action

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -48,20 +48,20 @@ export default class GetTeamController extends Controller {
     const matchingUsers = await this.store.query('user', { filter: { email } });
 
     // GET /users?filter[email] makes an approximative request ("LIKE %email%") and not a strict request
-    return matchingUsers.findBy('email', email);
+    return matchingUsers.find((user) => user.email.toLowerCase() == email.toLowerCase());
   }
 
   @action
   async addMembership() {
     const organization = this.model;
     const email = this.userEmailToAdd.trim();
-    if (await organization.hasMember(email)) {
-      return this.notifications.error('Compte déjà associé.');
-    }
-
     const user = await this._getUser(email);
     if (!user) {
       return this.notifications.error('Compte inconnu.');
+    }
+
+    if (await organization.hasMember(user.id)) {
+      return this.notifications.error('Compte déjà associé.');
     }
 
     try {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -29,9 +29,9 @@ export default class Organization extends Model {
   @hasMany('targetProfile') targetProfiles;
   @hasMany('tag') tags;
 
-  async hasMember(userEmail) {
+  async hasMember(userId) {
     const memberships = await this.memberships;
-    return !!memberships.findBy('user.email', userEmail);
+    return !!memberships.findBy('user.id', userId);
   }
 
   get archivedFormattedDate() {

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -33,7 +33,7 @@ export default class User extends Model {
   }
 
   get language() {
-    return this.lang.toUpperCase();
+    return this.lang?.toUpperCase();
   }
 
   get hasPixAuthenticationMethod() {

--- a/admin/tests/unit/controllers/authenticated/organizations/get/team_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/team_test.js
@@ -1,0 +1,164 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/organizations/get/team', function (hooks) {
+  setupTest(hooks);
+
+  let controller;
+  let store;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/organizations/get/team');
+    store = this.owner.lookup('service:store');
+    const notificationsStubs = {
+      error: sinon.stub().returns(),
+      success: sinon.stub().returns(),
+    };
+    controller.notifications = notificationsStubs;
+  });
+
+  module('#addMembership', function () {
+    module('when user is not existing', function () {
+      test('it should return an error', async function (assert) {
+        // given
+        const email = 'a-user-not-in-store@example.net';
+
+        const storeQueryStub = sinon.stub();
+        storeQueryStub.resolves([]);
+        store.query = storeQueryStub;
+
+        controller.model = {
+          organization: {
+            id: 1,
+          },
+        };
+
+        controller.userEmailToAdd = email;
+
+        // when
+        await controller.addMembership();
+
+        // then
+        sinon.assert.calledWith(controller.notifications.error, 'Compte inconnu.');
+        assert.ok(true);
+      });
+    });
+
+    module('when user has a membership in the organization', function () {
+      test('it should return an error (even if searched email is in uppercase', async function (assert) {
+        // given
+        const emailInLowerCase = 'a-user-already-in-organization@example.net';
+        const user = { email: emailInLowerCase, id: 5 };
+        const storeQueryStub = sinon.stub();
+        storeQueryStub.resolves([user]);
+        store.query = storeQueryStub;
+
+        const hasMemberStub = sinon.stub();
+        hasMemberStub.resolves(true);
+
+        controller.model = {
+          hasMember: hasMemberStub,
+          organization: {
+            id: 1,
+          },
+        };
+
+        controller.userEmailToAdd = emailInLowerCase.toUpperCase();
+
+        // when
+        await controller.addMembership();
+
+        // then
+        sinon.assert.calledWith(controller.notifications.error, 'Compte déjà associé.');
+        assert.ok(true);
+      });
+    });
+
+    module('when user has not yet a membership in the organization', function () {
+      test('it should give acces to the organization', async function (assert) {
+        // given
+        const email = 'a-user-not-in-organization@example.net';
+        const user = { email };
+        const storeQueryStub = sinon.stub();
+        storeQueryStub.resolves([user]);
+        store.query = storeQueryStub;
+
+        const hasMemberStub = sinon.stub();
+        const reloadStub = sinon.stub().resolves(true);
+        hasMemberStub.resolves(false);
+        controller.model = {
+          hasMember: hasMemberStub,
+          memberships: {
+            reload: reloadStub,
+          },
+          organization: {
+            id: 1,
+          },
+        };
+
+        controller.userEmailToAdd = email;
+
+        const createRecordStub = sinon.stub();
+        const saveStub = sinon.stub();
+
+        saveStub.resolves();
+        createRecordStub.returns({
+          save: saveStub,
+        });
+
+        store.createRecord = createRecordStub;
+
+        // when
+        await controller.addMembership();
+
+        // then
+        assert.deepEqual(controller.userEmailToAdd, null);
+        assert.ok(controller.model.memberships.reload.calledOnce);
+        sinon.assert.calledWith(controller.notifications.success, 'Accès attribué avec succès.');
+        assert.ok(true);
+      });
+
+      test('it should notify when error', async function (assert) {
+        // given
+        const email = 'a-user-not-in-organization@example.net';
+        const user = { email };
+        const storeQueryStub = sinon.stub();
+        storeQueryStub.resolves([user]);
+        store.query = storeQueryStub;
+
+        const hasMemberStub = sinon.stub();
+        const reloadStub = sinon.stub().rejects('some error');
+        hasMemberStub.resolves(false);
+        controller.model = {
+          hasMember: hasMemberStub,
+          memberships: {
+            reload: reloadStub,
+          },
+          organization: {
+            id: 1,
+          },
+        };
+
+        controller.userEmailToAdd = email;
+
+        const createRecordStub = sinon.stub();
+        const saveStub = sinon.stub();
+
+        saveStub.resolves();
+        createRecordStub.returns({
+          save: saveStub,
+        });
+
+        store.createRecord = createRecordStub;
+
+        // when
+        await controller.addMembership();
+
+        // then
+        sinon.assert.calledWith(controller.notifications.error, 'Une erreur est survenue.');
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -557,7 +557,7 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
     qb.whereRaw('LOWER("lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
   if (email) {
-    qb.whereRaw('email LIKE ?', `%${email.toLowerCase()}%`);
+    qb.whereRaw('LOWER("email") LIKE ?', `%${email.toLowerCase()}%`);
   }
   if (username) {
     qb.whereRaw('LOWER("username") LIKE ?', `%${username.toLowerCase()}%`);

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1172,6 +1172,8 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
             { email: 'otter@pix.fr' },
             { email: 'playpus@example.net' },
             { email: 'panda@example.net' },
+            { email: 'PANDA@example.net' },
+            { email: 'PANDA@PIX.be' },
           ],
           (user) => {
             databaseBuilder.factory.buildUser(user);
@@ -1179,6 +1181,26 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         );
 
         await databaseBuilder.commit();
+      });
+
+      it('should return only users matching "email" if given in filter even if it is in uppercase in database', async function () {
+        // Search returns emails in lowcase even if they are in uppercase in dbb !
+        // given
+        const filter = { email: 'panda' };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 4 };
+
+        // when
+        const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
+
+        // then
+        expect(map(matchingUsers, 'email')).to.have.members([
+          'panda@pix.fr',
+          'panda@example.net',
+          'panda@example.net',
+          'panda@pix.be',
+        ]);
+        expect(pagination).to.deep.equal(expectedPagination);
       });
 
       it('should return only users matching "email" if given in filter', async function () {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1184,7 +1184,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       });
 
       it('should return only users matching "email" if given in filter even if it is in uppercase in database', async function () {
-        // Search returns emails in lowcase even if they are in uppercase in dbb !
         // given
         const filter = { email: 'panda' };
         const page = { number: 1, size: 10 };


### PR DESCRIPTION
## :unicorn: Problème
Quand on ajoute un email avec le champ ‘ajouter un membre” à une orga dans Pix admin, le champ est case sensitive 
Si l'on cherche un email en majuscule, cela affiche une erreur de type 'compte inconnu' car l'email est considéré comme différent et si l'utilisateur existe déjà, il ne le trouvera donc pas.

## :robot: Solution
Côté front, on passe les emails en lower case au moment de la soumission de champ de recherche

## :rainbow: Remarques
1. Un petit fix à été fait car en allant sur http://localhost:4202/users/4, comme le user n'a pas de lang, ça bloquait l'application sans message d'erreurs (autre que la console)


`get language() {
    return this.lang?.toUpperCase();
  }
`


2. Un deuxième fix a été fait :
Quand on recherche un utilisateur en filtrant par email, la db nous renvoie les emails en lowercase même si c'est enregistré en uppercase en db, exemple `SCO.admin@example.net`. 

Ce qui a pour conséquence de ne pas trouver un utilisateur en base si on le cherche en tapant `SCO.admin@example.net`. 
Alors qu'il est affiché dans la liste des utilisateurs.

![Capture d’écran 2022-07-26 à 09 54 49](https://user-images.githubusercontent.com/7688741/180953766-0ff63d0b-28a6-4ba1-8867-2d42151368b5.png)


## :100: Pour tester

### Cas numéro 1
- Aller sur la page d'une organisation, par exemple http://localhost:4202/organizations/3/team
- Ajouter un membre avec l'un des emails présent comme par exemple 'SCO.admin@example.net' (Jon Snow, utilisateur 4)
- Vérifier que l'erreur `Compte déjà associé.` s'affiche


### Cas numéro 2
- Changer l'adresse email de cet utilisateur en SCO.admin@example.net
- Ajouter un membre avec `sco.admin@example.net`
- Vérifier que l'erreur `Compte déjà associé.` apparait 

### Cas numéro 3
- Dans le tableau des membres (onglet équipe d'une page d'orga)
- Vérifier que le filtre de recherche sur l'email marche autant avec des majuscules que des minuscules
