### PR TITLE
[FEATURE] Ajouter la colonne "imageUrl" à la table "complementary-certification-badges" (PIX-5208)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-badge.js
+++ b/api/db/database-builder/factory/build-complementary-certification-badge.js
@@ -9,6 +9,7 @@ module.exports = function buildComplementaryCertificationBadge({
   complementaryCertificationId,
   badgeId,
   createdAt = new Date('2020-01-01'),
+  imageUrl = 'http://badge-image-url.fr',
 } = {}) {
   complementaryCertificationId = _.isNull(complementaryCertificationId)
     ? buildComplementaryCertification().id
@@ -21,6 +22,7 @@ module.exports = function buildComplementaryCertificationBadge({
     complementaryCertificationId,
     badgeId,
     createdAt,
+    imageUrl,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'complementary-certification-badges',

--- a/api/db/migrations/20220802093742_add-imageUrl-to-complementary-certification-badges.js
+++ b/api/db/migrations/20220802093742_add-imageUrl-to-complementary-certification-badges.js
@@ -1,0 +1,102 @@
+const TABLE_NAME = 'complementary-certification-badges';
+const COLUMN_NAME = 'imageUrl';
+const {
+  PIX_DROIT_MAITRE_CERTIF,
+  PIX_DROIT_EXPERT_CERTIF,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+  PIX_EMPLOI_CLEA_V1,
+  PIX_EMPLOI_CLEA_V2,
+  PIX_EMPLOI_CLEA_V3,
+} = require('../../lib/domain/models/Badge').keys;
+
+const bluebird = require('bluebird');
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME);
+  });
+
+  const data = [
+    { imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg', key: PIX_DROIT_MAITRE_CERTIF },
+    { imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg', key: PIX_DROIT_EXPERT_CERTIF },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+      key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
+      key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
+      key: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
+      key: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-4-Expert-certif.svg',
+      key: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Autonome_PREMIER-DEGRE.svg',
+      key: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
+      key: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
+      key: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-avance_PREMIER-DEGRE.svg',
+      key: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Expert_PREMIER-DEGRE.svg',
+      key: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix-emploi.svg',
+      key: PIX_EMPLOI_CLEA_V1,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix-emploi.svg',
+      key: PIX_EMPLOI_CLEA_V2,
+    },
+    {
+      imageUrl: 'https://images.pix.fr/badges/Pix-emploi.svg',
+      key: PIX_EMPLOI_CLEA_V3,
+    },
+  ];
+
+  await bluebird.mapSeries(data, addImageUrlForBadgeKey);
+
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+
+  async function addImageUrlForBadgeKey({ imageUrl, key }) {
+    await knex(TABLE_NAME)
+      .update({ imageUrl })
+      .where({ badgeId: knex('badges').select('id').where({ key }) });
+  }
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -97,7 +97,8 @@ function certificationCentersBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE_BADGE_ID,
     level: 1,
-    complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME_BADGE_ID,
@@ -107,7 +108,8 @@ function certificationCentersBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME_BADGE_ID,
     level: 2,
-    complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME_BADGE_ID,
@@ -117,7 +119,8 @@ function certificationCentersBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME_BADGE_ID,
     level: 3,
-    complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE_BADGE_ID,
@@ -127,7 +130,8 @@ function certificationCentersBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE_BADGE_ID,
     level: 4,
-    complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT_BADGE_ID,
@@ -137,7 +141,8 @@ function certificationCentersBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT_BADGE_ID,
     level: 5,
-    complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-4-Expert-certif.svg',
   });
 
   databaseBuilder.factory.buildCertificationCenter({

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -49,18 +49,21 @@ function certificationCentersBuilder({ databaseBuilder }) {
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V1,
     level: 1,
     complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix-emploi.svg',
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V2,
     level: 2,
     complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix-emploi.svg',
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
     level: 3,
     complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix-emploi.svg',
   });
 
   databaseBuilder.factory.buildComplementaryCertification({
@@ -82,17 +85,20 @@ function certificationCentersBuilder({ databaseBuilder }) {
     badgeId: PIX_DROIT_MAITRE_BADGE_ID,
     level: 1,
     complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_DROIT_EXPERT_BADGE_ID,
     level: 2,
     complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
   });
 
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE_BADGE_ID,
     level: 1,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Autonome_PREMIER-DEGRE.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE_BADGE_ID,
@@ -104,6 +110,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     badgeId: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME_BADGE_ID,
     level: 2,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME_BADGE_ID,
@@ -115,6 +122,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME_BADGE_ID,
     level: 3,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME_BADGE_ID,
@@ -126,6 +134,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE_BADGE_ID,
     level: 4,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-avance_PREMIER-DEGRE.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE_BADGE_ID,
@@ -137,6 +146,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT_BADGE_ID,
     level: 5,
     complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
+    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Expert_PREMIER-DEGRE.svg',
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT_BADGE_ID,

--- a/api/lib/domain/read-models/CertifiedBadgeImage.js
+++ b/api/lib/domain/read-models/CertifiedBadgeImage.js
@@ -28,21 +28,17 @@ class CertifiedBadgeImage {
     });
   }
 
