### PR TITLE
[TECH] Ajouter les colonnes label et key aux certifications complémentaires (PIX-5329)

### DIFF
--- a/admin/app/components/certification-centers/form.hbs
+++ b/admin/app/components/certification-centers/form.hbs
@@ -84,7 +84,7 @@
               {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
             />
             <label class="form-field__label" for={{concat "habilitation_" index}}>
-              {{habilitation.name}}
+              {{habilitation.label}}
             </label>
           </li>
         {{/each}}

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -70,7 +70,7 @@
                   {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
                 />
                 <label class="field__label" for="habilitation-checkbox__{{habilitation.id}}">
-                  {{habilitation.name}}
+                  {{habilitation.label}}
                 </label>
               </li>
             {{/each}}
@@ -107,14 +107,14 @@
           <ul class="certification-center-information__display__habilitations-list">
             {{#each this.availableHabilitations as |habilitation|}}
               {{#if (contains habilitation @certificationCenter.habilitations)}}
-                <li aria-label={{concat "Habilité pour " habilitation.name}}>
+                <li aria-label={{concat "Habilité pour " habilitation.label}}>
                   <FaIcon class="granted-habilitation-icon" @icon="check-circle" />
-                  {{habilitation.name}}
+                  {{habilitation.label}}
                 </li>
               {{else}}
-                <li aria-label={{concat "Non-habilité pour " habilitation.name}}>
+                <li aria-label={{concat "Non-habilité pour " habilitation.label}}>
                   <FaIcon class="not-granted-habilitation-icon" @icon="times-circle" />
-                  {{habilitation.name}}
+                  {{habilitation.label}}
                 </li>
               {{/if}}
             {{/each}}

--- a/admin/app/models/habilitation.js
+++ b/admin/app/models/habilitation.js
@@ -1,5 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class Habilitation extends Model {
-  @attr() name;
+  @attr() key;
+  @attr() label;
 }

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -20,8 +20,8 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     });
     await createAuthenticateSession({ userId });
 
-    this.server.create('habilitation', { name: 'Pix+ Droit' });
-    this.server.create('habilitation', { name: 'CléA Numérique' });
+    server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
+    server.create('habilitation', { key: 'A', label: 'Pix+Autre' });
 
     const name = 'name';
     const type = { label: 'Organisation professionnelle', value: 'PRO' };
@@ -38,7 +38,7 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     await fillIn(screen.getByRole('combobox', { name: "Type d'établissement" }), type.value);
     await fillIn(screen.getByRole('textbox', { name: 'Identifiant externe' }), externalId);
 
-    await click(screen.getByRole('checkbox', { name: 'Pix+ Droit' }));
+    await click(screen.getByRole('checkbox', { name: 'Pix+Surf' }));
     await click(screen.getByRole('button', { name: 'Ajouter' }));
 
     // then
@@ -48,7 +48,7 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     assert.dom(screen.getByText(externalId)).exists();
     assert.strictEqual(screen.getByLabelText('Espace surveillant').textContent, 'oui');
 
-    assert.dom(screen.getByRole('listitem', { name: 'Non-habilité pour CléA Numérique' })).exists();
-    assert.dom(screen.getByRole('listitem', { name: 'Habilité pour Pix+ Droit' })).exists();
+    assert.dom(screen.getByRole('listitem', { name: 'Non-habilité pour Pix+Autre' })).exists();
+    assert.dom(screen.getByRole('listitem', { name: 'Habilité pour Pix+Surf' })).exists();
   });
 });

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, triggerEvent } from '@ember/test-helpers';
+import { currentURL, triggerEvent, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
@@ -48,8 +48,9 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   test('should display Certification center habilitations', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const habilitation1 = server.create('habilitation', { name: 'Pix+Edu' });
-    const habilitation2 = server.create('habilitation', { name: 'Pix+Surf' });
+    const habilitation1 = server.create('habilitation', { key: 'E', label: 'Pix+Edu' });
+    const habilitation2 = server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
+
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
       externalId: 'ABCDEF',
@@ -68,8 +69,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   test('should highlight the habilitations of the current certification center', async function (assert) {
     // given
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-    const habilitation1 = server.create('habilitation', { name: 'Pix+Edu' });
-    const habilitation2 = server.create('habilitation', { name: 'Pix+Surf' });
+    const habilitation1 = server.create('habilitation', { key: 'E', label: 'Pix+Edu' });
+    const habilitation2 = server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
     const certificationCenter = server.create('certification-center', {
       name: 'Center 1',
       externalId: 'ABCDEF',
@@ -77,7 +78,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       habilitations: [habilitation1, habilitation2],
     });
 
-    server.create('habilitation', { name: 'Pix+Autre' });
+    server.create('habilitation', { key: 'S', label: 'Pix+Autre' });
 
     // when
     const screen = await visit(`/certification-centers/${certificationCenter.id}`);
@@ -293,8 +294,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         externalId: 'ABCDEF',
         type: 'SCO',
       });
-      server.create('habilitation', { name: 'Pix+Surf' });
-      server.create('habilitation', { name: 'Pix+Autre' });
+      server.create('habilitation', { key: 'S', label: 'Pix+Surf' });
+      server.create('habilitation', { key: 'A', label: 'Pix+Autre' });
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Editer les informations');
@@ -302,7 +303,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // when
       await fillByLabel('Nom du centre', 'Centre des réussites');
-      await clickByName('Pix+Surf');
+      await click(screen.getByRole('checkbox', { name: 'Pix+Surf' }));
       await clickByName('Enregistrer');
 
       // then

--- a/admin/tests/integration/components/certification-centers/form_test.js
+++ b/admin/tests/integration/components/certification-centers/form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find } from '@ember/test-helpers';
-import { clickByName, render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { click, find } from '@ember/test-helpers';
+import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import { A as EmberArray } from '@ember/array';
@@ -49,18 +49,18 @@ module('Integration | Component | certification-centers/form', function (hooks) 
     test('should add habilitation to certification center on checked checkbox', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const habilitation1 = store.createRecord('habilitation', { name: 'habilitation 1' });
-      const habilitation2 = store.createRecord('habilitation', { name: 'habilitation 2' });
+      const habilitation1 = store.createRecord('habilitation', { key: 'E', label: 'Pix+Edu' });
+      const habilitation2 = store.createRecord('habilitation', { key: 'S', label: 'Pix+Surf' });
       this.certificationCenter = store.createRecord('certification-center');
       this.habilitations = EmberArray([habilitation1, habilitation2]);
       this.stub = () => {};
 
-      await render(
+      const screen = await render(
         hbs`<CertificationCenters::Form @certificationCenter={{this.certificationCenter}} @habilitations={{this.habilitations}} @onSubmit={{this.stub}} @onCancel={{this.stub}} />`
       );
 
       // when
-      await clickByName('habilitation 2');
+      await click(screen.getByRole('checkbox', { name: 'Pix+Surf' }));
 
       // then
       assert.ok(this.certificationCenter.habilitations.includes(habilitation2));
@@ -69,20 +69,20 @@ module('Integration | Component | certification-centers/form', function (hooks) 
     test('should remove habilitation to certification center on unchecked checkbox', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const habilitation1 = store.createRecord('habilitation', { name: 'habilitation 1' });
-      const habilitation2 = store.createRecord('habilitation', { name: 'habilitation 2' });
+      const habilitation1 = store.createRecord('habilitation', { key: 'E', label: 'Pix+Edu' });
+      const habilitation2 = store.createRecord('habilitation', { key: 'S', label: 'Pix+Surf' });
       this.certificationCenter = store.createRecord('certification-center', {
         habilitations: [habilitation2],
       });
       this.habilitations = EmberArray([habilitation1, habilitation2]);
       this.stub = () => {};
 
-      await render(
+      const screen = await render(
         hbs`<CertificationCenters::Form @certificationCenter={{this.certificationCenter}} @habilitations={{this.habilitations}} @onSubmit={{this.stub}} @onCancel={{this.stub}} />`
       );
 
       // when
-      await clickByName('habilitation 2');
+      await click(screen.getByRole('checkbox', { name: 'Pix+Surf' }));
 
       // then
       assert.notOk(this.certificationCenter.habilitations.includes(habilitation2));

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -10,8 +10,8 @@ import sinon from 'sinon';
 function _createEmberDataHabilitations(store) {
   return ArrayProxy.create({
     content: [
-      store.createRecord('habilitation', { id: 0, name: 'Pix+Droit' }),
-      store.createRecord('habilitation', { id: 1, name: 'Cléa' }),
+      store.createRecord('habilitation', { id: 0, key: 'DROIT', label: 'Pix+Droit' }),
+      store.createRecord('habilitation', { id: 1, key: 'CLEA', label: 'Cléa' }),
     ],
   });
 }

--- a/admin/tests/unit/components/certification-centers/information_test.js
+++ b/admin/tests/unit/components/certification-centers/information_test.js
@@ -19,28 +19,28 @@ module('Unit | Component | certification-center informations', function (hooks) 
   module('#updateGrantedHabilitation', function () {
     test('it should add the habilitation to the certification center', function (assert) {
       // given
-      const cleaHabilitation = { name: 'Pix+clea' };
+      const habilitation = { key: 'E', label: 'Pix+Surf' };
 
       component.form.habilitations = [];
 
       // when
-      component.updateGrantedHabilitation(cleaHabilitation);
+      component.updateGrantedHabilitation(habilitation);
 
       // then
-      assert.true(component.form.habilitations.includes(cleaHabilitation));
+      assert.true(component.form.habilitations.includes(habilitation));
     });
 
     test('it should remove the habilitation from the certification center', function (assert) {
       // given
-      const pixSurfHabilitation = { name: 'Pix+Surf' };
+      const habilitation = { key: 'E', label: 'Pix+Surf' };
 
-      component.form.habilitations = [pixSurfHabilitation];
+      component.form.habilitations = [habilitation];
 
       // when
-      component.updateGrantedHabilitation(pixSurfHabilitation);
+      component.updateGrantedHabilitation(habilitation);
 
       // then
-      assert.false(component.form.habilitations.includes(pixSurfHabilitation));
+      assert.false(component.form.habilitations.includes(habilitation));
     });
   });
 

--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -2,14 +2,16 @@ const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildComplementaryCertification({
   id = databaseBuffer.getNextId(),
-  name = 'UneSuperCertifComplémentaire',
+  label = 'UneSuperCertifComplémentaire',
+  key = 'SUPERCERTIF',
   createdAt = new Date('2020-01-01'),
   minimumReproducibilityRate,
   minimumEarnedPix,
 } = {}) {
   const values = {
     id,
-    name,
+    label,
+    key,
     createdAt,
     minimumReproducibilityRate,
     minimumEarnedPix,

--- a/api/db/migrations/20220729092523_add-column-key-and-rename-name-as-label-to-complemantary-certifications.js
+++ b/api/db/migrations/20220729092523_add-column-key-and-rename-name-as-label-to-complemantary-certifications.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'complementary-certifications';
+const COLUMN_NAME_NAME = 'name';
+const COLUMN_NAME_LABEL = 'label';
+const COLUMN_NAME_KEY = 'key';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME_KEY);
+  });
+
+  await knex(TABLE_NAME).where({ name: 'Pix+ Droit' }).update({ key: 'DROIT' });
+  await knex(TABLE_NAME).where({ name: 'CléA Numérique' }).update({ key: 'CLEA' });
+  await knex(TABLE_NAME).where({ name: 'Pix+ Édu 1er degré' }).update({ key: 'EDU_1ER_DEGRE' });
+  await knex(TABLE_NAME).where({ name: 'Pix+ Édu 2nd degré' }).update({ key: 'EDU_2ND_DEGRE' });
+
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME_KEY).notNullable().alter();
+    table.renameColumn(COLUMN_NAME_NAME, COLUMN_NAME_LABEL);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME_KEY);
+    table.renameColumn(COLUMN_NAME_LABEL, COLUMN_NAME_NAME);
+  });
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -42,7 +42,8 @@ const {
 
 function certificationCentersBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildComplementaryCertification({
-    name: 'CléA Numérique',
+    label: 'CléA Numérique',
+    key: 'CLEA',
     id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -67,17 +68,20 @@ function certificationCentersBuilder({ databaseBuilder }) {
   });
 
   databaseBuilder.factory.buildComplementaryCertification({
-    name: 'Pix+ Droit',
+    label: 'Pix+ Droit',
+    key: 'DROIT',
     id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
   databaseBuilder.factory.buildComplementaryCertification({
-    name: 'Pix+ Édu 2nd degré',
+    label: 'Pix+ Édu 2nd degré',
+    key: 'EDU_2ND_DEGRE',
     id: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   });
 
   databaseBuilder.factory.buildComplementaryCertification({
-    name: 'Pix+ Édu 1er degré',
+    label: 'Pix+ Édu 1er degré',
+    key: 'EDU_1ER_DEGRE',
     id: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   });
 

--- a/api/lib/domain/events/handle-clea-certification-scoring.js
+++ b/api/lib/domain/events/handle-clea-certification-scoring.js
@@ -15,7 +15,7 @@ async function handleCleaCertificationScoring({
   const complementaryCertificationCourseId =
     await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
       certificationCourseId,
-      complementaryCertificationName: CLEA,
+      complementaryCertificationKey: CLEA,
     });
   if (!complementaryCertificationCourseId) {
     return;

--- a/api/lib/domain/events/handle-pix-plus-droit-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-droit-certifications-scoring.js
@@ -29,7 +29,7 @@ async function handlePixPlusDroitCertificationsScoring({
   const complementaryCertificationCourseId =
     await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
       certificationCourseId,
-      complementaryCertificationName: PIX_PLUS_DROIT,
+      complementaryCertificationKey: PIX_PLUS_DROIT,
     });
   if (!complementaryCertificationCourseId) {
     return;

--- a/api/lib/domain/events/handle-pix-plus-droit-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-droit-certifications-scoring.js
@@ -9,11 +9,11 @@ const { PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF } = require('../models/
 
 const eventTypes = [CertificationScoringCompleted, CertificationRescoringCompleted];
 
-async function _isAllowedToBeScored(certifiableBadgeKey) {
+function _isAllowedToBeScored(certifiableBadgeKey) {
   return [PIX_DROIT_MAITRE_CERTIF, PIX_DROIT_EXPERT_CERTIF].includes(certifiableBadgeKey);
 }
 
-async function _allowedToBeScoredBadgeKeys({ certifiableBadgeKeys }) {
+function _allowedToBeScoredBadgeKeys({ certifiableBadgeKeys }) {
   return certifiableBadgeKeys.filter(_isAllowedToBeScored);
 }
 
@@ -39,10 +39,8 @@ async function handlePixPlusDroitCertificationsScoring({
     certificationCourseId,
   });
   const certifiableBadgeKeys = certificationAssessment.listCertifiableBadgePixPlusKeysTaken();
-  const allowedToBeScoredBadgeKeys = await _allowedToBeScoredBadgeKeys({
+  const allowedToBeScoredBadgeKeys = _allowedToBeScoredBadgeKeys({
     certifiableBadgeKeys,
-    certificationCourseId,
-    complementaryCertificationCourseRepository,
   });
 
   for (const certifiableBadgeKey of allowedToBeScoredBadgeKeys) {

--- a/api/lib/domain/events/handle-pix-plus-edu-1er-degre-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-edu-1er-degre-certifications-scoring.js
@@ -41,7 +41,7 @@ async function handlePixPlusEdu1erDegreCertificationsScoring({
   const complementaryCertificationCourseId =
     await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
       certificationCourseId,
-      complementaryCertificationName: PIX_PLUS_EDU_1ER_DEGRE,
+      complementaryCertificationKey: PIX_PLUS_EDU_1ER_DEGRE,
     });
   if (!complementaryCertificationCourseId) {
     return;

--- a/api/lib/domain/events/handle-pix-plus-edu-2nd-degre-certifications-scoring.js
+++ b/api/lib/domain/events/handle-pix-plus-edu-2nd-degre-certifications-scoring.js
@@ -41,7 +41,7 @@ async function handlePixPlusEdu2ndDegreCertificationsScoring({
   const complementaryCertificationCourseId =
     await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
       certificationCourseId,
-      complementaryCertificationName: PIX_PLUS_EDU_2ND_DEGRE,
+      complementaryCertificationKey: PIX_PLUS_EDU_2ND_DEGRE,
     });
   if (!complementaryCertificationCourseId) {
     return;

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -192,19 +192,19 @@ class CertificationCandidate {
   }
 
   isGrantedPixPlusDroit() {
-    return this.complementaryCertifications.some((comp) => comp.name === PIX_PLUS_DROIT);
+    return this.complementaryCertifications.some((comp) => comp.key === PIX_PLUS_DROIT);
   }
 
   isGrantedCleA() {
-    return this.complementaryCertifications.some((comp) => comp.name === CLEA);
+    return this.complementaryCertifications.some((comp) => comp.key === CLEA);
   }
 
   isGrantedPixPlusEdu1erDegre() {
-    return this.complementaryCertifications.some((comp) => comp.name === PIX_PLUS_EDU_1ER_DEGRE);
+    return this.complementaryCertifications.some((comp) => comp.key === PIX_PLUS_EDU_1ER_DEGRE);
   }
 
   isGrantedPixPlusEdu2ndDegre() {
-    return this.complementaryCertifications.some((comp) => comp.name === PIX_PLUS_EDU_2ND_DEGRE);
+    return this.complementaryCertifications.some((comp) => comp.key === PIX_PLUS_EDU_2ND_DEGRE);
   }
 
   isBillingModePrepaid() {

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -41,19 +41,19 @@ class CertificationCenter {
   }
 
   get isHabilitatedPixPlusDroit() {
-    return this.habilitations.some((habilitation) => habilitation.name === PIX_PLUS_DROIT);
+    return this.habilitations.some((habilitation) => habilitation.key === PIX_PLUS_DROIT);
   }
 
   get isHabilitatedPixPlusEdu1erDegre() {
-    return this.habilitations.some((habilitation) => habilitation.name === PIX_PLUS_EDU_1ER_DEGRE);
+    return this.habilitations.some((habilitation) => habilitation.key === PIX_PLUS_EDU_1ER_DEGRE);
   }
 
   get isHabilitatedPixPlusEdu2ndDegre() {
-    return this.habilitations.some((habilitation) => habilitation.name === PIX_PLUS_EDU_2ND_DEGRE);
+    return this.habilitations.some((habilitation) => habilitation.key === PIX_PLUS_EDU_2ND_DEGRE);
   }
 
   get isHabilitatedClea() {
-    return this.habilitations.some((habilitation) => habilitation.name === CLEA);
+    return this.habilitations.some((habilitation) => habilitation.key === CLEA);
   }
 }
 

--- a/api/lib/domain/models/ComplementaryCertification.js
+++ b/api/lib/domain/models/ComplementaryCertification.js
@@ -1,28 +1,29 @@
-const PIX_PLUS_DROIT = 'Pix+ Droit';
-const CLEA = 'CléA Numérique';
-const PIX_PLUS_EDU_1ER_DEGRE = 'Pix+ Édu 1er degré';
-const PIX_PLUS_EDU_2ND_DEGRE = 'Pix+ Édu 2nd degré';
+const PIX_PLUS_DROIT = 'DROIT';
+const CLEA = 'CLEA';
+const PIX_PLUS_EDU_1ER_DEGRE = 'EDU_1ER_DEGRE';
+const PIX_PLUS_EDU_2ND_DEGRE = 'EDU_2ND_DEGRE';
 
 class ComplementaryCertification {
-  constructor({ id, name }) {
+  constructor({ id, label, key }) {
     this.id = id;
-    this.name = name;
+    this.label = label;
+    this.key = key;
   }
 
   isClea() {
-    return this.name === CLEA;
+    return this.key === CLEA;
   }
 
   isPixPlusDroit() {
-    return this.name === PIX_PLUS_DROIT;
+    return this.key === PIX_PLUS_DROIT;
   }
 
   isPixPlusEdu1erDegre() {
-    return this.name === PIX_PLUS_EDU_1ER_DEGRE;
+    return this.key === PIX_PLUS_EDU_1ER_DEGRE;
   }
 
   isPixPlusEdu2ndDegre() {
-    return this.name === PIX_PLUS_EDU_2ND_DEGRE;
+    return this.key === PIX_PLUS_EDU_2ND_DEGRE;
   }
 }
 

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -165,27 +165,27 @@ async function _buildComplementaryCertificationsForLine({
   const complementaryCertificationsInDB = await complementaryCertificationRepository.findAll();
   if (hasCleaNumerique) {
     complementaryCertifications.push(
-      complementaryCertificationsInDB.find((complementaryCertification) => complementaryCertification.name === CLEA)
+      complementaryCertificationsInDB.find((complementaryCertification) => complementaryCertification.key === CLEA)
     );
   }
   if (hasPixPlusDroit) {
     complementaryCertifications.push(
       complementaryCertificationsInDB.find(
-        (complementaryCertification) => complementaryCertification.name === PIX_PLUS_DROIT
+        (complementaryCertification) => complementaryCertification.key === PIX_PLUS_DROIT
       )
     );
   }
   if (hasPixPlusEdu1erDegre) {
     complementaryCertifications.push(
       complementaryCertificationsInDB.find(
-        (complementaryCertification) => complementaryCertification.name === PIX_PLUS_EDU_1ER_DEGRE
+        (complementaryCertification) => complementaryCertification.key === PIX_PLUS_EDU_1ER_DEGRE
       )
     );
   }
   if (hasPixPlusEdu2ndDegre) {
     complementaryCertifications.push(
       complementaryCertificationsInDB.find(
-        (complementaryCertification) => complementaryCertification.name === PIX_PLUS_EDU_2ND_DEGRE
+        (complementaryCertification) => complementaryCertification.key === PIX_PLUS_EDU_2ND_DEGRE
       )
     );
   }

--- a/api/lib/infrastructure/files/candidates-import/CandidateData.js
+++ b/api/lib/infrastructure/files/candidates-import/CandidateData.js
@@ -52,21 +52,15 @@ module.exports = class CandidateData {
     this.organizationLearnerId = this._emptyStringIfNull(organizationLearnerId);
     this.billingMode = CertificationCandidate.translateBillingMode(billingMode);
     this.prepaymentCode = this._emptyStringIfNull(prepaymentCode);
-    this.cleaNumerique = this._displayYesIfCandidateHasComplementaryCertification(
-      complementaryCertifications,
-      'CléA Numérique'
-    );
-    this.pixPlusDroit = this._displayYesIfCandidateHasComplementaryCertification(
-      complementaryCertifications,
-      'Pix+ Droit'
-    );
+    this.cleaNumerique = this._displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, 'CLEA');
+    this.pixPlusDroit = this._displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, 'DROIT');
     this.pixPlusEdu1erDegre = this._displayYesIfCandidateHasComplementaryCertification(
       complementaryCertifications,
-      'Pix+ Édu 1er degré'
+      'EDU_1ER_DEGRE'
     );
     this.pixPlusEdu2ndDegre = this._displayYesIfCandidateHasComplementaryCertification(
       complementaryCertifications,
-      'Pix+ Édu 2nd degré'
+      'EDU_2ND_DEGRE'
     );
     this.count = number;
     this._clearBirthInformationDataForExport();
@@ -91,12 +85,12 @@ module.exports = class CandidateData {
     }
   }
 
-  _displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, certificationLabel) {
+  _displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, certificationKey) {
     if (!complementaryCertifications) {
       return '';
     }
     const hasComplementaryCertification = complementaryCertifications.some(
-      (complementaryCertification) => complementaryCertification.name === certificationLabel
+      (complementaryCertification) => complementaryCertification.key === certificationKey
     );
     return hasComplementaryCertification ? 'oui' : '';
   }

--- a/api/lib/infrastructure/files/candidates-import/CandidateData.js
+++ b/api/lib/infrastructure/files/candidates-import/CandidateData.js
@@ -2,6 +2,12 @@ const moment = require('moment');
 const _ = require('lodash');
 const FRANCE_COUNTRY_CODE = '99100';
 const CertificationCandidate = require('../../../domain/models/CertificationCandidate');
+const {
+  PIX_PLUS_DROIT,
+  CLEA,
+  PIX_PLUS_EDU_1ER_DEGRE,
+  PIX_PLUS_EDU_2ND_DEGRE,
+} = require('../../../domain/models/ComplementaryCertification');
 
 module.exports = class CandidateData {
   constructor({
@@ -52,15 +58,18 @@ module.exports = class CandidateData {
     this.organizationLearnerId = this._emptyStringIfNull(organizationLearnerId);
     this.billingMode = CertificationCandidate.translateBillingMode(billingMode);
     this.prepaymentCode = this._emptyStringIfNull(prepaymentCode);
-    this.cleaNumerique = this._displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, 'CLEA');
-    this.pixPlusDroit = this._displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, 'DROIT');
+    this.cleaNumerique = this._displayYesIfCandidateHasComplementaryCertification(complementaryCertifications, CLEA);
+    this.pixPlusDroit = this._displayYesIfCandidateHasComplementaryCertification(
+      complementaryCertifications,
+      PIX_PLUS_DROIT
+    );
     this.pixPlusEdu1erDegre = this._displayYesIfCandidateHasComplementaryCertification(
       complementaryCertifications,
-      'EDU_1ER_DEGRE'
+      PIX_PLUS_EDU_1ER_DEGRE
     );
     this.pixPlusEdu2ndDegre = this._displayYesIfCandidateHasComplementaryCertification(
       complementaryCertifications,
-      'EDU_2ND_DEGRE'
+      PIX_PLUS_EDU_2ND_DEGRE
     );
     this.count = number;
     this._clearBirthInformationDataForExport();

--- a/api/lib/infrastructure/files/candidates-import/candidates-import-placeholders.js
+++ b/api/lib/infrastructure/files/candidates-import/candidates-import-placeholders.js
@@ -97,19 +97,19 @@ const IMPORT_CANDIDATES_TEMPLATE_VALUES = [
     validator: 'val-prepayment-code',
   },
   {
-    placeholder: 'CléA Numérique',
+    placeholder: 'CLEA',
     propertyName: 'cleaNumerique',
   },
   {
-    placeholder: 'Pix+ Droit',
+    placeholder: 'DROIT',
     propertyName: 'pixPlusDroit',
   },
   {
-    placeholder: 'Pix+ Édu 1er degré',
+    placeholder: 'EDU_1ER_DEGRE',
     propertyName: 'pixPlusEdu1erDegre',
   },
   {
-    placeholder: 'Pix+ Édu 2nd degré',
+    placeholder: 'EDU_2ND_DEGRE',
     propertyName: 'pixPlusEdu2ndDegre',
   },
 ];

--- a/api/lib/infrastructure/files/candidates-import/candidates-import-placeholders.js
+++ b/api/lib/infrastructure/files/candidates-import/candidates-import-placeholders.js
@@ -1,3 +1,10 @@
+const {
+  PIX_PLUS_DROIT,
+  CLEA,
+  PIX_PLUS_EDU_1ER_DEGRE,
+  PIX_PLUS_EDU_2ND_DEGRE,
+} = require('../../../domain/models/ComplementaryCertification');
+
 const IMPORT_CANDIDATES_SESSION_TEMPLATE_VALUES = [
   {
     placeholder: 'SESSION_ID',
@@ -97,19 +104,19 @@ const IMPORT_CANDIDATES_TEMPLATE_VALUES = [
     validator: 'val-prepayment-code',
   },
   {
-    placeholder: 'CLEA',
+    placeholder: CLEA,
     propertyName: 'cleaNumerique',
   },
   {
-    placeholder: 'DROIT',
+    placeholder: PIX_PLUS_DROIT,
     propertyName: 'pixPlusDroit',
   },
   {
-    placeholder: 'EDU_1ER_DEGRE',
+    placeholder: PIX_PLUS_EDU_1ER_DEGRE,
     propertyName: 'pixPlusEdu1erDegre',
   },
   {
-    placeholder: 'EDU_2ND_DEGRE',
+    placeholder: PIX_PLUS_EDU_2ND_DEGRE,
     propertyName: 'pixPlusEdu2ndDegre',
   },
 ];

--- a/api/lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js
+++ b/api/lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js
@@ -98,16 +98,16 @@ function getTransformationStructsForPixCertifCandidatesImport({ complementaryCer
 
 function _includeComplementaryCertificationColumns(complementaryCertifications, transformationStruct) {
   const containsClea = complementaryCertifications.some(
-    (complementaryCertification) => complementaryCertification.name === CLEA
+    (complementaryCertification) => complementaryCertification.key === CLEA
   );
   const containsPixPlusDroit = complementaryCertifications.some(
-    (complementaryCertification) => complementaryCertification.name === PIX_PLUS_DROIT
+    (complementaryCertification) => complementaryCertification.key === PIX_PLUS_DROIT
   );
   const containsPixPlusEdu1erDegre = complementaryCertifications.some(
-    (complementaryCertification) => complementaryCertification.name === PIX_PLUS_EDU_1ER_DEGRE
+    (complementaryCertification) => complementaryCertification.key === PIX_PLUS_EDU_1ER_DEGRE
   );
   const containsPixPlusEdu2ndDegre = complementaryCertifications.some(
-    (complementaryCertification) => complementaryCertification.name === PIX_PLUS_EDU_2ND_DEGRE
+    (complementaryCertification) => complementaryCertification.key === PIX_PLUS_EDU_2ND_DEGRE
   );
 
   if (containsClea) {

--- a/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -94,9 +94,9 @@ function _addColumns({ odsBuilder, certificationCenterHabilitations, isScoCertif
 
 function _addComplementaryCertificationColumns({ odsBuilder, certificationCenterHabilitations }) {
   if (!_.isEmpty(certificationCenterHabilitations)) {
-    const habilitationColumns = certificationCenterHabilitations.map(({ name }) => ({
-      headerLabel: [name, '("oui" ou laisser vide)'],
-      placeholder: [name],
+    const habilitationColumns = certificationCenterHabilitations.map(({ key, label }) => ({
+      headerLabel: [label, '("oui" ou laisser vide)'],
+      placeholder: [key],
     }));
     odsBuilder.withColumnGroup({
       groupHeaderLabel: 'Certification(s) complémentaire(s)',

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -9,7 +9,8 @@ function _toDomain(bookshelfCertificationCenter) {
   const habilitations = _.map(dbCertificationCenter.habilitations, (dbComplementaryCertification) => {
     return new ComplementaryCertification({
       id: dbComplementaryCertification.id,
-      name: dbComplementaryCertification.name,
+      key: dbComplementaryCertification.key,
+      label: dbComplementaryCertification.label,
     });
   });
   return new CertificationCenter({

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -71,7 +71,7 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
       isSupervisorAccessEnabled: 'certification-centers.isSupervisorAccessEnabled',
       tags: knex.raw('array_agg(?? order by ??)', ['tags.name', 'tags.name']),
       habilitations: knex.raw(
-        `array_agg(json_build_object('id', "complementary-certifications".id, 'name', "complementary-certifications".name) order by "complementary-certifications".id)`
+        `array_agg(json_build_object('id', "complementary-certifications".id, 'label', "complementary-certifications".label, 'key', "complementary-certifications".key) order by "complementary-certifications".id)`
       ),
     })
     .from('certification-centers')

--- a/api/lib/infrastructure/repositories/complementary-certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-course-repository.js
@@ -1,7 +1,7 @@
 const { knex } = require('../bookshelf');
 
 module.exports = {
-  async getComplementaryCertificationCourseId({ certificationCourseId, complementaryCertificationName }) {
+  async getComplementaryCertificationCourseId({ certificationCourseId, complementaryCertificationKey }) {
     const result = await knex
       .from('complementary-certification-courses')
       .select('complementary-certification-courses.id')
@@ -10,7 +10,7 @@ module.exports = {
         'complementary-certifications.id',
         'complementary-certification-courses.complementaryCertificationId'
       )
-      .where({ certificationCourseId, name: complementaryCertificationName })
+      .where({ certificationCourseId, key: complementaryCertificationKey })
       .first();
 
     return result?.id;

--- a/api/lib/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-repository.js
@@ -9,7 +9,7 @@ function _toDomain(row) {
 
 module.exports = {
   async findAll() {
-    const result = await knex.from('complementary-certifications').select('id', 'name').orderBy('id', 'asc');
+    const result = await knex.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
 
     return result.map(_toDomain);
   },

--- a/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-scoring-repository.js
@@ -108,7 +108,7 @@ async function _getLatestPixScoreByCertificationCourseId(certificationCourseId) 
 async function _getMinimumReproducibilityRateAndMinimumEarnedPix() {
   const { minimumReproducibilityRate, minimumEarnedPix } = await knex('complementary-certifications')
     .select('minimumReproducibilityRate', 'minimumEarnedPix')
-    .where({ name: ComplementaryCertification.CLEA })
+    .where({ key: ComplementaryCertification.CLEA })
     .first();
 
   return {

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -53,7 +53,7 @@ module.exports = {
       .select('certification-candidates.*')
       .select({
         complementaryCertifications: knex.raw(`
-        json_agg(json_build_object('id', "complementary-certifications"."id", 'name', "complementary-certifications"."name"))
+        json_agg(json_build_object('id', "complementary-certifications"."id", 'label', "complementary-certifications"."label", 'key', "complementary-certifications"."key"))
         `),
       })
       .from('certification-candidates')

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
@@ -27,7 +27,7 @@ module.exports = {
       habilitations: {
         include: true,
         ref: 'id',
-        attributes: ['name'],
+        attributes: ['key', 'label'],
       },
       meta,
     }).serialize(certificationCenters);

--- a/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/complementary-certification-serializer.js
@@ -4,14 +4,15 @@ const ComplementaryCertification = require('../../../domain/models/Complementary
 module.exports = {
   serialize(habilitation) {
     return new Serializer('habilitation', {
-      attributes: ['name'],
+      attributes: ['label', 'key'],
     }).serialize(habilitation);
   },
 
   deserialize(jsonAPI) {
     return new ComplementaryCertification({
       id: jsonAPI.data.id,
-      name: jsonAPI.data.attributes.name,
+      label: jsonAPI.data.attributes.label,
+      key: jsonAPI.data.attributes.key,
     });
   },
 };

--- a/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
@@ -184,10 +184,12 @@ describe('Acceptance | API | Certifications candidates', function () {
       });
 
       const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        name: ComplementaryCertification.CLEA,
+        key: ComplementaryCertification.CLEA,
+        label: 'CléA Numérique',
       });
       const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_DROIT,
+        key: ComplementaryCertification.PIX_PLUS_DROIT,
+        label: 'Pix+ Droit',
       });
       databaseBuilder.factory.buildComplementaryCertificationSubscription({
         certificationCandidateId: candidate.id,
@@ -219,11 +221,13 @@ describe('Acceptance | API | Certifications candidates', function () {
           'non-eligible-subscriptions': [
             {
               id: cleaComplementaryCertification.id,
-              name: 'CléA Numérique',
+              label: 'CléA Numérique',
+              key: ComplementaryCertification.CLEA,
             },
             {
               id: pixPlusDroitComplementaryCertification.id,
-              name: 'Pix+ Droit',
+              label: 'Pix+ Droit',
+              key: ComplementaryCertification.PIX_PLUS_DROIT,
             },
           ],
         },

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -51,7 +51,8 @@ describe('Acceptance | API | Certification Center', function () {
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 12,
-          name: 'Pix+Edu',
+          label: 'Pix+Edu 1er degré',
+          key: 'EDU_1ER_DEGRE',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -119,7 +120,8 @@ describe('Acceptance | API | Certification Center', function () {
               id: '12',
               type: 'habilitations',
               attributes: {
-                name: 'Pix+Edu',
+                label: 'Pix+Edu 1er degré',
+                key: 'EDU_1ER_DEGRE',
               },
             },
           ],

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -5,6 +5,7 @@ const {
   generateValidRequestAuthorizationHeader,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
+const { CLEA, PIX_PLUS_EDU_1ER_DEGRE } = require('../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Acceptance | API | complementary-certification-controller', function () {
   let server;
@@ -27,12 +28,12 @@ describe('Acceptance | API | complementary-certification-controller', function (
       databaseBuilder.factory.buildComplementaryCertification({
         id: 1,
         label: 'Pix+ Edu 1er degré',
-        key: 'EDU_1ER_DEGRE',
+        key: PIX_PLUS_EDU_1ER_DEGRE,
       });
       databaseBuilder.factory.buildComplementaryCertification({
         id: 2,
         label: 'Cléa Numérique',
-        key: 'CLEA',
+        key: CLEA,
       });
       await databaseBuilder.commit();
 
@@ -48,7 +49,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
             id: '1',
             attributes: {
               label: 'Pix+ Edu 1er degré',
-              key: 'EDU_1ER_DEGRE',
+              key: PIX_PLUS_EDU_1ER_DEGRE,
             },
           },
           {
@@ -56,7 +57,7 @@ describe('Acceptance | API | complementary-certification-controller', function (
             id: '2',
             attributes: {
               label: 'Cléa Numérique',
-              key: 'CLEA',
+              key: CLEA,
             },
           },
         ],

--- a/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certifications/complementary-certification-controller_test.js
@@ -26,11 +26,13 @@ describe('Acceptance | API | complementary-certification-controller', function (
       };
       databaseBuilder.factory.buildComplementaryCertification({
         id: 1,
-        name: 'Pix+Edu',
+        label: 'Pix+ Edu 1er degré',
+        key: 'EDU_1ER_DEGRE',
       });
       databaseBuilder.factory.buildComplementaryCertification({
         id: 2,
-        name: 'Cléa Numérique',
+        label: 'Cléa Numérique',
+        key: 'CLEA',
       });
       await databaseBuilder.commit();
 
@@ -45,14 +47,16 @@ describe('Acceptance | API | complementary-certification-controller', function (
             type: 'habilitations',
             id: '1',
             attributes: {
-              name: 'Pix+Edu',
+              label: 'Pix+ Edu 1er degré',
+              key: 'EDU_1ER_DEGRE',
             },
           },
           {
             type: 'habilitations',
             id: '2',
             attributes: {
-              name: 'Cléa Numérique',
+              label: 'Cléa Numérique',
+              key: 'CLEA',
             },
           },
         ],

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -1,4 +1,10 @@
 const { expect, databaseBuilder, catchErr, domainBuilder } = require('../../../../test-helper');
+const {
+  CLEA,
+  PIX_PLUS_DROIT,
+  PIX_PLUS_EDU_1ER_DEGRE,
+  PIX_PLUS_EDU_2ND_DEGRE,
+} = require('../../../../../lib/domain/models/ComplementaryCertification');
 const certificationCandidatesOdsService = require('../../../../../lib/domain/services/certification-candidates-ods-service');
 const certificationCpfService = require('../../../../../lib/domain/services/certification-cpf-service');
 const certificationCpfCountryRepository = require('../../../../../lib/infrastructure/repositories/certification-cpf-country-repository');
@@ -185,16 +191,20 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     it('should return extracted and validated certification candidates with complementary certifications', async function () {
       // given
       const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'CléA Numérique',
+        label: 'CléA Numérique',
+        key: CLEA,
       });
       const pixPlusDroitComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Droit',
+        label: 'Pix+ Droit',
+        key: PIX_PLUS_DROIT,
       });
       const pixPlusEdu1erDegreComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Édu 1er degré',
+        label: 'Pix+ Édu 1er degré',
+        key: PIX_PLUS_EDU_1ER_DEGRE,
       });
       const pixPlusEdu2ndDegreComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Édu 2nd degré',
+        label: 'Pix+ Édu 2nd degré',
+        key: PIX_PLUS_EDU_2ND_DEGRE,
       });
 
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -298,10 +298,12 @@ describe('Integration | Repository | CertificationCandidate', function () {
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
         const rockCertification = databaseBuilder.factory.buildComplementaryCertification({
-          name: 'Pix+Rock',
+          label: 'Pix+Rock',
+          key: 'ROCK',
         });
         const jazzCertification = databaseBuilder.factory.buildComplementaryCertification({
-          name: 'Pix+Jazz',
+          label: 'Pix+Jazz',
+          key: 'JAZZ',
         });
         const matthieuChedid = databaseBuilder.factory.buildCertificationCandidate({
           lastName: 'Chedid',
@@ -346,15 +348,15 @@ describe('Integration | Repository | CertificationCandidate', function () {
         expect(firstCandidate.firstName).to.equal('Louis');
         expect(firstCandidate.lastName).to.equal('Chedid');
         expect(firstCandidate.complementaryCertifications[0]).to.deepEqualInstance(
-          new ComplementaryCertification({ id: rockCertification.id, name: 'Pix+Rock' })
+          new ComplementaryCertification({ id: rockCertification.id, label: 'Pix+Rock', key: 'ROCK' })
         );
         expect(firstCandidate.complementaryCertifications[1]).to.deepEqualInstance(
-          new ComplementaryCertification({ id: jazzCertification.id, name: 'Pix+Jazz' })
+          new ComplementaryCertification({ id: jazzCertification.id, label: 'Pix+Jazz', key: 'JAZZ' })
         );
         expect(secondCandidate.firstName).to.equal('Matthieu');
         expect(secondCandidate.lastName).to.equal('Chedid');
         expect(secondCandidate.complementaryCertifications[0]).to.deepEqualInstance(
-          new ComplementaryCertification({ id: rockCertification.id, name: 'Pix+Rock' })
+          new ComplementaryCertification({ id: rockCertification.id, label: 'Pix+Rock', key: 'ROCK' })
         );
 
         expect(thirdCandidate.firstName).to.equal('Hancock');

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -63,11 +63,13 @@ describe('Integration | Repository | Certification Center', function () {
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 12345,
-          name: 'Complementary certification test 1',
+          label: 'Complementary certification test 1',
+          key: 'COMP_1',
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 6789,
-          name: 'Complementary certification test 2',
+          label: 'Complementary certification test 2',
+          key: 'COMP_2',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -80,11 +82,13 @@ describe('Integration | Repository | Certification Center', function () {
 
         const expectedComplementaryCertification1 = domainBuilder.buildComplementaryCertification({
           id: 12345,
-          name: 'Complementary certification test 1',
+          label: 'Complementary certification test 1',
+          key: 'COMP_1',
         });
         const expectedComplementaryCertification2 = domainBuilder.buildComplementaryCertification({
           id: 6789,
-          name: 'Complementary certification test 2',
+          label: 'Complementary certification test 2',
+          key: 'COMP_2',
         });
         const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
           id: 1,
@@ -161,7 +165,8 @@ describe('Integration | Repository | Certification Center', function () {
         }).id;
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1234,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -170,7 +175,8 @@ describe('Integration | Repository | Certification Center', function () {
 
         const expectedComplementaryCertification = domainBuilder.buildComplementaryCertification({
           id: 1234,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
           id: 1,
@@ -260,7 +266,8 @@ describe('Integration | Repository | Certification Center', function () {
         }).id;
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1234,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -269,7 +276,8 @@ describe('Integration | Repository | Certification Center', function () {
 
         const expectedComplementaryCertification = domainBuilder.buildComplementaryCertification({
           id: 1234,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
           id: 1,
@@ -441,7 +449,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 11,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -449,7 +458,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         const expectedComplementaryCertification1 = domainBuilder.buildComplementaryCertification({
           id: 11,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         const expectedCertificationCenter1 = domainBuilder.buildCertificationCenter({
           id: 1,
@@ -470,7 +480,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 22,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 2,
@@ -478,7 +489,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         const expectedComplementaryCertification2 = domainBuilder.buildComplementaryCertification({
           id: 22,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         const expectedCertificationCenter2 = domainBuilder.buildCertificationCenter({
           id: 2,
@@ -499,7 +511,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 33,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 3,
@@ -507,7 +520,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         const expectedComplementaryCertification3 = domainBuilder.buildComplementaryCertification({
           id: 33,
-          name: 'Complementary certification name',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         const expectedCertificationCenter3 = domainBuilder.buildCertificationCenter({
           id: 3,
@@ -721,7 +735,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 123,
-          name: 'Complementary certification test',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -729,7 +744,8 @@ describe('Integration | Repository | Certification Center', function () {
         });
         const expectedComplementaryCertification = domainBuilder.buildComplementaryCertification({
           id: 123,
-          name: 'Complementary certification test',
+          label: 'Complementary certification name',
+          key: 'COMP',
         });
         const expectedCertificationCenter = domainBuilder.buildCertificationCenter({
           id: 1,

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -229,9 +229,9 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
 
     it('should return all the certification center habilitations', async function () {
       // given
-      databaseBuilder.factory.buildComplementaryCertification({ id: 1, name: 'Certif comp 1' });
-      databaseBuilder.factory.buildComplementaryCertification({ id: 2, name: 'Certif comp 2' });
-      databaseBuilder.factory.buildComplementaryCertification({ id: 3, name: 'Certif comp 3' });
+      databaseBuilder.factory.buildComplementaryCertification({ id: 1, label: 'Certif comp 1', key: 'COMP_1' });
+      databaseBuilder.factory.buildComplementaryCertification({ id: 2, label: 'Certif comp 2', key: 'COMP_2' });
+      databaseBuilder.factory.buildComplementaryCertification({ id: 3, label: 'Certif comp 3', key: 'COMP_3' });
       databaseBuilder.factory.buildCertificationCenter({
         id: 1,
         name: 'Centre de certif sans orga reliée',
@@ -285,8 +285,8 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
         habilitations: [
-          { id: 1, name: 'Certif comp 1' },
-          { id: 2, name: 'Certif comp 2' },
+          { id: 1, label: 'Certif comp 1', key: 'COMP_1' },
+          { id: 2, label: 'Certif comp 2', key: 'COMP_2' },
         ],
       });
       const expectedSecondAllowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
@@ -296,7 +296,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         type: CertificationCenter.types.PRO,
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
-        habilitations: [{ id: 3, name: 'Certif comp 3' }],
+        habilitations: [{ id: 3, label: 'Certif comp 3', key: 'COMP_3' }],
       });
       const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({
         id: 123,
@@ -317,8 +317,8 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
       function () {
         it('should return the certification point of contact with tags and habilitations', async function () {
           // given
-          databaseBuilder.factory.buildComplementaryCertification({ id: 1, name: 'Certif comp 1' });
-          databaseBuilder.factory.buildComplementaryCertification({ id: 2, name: 'Certif comp 2' });
+          databaseBuilder.factory.buildComplementaryCertification({ id: 1, label: 'Certif comp 1', key: 'COMP_1' });
+          databaseBuilder.factory.buildComplementaryCertification({ id: 2, label: 'Certif comp 2', key: 'COMP_2' });
           databaseBuilder.factory.buildCertificationCenter({
             id: 1,
             name: 'Centre de certif',
@@ -380,8 +380,8 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
             isRelatedToManagingStudentsOrganization: false,
             relatedOrganizationTags: ['tag1', 'tag2'],
             habilitations: [
-              { id: 1, name: 'Certif comp 1' },
-              { id: 2, name: 'Certif comp 2' },
+              { id: 1, label: 'Certif comp 1', key: 'COMP_1' },
+              { id: 2, label: 'Certif comp 2', key: 'COMP_2' },
             ],
           });
           const expectedCertificationPointOfContact = domainBuilder.buildCertificationPointOfContact({

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
@@ -8,11 +8,13 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // given
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          name: 'Pix+Edu',
+          label: 'Pix+ Edu 1er degré',
+          key: 'EDU_1ER_DEGRE',
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
-          name: 'Pix+Droit',
+          label: 'Pix+ Droit',
+          key: 'DROIT',
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -26,7 +28,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // when
         const hasPixPlusDroit = await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
           certificationCourseId: 99,
-          complementaryCertificationName: 'Pix+Droit',
+          complementaryCertificationKey: 'DROIT',
         });
 
         // then
@@ -39,11 +41,13 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // given
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          name: 'Pix+Edu',
+          label: 'Pix+ Edu',
+          key: 'EDU_1ER_DEGRE',
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
-          name: 'Pix+Droit',
+          label: 'Pix+ Droit',
+          key: 'DROIT',
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -56,7 +60,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // when
         const hasPixPlusDroit = await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
           certificationCourseId: 99,
-          complementaryCertificationName: 'Pix+Droit',
+          complementaryCertificationKey: 'DROIT',
         });
 
         // then
@@ -69,7 +73,8 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // given
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
-          name: 'Pix+Droit',
+          label: 'Pix+ Droit',
+          key: 'DROIT',
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildCertificationCourse({ id: 98 });
@@ -83,7 +88,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // when
         const hasPixPlusDroit = await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
           certificationCourseId: 99,
-          complementaryCertificationName: 'Pix+Droit',
+          complementaryCertificationKey: 'DROIT',
         });
 
         // then

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
@@ -1,5 +1,6 @@
 const { expect, databaseBuilder } = require('../../../test-helper');
 const complementaryCertificationCourseRepository = require('../../../../lib/infrastructure/repositories/complementary-certification-course-repository');
+const { PIX_PLUS_DROIT, PIX_PLUS_EDU_1ER_DEGRE } = require('../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Integration | Repository | complementary-certification-courses-repository', function () {
   describe('#getComplementaryCertificationCourseId', function () {
@@ -9,12 +10,12 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
           label: 'Pix+ Edu 1er degré',
-          key: 'EDU_1ER_DEGRE',
+          key: PIX_PLUS_EDU_1ER_DEGRE,
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
           label: 'Pix+ Droit',
-          key: 'DROIT',
+          key: PIX_PLUS_DROIT,
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -28,7 +29,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // when
         const hasPixPlusDroit = await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
           certificationCourseId: 99,
-          complementaryCertificationKey: 'DROIT',
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         });
 
         // then
@@ -42,12 +43,12 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
           label: 'Pix+ Edu',
-          key: 'EDU_1ER_DEGRE',
+          key: PIX_PLUS_EDU_1ER_DEGRE,
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
           label: 'Pix+ Droit',
-          key: 'DROIT',
+          key: PIX_PLUS_DROIT,
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -60,7 +61,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // when
         const hasPixPlusDroit = await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
           certificationCourseId: 99,
-          complementaryCertificationKey: 'DROIT',
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         });
 
         // then
@@ -74,7 +75,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
           label: 'Pix+ Droit',
-          key: 'DROIT',
+          key: PIX_PLUS_DROIT,
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildCertificationCourse({ id: 98 });
@@ -88,7 +89,7 @@ describe('Integration | Repository | complementary-certification-courses-reposit
         // when
         const hasPixPlusDroit = await complementaryCertificationCourseRepository.getComplementaryCertificationCourseId({
           certificationCourseId: 99,
-          complementaryCertificationKey: 'DROIT',
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         });
 
         // then

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-repository_test.js
@@ -8,15 +8,23 @@ describe('Integration | Repository | complementary-certification-repository', fu
         // given
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          name: 'Pix+Edu',
+          key: 'EDU_1ER_DEGRE',
+          label: 'Pix+ Édu 1er degré',
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 2,
-          name: 'Pix+Droit',
+          key: 'EDU_2ND_DEGRE',
+          label: 'Pix+ Édu 2nd degré',
         });
         databaseBuilder.factory.buildComplementaryCertification({
           id: 3,
-          name: 'CléA Numérique',
+          key: 'DROIT',
+          label: 'Pix+ Droit',
+        });
+        databaseBuilder.factory.buildComplementaryCertification({
+          id: 4,
+          key: 'CLEA',
+          label: 'CléA Numérique',
         });
 
         await databaseBuilder.commit();
@@ -28,15 +36,23 @@ describe('Integration | Repository | complementary-certification-repository', fu
         const expectedComplementaryCertifications = [
           domainBuilder.buildComplementaryCertification({
             id: 1,
-            name: 'Pix+Edu',
+            key: 'EDU_1ER_DEGRE',
+            label: 'Pix+ Édu 1er degré',
           }),
           domainBuilder.buildComplementaryCertification({
             id: 2,
-            name: 'Pix+Droit',
+            key: 'EDU_2ND_DEGRE',
+            label: 'Pix+ Édu 2nd degré',
           }),
           domainBuilder.buildComplementaryCertification({
             id: 3,
-            name: 'CléA Numérique',
+            key: 'DROIT',
+            label: 'Pix+ Droit',
+          }),
+          domainBuilder.buildComplementaryCertification({
+            id: 4,
+            key: 'CLEA',
+            label: 'CléA Numérique',
           }),
         ];
 

--- a/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-scoring-repository_test.js
@@ -255,7 +255,7 @@ describe('Integration | Repository | Partner Certification Scoring', function ()
             createdAt: new Date('2020-01-01'),
           });
           databaseBuilder.factory.buildComplementaryCertification({
-            name: ComplementaryCertification.CLEA,
+            key: ComplementaryCertification.CLEA,
             minimumReproducibilityRate: 66.5,
             minimumEarnedPix: 33,
           });

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -246,9 +246,15 @@ describe('Integration | Repository | Session', function () {
     it('should return candidates complementary certifications', async function () {
       // given
       const session = databaseBuilder.factory.buildSession();
-      const pixPlusFoot = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+Foot' });
-      const pixPlusRugby = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+Rugby' });
-      const pixPlusTennis = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+Tennis' });
+      const pixPlusFoot = databaseBuilder.factory.buildComplementaryCertification({ label: 'Pix+ Foot', key: 'FOOT' });
+      const pixPlusRugby = databaseBuilder.factory.buildComplementaryCertification({
+        label: 'Pix+ Rugby',
+        key: 'RUGBY',
+      });
+      const pixPlusTennis = databaseBuilder.factory.buildComplementaryCertification({
+        label: 'Pix+ Tennis',
+        key: 'TENNIS',
+      });
       const firstCandidate = databaseBuilder.factory.buildCertificationCandidate({
         lastName: 'Jackson',
         firstName: 'Michael',

--- a/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
@@ -128,7 +128,10 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
       expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification-sco.ods`;
       actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification-sco.tmp.ods`;
 
-      const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
+      const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'CLEA',
+        label: 'CléA Numérique',
+      });
 
       const certificationCenterName = 'Centre de certification';
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
@@ -218,13 +221,21 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
       expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-all-complementary-certifications-sco.ods`;
       actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-all-complementary-certifications-sco.tmp.ods`;
 
-      const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
-      const pixPlusDroit = databaseBuilder.factory.buildComplementaryCertification({ name: 'Pix+ Droit' });
+      const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'CLEA',
+        label: 'CléA Numérique',
+      });
+      const pixPlusDroit = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'DROIT',
+        label: 'Pix+ Droit',
+      });
       const pixPlusEdu1erDegre = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Édu 1er degré',
+        key: 'EDU_1ER_DEGRE',
+        label: 'Pix+ Édu 1er degré',
       });
       const pixPlusEdu2ndDegre = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Édu 2nd degré',
+        key: 'EDU_2ND_DEGRE',
+        label: 'Pix+ Édu 2nd degré',
       });
 
       const certificationCenterName = 'Centre de certification';
@@ -452,7 +463,10 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
         expectedOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-billing-columns-complementary.ods`;
         actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-billing-columns-complementary.tmp.ods`;
 
-        const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({ name: 'CléA Numérique' });
+        const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({
+          key: 'CLEA',
+          label: 'CléA Numérique',
+        });
 
         const certificationCenterName = 'Centre de certification';
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({

--- a/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
@@ -4,6 +4,12 @@ const { expect, databaseBuilder } = require('../../../../../test-helper');
 const readOdsUtils = require('../../../../../../lib/infrastructure/utils/ods/read-ods-utils');
 const fillCandidatesImportSheet = require('../../../../../../lib/infrastructure/files/candidates-import/fill-candidates-import-sheet');
 const usecases = require('../../../../../../lib/domain/usecases');
+const {
+  PIX_PLUS_DROIT,
+  CLEA,
+  PIX_PLUS_EDU_1ER_DEGRE,
+  PIX_PLUS_EDU_2ND_DEGRE,
+} = require('../../../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet', function () {
   let userId;
@@ -129,7 +135,7 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
       actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-one-complementary-certification-sco.tmp.ods`;
 
       const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({
-        key: 'CLEA',
+        key: CLEA,
         label: 'CléA Numérique',
       });
 
@@ -222,19 +228,19 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
       actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-all-complementary-certifications-sco.tmp.ods`;
 
       const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({
-        key: 'CLEA',
+        key: CLEA,
         label: 'CléA Numérique',
       });
       const pixPlusDroit = databaseBuilder.factory.buildComplementaryCertification({
-        key: 'DROIT',
+        key: PIX_PLUS_DROIT,
         label: 'Pix+ Droit',
       });
       const pixPlusEdu1erDegre = databaseBuilder.factory.buildComplementaryCertification({
-        key: 'EDU_1ER_DEGRE',
+        key: PIX_PLUS_EDU_1ER_DEGRE,
         label: 'Pix+ Édu 1er degré',
       });
       const pixPlusEdu2ndDegre = databaseBuilder.factory.buildComplementaryCertification({
-        key: 'EDU_2ND_DEGRE',
+        key: PIX_PLUS_EDU_2ND_DEGRE,
         label: 'Pix+ Édu 2nd degré',
       });
 
@@ -464,7 +470,7 @@ describe('Integration | Infrastructure | Utils | Ods | fillCandidatesImportSheet
         actualOdsFilePath = `${__dirname}/1.5/candidates_import_template-with-billing-columns-complementary.tmp.ods`;
 
         const cleaNumerique = databaseBuilder.factory.buildComplementaryCertification({
-          key: 'CLEA',
+          key: CLEA,
           label: 'CléA Numérique',
         });
 

--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -96,10 +96,10 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
                 centerType: type,
                 candidateNumber: 2,
                 complementaryCertifications: [
-                  { candidateNumber: 1, name: 'CléA Numérique' },
-                  { candidateNumber: 1, name: 'Pix+ Droit' },
-                  { candidateNumber: 1, name: 'Pix+ Édu 2nd degré' },
-                  { candidateNumber: 1, name: 'Pix+ Édu 1er degré' },
+                  { candidateNumber: 1, key: 'CLEA' },
+                  { candidateNumber: 1, key: 'DROIT' },
+                  { candidateNumber: 1, key: 'EDU_1ER_DEGRE' },
+                  { candidateNumber: 1, key: 'EDU_2ND_DEGRE' },
                 ],
               });
 
@@ -185,10 +185,10 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
               centerType: 'SCO',
               candidateNumber: 2,
               complementaryCertifications: [
-                { candidateNumber: 1, name: 'CléA Numérique' },
-                { candidateNumber: 1, name: 'Pix+ Droit' },
-                { candidateNumber: 1, name: 'Pix+ Édu 2nd degré' },
-                { candidateNumber: 1, name: 'Pix+ Édu 1er degré' },
+                { candidateNumber: 1, key: 'CLEA' },
+                { candidateNumber: 1, key: 'DROIT' },
+                { candidateNumber: 1, key: 'EDU_1ER_DEGRE' },
+                { candidateNumber: 1, key: 'EDU_2ND_DEGRE' },
               ],
               isSupervisorAccessEnabled: false,
             });
@@ -219,9 +219,10 @@ describe('Integration | Scripts | generate-certif-cli.js', function () {
       key: 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME',
       targetProfileId: null,
     });
-    databaseBuilderCli.factory.buildComplementaryCertification({ id: 52, name: 'CléA Numérique' });
-    databaseBuilderCli.factory.buildComplementaryCertification({ id: 53, name: 'Pix+ Droit' });
-    databaseBuilderCli.factory.buildComplementaryCertification({ id: 54, name: 'Pix+ Édu 1er degré' });
-    databaseBuilderCli.factory.buildComplementaryCertification({ id: 55, name: 'Pix+ Édu 2nd degré' });
+
+    databaseBuilderCli.factory.buildComplementaryCertification({ id: 52, key: 'CLEA' });
+    databaseBuilderCli.factory.buildComplementaryCertification({ id: 53, key: 'DROIT' });
+    databaseBuilderCli.factory.buildComplementaryCertification({ id: 54, key: 'EDU_1ER_DEGRE' });
+    databaseBuilderCli.factory.buildComplementaryCertification({ id: 55, key: 'EDU_2ND_DEGRE' });
   }
 });

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification.js
@@ -1,8 +1,13 @@
 const ComplementaryCertification = require('../../../../lib/domain/models/ComplementaryCertification');
 
-module.exports = function buildComplementaryCertification({ id = 1, name = 'Complementary certification name' } = {}) {
+module.exports = function buildComplementaryCertification({
+  id = 1,
+  label = 'Complementary certification name',
+  key = 'COMPLEMENTARY_CERTIFICATION_KEY',
+} = {}) {
   return new ComplementaryCertification({
     id,
-    name,
+    label,
+    key,
   });
 };

--- a/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-clea-certification-scoring_test.js
@@ -156,7 +156,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
             .withArgs({
               certificationCourseId,
-              complementaryCertificationName: CLEA,
+              complementaryCertificationKey: CLEA,
             })
             .resolves(complementaryCertificationCourseId);
 
@@ -187,7 +187,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
             .withArgs({
               certificationCourseId,
-              complementaryCertificationName: CLEA,
+              complementaryCertificationKey: CLEA,
             })
             .resolves(undefined);
 
@@ -268,7 +268,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
             .withArgs({
               certificationCourseId,
-              complementaryCertificationName: CLEA,
+              complementaryCertificationKey: CLEA,
             })
             .resolves(complementaryCertificationCourseId);
 
@@ -299,7 +299,7 @@ describe('Unit | Domain | Events | handle-clea-certification-scoring', function 
           complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
             .withArgs({
               certificationCourseId,
-              complementaryCertificationName: CLEA,
+              complementaryCertificationKey: CLEA,
             })
             .resolves(undefined);
 

--- a/api/tests/unit/domain/events/handle-pix-plus-droit-certifications-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-pix-plus-droit-certifications-scoring_test.js
@@ -63,7 +63,7 @@ describe('Unit | Domain | Events | handle-pix-plus-droit-certifications-scoring'
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_DROIT,
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         })
         .resolves(false);
 
@@ -102,7 +102,7 @@ describe('Unit | Domain | Events | handle-pix-plus-droit-certifications-scoring'
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_DROIT,
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         })
         .resolves(999);
 
@@ -188,7 +188,7 @@ describe('Unit | Domain | Events | handle-pix-plus-droit-certifications-scoring'
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_DROIT,
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         })
         .resolves(complementaryCertificationCourseId);
 
@@ -241,7 +241,7 @@ describe('Unit | Domain | Events | handle-pix-plus-droit-certifications-scoring'
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_DROIT,
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         })
         .resolves(999);
 
@@ -293,7 +293,7 @@ describe('Unit | Domain | Events | handle-pix-plus-droit-certifications-scoring'
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_DROIT,
+          complementaryCertificationKey: PIX_PLUS_DROIT,
         })
         .resolves(999);
 

--- a/api/tests/unit/domain/events/handle-pix-plus-edu-1er-degre-certifications-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-pix-plus-edu-1er-degre-certifications-scoring_test.js
@@ -81,7 +81,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-1er-degre-certifications-
         complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
           .withArgs({
             certificationCourseId: 123,
-            complementaryCertificationName: PIX_PLUS_EDU_1ER_DEGRE,
+            complementaryCertificationKey: PIX_PLUS_EDU_1ER_DEGRE,
           })
           .resolves(999);
 
@@ -128,7 +128,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-1er-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_1ER_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_1ER_DEGRE,
         })
         .resolves(999);
 
@@ -168,7 +168,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-1er-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_1ER_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_1ER_DEGRE,
         })
         .resolves(999);
 
@@ -221,7 +221,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-1er-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_1ER_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_1ER_DEGRE,
         })
         .resolves(999);
 
@@ -273,7 +273,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-1er-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_1ER_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_1ER_DEGRE,
         })
         .resolves(999);
 

--- a/api/tests/unit/domain/events/handle-pix-plus-edu-2nd-degre-certifications-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-pix-plus-edu-2nd-degre-certifications-scoring_test.js
@@ -81,7 +81,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-2nd-degre-certifications-
         complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
           .withArgs({
             certificationCourseId: 123,
-            complementaryCertificationName: PIX_PLUS_EDU_2ND_DEGRE,
+            complementaryCertificationKey: PIX_PLUS_EDU_2ND_DEGRE,
           })
           .resolves(999);
 
@@ -128,7 +128,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-2nd-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_2ND_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_2ND_DEGRE,
         })
         .resolves(999);
 
@@ -168,7 +168,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-2nd-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_2ND_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_2ND_DEGRE,
         })
         .resolves(999);
 
@@ -221,7 +221,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-2nd-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_2ND_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_2ND_DEGRE,
         })
         .resolves(999);
 
@@ -273,7 +273,7 @@ describe('Unit | Domain | Events | handle-pix-plus-edu-2nd-degre-certifications-
       complementaryCertificationCourseRepository.getComplementaryCertificationCourseId
         .withArgs({
           certificationCourseId: 123,
-          complementaryCertificationName: PIX_PLUS_EDU_2ND_DEGRE,
+          complementaryCertificationKey: PIX_PLUS_EDU_2ND_DEGRE,
         })
         .resolves(999);
 

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -616,7 +616,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return true when certification candidate has acquired PIX+ Droit complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: PIX_PLUS_DROIT })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: PIX_PLUS_DROIT })],
       });
 
       // then
@@ -626,7 +626,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return false when certification candidate has not acquired PIX+ Droit complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: 'toto' })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: 'toto' })],
       });
 
       // then
@@ -638,7 +638,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return true when certification candidate has acquired CleA complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: CLEA })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: CLEA })],
       });
 
       // then
@@ -648,7 +648,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return false when certification candidate has not acquired CleA complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: 'toto' })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: 'toto' })],
       });
 
       // then
@@ -660,7 +660,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return true when certification candidate has acquired Pix+ Edu 1er degre complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: PIX_PLUS_EDU_1ER_DEGRE })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: PIX_PLUS_EDU_1ER_DEGRE })],
       });
 
       // then
@@ -670,7 +670,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return false when certification candidate has not acquired Pix+ Edu 1er degre complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: 'toto' })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: 'toto' })],
       });
 
       // then
@@ -682,7 +682,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return true when certification candidate has acquired Pix+ Edu 2nd degre complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: PIX_PLUS_EDU_2ND_DEGRE })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: PIX_PLUS_EDU_2ND_DEGRE })],
       });
 
       // then
@@ -692,7 +692,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return false when certification candidate has not acquired Pix+ Edu 2nd degre complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
-        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ name: 'toto' })],
+        complementaryCertifications: [domainBuilder.buildComplementaryCertification({ key: 'toto' })],
       });
 
       // then

