### PR TITLE
[TECH] Corriger l'installation des domaines locaux (PIX-5542).

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -165,7 +165,7 @@ plutôt que `localhost:port` :
 Pour configurer les domaines locaux, exécuter le script :
 
 ```bash
-npm run domains:install
+sudo npm run domains:install
 ```
 
 Démarrer le conteneur docker :

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -180,10 +180,18 @@ Arrêter le conteneur :
 npm run domains:stop
 ```
 
-#### Activer le lint à chaque commit
+#### Exécuter le lint à chaque commit
+
+Activer
 
 Ce repository est configuré pour indiquer aux IDE Webstorm et Vscode la configuration du linter.
 Malgré cela, il peut arriver que des erreurs de lint soient introduites.
 
 Pour tenter de les corriger automatiquement lors du commit, installer un hook de pre-commit.
 Pour cela, exécuter `npm run local:trigger-lint-on-commit`
+
+Désactiver
+
+```
+npm run local:prevent-trigger-lint-on-commit
+```

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lint:yaml:files": "eslint --ext .yaml --ignore-pattern docker-compose.yaml ./*.yaml",
     "lint:docs": "find ./docs -type f -name '*.md' | xargs -L1 markdown-link-check --quiet --config ./docs/link--check-config.json ",
     "local:trigger-lint-on-commit": "husky install",
+    "local:prevent-trigger-lint-on-commit": "git config --unset core.hooksPath",
     "preinstall": "npx check-engine",
     "start": "run-p --print-label start:api start:mon-pix start:orga start:certif start:admin",
     "start:admin": "cd admin && npm start",


### PR DESCRIPTION
## :unicorn: Problème
L'installation des domaines locaux ne fonctionne pas

## :robot: Solution
Ajouter l'exécution en tant que root (via `sudo`)

## :rainbow: Remarques
La régression n'a pas été identifiée, peut-être que la commande n'a jamais fonctionné :thinking: 

## :100: Pour tester
Supprimer les lignes concernées dans le fichier hosts
Installer les domaines locaux 
Démarrer les domaines et pix-app
Vérifier si `[curl](curl http://app.dev.pix.fr/` renvoie bien 
```html
<!DOCTYPE html>
<html lang="fr">
  <head>
    <meta charset="utf-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <title>Pix</title>
    <meta name="viewport" content="width=device-width, initial-scale=1">
```
