### PR TITLE
[FEATURE] Ajouter une tooltip sur la date de la dernière participation de l’onglet Étudiants (PIX-5174).

### DIFF
--- a/orga/app/components/student/sup/list.hbs
+++ b/orga/app/components/student/sup/list.hbs
@@ -58,7 +58,7 @@
 
     {{#if @students}}
       <tbody>
-        {{#each @students as |student|}}
+        {{#each @students as |student index|}}
           <tr aria-label={{t "pages.students-sup.table.row-title"}}>
             <td class="ellipsis">{{student.studentNumber}}</td>
             <td class="ellipsis">{{student.lastName}}</td>
@@ -67,7 +67,17 @@
             <td class="ellipsis">{{student.group}}</td>
             <td class="table__column--right">{{student.participationCount}}</td>
             <td class="table__column--center">
-              {{moment-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}
+              {{#if student.lastParticipationDate}}
+                <div class="list-participants-page__last-participation">
+                  <span>{{moment-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>
+                  <Ui::LastParticipationDateTooltip
+                    @id={{index}}
+                    @campaignName={{student.campaignName}}
+                    @campaignType={{student.campaignType}}
+                    @participationStatus={{student.participationStatus}}
+                  />
+                </div>
+              {{/if}}
             </td>
             <td class="list-students-page__actions hide-on-mobile">
               {{#if this.currentUser.isAdminInOrganization}}

--- a/orga/tests/integration/components/students/sup/list_test.js
+++ b/orga/tests/integration/components/students/sup/list_test.js
@@ -82,6 +82,28 @@ module('Integration | Component | Student::Sup::List', function (hooks) {
     assert.contains('03/01/2022');
   });
 
+  test('it should display campaign name, type and status as tooltip information', async function (assert) {
+    // given
+    const students = [
+      {
+        lastParticipationDate: new Date('2022-01-03'),
+        campaignName: 'SUP - Campagne de collecte de profils',
+        campaignType: 'PROFILES_COLLECTION',
+        participationStatus: 'SHARED',
+      },
+    ];
+
+    this.set('students', students);
+
+    // when
+    await render(hbs`<Student::Sup::List @students={{students}} @onFilter={{noop}} />`);
+
+    // then
+    assert.contains('SUP - Campagne de collecte de profils');
+    assert.contains('Collecte de profils');
+    assert.contains('reçu');
+  });
+
   module('when user is filtering some users', function () {
     test('it should trigger filtering with lastname', async function (assert) {
       const triggerFiltering = sinon.spy();


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons avoir plus d'information sur la dernière participation d'un étudiant affiché dans l'onglet étudiant

## :robot: Solution
Ajouter une tooltip pour afficher d'info concernant la dernière participation ( nom et type de la campagne + status de la participation )

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Orga avec un compte sup
- Aller dans l'onglet  Étudiants,  constater la présence de la tooltip
- Survoler la tooltip pour afficher le nom + type de la campagne + le statut de la participation.