--- a/api/tests/unit/domain/models/CertificationCenter_test.js
+++ b/api/tests/unit/domain/models/CertificationCenter_test.js
@@ -1,4 +1,10 @@
 const { expect, domainBuilder } = require('../../../test-helper');
+const {
+  PIX_PLUS_DROIT,
+  CLEA,
+  PIX_PLUS_EDU_1ER_DEGRE,
+  PIX_PLUS_EDU_2ND_DEGRE,
+} = require('../../../../lib/domain/models/ComplementaryCertification');
 
 describe('Unit | Domain | Models | CertificationCenter', function () {
   describe('#isSco', function () {
@@ -31,7 +37,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Pix+ Droit complementary certification', function () {
       // given
       const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        key: 'DROIT',
+        key: PIX_PLUS_DROIT,
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [pixPlusDroitComplementaryCertification],
@@ -54,7 +60,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Pix+ Edu 1er degre habilitation', function () {
       // given
       const pixPlusEdu1erDegreComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        key: 'EDU_1ER_DEGRE',
+        key: PIX_PLUS_EDU_1ER_DEGRE,
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [pixPlusEdu1erDegreComplementaryCertification],
@@ -77,7 +83,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Pix+ Edu 2nd degre habilitation', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        key: 'EDU_2ND_DEGRE',
+        key: PIX_PLUS_EDU_2ND_DEGRE,
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [complementaryCertification],
@@ -100,7 +106,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Cléa numérique complementary certification', function () {
       // given
       const cleaComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        key: 'CLEA',
+        key: CLEA,
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [cleaComplementaryCertification],

--- a/api/tests/unit/domain/models/CertificationCenter_test.js
+++ b/api/tests/unit/domain/models/CertificationCenter_test.js
@@ -31,7 +31,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Pix+ Droit complementary certification', function () {
       // given
       const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Pix+ Droit',
+        key: 'DROIT',
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [pixPlusDroitComplementaryCertification],
@@ -54,7 +54,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Pix+ Edu 1er degre habilitation', function () {
       // given
       const pixPlusEdu1erDegreComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Pix+ Édu 1er degré',
+        key: 'EDU_1ER_DEGRE',
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [pixPlusEdu1erDegreComplementaryCertification],
@@ -77,7 +77,7 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
     it('should return true when the certification center has Pix+ Edu 2nd degre habilitation', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Pix+ Édu 2nd degré',
+        key: 'EDU_2ND_DEGRE',
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         habilitations: [complementaryCertification],
@@ -99,11 +99,11 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
 
     it('should return true when the certification center has Cléa numérique complementary certification', function () {
       // given
-      const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'CléA Numérique',
+      const cleaComplementaryCertification = domainBuilder.buildComplementaryCertification({
+        key: 'CLEA',
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
-        habilitations: [pixPlusDroitComplementaryCertification],
+        habilitations: [cleaComplementaryCertification],
       });
 
       // then

--- a/api/tests/unit/domain/models/ComplementaryCertification_test.js
+++ b/api/tests/unit/domain/models/ComplementaryCertification_test.js
@@ -6,7 +6,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return true id name equals CléA Numérique', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.CLEA,
+        key: ComplementaryCertification.CLEA,
       });
 
       // when
@@ -19,7 +19,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return false otherwise', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Not cléa',
+        key: 'Not cléa',
       });
 
       // when
@@ -34,7 +34,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return true id name equals Pix+ Droit', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_DROIT,
+        key: ComplementaryCertification.PIX_PLUS_DROIT,
       });
 
       // when
@@ -47,7 +47,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return false otherwise', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Not pix+ droit',
+        key: 'Not pix+ droit',
       });
 
       // when
