### PR TITLE
[TECH] Mise à jour GitHub Action notify-team-on-config-file-change

### DIFF
--- a/.github/workflows/on-dev-merge.yaml
+++ b/.github/workflows/on-dev-merge.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify team on config file change
-        uses: 1024pix/notify-team-on-config-file-change@v1.0.2
+        uses: 1024pix/notify-team-on-config-file-change@v1.0.3
         with:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_BOT_TOKEN: ${{ secrets.PIX_BOT_RUN_SLACK_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
La GitHub Action [`notify-team-on-config-file-change`](https://github.com/1024pix/notify-team-on-config-file-change) n'est plus à jour et ne nous permet pas de débugger les dernières erreurs constatées.

## :robot: Solution
La remettre à jour.

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir la prochaine fois que l'action est trigger que les logs sont différents.
