### PR TITLE
[BUGFIX] Le mode édition ne se fermait pas lorsque l'utilisateur sortait de la page de détails de profil cible sur PixAdmin (PIX-5493)

### DIFF
--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -105,4 +105,8 @@ export default class TargetProfileController extends Controller {
       }
     });
   }
+
+  reset() {
+    this.isEditMode = false;
+  }
 }

--- a/admin/app/routes/authenticated/target-profiles/target-profile.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile.js
@@ -12,4 +12,10 @@ export default class TargetProfileRoute extends Route {
   model(params) {
     return this.store.findRecord('target-profile', params.target_profile_id);
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.reset();
+    }
+  }
 }

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile_test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
@@ -20,17 +20,35 @@ module('Acceptance | Target Profiles | Target Profile', function (hooks) {
   });
 
   module('When admin member is logged in', function () {
-    module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
-      test('it should be accessible for an authenticated user', async function (assert) {
-        // given
+    module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function (hooks) {
+      hooks.beforeEach(async function () {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        server.create('target-profile', { id: 1 });
+        server.create('target-profile', { id: 1, name: 'Mon super profil cible' });
+      });
 
+      test('it should be accessible for an authenticated user', async function (assert) {
         // when
         await visit('/target-profiles/1');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1');
+      });
+
+      module('when user clicks on the edit button', function () {
+        module('when user goes to another page then comes back to a target profile details page', function () {
+          test('it should have ended edit mode', async function (assert) {
+            // given
+            const screen = await visit('/target-profiles/1');
+            await clickByName('Éditer');
+            await clickByName('Tous les profils cibles');
+
+            // when
+            await clickByName('Mon super profil cible');
+
+            // then
+            assert.dom(screen.getByText('Éditer')).exists();
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
On peut éditer des informations du profil cible en mode "inline".
Reproduire le bug :
- Aller sur la page de détails d'un profil cible
- Cliquer sur le bouton **Editer** et donc rentrer en mode édition
- Cliquer sur le lien en haut pour retourner la liste des profil-cibles (**Tous les profil-cibles**)
- Cliquer sur n'importe quel profil cible (pas forcément le même que la première fois)
- Constater que le mode édition est toujours actif

https://user-images.githubusercontent.com/48727874/184338092-cea072bc-dd74-4748-9383-066a80c7e604.mp4

## :robot: Solution
Reset le mode édition du controller lorsqu'on sort de la route.

https://user-images.githubusercontent.com/48727874/184338118-b33a9770-6b5b-4835-b591-22cc0ddae1ac.mp4

## :rainbow: Remarques

## :100: Pour tester
Refaire les mêmes étapes qu'au-dessus mais constater que le bug a disparu