@@ -62,7 +62,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return true if name equals Pix+ Édu 2nd degré', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_EDU_1ER_DEGRE,
+        key: ComplementaryCertification.PIX_PLUS_EDU_1ER_DEGRE,
       });
 
       // when
@@ -75,7 +75,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return false otherwise', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Not pix+ Édu',
+        key: 'Not pix+ Édu',
       });
 
       // when
@@ -87,10 +87,10 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
   });
 
   describe('#isPixPlusEdu2ndDegre', function () {
-    it('should return true id name equals Pix+ Édu 1er degré', function () {
+    it('should return true id key equals Pix+ Édu 1er degré', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_EDU_2ND_DEGRE,
+        key: ComplementaryCertification.PIX_PLUS_EDU_2ND_DEGRE,
       });
 
       // when
@@ -103,7 +103,7 @@ describe('Unit | Domain | Models | ComplementaryCertification', function () {
     it('should return false otherwise', function () {
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: 'Not pix+ Édu',
+        key: 'Not pix+ Édu',
       });
 
       // when

--- a/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -24,10 +24,10 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
       const sessionId = 789;
 
       const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_DROIT,
+        key: ComplementaryCertification.PIX_PLUS_DROIT,
       });
       const cleaComplementaryCertifications = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.CLEA,
+        key: ComplementaryCertification.CLEA,
       });
       const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
         id: certificationCandidateId,
@@ -76,10 +76,10 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
       const sessionId = 789;
 
       const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_DROIT,
+        key: ComplementaryCertification.PIX_PLUS_DROIT,
       });
       const cleaComplementaryCertifications = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.CLEA,
