### PR TITLE
[FEATURE] Ramener les formations du cache dans l'API (PIX-5419).

### DIFF
--- a/api/lib/infrastructure/datasources/learning-content/index.js
+++ b/api/lib/infrastructure/datasources/learning-content/index.js
@@ -3,6 +3,7 @@ const ChallengeDatasource = require('./challenge-datasource');
 const CompetenceDatasource = require('./competence-datasource');
 const CourseDatasource = require('./course-datasource');
 const SkillDatasource = require('./skill-datasource');
+const TrainingDatasource = require('./training-datasource');
 const TubeDatasource = require('./tube-datasource');
 const TutorialDatasource = require('./tutorial-datasource');
 
@@ -12,6 +13,7 @@ module.exports = {
   CompetenceDatasource,
   CourseDatasource,
   SkillDatasource,
+  TrainingDatasource,
   TubeDatasource,
   TutorialDatasource,
 };

--- a/api/lib/infrastructure/datasources/learning-content/training-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/training-datasource.js
@@ -1,0 +1,5 @@
+const datasource = require('./datasource');
+
+module.exports = datasource.extend({
+  modelName: 'trainings',
+});

--- a/api/tests/unit/infrastructure/datasources/learning-content/training-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/training-datasource_test.js
@@ -1,0 +1,19 @@
+const { expect, sinon } = require('../../../../test-helper');
+const trainingDatasource = require('../../../../../lib/infrastructure/datasources/learning-content/training-datasource');
+const lcms = require('../../../../../lib/infrastructure/lcms');
+
+describe('Unit | Infrastructure | Datasource | Learning Content | TrainingDatasource', function () {
+  describe('#list', function () {
+    it('should return an array of learning content trainings data objects', async function () {
+      // given
+      const records = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      sinon.stub(lcms, 'getLatestRelease').resolves({ trainings: records });
+
+      // when
+      const foundTrainings = await trainingDatasource.list();
+
+      // then
+      expect(foundTrainings).to.deep.equal(records);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le cache contient des formations (`trainings`), mais ne sont pas récupérable dans l'API.

## :robot: Solution
Ajouter un datasource pour les récupérer.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer la commande : 
```
node -p "require('dotenv').config(); require('./lib/infrastructure/datasources/learning-content/training-datasource').list().then(console.log)"
```
- Vérifier que des valeurs sont bien retournés. 