### PR TITLE
[TECH] Ajout de tests e2e sur l'accessibilité (PIX-5442).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -39,7 +39,7 @@ describe('a11y', () => {
         cy.injectAxe();
 
         // then
-        cy.checkA11yAndShowViolations({ skipFailures });
+        cy.checkA11yAndShowViolations({ skipFailures, url });
       });
     });
   });
@@ -68,7 +68,7 @@ describe('a11y', () => {
         // then
         viewports.forEach(({ width, height}) => {
           cy.viewport(width, height);
-          cy.checkA11yAndShowViolations({ skipFailures });
+          cy.checkA11yAndShowViolations({ skipFailures, url });
         })
       });
     });

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -1,0 +1,76 @@
+describe('a11y', () => {
+
+  const viewports = [
+    { width: 350, height: 667 },
+    { width: 1280,height: 800 },
+  ];
+
+  beforeEach(() => {
+    cy.task('db:fixture', 'users');
+    cy.task('db:fixture', 'authentication-methods');
+    cy.task('db:fixture', 'organizations');
+    cy.task('db:fixture', 'memberships');
+    cy.task('db:fixture', 'organization-invitations');
+    cy.task('db:fixture', 'user-orga-settings');
+    cy.task('db:fixture', 'target-profiles');
+    cy.task('db:fixture', 'target-profiles_skills');
+    cy.task('db:fixture', 'campaigns');
+    cy.task('db:fixture', 'organization-learners');
+    cy.task('db:fixture', 'campaign-participations');
+    cy.task('db:fixture', 'assessments');
+    cy.task('db:fixture', 'answers');
+    cy.task('db:fixture', 'knowledge-elements');
+  });
+
+  describe('Not authenticated pages', () => {
+
+    const notAuthenticatedPages = [
+      { url: '/connexion' },
+      { url: '/inscription' },
+      { url: '/mot-de-passe-oublie' },
+      { url: '/nonconnecte' },
+      { url: '/campagnes/WALL/presentation' },
+    ];
+
+    notAuthenticatedPages.forEach(({ url , skipFailures = false }) => {
+      it(`${url} should be accessible`, () => {
+        // when
+        cy.visitMonPix(url);
+        cy.injectAxe();
+
+        // then
+        cy.checkA11yAndShowViolations({ skipFailures });
+      });
+    });
+  });
+
+  describe('Authenticated pages', () => {
+
+    const authenticatedPages = [
+      { url: '/accueil', skipFailures: true },
+      { url: '/competences', skipFailures: true },
+      { url: '/certifications', skipFailures: true },
+      { url: '/mon-profil', skipFailures: true },
+      { url: '/mes-tutos/recommandes',skipFailures: true },
+      { url: '/mes-certifications', skipFailures: true },
+    ];
+
+    authenticatedPages.forEach(({ url, skipFailures = false }) => {
+      it(`${url} should be accessible`, () => {
+        // given
+        cy.visitMonPix('/');
+        cy.login('john.snow@pix.fr', 'pix123');
+
+        // when
+        cy.visitMonPix(url);
+        cy.injectAxe();
+
+        // then
+        viewports.forEach(({ width, height}) => {
+          cy.viewport(width, height);
+          cy.checkA11yAndShowViolations({ skipFailures });
+        })
+      });
+    });
+  });
+});

--- a/high-level-tests/e2e/cypress/integration/pix-app/demo.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/demo.feature
@@ -7,7 +7,6 @@ Fonctionnalité: Demo
     Alors je suis redirigé vers une page d'épreuve
     Et le titre sur l'épreuve est "Démo essentiels"
     Lorsque je vois l'épreuve "Combien font 2 + 2 ?"
-    Alors l'accessibilité de la page est correcte
     Et je clique sur "Je passe"
     Et je vois l'épreuve "Quel mot est synonyme de « regarder » ?"
     Et je choisis la réponse "radio_3"

--- a/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
@@ -4,14 +4,6 @@ Fonctionnalité: Connexion - Déconnexion
   Contexte:
     Étant donné que tous les comptes sont créés
 
-  Scénario: Je vérifie l'accessibilité des pages de connexion et d'inscription
-    Étant donné que je vais sur Pix
-    Et que je suis redirigé vers la page "/connexion"
-    Alors l'accessibilité de la page est correcte
-    Lorsque je clique sur "Créez un compte"
-    Et que je suis redirigé vers la page "/inscription"
-    Alors l'accessibilité de la page est correcte
-
   Scénario: Je me connecte puis je me déconnecte en fin de session
     Étant donné que je vais sur Pix
     Lorsque je me connecte avec le compte "daenerys.targaryen@pix.fr"
