### PR TITLE
[FEATURE] Enlever les espaces en trop quand on crée un profil cible(PIX-5405)

### DIFF
--- a/admin/app/components/campaigns/update.js
+++ b/admin/app/components/campaigns/update.js
@@ -98,18 +98,12 @@ export default class Update extends Component {
 
   async _update() {
     const campaign = this.args.campaign;
-    campaign.name = this.form.name.trim();
-    const titleTrim = this.form.title?.trim();
-    const customLandingPageTextTrim = this.form.customLandingPageText?.trim();
-    const customResultPageTextTrim = this.form.customResultPageText?.trim();
-    const customResultPageButtonTextTrim = this.form.customResultPageButtonText?.trim();
-    const customResultPageButtonUrlTrim = this.form.customResultPageButtonUrl?.trim();
-
-    campaign.title = titleTrim || null;
-    campaign.customLandingPageText = customLandingPageTextTrim || null;
-    campaign.customResultPageText = customResultPageTextTrim || null;
-    campaign.customResultPageButtonText = customResultPageButtonTextTrim || null;
-    campaign.customResultPageButtonUrl = customResultPageButtonUrlTrim || null;
+    campaign.name = this.form.name;
+    campaign.title = this.form.title;
+    campaign.customLandingPageText = this.form.customLandingPageText;
+    campaign.customResultPageText = this.form.customResultPageText;
+    campaign.customResultPageButtonText = this.form.customResultPageButtonText;
+    campaign.customResultPageButtonUrl = this.form.customResultPageButtonUrl;
     campaign.multipleSendings = this.form.multipleSendings;
 
     try {

--- a/admin/app/components/organizations/information-section.js
+++ b/admin/app/components/organizations/information-section.js
@@ -146,11 +146,11 @@ export default class OrganizationInformationSection extends Component {
       return;
     }
 
-    this.args.organization.set('name', this.form.name.trim());
-    this.args.organization.set('externalId', !this.form.externalId ? null : this.form.externalId.trim());
-    this.args.organization.set('provinceCode', !this.form.provinceCode ? null : this.form.provinceCode.trim());
-    this.args.organization.set('email', !this.form.email ? null : this.form.email.trim());
-    this.args.organization.set('credit', !this.form.credit ? null : this.form.credit);
+    this.args.organization.set('name', this.form.name);
+    this.args.organization.set('externalId', this.form.externalId);
+    this.args.organization.set('provinceCode', this.form.provinceCode);
+    this.args.organization.set('email', this.form.email);
+    this.args.organization.set('credit', this.form.credit);
     this.args.organization.set('isManagingStudents', this.form.isManagingStudents);
     this.args.organization.set('documentationUrl', this.form.documentationUrl);
     this.args.organization.set('showSkills', this.form.showSkills);

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -79,9 +79,9 @@ export default class UpdateTargetProfile extends Component {
 
   async _updateTargetProfile() {
     const model = this.args.model;
-    model.name = this.form.name.trim();
-    model.description = this.form.description ? this.form.description.trim() : null;
-    model.comment = this.form.comment ? this.form.comment.trim() : null;
+    model.name = this.form.name;
+    model.description = this.form.description;
+    model.comment = this.form.comment;
     model.category = this.form.category;
 
     try {

--- a/admin/app/models/campaign.js
+++ b/admin/app/models/campaign.js
@@ -1,11 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 export default class Campaign extends Model {
-  @attr('string') name;
-  @attr('string') title;
+  @attr('nullable-string') name;
+  @attr('nullable-string') title;
   @attr('date') archivedAt;
-  @attr('string') type;
+  @attr('nullable-string') type;
   @attr('string') code;
-  @attr('string') idPixLabel;
+  @attr('nullable-string') idPixLabel;
   @attr('date') createdAt;
   @attr('string') creatorLastName;
   @attr('string') creatorFirstName;
@@ -15,10 +15,10 @@ export default class Campaign extends Model {
   @attr('string') organizationName;
   @attr('string') targetProfileId;
   @attr('string') targetProfileName;
-  @attr('string') customLandingPageText;
-  @attr('string') customResultPageText;
-  @attr('string') customResultPageButtonText;
-  @attr('string') customResultPageButtonUrl;
+  @attr('nullable-text') customLandingPageText;
+  @attr('nullable-text') customResultPageText;
+  @attr('nullable-string') customResultPageButtonText;
+  @attr('nullable-string') customResultPageButtonUrl;
   @attr('number') sharedParticipationsCount;
   @attr('number') totalParticipationsCount;
   @attr('boolean') isTypeProfilesCollection;

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -5,22 +5,22 @@ import { equal } from '@ember/object/computed';
 import dayjs from 'dayjs';
 
 export default class Organization extends Model {
-  @attr() name;
-  @attr() type;
-  @attr() logoUrl;
-  @attr() externalId;
-  @attr() provinceCode;
+  @attr('nullable-string') name;
+  @attr('nullable-string') type;
+  @attr('nullable-string') logoUrl;
+  @attr('nullable-string') externalId;
+  @attr('nullable-string') provinceCode;
   @attr() isManagingStudents;
   @attr('boolean') showNPS;
   @attr('string') formNPSUrl;
   @attr() credit;
-  @attr() email;
+  @attr('nullable-string') email;
   @attr() createdBy;
   @attr('string') documentationUrl;
   @attr('boolean') showSkills;
-  @attr() archivistFullName;
+  @attr('nullable-string') archivistFullName;
   @attr() archivedAt;
-  @attr() creatorFullName;
+  @attr('nullable-string') creatorFullName;
 
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -10,16 +10,16 @@ export default class Organization extends Model {
   @attr('nullable-string') logoUrl;
   @attr('nullable-string') externalId;
   @attr('nullable-string') provinceCode;
-  @attr() isManagingStudents;
+  @attr('boolean') isManagingStudents;
   @attr('boolean') showNPS;
   @attr('string') formNPSUrl;
-  @attr() credit;
+  @attr('number') credit;
   @attr('nullable-string') email;
-  @attr() createdBy;
-  @attr('string') documentationUrl;
+  @attr('date') createdBy;
+  @attr('nullable-string') documentationUrl;
   @attr('boolean') showSkills;
   @attr('nullable-string') archivistFullName;
-  @attr() archivedAt;
+  @attr('date') archivedAt;
   @attr('nullable-string') creatorFullName;
 
   @equal('type', 'SCO') isOrganizationSCO;

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -16,13 +16,13 @@ export const optionsCategoryList = map(categories, function (key, value) {
 });
 
 export default class TargetProfile extends Model {
-  @attr('string') name;
+  @attr('nullable-string') name;
   @attr('boolean') isPublic;
   @attr('date') createdAt;
-  @attr('string') imageUrl;
+  @attr('nullable-string') imageUrl;
   @attr('boolean') outdated;
-  @attr('string') description;
-  @attr('string') comment;
+  @attr('nullable-text') description;
+  @attr('nullable-text') comment;
   @attr('string') ownerOrganizationId;
   @attr('string') category;
   @attr('boolean') isSimplifiedAccess;

--- a/admin/app/transforms/nullable-string.js
+++ b/admin/app/transforms/nullable-string.js
@@ -1,0 +1,15 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class NullableStringTransform extends Transform {
+  serialize(string) {
+    if (typeof string !== 'string') return null;
+
+    const result = string.trim();
+
+    return result || null;
+  }
+
+  deserialize(string) {
+    return string;
+  }
+}

--- a/admin/app/transforms/nullable-text.js
+++ b/admin/app/transforms/nullable-text.js
@@ -1,0 +1,13 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class NullableTextTransform extends Transform {
+  serialize(string) {
+    if (typeof string !== 'string') return null;
+
+    return string.trim() ? string : null;
+  }
+
+  deserialize(string) {
+    return string;
+  }
+}

--- a/admin/tests/integration/components/campaigns/update_test.js
+++ b/admin/tests/integration/components/campaigns/update_test.js
@@ -62,26 +62,6 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
       // then
       assert.dom(screen.getByText('Ce champ doit être une URL complète et valide')).exists();
     });
-
-    test('it should trim extra spaces written by user from title attibute', async function (assert) {
-      // when
-      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
-      await fillByLabel('Titre du parcours', ' text with space ');
-      await clickByName('Enregistrer');
-
-      // then
-      assert.deepEqual(this.campaign.title, 'text with space');
-    });
-
-    test("It should return 'null' when title is empty", async function (assert) {
-      // when
-      await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
-      await fillByLabel('Titre du parcours', '');
-      await clickByName('Enregistrer');
-
-      // then
-      assert.strictEqual(this.campaign.title, null);
-    });
   });
 
   module('when campaign is of type profiles collection', function (hooks) {
@@ -119,36 +99,6 @@ module('Integration | Component | Campaigns | Update', function (hooks) {
 
     // then
     assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();
-  });
-
-  test('it should trim extra spaces written by user from custom landing page attibute', async function (assert) {
-    // when
-    await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
-    await fillByLabel("Texte de la page d'accueil", ' text with space ');
-    await clickByName('Enregistrer');
-
-    // then
-    assert.deepEqual(this.campaign.customLandingPageText, 'text with space');
-  });
-
-  test("It should return 'null' when custom landing page attribute is empty", async function (assert) {
-    // when
-    await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
-    await fillByLabel("Texte de la page d'accueil", '');
-    await clickByName('Enregistrer');
-
-    // then
-    assert.strictEqual(this.campaign.customLandingPageText, null);
-  });
-
-  test("It should return 'null' when custom landing page attribute has only white space", async function (assert) {
-    // when
-    await render(hbs`<Campaigns::update @campaign={{this.campaign}} @onExit={{this.onExit}} />`);
-    await fillByLabel("Texte de la page d'accueil", ' ');
-    await clickByName('Enregistrer');
-
-    // then
-    assert.strictEqual(this.campaign.customLandingPageText, null);
   });
 
   test('it should call update when form is valid', async function (assert) {

--- a/admin/tests/unit/components/campaigns/update_test.js
+++ b/admin/tests/unit/components/campaigns/update_test.js
@@ -40,50 +40,12 @@ module('Unit | Component | Campaigns | update', function (hooks) {
       // then
       assert.ok(event.preventDefault.called);
       assert.ok(component.args.campaign.save.called);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.form.name, 'some name');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.form.title, 'some title');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.form.customLandingPageText, 'some text');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.form.customResultPageText, 'some text again');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.form.customResultPageButtonText, 'some button text');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.form.customResultPageButtonUrl, 'google.com');
-    });
-
-    test('it should update campaign title even if it is empty', async function (assert) {
-      // given
-      const component = createGlimmerComponent('component:campaigns/update', {
-        campaign: {
-          name: 'some name',
-          title: '',
-          save: sinon.stub(),
-          rollbackAttributes: sinon.stub(),
-        },
-      });
-
-      const event = {
-        preventDefault: sinon.stub(),
-      };
-      component.form.title = '';
-
-      // when
-      await component.update(event);
-
-      // then
-      assert.ok(component.args.campaign.save.called);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.campaign.title, null);
+      assert.strictEqual(component.form.name, 'some name');
+      assert.strictEqual(component.form.title, 'some title');
+      assert.strictEqual(component.form.customLandingPageText, 'some text');
+      assert.strictEqual(component.form.customResultPageText, 'some text again');
+      assert.strictEqual(component.form.customResultPageButtonText, 'some button text');
+      assert.strictEqual(component.form.customResultPageButtonUrl, 'google.com');
     });
 
     test('it should display a success notification when campaign has been saved', async function (assert) {

--- a/admin/tests/unit/transforms/nullable-string_test.js
+++ b/admin/tests/unit/transforms/nullable-string_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import NullableStringTransform from 'pix-admin/transforms/nullable-string';
+
+module('Unit | Transformer | Nullable String', function (hooks) {
+  setupTest(hooks);
+
+  module('#serialize', function () {
+    test('should return null when not a string', function (assert) {
+      // given
+      const transform = NullableStringTransform.create();
+      const string = undefined;
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+
+    test('should return a String without extra space', function (assert) {
+      // given
+      const transform = NullableStringTransform.create();
+      const string = ' Gozilla vs Kong ';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, 'Gozilla vs Kong');
+    });
+
+    test('should return null when empty string', function (assert) {
+      // given
+      const transform = NullableStringTransform.create();
+      const string = '';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+  });
+});

--- a/admin/tests/unit/transforms/nullable-text_test.js
+++ b/admin/tests/unit/transforms/nullable-text_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import NullableTextTransform from 'pix-admin/transforms/nullable-text';
+
+module('Unit | Transformer | Nullable Text', function (hooks) {
+  setupTest(hooks);
+
+  module('#serialize', function () {
+    test('should return null when not a string', function (assert) {
+      // given
+      const transform = NullableTextTransform.create();
+      const string = undefined;
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+
+    test('should return a String with extra space', function (assert) {
+      // given
+      const transform = NullableTextTransform.create();
+      const string = ' Gozilla vs Kong ';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, string);
+    });
+
+    test('should return null when empty string', function (assert) {
+      // given
+      const transform = NullableTextTransform.create();
+      const string = '';
+
+      // when
+      const serialized = transform.serialize(string);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+  });
+});

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -189,13 +189,12 @@ exports.register = async (server) => {
                 'is-public': Joi.boolean().required(),
                 'owner-organization-id': Joi.string()
                   .pattern(/^[0-9]+$/, 'numbers')
-                  .empty('')
                   .allow(null)
-                  .optional(),
-                'image-url': Joi.string().uri().empty('').allow(null).optional(),
+                  .required(),
+                'image-url': Joi.string().uri().allow(null).required(),
                 'skill-ids': Joi.array().required(),
-                comment: Joi.string().optional().allow(null).max(500).empty(''),
-                description: Joi.string().optional().allow(null).max(500).empty(''),
+                comment: Joi.string().allow(null).max(500).required(),
+                description: Joi.string().allow(null).max(500).required(),
                 'tubes-selection': Joi.array().required(),
               },
             },

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -85,6 +85,8 @@ describe('Acceptance | Controller | target-profile-controller', function () {
               'owner-organization-id': null,
               'skill-ids': [skillId],
               comment: 'comment',
+              description: null,
+              'image-url': null,
               'tubes-selection': [
                 { id: 'tubeId1', level: 5 },
                 { id: 'tubeId2', level: 7 },

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -207,6 +207,12 @@ describe('Unit | Application | Router | campaign-router ', function () {
           type: 'campaigns',
           attributes: {
             name: null,
+            title: null,
+            'custom-result-page-text': null,
+            'custom-result-page-button-text': null,
+            'custom-result-page-button-url': null,
+            'custom-landing-page-text': null,
+            'multiple-sendings': false,
           },
         },
       };
@@ -227,6 +233,12 @@ describe('Unit | Application | Router | campaign-router ', function () {
           type: 'campaigns',
           attributes: {
             name: '',
+            title: null,
+            'custom-result-page-text': null,
+            'custom-result-page-button-text': null,
+            'custom-result-page-button-url': null,
+            'custom-landing-page-text': null,
+            'multiple-sendings': false,
           },
         },
       };
@@ -248,6 +260,11 @@ describe('Unit | Application | Router | campaign-router ', function () {
           attributes: {
             name: 'name',
             title: '',
+            'custom-result-page-text': null,
+            'custom-result-page-button-text': null,
+            'custom-result-page-button-url': null,
+            'custom-landing-page-text': null,
+            'multiple-sendings': false,
           },
         },
       };

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -514,6 +514,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
           'is-public': false,
           'skill-ids': ['skill1', 'skill2'],
           comment: 'comment',
+          description: 'description',
           'tubes-selection': [
             {
               id: 'tube1',
@@ -567,39 +568,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
               'is-public': false,
               'skill-ids': ['skill1', 'skill2'],
               comment: 'comment',
-              'tubes-selection': [
-                {
-                  id: 'tube1',
-                  level: 7,
-                },
-              ],
-            },
-          },
-        });
-
-        // then
-        expect(statusCode).to.equal(200);
-      });
-
-      it('should resolve with owner organization id to empty', async function () {
-        // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
-        sinon
-          .stub(targetProfileController, 'createTargetProfile')
-          .callsFake((request, h) => h.response('ok').code(200));
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const { statusCode } = await httpTestServer.request(method, url, {
-          data: {
-            attributes: {
-              name: 'MyTargetProfile',
-              'owner-organization-id': '',
-              'image-url': null,
-              'is-public': false,
-              'skill-ids': ['skill1', 'skill2'],
-              comment: 'comment',
+              description: 'description',
               'tubes-selection': [
                 {
                   id: 'tube1',
@@ -629,6 +598,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
               'is-public': false,
               'skill-ids': ['skill1', 'skill2'],
               comment: 'comment',
+              description: 'description',
               'tubes-selection': [
                 {
                   id: 'tube1',


### PR DESCRIPTION
## :unicorn: Problème
Lors de création d'un profil cible, on pouvait par erreur ajouter des espaces à la fin ou au début du nom, espaces qui étaient conservés en BDD. Ceci posait problème quand on souhaitait rechercher le profil cible car on recherchait pas avec le bon nom (qui contient des espaces).

## :robot: Solution
Ajouter des méthodes qui clean les champs libres afin de ne plus avoir d'espaces indésirables

## :rainbow: Remarques
Cette méthode a aussi été ajoutée pour certains champs de la création d'organisation. 

## :100: Pour tester
- Se connecter à Pix Admin
- Créer un profil cible avec des espaces et voir qu'ils n'ont pas été sauvegardés en BDD
- Faire de même pour la création de l'organisation