-  static fromPartnerKey(partnerKey, isTemporaryBadge) {
+  static fromPartnerKey(partnerKey, isTemporaryBadge, imageUrl) {
     const badgeKey = partnerKey;
 
-    if (badgeKey === PIX_DROIT_MAITRE_CERTIF) {
-      return CertifiedBadgeImage.finalFromPath('https://images.pix.fr/badges-certifies/pix-droit/maitre.svg');
-    }
-
-    if (badgeKey === PIX_DROIT_EXPERT_CERTIF) {
-      return CertifiedBadgeImage.finalFromPath('https://images.pix.fr/badges-certifies/pix-droit/expert.svg');
+    if (badgeKey === PIX_DROIT_MAITRE_CERTIF || badgeKey === PIX_DROIT_EXPERT_CERTIF) {
+      return CertifiedBadgeImage.finalFromPath(imageUrl);
     }
 
     if (badgeKey === PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE) {
       const levelName = 'Initié (entrée dans le métier)';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -52,7 +48,7 @@ class CertifiedBadgeImage {
     if (badgeKey === PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE) {
       const levelName = 'Initié (entrée dans le métier)';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Autonome_PREMIER-DEGRE.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -64,7 +60,7 @@ class CertifiedBadgeImage {
     ) {
       const levelName = 'Confirmé';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -76,7 +72,7 @@ class CertifiedBadgeImage {
     ) {
       const levelName = 'Confirmé';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-confirme_PREMIER-DEGRE.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -86,7 +82,7 @@ class CertifiedBadgeImage {
     if (badgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE) {
       const levelName = 'Avancé';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-3-Avance-certif.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -96,7 +92,7 @@ class CertifiedBadgeImage {
     if (badgeKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE) {
       const levelName = 'Avancé';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-avance_PREMIER-DEGRE.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -106,7 +102,7 @@ class CertifiedBadgeImage {
     if (badgeKey === PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT) {
       const levelName = 'Expert';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-4-Expert-certif.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,
@@ -116,7 +112,7 @@ class CertifiedBadgeImage {
     if (badgeKey === PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT) {
       const levelName = 'Expert';
       return new CertifiedBadgeImage({
-        path: 'https://images.pix.fr/badges/Pix_plus_Edu-certif-Expert_PREMIER-DEGRE.svg',
+        path: imageUrl,
         message: _getBadgeMessage(isTemporaryBadge, levelName),
         isTemporaryBadge,
         levelName,

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -92,6 +92,7 @@ module.exports = {
   async findHighestCertifiable({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction.knexTransaction || knex;
     const certifiableBadgeAcquisitions = await knexConn('badge-acquisitions')
+      .select('badges.*', 'badge-acquisitions.*')
       .join('badges', 'badges.id', 'badge-acquisitions.badgeId')
       .join('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
       .where({

--- a/api/lib/infrastructure/repositories/shareable-certificate-repository.js
+++ b/api/lib/infrastructure/repositories/shareable-certificate-repository.js
@@ -127,13 +127,20 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
     PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
   ];
   const results = await knex
-    .select('complementary-certification-course-results.*')
+    .select('complementary-certification-course-results.*', 'complementary-certification-badges.imageUrl')
     .from('complementary-certification-course-results')
     .innerJoin(
       'complementary-certification-courses',
       'complementary-certification-courses.id',
       'complementary-certification-course-results.complementaryCertificationCourseId'
     )
+    .innerJoin('badges', 'badges.key', 'complementary-certification-course-results.partnerKey')
+    .innerJoin('complementary-certification-badges', function () {
+      this.on('complementary-certification-badges.badgeId', 'badges.id').on(
+        'complementary-certification-badges.complementaryCertificationId',
+        'complementary-certification-courses.complementaryCertificationId'
+      );
+    })
     .where({ certificationCourseId })
     .where(function () {
       this.whereIn('partnerKey', handledBadgeKeys);
@@ -155,9 +162,11 @@ async function _getCertifiedBadgeImages(certificationCourseId) {
   }).getAcquiredCertifiedBadgesDTO();
 
   return _.compact(
-    _.map(certifiedBadgesDTO, ({ partnerKey, isTemporaryBadge }) =>
-      CertifiedBadgeImage.fromPartnerKey(partnerKey, isTemporaryBadge)
-    )
+    _.map(certifiedBadgesDTO, ({ partnerKey, isTemporaryBadge }) => {
+      const imageUrl = results.find((result) => result.partnerKey === partnerKey).imageUrl;
+
+      return CertifiedBadgeImage.fromPartnerKey(partnerKey, isTemporaryBadge, imageUrl);
+    })
   );
 }
 

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -415,6 +415,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
         });
         const badgeLevel2 = databaseBuilder.factory.buildBadge.certifiable({
           key: 'level-2',
+          imageUrl: 'badge-url-2.fr',
         });
         const badgeLevel3 = databaseBuilder.factory.buildBadge.certifiable({
           key: 'level-3',
@@ -428,6 +429,7 @@ describe('Integration | Repository | Badge Acquisition', function () {
           badgeId: badgeLevel2.id,
           complementaryCertificationId,
           level: 2,
+          imageUrl: 'complementary-certification-badge-url-2.fr',
         });
 
         databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -469,7 +471,9 @@ describe('Integration | Repository | Badge Acquisition', function () {
 
         // then
         expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
-        expect(certifiableBadgesAcquiredByUser.map(({ badgeId }) => badgeId)).to.deep.equal([badgeLevel2.id]);
+        expect(
+          certifiableBadgesAcquiredByUser.map(({ badgeId, badge }) => ({ badgeId, imageUrl: badge.imageUrl }))
+        ).to.deep.equal([{ badgeId: badgeLevel2.id, imageUrl: badgeLevel2.imageUrl }]);
       });
     });
     describe('when the user has no certifiable acquired badge', function () {

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -78,10 +78,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         id: certificateId,
         ...privateCertificateData,
       });
-      expect(privateCertificate).to.be.instanceOf(PrivateCertificate);
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     describe('when "locale" is french', function () {
@@ -412,9 +409,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         id: certificateId,
         ...privateCertificateData,
       });
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     it('should get the clea certification result if taken with badge V1', async function () {
@@ -475,9 +470,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         id: certificateId,
         ...privateCertificateData,
       });
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     it('should get the clea certification result if taken with badge V2', async function () {
@@ -521,9 +514,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         id: certificateId,
         ...privateCertificateData,
       });
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     it('should get the clea certification result if taken with badge V3', async function () {
@@ -567,9 +558,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         id: certificateId,
         ...privateCertificateData,
       });
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     context('acquired certifiable badges', function () {
@@ -616,9 +605,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
           ...privateCertificateData,
         });
 
-        expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-          _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-        );
+        expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
       });
 
       it('should only take into account acquired ones', async function () {
@@ -664,9 +651,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
           ...privateCertificateData,
         });
 
-        expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-          _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-        );
+        expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
       });
     });
 
@@ -769,9 +754,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         ...privateCertificateData,
       });
 
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     it('should get the certified badge image when there is temporary partner key and no partner key', async function () {
@@ -821,9 +804,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         ...privateCertificateData,
       });
 
-      expect(_.omit(privateCertificate, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
   });
 
@@ -984,9 +965,7 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
         id: certificateId,
         ...privateCertificateData,
       });
-      expect(_.omit(privateCertificates[0], ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedPrivateCertificate, ['resultCompetenceTree'])
-      );
+      expect(privateCertificates[0]).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
     });
 
     it('should get the clea certification result if taken', async function () {

--- a/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/private-certificate-repository_test.js
@@ -35,6 +35,19 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
     },
   ];
 
+  let pixDroitComplementaryCertificationId, pixEduComplementaryCertificationId;
+
+  beforeEach(async function () {
+    pixDroitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+      name: 'PIX+ Droit',
+    }).id;
+    pixEduComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+      name: 'PIX+ Edu',
+    }).id;
+
+    await databaseBuilder.commit();
+  });
+
   describe('#get', function () {
     it('should throw a NotFoundError when private certificate does not exist', async function () {
       // when
@@ -592,8 +605,20 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
-          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, 'should_be_ignored'],
-          notAcquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
+          acquiredBadges: [
+            {
+              key: PIX_DROIT_EXPERT_CERTIF,
+              imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+              complementaryCertificationId: pixDroitComplementaryCertificationId,
+            },
+          ],
+          notAcquiredBadges: [
+            {
+              key: PIX_DROIT_MAITRE_CERTIF,
+              imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+              complementaryCertificationId: pixDroitComplementaryCertificationId,
+            },
+          ],
         });
 
         // when
@@ -638,8 +663,20 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
         const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
-          acquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
-          notAcquiredBadges: [PIX_DROIT_MAITRE_CERTIF],
+          acquiredBadges: [
+            {
+              key: PIX_DROIT_EXPERT_CERTIF,
+              imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+              complementaryCertificationId: pixDroitComplementaryCertificationId,
+            },
+          ],
+          notAcquiredBadges: [
+            {
+              key: PIX_DROIT_MAITRE_CERTIF,
+              imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+              complementaryCertificationId: pixDroitComplementaryCertificationId,
+            },
+          ],
         });
 
         // when
@@ -685,15 +722,33 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
       const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData,
-        acquiredBadges: [PIX_DROIT_MAITRE_CERTIF, 'should_be_ignored'],
-        notAcquiredBadges: [PIX_DROIT_EXPERT_CERTIF],
+        acquiredBadges: [
+          {
+            key: PIX_DROIT_MAITRE_CERTIF,
+            imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+            complementaryCertificationId: pixDroitComplementaryCertificationId,
+          },
+        ],
+        notAcquiredBadges: [
+          {
+            key: PIX_DROIT_EXPERT_CERTIF,
+            imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+            complementaryCertificationId: pixDroitComplementaryCertificationId,
+          },
+        ],
       });
 
       await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData: {},
         acquiredBadges: [],
         notAcquiredBadges: [],
