### PR TITLE
[TECH] Supprimer l'idToken dans redis après utilisation (PIX-4950).

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -1,5 +1,5 @@
 const Joi = require('joi');
-const OidcController = require('./oidc-controller');
+const oidcController = require('./oidc-controller');
 
 exports.register = async (server) => {
   server.route([
@@ -15,7 +15,7 @@ exports.register = async (server) => {
               .required(),
           }),
         },
-        handler: OidcController.getRedirectLogoutUrl,
+        handler: oidcController.getRedirectLogoutUrl,
         notes: [
           "Cette route reçoit un identity provider ainsi qu'une uri de redirection" +
             " et renvoie une uri de déconnexion auprès de l'identity provider renseigné.",

--- a/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-authentication-service.js
@@ -68,13 +68,16 @@ function getAuthUrl({ redirectUri }) {
 
 async function getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
   const redirectTarget = new URL(settings.poleEmploi.logoutUrl);
-  const idToken = await logoutUrlTemporaryStorage.get(`${userId}:${logoutUrlUUID}`);
+  const key = `${userId}:${logoutUrlUUID}`;
+  const idToken = await logoutUrlTemporaryStorage.get(key);
   const params = [
     { key: 'id_token_hint', value: idToken },
     { key: 'redirect_uri', value: settings.poleEmploi.afterLogoutUrl },
   ];
 
   params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
+
+  await logoutUrlTemporaryStorage.delete(key);
 
   return redirectTarget.toString();
 }

--- a/api/tests/acceptance/application/pole-emploi/token-route-post_test.js
+++ b/api/tests/acceptance/application/pole-emploi/token-route-post_test.js
@@ -438,7 +438,7 @@ describe('Acceptance | Route | pole emploi token', function () {
           );
         });
 
-        it('should return an 200 with access_token and id_token when authentication is ok', async function () {
+        it('should return an 200 with access_token and logout_url_uuid when authentication is ok', async function () {
           // given
           const authenticatedUser = databaseBuilder.factory.buildUser();
           await databaseBuilder.commit();
@@ -592,7 +592,7 @@ describe('Acceptance | Route | pole emploi token', function () {
         });
       });
 
-      it('should return an 200 with access_token and id_token when authentication is ok', async function () {
+      it('should return an 200 with access_token and logout_url_uuid when authentication is ok', async function () {
         const idToken = jsonwebtoken.sign(
           {
             given_name: 'John',

--- a/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-authentication-service_test.js
@@ -46,5 +46,25 @@ describe('Integration | Domain | Services | pole-emploi-authentication-service',
         'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=http%3A%2F%2Fafter-logout.url'
       );
     });
+
+    it('removes idToken from temporary storage', async function () {
+      // given
+      const idToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const userId = '2';
+      const logoutUrlUUID = 'f9f1b471-a74e-4722-8dde-f5731279146a';
+      const key = `${userId}:${logoutUrlUUID}`;
+      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
+
+      // when
+      await poleEmploiAuthenticationService.getRedirectLogoutUrl({
+        userId,
+        logoutUrlUUID,
+      });
+      const expectedIdToken = await logoutUrlTemporaryStorage.get(key);
+
+      // then
+      expect(expectedIdToken).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, l'idToken d'un utilisateur restera sur Redis pendant 7 jours après la déconnexion de cet utilisateur.

## :robot: Solution

Une fois l'idToken récupéré et l'url de déconnexion généré, supprimer l'idToken de redis.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter sur https://app-pr4711.review.pix.fr/
2. Cliquez sur le bouton `Se connecter à pôle emploi`
3. Utiliser le compte (par exemple) `cecile62`
4. Une fois connecté et sur Pix, ouvrir une console redis et afficher la liste des clés `logout-url:*`
5. Se déconnecter
6. Une fois déconnecté, afficher la liste des clés `logout-url:*`
7. Constatez la disparition de la clé associé à la connexion au compte `cecile62`