+        key: ComplementaryCertification.CLEA,
       });
       const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
         id: certificationCandidateId,
@@ -156,10 +156,10 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
       const sessionId = 789;
 
       const pixPlusDroitComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_DROIT,
+        key: ComplementaryCertification.PIX_PLUS_DROIT,
       });
       const cleaComplementaryCertifications = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.CLEA,
+        key: ComplementaryCertification.CLEA,
       });
       const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
         id: certificationCandidateId,
@@ -203,7 +203,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
       const sessionId = 789;
 
       const pixPlusEdu1erDegreComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_EDU_1ER_DEGRE,
+        key: ComplementaryCertification.PIX_PLUS_EDU_1ER_DEGRE,
       });
       const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
         id: certificationCandidateId,
@@ -249,7 +249,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
       const sessionId = 789;
 
       const pixPlusEdu2ndDegreComplementaryCertification = domainBuilder.buildComplementaryCertification({
-        name: ComplementaryCertification.PIX_PLUS_EDU_2ND_DEGRE,
+        key: ComplementaryCertification.PIX_PLUS_EDU_2ND_DEGRE,
       });
       const candidateWithComplementaryCertifications = domainBuilder.buildCertificationCandidate({
         id: certificationCandidateId,

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -471,7 +471,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             userId: 2,
                             sessionId: 1,
                             authorizedToStart: true,
-                            complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                            complementaryCertifications: [{ key: PIX_PLUS_DROIT }],
                           });
 
                           const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -485,7 +485,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             .resolves(foundCertificationCandidate);
 
                           const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_DROIT,
