### PR TITLE
[TECH] Mutualiser la déserialisation des payload avec un middleware (PIX-5415).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -127,15 +127,9 @@ module.exports = {
   update(request) {
     const { userId } = request.auth.credentials;
     const campaignId = request.params.id;
-    const {
-      name,
-      title,
-      'custom-landing-page-text': customLandingPageText,
-      'owner-id': ownerId,
-    } = request.payload.data.attributes;
 
     return usecases
-      .updateCampaign({ userId, campaignId, name, title, customLandingPageText, ownerId })
+      .updateCampaign({ userId, campaignId, ...request.deserializedPayload })
       .then(campaignReportSerializer.serialize);
   },
 

--- a/api/server.js
+++ b/api/server.js
@@ -12,6 +12,7 @@ const authentication = require('./lib/infrastructure/authentication');
 
 const { handleFailAction } = require('./lib/validate');
 const monitoringTools = require('./lib/infrastructure/monitoring-tools');
+const deserializer = require('./lib/infrastructure/serializers/jsonapi/deserializer');
 
 monitoringTools.installHapiHook();
 
@@ -31,6 +32,8 @@ const createServer = async () => {
   await setupRoutesAndPlugins(server);
 
   await setupOpenApiSpecification(server);
+
+  setupDeserialization(server);
 
   return server;
 };
@@ -77,6 +80,15 @@ const loadConfiguration = function () {
 
 const setupErrorHandling = function (server) {
   server.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
+};
+
+const setupDeserialization = function (server) {
+  server.ext('onPreHandler', async (request, h) => {
+    if (request.payload?.data) {
+      request.deserializedPayload = await deserializer.deserialize(request.payload);
+    }
+    return h.continue;
+  });
 };
 
 const setupAuthentication = function (server) {

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -355,38 +355,21 @@ describe('Unit | Application | Controller | Campaign', function () {
       const request = {
         auth: { credentials: { userId: 1 } },
         params: { id: 1 },
-        payload: {
-          data: {
-            attributes: {
-              name: 'New name',
-              title: 'New title',
-              'custom-landing-page-text': 'New text',
-              'owner-id': 5,
-            },
-          },
+        deserializedPayload: {
+          name: 'New name',
+          title: 'New title',
+          customLandingPageText: 'New text',
+          ownerId: 5,
         },
       };
 
-      const updatedCampaign = {
-        id: request.params.id,
-        name: request.payload.data.attributes.name,
-        title: request.payload.data.attributes.title,
-        customLandingPageText: request.payload.data.attributes['custom-landing-page-text'],
-        ownerId: request.payload.data.attributes['owner-id'],
-      };
-
-      const updateCampaignArgs = {
-        userId: request.auth.credentials.userId,
-        campaignId: updatedCampaign.id,
-        name: updatedCampaign.name,
-        title: updatedCampaign.title,
-        customLandingPageText: updatedCampaign.customLandingPageText,
-        ownerId: updatedCampaign.ownerId,
-      };
-
+      const updatedCampaign = Symbol('campaign');
       const updatedCampaignSerialized = Symbol('campaign serialized');
 
-      sinon.stub(usecases, 'updateCampaign').withArgs(updateCampaignArgs).resolves(updatedCampaign);
+      sinon
+        .stub(usecases, 'updateCampaign')
+        .withArgs({ userId: 1, campaignId: 1, ...request.deserializedPayload })
+        .resolves(updatedCampaign);
       sinon.stub(campaignReportSerializer, 'serialize').withArgs(updatedCampaign).returns(updatedCampaignSerialized);
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Pour chaque requête on doit écrire désérialiser le payload de la requête et parfois on change passe de la kebab-case à la camel-case. 
On ré-écrit du code pour désérialiser alors que techniquement on fait toujours la même chose.


## :robot: Solution
Utiliser un middleware pour desérialiser tous les payload.

## :rainbow: Remarques
Pour ne pas changer toute l'application, on garde le payload pour les routes qui l'utilisent, mais quand on veut on peut utiliser le payload désérialisé.

On peut faire la même chose pour extraire la locale et les query params.

## :100: Pour tester
Tester la mise à jour de campagne.
