### PR TITLE
[FEATURE] Créer la nouvelle route de pré-réconciliation pour la nouvelle pérennité des comptes (PIX-5050).

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -100,8 +100,8 @@ exports.register = async (server) => {
         auth: false,
         pre: [
           {
-            method: featureToggles.checkIfSSOAccountReconciliationIsEnabled,
-            assign: 'checkIfSSOAccountReconciliationIsEnabled',
+            method: featureToggles.checkIfSsoAccountReconciliationIsEnabled,
+            assign: 'checkIfSsoAccountReconciliationIsEnabled',
           },
         ],
         validate: {

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
 const oidcController = require('./oidc-controller');
+const featureToggles = require('../../preHandlers/feature-toggles');
 
 exports.register = async (server) => {
   server.route([
@@ -90,6 +91,38 @@ exports.register = async (server) => {
             "- Elle retournera un access token Pix correspondant à l'utilisateur.",
         ],
         tags: ['api', 'oidc', 'authentication'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/oidc/token-reconciliation',
+      config: {
+        auth: false,
+        pre: [
+          {
+            method: featureToggles.checkIfSSOAccountReconciliationIsEnabled,
+            assign: 'checkIfSSOAccountReconciliationIsEnabled',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                email: Joi.string().email().required(),
+                password: Joi.string().required(),
+                'identity-provider': Joi.string().required().valid('POLE_EMPLOI', 'CNAV'),
+                'authentication-key': Joi.string().required(),
+              }),
+              type: Joi.string(),
+            }),
+          }),
+        },
+        handler: oidcController.findUserForReconciliation,
+        notes: [
+          "- Cette route permet d'identifier un utilisateur Pix provenant de la double mire oidc.\n" +
+            '- Elle retournera un access token et une uri de déconnexion',
+        ],
+        tags: ['api', 'oidc'],
       },
     },
   ]);

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -436,6 +436,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.ConflictError(error.message);
   }
 