+                            key: PIX_PLUS_DROIT,
                           });
                           const certificationCenter = domainBuilder.buildCertificationCenter({
                             habilitations: [complementaryCertificationPixPlusDroit],
@@ -587,7 +587,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             userId: 2,
                             sessionId: 1,
                             authorizedToStart: true,
-                            complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                            complementaryCertifications: [{ key: PIX_PLUS_DROIT }],
                           });
 
                           const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -601,7 +601,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             .resolves(foundCertificationCandidate);
 
                           const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_DROIT,
+                            key: PIX_PLUS_DROIT,
                           });
                           const certificationCenter = domainBuilder.buildCertificationCenter({
                             habilitations: [complementaryCertificationPixPlusDroit],
@@ -701,7 +701,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             userId: 2,
                             sessionId: 1,
                             authorizedToStart: true,
-                            complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                            complementaryCertifications: [{ key: PIX_PLUS_DROIT }],
                           });
 
                           certificationCandidateRepository.getBySessionIdAndUserId
@@ -715,7 +715,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                           const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_DROIT,
+                            key: PIX_PLUS_DROIT,
                           });
                           const certificationCenter = domainBuilder.buildCertificationCenter({
                             habilitations: [complementaryCertificationPixPlusDroit],
@@ -850,7 +850,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                             const complementaryCertificationPixPlusDroit =
                               domainBuilder.buildComplementaryCertification({
-                                name: PIX_PLUS_DROIT,
+                                key: PIX_PLUS_DROIT,
                               });
                             const certificationCenter = domainBuilder.buildCertificationCenter({
                               habilitations: [complementaryCertificationPixPlusDroit],
@@ -946,7 +946,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                          complementaryCertifications: [{ key: PIX_PLUS_DROIT }],
                         });
 
                         certificationCandidateRepository.getBySessionIdAndUserId
@@ -960,7 +960,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                         const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                          name: PIX_PLUS_DROIT,
+                          key: PIX_PLUS_DROIT,
                         });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationPixPlusDroit],
