### PR TITLE
[TECH] Mettre à jour Cypress de la version 5.6.0 à la version 6.8.0 (PIX-5431).

### DIFF
--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -26,8 +26,7 @@ function setEmberSimpleAuthSession(response) {
 }
 
 Cypress.Commands.add('login', (username, password) => {
-  cy.server();
-  cy.route('/api/users/me').as('getCurrentUser');
+  cy.intercept('/api/users/me').as('getCurrentUser');
   cy.request({
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',
@@ -38,8 +37,7 @@ Cypress.Commands.add('login', (username, password) => {
 });
 
 Cypress.Commands.add('loginOrga', (username, password) => {
-  cy.server();
-  cy.route('/api/prescription/prescribers/**').as('getCurrentUser');
+  cy.intercept('/api/prescription/prescribers/**').as('getCurrentUser');
   cy.request({
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',
@@ -50,8 +48,7 @@ Cypress.Commands.add('loginOrga', (username, password) => {
 });
 
 Cypress.Commands.add('loginAdmin', (username, password) => {
-  cy.server();
-  cy.route('/api/users/me').as('getCurrentUser');
+  cy.intercept('/api/users/me').as('getCurrentUser');
   cy.request({
     url: `${Cypress.env('API_URL')}/api/token`,
     method: 'POST',
@@ -74,7 +71,6 @@ Cypress.Commands.add('loginAdmin', (username, password) => {
 });
 
 Cypress.Commands.add('loginExternalPlatformForTheFirstTime', () => {
-  cy.server();
   const externalUserToken = jsonwebtoken.sign(
     {
       first_name: 'Daenerys',
@@ -90,8 +86,7 @@ Cypress.Commands.add('loginExternalPlatformForTheFirstTime', () => {
 });
 
 Cypress.Commands.add('loginExternalPlatformForTheSecondTime', () => {
-  cy.server();
-  cy.route('/api/users/me').as('getCurrentUser');
+  cy.intercept('/api/users/me').as('getCurrentUser');
   const token = jsonwebtoken.sign(
     {
       user_id: 1,
@@ -105,8 +100,7 @@ Cypress.Commands.add('loginExternalPlatformForTheSecondTime', () => {
 });
 
 Cypress.Commands.add('loginWithAlmostExpiredToken', () => {
-  cy.server();
-  cy.route('/api/users/me').as('getCurrentUser');
+  cy.intercept('/api/users/me').as('getCurrentUser');
   const token = jsonwebtoken.sign({ user_id: 1 }, Cypress.env('AUTH_SECRET'), {
     expiresIn: '2s',
   });

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pix-e2e",
-      "version": "0.334.0",
+      "version": "0.344.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "axe-core": "^4.1.3",
-        "cypress": "^5.6.0",
+        "cypress": "^6.8.0",
         "cypress-axe": "^0.12.2",
         "cypress-cucumber-preprocessor": "^4.1.1",
         "cypress-visual-regression": "^1.5.7",
@@ -24,7 +24,7 @@
       },
       "engines": {
         "node": "16.14.0",
-        "npm": "^8.3.1"
+        "npm": ">=8.3.1 <=8.13.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1311,6 +1311,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@types/node": {
+      "version": "12.12.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
+      "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
+      "dev": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "6.0.2",
@@ -2919,15 +2925,16 @@
       }
     },
     "node_modules/cypress": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.6.0.tgz",
-      "integrity": "sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.8.0.tgz",
+      "integrity": "sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "12.12.50",
         "@types/sinonjs__fake-timers": "^6.0.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.1.2",
@@ -2939,7 +2946,8 @@
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
+        "dayjs": "^1.9.3",
+        "debug": "4.3.2",
         "eventemitter2": "^6.4.2",
         "execa": "^4.0.2",
         "executable": "^4.1.1",
@@ -2953,10 +2961,10 @@
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
+        "moment": "^2.29.1",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.4.1",
-        "ramda": "~0.26.1",
+        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^7.2.0",
         "tmp": "~0.2.1",
@@ -3080,6 +3088,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/cypress/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -3112,6 +3137,12 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==",
       "dev": true
     },
     "node_modules/debug": {
@@ -7060,9 +7091,9 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "dev": true
     },
     "node_modules/randombytes": {
@@ -9928,6 +9959,12 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/node": {
+      "version": "12.12.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
+      "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
+      "dev": true
+    },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
@@ -11259,14 +11296,15 @@
       "dev": true
     },
     "cypress": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.6.0.tgz",
-      "integrity": "sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.8.0.tgz",
+      "integrity": "sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "12.12.50",
         "@types/sinonjs__fake-timers": "^6.0.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.1.2",
@@ -11278,7 +11316,8 @@
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
+        "dayjs": "^1.9.3",
+        "debug": "4.3.2",
         "eventemitter2": "^6.4.2",
         "execa": "^4.0.2",
         "executable": "^4.1.1",
@@ -11292,10 +11331,10 @@
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
+        "moment": "^2.29.1",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.4.1",
-        "ramda": "~0.26.1",
+        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^7.2.0",
         "tmp": "~0.2.1",
@@ -11337,6 +11376,15 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
         }
       }
     },
@@ -11419,6 +11467,12 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "dayjs": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==",
       "dev": true
     },
     "debug": {
@@ -14583,9 +14637,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "dev": true
     },
     "randombytes": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "axe-core": "^4.1.3",
-    "cypress": "^5.6.0",
+    "cypress": "^6.8.0",
     "cypress-axe": "^0.12.2",
     "cypress-cucumber-preprocessor": "^4.1.1",
     "cypress-visual-regression": "^1.5.7",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons actuellement presque 2 ans de retard sur les MAJ de Cypress. En effet [la version 6 est sortie en novembre 2020](https://github.com/cypress-io/cypress/releases/tag/v6.0.0).  

## :robot: Solution
Faire la montée de version pour bénéficier des nouveautés en suivant [le guide de migration](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-6-0).
J'ai choisi de monter de version jusqu'à la dernière version de la version 6. 

## :rainbow: Remarques


## :100: Pour tester
- Constater que la CI fonctionne 
