### PR TITLE
[TECH] Améliorations CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,16 @@ workflows:
                 - prod
                 - /release-.*/
 
+      - root_install:
+          requires:
+            - checkout
+      - root_lint:
+          requires:
+            - root_install
+      - root_test:
+          requires:
+            - root_install
+
       - api_install:
           requires:
             - checkout
@@ -102,17 +112,44 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Lint and test root
-          command: |
-            npm ci
-            npm run lint:scripts
-            npm run lint:yaml
-            npm run test:root
-            rm -rf .git/
+          command: rm -rf .git/
       - persist_to_workspace:
           root: ~/pix
           paths:
             - .
+
+  root_install:
+    executor: checkout
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Install
+          command: npm ci
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - .
+
+  root_lint:
+    executor: checkout
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Lint
+          command: |
+            npm run lint:scripts
+            npm run lint:yaml
+
+  root_test:
+    executor: checkout
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Test
+          command: npm run test:root
 
   api_install:
     executor: api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
 
       - api_install:
           requires:
-            - checkout
+            - root_install
       - api_lint:
           requires:
             - api_install
@@ -59,7 +59,7 @@ workflows:
 
       - mon_pix_install:
           requires:
-            - checkout
+            - root_install
       - mon_pix_lint:
           requires:
             - mon_pix_install
@@ -69,7 +69,7 @@ workflows:
 
       - orga_install:
           requires:
-            - checkout
+            - root_install
       - orga_lint:
           requires:
             - orga_install
@@ -79,7 +79,7 @@ workflows:
 
       - certif_install:
           requires:
-            - checkout
+            - root_install
       - certif_lint:
           requires:
             - certif_install
@@ -89,7 +89,7 @@ workflows:
 
       - admin_install:
           requires:
-            - checkout
+            - root_install
       - admin_lint:
           requires:
             - admin_install
@@ -104,7 +104,7 @@ workflows:
 
       - algo_test:
           requires:
-            - checkout
+            - root_install
 
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,15 @@ workflows:
           requires:
             - mon_pix_install
 
-      - orga_build_and_test:
+      - orga_install:
           requires:
             - checkout
+      - orga_lint:
+          requires:
+            - orga_install
+      - orga_test:
+          requires:
+            - orga_install
 
       - certif_build_and_test:
           requires:
@@ -192,11 +198,10 @@ jobs:
           name: Test
           command: npm run test:ci
 
-  orga_build_and_test:
+  orga_install:
     executor: front
     working_directory: ~/pix/orga
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -208,9 +213,28 @@ jobs:
           key: v7-orga-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - .
+
+  orga_lint:
+    executor: front
+    working_directory: ~/pix/orga
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+
+  orga_test:
+    executor: front
+    working_directory: ~/pix/orga
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Test
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,15 @@ workflows:
           requires:
             - orga_install
 
-      - certif_build_and_test:
+      - certif_install:
           requires:
             - checkout
+      - certif_lint:
+          requires:
+            - certif_install
+      - certif_test:
+          requires:
+            - certif_install
 
       - admin_build_and_test:
           requires:
@@ -239,11 +245,10 @@ jobs:
           name: Test
           command: npm run test:ci
 
-  certif_build_and_test:
+  certif_install:
     executor: front
     working_directory: ~/pix/certif
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -255,9 +260,28 @@ jobs:
           key: v7-certif-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - .
+
+  certif_lint:
+    executor: front
+    working_directory: ~/pix/certif
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+
+  certif_test:
+    executor: front
+    working_directory: ~/pix/certif
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Test
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,7 @@ workflows:
 
 jobs:
   checkout:
-    docker:
-      - image: cimg/node:16.14.0
-    resource_class: small
-    working_directory: ~/pix
+    executor: checkout
     steps:
       - checkout
       - run:
@@ -88,15 +85,7 @@ jobs:
             - .
 
   api_build_and_test:
-    docker:
-      - image: cimg/node:16.14.0
-      - image: postgres:13.7-alpine
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:6.2.7-alpine
-    resource_class: small
-    working_directory: ~/pix/api
+    executor: api
     steps:
       - attach_workspace:
           at: ~/pix
@@ -126,12 +115,7 @@ jobs:
           path: /home/circleci/test-results
 
   mon_pix_build_and_test:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          # See https://git.io/vdao3 for details.
-          JOBS: 2
-    working_directory: ~/pix/mon-pix
+    executor: mon_pix
     parallelism: 3
     steps:
       - browser-tools/install-chrome
@@ -154,12 +138,7 @@ jobs:
           command: npm run test:ci
 
   orga_build_and_test:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          JOBS: 2
