### PR TITLE
[FEATURE] Affiche le nombre de places actives d'une organisation (PIX-55343)

### DIFF
--- a/admin/app/adapters/organization-places-capacity.js
+++ b/admin/app/adapters/organization-places-capacity.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationPlacesCapacityAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForQueryRecord(query) {
+    const organizationId = query.organizationId;
+    delete query.organizationId;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/places/capacity`;
+  }
+}

--- a/admin/app/components/organizations/places-capacity.hbs
+++ b/admin/app/components/organizations/places-capacity.hbs
@@ -1,0 +1,10 @@
+<table class="places__capacity">
+  <tbody>
+    {{#each this.placesCapacityCategories as |placesCapacityCategory|}}
+      <tr>
+        <td>{{placesCapacityCategory.count}}</td>
+        <td><strong>{{placesCapacityCategory.label}}</strong></td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/admin/app/components/organizations/places-capacity.js
+++ b/admin/app/components/organizations/places-capacity.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+
+const categories = {
+  FREE_RATE: 'Tarif gratuit',
+  PUBLIC_RATE: 'Tarif public',
+  REDUCE_RATE: 'Tarif réduit',
+  SPECIAL_REDUCE_RATE: 'Tarif réduit spécial',
+  FULL_RATE: 'Tarif plein',
+};
+
+export default class PlacesCapacity extends Component {
+  get placesCapacityCategories() {
+    return this.args.placesCapacity?.categories
+      .filter(({ count }) => count > 0)
+      .map(({ category, count }) => ({
+        label: categories[category],
+        count,
+      }));
+  }
+}

--- a/admin/app/components/organizations/places.hbs
+++ b/admin/app/components/organizations/places.hbs
@@ -3,6 +3,9 @@
     <h2 class="page-section__title">Places</h2>
   </header>
   <div class="places__resume">
+    <h3 class="page-section__title page-section__title--sub">Nombre de places actives</h3>
+    <Organizations::PlacesCapacity @placesCapacity={{@placesCapacity}} />
+
     {{#if this.accessControl.hasAccessToOrganizationPlacesActionsScope}}
       <PixButtonLink
         class="places__button"

--- a/admin/app/models/organization-places-capacity.js
+++ b/admin/app/models/organization-places-capacity.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationPlacesCapacity extends Model {
+  @attr() categories;
+}

--- a/admin/app/routes/authenticated/organizations/get/places/list.js
+++ b/admin/app/routes/authenticated/organizations/get/places/list.js
@@ -9,7 +9,10 @@ export default class Places extends Route {
     const places = await this.store.query('organization-place', {
       organizationId: organization.id,
     });
+    const placesCapacity = await this.store.queryRecord('organization-places-capacity', {
+      organizationId: organization.id,
+    });
 
-    return { organization, places };
+    return { organization, places, placesCapacity };
   }
 }

--- a/admin/app/styles/components/organizations/places.scss
+++ b/admin/app/styles/components/organizations/places.scss
@@ -7,6 +7,7 @@
   }
 
   &__button {
+    margin-top: $spacing-s;
     display: inline-flex;
 
     &:hover {

--- a/admin/app/styles/components/organizations/places.scss
+++ b/admin/app/styles/components/organizations/places.scss
@@ -15,6 +15,18 @@
     }
   }
 
+  &__capacity {
+    width: auto;
+
+    tr {
+      height: auto;
+    }
+
+    td:first-child {
+      padding: 0;
+    }
+  }
+
   &__button-icon {
     margin: 0 $spacing-xxs;
   }

--- a/admin/app/templates/authenticated/organizations/get/places/list.hbs
+++ b/admin/app/templates/authenticated/organizations/get/places/list.hbs
@@ -1,2 +1,6 @@
 {{page-title "Orga " @model.organization.id " | Places"}}
-<Organizations::Places @places={{@model.places}} @organizationId={{@model.organization.id}} />
+<Organizations::Places
+  @places={{@model.places}}
+  @organizationId={{@model.organization.id}}
+  @placesCapacity={{@model.placesCapacity}}
+/>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -23,6 +23,7 @@ import {
   findPaginatedOrganizationMemberships,
   getOrganizationInvitations,
   getOrganizationPlaces,
+  getOrganizationPlacesCapacity,
 } from './handlers/organizations';
 import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { createAdminMember } from './handlers/admin-members';
@@ -139,6 +140,7 @@ export default function () {
   this.post('/admin/organizations/:id/target-profiles', attachTargetProfiles);
   this.get('/admin/organizations/:id/invitations', getOrganizationInvitations);
   this.get('/admin/organizations/:id/places', getOrganizationPlaces);
+  this.get('/admin/organizations/:id/places/capacity', getOrganizationPlacesCapacity);
   this.get('/admin/badges/:id', getBadge);
   this.post('/admin/badges/:id/badge-criteria', createBadgeCriterion);
   this.post('/admin/target-profiles');

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -5,6 +5,24 @@ function getOrganizationPlaces(schema) {
   return schema.organizationPlaces.all();
 }
 
+function getOrganizationPlacesCapacity() {
+  return {
+    data: {
+      id: '1_places_capacity',
+      type: 'organization-places-capacities',
+      attributes: {
+        categories: [
+          { count: 7777, category: 'FREE_RATE' },
+          { count: 0, category: 'PUBLIC_RATE' },
+          { count: 0, category: 'REDUCE_RATE' },
+          { count: 0, category: 'SPECIAL_REDUCE_RATE' },
+          { count: 0, category: 'FULL_RATE' },
+        ],
+      },
+    },
+  };
+}
+
 function getOrganizationInvitations(schema, request) {
   const organizationId = request.params.id;
   return schema.organizationInvitations.where({ organizationId });
@@ -68,4 +86,10 @@ function _applyPagination(memberships, { page, pageSize }) {
   return slice(memberships, start, end);
 }
 
-export { archiveOrganization, getOrganizationInvitations, getOrganizationPlaces, findPaginatedOrganizationMemberships };
+export {
+  archiveOrganization,
+  getOrganizationInvitations,
+  getOrganizationPlaces,
+  getOrganizationPlacesCapacity,
+  findPaginatedOrganizationMemberships,
+};

--- a/admin/tests/acceptance/authenticated/organizations/places_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/places_test.js
@@ -14,6 +14,18 @@ module('Acceptance | Organizations | places', function (hooks) {
       await authenticateAdminMemberWithRole({ isSupport: true })(server);
     });
 
+    test('should display current organization places capacity', async function (assert) {
+      // given
+      const ownerOrganizationId = this.server.create('organization').id;
+
+      // when
+      const screen = await visit(`/organizations/${ownerOrganizationId}/places`);
+
+      // then
+      assert.dom(screen.getByText('Nombre de places actives')).exists();
+      assert.dom(screen.getByText('7777')).exists();
+    });
+
     test('should display organization places', async function (assert) {
       // given
       const ownerOrganizationId = this.server.create('organization').id;

--- a/admin/tests/integration/components/organizations/places-capacity_test.js
+++ b/admin/tests/integration/components/organizations/places-capacity_test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Organizations | placesCapacity', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('Display places capacity', function () {
+    test('it should display places capacity', async function (assert) {
+      // given
+      const placesCapacity = {
+        categories: [
+          { count: 10, category: 'FREE_RATE' },
+          { count: 0, category: 'PUBLIC_RATE' },
+          { count: 0, category: 'REDUCE_RATE' },
+          { count: 0, category: 'SPECIAL_REDUCE_RATE' },
+          { count: 7777, category: 'FULL_RATE' },
+        ],
+      };
+
+      this.set('placesCapacity', placesCapacity);
+
+      // when
+      const screen = await render(hbs`<Organizations::PlacesCapacity @placesCapacity={{this.placesCapacity}}/>`);
+
+      // then
+      assert.dom(screen.queryByText('7777')).exists();
+      assert.dom(screen.queryByText('Tarif plein')).exists();
+      assert.dom(screen.queryByText('10')).exists();
+      assert.dom(screen.queryByText('Tarif gratuit')).exists();
+
+      assert.dom(screen.queryByText('Tarif public')).doesNotExist();
+      assert.dom(screen.queryByText('Tarif réduit')).doesNotExist();
+      assert.dom(screen.queryByText('Tarif réduit spécial')).doesNotExist();
+    });
+  });
+});

--- a/admin/tests/unit/adapters/organization-places-capacity_test.js
+++ b/admin/tests/unit/adapters/organization-places-capacity_test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ENV from 'pix-admin/config/environment';
+
+module('Unit | Adapters | organization-places-capacity', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:organization-places-capacity');
+  });
+
+  module('#urlForQueryRecord', function () {
+    test('should build url with query params', async function (assert) {
+      // given
+      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/organizations/1/places/capacity`;
+
+      // when
+      const url = adapter.urlForQueryRecord({ organizationId: 1 });
+
+      // then
+      assert.deepEqual(url, expectedUrl);
+    });
+  });
+});

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -276,6 +276,34 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/organizations/{id}/places/capacity',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationController.getOrganizationPlacesCapacity,
+        tags: ['api', 'organizations'],
+        notes: [
+          `- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n- Elle retourne la capacité en places par catégorie pour une organisation`,
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/organizations/{id}/places',
       config: {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -15,6 +15,7 @@ const TargetProfileForSpecifierSerializer = require('../../infrastructure/serial
 const organizationMemberIdentitySerializer = require('../../infrastructure/serializers/jsonapi/organization-member-identity-serializer');
 const organizationPlacesLotManagmentSerializer = require('../../infrastructure/serializers/jsonapi/organization/organization-places-lot-management-serializer');
 const organizationPlacesLotSerializer = require('../../infrastructure/serializers/jsonapi/organization/organization-places-lot-serializer');
+const organizationPlacesCapacitySerializer = require('../../infrastructure/serializers/jsonapi/organization-places-capacity-serializer');
 const organizationParticipantsSerializer = require('../../infrastructure/serializers/jsonapi/organization/organization-participants-serializer');
 
 const SupOrganizationLearnerParser = require('../../infrastructure/serializers/csv/sup-organization-learner-parser');
@@ -127,6 +128,12 @@ module.exports = {
     const organizationId = request.params.id;
     const members = await usecases.getOrganizationMemberIdentities({ organizationId });
     return organizationMemberIdentitySerializer.serialize(members);
+  },
+
+  async getOrganizationPlacesCapacity(request) {
+    const organizationId = request.params.id;
+    const organizationPlacesCapacity = await usecases.getOrganizationPlacesCapacity({ organizationId });
+    return organizationPlacesCapacitySerializer.serialize(organizationPlacesCapacity);
   },
 
   async findOrganizationPlacesLot(request) {

--- a/api/lib/domain/read-models/OrganizationPlacesCapacity.js
+++ b/api/lib/domain/read-models/OrganizationPlacesCapacity.js
@@ -1,0 +1,32 @@
+const sumBy = require('lodash/sumBy');
+const categories = require('../constants/organization-places-categories');
+
+const categoriesByCode = {
+  [categories.T0]: categories.FREE_RATE,
+  [categories.T1]: categories.PUBLIC_RATE,
+  [categories.T2]: categories.REDUCE_RATE,
+  [categories.T2bis]: categories.SPECIAL_REDUCE_RATE,
+  [categories.T3]: categories.FULL_RATE,
+};
+
+class OrganizationPlacesCapacity {
+  constructor({ placesLots, organizationId }) {
+    this.id = `${organizationId}_places_capacity`;
+    this.categories = [categories.T0, categories.T1, categories.T2, categories.T2bis, categories.T3].map((category) =>
+      this.getPlacesCapacityForCategory(placesLots, category)
+    );
+  }
+
+  getPlacesCapacityForCategory(placesLots, category) {
+    const organizationPlacesLotsForCategory = placesLots.filter(
+      ({ category: lotCategory }) => lotCategory === category
+    );
+
+    return {
+      category: categoriesByCode[category],
+      count: sumBy(organizationPlacesLotsForCategory, 'count'),
+    };
+  }
+}
+
+module.exports = OrganizationPlacesCapacity;

--- a/api/lib/domain/usecases/get-organization-places-capacity.js
+++ b/api/lib/domain/usecases/get-organization-places-capacity.js
@@ -1,0 +1,3 @@
+module.exports = function getOrganizationPlacesCapacity({ organizationId, organizationPlacesCapacityRepository }) {
+  return organizationPlacesCapacityRepository.findByOrganizationId(organizationId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -93,6 +93,7 @@ const dependencies = {
   organizationForAdminRepository: require('../../infrastructure/repositories/organization-for-admin-repository'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
   organizationPlacesLotRepository: require('../../infrastructure/repositories/organizations/organization-places-lot-repository'),
+  organizationPlacesCapacityRepository: require('../../infrastructure/repositories/organization-places-capacity-repository'),
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
   organizationInvitedUserRepository: require('../../infrastructure/repositories/organization-invited-user-repository'),
   organizationTagRepository: require('../../infrastructure/repositories/organization-tag-repository'),
@@ -408,6 +409,7 @@ module.exports = injectDependencies(
     updateUserDetailsForAdministration: require('./update-user-details-for-administration'),
     updateUserEmailWithValidation: require('./update-user-email-with-validation'),
     updateUserPassword: require('./update-user-password'),
+    getOrganizationPlacesCapacity: require('./get-organization-places-capacity'),
   },
   dependencies
 );

--- a/api/lib/infrastructure/repositories/organization-places-capacity-repository.js
+++ b/api/lib/infrastructure/repositories/organization-places-capacity-repository.js
@@ -1,0 +1,19 @@
+const { knex } = require('../../../db/knex-database-connection');
+const OrganizationPlacesCapacity = require('../../domain/read-models/OrganizationPlacesCapacity');
+
+async function findByOrganizationId(organizationId) {
+  const now = new Date();
+  const organizationPlacesLots = await knex('organization-places')
+    .select('category', 'count')
+    .where({ organizationId })
+    .where('activationDate', '<', now)
+    .where(function () {
+      this.where('expirationDate', '>', now).orWhereNull('expirationDate');
+    });
+
+  return new OrganizationPlacesCapacity({ placesLots: organizationPlacesLots, organizationId });
+}
+
+module.exports = {
+  findByOrganizationId,
+};

--- a/api/lib/infrastructure/serializers/jsonapi/organization-places-capacity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-places-capacity-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(places) {
+    return new Serializer('organization-places-capacity', {
+      attributes: ['categories'],
+    }).serialize(places);
+  },
+};

--- a/api/tests/acceptance/application/organizations/get-organization-places-capacity_test.js
+++ b/api/tests/acceptance/application/organizations/get-organization-places-capacity_test.js
@@ -1,0 +1,66 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+const categories = require('../../../../lib/domain/constants/organization-places-categories');
+
+describe('Acceptance | Route | Organizations', function () {
+  describe('GET /api/admin/organizations/{id}/places/capacity', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+
+      const adminUser = await insertUserWithRoleSuperAdmin();
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/organizations/${organizationId}/places/capacity`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return list of places', async function () {
+      // given
+      const server = await createServer();
+
+      const adminUser = await insertUserWithRoleSuperAdmin();
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        count: 10,
+        category: categories.T0,
+        createdBy: adminUser.id,
+      });
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/organizations/${organizationId}/places/capacity`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.result.data.attributes.categories[0].count).to.equal(10);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
@@ -1,0 +1,131 @@
+const sinon = require('sinon');
+const { expect, databaseBuilder } = require('../../../test-helper');
+const organizationPlacesCapacityRepository = require('../../../../lib/infrastructure/repositories/organization-places-capacity-repository');
+const categories = require('../../../../lib/domain/constants/organization-places-categories');
+
+describe('Integration | Infrastructure | Repository | OrganizationPlacesCapacityRepository', function () {
+  describe('#findByOrganizationId', function () {
+    let organizationId;
+    let clock;
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers(new Date(Date.parse('10/10/2021')));
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should return 0 if there is no places', async function () {
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.have.deep.members([
+        { category: categories.FREE_RATE, count: 0 },
+        { category: categories.PUBLIC_RATE, count: 0 },
+        { category: categories.REDUCE_RATE, count: 0 },
+        { category: categories.SPECIAL_REDUCE_RATE, count: 0 },
+        { category: categories.FULL_RATE, count: 0 },
+      ]);
+    });
+
+    it('should return count if there are places', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T1, count: 5, organizationId });
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T2, count: 2, organizationId });
+      databaseBuilder.factory.buildOrganizationPlace({
+        category: categories.T2bis,
+        count: 20,
+        organizationId,
+      });
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T3, count: 1, organizationId });
+      await databaseBuilder.commit();
+
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.have.deep.members([
+        { category: categories.FREE_RATE, count: 10 },
+        { category: categories.PUBLIC_RATE, count: 5 },
+        { category: categories.REDUCE_RATE, count: 2 },
+        { category: categories.SPECIAL_REDUCE_RATE, count: 20 },
+        { category: categories.FULL_RATE, count: 1 },
+      ]);
+    });
+
+    it('should sum places lot of a same category', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
+      await databaseBuilder.commit();
+
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.include.deep.members([
+        { category: categories.FREE_RATE, count: 20 },
+      ]);
+    });
+
+    it('should return places capacity for a specific organization', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationPlace({
+        category: categories.T0,
+        count: 1,
+        organizationId: otherOrganizationId,
+      });
+      await databaseBuilder.commit();
+
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.include.deep.members([
+        { category: categories.FREE_RATE, count: 10 },
+      ]);
+    });
+
+    it('should not take in account expired places lot', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
+      databaseBuilder.factory.buildOrganizationPlace({
+        category: categories.T0,
+        count: 1,
+        expirationDate: new Date(Date.parse('01/10/2021')),
+        organizationId,
+      });
+      await databaseBuilder.commit();
+
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.include.deep.members([
+        { category: categories.FREE_RATE, count: 10 },
+      ]);
+    });
+
+    it('should not take in account places lot that are not activated yet', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
+      databaseBuilder.factory.buildOrganizationPlace({
+        category: categories.T0,
+        count: 1,
+        activationDate: new Date(Date.parse('11/10/2021')),
+        organizationId,
+      });
+      await databaseBuilder.commit();
+
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.include.deep.members([
+        { category: categories.FREE_RATE, count: 10 },
+      ]);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-places-capacity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-places-capacity-serializer_test.js
@@ -1,0 +1,38 @@
+const { expect } = require('../../../../../test-helper');
+const categories = require('../../../../../../lib/domain/constants/organization-places-categories');
+const serializer = require('../../../../../../lib/infrastructure/serializers/jsonapi/organization-places-capacity-serializer');
+const OrganizationPlacesCapacity = require('../../../../../../lib/domain/read-models/OrganizationPlacesCapacity');
+
+describe('Unit | Serializer | JSONAPI | organization-places-capacity-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an organization participant model object into JSON API data', function () {
+      // given
+      const organizationPlacesCapacity = new OrganizationPlacesCapacity({
+        organizationId: 1,
+        placesLots: [{ category: categories.T0, count: 10 }],
+      });
+
+      const expectedJSON = {
+        data: {
+          attributes: {
+            categories: [
+              { category: categories.FREE_RATE, count: 10 },
+              { category: categories.PUBLIC_RATE, count: 0 },
+              { category: categories.REDUCE_RATE, count: 0 },
+              { category: categories.SPECIAL_REDUCE_RATE, count: 0 },
+              { category: categories.FULL_RATE, count: 0 },
+            ],
+          },
+          id: '1_places_capacity',
+          type: 'organization-places-capacities',
+        },
+      };
+
+      // when
+      const json = serializer.serialize(organizationPlacesCapacity);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Dans l'épix création des places et calcul d’une capacité d’une organisation, nous avons créé une gestion de places dans pix admin. 
Actuellement il y a un tableau avec chaque ligne représentant un lot de place, ce qui est très compliqué à la lecture pour trouver le nombre de places actives, d’ou le fait de rajouter un bloc pour faciliter la lecture.

## :robot: Solution
Dans ce bloc, nous affichons le nombres de places actives par catégories.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixAdmin
- Aller sur la page de la première organisation
- Aller dans l'onglet "Places"
- Constater au dessus du bouton d'ajout de la lots la présence du bloc de places actives