### PR TITLE
[TECH] Résoudre un test flaky.

### DIFF
--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -130,7 +130,9 @@ function _fetchPossibleCampaignAssociatedBadges(campaignParticipation, badgeRepo
 }
 
 async function getCampaignParticipationsBetweenIds({ idMin, idMax }) {
-  const campaignParticipations = await knex('campaign-participations').whereBetween('id', [idMin, idMax]);
+  const campaignParticipations = await knex('campaign-participations')
+    .whereBetween('id', [idMin, idMax])
+    .orderBy('id', 'asc');
   return campaignParticipations.map((campaignParticipation) => new CampaignParticipation(campaignParticipation));
 }
 


### PR DESCRIPTION
## :unicorn: Problème
La requête dans le script `compute-badge-acquisitions` n'a pas d'order by sur l'id ce qui provoque rend le test associé flaky.

## :robot: Solution
Ajouter un orderby sur la requête afin d'être déterministe sur l'ordre dont nous renvoie les résultats PG 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
CI
