### PR TITLE
[FEATURE] Rapporter les formations dans Pix App (PIX-5465).

### DIFF
--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -1,4 +1,4 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class CampaignParticipation extends Model {
   // attributes
@@ -15,4 +15,6 @@ export default class CampaignParticipation extends Model {
   @belongsTo('campaign') campaign;
   @belongsTo('campaignParticipationResult') campaignParticipationResult;
   @belongsTo('user') user;
+
+  @hasMany('training') trainings;
 }

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -1,0 +1,12 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class Training extends Model {
+  @attr('string') status;
+  @attr('string') title;
+  @attr('string') link;
+  @attr('string') type;
+  @attr('string') locale;
+  @attr() duration;
+
+  @belongsTo('campaign-participation') campaignParticpation;
+}

--- a/mon-pix/app/routes/campaigns/assessment.js
+++ b/mon-pix/app/routes/campaigns/assessment.js
@@ -13,6 +13,7 @@ export default class AssessmentRoute extends Route.extend(SecuredRouteMixin) {
     });
     return {
       assessment: await campaignParticipation.assessment,
+      campaignParticipation,
       campaign,
     };
   }

--- a/mon-pix/app/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/routes/campaigns/assessment/skill-review.js
@@ -8,13 +8,14 @@ export default class SkillReviewRoute extends Route.extend(SecuredRouteMixin) {
 
   async model() {
     const user = this.currentUser.user;
-    const campaign = this.modelFor('campaigns');
+    const { campaignParticipation, campaign } = this.modelFor('campaigns.assessment');
     try {
       const campaignParticipationResult = await this.store.queryRecord('campaignParticipationResult', {
         campaignId: campaign.id,
         userId: user.id,
       });
-      return { campaign, campaignParticipationResult };
+      const trainings = await campaignParticipation.hasMany('trainings').reload();
+      return { campaign, campaignParticipationResult, trainings };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {
         return this.router.transitionTo('campaigns.entry-point', campaign.code);

--- a/mon-pix/mirage/routes/campaign-participations/get-campaign-participation-trainings.js
+++ b/mon-pix/mirage/routes/campaign-participations/get-campaign-participation-trainings.js
@@ -1,0 +1,3 @@
+export default function (schema) {
+  return schema.trainings.all();
+}

--- a/mon-pix/mirage/routes/campaign-participations/index.js
+++ b/mon-pix/mirage/routes/campaign-participations/index.js
@@ -1,8 +1,11 @@
 import postCampaignParticipation from './post-campaign-participation';
 import shareCampaignParticipation from './share-campaign-participation';
+import getCampaignParticipationTrainings from './get-campaign-participation-trainings';
 
 export default function index(config) {
   config.post('/campaign-participations', postCampaignParticipation);
 
   config.patch('/campaign-participations/:id', shareCampaignParticipation);
+
+  config.get('/campaign-participations/:id/trainings', getCampaignParticipationTrainings);
 }

--- a/mon-pix/tests/unit/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/skill-review_test.js
@@ -7,6 +7,7 @@ describe('Unit | Route | Campaign | Assessment | Skill review', function () {
 
   let route;
   const campaign = { id: 123456, code: 'NEW_CODE' };
+  const campaignParticipation = { id: 1212, isShared: true, hasMany: sinon.stub() };
   const user = { id: 567890 };
   const storeStub = {
     queryRecord: sinon.stub(),
@@ -15,10 +16,11 @@ describe('Unit | Route | Campaign | Assessment | Skill review', function () {
 
   beforeEach(function () {
     route = this.owner.lookup('route:campaigns.assessment.skill-review');
-    route.modelFor = sinon.stub().returns(campaign);
+    route.modelFor = sinon.stub().returns({ campaign, campaignParticipation });
     route.router = { transitionTo: sinon.stub() };
     route.store = storeStub;
     route.currentUser = currentUserStub;
+    campaignParticipation.hasMany.returns({ reload: sinon.stub() });
   });
 
   describe('#model', function () {


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, nous souhaitons proposer des formations en fin de parcours, cependant ceux-ci ne sont pas rapporter dans le front. 

## :robot: Solution
Ajouter le model ember data `Training` et ramener les formations dans le model `skill-review` qui correspond à la route de résultat d'une campagne.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App
- Passer une campagne 
- Se rendre sur la page de fin d'une campagne ex : `/campagnes/PROCOMP51/evaluation/resultats` 
- Constater dans l'onglet network qu'un appel à la route trainings est fait.
