### PR TITLE
[FEATURE] Migrer l'identifiant de la table answers en Bigint pour les environnements hors production et datawarehouse.

### DIFF
--- a/api/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint.js
+++ b/api/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint.js
@@ -25,6 +25,11 @@ exports.up = async function (knex) {
 
     if (nbAnswers < maxAnswersToRunAlterMigration) {
       await changeAnswerIdTypeToBigint(knex);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(
+        'Columns in table answers not migrated to bigint as there is too much data. Run api/scripts/bigint/change-answers-id-type-to-bigint-with-downtime.js.'
+      );
     }
   }
 };

--- a/api/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint.js
+++ b/api/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint.js
@@ -1,0 +1,34 @@
+// In order to avoid alter bigint migration timeout, we check the number of answers in the target env before and run the alter bigint only if the limit is not exeeded.
+const maxAnswersToRunAlterMigration = 500000;
+
+const changeAnswerIdTypeToBigint = async (knex) => {
+  await knex.transaction(async (trx) => {
+    await knex.raw(`ALTER TABLE "knowledge-elements" ALTER COLUMN "answerId" TYPE BIGINT`).transacting(trx);
+    await knex.raw(`ALTER TABLE "answers" ALTER COLUMN "id" TYPE BIGINT`).transacting(trx);
+    await knex.raw(`ALTER SEQUENCE "answers_id_seq" AS BIGINT`).transacting(trx);
+  });
+};
+
+exports.up = async function (knex) {
+  const { rows: answersCheckDataTypeQueryResult } = await knex.raw(`
+  SELECT "column_name","data_type"
+  FROM "information_schema"."columns"
+  WHERE "table_schema" = 'public' AND "table_name" = 'answers' AND "column_name" = 'id'`);
+  const answersDataTypeId = answersCheckDataTypeQueryResult[0]['data_type'];
+
+  if (answersDataTypeId === 'integer') {
+    const { rows: answersCountQueryResult } = await knex.raw(`
+    SELECT reltuples::bigint AS estimate
+    FROM pg_class
+    WHERE relname = 'answers'`);
+    const nbAnswers = answersCountQueryResult[0]['estimate'];
+
+    if (nbAnswers < maxAnswersToRunAlterMigration) {
+      await changeAnswerIdTypeToBigint(knex);
+    }
+  }
+};
+
+exports.down = function () {
+  // no need for rollback
+};

--- a/api/tests/acceptance/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint_test.js
+++ b/api/tests/acceptance/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint_test.js
@@ -1,0 +1,54 @@
+const { expect, knex, databaseBuilder } = require('../../../test-helper');
+
+describe('#changeAnswerIdTypeToBigint', function () {
+  it('should insert answer with an id bigger than the maximum integer type value', async function () {
+    // when migration 20220721115757_alter-answers-id-from-int-to-bigint.js is done
+    const maxValueBigIntType = '9223372036854775807';
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment();
+    const { id: answerId } = databaseBuilder.factory.buildAnswer({ id: maxValueBigIntType, assessmentId });
+    databaseBuilder.factory.buildKnowledgeElement({ assessmentId, answerId });
+    await databaseBuilder.commit();
+
+    // then
+    expect(answerId).to.be.equal(maxValueBigIntType);
+  });
+
+  it('should change type of answer sequence from integer to bigint', async function () {
+    // when migration 20220721115757_alter-answers-id-from-int-to-bigint.js is done
+    // then
+    const { rows: sequenceDataType } = await knex.raw(
+      `SELECT data_type FROM information_schema.sequences WHERE sequence_name = 'answers_id_seq'`
+    );
+    expect(sequenceDataType[0]['data_type']).to.equal('bigint');
+  });
+
+  it('should sequence are correctly reassigned', async function () {
+    // given
+    const [{ id: answerIdInsertedBeforeSwitch }] = await knex('answers')
+      .insert({
+        value: 'Some value for answer',
+        result: 'Some result for answer',
+        challengeId: 'rec123ABC',
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-01-02'),
+        resultDetails: 'Some result details for answer.',
+        timeSpent: 30,
+      })
+      .returning('id');
+
+    // when migration 20220721115757_alter-answers-id-from-int-to-bigint.js is done
+    const [{ id: answerIdInsertedAfterSwitch }] = await knex('answers')
+      .insert({
+        value: 'Some value for answer',
+        result: 'Some result for answer',
+        challengeId: 'rec123ABC',
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-01-02'),
+        resultDetails: 'Some result details for answer.',
+        timeSpent: 30,
+      })
+      .returning('id');
+    // then
+    expect(answerIdInsertedAfterSwitch).to.equal(answerIdInsertedBeforeSwitch + 1);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La migration BIGINT a été effectuée via un script dans les environnements recette, prod et datawarehouse.
Les environnements local et integration ne sont pas encore à jour.
D'autant plus, qu'il faut garantir un état cohérent de notre base de donnée via les migrations Knex.

## :robot: Solution
Pour avoir une cohérence dans nos migrations Knex, il faut créer une migration pour migrer ces environnements.

## :rainbow: Remarques
Afin de ne pas relancer la migration en production, on check le type de l'identifiant de la table answers avant de lancer la migration. Si le type est encore un INTEGER, on va conditionner l'exécution de la migration avec le nombre d'answers dans l'environnement cible afin d'éviter le timeout des migrations knex.
L'env de recette contient : 
```
pix_api_qual_1568=> select count(*) from answers;
 count
--------
 390125
(1 row)

```
## :100: Pour tester
En locale et en RA:

Une fois la migration lancée.
> Vérifier que les types sont bien en BIGINT avec la requête ci-dessous:
```
select table_name, column_name, data_type
from information_schema.columns
where (table_name = 'answers' and column_name='id') or (table_name = 'knowledge-elements' and column_name='answerId') or (table_name = 'flash-assessment-results' and column_name='answerId');
`\d answers`
`\d 'knowledge-elements'`
`\d 'flash-assessment-results'`
```
> check du type de la séquence:
```
SELECT data_type FROM information_schema.sequences WHERE sequence_name = 'answers_id_seq'
```
