### PR TITLE
[TECH] Appeler l'endpoint userinfo lorsqu'une information est manquante dans le token du partenaire (PIX-5393).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -214,7 +214,7 @@ module.exports = (function () {
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
-      userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
+      userInfoUrl: process.env.POLE_EMPLOI_OIDC_USER_INFO_URL,
       authenticationUrl: process.env.POLE_EMPLOI_OIDC_AUTHENTICATION_URL,
       logoutUrl: process.env.POLE_EMPLOI_OIDC_LOGOUT_URL,
       afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
@@ -232,6 +232,7 @@ module.exports = (function () {
     cnav: {
       clientId: process.env.CNAV_CLIENT_ID,
       authenticationUrl: process.env.CNAV_AUTHENTICATION_URL,
+      userInfoUrl: process.env.CNAV_OIDC_USER_INFO_URL,
       tokenUrl: process.env.CNAV_TOKEN_URL,
       clientSecret: process.env.CNAV_CLIENT_SECRET,
       accessTokenLifespanMs: ms(process.env.CNAV_ACCESS_TOKEN_LIFESPAN || '7d'),
@@ -349,6 +350,7 @@ module.exports = (function () {
 
     config.cnav.clientId = 'PIX_CNAV_CLIENT_ID';
     config.cnav.authenticationUrl = 'http://idp.cnav/auth';
+    config.cnav.userInfoUrl = 'http://userInfoUrl.fr';
     config.cnav.tokenUrl = 'http://idp.cnav/token';
     config.cnav.clientSecret = 'PIX_CNAV_CLIENT_SECRET';
 

--- a/api/lib/domain/services/authentication/cnav-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/cnav-oidc-authentication-service.js
@@ -12,6 +12,7 @@ class CnavOidcAuthenticationService extends OidcAuthenticationService {
     const tokenUrl = settings.cnav.tokenUrl;
     const authenticationUrl = settings.cnav.authenticationUrl;
     const authenticationUrlParameters = [{ key: 'scope', value: 'openid profile' }];
+    const userInfoUrl = settings.cnav.userInfoUrl;
 
     super({
       source,
@@ -22,6 +23,7 @@ class CnavOidcAuthenticationService extends OidcAuthenticationService {
       tokenUrl,
       authenticationUrl,
       authenticationUrlParameters,
+      userInfoUrl,
     });
   }
 }

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -24,6 +24,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
         value: `application_${clientId} api_peconnect-individuv1 openid profile`,
       },
     ];
+    const userInfoUrl = settings.poleEmploi.userInfoUrl;
 
     super({
       source,
@@ -34,6 +35,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
       tokenUrl,
       authenticationUrl,
       authenticationUrlParameters,
+      userInfoUrl,
     });
 
     this.logoutUrl = settings.poleEmploi.logoutUrl;

--- a/api/lib/domain/usecases/authentication/authenticate-cnav-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-cnav-user.js
@@ -17,7 +17,10 @@ module.exports = async function authenticateCnavUser({
   }
   const authenticationSessionContent = await oidcAuthenticationService.exchangeCodeForTokens({ code, redirectUri });
 
-  const userInfo = await oidcAuthenticationService.getUserInfo({ idToken: authenticationSessionContent.idToken });
+  const userInfo = await oidcAuthenticationService.getUserInfo({
+    idToken: authenticationSessionContent.idToken,
+    accessToken: authenticationSessionContent.accessToken,
+  });
 
   const user = await userRepository.findByExternalIdentifier({
     externalIdentityId: userInfo.externalIdentityId,

--- a/api/lib/domain/usecases/authentication/authenticate-cnav-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-cnav-user.js
@@ -15,9 +15,9 @@ module.exports = async function authenticateCnavUser({
     logger.error(`State sent ${stateSent} did not match the state received ${stateReceived}`);
     throw new UnexpectedOidcStateError();
   }
-  const { idToken } = await oidcAuthenticationService.exchangeCodeForTokens({ code, redirectUri });
+  const authenticationSessionContent = await oidcAuthenticationService.exchangeCodeForTokens({ code, redirectUri });
 
-  const userInfo = await oidcAuthenticationService.getUserInfo({ idToken });
+  const userInfo = await oidcAuthenticationService.getUserInfo({ idToken: authenticationSessionContent.idToken });
 
   const user = await userRepository.findByExternalIdentifier({
     externalIdentityId: userInfo.externalIdentityId,
@@ -31,7 +31,9 @@ module.exports = async function authenticateCnavUser({
 
     return { pixAccessToken, isAuthenticationComplete: true };
   } else {
-    const authenticationKey = await authenticationSessionService.save({ idToken });
+    const authenticationKey = await authenticationSessionService.save({
+      idToken: authenticationSessionContent.idToken,
+    });
 
     return { authenticationKey, isAuthenticationComplete: false };
   }

--- a/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-pole-emploi-user.js
@@ -27,6 +27,7 @@ module.exports = async function authenticatePoleEmploiUser({
 
   const userInfo = await oidcAuthenticationService.getUserInfo({
     idToken: poleEmploiAuthenticationSessionContent.idToken,
+    accessToken: poleEmploiAuthenticationSessionContent.accessToken,
   });
 
   const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({

--- a/api/lib/domain/usecases/create-user-from-external-identity-provider.js
+++ b/api/lib/domain/usecases/create-user-from-external-identity-provider.js
@@ -19,7 +19,10 @@ module.exports = async function createUserFromExternalIdentityProvider({
     throw new AuthenticationKeyExpired();
   }
   const oidcAuthenticationService = await authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
-  const userInfo = await oidcAuthenticationService.getUserInfo(sessionContent);
+  const userInfo = await oidcAuthenticationService.getUserInfo({
+    idToken: sessionContent.idToken,
+    accessToken: sessionContent.accessToken,
+  });
 
   if (!userInfo.firstName || !userInfo.lastName || !userInfo.externalIdentityId) {
     logger.error(`Un des champs obligatoires n'a pas été renvoyé : ${JSON.stringify(userInfo)}.`);

--- a/api/lib/domain/usecases/create-user-from-external-identity-provider.js
+++ b/api/lib/domain/usecases/create-user-from-external-identity-provider.js
@@ -1,10 +1,5 @@
 const UserToCreate = require('../models/UserToCreate');
-const {
-  InvalidExternalAPIResponseError,
-  AuthenticationKeyExpired,
-  UserAlreadyExistsWithAuthenticationMethodError,
-} = require('../errors');
-const logger = require('../../infrastructure/logger');
+const { AuthenticationKeyExpired, UserAlreadyExistsWithAuthenticationMethodError } = require('../errors');
 
 module.exports = async function createUserFromExternalIdentityProvider({
   identityProvider,
@@ -23,11 +18,6 @@ module.exports = async function createUserFromExternalIdentityProvider({
     idToken: sessionContent.idToken,
     accessToken: sessionContent.accessToken,
   });
-
-  if (!userInfo.firstName || !userInfo.lastName || !userInfo.externalIdentityId) {
-    logger.error(`Un des champs obligatoires n'a pas été renvoyé : ${JSON.stringify(userInfo)}.`);
-    throw new InvalidExternalAPIResponseError('Les informations utilisateurs récupérées sont incorrectes.');
-  }
 
   const authenticationMethod = await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
     externalIdentifier: userInfo.externalIdentityId,

--- a/api/sample.env
+++ b/api/sample.env
@@ -475,6 +475,13 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL=
 
+# User info URL
+# Refer to https://pole-emploi.io/data/documentation/comprendre-dispositif-pole-emploi-connect/open-id-connect/requeter-api
+#
+# presence: required for POLE EMPLOI authentication, optional otherwise
+# type: URL
+# sample: POLE_EMPLOI_OIDC_USER_INFO_URL=
+
 # Temporary storage expiration delay
 #
 # presence: optional
@@ -524,6 +531,12 @@ AUTH_SECRET=Change me!
 # presence: required for CNAV authentication, optional otherwise
 # type: URL
 # sample: CNAV_AUTHENTICATION_URL=
+
+# User info URL
+#
+# presence: required for CNAV authentication, optional otherwise
+# type: URL
+# sample: CNAV_OIDC_USER_INFO_URL=
 
 
 # ===================

--- a/api/tests/unit/domain/usecases/authentication/authenticate-cnav-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-cnav-user_test.js
@@ -133,7 +133,7 @@ describe('Unit | UseCase | authenticate-cnav-user', function () {
   context('When user has no account', function () {
     it('should save the id token', async function () {
       // given
-      const { authenticationSessionContent } = _fakeCnavAPI({ oidcAuthenticationService });
+      const authenticationSessionContent = _fakeCnavAPI({ oidcAuthenticationService });
       userRepository.findByExternalIdentifier.resolves(null);
 
       // when
@@ -189,7 +189,9 @@ function _fakeCnavAPI({ oidcAuthenticationService }) {
   };
 
   oidcAuthenticationService.exchangeCodeForTokens.resolves(authenticationSessionContent);
-  oidcAuthenticationService.getUserInfo.resolves(userInfo);
+  oidcAuthenticationService.getUserInfo
+    .withArgs({ idToken: authenticationSessionContent.idToken, accessToken: authenticationSessionContent.accessToken })
+    .resolves(userInfo);
 
-  return { authenticationSessionContent };
+  return authenticationSessionContent;
 }

--- a/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-pole-emploi-user_test.js
@@ -108,9 +108,9 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       });
     });
 
-    it('should call get pole emploi user info with id token parameter', async function () {
+    it('should call get pole emploi user info with id token and access token parameters', async function () {
       // given
-      _fakePoleEmploiAPI({ oidcAuthenticationService });
+      const poleEmploiAuthenticationSessionContent = _fakePoleEmploiAPI({ oidcAuthenticationService });
 
       // when
       await authenticatePoleEmploiUser({
@@ -127,7 +127,10 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       });
 
       // then
-      expect(oidcAuthenticationService.getUserInfo).to.have.been.calledWith({ idToken: 'idToken' });
+      expect(oidcAuthenticationService.getUserInfo).to.have.been.calledWith({
+        idToken: poleEmploiAuthenticationSessionContent.idToken,
+        accessToken: poleEmploiAuthenticationSessionContent.accessToken,
+      });
     });
 
     it('should return accessToken and logoutUrlUUID', async function () {
@@ -187,7 +190,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       it('should call authentication repository updatePoleEmploiAuthenticationComplementByUserId function', async function () {
         // given
         userRepository.findByExternalIdentifier.resolves({ id: 1 });
-        const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ oidcAuthenticationService });
+        const poleEmploiAuthenticationSessionContent = _fakePoleEmploiAPI({ oidcAuthenticationService });
 
         // when
         await authenticatePoleEmploiUser({
@@ -245,7 +248,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       context('When the user does not have a pole emploi authentication method', function () {
         it('should call authentication method repository create function with pole emploi authentication method in domain transaction', async function () {
           // given
-          const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ oidcAuthenticationService });
+          const poleEmploiAuthenticationSessionContent = _fakePoleEmploiAPI({ oidcAuthenticationService });
           userRepository.findByExternalIdentifier.resolves(null);
 
           // when
@@ -282,7 +285,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
       context('When the user does have a pole emploi authentication method', function () {
         it('should call authentication repository updatePoleEmploiAuthenticationComplementByUserId function', async function () {
           // given
-          const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ oidcAuthenticationService });
+          const poleEmploiAuthenticationSessionContent = _fakePoleEmploiAPI({ oidcAuthenticationService });
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
             domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
               externalIdentifier: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
@@ -351,7 +354,7 @@ describe('Unit | UseCase | authenticate-pole-emploi-user', function () {
   context('When user has no account', function () {
     it('should call AuthenticationSessionContent repository save method', async function () {
       // given
-      const { poleEmploiAuthenticationSessionContent } = _fakePoleEmploiAPI({ oidcAuthenticationService });
+      const poleEmploiAuthenticationSessionContent = _fakePoleEmploiAPI({ oidcAuthenticationService });
       const key = 'aaa-bbb-ccc';
       authenticationSessionService.save.resolves(key);
       userRepository.findByExternalIdentifier.resolves(null);
@@ -417,5 +420,5 @@ function _fakePoleEmploiAPI({ oidcAuthenticationService }) {
   oidcAuthenticationService.exchangeCodeForTokens.resolves(poleEmploiAuthenticationSessionContent);
   oidcAuthenticationService.getUserInfo.resolves(userInfo);
 
-  return { poleEmploiAuthenticationSessionContent };
+  return poleEmploiAuthenticationSessionContent;
 }

--- a/api/tests/unit/domain/usecases/create-user-from-external-identity-provider_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-external-identity-provider_test.js
@@ -62,12 +62,14 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
   context('when there is already an authentication method for this external id', function () {
     it('should throw UserAlreadyExistsWithAuthenticationMethodError', async function () {
       // given
-      authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves('SESSION_CONTENT');
+      authenticationSessionService.getByKey
+        .withArgs('AUTHENTICATION_KEY')
+        .resolves({ idToken: 'idToken', accessToken: 'accessToken' });
       authenticationServiceRegistry.lookupAuthenticationService
         .withArgs('SOME_IDP')
         .resolves(oidcAuthenticationService);
       oidcAuthenticationService.getUserInfo
-        .withArgs('SESSION_CONTENT')
+        .withArgs({ idToken: 'idToken', accessToken: 'accessToken' })
         .resolves({ firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'duGAR' });
       authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
         .withArgs({ externalIdentifier: 'duGAR', identityProvider: 'SOME_IDP' })
@@ -125,10 +127,12 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
 
   it('should call createUserAccount method to return user id and id token', async function () {
     // given
-    authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves('SESSION_CONTENT');
+    authenticationSessionService.getByKey
+      .withArgs('AUTHENTICATION_KEY')
+      .resolves({ idToken: 'idToken', accessToken: 'accessToken' });
     authenticationServiceRegistry.lookupAuthenticationService.withArgs('SOME_IDP').resolves(oidcAuthenticationService);
     oidcAuthenticationService.getUserInfo
-      .withArgs('SESSION_CONTENT')
+      .withArgs({ idToken: 'idToken', accessToken: 'accessToken' })
       .resolves({ firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'duGAR' });
     authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
       .withArgs({ externalIdentifier: 'duGAR', identityProvider: 'SOME_IDP' })
@@ -153,7 +157,7 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
     };
     expect(oidcAuthenticationService.createUserAccount).to.have.been.calledWithMatch({
       user: expectedUser,
-      sessionContent: 'SESSION_CONTENT',
+      sessionContent: { idToken: 'idToken', accessToken: 'accessToken' },
       externalIdentityId: 'duGAR',
       authenticationMethodRepository,
       userToCreateRepository,

--- a/api/tests/unit/domain/usecases/create-user-from-external-identity-provider_test.js
+++ b/api/tests/unit/domain/usecases/create-user-from-external-identity-provider_test.js
@@ -1,10 +1,8 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const {
-  InvalidExternalAPIResponseError,
   AuthenticationKeyExpired,
   UserAlreadyExistsWithAuthenticationMethodError,
 } = require('../../../../lib/domain/errors');
-const logger = require('../../../../lib/infrastructure/logger');
 const createUserFromExternalIdentityProvider = require('../../../../lib/domain/usecases/create-user-from-external-identity-provider');
 
 describe('Unit | UseCase | create-user-from-external-identity-provider', function () {
@@ -88,40 +86,6 @@ describe('Unit | UseCase | create-user-from-external-identity-provider', functio
       // then
       expect(error).to.be.instanceOf(UserAlreadyExistsWithAuthenticationMethodError);
       expect(error.message).to.equal('Authentication method already exists for this external identifier.');
-    });
-  });
-
-  context('when required properties are not returned by external API', function () {
-    it('should raise an error and log details', async function () {
-      // given
-      const authenticationSessionContent = 'SESSION_CONTENT';
-      authenticationSessionService.getByKey.resolves(authenticationSessionContent);
-      authenticationServiceRegistry.lookupAuthenticationService.resolves(oidcAuthenticationService);
-      oidcAuthenticationService.getUserInfo.resolves({
-        firstName: 'Jean',
-        lastName: undefined,
-        externalIdentityId: 'externalIdentityId',
-      });
-      sinon.stub(logger, 'error');
-
-      // when
-      const error = await catchErr(createUserFromExternalIdentityProvider)({
-        authenticationKey: 'AUTHENTICATION_KEY',
-        authenticationSessionService,
-        authenticationServiceRegistry,
-        authenticationMethodRepository,
-        userToCreateRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
-      expect(error.message).to.be.equal('Les informations utilisateurs récupérées sont incorrectes.');
-      const expectedMessage = `Un des champs obligatoires n'a pas été renvoyé : ${JSON.stringify({
-        firstName: 'Jean',
-        lastName: undefined,
-        externalIdentityId: 'externalIdentityId',
-      })}.`;
-      expect(logger.error).to.have.been.calledWith(expectedMessage);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque nos partenaires nous fournissent l’idToken de l’utilisateur, nous décodons celui-ci pour récupérer les infos. Or coté Pôle Emploi, de nombreux utilisateurs n’ont pas pu finaliser le scénario car nous ne récupérions pas toute les infos obligatoire dans leur idToken. Parfois le prénom manquait, parfois le nom.

## :robot: Solution
Si une info est manquante dans l'id token, faire un appel à leur endpoint /userinfo pour récupérer ce qu’il nous manque

## :rainbow: Remarques
si l’info manque toujours après l'appel, alors on jette une erreur (+logger).

Mettre les variables suivantes en prod : 
POLE_EMPLOI_OIDC_USER_INFO_URL: https://api.emploi-store.fr/partenaire/peconnect-individu/v1/userinfo
CNAV_OIDC_USER_INFO_URL: https://fs.cnav.fr/adfs/userinfo

## :100: Pour tester
Reproduire les parcours Pôle Emploi et CNAV en local, en masquant la ligne qui décode l'idToken