-    resource_class: small
-    working_directory: ~/pix/orga
+    executor: orga
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -181,12 +160,7 @@ jobs:
           command: npm run test:ci
 
   certif_build_and_test:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          JOBS: 2
-    resource_class: small
-    working_directory: ~/pix/certif
+    executor: certif
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -208,12 +182,7 @@ jobs:
           command: npm run test:ci
 
   admin_build_and_test:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          JOBS: 2
-    resource_class: small
-    working_directory: ~/pix/admin
+    executor: admin
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -235,16 +204,8 @@ jobs:
           command: npm run test:ci
 
   e2e_test:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-      - image: postgres:13.7-alpine
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:6.2.7-alpine
-    resource_class: medium+
+    executor: e2e
     parallelism: 5
-    working_directory: ~/pix/high-level-tests/e2e
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -334,11 +295,8 @@ jobs:
           path: /home/circleci/test-results
 
   algo_test:
-    docker:
-      - image: cimg/node:16.14.0
-    resource_class: small
+    executor: algo
     parallelism: 1
-    working_directory: ~/pix/high-level-tests/test-algo
     steps:
       - attach_workspace:
           at: ~/pix
@@ -376,3 +334,63 @@ jobs:
           name: Test
           command: npm run test:ci
 
+executors:
+  checkout:
+    docker:
+      - image: cimg/node:16.14.0
+    resource_class: small
+    working_directory: ~/pix
+  api:
+    docker:
+      - image: cimg/node:16.14.0
+      - image: postgres:13.7-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:6.2.7-alpine
+    resource_class: small
+    working_directory: ~/pix/api
+  mon_pix:
+    docker:
+      - image: cimg/node:16.14.0-browsers
+        environment:
+          # See https://git.io/vdao3 for details.
+          JOBS: 2
+    resource_class: medium
+    working_directory: ~/pix/mon-pix
+  orga:
+    docker:
+      - image: cimg/node:16.14.0-browsers
+        environment:
+          JOBS: 2
+    resource_class: small
+    working_directory: ~/pix/orga
+  certif:
+    docker:
+      - image: cimg/node:16.14.0-browsers
+        environment:
+          JOBS: 2
+    resource_class: small
+    working_directory: ~/pix/certif
+  admin:
+    docker:
+      - image: cimg/node:16.14.0-browsers
+        environment:
+          JOBS: 2
+    resource_class: small
+    working_directory: ~/pix/admin
+  e2e:
+    docker:
+      - image: cimg/node:16.14.0-browsers
+      - image: postgres:13.7-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:6.2.7-alpine
+    resource_class: medium+
+    working_directory: ~/pix/high-level-tests/e2e
+  algo:
+    docker:
+      - image: cimg/node:16.14.0
+    resource_class: small
+    working_directory: ~/pix/high-level-tests/test-algo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,8 @@ jobs:
           command: npm run test:ci
 
   orga_build_and_test:
-    executor: orga
+    executor: front
+    working_directory: ~/pix/orga
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -160,7 +161,8 @@ jobs:
           command: npm run test:ci
 
   certif_build_and_test:
-    executor: certif
+    executor: front
+    working_directory: ~/pix/certif
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -182,7 +184,8 @@ jobs:
           command: npm run test:ci
 
   admin_build_and_test:
-    executor: admin
+    executor: front
+    working_directory: ~/pix/admin
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
@@ -350,6 +353,12 @@ executors:
       - image: redis:6.2.7-alpine
     resource_class: small
     working_directory: ~/pix/api
+  front:
+    docker:
+      - image: cimg/node:16.14.0-browsers
+        environment:
+          JOBS: 2
+    resource_class: small
   mon_pix:
     docker:
       - image: cimg/node:16.14.0-browsers
@@ -358,27 +367,6 @@ executors:
           JOBS: 2
     resource_class: medium
     working_directory: ~/pix/mon-pix
-  orga:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          JOBS: 2
-    resource_class: small
-    working_directory: ~/pix/orga
-  certif:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          JOBS: 2
-    resource_class: small
-    working_directory: ~/pix/certif
-  admin:
-    docker:
-      - image: cimg/node:16.14.0-browsers
-        environment:
-          JOBS: 2
-    resource_class: small
-    working_directory: ~/pix/admin
   e2e:
     docker:
       - image: cimg/node:16.14.0-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,10 @@ workflows:
       - mon_pix_install:
           requires:
             - checkout
-      - mon_pix_build_and_test:
+      - mon_pix_lint:
+          requires:
+            - mon_pix_install
+      - mon_pix_test:
           requires:
             - mon_pix_install
 
