### PR TITLE
[FEATURE] Affiche un message d'erreur aux utilisateurs lorsque le rate limit est déclenché

### DIFF
--- a/admin/app/components/login-form.js
+++ b/admin/app/components/login-form.js
@@ -45,6 +45,7 @@ export default class LoginForm extends Component {
       504: ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
       401: error,
       403: error,
+      429: error,
       default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
     };
     return httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default'];

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -68,6 +68,7 @@ export default class LoginForm extends Component {
       504: ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
       401: apiError,
       403: apiError,
+      429: apiError,
       default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
     };
     return httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default'];

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -47,6 +47,7 @@ export default class SigninForm extends Component {
     const httpStatusCodeMessages = {
       400: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
       401: ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.MESSAGE,
+      429: ENV.APP.API_ERROR_MESSAGES.TOO_MANY_REQUESTS.MESSAGE,
       default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
     };
     return this.intl.t(httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default']);

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -93,6 +93,10 @@ module.exports = function (environment) {
           CODE: '401',
           MESSAGE: 'api-error-messages.login-unauthorized-error',
         },
+        TOO_MANY_REQUESTS: {
+          CODE: '429',
+          MESSAGE: 'api-error-messages.too-many-requests-error',
+        },
         INTERNAL_SERVER_ERROR: {
           CODE: '500',
           MESSAGE: 'api-error-messages.internal-server-error',

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -32,7 +32,8 @@
       "s61": "{ value }",
       "s62": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code S62)",
       "s63": "You already have a Pix account through your virtual learning environment (\"ENT\") in another school '<br> 'To continue, contact a teacher who can give you access to this account using Pix Orga.'<br>'(Code S63)"
-    }
+    },
+    "too-many-requests-error": "Too many requests in a short time. Please retry in a few minutes."
   },
   "application": {
     "description": "Pix is an online platform open to all (pupils, students, anyone working or in professional training, seniors) designed to assess, develop and certify digital skills"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -32,7 +32,8 @@
       "s61": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R61)",
       "s62": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R62)",
       "s63": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br><br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R63)"
-    }
+    },
+    "too-many-requests-error": "Trop d'essais en peu de temps. Réessayez dans quelques minutes."
   },
   "application": {
     "description": "Pix est une plateforme en ligne d'évaluation et de certification des compétences numériques des citoyens francophones (élèves, étudiant•e•s, décrocheur•se•s, demandeur•se•s d'emploi, sénior•e•s)"

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -134,6 +134,8 @@ export default class LoginForm extends Component {
             : this.ERROR_MESSAGES.STATUS_401;
         case '403':
           return this.ERROR_MESSAGES.STATUS_403;
+        case '429':
+          return this.ERROR_MESSAGES.STATUS_429;
         default:
           return this.ERROR_MESSAGES.DEFAULT;
       }
@@ -149,6 +151,7 @@ export default class LoginForm extends Component {
       STATUS_401: this.intl.t('pages.login-form.errors.status.401'),
       STATUS_401_SHOULD_CHANGE_PASSWORD: this.intl.t('pages.login-form.errors.status.401-should-change-password'),
       STATUS_403: this.intl.t('pages.login-form.errors.status.403'),
+      STATUS_429: this.intl.t('pages.login-form.errors.status.429'),
     };
   }
 }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -595,7 +595,8 @@
         "status": {
           "401": "Missing or invalid credentials",
           "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
-          "401-should-change-password": "An error occurred. Please change your password."
+          "401-should-change-password": "An error occurred. Please change your password.",
+          "429": "Too many requests in a short time. Please retry in a few minutes."
         }
       },
       "forgot-password": "Forgot your password?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -594,7 +594,8 @@
         "status": {
           "401": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
           "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
-          "401-should-change-password": "Erreur, vous devez changer votre mot de passe."
+          "401-should-change-password": "Erreur, vous devez changer votre mot de passe.",
+          "429": "Trop d'essais en peu de temps. Réessayez dans quelques minutes."
         }
       },
       "forgot-password": "Mot de passe oublié ?",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement si le rate limit est atteint, on n'affiche rien de spécial a l'utilisateur. Pas top en terme d'expérience si le motif est légitime.

## :robot: Solution
On affiche un message spécifique

## :100: Pour tester
Voir la RA. Tenter de s'authentifier 11 fois sur chaque front en moins de 1 minute.
