### PR TITLE
[FEATURE] Notifier par email de la génération des fichiers CPF (PIX-5398).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -293,11 +293,11 @@ module.exports = (function () {
         chunkSize: process.env.CPF_PLANNER_JOB_CHUNK_SIZE || 50000,
         monthsToProcess: process.env.CPF_PLANNER_JOB_MONTHS_TO_PROCESS || 1,
         minimumReliabilityPeriod: process.env.CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD || 3,
-        cron: process.env.CPF_PLANNER_JOB_CRON,
+        cron: process.env.CPF_PLANNER_JOB_CRON || '0 0 1 1 *',
       },
       sendEmailJob: {
         recipient: process.env.CPF_SEND_EMAIL_JOB_RECIPIENT,
-        cron: process.env.CPF_SEND_EMAIL_JOB_CRON,
+        cron: process.env.CPF_SEND_EMAIL_JOB_CRON || '0 0 1 1 *',
       },
     },
   };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -100,6 +100,7 @@ module.exports = (function () {
           certificationResultTemplateId: process.env.SENDINBLUE_CERTIFICATION_RESULT_TEMPLATE_ID,
           accountRecoveryTemplateId: process.env.SENDINBLUE_ACCOUNT_RECOVERY_TEMPLATE_ID,
           emailVerificationCodeTemplateId: process.env.SENDINBLUE_EMAIL_VERIFICATION_CODE_TEMPLATE_ID,
+          cpfEmailTemplateId: process.env.SENDINBLUE_CPF_TEMPLATE_ID,
         },
       },
     },
@@ -334,6 +335,7 @@ module.exports = (function () {
     config.mailing.sendinblue.templates.emailChangeTemplateId = 'test-email-change-template-id';
     config.mailing.sendinblue.templates.accountRecoveryTemplateId = 'test-account-recovery-template-id';
     config.mailing.sendinblue.templates.emailVerificationCodeTemplateId = 'test-email-verification-code-template-id';
+    config.mailing.sendinblue.templates.cpfEmailTemplateId = 'test-cpf-email-template-id';
 
     config.bcryptNumberOfSaltRounds = 1;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -297,6 +297,7 @@ module.exports = (function () {
       },
       sendEmailJob: {
         recipient: process.env.CPF_SEND_EMAIL_JOB_RECIPIENT,
+        cron: process.env.CPF_SEND_EMAIL_JOB_CRON,
       },
     },
   };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -287,12 +287,16 @@ module.exports = (function () {
         endpoint: process.env.CPF_STORAGE_ENDPOINT,
         region: process.env.CPF_STORAGE_REGION,
         bucket: process.env.CPF_STORAGE_BUCKET_NAME,
+        preSignedExpiresIn: process.env.CPF_STORAGE_PRE_SIGNED_EXPIRES_IN || 3600,
       },
       plannerJob: {
         chunkSize: process.env.CPF_PLANNER_JOB_CHUNK_SIZE || 50000,
         monthsToProcess: process.env.CPF_PLANNER_JOB_MONTHS_TO_PROCESS || 1,
         minimumReliabilityPeriod: process.env.CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD || 3,
         cron: process.env.CPF_PLANNER_JOB_CRON,
+      },
+      sendEmailJob: {
+        recipient: process.env.CPF_SEND_EMAIL_JOB_RECIPIENT,
       },
     },
   };

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -330,6 +330,18 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
   return mailer.sendEmail(options);
 }
 
