### PR TITLE
[TECH] Utilise l'`automerge` 1024pix

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -7,17 +7,11 @@ on:
   check_suite:
     types:
       - completed
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: automerge
-        uses: pascalgn/automerge-action@v0.15.3
-        env:
-          GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
-          MERGE_LABELS: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'
-          MERGE_COMMIT_MESSAGE: pull-request-title
-          UPDATE_LABELS: ':rocket: Ready to Merge'
-          UPDATE_METHOD: rebase
-          MERGE_FORKS: 'false'
-          MERGE_REQUIRED_APPROVALS: 1
+      - uses: 1024pix/pix-actions/auto-merge@v0.1.3
+        with:
+          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :unicorn: Problème
On utilise une action d'`automerge` externe nécessitant plusieurs paramètres ce qui complexifie la réutilisation dans nos autres projets.

## :robot: Solution
Utiliser la GitHub Action interne 1024pix/pix permettant de centraliser le paramétrage et les montées de version.

## :rainbow: Remarques
En faisant cette modification, on supprime le paramétrage `MERGE_REQUIRED_APPROVALS` mais qui n'est pas nécessaire car GitHub bloque le merge si on a pas un approve (config projet).

## :100: Pour tester
Vérifier que l'automerge fonctionne toujours.