+  if (error instanceof DomainErrors.DifferentExternalIdentifierError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/application/preHandlers/feature-toggles.js
+++ b/api/lib/application/preHandlers/feature-toggles.js
@@ -2,7 +2,7 @@ const config = require('../../config');
 const { NotFoundError } = require('../../application/http-errors');
 
 module.exports = {
-  async checkIfSSOAccountReconciliationIsEnabled() {
+  async checkIfSsoAccountReconciliationIsEnabled() {
     if (!config.featureToggles.isSsoAccountReconciliationEnabled) {
       throw new NotFoundError('Cette route est désactivée');
     }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1123,6 +1123,14 @@ class SessionStartedDeletionError extends DomainError {
   }
 }
 
+class DifferentExternalIdentifierError extends DomainError {
+  constructor(
+    message = "La valeur de l'externalIdentifier de la méthode de connexion ne correspond pas à celui reçu par le partenaire."
+  ) {
+    super(message);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -1190,6 +1198,7 @@ module.exports = {
   CsvParsingError,
   DeprecatedCertificationIssueReportCategoryError,
   DeprecatedCertificationIssueReportSubcategoryError,
+  DifferentExternalIdentifierError,
   DomainError,
   EmailModificationDemandNotFoundOrExpiredError,
   EntityValidationError,

--- a/api/lib/domain/services/authentication/authentication-session-service.js
+++ b/api/lib/domain/services/authentication/authentication-session-service.js
@@ -14,4 +14,8 @@ module.exports = {
       expirationDelaySeconds: EXPIRATION_DELAY_SECONDS,
     });
   },
+
+  update(key, value) {
+    temporaryStorage.update(key, value);
+  },
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -41,6 +41,10 @@ module.exports = async function findUserForOidcReconciliation({
   }
 
   const pixAccessToken = await oidcAuthenticationService.createAccessToken(foundUser.id);
+  const logoutUrlUUID = await oidcAuthenticationService.saveIdToken({
+    idToken: sessionContentAndUserInfo.sessionContent.idToken,
+    userId: foundUser.id,
+  });
 
-  return { pixAccessToken };
+  return { pixAccessToken, logoutUrlUUID };
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -30,7 +30,7 @@ module.exports = async function findUserForOidcReconciliation({
   if (!oidcAuthenticationMethod) {
     sessionContentAndUserInfo.userInfo.userId = foundUser.id;
     await authenticationSessionService.update(authenticationKey, sessionContentAndUserInfo);
-    return authenticationKey;
+    return { isAuthenticationComplete: false };
   }
 
   const isSameExternalIdentifier =
@@ -48,5 +48,5 @@ module.exports = async function findUserForOidcReconciliation({
 
   userRepository.updateLastLoggedAt({ userId: foundUser.id });
 
-  return { pixAccessToken, logoutUrlUUID };
+  return { pixAccessToken, logoutUrlUUID, isAuthenticationComplete: true };
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -7,6 +7,7 @@ module.exports = async function findUserForOidcReconciliation({
   identityProvider,
   authenticationSessionService,
   pixAuthenticationService,
+  oidcAuthenticationService,
   authenticationMethodRepository,
   userRepository,
 }) {
@@ -38,4 +39,8 @@ module.exports = async function findUserForOidcReconciliation({
   if (!isSameExternalIdentifier) {
     throw new DifferentExternalIdentifierError();
   }
+
+  const pixAccessToken = await oidcAuthenticationService.createAccessToken(foundUser.id);
+
+  return { pixAccessToken };
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -1,4 +1,4 @@
-const { AuthenticationKeyExpired } = require('../errors');
+const { AuthenticationKeyExpired, DifferentExternalIdentifierError } = require('../errors');
 
 module.exports = async function findUserForOidcReconciliation({
   authenticationKey,
@@ -30,5 +30,12 @@ module.exports = async function findUserForOidcReconciliation({
     sessionContentAndUserInfo.userInfo.userId = foundUser.id;
     await authenticationSessionService.update(authenticationKey, sessionContentAndUserInfo);
     return authenticationKey;
+  }
+
+  const isSameExternalIdentifier =
+    oidcAuthenticationMethod.externalIdentifier === sessionContentAndUserInfo.userInfo.externalIdentityId;
+
+  if (!isSameExternalIdentifier) {
+    throw new DifferentExternalIdentifierError();
   }
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -1,12 +1,19 @@
 module.exports = async function findUserForOidcReconciliation({
   email,
   password,
+  identityProvider,
   pixAuthenticationService,
+  authenticationMethodRepository,
   userRepository,
 }) {
-  await pixAuthenticationService.getUserByUsernameAndPassword({
+  const foundUser = await pixAuthenticationService.getUserByUsernameAndPassword({
     username: email,
     password,
     userRepository,
+  });
+
+  await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+    userId: foundUser.id,
+    identityProvider: identityProvider,
   });
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -46,5 +46,7 @@ module.exports = async function findUserForOidcReconciliation({
     userId: foundUser.id,
   });
 
+  userRepository.updateLastLoggedAt({ userId: foundUser.id });
+
   return { pixAccessToken, logoutUrlUUID };
 };

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -1,0 +1,12 @@
+module.exports = async function findUserForOidcReconciliation({
+  email,
+  password,
+  pixAuthenticationService,
+  userRepository,
+}) {
+  await pixAuthenticationService.getUserByUsernameAndPassword({
+    username: email,
+    password,
+    userRepository,
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -278,6 +278,7 @@ module.exports = injectDependencies(
     findTargetProfileStages: require('./find-target-profile-stages'),
     findTutorials: require('./find-tutorials'),
     findUserCampaignParticipationOverviews: require('./find-user-campaign-participation-overviews'),
+    findUserForOidcReconciliation: require('./find-user-for-oidc-reconciliation'),
     findUserPrivateCertificates: require('./find-user-private-certificates'),
     flagSessionResultsAsSentToPrescriber: require('./flag-session-results-as-sent-to-prescriber'),
     generateUsername: require('./generate-username'),

--- a/api/lib/infrastructure/serializers/jsonapi/oidc-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/oidc-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(authenticationContent) {
+    return new Serializer('user-oidc-authentication-requests', {
+      attributes: ['accessToken', 'logoutUrlUUID'],
+    }).serialize(authenticationContent);
+  },
+};

--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -14,6 +14,11 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
     return storageKey;
   }
 
+  update(key, value) {
+    const storageKey = trim(key);
+    this._client.set(storageKey, value);
+  }
+
   get(key) {
     return this._client.get(key);
   }

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -4,6 +4,7 @@ const TemporaryStorage = require('./TemporaryStorage');
 const RedisClient = require('../utils/RedisClient');
 
 const EXPIRATION_PARAMETER = 'ex';
+const KEEPTTL_PARAMETER = 'keepttl';
 
 class RedisTemporaryStorage extends TemporaryStorage {
   constructor(redisUrl) {
@@ -21,6 +22,13 @@ class RedisTemporaryStorage extends TemporaryStorage {
     const objectAsString = JSON.stringify(value);
     await this._client.set(storageKey, objectAsString, EXPIRATION_PARAMETER, expirationDelaySeconds);
     return storageKey;
+  }
+
+  async update(key, value) {
+    const storageKey = trim(key);
+
+    const objectAsString = JSON.stringify(value);
+    await this._client.set(storageKey, objectAsString, KEEPTTL_PARAMETER);
   }
 
   async get(key) {

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -9,6 +9,10 @@ class TemporaryStorage {
     throw new Error('Method #save({ key, value, expirationDelaySeconds }) must be overridden');
   }
 
+  async update(/* key, value */) {
+    throw new Error('Method #update(key, value) must be overridden');
+  }
+
   async get(/* key */) {
     throw new Error('Method #get(key) must be overridden');
   }
@@ -28,6 +32,10 @@ class TemporaryStorage {
         key = key ?? TemporaryStorage.generateKey();
         await storage.save({ key: prefix + key, ...args });
         return key;
+      },
+
+      update(key, value) {
+        return storage.update(prefix + key, value);
       },
 
       get(key) {

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -25,6 +25,7 @@ module.exports = class RedisClient {
       { retryCount: 0 }
     );
 
+    this.ttl = promisify(this._wrapWithPrefix(this._client.ttl)).bind(this._client);
     this.get = promisify(this._wrapWithPrefix(this._client.get)).bind(this._client);
     this.set = promisify(this._wrapWithPrefix(this._client.set)).bind(this._client);
     this.del = promisify(this._wrapWithPrefix(this._client.del)).bind(this._client);

--- a/api/tests/acceptance/application/authentication/oidc/oidc-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/oidc-route-post_test.js
@@ -1,0 +1,176 @@
+const { expect, databaseBuilder } = require('../../../../test-helper');
+const createServer = require('../../../../../server');
+const jsonwebtoken = require('jsonwebtoken');
+const authenticationSessionService = require('../../../../../lib/domain/services/authentication/authentication-session-service');
+const { featureToggles } = require('../../../../../lib/config');
+
+describe('Acceptance | Application | Oidc | Routes', function () {
+  describe('POST /api/oidc/token-reconciliation', function () {
+    let server;
+
+    beforeEach(async function () {
+      server = await createServer();
+      featureToggles.isSsoAccountReconciliationEnabled = true;
+    });
+
+    afterEach(async function () {
+      featureToggles.isSsoAccountReconciliationEnabled = false;
+    });
+
+    context('when user has no oidc authentication method', function () {
+      it('should return 204 HTTP status', async function () {
+        // given
+        databaseBuilder.factory.buildUser.withRawPassword({ email: 'eva.poree@example.net', rawPassword: 'pix123' });
+        await databaseBuilder.commit();
+
+        const idToken = jsonwebtoken.sign(
+          {
+            given_name: 'Brice',
+            family_name: 'Glace',
+            nonce: 'nonce',
+            sub: 'some-user-unique-id',
+          },
+          'secret'
+        );
+        const userAuthenticationKey = await authenticationSessionService.save({
+          sessionContent: { idToken },
+          userInfo: {
+            firstName: 'Brice',
+            lastName: 'Glace',
+            nonce: 'nonce',
+            externalIdentityId: 'some-user-unique-id',
+          },
+        });
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/oidc/token-reconciliation`,
+          payload: {
+            data: {
+              attributes: {
+                email: 'eva.poree@example.net',
+                password: 'pix123',
+                'identity-provider': 'CNAV',
+                'authentication-key': userAuthenticationKey,
+              },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    context('when user has an oidc authentication method', function () {
+      it('should return access token with 200 HTTP status', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRawPassword({
+          email: 'eva.poree@example.net',
+          rawPassword: 'pix123',
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+          identityProvider: 'CNAV',
+          userId: user.id,
+          externalIdentifier: 'some-user-unique-id',
+        });
+        await databaseBuilder.commit();
+
+        const idToken = jsonwebtoken.sign(
+          {
+            given_name: 'Brice',
+            family_name: 'Glace',
+            nonce: 'nonce',
+            sub: 'some-user-unique-id',
+          },
+          'secret'
+        );
+        const userAuthenticationKey = await authenticationSessionService.save({
+          sessionContent: { idToken },
+          userInfo: {
+            firstName: 'Brice',
+            lastName: 'Glace',
+            nonce: 'nonce',
+            externalIdentityId: 'some-user-unique-id',
+          },
+        });
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/oidc/token-reconciliation`,
+          payload: {
+            data: {
+              attributes: {
+                email: 'eva.poree@example.net',
+                password: 'pix123',
+                'identity-provider': 'CNAV',
+                'authentication-key': userAuthenticationKey,
+              },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes['access-token']).to.exist;
+      });
+
+      context('when identity provider is POLE_EMPLOI', function () {
+        it('should return logout url uuid with 200 HTTP status', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser.withRawPassword({
+            email: 'eva.poree@example.net',
+            rawPassword: 'pix123',
+          });
+          databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
+            userId: user.id,
+            externalIdentifier: 'some-user-unique-id',
+          });
+          await databaseBuilder.commit();
+
+          const idToken = jsonwebtoken.sign(
+            {
+              given_name: 'Brice',
+              family_name: 'Glace',
+              nonce: 'nonce',
+              sub: 'some-user-unique-id',
+            },
+            'secret'
+          );
+          const userAuthenticationKey = await authenticationSessionService.save({
+            sessionContent: { idToken, accessToken: 'accessToken', refreshToken: 'refreshToken' },
+            userInfo: {
+              firstName: 'Brice',
+              lastName: 'Glace',
+              nonce: 'nonce',
+              externalIdentityId: 'some-user-unique-id',
+            },
+          });
+
+          // when
+          const response = await server.inject({
+            method: 'POST',
+            url: `/api/oidc/token-reconciliation`,
+            payload: {
+              data: {
+                attributes: {
+                  email: 'eva.poree@example.net',
+                  password: 'pix123',
+                  'identity-provider': 'POLE_EMPLOI',
+                  'authentication-key': userAuthenticationKey,
+                },
+              },
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.data.attributes['access-token']).to.exist;
+          expect(response.result.data.attributes['logout-url-uuid']).to.exist;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -110,7 +110,7 @@ describe('Acceptance | Route | oidc | token', function () {
       }).id;
 
       databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-        identityProvider: AuthenticationMethod.identityProviders.CNAV,
+        identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
         externalIdentifier,
         accessToken: 'access_token',
         refreshToken: 'refresh_token',

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -23,5 +23,24 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
         expect(await storage.get('456:c')).to.exist;
       });
     });
+
+    describe('#set', function () {
+      it('should set new value', async function () {
+        // given
+        const TWO_MINUTES_IN_SECONDS = 2 * 60;
+        const value = { url: 'url' };
+        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const key = await storage.save({ value: 'c', expirationDelaySeconds: TWO_MINUTES_IN_SECONDS });
+
+        // when
+        await storage.update(key, value);
+
+        // then
+        const result = await storage.get(key);
+        const expirationDelaySeconds = await storage._client.ttl(key);
+        expect(result).to.deep.equal({ url: 'url' });
+        expect(expirationDelaySeconds).to.equal(TWO_MINUTES_IN_SECONDS);
+      });
+    });
   }
 });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -7,6 +7,7 @@ const {
   AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
   AuthenticationKeyExpired,
+  DifferentExternalIdentifierError,
   EntityValidationError,
   InvalidExternalAPIResponseError,
   MissingOrInvalidCredentialsError,
@@ -450,6 +451,19 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
+    });
+
+    it('should instantiate PreconditionFailedError when DifferentExternalIdentifierError', async function () {
+      // given
+      const error = new DifferentExternalIdentifierError();
+      sinon.stub(HttpErrors, 'PreconditionFailedError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
     });
   });
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -581,4 +581,8 @@ describe('Unit | Domain | Errors', function () {
       });
     });
   });
+
+  it('should export an DifferentExternalIdentifierError', function () {
+    expect(errors.DifferentExternalIdentifierError).to.exist;
+  });
 });

--- a/api/tests/unit/domain/services/authentication/authentication-session-service_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-session-service_test.js
@@ -45,4 +45,27 @@ describe('Unit | Domain | Services | authentication session', function () {
       expect(key).to.exist;
     });
   });
+
+  describe('#update', function () {
+    it('should set a new value', async function () {
+      // given
+      const key = await authenticationSessionService.save({
+        sessionContent: { idToken: 'idToken' },
+        userInfo: { firstName: 'Eva', lastName: 'Porée' },
+      });
+
+      // when
+      await authenticationSessionService.update(key, {
+        sessionContent: { idToken: 'idToken' },
+        userInfo: { firstName: 'Celine', lastName: 'Évitable', userId: 123 },
+      });
+
+      // then
+      const result = await authenticationSessionService.getByKey(key);
+      expect(result).to.deep.equal({
+        sessionContent: { idToken: 'idToken' },
+        userInfo: { firstName: 'Celine', lastName: 'Évitable', userId: 123 },
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -11,7 +11,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
     userRepository = {};
     pixAuthenticationService = { getUserByUsernameAndPassword: sinon.stub() };
     authenticationSessionService = { getByKey: sinon.stub(), update: sinon.stub() };
-    oidcAuthenticationService = { createAccessToken: sinon.stub() };
+    oidcAuthenticationService = { createAccessToken: sinon.stub(), saveIdToken: sinon.stub() };
   });
 
   it('should find pix user and their oidc authentication method', async function () {
@@ -151,7 +151,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
     });
 
     context('when externalIdentifier and externalIdentityId are the same', function () {
-      it('should return access token', async function () {
+      it('should return access token and logout url uuid', async function () {
         // given
         const oidcAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           externalIdentifier: '123abc',
@@ -159,10 +159,11 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
         pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(oidcAuthenticationMethod);
         authenticationSessionService.getByKey.resolves({
-          sessionContent: {},
+          sessionContent: { idToken: 'idToken' },
           userInfo: { externalIdentityId: '123abc' },
         });
         oidcAuthenticationService.createAccessToken.resolves('accessToken');
+        oidcAuthenticationService.saveIdToken.resolves('logoutUrl');
 
         // when
         const result = await findUserForOidcReconciliation({
@@ -179,7 +180,8 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
 
         // then
         expect(oidcAuthenticationService.createAccessToken).to.be.calledOnceWith(2);
-        expect(result).to.deep.equal({ pixAccessToken: 'accessToken' });
+        expect(oidcAuthenticationService.saveIdToken).to.be.calledOnceWith({ idToken: 'idToken', userId: 2 });
+        expect(result).to.deep.equal({ pixAccessToken: 'accessToken', logoutUrlUUID: 'logoutUrl' });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -103,7 +103,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
       authenticationSessionService.getByKey.resolves(sessionContentAndUserInfo);
 
       // when
-      await findUserForOidcReconciliation({
+      const result = await findUserForOidcReconciliation({
         authenticationKey: 'authenticationKey',
         email: 'ane.trotro@example.net',
         password: 'pix123',
@@ -116,6 +116,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
 
       // then
       expect(authenticationSessionService.update).to.be.calledOnceWith('authenticationKey', sessionContentAndUserInfo);
+      expect(result).to.deep.equal({ isAuthenticationComplete: false });
     });
   });
 
@@ -182,7 +183,11 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
         expect(oidcAuthenticationService.createAccessToken).to.be.calledOnceWith(2);
         expect(oidcAuthenticationService.saveIdToken).to.be.calledOnceWith({ idToken: 'idToken', userId: 2 });
         expect(userRepository.updateLastLoggedAt).to.be.calledOnceWith({ userId: 2 });
-        expect(result).to.deep.equal({ pixAccessToken: 'accessToken', logoutUrlUUID: 'logoutUrl' });
+        expect(result).to.deep.equal({
+          pixAccessToken: 'accessToken',
+          logoutUrlUUID: 'logoutUrl',
+          isAuthenticationComplete: true,
+        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -8,7 +8,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
 
   beforeEach(function () {
     authenticationMethodRepository = { findOneByUserIdAndIdentityProvider: sinon.stub() };
-    userRepository = {};
+    userRepository = { updateLastLoggedAt: sinon.stub() };
     pixAuthenticationService = { getUserByUsernameAndPassword: sinon.stub() };
     authenticationSessionService = { getByKey: sinon.stub(), update: sinon.stub() };
     oidcAuthenticationService = { createAccessToken: sinon.stub(), saveIdToken: sinon.stub() };
@@ -151,7 +151,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
     });
 
     context('when externalIdentifier and externalIdentityId are the same', function () {
-      it('should return access token and logout url uuid', async function () {
+      it('should return access token, logout url uuid and update last logged at parameter', async function () {
         // given
         const oidcAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({
           externalIdentifier: '123abc',
@@ -181,6 +181,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
         // then
         expect(oidcAuthenticationService.createAccessToken).to.be.calledOnceWith(2);
         expect(oidcAuthenticationService.saveIdToken).to.be.calledOnceWith({ idToken: 'idToken', userId: 2 });
+        expect(userRepository.updateLastLoggedAt).to.be.calledOnceWith({ userId: 2 });
         expect(result).to.deep.equal({ pixAccessToken: 'accessToken', logoutUrlUUID: 'logoutUrl' });
       });
     });

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -2,16 +2,20 @@ const { expect, sinon } = require('../../../test-helper');
 const findUserForOidcReconciliation = require('../../../../lib/domain/usecases/find-user-for-oidc-reconciliation');
 
 describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
-  it('should find pix user', async function () {
+  it('should find pix user and their oidc authentication method', async function () {
     // given
+    const authenticationMethodRepository = { findOneByUserIdAndIdentityProvider: sinon.stub() };
     const userRepository = {};
     const pixAuthenticationService = { getUserByUsernameAndPassword: sinon.stub() };
+    pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
 
     // when
     await findUserForOidcReconciliation({
       email: 'ane.trotro@example.net',
       password: 'pix123',
+      identityProvider: 'oidc',
       pixAuthenticationService,
+      authenticationMethodRepository,
       userRepository,
     });
 
@@ -20,6 +24,11 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
       username: 'ane.trotro@example.net',
       password: 'pix123',
       userRepository,
+    });
+
+    expect(authenticationMethodRepository.findOneByUserIdAndIdentityProvider).to.be.calledOnceWith({
+      userId: 2,
+      identityProvider: 'oidc',
     });
   });
 });

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon } = require('../../../test-helper');
+const findUserForOidcReconciliation = require('../../../../lib/domain/usecases/find-user-for-oidc-reconciliation');
+
+describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
+  it('should find pix user', async function () {
+    // given
+    const userRepository = {};
+    const pixAuthenticationService = { getUserByUsernameAndPassword: sinon.stub() };
+
+    // when
+    await findUserForOidcReconciliation({
+      email: 'ane.trotro@example.net',
+      password: 'pix123',
+      pixAuthenticationService,
+      userRepository,
+    });
+
+    // then
+    expect(pixAuthenticationService.getUserByUsernameAndPassword).to.be.calledOnceWith({
+      username: 'ane.trotro@example.net',
+      password: 'pix123',
+      userRepository,
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -1,19 +1,32 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 const findUserForOidcReconciliation = require('../../../../lib/domain/usecases/find-user-for-oidc-reconciliation');
+const { AuthenticationKeyExpired } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
+  let authenticationMethodRepository, userRepository;
+  let pixAuthenticationService, authenticationSessionService;
+
+  beforeEach(function () {
+    authenticationMethodRepository = { findOneByUserIdAndIdentityProvider: sinon.stub() };
+    userRepository = {};
+    pixAuthenticationService = { getUserByUsernameAndPassword: sinon.stub() };
+    authenticationSessionService = { getByKey: sinon.stub(), update: sinon.stub() };
+  });
+
   it('should find pix user and their oidc authentication method', async function () {
     // given
-    const authenticationMethodRepository = { findOneByUserIdAndIdentityProvider: sinon.stub() };
-    const userRepository = {};
-    const pixAuthenticationService = { getUserByUsernameAndPassword: sinon.stub() };
     pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
+    authenticationSessionService.getByKey.resolves({
+      sessionContent: { idToken: 'idToken' },
+      userInfo: { firstName: 'Anne' },
+    });
 
     // when
     await findUserForOidcReconciliation({
       email: 'ane.trotro@example.net',
       password: 'pix123',
       identityProvider: 'oidc',
+      authenticationSessionService,
       pixAuthenticationService,
       authenticationMethodRepository,
       userRepository,
@@ -29,6 +42,79 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
     expect(authenticationMethodRepository.findOneByUserIdAndIdentityProvider).to.be.calledOnceWith({
       userId: 2,
       identityProvider: 'oidc',
+    });
+  });
+
+  it('should retrieve user session content', async function () {
+    // given
+    pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
+    authenticationSessionService.getByKey.resolves({
+      sessionContent: { idToken: 'idToken' },
+      userInfo: { firstName: 'Anne' },
+    });
+
+    // when
+    await findUserForOidcReconciliation({
+      authenticationKey: 'authenticationKey',
+      email: 'ane.trotro@example.net',
+      password: 'pix123',
+      identityProvider: 'oidc',
+      authenticationSessionService,
+      pixAuthenticationService,
+      authenticationMethodRepository,
+      userRepository,
+    });
+
+    // then
+    expect(authenticationSessionService.getByKey).to.be.calledOnceWith('authenticationKey');
+  });
+
+  context('when authentication key is expired', function () {
+    it('should throw an AuthenticationKeyExpired', async function () {
+      // given
+      pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
+      authenticationSessionService.getByKey.resolves(null);
+
+      // when
+      const error = await catchErr(findUserForOidcReconciliation)({
+        authenticationKey: 'authenticationKey',
+        email: 'ane.trotro@example.net',
+        password: 'pix123',
+        identityProvider: 'oidc',
+        authenticationSessionService,
+        pixAuthenticationService,
+        authenticationMethodRepository,
+        userRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AuthenticationKeyExpired);
+      expect(error.message).to.be.equal('This authentication key has expired.');
+    });
+  });
+
+  context('when user has no oidc authentication method', function () {
+    it('should save user id in existing key', async function () {
+      // given
+      const sessionContentAndUserInfo = { sessionContent: { idToken: 'idToken' }, userInfo: { firstName: 'Anne' } };
+      pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(null);
+      authenticationSessionService.getByKey.resolves(sessionContentAndUserInfo);
+
+      // when
+      await findUserForOidcReconciliation({
+        authenticationKey: 'authenticationKey',
+        email: 'ane.trotro@example.net',
+        password: 'pix123',
+        identityProvider: 'oidc',
+        authenticationSessionService,
+        pixAuthenticationService,
+        authenticationMethodRepository,
+        userRepository,
+      });
+
+      // then
+      expect(authenticationSessionService.update).to.be.calledOnceWith('authenticationKey', sessionContentAndUserInfo);
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/oidc-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/oidc-serializer_test.js
@@ -1,0 +1,29 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/oidc-serializer');
+
+describe('Unit | Serializer | JSONAPI | oidc-serializer', function () {
+  describe('#serialize()', function () {
+    it('should format into JSON API data', function () {
+      // given
+      const authenticationContent = {
+        accessToken: 'access.token',
+        logoutUrlUUID: 'logout.url.uuid',
+      };
+
+      // when
+      const json = serializer.serialize(authenticationContent);
+
+      // then
+      const expectedJson = {
+        data: {
+          attributes: {
+            'access-token': 'access.token',
+            'logout-url-uuid': 'logout.url.uuid',
+          },
+          type: 'user-oidc-authentication-requests',
+        },
+      };
+      expect(json).to.deep.equal(expectedJson);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -103,6 +103,24 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
     });
   });
 
+  describe('#update', function () {
+    it('should set a new value', function () {
+      // given
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+      const key = inMemoryTemporaryStorage.save({
+        value: { name: 'name' },
+        expirationDelaySeconds: 1000,
+      });
+
+      // when
+      inMemoryTemporaryStorage.update(key, { url: 'url' });
+
+      // then
+      const result = inMemoryTemporaryStorage.get(key);
+      expect(result).to.deep.equal({ url: 'url' });
+    });
+  });
+
   describe('#delete', function () {
     it('should delete the value if it exists', async function () {
       // given

--- a/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -106,6 +106,22 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
     });
   });
 
+  describe('#update', function () {
+    it('should call client set to set new value with KEEPTTL parameters', async function () {
+      // given
+      const KEEPTTL_PARAMETER = 'keepttl';
+      const key = 'valueKey';
+      const value = { name: 'name' };
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // when
+      await redisTemporaryStorage.update(key, value);
+
+      // then
+      expect(clientStub.set).to.have.been.calledWith(sinon.match.any, JSON.stringify(value), KEEPTTL_PARAMETER);
+    });
+  });
+
   describe('#delete', function () {
     it('should call client del to delete value', async function () {
       // given

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -106,4 +106,17 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
       expect(await storage.get('123:a-key')).to.be.undefined;
     });
   });
+
+  describe('#update', function () {
+    it('should reject an error (because this class actually mocks an interface)', function () {
+      // given
+      const temporaryStorageInstance = new TemporaryStorage();
+
+      // when
+      const result = temporaryStorageInstance.update('key', 'value');
+
+      // then
+      expect(result).to.be.rejected;
+    });
+  });
 });

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -12,6 +12,7 @@ import fetch from 'fetch';
 export default class OidcAuthenticator extends BaseAuthenticator {
   @service session;
   @service location;
+  @service featureToggles;
 
   async authenticate({ code, redirectUri, state, identityProviderSlug, authenticationKey }) {
     const request = {
@@ -42,8 +43,10 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       };
 
       if (this.session.isAuthenticated) {
-        const accessToken = this.session.get('data.authenticated.access_token');
-        request.headers['Authorization'] = `Bearer ${accessToken}`;
+        if (!this.featureToggles.featureToggles.isSsoAccountReconciliationEnabled) {
+          const accessToken = this.session.get('data.authenticated.access_token');
+          request.headers['Authorization'] = `Bearer ${accessToken}`;
+        }
         await this.session.invalidate();
       }
     }


### PR DESCRIPTION
## :unicorn: Problème
L'actuel scénario de réconciliation de compte n'est plus pertinent. Il permet entre autres de mauvaises réconciliation, comme un élève sco connecté sur Pix dont le parent va se connecter via Pôle Emploi en commençant une campagne.
Les deux comptes sont alors réconcilés.

Dans le nouveau scénario, nous avons désormais une double mire permettant à l'utilisateur de se connecter à un compte Pix qu'il possède déjà. Cette connexion entraîne de nouvelles vérifications coté back. Or nous n'avons pas encore implémenté cette nouvelle route

## :robot: Solution
Créer la nouvelle route pour identifier l'utilisateur.

Nous récupérons pour cela son email et mot de passe, puis nous vérifions plusieurs choses : 
As t'il déjà une méthode de connexion (authentication-methods) du partenaire vers lequel il est passé ? 
En fonction des vérifications, la route retourne 3 réponses : 
- Tu es identifié et tu as déjà méthode de connexion : retourne un access token
- Tu es identifié, tu as déjà méthode de connexion mais les external identity id sont différents : erreur 412
- Tu es identifié et tu n'as pas de méthode de connexion du partenaire : 204 avec le userId dans redis

## ℹ️ Remarques 

Le paramètre `KEEPTTL` de redis n'existe qu'a partir de la version 6.0, or nous on est sur un 3.2 coté dev. 
La prod étant sur un redis 6.2.5, on peut à priori  garder ce paramètre.

On peut vérifier ça avec un test fonctionnel (quand le front sera implémenté), on utilisant le redis console et faire un `ttl` après avoir update le userId. 

## :100: Pour tester
comme le front n'est pas relié au back, on ne peut pas tester fonctionnellement. Vérifier que les tests passent