@@ -1038,7 +1038,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: PIX_PLUS_DROIT }],
+                          complementaryCertifications: [{ key: PIX_PLUS_DROIT }],
                         });
 
                         certificationCandidateRepository.getBySessionIdAndUserId
@@ -1052,7 +1052,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                         const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                          name: PIX_PLUS_DROIT,
+                          key: PIX_PLUS_DROIT,
                         });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationPixPlusDroit],
@@ -1135,7 +1135,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                       const complementaryCertificationPixPlusDroit = domainBuilder.buildComplementaryCertification({
-                        name: PIX_PLUS_DROIT,
+                        key: PIX_PLUS_DROIT,
                       });
                       const certificationCenter = domainBuilder.buildCertificationCenter({
                         habilitations: [complementaryCertificationPixPlusDroit],
@@ -1215,7 +1215,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             userId: 2,
                             sessionId: 1,
                             authorizedToStart: true,
-                            complementaryCertifications: [{ name: CLEA }],
+                            complementaryCertifications: [{ key: CLEA }],
                           });
 
                           certificationCandidateRepository.getBySessionIdAndUserId
@@ -1229,7 +1229,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                           const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                            name: CLEA,
+                            key: CLEA,
                           });
                           const certificationCenter = domainBuilder.buildCertificationCenter({
                             habilitations: [complementaryCertificationCleA],
@@ -1307,7 +1307,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: CLEA }],
+                          complementaryCertifications: [{ key: CLEA }],
                         });
 
                         certificationCandidateRepository.getBySessionIdAndUserId
