### PR TITLE
[FEATURE] Création d'un script pour l'ajout des lots de places déjà existants pour une organisation à partir d'un fichier (PIX-5066).

### DIFF
--- a/api/lib/domain/models/OrganizationPlacesLot.js
+++ b/api/lib/domain/models/OrganizationPlacesLot.js
@@ -13,7 +13,7 @@ class OrganizationPlacesLot {
     this.organizationId = organizationId;
     this.count = count || null;
     this.activationDate = activationDate;
-    this.expirationDate = expirationDate;
+    this.expirationDate = expirationDate || null;
     this.reference = reference;
     this.category = codeByCategories[category];
     this.createdBy = createdBy;

--- a/api/scripts/prod/create-organization-places-lot.js
+++ b/api/scripts/prod/create-organization-places-lot.js
@@ -1,0 +1,90 @@
+// Usage: node create-organization-places-lot.js path/file.csv
+// To use on file with columns |createdBy, organizationId, count, category, reference, activationDate, expirationDate|, those headers included
+const { knex } = require('../../db/knex-database-connection');
+const { parseCsvWithHeader } = require('../helpers/csvHelpers');
+const OrganizationPlacesLot = require('../../lib/domain/models/OrganizationPlacesLot');
+const categories = require('../../lib/domain/constants/organization-places-categories');
+const categoriesByCode = {
+  [categories.T0]: categories.FREE_RATE,
+  [categories.T1]: categories.PUBLIC_RATE,
+  [categories.T2]: categories.REDUCE_RATE,
+  [categories.T2bis]: categories.SPECIAL_REDUCE_RATE,
+  [categories.T3]: categories.FULL_RATE,
+};
+
+let logEnable;
+async function prepareOrganizationPlacesLot(organizationPlacesLotData, log = true) {
+  logEnable = log;
+  const organizationPlacesLot = organizationPlacesLotData.map(
+    ({ createdBy, organizationId, count, category, reference, activationDate, expirationDate }) => {
+      const activationDateInCorrectFormat = activationDate?.split('/').reverse().join('-');
+      const expirationDateInCorrectFormat = expirationDate?.split('/').reverse().join('-');
+
+      const organizationPlaceLot = new OrganizationPlacesLot({
+        createdBy,
+        organizationId,
+        count,
+        category: categoriesByCode[category],
+        reference,
+        activationDate: activationDateInCorrectFormat,
+        expirationDate: expirationDateInCorrectFormat,
+      });
+
+      _log(
+        `Lot de ${organizationPlaceLot.count} places ${organizationPlaceLot.category} pour l'organisation ${organizationPlaceLot.organizationId} ===> ✔\n`
+      );
+      return organizationPlaceLot;
+    }
+  );
+
+  return organizationPlacesLot.flat();
+}
+
+function createOrganizationPlacesLots(organizationPlacesLot) {
+  return knex.batchInsert('organization-places', organizationPlacesLot);
+}
+
+async function main() {
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Lecture et parsing du fichier csv... ');
+    const csvData = await parseCsvWithHeader(filePath);
+
+    console.log('Création des modèles et vérification de la cohérence...');
+    const organizationPlacesLot = await prepareOrganizationPlacesLot(csvData);
+
+    console.log('Insertion en base...');
+    await createOrganizationPlacesLots(organizationPlacesLot);
+
+    console.log('FIN');
+  } catch (error) {
+    console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+    if (error.invalidAttributes) {
+      error.invalidAttributes.map((invalidAttribute) => {
+        console.error(invalidAttribute.message);
+      });
+    }
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+function _log(message) {
+  if (logEnable) {
+    console.log(message);
+  }
+}
+
+module.exports = {
+  prepareOrganizationPlacesLot,
+};

--- a/api/tests/integration/scripts/prod/create-organization-places-lot_test.js
+++ b/api/tests/integration/scripts/prod/create-organization-places-lot_test.js
@@ -1,0 +1,190 @@
+const { expect, catchErr } = require('../../../test-helper');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+const { prepareOrganizationPlacesLot } = require('../../../../scripts/prod/create-organization-places-lot');
+
+describe('Integration | Scripts | create-organization-places-lot', function () {
+  describe('#prepareOrganizationPlacesLot', function () {
+    it('should create organization places lot for each organizationId', async function () {
+      // given
+      const organizationPlacesLotData1 = {
+        count: '10',
+        category: 'T1',
+        createdBy: '123',
+        organizationId: '987',
+        reference: 'Some reference',
+        activationDate: '31/10/2021',
+        expirationDate: '31/10/2022',
+      };
+      const organizationPlacesLotData2 = {
+        category: 'T2bis',
+        createdBy: '456',
+        organizationId: '654',
+        reference: 'Some reference bis',
+        activationDate: '31/10/2021',
+      };
+
+      // when
+      const organizationPlacesLotData = await prepareOrganizationPlacesLot(
+        [organizationPlacesLotData1, organizationPlacesLotData2],
+        false
+      );
+
+      // then
+      expect(organizationPlacesLotData).to.deep.equal([
+        {
+          activationDate: '2021-10-31',
+          category: organizationPlacesLotData1.category,
+          count: organizationPlacesLotData1.count,
+          createdBy: organizationPlacesLotData1.createdBy,
+          expirationDate: '2022-10-31',
+          organizationId: organizationPlacesLotData1.organizationId,
+          reference: organizationPlacesLotData1.reference,
+        },
+        {
+          activationDate: '2021-10-31',
+          category: organizationPlacesLotData2.category,
+          count: null,
+          createdBy: organizationPlacesLotData2.createdBy,
+          expirationDate: null,
+          organizationId: organizationPlacesLotData2.organizationId,
+          reference: organizationPlacesLotData2.reference,
+        },
+      ]);
+    });
+
+    it('should throw a validate error when createdBy is not valid', async function () {
+      // given
+      const organizationPlacesLotData = {
+        createdBy: undefined,
+        count: '10',
+        category: 'T1',
+        organizationId: '987',
+        reference: 'Some reference',
+        activationDate: '10/10/2021',
+        expirationDate: '10/10/2022',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('createdBy');
+    });
+
+    it('should throw a validate error when organizationId is not valid', async function () {
+      // given
+      const organizationPlacesLotData = {
+        count: '10',
+        category: 'T1',
+        organizationId: undefined,
+        reference: 'Some reference',
+        activationDate: '10/10/2021',
+        expirationDate: '10/10/2022',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('organizationId');
+    });
+
+    it('should throw a validate error when category is not valid', async function () {
+      // given
+      const organizationPlacesLotData = {
+        count: '10',
+        category: 'C1',
+        organizationId: '987',
+        reference: 'Some reference',
+        activationDate: '10/10/2020',
+        expirationDate: '10/10/2021',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('category');
+    });
+
+    it('should throw a validate error when reference is not valid', async function () {
+      // given
+      const organizationPlacesLotData = {
+        count: '10',
+        category: 'T1',
+        organizationId: '987',
+        reference: undefined,
+        activationDate: '10/10/2020',
+        expirationDate: '10/10/2021',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('reference');
+    });
+
+    it('should throw a validate error when activationDate is not valid', async function () {
+      // given
+      const organizationPlacesLotData = {
+        count: '10',
+        category: 'T1',
+        organizationId: '987',
+        reference: 'Some reference',
+        activationDate: undefined,
+        expirationDate: '10/10/2021',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('activationDate');
+    });
+
+    it('should throw a validate error when expirationDate is before activationDate', async function () {
+      // given
+      const organizationPlacesLotData = {
+        count: '10',
+        category: 'T1',
+        organizationId: '987',
+        reference: 'Some reference',
+        activationDate: '10/10/2021',
+        expirationDate: '10/10/2020',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('expirationDate');
+    });
+
+    it('should throw a validate error when count is not valid', async function () {
+      // given
+      const organizationPlacesLotData = {
+        count: '1.2',
+        category: 'T1',
+        organizationId: '987',
+        reference: 'Some reference',
+        activationDate: '10/10/2021',
+        expirationDate: '10/10/2020',
+      };
+
+      // when
+      const error = await catchErr(prepareOrganizationPlacesLot)([organizationPlacesLotData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+      expect(error.invalidAttributes[0].attribute).to.equal('count');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On a récemment ajouté la gestion des lots de places par organisation dans Pix Admin, cependant, il est nécéssaire de rattraper tous les lots de places déjà effectifs car les contrats sont déjà signés. Cette gestion est laborieuse à faire à la main. 

## :robot: Solution
Création d'un script qui prend un entrée un fichier avec toutes les informations nécéssaire pour la création des lots de place.

## :rainbow: Remarques
RAS

## :100: Pour tester
lancer le script avec un fichier CSV :
- soit en local : `node scripts/prod/create-organization-places-lot.js path/file.csv`
- soit sur la RA : `scalingo -a pix-api-review-pr4758 run --file fichier.csv node scripts/prod/create-organization-places-lot.js /tmp/uploads/fichier.csv
`
```
createdBy,organizationId,count,category,reference,activationDate,expirationDate
1,1,100,T1,some reference,01/01/2022,31/12/2022
```