@@ -31,7 +23,6 @@ Fonctionnalité: Connexion - Déconnexion
     Alors je suis redirigé vers la page d'accueil de "Daenerys"
     Lorsque je me déconnecte
     Alors je suis redirigé vers la page "/nonconnecte"
-    Et l'accessibilité de la page est correcte
 
   Scénario: Je me connecte via un organisme externe alors qu'il y a une personne déjà connectée puis je me déconnecte
     Étant donné que je suis connecté à Pix en tant que "John Snow"

--- a/high-level-tests/e2e/cypress/plugins/index.js
+++ b/high-level-tests/e2e/cypress/plugins/index.js
@@ -26,7 +26,12 @@ module.exports = (on, config) => {
           });
           return Promise.all(sequenceUpdatePromises);
         });
-    }
+    },
+    log(message) {
+      console.log(message)
+
+      return null
+    },
   });
   return config;
 };

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -126,4 +126,27 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   return originalFn(url, options);
 });
 
+Cypress.Commands.add('checkA11yAndShowViolations', ({ context = {}, options = {}, skipFailures = false }) => {
+  const logViolations = (violations) => {
+    cy.task(
+      'log',
+      `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${violations.length === 1 ? 'was' : 'were'} detected`
+    )
+
+    const violationData = violations.map(
+      ({ id, impact, description, nodes, help, helpUrl }) => ({
+        id,
+        impact,
+        description,
+        help,
+        helpUrl,
+        nodes: nodes.map(({ target }) => target).join(','),
+      })
+    )
+    cy.task('log', violationData)
+  }
+
+  return cy.checkA11y(context, options, logViolations, skipFailures);
+})
+
 compareSnapshotCommand();

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -126,11 +126,11 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   return originalFn(url, options);
 });
 
-Cypress.Commands.add('checkA11yAndShowViolations', ({ context = {}, options = {}, skipFailures = false }) => {
+Cypress.Commands.add('checkA11yAndShowViolations', ({ context = {}, options = {}, url, skipFailures = false }) => {
   const logViolations = (violations) => {
     cy.task(
       'log',
-      `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${violations.length === 1 ? 'was' : 'were'} detected`
+      `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${violations.length === 1 ? 'was' : 'were'} detected on ${url}`
     )
 
     const violationData = violations.map(

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -13,7 +13,7 @@
         "jsonwebtoken": "8.5.1"
       },
       "devDependencies": {
-        "axe-core": "^4.1.3",
+        "axe-core": "^4.4.3",
         "cypress": "^6.8.0",
         "cypress-axe": "^0.12.2",
         "cypress-cucumber-preprocessor": "^4.1.1",
@@ -1697,9 +1697,9 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
-      "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -10267,9 +10267,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
-      "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "dev": true
     },
     "babel-plugin-add-module-exports": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -34,7 +34,7 @@
     "test:ci": "npx wait-on http://localhost:3000/api http://localhost:4200 http://localhost:4201 && npm run cy:run:ci"
   },
   "devDependencies": {
-    "axe-core": "^4.1.3",
+    "axe-core": "^4.4.3",
     "cypress": "^6.8.0",
     "cypress-axe": "^0.12.2",
     "cypress-cucumber-preprocessor": "^4.1.1",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, très peu de tests d'accessibilité sont présents en e2e, alors que la stack est prête pour. 
Ce qui fait que nous devons tester l'accessibilité manuellement sur la plupart des pages. 

## :robot: Solution
Ajouter des tests sur différentes pages, tout en simplifiant l'ajout de nouvelles pages. 

## :rainbow: Remarques
Pour l'instant les tests ne passent pas mais reflète l'état actuel de Pix Aop, pour cela on a utilisé l'option `skipFailures` pour ne pas faire planter la CI. L'objectif est donc de ne plus avoir de tests avec cette option. 

Je me suis basé sur ce que @MelanieMEB  avait déjà mis en place et de [cet article](https://timdeschryver.dev/blog/setting-up-cypress-with-axe-for-accessibility#assert-a-pages-accessibility).

## :100: Pour tester
Vérifier que la CI passe. 