@@ -1321,7 +1321,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                         const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                          name: CLEA,
+                          key: CLEA,
                         });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationCleA],
@@ -1432,7 +1432,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                             .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                           const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                            name: CLEA,
+                            key: CLEA,
                           });
                           const certificationCenter = domainBuilder.buildCertificationCenter({
                             habilitations: [complementaryCertificationCleA],
@@ -1526,7 +1526,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           .resolves(_.flatMap(userCompetencesWithChallenges, 'challenges'));
 
                         const complementaryCertificationCleA = domainBuilder.buildComplementaryCertification({
-                          name: CLEA,
+                          key: CLEA,
                         });
                         const certificationCenter = domainBuilder.buildCertificationCenter();
                         certificationCenterRepository.getBySessionId.resolves(certificationCenter);
@@ -1610,7 +1610,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: PIX_PLUS_EDU_1ER_DEGRE }],
+                          complementaryCertifications: [{ key: PIX_PLUS_EDU_1ER_DEGRE }],
                         });
 
                         const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -1625,7 +1625,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         const complementaryCertificationPixPlusEdu1erDegre =
                           domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_EDU_1ER_DEGRE,
+                            key: PIX_PLUS_EDU_1ER_DEGRE,
                           });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationPixPlusEdu1erDegre],
@@ -1728,7 +1728,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: PIX_PLUS_EDU_1ER_DEGRE }],
+                          complementaryCertifications: [{ key: PIX_PLUS_EDU_1ER_DEGRE }],
                         });
 
                         const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -1743,7 +1743,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         const complementaryCertificationPixPlusEdu1erDegre =
                           domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_EDU_1ER_DEGRE,
+                            key: PIX_PLUS_EDU_1ER_DEGRE,
                           });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationPixPlusEdu1erDegre],
@@ -1860,7 +1860,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                       const complementaryCertificationPixPlusEdu1erDegre =
                         domainBuilder.buildComplementaryCertification({
-                          name: PIX_PLUS_EDU_1ER_DEGRE,
+                          key: PIX_PLUS_EDU_1ER_DEGRE,
                         });
                       const certificationCenter = domainBuilder.buildCertificationCenter({
                         habilitations: [],
@@ -1943,7 +1943,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: PIX_PLUS_EDU_2ND_DEGRE }],
+                          complementaryCertifications: [{ key: PIX_PLUS_EDU_2ND_DEGRE }],
                         });
 
                         const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -1958,7 +1958,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         const complementaryCertificationPixPlusEdu2ndDegre =
                           domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_EDU_2ND_DEGRE,
+                            key: PIX_PLUS_EDU_2ND_DEGRE,
                           });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationPixPlusEdu2ndDegre],
@@ -2061,7 +2061,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
-                          complementaryCertifications: [{ name: PIX_PLUS_EDU_2ND_DEGRE }],
+                          complementaryCertifications: [{ key: PIX_PLUS_EDU_2ND_DEGRE }],
                         });
 
                         const { challenge1, challenge2, placementProfile, userCompetencesWithChallenges } =
