### PR TITLE
[FEATURE] Envoyer le contexte du tutorial lors de l'enregistrement de ce dernier (PIX-5339).

### DIFF
--- a/mon-pix/app/adapters/user-tutorial.js
+++ b/mon-pix/app/adapters/user-tutorial.js
@@ -4,7 +4,7 @@ export default class UserTutorial extends ApplicationAdapter {
   createRecord(store, type, snapshot) {
     const tutorial = snapshot.belongsTo('tutorial');
     const url = `${this.host}/${this.namespace}/users/tutorials/${tutorial.id}`;
-    return this.ajax(url, 'PUT');
+    return this.ajax(url, 'PUT', { data: { data: { attributes: { 'skill-id': tutorial.attr('skillId') } } } });
   }
 
   urlForDeleteRecord(id, modelName, snapshot) {

--- a/mon-pix/app/adapters/user-tutorial.js
+++ b/mon-pix/app/adapters/user-tutorial.js
@@ -1,12 +1,14 @@
 import ApplicationAdapter from './application';
 
 export default class UserTutorial extends ApplicationAdapter {
-  createRecord(store, type, { adapterOptions }) {
-    const url = `${this.host}/${this.namespace}/users/tutorials/${adapterOptions.tutorialId}`;
+  createRecord(store, type, snapshot) {
+    const tutorial = snapshot.belongsTo('tutorial');
+    const url = `${this.host}/${this.namespace}/users/tutorials/${tutorial.id}`;
     return this.ajax(url, 'PUT');
   }
 
-  urlForDeleteRecord(id, modelName, { adapterOptions }) {
-    return `${this.host}/${this.namespace}/users/tutorials/${adapterOptions.tutorialId}`;
+  urlForDeleteRecord(id, modelName, snapshot) {
+    const tutorial = snapshot.belongsTo('tutorial');
+    return `${this.host}/${this.namespace}/users/tutorials/${tutorial.id}`;
   }
 }

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -53,7 +53,7 @@ export default class Card extends Component {
   async _saveTutorial() {
     try {
       const userTutorial = this.store.createRecord('userTutorial', { tutorial: this.args.tutorial });
-      await userTutorial.save({ adapterOptions: { tutorialId: this.args.tutorial.id } });
+      await userTutorial.save();
       this.savingStatus = buttonStatusTypes.recorded;
     } catch (e) {
       this.savingStatus = buttonStatusTypes.unrecorded;
@@ -62,7 +62,7 @@ export default class Card extends Component {
 
   async _removeTutorial() {
     try {
-      await this.args.tutorial.userTutorial.destroyRecord({ adapterOptions: { tutorialId: this.args.tutorial.id } });
+      await this.args.tutorial.userTutorial.destroyRecord();
       this.savingStatus = buttonStatusTypes.unrecorded;
     } catch (e) {
       this.savingStatus = buttonStatusTypes.recorded;

--- a/mon-pix/tests/unit/adapters/user-tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/user-tutorial_test.js
@@ -14,20 +14,36 @@ describe('Unit | Adapters | user-tutorial', function () {
   });
 
   describe('#createRecord', () => {
-    it('should call API to create a user-tutorial', async function () {
+    it('should call API to create a user-tutorial with skill-id from tutorial', async function () {
       // given
       const tutorialId = 'tutorialId';
-      const tutorial = { id: tutorialId };
+      const skillId = 'skillId';
+      const tutorial = { id: tutorialId, attr: sinon.stub() };
       const snapshot = {
         belongsTo: sinon.stub(),
       };
       snapshot.belongsTo.withArgs('tutorial').returns(tutorial);
+      tutorial.attr.withArgs('skillId').returns(skillId);
 
       // when
       await adapter.createRecord(null, 'user-tutorial', snapshot);
 
       // then
-      sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/users/tutorials/tutorialId', 'PUT');
+      const expectedOptions = {
+        data: {
+          data: {
+            attributes: {
+              'skill-id': skillId,
+            },
+          },
+        },
+      };
+      sinon.assert.calledWith(
+        adapter.ajax,
+        'http://localhost:3000/api/users/tutorials/tutorialId',
+        'PUT',
+        expectedOptions
+      );
     });
   });
 

--- a/mon-pix/tests/unit/adapters/user-tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/user-tutorial_test.js
@@ -17,10 +17,14 @@ describe('Unit | Adapters | user-tutorial', function () {
     it('should call API to create a user-tutorial', async function () {
       // given
       const tutorialId = 'tutorialId';
-      const tutorial = { adapterOptions: { tutorialId } };
+      const tutorial = { id: tutorialId };
+      const snapshot = {
+        belongsTo: sinon.stub(),
+      };
+      snapshot.belongsTo.withArgs('tutorial').returns(tutorial);
 
       // when
-      await adapter.createRecord(null, 'user-tutorial', tutorial);
+      await adapter.createRecord(null, 'user-tutorial', snapshot);
 
       // then
       sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/users/tutorials/tutorialId', 'PUT');
@@ -31,10 +35,14 @@ describe('Unit | Adapters | user-tutorial', function () {
     it('should return API to delete a user-tutorial', async function () {
       // given
       const tutorialId = 'tutorialId';
-      const tutorial = { adapterOptions: { tutorialId } };
+      const tutorial = { id: tutorialId };
+      const snapshot = {
+        belongsTo: sinon.stub(),
+      };
+      snapshot.belongsTo.withArgs('tutorial').returns(tutorial);
 
       // when
-      const url = adapter.urlForDeleteRecord(null, 'user-tutorial', tutorial);
+      const url = adapter.urlForDeleteRecord(null, 'user-tutorial', snapshot);
 
       // then
       expect(url).to.equal('http://localhost:3000/api/users/tutorials/tutorialId');

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -135,7 +135,7 @@ describe('Unit | Component | Tutorial | card item', function () {
         await component.toggleSaveTutorial();
 
         // then
-        sinon.assert.calledWith(userTutorial.save, { adapterOptions: { tutorialId: tutorial.id } });
+        sinon.assert.called(userTutorial.save);
       });
 
       it('should set status to recorded', async function () {
@@ -165,7 +165,7 @@ describe('Unit | Component | Tutorial | card item', function () {
         await component.toggleSaveTutorial();
 
         // then
-        sinon.assert.calledWith(userTutorial.destroyRecord, { adapterOptions: { tutorialId: tutorial.id } });
+        sinon.assert.called(userTutorial.destroyRecord);
       });
 
       it('should set status to unrecorded', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix App, nous n'enregistrons pas le contexte du tutoriel lorsque l'utilisateur l'enregistre. Le contexte correspond au skillId qui nous a permis de proposer ce tutoriel. 

## :robot: Solution
La route étant déjà prête à recevoir le skillId, il nous manquait juste de l'envoyer au moment de l'enregistrement.

## :rainbow: Remarques
Au passage, j'ai retiré les `adapterOptions` car ils sont inutiles dans notre cas, le snapshot contenant déjà les informations que l'on souhaite. 

## :100: Pour tester
- Se connecter sur Pix APP
- Enregistrer un tutoriel et vérifier que dans la requête que le skillId est bien envoyé. 
- Vérifier aussi le désenregistrement. 
