### PR TITLE
[FEATURE] Permettre à un administrateur d'annuler une invitation à rejoindre une organisation (PIX-4692)

### DIFF
--- a/admin/app/adapters/organization-invitation.js
+++ b/admin/app/adapters/organization-invitation.js
@@ -14,6 +14,10 @@ export default class OrganizationInvitation extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/organizations/${organizationId}/invitations`;
   }
 
+  urlForDeleteRecord(id, modelName, { adapterOptions }) {
+    return `${this.host}/${this.namespace}/organizations/${adapterOptions.organizationId}/invitations/${adapterOptions.organizationInvitationId}`;
+  }
+
   createRecord() {
     return super.createRecord(...arguments).then((response) => {
       response.data = response.data[0];

--- a/admin/app/components/organizations/invitations.hbs
+++ b/admin/app/components/organizations/invitations.hbs
@@ -11,14 +11,26 @@
               <th>Adresse e-mail</th>
               <th>Rôle</th>
               <th>Date de dernier envoi</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             {{#each this.sortedInvitations as |invitation|}}
-              <tr aria-label="Invitation en attente">
+              <tr aria-label="Invitation en attente de {{invitation.email}}">
                 <td>{{invitation.email}}</td>
                 <td>{{invitation.roleInFrench}}</td>
                 <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>
+                <td>
+                  <PixButton
+                    @size="small"
+                    @backgroundColor="red"
+                    class="organization-invitations-actions__button"
+                    aria-label="Annuler l’invitation de {{invitation.email}}"
+                    @triggerAction={{fn @onCancelOrganizationInvitation invitation}}
+                  >
+                    <FaIcon @icon="trash" />Annuler l’invitation
+                  </PixButton>
+                </td>
               </tr>
             {{/each}}
           </tbody>

--- a/admin/app/components/organizations/invitations.hbs
+++ b/admin/app/components/organizations/invitations.hbs
@@ -11,7 +11,9 @@
               <th>Adresse e-mail</th>
               <th>Rôle</th>
               <th>Date de dernier envoi</th>
-              <th>Actions</th>
+              {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+                <th>Actions</th>
+              {{/if}}
             </tr>
           </thead>
           <tbody>
@@ -20,17 +22,19 @@
                 <td>{{invitation.email}}</td>
                 <td>{{invitation.roleInFrench}}</td>
                 <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>
-                <td>
-                  <PixButton
-                    @size="small"
-                    @backgroundColor="red"
-                    class="organization-invitations-actions__button"
-                    aria-label="Annuler l’invitation de {{invitation.email}}"
-                    @triggerAction={{fn @onCancelOrganizationInvitation invitation}}
-                  >
-                    <FaIcon @icon="trash" />Annuler l’invitation
-                  </PixButton>
-                </td>
+                {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
+                  <td>
+                    <PixButton
+                      @size="small"
+                      @backgroundColor="red"
+                      class="organization-invitations-actions__button"
+                      aria-label="Annuler l’invitation de {{invitation.email}}"
+                      @triggerAction={{fn @onCancelOrganizationInvitation invitation}}
+                    >
+                      <FaIcon @icon="trash" />Annuler l’invitation
+                    </PixButton>
+                  </td>
+                {{/if}}
               </tr>
             {{/each}}
           </tbody>

--- a/admin/app/components/organizations/invitations.js
+++ b/admin/app/components/organizations/invitations.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class OrganizationInvitations extends Component {
+  @service accessControl;
+
   get sortedInvitations() {
     return this.args.invitations.sortBy('updatedAt').reverse();
   }

--- a/admin/app/controllers/authenticated/organizations/get/invitations.js
+++ b/admin/app/controllers/authenticated/organizations/get/invitations.js
@@ -56,4 +56,20 @@ export default class InvitationsController extends Controller {
   onChangeUserEmailToInvite(event) {
     this.userEmailToInvite = event.target.value;
   }
+
+  @action
+  async cancelOrganizationInvitation(organizationInvitation) {
+    try {
+      await organizationInvitation.destroyRecord({
+        adapterOptions: {
+          organizationInvitationId: organizationInvitation.id,
+          organizationId: this.model.organization.id,
+        },
+      });
+      this.notifications.success(`Cette invitation a bien été annulée.`);
+    } catch (error) {
+      console.error(error);
+      this.notifications.error('Une erreur s’est produite, veuillez réessayer.');
+    }
+  }
 }

--- a/admin/app/styles/components/organization-invitations.scss
+++ b/admin/app/styles/components/organization-invitations.scss
@@ -1,5 +1,4 @@
 .organization-invitations {
-
   &__input {
     min-width: 320px;
   }
@@ -10,5 +9,11 @@
 
   &__message {
     text-align: center;
+  }
+
+  &-actions__button {
+    svg {
+      margin-right: 6px;
+    }
   }
 }

--- a/admin/app/styles/components/organization-invitations.scss
+++ b/admin/app/styles/components/organization-invitations.scss
@@ -1,4 +1,5 @@
 .organization-invitations {
+
   &__input {
     min-width: 320px;
   }
@@ -12,6 +13,7 @@
   }
 
   &-actions__button {
+
     svg {
       margin-right: 6px;
     }

--- a/admin/app/templates/authenticated/organizations/get/invitations.hbs
+++ b/admin/app/templates/authenticated/organizations/get/invitations.hbs
@@ -7,4 +7,7 @@
     @createOrganizationInvitation={{this.createOrganizationInvitation}}
   />
 {{/if}}
-<Organizations::Invitations @invitations={{@model.organizationInvitations}} />
+<Organizations::Invitations
+  @invitations={{@model.organizationInvitations}}
+  @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}
+/>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -186,6 +186,15 @@ export default function () {
     return schema.organizationInvitations.create({ email, lang, role, updatedAt });
   });
 
+  this.delete('/admin/organizations/:id/invitations/:invitation-id', (schema, request) => {
+    const organizationInvitationId = request.params['invitation-id'];
+
+    const invitation = schema.organizationInvitations.find(organizationInvitationId);
+    invitation.status = 'cancelled';
+
+    return invitation;
+  });
+
   this.patch('/admin/memberships/:id', (schema, request) => {
     const membershipId = request.params.id;
     const params = JSON.parse(request.requestBody);

--- a/admin/mirage/factories/organization-invitation.js
+++ b/admin/mirage/factories/organization-invitation.js
@@ -1,0 +1,10 @@
+import { Factory, association } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+  email() {
+    return faker.internet.exampleEmail();
+  },
+
+  organization: association(),
+});

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -6,8 +6,8 @@ function getOrganizationPlaces(schema) {
 }
 
 function getOrganizationInvitations(schema, request) {
-  const ownerOrganizationId = request.params.id;
-  return schema.organizationInvitations.where({ ownerOrganizationId });
+  const organizationId = request.params.id;
+  return schema.organizationInvitations.where({ organizationId });
 }
 
 function findPaginatedOrganizationMemberships(schema, request) {

--- a/admin/tests/acceptance/authenticated/organizations/invitations-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/invitations-management_test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
-import { fillIn } from '@ember/test-helpers';
+import { fillIn, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { visit, clickByName } from '@1024pix/ember-testing-library';
+import { visit } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 
 module('Acceptance | Organizations | Invitations management', function (hooks) {
@@ -19,7 +19,7 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
     // when
     const screen = await visit(`/organizations/${organization.id}/invitations`);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' }), 'user@example.com');
-    await clickByName('Inviter un membre');
+    await click(screen.getByRole('button', { name: 'Inviter un membre' }));
 
     // then
     assert.dom(screen.getByText('user@example.com')).exists();
@@ -38,5 +38,58 @@ module('Acceptance | Organizations | Invitations management', function (hooks) {
 
     // then
     assert.dom(screen.queryByText('Inviter un membre')).doesNotExist();
+  });
+
+  module('when an admin member cancels an invitation', function () {
+    test('it should display a success notification', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const organization = this.server.create('organization', {
+        id: 5,
+        name: 'Kabuki',
+      });
+      this.server.create('organization-invitation', {
+        email: 'kabuki@example.net',
+        lang: 'fr',
+        organization,
+      });
+
+      // when
+      const screen = await visit(`/organizations/${organization.id}/invitations`);
+      await click(screen.getByRole('button', { name: 'Annuler l’invitation de kabuki@example.net' }));
+
+      // then
+      assert.dom(screen.getByText('Cette invitation a bien été annulée.')).exists();
+    });
+
+    module('and an error occurs', function () {
+      test('it should display an error notification and the invitation should remain in the list', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const organization = this.server.create('organization', {
+          id: 5,
+          name: 'Kabuki',
+        });
+        const organizationInvitation = this.server.create('organization-invitation', {
+          id: 10,
+          email: 'kabuki@example.net',
+          lang: 'fr',
+          organization,
+        });
+        this.server.delete(
+          `/admin/organizations/${organization.id}/invitations/${organizationInvitation.id}`,
+          () => new Response({}),
+          500
+        );
+
+        // when
+        const screen = await visit(`/organizations/${organization.id}/invitations`);
+        await click(screen.getByRole('button', { name: 'Annuler l’invitation de kabuki@example.net' }));
+
+        // then
+        assert.dom(screen.getByText('Une erreur s’est produite, veuillez réessayer.')).exists();
+        assert.dom(screen.getByRole('row', { name: 'Invitation en attente de kabuki@example.net' })).exists();
+      });
+    });
   });
 });

--- a/admin/tests/integration/components/organizations/invitations_test.js
+++ b/admin/tests/integration/components/organizations/invitations_test.js
@@ -1,74 +1,178 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import dayjs from 'dayjs';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Integration | Component | organization-invitations', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('without invitation', function () {
-    test('it should display a message when there is no invitations', async function (assert) {
-      // given
-      this.set('invitations', []);
-
-      // when
-      const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
-
-      // then
-      assert.dom(screen.getByText('Aucune invitation en attente')).exists();
-    });
-  });
-
-  module('with invitations', function () {
-    test('it should list the pending team invitations', async function (assert) {
-      // given
-      const cancelOrganizationInvitationStub = sinon.stub();
-      this.set('cancelOrganizationInvitation', cancelOrganizationInvitationStub);
-      this.set('invitations', [
-        {
-          email: 'riri@example.net',
-          role: 'ADMIN',
-          roleInFrench: 'Administrateur',
-          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-        },
-        {
-          email: 'fifi@example.net',
-          role: 'MEMBER',
-          roleInFrench: 'Membre',
-          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-        },
-        {
-          email: 'loulou@example.net',
-          role: null,
-          roleInFrench: '-',
-          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-        },
-      ]);
-
-      // when
-      const screen = await render(
-        hbs`<Organizations::Invitations
-          @invitations={{invitations}}
-          @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}/>`
-      );
-
-      // then
-      assert.dom(screen.getByText('Membre')).exists();
-      assert.dom(screen.getByText('Administrateur')).exists();
-      assert.dom(screen.getByText('-')).exists();
-      assert.dom(screen.queryByText('Aucune invitation en attente')).doesNotExist();
+  module('when the admin member have access to organization scope', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
     });
 
-    module('when an admin member cancels an invitation', function () {
-      test('it should cancel the organization invitation', async function (assert) {
+    module('without invitation', function () {
+      test('it should display a message when there is no invitations', async function (assert) {
+        // given
+        this.set('invitations', []);
+
+        // when
+        const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+
+        // then
+        assert.dom(screen.getByText('Aucune invitation en attente')).exists();
+      });
+    });
+
+    module('with invitations', function () {
+      test('it should list the pending team invitations', async function (assert) {
         // given
         const cancelOrganizationInvitationStub = sinon.stub();
         this.set('cancelOrganizationInvitation', cancelOrganizationInvitationStub);
         this.set('invitations', [
           {
+            email: 'riri@example.net',
+            role: 'ADMIN',
+            roleInFrench: 'Administrateur',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+          {
+            email: 'fifi@example.net',
+            role: 'MEMBER',
+            roleInFrench: 'Membre',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+          {
+            email: 'loulou@example.net',
+            role: null,
+            roleInFrench: '-',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+        ]);
+
+        // when
+        const screen = await render(
+          hbs`<Organizations::Invitations
+          @invitations={{invitations}}
+          @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}/>`
+        );
+
+        // then
+        assert.dom(screen.getByText('Membre')).exists();
+        assert.dom(screen.getByText('Administrateur')).exists();
+        assert.dom(screen.getByText('-')).exists();
+        assert.dom(screen.queryByText('Aucune invitation en attente')).doesNotExist();
+      });
+
+      module('when the admin member cancels an invitation', function () {
+        test('it should cancel the organization invitation', async function (assert) {
+          // given
+          const cancelOrganizationInvitationStub = sinon.stub();
+          this.set('cancelOrganizationInvitation', cancelOrganizationInvitationStub);
+          this.set('invitations', [
+            {
+              email: 'naruto.uzumaki@example.net',
+              role: 'ADMIN',
+              roleInFrench: 'Administrateur',
+              updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+            },
+          ]);
+
+          // when
+          const screen = await render(
+            hbs`<Organizations::Invitations
+        @invitations={{this.invitations}}
+        @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}
+      />`
+          );
+          await click(screen.getByRole('button', { name: 'Annuler l’invitation de naruto.uzumaki@example.net' }));
+
+          // then
+          sinon.assert.calledWith(cancelOrganizationInvitationStub, {
             email: 'naruto.uzumaki@example.net',
+            role: 'ADMIN',
+            roleInFrench: 'Administrateur',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          });
+          assert.ok(true);
+        });
+      });
+    });
+  });
+
+  module('when the admin member does not have access to organization scope', function (hooks) {
+    hooks.beforeEach(function () {
+      class AccessControlStub extends Service {
+        hasAccessToOrganizationActionsScope = false;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    module('without invitation', function () {
+      test('it should display a message when there is no invitations', async function (assert) {
+        // given
+        this.set('invitations', []);
+
+        // when
+        const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+
+        // then
+        assert.dom(screen.getByText('Aucune invitation en attente')).exists();
+      });
+    });
+
+    module('with invitations', function () {
+      test('it should list the pending team invitations', async function (assert) {
+        // given
+        const cancelOrganizationInvitationStub = sinon.stub();
+        this.set('cancelOrganizationInvitation', cancelOrganizationInvitationStub);
+        this.set('invitations', [
+          {
+            email: 'riri@example.net',
+            role: 'ADMIN',
+            roleInFrench: 'Administrateur',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+          {
+            email: 'fifi@example.net',
+            role: 'MEMBER',
+            roleInFrench: 'Membre',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+          {
+            email: 'loulou@example.net',
+            role: null,
+            roleInFrench: '-',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+        ]);
+
+        // when
+        const screen = await render(
+          hbs`<Organizations::Invitations
+          @invitations={{invitations}}
+          @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}/>`
+        );
+
+        // then
+        assert.dom(screen.getByText('Membre')).exists();
+        assert.dom(screen.getByText('Administrateur')).exists();
+        assert.dom(screen.getByText('-')).exists();
+        assert.dom(screen.queryByText('Aucune invitation en attente')).doesNotExist();
+      });
+
+      test('it should not be able to see the cancel button', async function (assert) {
+        // given
+        this.set('invitations', [
+          {
+            email: 'sakura.haruno@example.net',
             role: 'ADMIN',
             roleInFrench: 'Administrateur',
             updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
@@ -76,22 +180,17 @@ module('Integration | Component | organization-invitations', function (hooks) {
         ]);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Organizations::Invitations
         @invitations={{this.invitations}}
         @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}
       />`
         );