+function sendCpfEmail({ email, generatedFiles }) {
+  const options = {
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME_FR,
+    to: email,
+    template: mailer.cpfEmailTemplateId,
+    variables: { generatedFiles },
+  };
+
+  return mailer.sendEmail(options);
+}
+
 module.exports = {
   sendAccountCreationEmail,
   sendAccountRecoveryEmail,
@@ -338,4 +350,5 @@ module.exports = {
   sendScoOrganizationInvitationEmail,
   sendResetPasswordDemandEmail,
   sendVerificationCodeEmail,
+  sendCpfEmail,
 };

--- a/api/lib/infrastructure/external-storage/cpf-external-storage.js
+++ b/api/lib/infrastructure/external-storage/cpf-external-storage.js
@@ -23,4 +23,22 @@ module.exports = {
 
     await upload.done();
   },
+
+  getPreSignUrlsOfFilesModifiedAfter: async function ({ date }) {
+    const { accessKeyId, secretAccessKey, endpoint, region, bucket, preSignedExpiresIn: expiresIn } = cpf.storage;
+    const s3Client = s3Utils.getS3Client({
+      accessKeyId,
+      secretAccessKey,
+      endpoint,
+      region,
+    });
+
+    const filesInBucket = await s3Utils.listFiles({ client: s3Client, bucket });
+
+    const keysOfFilesModifiedAfter = filesInBucket?.Contents.filter(({ LastModified }) => LastModified >= date).map(
+      ({ Key }) => Key
+    );
+
+    return await s3Utils.preSignFiles({ client: s3Client, bucket, keys: keysOfFilesModifiedAfter, expiresIn });
+  },
 };

