### PR TITLE
[BUGFIX] Rediriger l'utilisateur a la page de login quand le service de partenaire n'est pas reconnu.

### DIFF
--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 import fetch from 'fetch';
+import IdentityProviders from 'mon-pix/identity-providers';
 
 export default class LoginOidcRoute extends Route {
   @service session;
@@ -18,7 +19,10 @@ export default class LoginOidcRoute extends Route {
 
     if (!queryParams.code) {
       const identityProviderSlug = transition.to.params.identity_provider_slug.toString();
-      return this._handleRedirectRequest(identityProviderSlug);
+      const isSupportedIdentityProvider = Object.keys(IdentityProviders).some((key) => key === identityProviderSlug);
+      if (isSupportedIdentityProvider) return this._handleRedirectRequest(identityProviderSlug);
+
+      return this.router.replaceWith('authentication.login');
     }
   }
 

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -46,6 +46,20 @@ describe('Unit | Route | login-oidc', function () {
         sinon.restore();
       });
 
+      context('when identity provider is not supported', function () {
+        it('should redirect the user to main login page', async function () {
+          // given
+          const route = this.owner.lookup('route:authentication/login-oidc');
+          route.router = { replaceWith: sinon.stub() };
+
+          // when
+          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc' } } });
+
+          // then
+          sinon.assert.calledWith(route.router.replaceWith, 'authentication.login');
+        });
+      });
+
       context('when attempting transition', function () {
         it('should store the intent url in session data nextUrl', async function () {
           // given
@@ -64,7 +78,7 @@ describe('Unit | Route | login-oidc', function () {
           route.location = { replace: sinon.stub() };
 
           // when
-          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc' } } });
+          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'cnav' } } });
 
           // then
           expect(sessionStub.data.nextURL).to.equal('/campagnes/PIXEMPLOI/acces');
@@ -88,7 +102,7 @@ describe('Unit | Route | login-oidc', function () {
           route.location = { replace: sinon.stub() };
 
           // when
-          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc' } } });
+          await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'cnav' } } });
 
           // then
           expect(sessionStub.data.nextURL).to.equal('/campagnes/PIXEMPLOI/acces');
@@ -112,7 +126,7 @@ describe('Unit | Route | login-oidc', function () {
         route.location = { replace: sinon.stub() };
 
         // when
-        await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc' } } });
+        await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'cnav' } } });
 
         // then
         sinon.assert.calledWithMatch(route.location.replace, 'https://oidc/connexion');


### PR DESCRIPTION
## :unicorn: Problème
Si l'utilisateur entre un adresse avec un identity provider qu'on ne reconnait pas, la page est rafraichie en boucle

## :robot: Solution
Dans ce cas, rediriger l'utilisateur vers la page de login principale.

## :rainbow: Remarques
RAS

## :100: Pour tester
Allez sur PixApp avec l'url `/connexion/inconnu` et vérifiez que vous êtes redirigé à la page de login principale