-        temporaryAcquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
+        temporaryAcquiredBadges: [
+          {
+            key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+            complementaryCertificationId: pixDroitComplementaryCertificationId,
+          },
+        ],
       });
 
       // when
@@ -741,7 +796,18 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
       const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData,
-        acquiredBadges: [PIX_DROIT_EXPERT_CERTIF, PIX_DROIT_MAITRE_CERTIF, 'should_be_ignored'],
+        acquiredBadges: [
+          {
+            key: PIX_DROIT_EXPERT_CERTIF,
+            imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/expert.svg',
+            complementaryCertificationId: pixDroitComplementaryCertificationId,
+          },
+          {
+            key: PIX_DROIT_MAITRE_CERTIF,
+            imageUrl: 'https://images.pix.fr/badges-certifies/pix-droit/maitre.svg',
+            complementaryCertificationId: pixDroitComplementaryCertificationId,
+          },
+        ],
         notAcquiredBadges: [],
       });
 
@@ -790,8 +856,14 @@ describe('Integration | Infrastructure | Repository | Private Certificate', func
 
       const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         privateCertificateData,
-        temporaryAcquiredBadges: [PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE],
-        acquiredBadges: ['should_be_ignored'],
+        temporaryAcquiredBadges: [
+          {
+            key: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
+            complementaryCertificationId: pixEduComplementaryCertificationId,
+          },
+        ],
+        acquiredBadges: [],
         notAcquiredBadges: [],
       });
 