--- a/api/lib/infrastructure/external-storage/cpf-external-storage.js
+++ b/api/lib/infrastructure/external-storage/cpf-external-storage.js
@@ -1,20 +1,22 @@
-const { S3Client } = require('@aws-sdk/client-s3');
-const { Upload } = require('@aws-sdk/lib-storage');
+const s3Utils = require('./s3-utils');
 const { cpf } = require('../../config');
 const logger = require('../logger');
 
 module.exports = {
   upload: async function ({ filename, writableStream }) {
     const { accessKeyId, secretAccessKey, endpoint, region, bucket } = cpf.storage;
-    const s3Client = new S3Client({
-      credentials: { accessKeyId, secretAccessKey },
+    const s3Client = s3Utils.getS3Client({
+      accessKeyId,
+      secretAccessKey,
       endpoint,
       region,
     });
 
-    const upload = new Upload({
+    const upload = s3Utils.startUpload({
       client: s3Client,
-      params: { Key: filename, Bucket: bucket, ContentType: 'text/xml', Body: writableStream },
+      filename,
+      bucket,
+      writableStream,
     });
 
     upload.on('httpUploadProgress', (progress) => logger.trace(progress));

--- a/api/lib/infrastructure/external-storage/s3-utils.js
+++ b/api/lib/infrastructure/external-storage/s3-utils.js
@@ -1,0 +1,18 @@
+const { S3Client } = require('@aws-sdk/client-s3');
+const { Upload } = require('@aws-sdk/lib-storage');
+
+module.exports = {
+  getS3Client({ accessKeyId, secretAccessKey, endpoint, region }) {
+    return new S3Client({
+      credentials: { accessKeyId, secretAccessKey },
+      endpoint,
+      region,
+    });
+  },
+  startUpload({ client, filename, bucket, writableStream }) {
+    return new Upload({
+      client,
+      params: { Key: filename, Bucket: bucket, ContentType: 'text/xml', Body: writableStream },
+    });
+  },
+};

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
@@ -1,0 +1,11 @@
+const { cpf } = require('../../../../config');
+const cronParser = require('cron-parser');
+
+module.exports = async function sendEmail({ cpfExternalStorage, mailService }) {
+  const parsedCron = cronParser.parseExpression(cpf.plannerJob.cron, { tz: 'Europe/Paris' });
+  const date = parsedCron.prev().toDate();
+
+  const generatedFiles = await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date: date });
+
+  await mailService.sendCpfEmail({ email: cpf.sendEmailJob.recipient, generatedFiles });
+};

--- a/api/lib/infrastructure/jobs/cpf-export/index.js
+++ b/api/lib/infrastructure/jobs/cpf-export/index.js
@@ -4,12 +4,14 @@ const dependencies = {
   cpfCertificationResultRepository: require('../../repositories/cpf-certification-result-repository'),
   cpfCertificationXmlExportService: require('../../../domain/services/cpf-certification-xml-export-service'),
   cpfExternalStorage: require('../../external-storage/cpf-external-storage'),
+  mailService: require('../../../domain/services/mail-service'),
 };
 
 module.exports = injectDependencies(
   {
     planner: require('./handlers/planner'),
     createAndUpload: require('./handlers/create-and-upload'),
+    sendEmail: require('./handlers/send-email'),
   },
   dependencies
 );

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -70,6 +70,10 @@ class Mailer {
   get emailVerificationCodeTemplateId() {
     return mailing[this._providerName].templates.emailVerificationCodeTemplateId;
   }
+
+  get cpfEmailTemplateId() {
+    return mailing[this._providerName].templates.cpfEmailTemplateId;
+  }
 }
 
 module.exports = new Mailer();

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -55,6 +55,7 @@ const schema = Joi.object({
   CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD: Joi.number().optional(),
   CPF_PLANNER_JOB_CRON: Joi.string().optional(),
   CPF_SEND_EMAIL_JOB_RECIPIENT: Joi.string().optional(),
+  CPF_SEND_EMAIL_JOB_CRON: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -49,10 +49,12 @@ const schema = Joi.object({
   CPF_STORAGE_ENDPOINT: Joi.string().optional(),
   CPF_STORAGE_REGION: Joi.string().optional(),
   CPF_STORAGE_BUCKET_NAME: Joi.string().optional(),
+  CPF_STORAGE_PRE_SIGNED_EXPIRES_IN: Joi.number().optional(),
   CPF_PLANNER_JOB_CHUNK_SIZE: Joi.number().optional(),
   CPF_PLANNER_JOB_MONTHS_TO_PROCESS: Joi.number().optional(),
   CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD: Joi.number().optional(),
   CPF_PLANNER_JOB_CRON: Joi.string().optional(),
+  CPF_SEND_EMAIL_JOB_RECIPIENT: Joi.string().optional(),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -27,6 +27,7 @@
         "bookshelf-json-columns": "^3.0.0",
         "bookshelf-validate": "^2.0.3",
         "boom": "^7.3.0",
+        "cron-parser": "^4.6.0",
         "dayjs": "^1.11.5",
         "dotenv": "^16.0.1",
         "fast-levenshtein": "^3.0.0",
@@ -5020,14 +5021,14 @@
       "integrity": "sha1-aYECRaYp5lRDK/BDdzYAA6U1GiM="
     },
     "node_modules/cron-parser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.4.0.tgz",
-      "integrity": "sha512-TrE5Un4rtJaKgmzPewh67yrER5uKM0qI9hGLDBfWb8GGRe9pn/SDkhVrdHa4z7h0SeyeNxnQnogws/H+AQANQA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.6.0.tgz",
+      "integrity": "sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==",
       "dependencies": {
-        "luxon": "^1.28.0"
+        "luxon": "^3.0.1"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -9112,11 +9113,11 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -17907,11 +17908,11 @@
       "integrity": "sha1-aYECRaYp5lRDK/BDdzYAA6U1GiM="
     },
     "cron-parser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.4.0.tgz",
-      "integrity": "sha512-TrE5Un4rtJaKgmzPewh67yrER5uKM0qI9hGLDBfWb8GGRe9pn/SDkhVrdHa4z7h0SeyeNxnQnogws/H+AQANQA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.6.0.tgz",
+      "integrity": "sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==",
       "requires": {
-        "luxon": "^1.28.0"
+        "luxon": "^3.0.1"
       }
     },
     "cross-spawn": {
@@ -20944,9 +20945,9 @@
       }
     },
     "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw=="
     },
     "magic-string": {
       "version": "0.25.7",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
+        "@aws-sdk/s3-request-presigner": "^3.145.0",
         "@hapi/accept": "^6.0.0",
         "@hapi/hapi": "^20.2.2",
         "@hapi/inert": "^6.0.5",
@@ -1272,6 +1273,153 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.145.0.tgz",
+      "integrity": "sha512-GFUyhtF8RfGjsgadkuruJVdoxwQrEweTuAJPrfIn6FIYnPofJ/8BiYt43xsxlh3BGrEulu9hwOoI0ZIVabcsXw==",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4-multi-region": "3.130.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-create-request": "3.142.0",
+        "@aws-sdk/util-format-url": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.127.0.tgz",
+      "integrity": "sha512-wJpXxWceBDhWktoxrRb4s6tMx0dWsEGYIaV0KkQPGhTPk2KMUgwa4xApfCXXVfYcE3THk486OKwHhPrR5jpe+g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "@aws-sdk/util-config-provider": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.127.0.tgz",
+      "integrity": "sha512-q1mkEN7kYYdQ3LOHIhaT56omYe8DCubyiCKOXuEo5ZiIkE5iq06K/BxWxj3f8bFZxSX80Ma1m8XA5jcOEMphSA==",
+      "dependencies": {
+        "@aws-sdk/middleware-bucket-endpoint": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+      "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+      "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+      "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "@aws-sdk/util-middleware": "3.127.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.130.0.tgz",
+      "integrity": "sha512-ZRRoPRoCVdkGDtjuog81pqHsSLfnXK6ELrWm4Dq8xdcHQGbEDNdYmeXARXG9yPAO42x9yIJXHNutMz5Y/P64cw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4": "3.130.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+      "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+      "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/@aws-sdk/service-error-classification": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz",
@@ -1494,6 +1642,57 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/@aws-sdk/util-create-request": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.142.0.tgz",
+      "integrity": "sha512-NP7v7Cf251Irbwa25aFcUCSaL7/JbxdlgVDyXtXlAQ6j+USIz0MczdHKnX5bRgnnloCJv7I4f935ZApLIVLh5w==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-create-request/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+      "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-create-request/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+      "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-create-request/node_modules/@aws-sdk/types": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-create-request/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.110.0.tgz",
@@ -1530,6 +1729,45 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.127.0.tgz",
+      "integrity": "sha512-leZeq6vxm6MSpu9Ruc5WKr7pzJ8kVXNJVerB4ixEk5KtFPPrJDw7MoEtnbnhVzhraLUnqHqYvrb6OlmkkISR+Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-builder": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+      "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
@@ -14634,6 +14872,117 @@
         }
       }
     },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.145.0.tgz",
+      "integrity": "sha512-GFUyhtF8RfGjsgadkuruJVdoxwQrEweTuAJPrfIn6FIYnPofJ/8BiYt43xsxlh3BGrEulu9hwOoI0ZIVabcsXw==",
+      "requires": {
+        "@aws-sdk/middleware-sdk-s3": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4-multi-region": "3.130.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-create-request": "3.142.0",
+        "@aws-sdk/util-format-url": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/middleware-bucket-endpoint": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.127.0.tgz",
+          "integrity": "sha512-wJpXxWceBDhWktoxrRb4s6tMx0dWsEGYIaV0KkQPGhTPk2KMUgwa4xApfCXXVfYcE3THk486OKwHhPrR5jpe+g==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-arn-parser": "3.55.0",
+            "@aws-sdk/util-config-provider": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-sdk-s3": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.127.0.tgz",
+          "integrity": "sha512-q1mkEN7kYYdQ3LOHIhaT56omYe8DCubyiCKOXuEo5ZiIkE5iq06K/BxWxj3f8bFZxSX80Ma1m8XA5jcOEMphSA==",
+          "requires": {
+            "@aws-sdk/middleware-bucket-endpoint": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-arn-parser": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+          "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-hex-encoding": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4-multi-region": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.130.0.tgz",
+          "integrity": "sha512-ZRRoPRoCVdkGDtjuog81pqHsSLfnXK6ELrWm4Dq8xdcHQGbEDNdYmeXARXG9yPAO42x9yIJXHNutMz5Y/P64cw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-arn-parser": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+          "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+          "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@aws-sdk/service-error-classification": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz",
@@ -14839,6 +15188,47 @@
         }
       }
     },
+    "@aws-sdk/util-create-request": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.142.0.tgz",
+      "integrity": "sha512-NP7v7Cf251Irbwa25aFcUCSaL7/JbxdlgVDyXtXlAQ6j+USIz0MczdHKnX5bRgnnloCJv7I4f935ZApLIVLh5w==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+          "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@aws-sdk/util-defaults-mode-browser": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.110.0.tgz",
@@ -14870,6 +15260,38 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.127.0.tgz",
+      "integrity": "sha512-leZeq6vxm6MSpu9Ruc5WKr7pzJ8kVXNJVerB4ixEk5KtFPPrJDw7MoEtnbnhVzhraLUnqHqYvrb6OlmkkISR+Q==",
+      "requires": {
+        "@aws-sdk/querystring-builder": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",
+    "@aws-sdk/s3-request-presigner": "^3.145.0",
     "@hapi/accept": "^6.0.0",
     "@hapi/hapi": "^20.2.2",
     "@hapi/inert": "^6.0.5",

--- a/api/package.json
+++ b/api/package.json
@@ -34,6 +34,7 @@
     "bookshelf-validate": "^2.0.3",
     "boom": "^7.3.0",
     "dayjs": "^1.11.5",
+    "cron-parser": "^4.6.0",
     "dotenv": "^16.0.1",
     "fast-levenshtein": "^3.0.0",
     "file-type": "^16.5.3",

--- a/api/sample.env
+++ b/api/sample.env
@@ -784,3 +784,9 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 # presence: required for CPF xml file generation, optional otherwise
 # type: string
 # sample:CPF_SEND_EMAIL_JOB_RECIPIENT=
+
+# Cron of the cpf email job
+#
+# presence: required for CPF xml file generation, optional otherwise
+# type: string
+# sample:CPF_SEND_EMAIL_JOB_CRON=0 0 1 * *

--- a/api/sample.env
+++ b/api/sample.env
@@ -746,6 +746,12 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 # type: string
 # sample: CPF_STORAGE_BUCKET_NAME=pix-cpf-dev
 
+# Duration in seconds for which a pre signed get file request is available
+#
+# presence: required for CPF xml file generation, optional otherwise
+# type: string
+# sample: CPF_STORAGE_PRE_SIGNED_EXPIRES_IN=3600
+
 # Total number of certification that can fit in a 200 Mo xml file
 #
 # presence: required for CPF xml file generation, optional otherwise
@@ -772,3 +778,9 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 # presence: required for CPF xml file generation, optional otherwise
 # type: string
 # sample: CPF_PLANNER_JOB_CRON=0 0 1 * *
+
+# Recipient of the email with generated cpf file links
+#
+# presence: required for CPF xml file generation, optional otherwise
+# type: string
+# sample:CPF_SEND_EMAIL_JOB_RECIPIENT=

--- a/api/sample.env
+++ b/api/sample.env
@@ -777,7 +777,7 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 #
 # presence: required for CPF xml file generation, optional otherwise
 # type: string
-# sample: CPF_PLANNER_JOB_CRON=0 0 1 * *
+# sample: CPF_PLANNER_JOB_CRON=0 0 1 1 *
 
 # Recipient of the email with generated cpf file links
 #
@@ -789,4 +789,4 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 #
 # presence: required for CPF xml file generation, optional otherwise
 # type: string
-# sample:CPF_SEND_EMAIL_JOB_CRON=0 0 1 * *
+# sample:CPF_SEND_EMAIL_JOB_CRON=0 0 1 1 *

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -625,4 +625,27 @@ describe('Unit | Service | MailService', function () {
       });
     });
   });
