### PR TITLE
[FEATURE] Ne pas prendre en compte l'adresse e-mail lors de l'exécution du script OGA (PIX-5434).

### DIFF
--- a/api/lib/domain/validators/organization-with-tags-script.js
+++ b/api/lib/domain/validators/organization-with-tags-script.js
@@ -23,8 +23,7 @@ const schema = Joi.object({
   credit: Joi.number().required().messages({
     'number.base': "Le crédit n'est pas renseigné.",
   }),
-  email: Joi.string().email().required().messages({
-    'string.empty': "L'email n’est pas renseigné.",
+  email: Joi.string().email().messages({
     'string.email': "L'email fourni n'est pas valide.",
   }),
   organizationInvitationRole: Joi.string().valid(Membership.roles.ADMIN, Membership.roles.MEMBER).required().messages({

--- a/api/scripts/create-pro-organizations-with-tags.js
+++ b/api/scripts/create-pro-organizations-with-tags.js
@@ -26,6 +26,13 @@ const REQUIRED_FIELD_NAMES = [
   'documentationUrl',
 ];
 
+function cleanEmailPropertyFromOrganizations(organizationsToClean) {
+  return organizationsToClean.map(({ email, ...organization }) => ({
+    ...organization,
+    email: email?.trim().replaceAll(' ', '').toLowerCase(),
+  }));
+}
+
 async function createOrganizationWithTags(filePath) {
   await checkCsvHeader({
     filePath,
@@ -35,7 +42,8 @@ async function createOrganizationWithTags(filePath) {
   console.log('Reading and parsing csv data file... ');
   const options = { ...optionsWithHeader };
 
-  const organizations = await parseCsv(filePath, options);
+  const organizationsToClean = await parseCsv(filePath, options);
+  const organizations = cleanEmailPropertyFromOrganizations(organizationsToClean);
 
   console.log('Creating PRO organizations...');
   const createdOrganizations = await createProOrganizationsWithTags({

--- a/api/tests/integration/domain/usecases/create-pro-organization-with-tags_test.js
+++ b/api/tests/integration/domain/usecases/create-pro-organization-with-tags_test.js
@@ -176,7 +176,6 @@ describe('Integration | UseCases | create-pro-organization', function () {
           name: '',
           provinceCode: '',
           credit: '',
-          email: '',
           locale: '',
           tags: '',
           createdBy: '',
@@ -227,10 +226,6 @@ describe('Integration | UseCases | create-pro-organization', function () {
           message: "Le crédit n'est pas renseigné.",
         },
         {
-          attribute: 'email',
-          message: "L'email n’est pas renseigné.",
-        },
-        {
           attribute: 'organizationInvitationRole',
           message: "Le rôle fourni doit avoir l'une des valeurs suivantes : ADMIN ou MEMBER",
         },
@@ -245,7 +240,7 @@ describe('Integration | UseCases | create-pro-organization', function () {
       ]);
     });
 
-    it('should throw an error when first error found whend an externalId is missing and email is not valid', async function () {
+    it('should throw an error when first error found when an externalId is missing and email is not valid', async function () {
       //given
       const organizationsWithTagsWithOneMissingExternalId = [
         {
@@ -497,8 +492,17 @@ describe('Integration | UseCases | create-pro-organization', function () {
         const organizationInDB = await knex('organizations')
           .first('id', 'externalId', 'name', 'provinceCode', 'credit', 'email')
           .where({ externalId: organization.externalId });
-        expect(omit(organizationInDB, 'id')).to.be.deep.equal(
-          omit(organization, 'locale', 'tags', 'type', 'createdBy', 'documentationUrl', 'organizationInvitationRole')
+        expect(omit(organizationInDB, 'id', 'email')).to.be.deep.equal(
+          omit(
+            organization,
+            'locale',
+            'tags',
+            'type',
+            'createdBy',
+            'documentationUrl',
+            'organizationInvitationRole',
+            'email'
+          )
         );
 
         const organizationTagInDB = await knex('organization-tags')

--- a/api/tests/unit/domain/usecases/create-pro-organizations-with-tags_test.js
+++ b/api/tests/unit/domain/usecases/create-pro-organizations-with-tags_test.js
@@ -145,13 +145,15 @@ describe('Unit | UseCase | create-pro-organizations-with-tags', function () {
       externalId: 'externalId A',
       tags: 'Tag1_Tag2_Tag3',
       type: 'PRO',
-      email: 'fake@axample.net',
+      email: 'fake@example.net',
       createdBy: 4,
     };
+    // eslint-disable-next-line no-unused-vars
+    const { email, ...organizationWithoutEmail } = new Organization(organization);
 
-    const expectedProOrganizationToInsert = [new Organization({ ...organization })];
+    const expectedProOrganizationToInsert = [organizationWithoutEmail];
     tagRepositoryStub.findAll.resolves(allTags);
-    organizationRepositoryStub.batchCreateProOrganizations.resolves([organization]);
+    organizationRepositoryStub.batchCreateProOrganizations.resolves([organizationWithoutEmail]);
 
     // when
     await createProOrganizations({


### PR DESCRIPTION
## :unicorn: Problème

##### Aujourd’hui:

Dans le fichier d’input du script OGA, il y a une adresse email.

Lors du lancement du script:
- Un email d’invitation est envoyé à cette adresse email
- Cette adresse email est stocké en base de données dans le champ “organizations.email”

##### Le souci:

Ce champ “organizations.email” est utilisé dans un but bien specifique, et est réservé au SCO. Le script OGA ne créé que des organisations de type PRO

## :robot: Solution

Permettre la création d'une organisation sans fournir d'e-mail.

## :rainbow: Remarques

RAS

## :100: Pour tester

##### En local

- Utilisez ce fichier de test [OGA_test.csv](https://github.com/1024pix/pix/files/9260961/OGA_test.csv)
- Exécutez le script `create-pro-organizations-with-tags.js` avec votre fichier CSV
- Constatez que le script s'est exécuté sans erreur même en ayant fourni des organisations contenant un champs `email`
