### PR TITLE
[FEATURE]  Ne pas autoriser de modifier manuellement une resolution automatique (PIX-5368 )

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -88,6 +88,7 @@ export default class CertificationIssueReportModel extends Model {
   @attr('boolean') isImpactful;
   @attr() resolvedAt;
   @attr() resolution;
+  @attr('boolean') hasBeenAutomaticallyResolved;
 
   @belongsTo('certification') certification;
 
@@ -108,7 +109,7 @@ export default class CertificationIssueReportModel extends Model {
   }
 
   get canBeModified() {
-    return this.isResolved && this.isImpactful;
+    return this.isResolved && this.isImpactful && !this.hasBeenAutomaticallyResolved;
   }
 
   resolve = memberAction({

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -74,7 +74,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
         const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
         // Then
-        assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Résoudre le signalement' })).doesNotExist();
       });
     });
   });
@@ -97,7 +97,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
       // Then
-      assert.dom(screen.queryByText('Résoudre le signalement')).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Résoudre le signalement' })).doesNotExist();
     });
 
     test('it should display resolution modification button', async function (assert) {
@@ -119,7 +119,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
       const screen = await renderScreen(hbs`<Certifications::IssueReport @issueReport={{this.issueReport}}/>`);
 
       // Then
-      assert.dom(screen.queryByText('Modifier la résolution')).exists();
+      assert.dom(screen.queryByRole('button', { name: 'Modifier la résolution' })).exists();
     });
   });
 

--- a/admin/tests/unit/models/certification-issue-report_test.js
+++ b/admin/tests/unit/models/certification-issue-report_test.js
@@ -83,45 +83,64 @@ module('Unit | Model | certification issue report', function (hooks) {
   });
 
   module('#canBeModified', function () {
-    test('it should return false if the issue is impactful but not resolved', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-
-      const model = store.createRecord('certification-issue-report', {
-        isImpactful: true,
-        resolvedAt: null,
-        resolution: null,
+    module('when the issue is impactful', function () {
+      module('when the issue is not resolved', function () {
+        test('it should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const model = store.createRecord('certification-issue-report', {
+            isImpactful: true,
+            resolvedAt: null,
+            resolution: null,
+          });
+          // when / then
+          assert.false(model.canBeModified);
+        });
       });
 
-      // when / then
-      assert.false(model.canBeModified);
+      module('when the issue is resolved', function () {
+        test('it should return true', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const model = store.createRecord('certification-issue-report', {
+            isImpactful: true,
+            resolvedAt: new Date(),
+            resolution: 'resolved',
+          });
+          // when / then
+          assert.true(model.canBeModified);
+        });
+      });
     });
 
-    test('it should return true if the issue is impactful and resolved', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-
-      const model = store.createRecord('certification-issue-report', {
-        isImpactful: true,
-        resolvedAt: new Date(),
-        resolution: 'resolved',
+    module('when the issue is not impactful', function () {
+      module('when the issue is not resolved', function () {
+        test('it should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const model = store.createRecord('certification-issue-report', {
+            isImpactful: false,
+            resolvedAt: null,
+            resolution: null,
+          });
+          // when / then
+          assert.false(model.canBeModified);
+        });
       });
 
-      // when / then
-      assert.true(model.canBeModified);
-    });
-    test('it should return false if the issue is not impactful and not resolved', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-
-      const model = store.createRecord('certification-issue-report', {
-        isImpactful: false,
-        resolvedAt: null,
-        resolution: null,
+      module('when the issue is resolved', function () {
+        test('it should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const model = store.createRecord('certification-issue-report', {
+            isImpactful: false,
+            resolvedAt: new Date(),
+            resolution: 'resolved',
+          });
+          // when / then
+          assert.false(model.canBeModified);
+        });
       });
-
-      // when / then
-      assert.false(model.canBeModified);
     });
   });
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -339,6 +339,11 @@ class InvalidCertificationIssueReportForSaving extends DomainError {
     super(message);
   }
 }
+class CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually extends DomainError {
+  constructor(message = 'Le signalement ne peut pas être modifié manuellement') {
+    super(message);
+  }
+}
 
 class DeprecatedCertificationIssueReportCategoryError extends DomainError {
   constructor(message = 'La catégorie de signalement choisie est dépréciée.') {
@@ -1172,6 +1177,7 @@ module.exports = {
   ChallengeNotAskedError,
   ChallengeToBeNeutralizedNotFoundError,
   ChallengeToBeDeneutralizedNotFoundError,
+  CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually,
   CompetenceResetError,
   CpfBirthInformationValidationError,
   CsvImportError,

--- a/api/lib/domain/usecases/manually-resolve-certification-issue-report.js
+++ b/api/lib/domain/usecases/manually-resolve-certification-issue-report.js
@@ -1,9 +1,15 @@
+const { CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually } = require('../errors');
+
 module.exports = async function manuallyResolveCertificationIssueReport({
   certificationIssueReportId,
   resolution,
   certificationIssueReportRepository,
 }) {
   const certificationIssueReport = await certificationIssueReportRepository.get(certificationIssueReportId);
+  if (certificationIssueReport.hasBeenAutomaticallyResolved) {
+    throw new CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually();
+  }
+
   certificationIssueReport.resolveManually(resolution);
   await certificationIssueReportRepository.save(certificationIssueReport);
 };

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -61,6 +61,7 @@ module.exports = {
           'isImpactful',
           'resolvedAt',
           'resolution',
+          'hasBeenAutomaticallyResolved',
         ],
       },
     }).serialize(juryCertification);

