### PR TITLE
[TECH] Ajouter un plugin eslint pour prévenir les erreurs d'assertions Chai sur l'API (PIX-5432).

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -3,6 +3,8 @@ extends:
   - 'plugin:i18n-json/recommended'
   - 'plugin:mocha/recommended'
   - 'plugin:prettier/recommended'
+  - 'plugin:chai-expect/recommended'
+
 parserOptions:
   ecmaVersion: 2020
   requireConfigFile: false
@@ -15,6 +17,7 @@ globals:
 plugins:
   - knex
   - node
+  - chai-expect
 
 rules:
   no-console: error

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "3.229.0",
+      "version": "3.237.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -87,6 +87,7 @@
         "depcheck": "^1.4.3",
         "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-i18n-json": "^3.1.0",
         "eslint-plugin-knex": "^0.2.1",
         "eslint-plugin-mocha": "^10.0.5",
@@ -5379,6 +5380,18 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-chai-expect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-3.0.0.tgz",
+      "integrity": "sha512-NS0YBcToJl+BRKBSMCwRs/oHJIX67fG5Gvb4tGked+9Wnd1/PzKijd82B2QVKcSSOwRe+pp4RAJ2AULeck4eQw==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || 12.* || >= 14.*"
+      },
+      "peerDependencies": {
+        "eslint": ">=2.0.0 <= 8.x"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -17315,6 +17328,13 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-chai-expect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-3.0.0.tgz",
+      "integrity": "sha512-NS0YBcToJl+BRKBSMCwRs/oHJIX67fG5Gvb4tGked+9Wnd1/PzKijd82B2QVKcSSOwRe+pp4RAJ2AULeck4eQw==",
       "dev": true,
       "requires": {}
     },

--- a/api/package.json
+++ b/api/package.json
@@ -93,6 +93,7 @@
     "depcheck": "^1.4.3",
     "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-i18n-json": "^3.1.0",
     "eslint-plugin-knex": "^0.2.1",
     "eslint-plugin-mocha": "^10.0.5",

--- a/api/tests/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/integration/domain/usecases/create-campaign_test.js
@@ -66,8 +66,8 @@ describe('Integration | UseCases | create-campaign', function () {
 
     expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
 
-    expect('code').to.be.ok;
-    expect('id').to.be.ok;
+    expect(result.code).to.be.ok;
+    expect(result.id).to.be.ok;
   });
 
   it('should save a new campaign of type PROFILES_COLLECTION', async function () {
@@ -96,7 +96,7 @@ describe('Integration | UseCases | create-campaign', function () {
 
     expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
 
-    expect('code').to.be.ok;
-    expect('id').to.be.ok;
+    expect(result.code).to.be.ok;
+    expect(result.id).to.be.ok;
   });
 });

--- a/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
@@ -191,13 +191,15 @@ describe('Integration | Infrastructure | Utils | Ods | read-ods-utils', function
         odsBuffer = await readFile(DEFAULT_ODS_FILE_PATH);
 
         // when
-        await validateOdsHeaders({
-          odsBuffer,
-          headers: VALID_HEADERS,
-        });
+        const call = () => {
+          validateOdsHeaders({
+            odsBuffer,
+            headers: VALID_HEADERS,
+          });
+        };
 
         // then
-        expect(true).to.be.true;
+        expect(call).to.not.throw();
       });
     });
 
@@ -223,13 +225,15 @@ describe('Integration | Infrastructure | Utils | Ods | read-ods-utils', function
         odsBuffer = await readFile(NEW_LINE_ODS_FILE_PATH);
 
         // when
-        await validateOdsHeaders({
-          odsBuffer,
-          headers: VALID_HEADERS,
-        });
+        const call = () => {
+          validateOdsHeaders({
+            odsBuffer,
+            headers: VALID_HEADERS,
+          });
+        };
 
         // then
-        expect(true).to.be.true;
+        expect(call).to.not.throw();
       });
     });
   });

--- a/api/tests/integration/scripts/add-tags-to-organizations_test.js
+++ b/api/tests/integration/scripts/add-tags-to-organizations_test.js
@@ -106,10 +106,12 @@ describe('Integration | Scripts | add-tags-to-organizations.js', function () {
         const checkedData = [{ organizationId: firstOrganizationId, tagName: firstTag.name }];
 
         // when
-        await addTagsToOrganizations({ tagsByName, checkedData });
+        const call = () => {
+          addTagsToOrganizations({ tagsByName, checkedData });
+        };
 
         // then
-        expect(true).to.be.true;
+        expect(call).to.not.throw();
       });
     });
   });

--- a/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
+++ b/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
@@ -31,7 +31,7 @@ describe('Integration | Scripts | create-assessment-campaigns', function () {
       const campaigns = await prepareCampaigns([campaignData]);
 
       // then
-      expect(typeof campaigns[0].code === 'string').to.be.true;
+      expect(campaigns[0].code).to.be.a('string');
       expect(campaigns[0].code.length).to.equal(9);
     });
 

--- a/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/create-profiles-collection-campaigns_test.js
@@ -30,7 +30,7 @@ describe('Integration | Scripts | create-profile-collection-campaigns', function
       const campaigns = await prepareCampaigns([campaignData]);
 
       // then
-      expect(typeof campaigns[0].code === 'string').to.be.true;
+      expect(campaigns[0].code).to.be.a('string');
       expect(campaigns[0].code.length).to.equal(9);
     });
 

--- a/api/tests/tooling/i18n/i18n_test.js
+++ b/api/tests/tooling/i18n/i18n_test.js
@@ -4,6 +4,6 @@ const { getI18n } = require('./i18n');
 describe('Unit | Tooling | i18n', function () {
   it('should translate by default to fr', function () {
     const i18n = getI18n();
-    expect(i18n.__('current-lang'), 'fr');
+    expect(i18n.__('current-lang')).to.equal('fr');
   });
 });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -309,10 +309,12 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
 
       // when
-      certificationCandidate.validateParticipation();
+      const call = () => {
+        certificationCandidate.validateParticipation();
+      };
 
       // then
-      expect(true).to.be.true;
+      expect(call).to.not.throw();
     });
 
     it('should return an error if firstName is not defined', function () {

--- a/api/tests/unit/domain/models/CertificationReport_test.js
+++ b/api/tests/unit/domain/models/CertificationReport_test.js
@@ -30,10 +30,12 @@ describe('Unit | Domain | Models | CertificationReport', function () {
       });
 
       // when
-      certificationReport.validateForFinalization();
+      const call = () => {
+        certificationReport.validateForFinalization();
+      };
 
       // then
-      expect(true).to.be.true;
+      expect(call).to.not.throw();
     });
 
     // eslint-disable-next-line mocha/no-setup-in-describe

--- a/api/tests/unit/tooling/chai-custom-helpers/deep-equal-array_test.js
+++ b/api/tests/unit/tooling/chai-custom-helpers/deep-equal-array_test.js
@@ -6,7 +6,8 @@ describe('Unit | chai-custom-helpers | deepEqualArray', function () {
       expect([]).to.deepEqualArray('coucou');
     }, "expected 'String' to equal 'Array'");
     global.chaiErr(function () {
-      expect('coucou').to.deepEqualArray([]);
+      const foo = 'bar';
+      expect(foo).to.deepEqualArray([]);
     }, "expected 'String' to equal 'Array'");
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous avons des fausses assertions. 

## :robot: Solution
Utiliser un plugin eslint pour prévenir des fausses assertions.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que la CI passe
