### PR TITLE
[BUGFIX] Retirer les espaces en début/fin de chaine, renvoie null si vide (PIX-5406)

### DIFF
--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -79,9 +79,9 @@ export default class UpdateTargetProfile extends Component {
 
   async _updateTargetProfile() {
     const model = this.args.model;
-    model.name = this.form.name.trim();
-    model.description = this.form.description ? this.form.description.trim() : null;
-    model.comment = this.form.comment ? this.form.comment.trim() : null;
+    model.name = this.form.name;
+    model.description = this.form.description ? this.form.description : null;
+    model.comment = this.form.comment ? this.form.comment : null;
     model.category = this.form.category;
 
     try {

--- a/admin/app/models/campaign.js
+++ b/admin/app/models/campaign.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 export default class Campaign extends Model {
-  @attr('string') name;
-  @attr('string') title;
+  @attr('nullable-string') name;
+  @attr('nullable-string') title;
   @attr('date') archivedAt;
   @attr('string') type;
   @attr('string') code;
@@ -15,10 +15,10 @@ export default class Campaign extends Model {
   @attr('string') organizationName;
   @attr('string') targetProfileId;
   @attr('string') targetProfileName;
-  @attr('string') customLandingPageText;
-  @attr('string') customResultPageText;
-  @attr('string') customResultPageButtonText;
-  @attr('string') customResultPageButtonUrl;
+  @attr('nullable-text') customLandingPageText;
+  @attr('nullable-text') customResultPageText;
+  @attr('nullable-string') customResultPageButtonText;
+  @attr('nullable-string') customResultPageButtonUrl;
   @attr('number') sharedParticipationsCount;
   @attr('number') totalParticipationsCount;
   @attr('boolean') isTypeProfilesCollection;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -16,13 +16,13 @@ export const optionsCategoryList = map(categories, function (key, value) {
 });
 
 export default class TargetProfile extends Model {
-  @attr('string') name;
+  @attr('nullable-string') name;
   @attr('boolean') isPublic;
   @attr('date') createdAt;
   @attr('string') imageUrl;
   @attr('boolean') outdated;
-  @attr('string') description;
-  @attr('string') comment;
+  @attr('nullable-string') description;
+  @attr('nullable-string') comment;
   @attr('string') ownerOrganizationId;
   @attr('string') category;
   @attr('boolean') isSimplifiedAccess;

--- a/admin/app/transforms/nullable-string.js
+++ b/admin/app/transforms/nullable-string.js
@@ -1,0 +1,15 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class NullableString extends Transform {
+  serialize(string) {
+    if (typeof string !== 'string') return null;
+
+    const result = string.trim();
+
+    return result || null;
+  }
+
+  deserialize(string) {
+    return string;
+  }
+}

--- a/admin/app/transforms/nullable-text.js
+++ b/admin/app/transforms/nullable-text.js
@@ -1,0 +1,13 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class NullableText extends Transform {
+  serialize(string) {
+    if (typeof string !== 'string') return null;
+
+    return string.trim() ? string : null;
+  }
+
+  deserialize(string) {
+    return string;
+  }
+}

--- a/admin/tests/unit/transforms/nullable-string_test.js
+++ b/admin/tests/unit/transforms/nullable-string_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import NullableStringTransform from 'pix-admin/transforms/nullable-string';
+
+module('Unit | Transformer | String', function (hooks) {
+  setupTest(hooks);
+
+  module('#serialize', function () {
+    test('should return null when not a string', function (assert) {
+      // given
+      const transform = NullableStringTransform.create();
+      const string = undefined;
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+
+    test('should return a String without extra space', function (assert) {
+      // given
+      const transform = NullableStringTransform.create();
+      const string = ' Gozilla vs Kong ';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, 'Gozilla vs Kong');
+    });
+
+    test('should return null when empty string', function (assert) {
+      // given
+      const transform = NullableStringTransform.create();
+      const string = '';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+  });
+});

--- a/admin/tests/unit/transforms/nullable-text_test.js
+++ b/admin/tests/unit/transforms/nullable-text_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import NullableTextTransform from 'pix-admin/transforms/nullable-text';
+
+module('Unit | Transformer | String', function (hooks) {
+  setupTest(hooks);
+
+  module('#serialize', function () {
+    test('should return null when not a string', function (assert) {
+      // given
+      const transform = NullableTextTransform.create();
+      const string = undefined;
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+
+    test('should return a String with extra space', function (assert) {
+      // given
+      const transform = NullableTextTransform.create();
+      const string = ' Gozilla vs Kong ';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, string);
+    });
+
+    test('should return null when empty string', function (assert) {
+      // given
+      const transform = NullableTextTransform.create();
+      const string = '';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Des chaines de caractère malformaté sont envoyés à l'API, ( extra space, chaine vide)

## :robot: Solution
Nettoyer la chaîne de caractère avant de l'envoyer à l'API

## :rainbow: Remarques

## :100: Pour tester
RAS