### PR TITLE
[FEATURE] Uniformiser le bandeau d'informations de rentrée 2022 des organisations SCO avec import (PIX-5468) 

### DIFF
--- a/orga/app/components/banner/information.hbs
+++ b/orga/app/components/banner/information.hbs
@@ -1,4 +1,4 @@
-{{#if this.displayNewYearSchoolingRegistrationsImportBanner}}
+{{#if this.displayNewYearOrganizationLearnersImportBanner}}
   <PixBanner @type="information">
     <Ui::TranslateExtended
       @key="banners.import.message"
@@ -10,8 +10,7 @@
           "authenticated.sco-students"
           class="link link--banner link--bold link--underlined"
         )
-        middleSchoolDocumentationLink=this.importMiddleSchoolDocumentationLink
-        highSchoolDocumentationLink=this.importHighSchoolDocumentationLink
+        documentationLink=this.importDocumentationLink
         externalLinkClasses='"link link--banner link--bold link--underlined"'
       }}
     />

--- a/orga/app/components/banner/information.js
+++ b/orga/app/components/banner/information.js
@@ -9,24 +9,16 @@ export default class InformationBanner extends Component {
     return this.router.currentRouteName === 'authenticated.certifications';
   }
 
-  get displayNewYearSchoolingRegistrationsImportBanner() {
+  get displayNewYearOrganizationLearnersImportBanner() {
     return (
-      !this.currentUser.prescriber.areNewYearSchoolingRegistrationsImported &&
+      !this.currentUser.prescriber.areNewYearOrganizationLearnersImported &&
       this.currentUser.isSCOManagingStudents &&
       !this._isOnCertificationsPage
     );
   }
 
-  get importMiddleSchoolDocumentationLink() {
-    return this.currentUser.isAgriculture
-      ? 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=50100e2e-cbe3-41ff-b424-d965e5eeac7c'
-      : 'https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23';
-  }
-
-  get importHighSchoolDocumentationLink() {
-    return this.currentUser.isAgriculture
-      ? 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=50100e2e-cbe3-41ff-b424-d965e5eeac7c'
-      : 'https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23';
+  get importDocumentationLink() {
+    return 'https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23';
   }
 
   get displayNewYearCampaignsBanner() {

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -4,7 +4,7 @@ export default class Prescriber extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
-  @attr('boolean') areNewYearSchoolingRegistrationsImported;
+  @attr('boolean') areNewYearOrganizationLearnersImported;
   @attr('string') lang;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^15.0.2",
+        "@1024pix/pix-ui": "^17.0.0",
         "@ember/optional-features": "^2.0.0",
         "@formatjs/intl-getcanonicallocales": "^1.5.3",
         "@formatjs/intl-locale": "^2.4.14",
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-15.0.2.tgz",
-      "integrity": "sha512-D8u3E5oBqMt/uwzvF7KKngRX1FBWJ49USaQ39RIBJzjVDoNbC5Nvbu3qaQyWHHCiefvuJdIF4sVEyPJkZEkFdQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-17.0.0.tgz",
+      "integrity": "sha512-9yIf51LF1O+3tGTr+aRvTTmLToiOVLD/0kzCOg/BLVLIImBCusTgazFOROSmOQyu83Z95WZxjzJnIQcIF56oIw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -36219,9 +36219,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-15.0.2.tgz",
-      "integrity": "sha512-D8u3E5oBqMt/uwzvF7KKngRX1FBWJ49USaQ39RIBJzjVDoNbC5Nvbu3qaQyWHHCiefvuJdIF4sVEyPJkZEkFdQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-17.0.0.tgz",
+      "integrity": "sha512-9yIf51LF1O+3tGTr+aRvTTmLToiOVLD/0kzCOg/BLVLIImBCusTgazFOROSmOQyu83Z95WZxjzJnIQcIF56oIw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^15.0.2",
+    "@1024pix/pix-ui": "^17.0.0",
     "@ember/optional-features": "^2.0.0",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",
     "@formatjs/intl-locale": "^2.4.14",

--- a/orga/tests/acceptance/information-banner_test.js
+++ b/orga/tests/acceptance/information-banner_test.js
@@ -26,7 +26,6 @@ module('Acceptance | Information Banner', function (hooks) {
       server.create('prescriber', {
         id: user.id,
         pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
-        areNewYearSchoolingRegistrationsImported: false,
         memberships: user.memberships,
         userOrgaSettings: user.userOrgaSettings,
       });
@@ -37,9 +36,7 @@ module('Acceptance | Information Banner', function (hooks) {
       await clickByName(this.intl.t('banners.import.link-to'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/eleves');
+      assert.strictEqual(currentURL(), '/eleves');
     });
   });
 });

--- a/orga/tests/acceptance/information-banner_test.js
+++ b/orga/tests/acceptance/information-banner_test.js
@@ -5,9 +5,12 @@ import { clickByName } from '@1024pix/ember-testing-library';
 import authenticateSession from '../helpers/authenticate-session';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
+import setupIntl from '../helpers/setup-intl';
+
 module('Acceptance | Information Banner', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   module('ImportStudents banner', function () {
     test('should redirect to /eleves when clicking on banner button', async function (assert) {
@@ -31,7 +34,7 @@ module('Acceptance | Information Banner', function (hooks) {
 
       // when
       await visit('/');
-      await clickByName('importer ou ré-importer la base élèves');
+      await clickByName(this.intl.t('banners.import.link-to'));
 
       // then
       // TODO: Fix this the next time the file is edited.

--- a/orga/tests/integration/components/banner/information_test.js
+++ b/orga/tests/integration/components/banner/information_test.js
@@ -11,7 +11,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
     module('when prescriber’s organization is of type SCO that manages students', function () {
       module('when prescriber has not imported student yet', function () {
         class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: false };
+          prescriber = { areNewYearOrganizationLearnersImported: false };
           organization = { isSco: true };
           isSCOManagingStudents = true;
         }
@@ -26,63 +26,23 @@ module('Integration | Component | Banner::Information', function (hooks) {
           // then
           assert
             .dom(
-              'a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]'
-            )
-            .exists();
-          assert
-            .dom(
-              'a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]'
+              'a[href="https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]'
             )
             .exists();
           assert
             .dom('.pix-banner')
             .includesText(
-              'Rentrée 2021 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)'
-            );
-        });
-      });
-    });
-
-    module('when prescriber’s organization is of type SCO that manages AGRI students', function () {
-      module('when prescriber has not imported student yet', function () {
-        class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: false };
-          isSCOManagingStudents = true;
-          isAgriculture = true;
-        }
-
-        test('should  render the banner', async function (assert) {
-          // given
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          await render(hbs`<Banner::Information />`);
-
-          // then
-          assert
-            .dom(
-              'a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]'
-            )
-            .doesNotExist();
-          assert
-            .dom(
-              'a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]'
-            )
-            .doesNotExist();
-          assert
-            .dom('.pix-banner')
-            .includesText(
-              'Rentrée 2021 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)'
+              'Rentrée 2022 : l’administrateur doit importer la base élèves 2022 pour initialiser Pix Orga. Plus d’info'
             );
         });
       });
     });
 
     module('when prescriber has already imported students', function () {
-      test('should not render the banner', async function (assert) {
+      test('should not display import informations', async function (assert) {
         // given
         class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: true };
+          prescriber = { areNewYearOrganizationLearnersImported: true };
           organization = { isSco: true };
           isSCOManagingStudents = true;
         }
@@ -95,7 +55,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
         assert
           .dom('.pix-banner')
           .doesNotIncludeText(
-            'Rentrée 2021 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)'
+            'Rentrée 2022 : l’administrateur doit importer la base élèves 2022 pour initialiser Pix Orga. Plus d’info'
           );
       });
     });
@@ -104,7 +64,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
       test('should not render the banner regardless of whether students have been imported or not', async function (assert) {
         // given
         class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: false };
+          prescriber = { areNewYearOrganizationLearnersImported: false };
           organization = { isSco: false };
           isSCOManagingStudents = false;
         }
@@ -124,7 +84,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
       test('should render the campaign banner', async function (assert) {
         // given
         class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: true };
+          prescriber = { areNewYearOrganizationLearnersImported: true };
           organization = { isSco: true };
         }
         this.owner.register('service:current-user', CurrentUserStub);
@@ -144,7 +104,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
         test('should display AGRICULTURE links', async function (assert) {
           // given
           class CurrentUserStub extends Service {
-            prescriber = { areNewYearSchoolingRegistrationsImported: true };
+            prescriber = { areNewYearOrganizationLearnersImported: true };
             organization = { isSco: true };
             isSCOManagingStudents = true;
             isAgriculture = true;
@@ -167,7 +127,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
         test('should display links', async function (assert) {
           // given
           class CurrentUserStub extends Service {
-            prescriber = { areNewYearSchoolingRegistrationsImported: true };
+            prescriber = { areNewYearOrganizationLearnersImported: true };
             organization = { isSco: true };
             isSCOManagingStudents = true;
             isAgriculture = false;
@@ -195,7 +155,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
         test('should display default links', async function (assert) {
           // given
           class CurrentUserStub extends Service {
-            prescriber = { areNewYearSchoolingRegistrationsImported: true };
+            prescriber = { areNewYearOrganizationLearnersImported: true };
             organization = { isSco: true };
             isSCOManagingStudents = false;
             isAgriculture = false;
@@ -215,7 +175,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
       test('should not display the campaign banner', async function (assert) {
         // given
         class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: true };
+          prescriber = { areNewYearOrganizationLearnersImported: true };
           organization = { isSco: false };
         }
         this.owner.register('service:current-user', CurrentUserStub);

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -360,9 +360,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('[aria-label="Statut"]').selectedOptions[0].value, 'STARTED');
+        assert.strictEqual(find('[aria-label="Statut"]').selectedOptions[0].value, 'STARTED');
       });
 
       test('it should display 3 statuses for assessment campaign', async function (assert) {
@@ -435,7 +433,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
   module('when user works for a SCO organization which manages students', function () {
     class CurrentUserStub extends Service {
-      prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSCOManagingStudents = true;
     }
 
@@ -481,7 +478,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
   module('when user works for a SUP organization which manages students', function () {
     class CurrentUserStub extends Service {
-      prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSUPManagingStudents = true;
     }
 

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -257,7 +257,6 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
 
   module('when user works for a SCO organization which manages students', function () {
     class CurrentUserStub extends Service {
-      prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSCOManagingStudents = true;
     }
 
@@ -295,7 +294,6 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
 
   module('when user reset current filters', function () {
     class CurrentUserStub extends Service {
-      prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSCOManagingStudents = true;
     }
 

--- a/orga/tests/integration/components/campaign/results/profile-list_test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list_test.js
@@ -171,7 +171,6 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
 
   module('when user works for a SCO organization which manages students', function () {
     class CurrentUserStub extends Service {
-      prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSCOManagingStudents = true;
     }
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -51,8 +51,8 @@
       "message": "Don't forget to create your back-to-school campaigns and share the codes with your students before November. More info for '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
     },
     "import": {
-      "link-to": "import or reimport the students database",
-      "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
+      "link-to": "import the students database",
+      "message": "'<strong>'Start of school year:'</strong>' the admin must {linkTo} to start using Pix Orga. '<'a href={documentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'Learn more {faIcon}'</a>"
     }
   },
   "cards": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -51,8 +51,8 @@
       "message": "'<strong>'Parcours de rentrée 2021'</strong>' : N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
     },
     "import": {
-      "link-to": "importer ou ré-importer la base élèves",
-      "message": "Rentrée 2021 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
+      "link-to": "importer la base élèves",
+      "message": "'<strong>'Rentrée 2022 :'</strong>' l’administrateur doit {linkTo} 2022 pour initialiser Pix Orga. '<'a href={documentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info {faIcon}'</a>'"
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème
Les bandeaux d'import d'elèves ne sont plus d'actualité.

## :robot: Solution
Uniformiser le bandeau pour qu'il soit identiques pour toutes les organisations SCO ayant l'import d'élèves.

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur Pix Orga `sco.admin@example.net`, vérifier que le bandeau s'affiche pour College / Lycee (night watch) / Lycee Agriculture est identique.