-        await clickByName('Annuler l’invitation de naruto.uzumaki@example.net');
 
         // then
-        sinon.assert.calledWith(cancelOrganizationInvitationStub, {
-          email: 'naruto.uzumaki@example.net',
-          role: 'ADMIN',
-          roleInFrench: 'Administrateur',
-          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-        });
-        assert.ok(true);
+        assert
+          .dom(screen.queryByRole('button', { name: 'Annuler l’invitation de sakura.haruno@example.net' }))
+          .doesNotExist();
       });
     });
   });

--- a/admin/tests/integration/components/organizations/invitations_test.js
+++ b/admin/tests/integration/components/organizations/invitations_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import dayjs from 'dayjs';
+import sinon from 'sinon';
 
 module('Integration | Component | organization-invitations', function (hooks) {
   setupRenderingTest(hooks);
@@ -23,6 +24,8 @@ module('Integration | Component | organization-invitations', function (hooks) {
   module('with invitations', function () {
     test('it should list the pending team invitations', async function (assert) {
       // given
+      const cancelOrganizationInvitationStub = sinon.stub();
+      this.set('cancelOrganizationInvitation', cancelOrganizationInvitationStub);
       this.set('invitations', [
         {
           email: 'riri@example.net',
@@ -45,13 +48,51 @@ module('Integration | Component | organization-invitations', function (hooks) {
       ]);
 
       // when
-      const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+      const screen = await render(
+        hbs`<Organizations::Invitations
+          @invitations={{invitations}}
+          @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}/>`
+      );
 
       // then
       assert.dom(screen.getByText('Membre')).exists();
       assert.dom(screen.getByText('Administrateur')).exists();
       assert.dom(screen.getByText('-')).exists();
       assert.dom(screen.queryByText('Aucune invitation en attente')).doesNotExist();
+    });
+
+    module('when an admin member cancels an invitation', function () {
+      test('it should cancel the organization invitation', async function (assert) {
+        // given
+        const cancelOrganizationInvitationStub = sinon.stub();
+        this.set('cancelOrganizationInvitation', cancelOrganizationInvitationStub);
+        this.set('invitations', [
+          {
+            email: 'naruto.uzumaki@example.net',
+            role: 'ADMIN',
+            roleInFrench: 'Administrateur',
+            updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+          },
+        ]);
+
+        // when
+        await render(
+          hbs`<Organizations::Invitations
+        @invitations={{this.invitations}}
+        @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}
+      />`
+        );
+        await clickByName('Annuler l’invitation de naruto.uzumaki@example.net');
+
+        // then
+        sinon.assert.calledWith(cancelOrganizationInvitationStub, {
+          email: 'naruto.uzumaki@example.net',
+          role: 'ADMIN',
+          roleInFrench: 'Administrateur',
+          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+        });
+        assert.ok(true);
+      });
     });
   });
 });

--- a/admin/tests/integration/components/organizations/invitations_test.js
+++ b/admin/tests/integration/components/organizations/invitations_test.js
@@ -7,47 +7,51 @@ import dayjs from 'dayjs';
 module('Integration | Component | organization-invitations', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it should list the pending team invitations', async function (assert) {
-    // given
-    this.set('invitations', [
-      {
-        email: 'riri@example.net',
-        role: 'ADMIN',
-        roleInFrench: 'Administrateur',
-        updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-      },
-      {
-        email: 'fifi@example.net',
-        role: 'MEMBER',
-        roleInFrench: 'Membre',
-        updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-      },
-      {
-        email: 'loulou@example.net',
-        role: null,
-        roleInFrench: '-',
-        updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
-      },
-    ]);
+  module('without invitation', function () {
+    test('it should display a message when there is no invitations', async function (assert) {
+      // given
+      this.set('invitations', []);
 
-    // when
-    const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+      // when
+      const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
 
-    // then
-    assert.dom(screen.getByText('Membre')).exists();
-    assert.dom(screen.getByText('Administrateur')).exists();
-    assert.dom(screen.getByText('-')).exists();
-    assert.dom(screen.queryByText('Aucune invitation en attente')).doesNotExist();
+      // then
+      assert.dom(screen.getByText('Aucune invitation en attente')).exists();
+    });
   });
 
-  test('it should display a message when there is no invitations', async function (assert) {
-    // given
-    this.set('invitations', []);
+  module('with invitations', function () {
+    test('it should list the pending team invitations', async function (assert) {
+      // given
+      this.set('invitations', [
+        {
+          email: 'riri@example.net',
+          role: 'ADMIN',
+          roleInFrench: 'Administrateur',
+          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+        },
+        {
+          email: 'fifi@example.net',
+          role: 'MEMBER',
+          roleInFrench: 'Membre',
+          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+        },
+        {
+          email: 'loulou@example.net',
+          role: null,
+          roleInFrench: '-',
+          updatedAt: dayjs('2019-10-08T10:50:00Z').utcOffset(2),
+        },
+      ]);
 
-    // when
-    const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+      // when
+      const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
 
-    // then
-    assert.dom(screen.getByText('Aucune invitation en attente')).exists();
+      // then
+      assert.dom(screen.getByText('Membre')).exists();
+      assert.dom(screen.getByText('Administrateur')).exists();
+      assert.dom(screen.getByText('-')).exists();
+      assert.dom(screen.queryByText('Aucune invitation en attente')).doesNotExist();
+    });
   });
 });

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -218,6 +218,35 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'DELETE',
+      path: '/api/admin/organizations/{id}/invitations/{organizationInvitationId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+            organizationInvitationId: identifiersType.organizationInvitationId,
+          }),
+        },
+        handler: organizationController.cancelOrganizationInvitation,
+        tags: ['api', 'admin', 'invitations', 'cancel'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet d'annuler une invitation envoyée mais non acceptée encore.",
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/admin/organizations/{id}/places',
       config: {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -314,8 +314,8 @@ module.exports = {
 
   async cancelOrganizationInvitation(request, h) {
     const organizationInvitationId = request.params.organizationInvitationId;
-    const cancelledOrganizationInvitation = await usecases.cancelOrganizationInvitation({ organizationInvitationId });
-    return h.response(organizationInvitationSerializer.serialize(cancelledOrganizationInvitation));
+    await usecases.cancelOrganizationInvitation({ organizationInvitationId });
+    return h.response().code(204);
   },
 
   async sendInvitationByLangAndRole(request, h) {

--- a/api/tests/acceptance/application/organizations/cancel-organization-invitation-delete_test.js
+++ b/api/tests/acceptance/application/organizations/cancel-organization-invitation-delete_test.js
@@ -3,13 +3,14 @@ const {
   expect,
   generateValidRequestAuthorizationHeader,
   insertOrganizationUserWithRoleAdmin,
+  insertUserWithRoleSuperAdmin,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 
 describe('Acceptance | Route | Organizations', function () {
   describe('DELETE /api/organizations/{id}/invitations/{invitationId}', function () {
-    it('should return 200 HTTP status code', async function () {
+    it('should return 204 HTTP status code', async function () {
       // given
       const server = await createServer();
 
@@ -33,7 +34,37 @@ describe('Acceptance | Route | Organizations', function () {
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+
+  describe('DELETE /api/admin/organizations/{organizationId}/invitations/{invitationId}', function () {
+    it('should return 204 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+
+      const adminMember = await insertUserWithRoleSuperAdmin();
+      const { organization } = await insertOrganizationUserWithRoleAdmin();
+      const invitation = databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+
+      const options = {
+        method: 'DELETE',
+        url: `/api/admin/organizations/${organization.id}/invitations/${invitation.id}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminMember.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -128,6 +128,29 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
+  describe('DELETE /api/admin/organizations/:organizationId/invitations/:organizationInvitationId', function () {
+    it('should return an HTTP status code 204', async function () {
+      // given
+      const method = 'DELETE';
+      const url = '/api/admin/organizations/1/invitations/1';
+
+      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon
+        .stub(organizationController, 'cancelOrganizationInvitation')
+        .returns((request, h) => h.response().code(204));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const { statusCode } = await httpTestServer.request(method, url);
+
+      // then
+      expect(statusCode).to.equal(204);
+      expect(organizationController.cancelOrganizationInvitation).to.have.been.calledOnce;
+    });
+  });
+
   describe('POST /api/admin/organizations/:id/target-profiles', function () {
     it('should resolve with a 204 status code', async function () {
       // given

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -66,26 +66,6 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
-  describe('GET /api/organizations/:id/campaigns', function () {
-    it('should call the organization controller to get the campaigns', async function () {
-      // given
-      const method = 'GET';
-      const url = '/api/organizations/1/campaigns';
-
-      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
-      sinon.stub(organizationController, 'findPaginatedFilteredCampaigns').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request(method, url);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(organizationController.findPaginatedFilteredCampaigns).to.have.been.calledOnce;
-    });
-  });
-
   describe('POST /api/admin/organizations/:id/archive', function () {
     it('should call the controller to archive the organization', async function () {
       // given
@@ -128,6 +108,73 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
+  describe('GET /api/admin/organizations/:id/invitations', function () {
+    it('should exist', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/organizations/1/invitations';
+
+      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(organizationController, 'findPendingInvitations').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(organizationController.findPendingInvitations).to.have.been.calledOnce;
+    });
+  });
+
+  describe('POST /api/admin/organizations/:id/target-profiles', function () {
+    it('should resolve with a 204 status code', async function () {
+      // given
+      const method = 'POST';
+      const url = '/api/admin/organizations/1/target-profiles';
+      const payload = {
+        data: {
+          type: 'target-profile-shares',
+          attributes: {
+            'target-profiles-to-attach': [1, 2],
+          },
+        },
+      };
+
+      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(organizationController, 'attachTargetProfiles').callsFake((request, h) => h.response('ok').code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+
+  describe('GET /api/organizations/:id/campaigns', function () {
+    it('should call the organization controller to get the campaigns', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/organizations/1/campaigns';
+
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(organizationController, 'findPaginatedFilteredCampaigns').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(organizationController.findPaginatedFilteredCampaigns).to.have.been.calledOnce;
+    });
+  });
+
   describe('POST /api/organizations/:id/invitations', function () {
     it('should call the organization controller to send invitations', async function () {
       // given
@@ -163,26 +210,6 @@ describe('Integration | Application | Organizations | Routes', function () {
       const url = '/api/organizations/1/invitations';
 
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
-      sinon.stub(organizationController, 'findPendingInvitations').returns('ok');
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request(method, url);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(organizationController.findPendingInvitations).to.have.been.calledOnce;
-    });
-  });
-
-  describe('GET /api/admin/organizations/:id/invitations', function () {
-    it('should exist', async function () {
-      // given
-      const method = 'GET';
-      const url = '/api/admin/organizations/1/invitations';
-
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(organizationController, 'findPendingInvitations').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -264,33 +291,6 @@ describe('Integration | Application | Organizations | Routes', function () {
         // then
         expect(response.statusCode).to.equal(400);
       });
-    });
-  });
-
-  describe('POST /api/admin/organizations/:id/target-profiles', function () {
-    it('should resolve with a 204 status code', async function () {
-      // given
-      const method = 'POST';
-      const url = '/api/admin/organizations/1/target-profiles';
-      const payload = {
-        data: {
-          type: 'target-profile-shares',
-          attributes: {
-            'target-profiles-to-attach': [1, 2],
-          },
-        },
-      };
-
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
-      sinon.stub(organizationController, 'attachTargetProfiles').callsFake((request, h) => h.response('ok').code(204));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(204);
     });
   });
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -987,7 +987,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
   });
 
   describe('#cancelOrganizationInvitation', function () {
-    it('should call the usecase to cancel invitation with organizationInvitationId', async function () {
+    it('should call the use case to cancel invitation with organizationInvitationId', async function () {
       //given
       const organizationInvitationId = 123;
 
@@ -1017,7 +1017,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const response = await organizationController.cancelOrganizationInvitation(request, hFake);
 
       // then
-      expect(response.source).to.equal(serializedResponse);
+      expect(response.statusCode).to.equal(204);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, l'annulation d'une invitation à une organisation se fait au travers de l'application `Pix Orga`. Il faut être membre de cette organisation et également avoir les droits nécessaire pour exécuter cette action.

Cette possibilité d'annuler une invitation est manquante sur l'application `Pix Admin`.

## :robot: Solution

1. Ajouter une nouvelle colonne au tableau avec un bouton d'action pour annuler une invitation
2. Restreindre l'accès à cette action aux rôles suivants : SuperAdmin, Metier et Support. 

## :rainbow: Remarques
 RAS

## :100: Pour tester

##### Action disponible pour les rôles : **SuperAdmin**, **Support** et **Metier**

1. Se connecter avec `superadmin@example.net`, `pixsupport@example.net` ou `pixmetier@example.net`
2. Allez sur la page listant toutes les organisations
3. Sélectionnez une organisation ayant des invitations en attente
4. Allez sur l'onglet `Invitations`
5. Constatez l'affichage d'une nouvelle colonne `Actions`
6. Cliquez sur le bouton `Annuler l'invitation` pour une invitation
7. Constatez l'affichage d'une notification de succès ainsi que la disparition de la ligne dans le tableau des invitations 

##### Action indisponible pour le rôle : **Certif**

1. Se connecter avec `pixcertif@example.net`
2. Allez sur la page listant toutes les organisations
3. Sélectionnez une organisation ayant des invitations en attente
4. Allez sur l'onglet `Invitations`
5. Constatez que la colonne `Actions` n'est pas disponible