@@ -2076,7 +2076,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         const complementaryCertificationPixPlusEdu2ndDegre =
                           domainBuilder.buildComplementaryCertification({
-                            name: PIX_PLUS_EDU_2ND_DEGRE,
+                            key: PIX_PLUS_EDU_2ND_DEGRE,
                           });
                         const certificationCenter = domainBuilder.buildCertificationCenter({
                           habilitations: [complementaryCertificationPixPlusEdu2ndDegre],
@@ -2193,7 +2193,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                       const complementaryCertificationPixPlusEdu2ndDegre =
                         domainBuilder.buildComplementaryCertification({
-                          name: PIX_PLUS_EDU_2ND_DEGRE,
+                          key: PIX_PLUS_EDU_2ND_DEGRE,
                         });
                       const certificationCenter = domainBuilder.buildCertificationCenter({
                         habilitations: [],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -13,7 +13,8 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
       complementaryCertifications: [
         domainBuilder.buildComplementaryCertification({
           id: 2,
-          name: 'Pix+Patisserie',
+          label: 'Pix+Patisserie',
+          key: 'PATISSERIE',
         }),
       ],
     });
@@ -48,7 +49,8 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
             'complementary-certifications': [
               {
                 id: 2,
-                name: 'Pix+Patisserie',
+                label: 'Pix+Patisserie',
+                key: 'PATISSERIE',
               },
             ],
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer_test.js
@@ -7,8 +7,18 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-subscription-ser
       const certificationCandidateSubscription = domainBuilder.buildCertificationCandidateSubscription({
         id: 123,
         sessionId: 456,
-        eligibleSubscriptions: [domainBuilder.buildComplementaryCertification({ name: 'Comp 1' })],
-        nonEligibleSubscriptions: [domainBuilder.buildComplementaryCertification({ name: 'Comp 2' })],
+        eligibleSubscriptions: [
+          domainBuilder.buildComplementaryCertification({
+            key: 'FIRST_COMPLEMENTARY',
+            label: 'First Complementary Certification',
+          }),
+        ],
+        nonEligibleSubscriptions: [
+          domainBuilder.buildComplementaryCertification({
+            key: 'SECOND_COMPLEMENTARY',
+            label: 'Second Complementary Certification',
+          }),
+        ],
       });
 
       const expectedSerializedResult = {
@@ -19,13 +29,15 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-subscription-ser
             'eligible-subscriptions': [
               {
                 id: 1,
-                name: 'Comp 1',
+                key: 'FIRST_COMPLEMENTARY',
+                label: 'First Complementary Certification',
               },
             ],
             'non-eligible-subscriptions': [
               {
                 id: 1,
-                name: 'Comp 2',
+                key: 'SECOND_COMPLEMENTARY',
+                label: 'Second Complementary Certification',
               },
             ],
             'session-id': 456,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
@@ -7,7 +7,8 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
       // given
       const complementaryCertification = domainBuilder.buildComplementaryCertification({
         id: 1,
-        name: 'Pix+surf',
+        label: 'Pix+surf',
+        key: 'SURF',
       });
       const certificationCenter = domainBuilder.buildCertificationCenter({
         id: 12,
@@ -51,7 +52,8 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
             id: '1',
             type: 'habilitations',
             attributes: {
-              name: 'Pix+surf',
+              key: 'SURF',
+              label: 'Pix+surf',
             },
           },
         ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/complementary-certification-serializer_test.js
@@ -8,11 +8,13 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
       const complementaryCertifications = [
         domainBuilder.buildComplementaryCertification({
           id: 11,
-          name: 'Pix+Edu',
+          label: 'Pix+Edu',
+          key: 'EDU',
         }),
         domainBuilder.buildComplementaryCertification({
           id: 22,
-          name: 'Cléa Numérique',
+          label: 'Cléa Numérique',
+          key: 'CLEA',
         }),
       ];
 
@@ -26,14 +28,16 @@ describe('Unit | Serializer | JSONAPI | complementary-certification-serializer',
             id: '11',
             type: 'habilitations',
             attributes: {
-              name: 'Pix+Edu',
+              label: 'Pix+Edu',
+              key: 'EDU',
             },
           },
           {
             id: '22',
             type: 'habilitations',
             attributes: {
-              name: 'Cléa Numérique',
+              label: 'Cléa Numérique',
+              key: 'CLEA',
             },
           },
         ],

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -300,9 +300,10 @@
                     <Input
                       @type="checkbox"
                       id={{concat "complementaryCertification_" index}}
+                      @checked={{contains complementaryCertification @candidateData.complementaryCertifications}}
                       {{on "input" (fn this.updateComplementaryCertifications complementaryCertification)}}
                     />
-                    {{complementaryCertification.name}}
+                    {{complementaryCertification.label}}
                   </label>
                 </li>
               {{/each}}

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -31,6 +31,6 @@ export default class CertificationCandidate extends Model {
   }
 
   get complementaryCertificationsList() {
-    return this.complementaryCertifications.map(({ name }) => name).join(', ');
+    return this.complementaryCertifications.map(({ label }) => label).join(', ');
   }
 }

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -28,11 +28,11 @@ module('Integration | Component | certification-candidate-details-modal', functi
       complementaryCertifications: [
         {
           id: 1,
-          name: 'Pix+Edu',
+          label: 'Pix+Edu',
         },
         {
           id: 2,
-          name: 'Pix+Droit',
+          label: 'Pix+Droit',
         },
       ],
     });

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -289,11 +289,11 @@ function _buildCertificationCandidate({
   complementaryCertifications = [
     {
       id: 1,
-      name: 'Pix+Edu',
+      label: 'Pix+Edu',
     },
     {
       id: 2,
-      name: 'Pix+Droit',
+      label: 'Pix+Droit',
     },
   ],
   billingMode = '',

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -13,7 +13,10 @@ module('Integration | Component | new-certification-candidate-modal', function (
     const store = this.owner.lookup('service:store');
     class CurrentUserStub extends Service {
       currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        habilitations: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+        habilitations: [
+          { id: 0, label: 'Certif complémentaire 1', key: 'COMP_1' },
+          { id: 1, label: 'Certif complémentaire 2', key: 'COMP_2' },
+        ],
       });
     }
     this.owner.register('service:current-user', CurrentUserStub);
@@ -461,13 +464,13 @@ module('Integration | Component | new-certification-candidate-modal', function (
           @saveCandidate={{this.saveCandidate}}
           />
       `);
-
       await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
       await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
       await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
       await click(screen.getByRole('radio', { name: 'Homme' }));
       await fillIn(screen.getByLabelText('* Pays de naissance'), 99100);
       await click(screen.getByRole('radio', { name: 'Code INSEE' }));
+      await click(screen.getByRole('checkbox', { name: 'Certif complémentaire 1' }));
       await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
       await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
       await fillIn(screen.getByLabelText('Temps majoré (%)'), '20');
@@ -482,7 +485,21 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // then
       assert.strictEqual(updateCandidateFromValueStub.callCount, 7);
       assert.strictEqual(updateCandidateFromEventStub.callCount, 8);
-      sinon.assert.calledOnce(saveCandidateStub);
+      sinon.assert.calledOnceWithExactly(saveCandidateStub, {
+        firstName: 'Guybrush',
+        lastName: 'Threepwood',
+        birthdate: '',
+        birthCity: '',
+        birthCountry: '',
+        email: 'roooooar@example.net',
+        externalId: '44AA3355',
+        resultRecipientEmail: 'guybrush.threepwood@example.net',
+        birthPostalCode: '',
+        birthInseeCode: '75100',
+        sex: '',
+        extraTimePercentage: '20',
+        complementaryCertifications: [{ id: 0, label: 'Certif complémentaire 1', key: 'COMP_1' }],
+      });
     });
   });
 });

--- a/certif/tests/unit/models/certification-candidate_test.js
+++ b/certif/tests/unit/models/certification-candidate_test.js
@@ -78,20 +78,21 @@ module('Unit | Model | certification-candidate', function (hooks) {
         complementaryCertifications: [
           {
             id: 1,
-            name: 'Pix+Edu',
+            key: 'A',
+            label: 'Pix+Edu',
           },
           {
             id: 2,
-            name: 'Pix+Droit',
+            key: 'B',
+            label: 'Pix+Droit',
           },
         ],
       };
       // when
       const model = store.createRecord('certification-candidate', data);
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.complementaryCertificationsList, 'Pix+Edu, Pix+Droit');
+      assert.strictEqual(model.complementaryCertificationsList, 'Pix+Edu, Pix+Droit');
     });
   });
 

--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -16,7 +16,7 @@
                   @icon="circle-check"
                   class="certification-starter-subscriptions-container-items__eligible-icon"
                 />
-                {{eligibleSubscription.name}}
+                {{eligibleSubscription.label}}
               </span>
             {{/each}}
             {{#each @certificationCandidateSubscription.nonEligibleSubscriptions as |nonEligibleSubscription|}}
@@ -25,21 +25,21 @@
                   @icon="circle-check"
                   class="certification-starter-subscriptions-container-items__non-eligible-icon"
                 />
-                {{nonEligibleSubscription.name}}
+                {{nonEligibleSubscription.label}}
               </span>
             {{/each}}
           </div>
         </div>
       {{/if}}
-      {{#if this.nonEligibleSubscriptionNames.length}}
+      {{#if this.nonEligibleSubscriptionLabels.length}}
         <div class="certification-starter-subscriptions-container__non-eligible">
           <FaIcon @icon="circle-exclamation" class="certification-starter-subscriptions-container__info-icon" />
           <span>
             {{t
               "pages.certification-start.non-eligible-subscriptions"
-              nonEligibleSubscription=this.nonEligibleSubscriptionNames
-              eligibleSubscription=this.eligibleSubscriptionNames
-              eligibleSubscriptionLength=this.eligibleSubscriptionNames.length
+              nonEligibleSubscription=this.nonEligibleSubscriptionLabels
+              eligibleSubscription=this.eligibleSubscriptionLabels
+              eligibleSubscriptionLength=this.eligibleSubscriptionLabels.length
               itemCount=@certificationCandidateSubscription.nonEligibleSubscriptions.length
             }}
           </span>

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -26,15 +26,15 @@ export default class CertificationJoiner extends Component {
     );
   }
 
-  get nonEligibleSubscriptionNames() {
+  get nonEligibleSubscriptionLabels() {
     return this.args.certificationCandidateSubscription.nonEligibleSubscriptions
-      .map((nonEligibleSubscription) => nonEligibleSubscription.name)
+      .map((nonEligibleSubscription) => nonEligibleSubscription.label)
       .join(', ');
   }
 
-  get eligibleSubscriptionNames() {
+  get eligibleSubscriptionLabels() {
     return this.args.certificationCandidateSubscription.eligibleSubscriptions
-      .map((eligibleSubscription) => eligibleSubscription.name)
+      .map((eligibleSubscription) => eligibleSubscription.label)
       .join(', ');
   }
 

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -51,7 +51,7 @@ describe('Integration | Component | certification-starter', function () {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+            eligibleSubscriptions: [{ label: 'Certif complémentaire 1' }, { label: 'Certif complémentaire 2' }],
             nonEligibleSubscriptions: [],
           })
         );
@@ -76,7 +76,7 @@ describe('Integration | Component | certification-starter', function () {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+            eligibleSubscriptions: [{ label: 'Certif complémentaire 1' }, { label: 'Certif complémentaire 2' }],
             nonEligibleSubscriptions: [],
           })
         );
@@ -102,8 +102,8 @@ describe('Integration | Component | certification-starter', function () {
         this.set(
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
-            eligibleSubscriptions: [{ name: 'Certif complémentaire 2' }],
-            nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }],
+            eligibleSubscriptions: [{ label: 'Certif complémentaire 2' }],
+            nonEligibleSubscriptions: [{ label: 'Certif complémentaire 1' }],
           })
         );
 
@@ -127,7 +127,7 @@ describe('Integration | Component | certification-starter', function () {
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
             eligibleSubscriptions: [],
-            nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+            nonEligibleSubscriptions: [{ label: 'Certif complémentaire 1' }, { label: 'Certif complémentaire 2' }],
           })
         );
 
@@ -151,7 +151,7 @@ describe('Integration | Component | certification-starter', function () {
           'certificationCandidateSubscription',
           store.createRecord('certification-candidate-subscription', {
             eligibleSubscriptions: [],
-            nonEligibleSubscriptions: [{ name: 'Certif complémentaire 1' }, { name: 'Certif complémentaire 2' }],
+            nonEligibleSubscriptions: [{ label: 'Certif complémentaire 1' }, { label: 'Certif complémentaire 2' }],
           })
         );
 


### PR DESCRIPTION
## :unicorn: Problème
La table complementary-certifications à une colonne name qui contient un label et qui est utilisé en tant que clé. Ce n’est pas dynamique

## :robot: Solution
- Remplacer la colonne name par label
- Ajouter une colonne key
- Récupérer les certifications complémentaire via cette clé

## :rainbow: Remarques
Pix+ Droit: DROIT
CléA Numérique: CLEA
Pix+ Édu 2nd degré : EDU_2ND_DEGRE
Pix+ Édu 1er degré : EDU_1ND_DEGRE

## :100: Pour tester
Il faut faire un test de regression sur l'inscription + passage des certifications complémentaires
- Verifier dans admin les habilitations aux certifications complementaires
- Inscrire un candidat en certification X via la modale/via ods
- Lui faire passer la certification
- S'assurer qu'il l'a obtenu
- Verifier les resultats sur admin
- Verifier les certificats "private" et "partagés"