+
+  describe('#sendCpfEmail', function () {
+    it(`should call sendEmail with the right options`, async function () {
+      // given
+      const email = 'user@example.net';
+      const generatedFiles = Symbol('generatedFiles');
+
+      // when
+      await mailService.sendCpfEmail({
+        email,
+        generatedFiles,
+      });
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWith({
+        from: 'ne-pas-repondre@pix.fr',
+        fromName: 'PIX - Ne pas répondre',
+        to: email,
+        template: mailer.cpfEmailTemplateId,
+        variables: { generatedFiles },
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/external-storage/cpf-external-storage_test.js
+++ b/api/tests/unit/infrastructure/external-storage/cpf-external-storage_test.js
@@ -83,4 +83,135 @@ describe('Unit | Infrastructure | external-storage | cpf-external-storage', func
       expect(doneStub).to.have.been.called;
     });
   });
+
+  context('#getFilesModifiedAfter', function () {
+    it('should instantiate a properly configured S3 client', async function () {
+      // given
+      sinon.stub(s3Utils, 'getS3Client');
+      sinon.stub(s3Utils, 'listFiles');
+      sinon.stub(s3Utils, 'preSignFiles');
+
+      sinon.stub(cpf, 'storage').value({
+        accessKeyId: 'accessKeyId',
+        secretAccessKey: 'secretAccessKey',
+        endpoint: 'endpoint',
+        region: 'region',
+      });
+
+      // when
+      await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date: null });
+
+      // then
+      expect(s3Utils.getS3Client).to.have.been.calledWith({
+        accessKeyId: 'accessKeyId',
+        secretAccessKey: 'secretAccessKey',
+        endpoint: 'endpoint',
+        region: 'region',
+      });
+    });
+
+    it('should list files of the right bucket', async function () {
+      // given
+      sinon.stub(s3Utils, 'getS3Client');
+      sinon.stub(s3Utils, 'listFiles');
+      sinon.stub(s3Utils, 'preSignFiles');
+
+      const s3ClientMock = Symbol('s3Client');
+      s3Utils.getS3Client.returns(s3ClientMock);
+
+      sinon.stub(cpf, 'storage').value({
+        accessKeyId: 'accessKeyId',
+        secretAccessKey: 'secretAccessKey',
+        endpoint: 'endpoint',
+        region: 'region',
+        bucket: 'bucket',
+      });
+
+      // when
+      await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date: null });
+
+      // then
+      expect(s3Utils.listFiles).to.have.been.calledWith({ client: s3ClientMock, bucket: 'bucket' });
+    });
+
+    it('should pre sign files modified after a date', async function () {
+      // given
+      const date = '2022-03-01';
+      const filesModifiedBeforeDate = [
+        { Key: 'firstFile', LastModified: '2022-02-14' },
+        { Key: 'secondFile', LastModified: '2022-02-17' },
+      ];
+      const filesModifiedAfterDate = [
+        { Key: 'thirdFile', LastModified: '2022-03-01' },
+        { Key: 'fourthFile', LastModified: '2022-03-04' },
+      ];
+
+      sinon.stub(s3Utils, 'getS3Client');
+      sinon.stub(s3Utils, 'listFiles');
+      sinon.stub(s3Utils, 'preSignFiles');
+
+      const s3ClientMock = Symbol('s3Client');
+      s3Utils.getS3Client.returns(s3ClientMock);
+
+      s3Utils.listFiles.resolves({
+        Contents: [...filesModifiedBeforeDate, ...filesModifiedAfterDate],
+      });
+
+      sinon.stub(cpf, 'storage').value({
+        accessKeyId: 'accessKeyId',
+        secretAccessKey: 'secretAccessKey',
+        endpoint: 'endpoint',
+        region: 'region',
+        bucket: 'bucket',
+        preSignedExpiresIn: 3600,
+      });
+
+      // when
+      await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date });
+
+      // then
+      expect(s3Utils.preSignFiles).to.have.been.calledWith({
+        client: s3ClientMock,
+        bucket: 'bucket',
+        keys: ['thirdFile', 'fourthFile'],
+        expiresIn: 3600,
+      });
+    });
+
+    it('should return pre signed url of files modified after a date', async function () {
+      // given
+      const date = '2022-03-01';
+      const filesModifiedBeforeDate = [
+        { Key: 'firstFile', LastModified: '2022-02-14' },
+        { Key: 'secondFile', LastModified: '2022-02-17' },
+      ];
+      const filesModifiedAfterDate = [
+        { Key: 'thirdFile', LastModified: '2022-03-01' },
+        { Key: 'fourthFile', LastModified: '2022-03-04' },
+      ];
+
+      sinon.stub(s3Utils, 'getS3Client');
+      sinon.stub(s3Utils, 'listFiles');
+      sinon.stub(s3Utils, 'preSignFiles');
+
+      s3Utils.listFiles.resolves({
+        Contents: [...filesModifiedBeforeDate, ...filesModifiedAfterDate],
+      });
+      s3Utils.preSignFiles.resolves(['preSignedThirdFile', 'preSignedFourthFile']);
+
+      sinon.stub(cpf, 'storage').value({
+        accessKeyId: 'accessKeyId',
+        secretAccessKey: 'secretAccessKey',
+        endpoint: 'endpoint',
+        region: 'region',
+        bucket: 'bucket',
+      });
+
+      // when
+      const result = await cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter({ date });
+
+      // then
+      expect(result).to.deep.equals(['preSignedThirdFile', 'preSignedFourthFile']);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
@@ -1,0 +1,57 @@
+const { expect, sinon } = require('../../../../../test-helper');
+const sendEmail = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/send-email');
+const { cpf } = require('../../../../../../lib/config');
+const moment = require('moment-timezone');
+
+describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
+  let cpfExternalStorage;
+  let mailService;
+  beforeEach(function () {
+    cpfExternalStorage = {
+      getPreSignUrlsOfFilesModifiedAfter: sinon.stub(),
+    };
+    mailService = {
+      sendCpfEmail: sinon.stub(),
+    };
+  });
+
+  it('should get files from external storage modified after the previous planner cron', async function () {
+    // given
+    const day = '15';
+    const month = '01';
+    sinon.stub(cpf, 'plannerJob').value({ cron: `0 0 ${day} ${month} *` });
+
+    // when
+    await sendEmail({ cpfExternalStorage, mailService });
+
+    // then
+    const expectedDate = moment.tz('01-15', 'MM-DD', 'Europe/Paris').toDate();
+    expect(cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter).to.have.been.calledWith({ date: expectedDate });
+  });
+
+  it('should send an email with a list of generated files url', async function () {
+    // given
+    const day = '15';
+    const month = '01';
+    sinon.stub(cpf, 'plannerJob').value({ cron: `0 0 ${day} ${month} *` });
+    sinon.stub(cpf, 'sendEmailJob').value({ recipient: 'teamcertif@example.net' });
+
+    cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter.resolves([
+      'https://bucket.url.com/file1.xml',
+      'https://bucket.url.com/file2.xml',
+      'https://bucket.url.com/file3.xml',
+    ]);
+    // when
+    await sendEmail({ cpfExternalStorage, mailService });
+
+    // then
+    expect(mailService.sendCpfEmail).to.have.been.calledWith({
+      email: 'teamcertif@example.net',
+      generatedFiles: [
+        'https://bucket.url.com/file1.xml',
+        'https://bucket.url.com/file2.xml',
+        'https://bucket.url.com/file3.xml',
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il est possible de générer les fichiers CPF contenant les certifications publiées depuis une certaine date à partir d'un cron. Cependant, la team certif métier, qui est censé uploader ces fichiers sur le portail du cpf ne sont pas au courant que des fichiers ont été générés. 

## :robot: Solution
Envoyer un mail suite à al génération des fichiers CPF avec les liens des fichiers qui viennent d'être générés.

## :100: Pour tester
- Aller sur Scalingo et modifier la valeur de:
    - CPF_SEND_EMAIL_JOB_RECIPIENT par votre adresse email  
    - CPF_SEND_EMAIL_JOB_CRON par une date (dans le futur) où le job d'envoi d'email doit s'éxécuter
- Attendre que le job se lance et vérifier que le mail a bien été reçu.