--- a/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
@@ -1,29 +1,63 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const manuallyResolveCertificationIssueReport = require('../../../../lib/domain/usecases/manually-resolve-certification-issue-report');
 
 describe('Unit | UseCase | manually-resolve-certification-issue-report', function () {
-  it('should resolve and save certification issue report', async function () {
-    // given
-    const certificationIssueReportRepository = {
-      get: sinon.stub(),
-      save: sinon.stub(),
-    };
-    const resolution = 'issue solved';
-    const certificationIssueReportId = 1;
-    const expectedCertificationIssueReport = { resolveManually: sinon.stub() };
-    certificationIssueReportRepository.get.resolves(expectedCertificationIssueReport);
-    certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
+  describe('when certification issue report is not resolved', function () {
+    it('should resolve and save certification issue report', async function () {
+      // given
+      const certificationIssueReportRepository = {
+        get: sinon.stub(),
+        save: sinon.stub(),
+      };
+      const resolution = 'issue solved';
+      const certificationIssueReportId = 1;
+      const expectedCertificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        hasBeenAutomaticallyResolved: null,
+      });
+      sinon.spy(expectedCertificationIssueReport, 'resolveManually');
+      certificationIssueReportRepository.get.resolves(expectedCertificationIssueReport);
+      certificationIssueReportRepository.save.resolves();
 
-    // when
-    await manuallyResolveCertificationIssueReport({
-      resolution,
-      certificationIssueReportRepository,
-      certificationIssueReportId,
+      // when
+      await manuallyResolveCertificationIssueReport({
+        resolution,
+        certificationIssueReportRepository,
+        certificationIssueReportId,
+      });
+
+      // then
+      expect(certificationIssueReportRepository.get).to.have.been.called;
+      expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
+      expect(expectedCertificationIssueReport.resolveManually).to.have.been.calledWith(resolution);
     });
+  });
 
-    // then
-    expect(certificationIssueReportRepository.get).to.have.been.called;
-    expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
-    expect(expectedCertificationIssueReport.resolveManually).to.have.been.calledWith(resolution);
+  describe('when certification issue report is resolved', function () {
+    describe('when certification issue report is resolved manually', function () {
+      it('should update certification issue report', async function () {
+        // given
+        const certificationIssueReportRepository = {
+          get: sinon.stub(),
+          save: sinon.stub(),
+        };
+        const resolution = 'issue solved';
+        const certificationIssueReportId = 1;
+        const expectedCertificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          hasBeenAutomaticallyResolved: false,
+        });
+        certificationIssueReportRepository.get.resolves(expectedCertificationIssueReport);
+        certificationIssueReportRepository.save.resolves();
+
+        // when
+        await manuallyResolveCertificationIssueReport({
+          resolution,
+          certificationIssueReportRepository,
+          certificationIssueReportId,
+        });
+
+        // then
+        expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/manually-resolve-certification-issue-report_test.js
@@ -1,5 +1,8 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const manuallyResolveCertificationIssueReport = require('../../../../lib/domain/usecases/manually-resolve-certification-issue-report');
+const {
+  CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually,
+} = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | manually-resolve-certification-issue-report', function () {
   describe('when certification issue report is not resolved', function () {
@@ -57,6 +60,33 @@ describe('Unit | UseCase | manually-resolve-certification-issue-report', functio
 
         // then
         expect(certificationIssueReportRepository.save).to.have.been.calledWith(expectedCertificationIssueReport);
+      });
+    });
+
+    describe('when certification issue report is resolved automatically', function () {
+      it('should throw a CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually error', async function () {
+        // given
+        const certificationIssueReportRepository = {
+          get: sinon.stub(),
+          save: sinon.stub(),
+        };
+        const resolution = 'issue solved';
+        const certificationIssueReportId = 1;
+        const expectedCertificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          hasBeenAutomaticallyResolved: true,
+        });
+        certificationIssueReportRepository.get.resolves(expectedCertificationIssueReport);
+        certificationIssueReportRepository.save.resolves();
+
+        // when
+        const error = await catchErr(manuallyResolveCertificationIssueReport)({
+          resolution,
+          certificationIssueReportRepository,
+          certificationIssueReportId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(CertificationIssueReportAutomaticallyResolvedShouldNotBeUpdatedManually);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -11,6 +11,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
         certificationCourseId,
         resolvedAt: new Date(),
         resolution: 'le challenge est neutralisé',
+        hasBeenAutomaticallyResolved: true,
       });
       const certificationIssueReports = [certificationIssueReport];
       const competenceMarks = [domainBuilder.buildCompetenceMark()];
@@ -172,6 +173,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
               resolution: certificationIssueReport.resolution,
               'question-number': certificationIssueReport.questionNumber,
               subcategory: certificationIssueReport.subcategory,
+              'has-been-automatically-resolved': certificationIssueReport.hasBeenAutomaticallyResolved,
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
On est capable de savoir si un signalement a été résolu manuellement par le pôle certif, ou automatiquement au moment de la finalisation de la session. Un signalement résolu automatiquement ne devrait pas pouvoir voir sa résolution modifiée.

## :robot: Solution
Bloquer la modification de la résolution des signalements résolus automatiquement : ne PAS afficher le bouton “Modifier la résolution” dans PA pour ces signalements.

## :100: Pour tester
- Se rendre sur une session de certif finalisable.
- Ajouter un signalement à résolution automatique puis finaliser la session.
OU
- Se rendre sur un client PGSQL sur la RA, modifier un signalement pré-existant avec la requête suivante : 
- update "certification-issue-reports" set "hasBeenAutomaticallyResolved" = true where id=106572;

- Se rendre sur Pix Admin, sur le détail de la certification, et constater que le signalement a été résolu et qu'aucune bouton de modification du signalement n'apparait.  