### PR TITLE
[TECH] Réparer le lancement des tests de l'algo avec des KE (PIX-5435).

### DIFF
--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -48,7 +48,7 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
       isFirstAnswer ? result = AnswerStatus.KO : result = AnswerStatus.OK;
       break;
     case 'KE': {
-      const ke = find(userKE, (ke) => find(challenge.skills, (skill) => skill.id === ke.skillId));
+      const ke = find(userKE, (ke) => challenge.skill.id === ke.skillId);
       const status = ke ? ke.status : KnowledgeElement.StatusType.INVALIDATED;
       result = status === KnowledgeElement.StatusType.VALIDATED ? AnswerStatus.OK : AnswerStatus.KO;
       break;

--- a/high-level-tests/test-algo/tests/algo_test.js
+++ b/high-level-tests/test-algo/tests/algo_test.js
@@ -193,7 +193,7 @@ describe('#answerTheChallenge', () => {
     ].forEach((testCase) => {
       it(`should return the list of answers with ${testCase.answerStatus} answers for ${testCase.userKE ? testCase.userKE.status : 'empty' } KE`, () => {
         // given
-        challenge.skills = [{ id: 'recPgkHUdzk0HPGt1' }];
+        challenge.skill = { id: 'recPgkHUdzk0HPGt1' };
 
         // when
         const result = answerTheChallenge({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne pouvons plus lancer les tests de l'algo. 

## :robot: Solution
Les Challenge pouvait avoir précédemment plusieurs acquis seulement ce n'est plus le cas depuis [cette PR](https://github.com/1024pix/pix/pull/4040)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se positionner sur la branche en local
- Télécharger des KE 
- Lancer le test avec un fichier de KE 
- Constater que les tests fonctionnent. 
