### PR TITLE
[FEATURE] Filtrer les participants par nom et prénom (PIX-5122).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -378,6 +378,7 @@ module.exports = {
     const results = await usecases.getPaginatedParticipantsForAnOrganization({
       organizationId,
       page: options.page,
+      filters: options.filter,
     });
     return organizationParticipantsSerializer.serialize(results);
   },

--- a/api/lib/domain/usecases/get-paginated-participants-for-an-organization.js
+++ b/api/lib/domain/usecases/get-paginated-participants-for-an-organization.js
@@ -1,10 +1,12 @@
 module.exports = function getPaginatedParticipantsForAnOrganization({
   organizationId,
+  filters,
   page,
   organizationParticipantRepository,
 }) {
   return organizationParticipantRepository.getParticipantsByOrganizationId({
     organizationId,
+    filters,
     page,
   });
 };

--- a/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -1,6 +1,7 @@
 const { knex } = require('../../../db/knex-database-connection');
 const CampaignParticipantActivity = require('../../domain/read-models/CampaignParticipantActivity');
 const { fetchPage } = require('../utils/knex-utils');
+const { filterByFullName } = require('../utils/filter-utils');
 
 const campaignParticipantActivityRepository = {
   async findPaginatedByCampaignId({ page = { size: 25 }, campaignId, filters = {} }) {
@@ -55,16 +56,7 @@ function _filterParticipations(queryBuilder, filters, campaignId) {
 
 function _filterBySearch(queryBuilder, filters) {
   if (filters.search) {
-    const search = filters.search.trim().toLowerCase();
-    queryBuilder.where(function () {
-      this.where(
-        knex.raw(`CONCAT ("organization-learners"."firstName", ' ', "organization-learners"."lastName") <-> ?`, search),
-        '<=',
-        0.8
-      )
-        .orWhereRaw('LOWER("organization-learners"."lastName") LIKE ?', `%${search}%`)
-        .orWhereRaw('LOWER("organization-learners"."firstName") LIKE ?', `%${search}%`);
-    });
+    filterByFullName(queryBuilder, filters.search, 'organization-learners.firstName', 'organization-learners.lastName');
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -6,6 +6,7 @@ const CampaignProfilesCollectionParticipationSummary = require('../../domain/rea
 const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const constants = require('../constants');
 const { fetchPage } = require('../utils/knex-utils');
+const { filterByFullName } = require('../utils/filter-utils');
 
 const CampaignProfilesCollectionParticipationSummaryRepository = {
   async findPaginatedByCampaignId(campaignId, page, filters = {}) {
@@ -88,16 +89,7 @@ function _filterQuery(queryBuilder, filters) {
     queryBuilder.whereIn(knex.raw('LOWER("organization-learners"."group")'), groupsLowerCase);
   }
   if (filters.search) {
-    const search = filters.search.trim().toLowerCase();
-    queryBuilder.where(function () {
-      this.where(
-        knex.raw(`CONCAT ("organization-learners"."firstName", ' ', "organization-learners"."lastName") <-> ?`, search),
-        '<=',
-        0.8
-      )
-        .orWhereRaw('LOWER("organization-learners"."lastName") LIKE ?', `%${search}%`)
-        .orWhereRaw('LOWER("organization-learners"."firstName") LIKE ?', `%${search}%`);
-    });
+    filterByFullName(queryBuilder, filters.search, 'organization-learners.firstName', 'organization-learners.lastName');
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -6,7 +6,7 @@ const CampaignParticipationStatuses = require('../../domain/models/CampaignParti
 const { fetchPage } = require('../utils/knex-utils');
 const { NotFoundError } = require('../../domain/errors');
 const _ = require('lodash');
-
+const { filterByFullName } = require('../utils/filter-utils');
 const skillDataSource = require('../datasources/learning-content/skill-datasource');
 
 const { SHARED } = CampaignParticipationStatuses;
@@ -21,12 +21,7 @@ function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, ownerName,
     qb.whereNotNull('campaigns.archivedAt');
   }
   if (ownerName) {
-    qb.where(function () {
-      const search = ownerName.toLowerCase().trim();
-      this.where(knex.raw(`CONCAT ("users"."firstName", ' ', "users"."lastName") <-> ?`, search), '<=', 0.8)
-        .orWhereRaw('LOWER("users"."lastName") LIKE ?', `%${search}%`)
-        .orWhereRaw('LOWER("users"."firstName") LIKE ?', `%${search}%`);
-    });
+    filterByFullName(qb, ownerName, 'users.firstName', 'users.lastName');
   }
   if (isOwnedByMe) {
     qb.where('users.id', '=', userId);

--- a/api/lib/infrastructure/utils/filter-utils.js
+++ b/api/lib/infrastructure/utils/filter-utils.js
@@ -1,0 +1,13 @@
+const { knex } = require('../../../db/knex-database-connection');
+
+const DISTANCE = 0.8;
+module.exports = {
+  filterByFullName(queryBuilder, search, firstName, lastName) {
+    const searchLowerCase = search.trim().toLowerCase();
+    queryBuilder.where(function () {
+      this.where(knex.raw(`CONCAT (??, ' ', ??) <-> ?`, [firstName, lastName, searchLowerCase]), '<=', DISTANCE);
+      this.orWhereRaw('LOWER(??) LIKE ?', [firstName, `%${searchLowerCase}%`]);
+      this.orWhereRaw('LOWER(??) LIKE ?', [lastName, `%${searchLowerCase}%`]);
+    });
+  },
+};

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -471,16 +471,18 @@ describe('Integration | Application | Organizations | organization-controller', 
     context('when the organization has participants', function () {
       it('returns organization participants', async function () {
         const organizationId = 5678;
-        usecases.getPaginatedParticipantsForAnOrganization.withArgs({ organizationId, page: {} }).resolves({
-          organizationParticipants: [
-            {
-              id: 5678,
-              firstName: 'Mei',
-              lastName: 'Lee',
-            },
-          ],
-          pagination: 1,
-        });
+        usecases.getPaginatedParticipantsForAnOrganization
+          .withArgs({ organizationId, page: {}, filters: {} })
+          .resolves({
+            organizationParticipants: [
+              {
+                id: 5678,
+                firstName: 'Mei',
+                lastName: 'Lee',
+              },
+            ],
+            pagination: 1,
+          });
         securityPreHandlers.checkUserBelongsToOrganization.returns(() => true);
 
         const response = await httpTestServer.request('GET', `/api/organizations/${organizationId}/participants`);

--- a/api/tests/integration/domain/usecases/get-paginated-participants-for-an-organization_test.js
+++ b/api/tests/integration/domain/usecases/get-paginated-participants-for-an-organization_test.js
@@ -6,7 +6,10 @@ describe('Integration | UseCases | get-paginated-participants-for-an-organizatio
   it('should get all participations for an organization', async function () {
     // given
     const organizationId = databaseBuilder.factory.buildOrganization().id;
-    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+    const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Ah',
+      organizationId,
+    }).id;
     const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
     databaseBuilder.factory.buildCampaignParticipation({
       organizationLearnerId,
@@ -18,6 +21,7 @@ describe('Integration | UseCases | get-paginated-participants-for-an-organizatio
     // when
     const results = await getPaginatedParticipantsForAnOrganization({
       organizationId,
+      filters: { fullName: 'Ah' },
       page: { number: 1, size: 10 },
       organizationParticipantRepository,
     });

--- a/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -321,5 +321,101 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
         expect(pagination).to.deep.equals({ page: 2, pageCount: 2, pageSize: 1, rowCount: 2 });
       });
     });
+
+    context('fullName', function () {
+      it('returns the participants which match by first name', async function () {
+        // given
+        const { id: id1 } = buildLearnerWithParticipation(organizationId, { firstName: 'Anton' });
+        const { id: id2 } = buildLearnerWithParticipation(organizationId, { firstName: 'anton' });
+        buildLearnerWithParticipation(organizationId, { firstName: 'Llewelyn' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+          filters: { fullName: ' Anton ' },
+        });
+
+        const ids = organizationParticipants.map(({ id }) => id);
+
+        // then
+        expect(ids).to.exactlyContain([id1, id2]);
+      });
+
+      it('returns the participants which match by last name when fullName text is a part of first name', async function () {
+        // given
+        const { id: id1 } = buildLearnerWithParticipation(organizationId, { firstName: 'Anton' });
+        buildLearnerWithParticipation(organizationId, { firstName: 'Llewelyn' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+          filters: { fullName: 'nt' },
+        });
+
+        const ids = organizationParticipants.map(({ id }) => id);
+
+        // then
+        expect(ids).to.exactlyContain([id1]);
+      });
+
+      it('returns the participants which match by last name', async function () {
+        // given
+        const { id: id1 } = buildLearnerWithParticipation(organizationId, { lastName: 'Chigurh' });
+        const { id: id2 } = buildLearnerWithParticipation(organizationId, { lastName: 'chigurh' });
+        buildLearnerWithParticipation(organizationId, { lastName: 'Moss' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+          filters: { fullName: ' chigurh ' },
+        });
+
+        const ids = organizationParticipants.map(({ id }) => id);
+
+        // then
+        expect(ids).to.exactlyContain([id1, id2]);
+      });
+
+      it('returns the participants which match by last name when fullName text is a part of last name', async function () {
+        // given
+        // given
+        buildLearnerWithParticipation(organizationId, { lastName: 'Moss' });
+        const { id: id1 } = buildLearnerWithParticipation(organizationId, { lastName: 'Chigur' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+          filters: { fullName: 'gu' },
+        });
+
+        const ids = organizationParticipants.map(({ id }) => id);
+
+        // then
+        expect(ids).to.exactlyContain([id1]);
+      });
+
+      it('returns the participants which match by full name', async function () {
+        const { id: id1 } = buildLearnerWithParticipation(organizationId, { firstName: 'Anton', lastName: 'Chigurh' });
+
+        await databaseBuilder.commit();
+
+        const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+          filters: { fullName: 'anton chur' },
+        });
+
+        const ids = organizationParticipants.map(({ id }) => id);
+
+        expect(ids).to.exactlyContain([id1]);
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/utils/filter-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/filter-utils_test.js
@@ -1,0 +1,81 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { filterByFullName } = require('../../../../lib/infrastructure/utils/filter-utils');
+
+describe('Integration | Utils | filter-utils', function () {
+  describe('#filterByFullName', function () {
+    context('when some rows match by full name', function () {
+      it('should return the matching rows', async function () {
+        // given
+        databaseBuilder.factory.buildUser({ firstName: 'Bernard', lastName: 'Dupuy' });
+        const { id } = databaseBuilder.factory.buildUser({ firstName: 'Robert', lastName: 'Howard' });
+        await databaseBuilder.commit();
+
+        // when
+        const ids = await knex('users').modify(filterByFullName, 'Robert H', 'firstName', 'lastName').pluck('id');
+
+        // then
+        expect(ids).to.deep.equal([id]);
+      });
+
+      it('should handle space before search', async function () {
+        // given
+        const { id } = databaseBuilder.factory.buildUser({ firstName: 'Bernard', lastName: 'Dupuy' });
+        databaseBuilder.factory.buildUser({ firstName: 'Robert', lastName: 'Howard' });
+        await databaseBuilder.commit();
+
+        // when
+        const ids = await knex('users').modify(filterByFullName, '  dup', 'firstName', 'lastName').pluck('id');
+
+        // then
+        expect(ids).to.deep.equal([id]);
+      });
+
+      it('should handle space after search', async function () {
+        // given
+        const { id } = databaseBuilder.factory.buildUser({ firstName: 'Robert', lastName: 'Howard' });
+        databaseBuilder.factory.buildUser({ firstName: 'Bernard', lastName: 'Dupuy' });
+        await databaseBuilder.commit();
+
+        // when
+        const ids = await knex('users').modify(filterByFullName, 'ert ', 'firstName', 'lastName').pluck('id');
+
+        // then
+        expect(ids).to.deep.equal([id]);
+      });
+    });
+
+    context('when some some rows match by first name', function () {
+      it('should return the matching rows', async function () {
+        // given
+        const { id: id1 } = databaseBuilder.factory.buildUser({ firstName: 'Robert' });
+        const { id: id2 } = databaseBuilder.factory.buildUser({ firstName: 'Bernard' });
+        const { id: id3 } = databaseBuilder.factory.buildUser({ firstName: 'Barnarbe' });
+        databaseBuilder.factory.buildUser({ firstName: 'Luc' });
+
+        await databaseBuilder.commit();
+
+        const ids = await knex('users').modify(filterByFullName, 'be ', 'firstName', 'lastName').pluck('id');
+
+        // then
+        expect(ids).to.exactlyContain([id1, id2, id3]);
+      });
+    });
+
+    context('when some some rows match by last name', function () {
+      it('should return the matching rows', async function () {
+        // given
+        databaseBuilder.factory.buildUser({ lastName: 'Batman' });
+        const { id: id1 } = databaseBuilder.factory.buildUser({ lastName: 'Alfred' });
+        const { id: id2 } = databaseBuilder.factory.buildUser({ lastName: 'Fredal' });
+        const { id: id3 } = databaseBuilder.factory.buildUser({ lastName: 'Fraled' });
+
+        await databaseBuilder.commit();
+
+        const ids = await knex('users').modify(filterByFullName, 'al ', 'firstName', 'lastName').pluck('id');
+
+        // then
+        expect(ids).to.exactlyContain([id1, id2, id3]);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1301,7 +1301,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
   describe('#getPaginatedParticipantsForAnOrganization', function () {
     it('should call the usecase to get the participants of the organization', async function () {
       const organizationId = 1;
-      const expectedPage = { page: 2 };
+      const parameters = { page: 2, filter: { fullName: 'name' } };
       const organizationLearner = domainBuilder.buildOrganizationLearner();
       domainBuilder.buildCampaignParticipation({ organizationLearnerId: organizationLearner.id });
 
@@ -1312,7 +1312,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
             userId: 1,
           },
         },
-        query: expectedPage,
+        query: parameters,
       };
 
       const participant = {
@@ -1328,13 +1328,13 @@ describe('Unit | Application | Organizations | organization-controller', functio
           'last-name': organizationLearner.lastName,
         },
       ];
-      const expectedPagination = { ...expectedPage, pageSize: 25, itemsCount: 100, pagesCount: 4 };
+      const expectedPagination = { ...parameters, pageSize: 25, itemsCount: 100, pagesCount: 4 };
       const expectedResponse = { data: serializedOrganizationParticipants, meta: {} };
 
-      sinon.stub(queryParamsUtils, 'extractParameters').withArgs(request.query).returns(expectedPage);
+      sinon.stub(queryParamsUtils, 'extractParameters').withArgs(request.query).returns(parameters);
       sinon
         .stub(usecases, 'getPaginatedParticipantsForAnOrganization')
-        .withArgs({ organizationId, page: 2 })
+        .withArgs({ organizationId, page: 2, filters: parameters.filter })
         .returns({
           organizationParticipants: [participant],
           pagination: expectedPagination,

--- a/api/tests/unit/domain/usecases/get-paginated-participants-for-an-organization_test.js
+++ b/api/tests/unit/domain/usecases/get-paginated-participants-for-an-organization_test.js
@@ -9,10 +9,14 @@ describe('Unit | UseCase | get-participants-by-organization-id', function () {
     const organizationParticipantRepository = {
       getParticipantsByOrganizationId: sinon.stub(),
     };
+    const filters = {
+      fullName: 'name',
+    };
 
     // when
     await getPaginatedParticipantsForAnOrganization({
       organizationId,
+      filters,
       page,
       organizationParticipantRepository,
     });
@@ -21,6 +25,7 @@ describe('Unit | UseCase | get-participants-by-organization-id', function () {
     expect(organizationParticipantRepository.getParticipantsByOrganizationId).to.have.been.calledWithExactly({
       organizationId,
       page,
+      filters,
     });
   });
 });

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -1,3 +1,19 @@
+<PixFilterBanner
+  @title={{t "pages.organization-participants.filters.title"}}
+  class="participant-filter-banner hide-on-mobile"
+  aria-label={{t "pages.organization-participants.filters.aria-label"}}
+  @details={{t "pages.organization-participants.filters.participations-count" count=@participants.meta.rowCount}}
+  @clearFiltersLabel={{t "pages.organization-participants.filters.actions.clear"}}
+  @onClearFilters={{@onResetFilter}}
+>
+  <Campaign::Filter::SearchInputFilter
+    @field="fullName"
+    @value={{@fullName}}
+    @placeholder={{t "pages.organization-participants.filters.type.fullName.placeholder"}}
+    @ariaLabel={{t "pages.organization-participants.filters.type.fullName.title"}}
+    @triggerFiltering={{this.onSearch}}
+  />
+</PixFilterBanner>
 <div class="panel">
   <table class="table content-text content-text--small">
     <thead>

--- a/orga/app/components/organization-participant/list.js
+++ b/orga/app/components/organization-participant/list.js
@@ -1,0 +1,9 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class List extends Component {
+  @action
+  onSearch(field, value) {
+    this.args.triggerFiltering({ [field]: value });
+  }
+}

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -1,6 +1,22 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+
 export default class ListController extends Controller {
+  queryParams = ['pageNumber', 'pageSize', 'fullName'];
+
   @tracked pageNumber = 1;
   @tracked pageSize = 25;
+  @tracked fullName = null;
+
+  @action
+  triggerFiltering(params) {
+    this.fullName = params.fullName || undefined;
+  }
+
+  @action
+  resetFilters() {
+    this.pageNumber = undefined;
+    this.fullName = undefined;
+  }
 }

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -5,6 +5,7 @@ export default class ListRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    fullName: { refreshModel: true },
   };
 
   @service currentUser;
@@ -13,6 +14,7 @@ export default class ListRoute extends Route {
     return this.store.query('organization-participant', {
       filter: {
         organizationId: this.currentUser.organization.id,
+        fullName: params.fullName,
       },
       page: {
         number: params.pageNumber,
@@ -24,5 +26,6 @@ export default class ListRoute extends Route {
   resetController(controller) {
     controller.pageNumber = 1;
     controller.pageSize = 25;
+    controller.fullName = null;
   }
 }

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -1,4 +1,9 @@
 <div class="list-organization-participants-page">
   <h1 class="page__title page-title">{{t "pages.organization-participants.title"}}</h1>
-  <OrganizationParticipant::List @participants={{@model}} />
+  <OrganizationParticipant::List
+    @participants={{@model}}
+    @triggerFiltering={{this.triggerFiltering}}
+    @onResetFilter={{this.resetFilters}}
+    @fullName={{this.fullName}}
+  />
 </div>

--- a/orga/tests/integration/components/organization-participants/list_test.js
+++ b/orga/tests/integration/components/organization-participants/list_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@1024pix/ember-testing-library';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
+import sinon from 'sinon';
 
 module('Integration | Component | OrganizationParticipant::List', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -13,6 +14,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       organization = organization;
     }
     this.owner.register('service:current-user', CurrentUserStub);
+    this.set('stub', () => {});
   });
 
   test('it should display the header labels', async function (assert) {
@@ -20,7 +22,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('participants', []);
 
     // when
-    await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    await render(hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{stub}} />`);
 
     // then
     assert.contains('Nom');
@@ -38,7 +40,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('participants', participants);
 
     // when
-    await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    await render(hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{stub}}/>`);
 
     // then
     assert.contains('La Terreur');
@@ -57,7 +59,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('participants', participants);
 
     // when
-    await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    await render(hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{stub}}/>`);
 
     // then
     assert.contains('La Terreur');
@@ -74,7 +76,9 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('participants', participants);
 
     // when
-    const screen = await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    const screen = await render(
+      hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{stub}}/>`
+    );
     const allRows = screen.getAllByLabelText(this.intl.t('pages.organization-participants.table.row-title'));
 
     // then
@@ -92,7 +96,9 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('participants', participants);
 
     // when
-    const screen = await render(hbs`<OrganizationParticipant::List @participants={{participants}} />`);
+    const screen = await render(
+      hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{stub}}/>`
+    );
     const allRows = screen.getAllByLabelText(this.intl.t('pages.organization-participants.table.row-title'));
 
     // then
@@ -104,5 +110,27 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       ).length,
       2
     );
+  });
+
+  test('it filters participant when the input is filled', async function (assert) {
+    // given
+    const participants = [
+      {
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+      },
+    ];
+
+    this.set('participants', participants);
+    this.triggerFiltering = sinon.stub();
+
+    // when
+    await render(
+      hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{triggerFiltering}}/>`
+    );
+    await fillByLabel('Recherche sur le nom et prénom', 'Karam');
+    // then
+    sinon.assert.calledWith(this.triggerFiltering, { fullName: 'Karam' });
+    assert.ok(true);
   });
 });

--- a/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/organization-participants/list_test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/organization-participants', function (hooks) {
+  setupTest(hooks);
+
+  module('#triggerFiltering', function () {
+    module('when the filters contain the field fullName', function () {
+      test('updates the fullName value', async function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/organization-participants/list');
+
+        controller.fullName = 'old-value';
+
+        // when
+        controller.triggerFiltering({ fullName: 'new-value' });
+
+        // then
+        assert.strictEqual(controller.fullName, 'new-value');
+      });
+    });
+
+    module('when the filters contain an empty for fullName', function () {
+      test('clear the searched value', async function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/organization-participants/list');
+
+        controller.fullName = 'old-value';
+
+        // when
+        controller.triggerFiltering({ fullName: '' });
+
+        // then
+        assert.strictEqual(controller.fullName, undefined);
+      });
+    });
+  });
+
+  module('#resetFilters', function () {
+    test('it resets all filters', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/organization-participants/list');
+
+      controller.fullName = 'value';
+      controller.pageNumber = 2;
+
+      // when
+      controller.resetFilters();
+
+      // then
+      assert.strictEqual(controller.fullName, undefined);
+      assert.strictEqual(controller.pageNumber, undefined);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -652,6 +652,21 @@
       }
     },
     "organization-participants": {
+      "filters": {
+        "actions": {
+          "clear": "Clear filters"
+        },
+        "aria-label": "Filters on participants",
+        "title": "Filters",
+        "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
+        "type": {
+          "fullName": {
+            "title": "Search by lastname and firstname",
+            "placeholder": "Lastname, firstname"
+          }
+        }
+
+      },
       "title": "Participants",
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -651,6 +651,20 @@
       }
     },
     "organization-participants": {
+      "filters": {
+        "actions": {
+          "clear": "Effacer les filtres"
+        },
+        "aria-label": "Filtres sur les participants",
+        "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
+        "title": "Filtres",
+        "type": {
+          "fullName": {
+            "title": "Recherche sur le nom et prénom",
+            "placeholder": "Nom, prénom"
+          }
+        }
+      },
       "title": "Participants",
       "table": {
         "column": {


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas rechercher de prescrit dans la liste des prescrit d'une organisation.

## :robot: Solution
Ajouter un filtre sur le nom et prénom des participants

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Aller sur PixOrga avec le compte : pro.admin@example.net
Aller sur l'onglet participants
FIlter les participations avec le nom et le prénom