@@ -136,16 +139,22 @@ jobs:
           paths:
             - .
 
-  mon_pix_build_and_test:
+  mon_pix_lint:
+    executor: mon_pix
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Lint
+          command: npm run lint
+
+  mon_pix_test:
     executor: mon_pix
     parallelism: 3
     steps:
       - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
-      - run:
-          name: Lint
-          command: npm run lint
       - run:
           name: Test
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,15 @@ workflows:
           requires:
             - certif_install
 
-      - admin_build_and_test:
+      - admin_install:
           requires:
             - checkout
+      - admin_lint:
+          requires:
+            - admin_install
+      - admin_test:
+          requires:
+            - admin_install
 
       - e2e_test:
           context: Pix
@@ -286,11 +292,10 @@ jobs:
           name: Test
           command: npm run test:ci
 
-  admin_build_and_test:
+  admin_install:
     executor: front
     working_directory: ~/pix/admin
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -302,9 +307,28 @@ jobs:
           key: v7-admin-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - .
+
+  admin_lint:
+    executor: front
+    working_directory: ~/pix/admin
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+
+  admin_test:
+    executor: front
+    working_directory: ~/pix/admin
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Test
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,12 @@ workflows:
           requires:
             - checkout
 
-      - mon_pix_build_and_test:
+      - mon_pix_install:
           requires:
             - checkout
+      - mon_pix_build_and_test:
+          requires:
+            - mon_pix_install
 
       - orga_build_and_test:
           requires:
@@ -114,11 +117,9 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results
 
-  mon_pix_build_and_test:
+  mon_pix_install:
     executor: mon_pix
-    parallelism: 3
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -130,6 +131,18 @@ jobs:
           key: v7-mon-pix-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - .
+
+  mon_pix_build_and_test:
+    executor: mon_pix
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,15 @@ workflows:
                 - prod
                 - /release-.*/
 
-      - api_build_and_test:
+      - api_install:
           requires:
             - checkout
+      - api_lint:
+          requires:
+            - api_install
+      - api_test:
+          requires:
+            - api_install
 
       - mon_pix_install:
           requires:
@@ -90,7 +96,7 @@ jobs:
           paths:
             - .
 
-  api_build_and_test:
+  api_install:
     executor: api
     steps:
       - attach_workspace:
@@ -104,11 +110,38 @@ jobs:
           key: v7-api-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - .
+
+  api_lint:
+    executor: api
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
-          name: Lint and test
-          command: |
-            npm run lint
-            npm run test:ci
+          name: Lint
+          command: npm run lint
+          environment:
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
+            TEST_REDIS_URL: redis://localhost:6379
+            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
+            MOCHA_REPORTER: mocha-junit-reporter
+          when: always
+      - store_test_results:
+          path: /home/circleci/test-results
+      - store_artifacts:
+          path: /home/circleci/test-results
+
+  api_test:
+    executor: api
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Test
+          command: npm run test:ci
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
             TEST_REDIS_URL: redis://localhost:6379


### PR DESCRIPTION
## :unicorn: Problème
Dans CircleCI, nous exécutons en parallèle l'install, le lint, et les tests de `mon_pix`. On ne tire bénéfice de cette parallélisation uniquement dans nos tests car cela réduit la durée d'exécution.

## :robot: Solution
Exécuter l'install et le lint à part des tests qui nécessitent cette parallélisation. J'ai fait de même sur les autres packages pour paralléliser `lint` et `test`.

## :rainbow: Remarques
J'ai créé des `executors` pour éviter la duplication dans la définition des jobs. Un executor `front` permet d'utiliser la même config sur orga, certif et admin. Je n'ai pas réussi à mettre en commun celui de `mon_pix` qui utilise une `resource_class: medium`.

Je pense qu'on peut pousser plus loin l'utilisation des workspaces. Ici, je relie tout à `~/pix` car je n'ai pas réussi à n'archiver que `~/pix/mon-pix`. Je suis preneur d'avis pour éviter de stocker une archive plus conséquente.

IMO on gagne en clareté dans l'UI en séparant install, lint et test. J'apporte également ces changements aux autres applis.

Question subsidiaire : est-ce souhaité que le lint des applis nécessite le `npm ci` root ? Si on ne le fait il manque le package `eslint-plugin-eslint-comments`.

Par ailleurs, je propose de renommer `build` and `lint` car on ne fait jamais de `build` dans Circle CI.

Je pense qu'on peut optimiser un peu la partie `e2e` (qui refait des install déjà fait ailleurs) et tests d'algo.

## :100: Pour tester
Comparer Circle CI dans cette PR et sur une autre PR.