@@ -1103,39 +1175,59 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     createdAt: new Date('2021-01-01'),
   });
 
-  acquiredBadges?.forEach((badgeKey) => {
-    databaseBuilder.factory.buildBadge({ key: badgeKey });
+  acquiredBadges?.forEach(({ key, imageUrl, complementaryCertificationId }) => {
+    const badgeId = databaseBuilder.factory.buildBadge({ key }).id;
     const { id: complementaryCertificationCourseId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
       certificationCourseId: certificateId,
+      complementaryCertificationId,
     });
     databaseBuilder.factory.buildComplementaryCertificationCourseResult({
       complementaryCertificationCourseId,
-      partnerKey: badgeKey,
+      partnerKey: key,
       acquired: true,
     });
+
+    databaseBuilder.factory.buildComplementaryCertificationBadge({
+      badgeId,
+      complementaryCertificationId,
+      imageUrl,
+    });
   });
-  temporaryAcquiredBadges?.forEach((badgeKey) => {
-    databaseBuilder.factory.buildBadge({ key: badgeKey });
+  temporaryAcquiredBadges?.forEach(({ key, imageUrl, complementaryCertificationId }) => {
+    const badgeId = databaseBuilder.factory.buildBadge({ key }).id;
     const { id: complementaryCertificationCourseId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
       certificationCourseId: certificateId,
+      complementaryCertificationId,
     });
     databaseBuilder.factory.buildComplementaryCertificationCourseResult({
       complementaryCertificationCourseId,
-      partnerKey: badgeKey,
+      partnerKey: key,
       acquired: true,
       source: ComplementaryCertificationCourseResult.sources.PIX,
     });
+    databaseBuilder.factory.buildComplementaryCertificationBadge({
+      badgeId,
+      complementaryCertificationId,
+      imageUrl,
+    });
   });
 
-  notAcquiredBadges.forEach((badgeKey) => {
-    databaseBuilder.factory.buildBadge({ key: badgeKey });
+  notAcquiredBadges.forEach(({ key, imageUrl, complementaryCertificationId }) => {
+    const badgeId = databaseBuilder.factory.buildBadge({ key }).id;
     const { id: complementaryCertificationCourseId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
       certificationCourseId: certificateId,
+      complementaryCertificationId,
     });
     databaseBuilder.factory.buildComplementaryCertificationCourseResult({
       complementaryCertificationCourseId,
-      partnerKey: badgeKey,
+      partnerKey: key,
       acquired: false,
+    });
+
+    databaseBuilder.factory.buildComplementaryCertificationBadge({
+      badgeId,
+      complementaryCertificationId,
+      imageUrl,
     });
   });
   await databaseBuilder.commit();

--- a/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
+++ b/api/tests/unit/domain/read-models/CertifiedBadgeImage_test.js
@@ -72,17 +72,44 @@ const pixPlusEdu1erDegreBadgesInfos = {
 
 describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
   describe('#fromPartnerKey', function () {
-    context('when badge is final', function () {
-      context('when badge is Pix+Edu', function () {
+    context('when badge is Pix+Edu', function () {
+      context('when badge is temporary', function () {
+        // given
+        const badges = { ...pixPlusEdu2ndDegreBadgesInfos, ...pixPlusEdu1erDegreBadgesInfos };
+
+        for (const badgeKey in badges) {
+          it(`returns temporary badge image for "PIX" source ${badgeKey}`, function () {
+            // when
+            const isTemporaryBadge = true;
+            const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge, badges[badgeKey].path);
+
+            // then
+            const { path, levelName } = badges[badgeKey];
+
+            expect(result).to.deepEqualInstance(
+              new CertifiedBadgeImage({
+                path,
+                levelName,
+                isTemporaryBadge,
+                message: `Vous avez obtenu le niveau “${levelName}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
+              })
+            );
+          });
+        }
+      });
+
+      context('when badge is final', function () {
+        // given
         const badges = {
           ...pixPlusEdu2ndDegreBadgesInfos,
           ...pixPlusEdu1erDegreBadgesInfos,
         };
+
         for (const badgeKey in badges) {
           it(`returns final badge image for partner key ${badgeKey}`, function () {
             // when
             const isTemporaryBadge = false;
-            const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge);
+            const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge, badges[badgeKey].path);
 
             // then
             const { path, levelName } = badges[badgeKey];
@@ -98,39 +125,19 @@ describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
           });
         }
       });
-
-      context('when badge is not Pix+Edu', function () {
-        const badges = {
-          ...pixPlusDroitBadgesInfos,
-        };
-        for (const badgeKey in badges) {
-          it(`returns final badge image for partner key ${badgeKey}`, function () {
-            // when
-            const isTemporaryBadge = false;
-            const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge);
-
-            // then
-            const { path, levelName } = badges[badgeKey];
-
-            expect(result).to.deepEqualInstance(
-              new CertifiedBadgeImage({
-                path,
-                levelName,
-                isTemporaryBadge,
-                message: null,
-              })
-            );
-          });
-        }
-      });
     });
-    context('when badge is temporary', function () {
-      const badges = { ...pixPlusEdu2ndDegreBadgesInfos, ...pixPlusEdu1erDegreBadgesInfos };
+
+    context('when badge is not Pix+Edu', function () {
+      // given
+      const badges = {
+        ...pixPlusDroitBadgesInfos,
+      };
+
       for (const badgeKey in badges) {
-        it(`returns temporary badge image for "PIX" source ${badgeKey}`, function () {
+        it(`returns final badge image for partner key ${badgeKey}`, function () {
           // when
-          const isTemporaryBadge = true;
-          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge);
+          const isTemporaryBadge = false;
+          const result = CertifiedBadgeImage.fromPartnerKey(badgeKey, isTemporaryBadge, badges[badgeKey].path);
 
           // then
           const { path, levelName } = badges[badgeKey];
@@ -140,7 +147,7 @@ describe('Unit | Domain | Models | CertifiedBadgeImage', function () {
               path,
               levelName,
               isTemporaryBadge,
-              message: `Vous avez obtenu le niveau “${levelName}” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2`,
+              message: null,
             })
           );
         });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les macarons ou images associés aux badges sont hébergées sur [images.pix.fr](http://images.pix.fr/). Bien que les images à afficher en fin de parcours, afin d’informer le candidat qu’il a obtenu tel ou tel badge soient stockés en base (colonne imageUrl de la table badges), ceux à afficher dans les certificats une fois le candidat certifié sont en dur dans le code.

## :robot: Solution
- Ajouter une colonne imageUrl à la table complementary-certification-badges via un script de migration

- Alimenter cette colonne (dans le script de migration précédent) + seeds

- Utiliser la valeur de l’url de l’image dans les certificats plutôt que des constantes en dur dans le code.

-  Supprimer les constantes en dur dans le code.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Passer avec succès des certification complémentaires (clea, edu1er, edu2nd, droit)
- Finaliser et publier la ou les session(s)
- Constater que les macarons apparaissent bien sur les certificats privés et partagés
![image](https://user-images.githubusercontent.com/37305474/182820024-6ec9ffcf-ebc8-4e9c-af77-6ab74f7c0a3e.png)
![image](https://user-images.githubusercontent.com/37305474/182820129-d4ccb842-2525-4d20-9a12-de5aca862bd1.png)



- Constater que la colonne 'imageUrl' est bien présente et remplie

![image](https://user-images.githubusercontent.com/37305474/182819932-6efade47-3536-4422-8148-2e84d7d2e4a4.png)


