### PR TITLE
[FEATURE] Uniformiser la bannière d'incitation à créer des campagnes pour les Organisations SCO (PIX-5469)

### DIFF
--- a/orga/app/components/banner/information.hbs
+++ b/orga/app/components/banner/information.hbs
@@ -21,8 +21,7 @@
       @key="banners.campaigns.message"
       @options={{hash
         faIcon=(component "fa-icon" icon="external-link-alt")
-        middleSchoolDocumentationLink=this.campaignMiddleSchoolDocumentationLink
-        highSchoolDocumentationLink=this.campaignHighSchoolDocumentationLink
+        documentationLink=this.campaignDocumentationLink
         externalLinkClasses='"link link--banner link--bold link--underlined"'
       }}
     />

--- a/orga/app/components/banner/information.js
+++ b/orga/app/components/banner/information.js
@@ -25,21 +25,10 @@ export default class InformationBanner extends Component {
     return this.currentUser.organization.isSco && !this._isOnCertificationsPage;
   }
 
-  get campaignMiddleSchoolDocumentationLink() {
-    if (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) {
-      return 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=cf788556-ff93-4aba-a5c2-312c450c7553';
-    } else if (this.currentUser.isSCOManagingStudents) {
-      return 'https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba';
+  get campaignDocumentationLink() {
+    if (this.currentUser.isSCOManagingStudents) {
+      return 'https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba';
     }
-    return 'https://kutt.it/prefe';
-  }
-
-  get campaignHighSchoolDocumentationLink() {
-    if (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) {
-      return 'https://view.genial.ly/5f687a0451337070914e54f9?idSlide=cf788556-ff93-4aba-a5c2-312c450c7553';
-    } else if (this.currentUser.isSCOManagingStudents) {
-      return 'https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba';
-    }
-    return 'https://kutt.it/prefe';
+    return 'https://view.genial.ly/5fea2c3d6157fe0d69196ed9?idSlide=16cedb0c-3c1c-4cd3-a00b-49c01b0afcc2';
   }
 }

--- a/orga/tests/integration/components/banner/information_test.js
+++ b/orga/tests/integration/components/banner/information_test.js
@@ -96,34 +96,11 @@ module('Integration | Component | Banner::Information', function (hooks) {
         assert
           .dom('.pix-banner')
           .includesText(
-            'Parcours de rentrée 2021 : N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. Plus d’info collège et lycée (GT et Pro)'
+            'Parcours de rentrée 2022 : N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. Plus d’info'
           );
       });
 
-      module('when prescriber’s organization is managing students and is AGRICULTURE', function () {
-        test('should display AGRICULTURE links', async function (assert) {
-          // given
-          class CurrentUserStub extends Service {
-            prescriber = { areNewYearOrganizationLearnersImported: true };
-            organization = { isSco: true };
-            isSCOManagingStudents = true;
-            isAgriculture = true;
-          }
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          await render(hbs`<Banner::Information />`);
-
-          // then
-          assert
-            .dom(
-              'a[href="https://view.genial.ly/5f687a0451337070914e54f9?idSlide=cf788556-ff93-4aba-a5c2-312c450c7553"'
-            )
-            .exists();
-        });
-      });
-
-      module('when prescriber’s organization is managing students but is not AGRICULTURE', function () {
+      module('when prescriber’s organization is managing students', function () {
         test('should display links', async function (assert) {
           // given
           class CurrentUserStub extends Service {
@@ -140,12 +117,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
           // then
           assert
             .dom(
-              'a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"'
-            )
-            .exists();
-          assert
-            .dom(
-              'a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"'
+              'a[href="https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"'
             )
             .exists();
         });
@@ -166,7 +138,11 @@ module('Integration | Component | Banner::Information', function (hooks) {
           await render(hbs`<Banner::Information />`);
 
           // then
-          assert.dom('a[href="https://kutt.it/prefe"').exists();
+          assert
+            .dom(
+              'a[href="https://view.genial.ly/5fea2c3d6157fe0d69196ed9?idSlide=16cedb0c-3c1c-4cd3-a00b-49c01b0afcc2"'
+            )
+            .exists();
         });
       });
     });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -48,7 +48,7 @@
   },
   "banners": {
     "campaigns": {
-      "message": "Don't forget to create your back-to-school campaigns and share the codes with your students before November. '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'More info {faIcon}'</a>'"
+      "message": "Don't forget to create your back-to-school campaigns and share the codes with your students before November. '<'a href={documentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'More info {faIcon}'</a>'"
     },
     "import": {
       "link-to": "import the students database",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -48,7 +48,7 @@
   },
   "banners": {
     "campaigns": {
-      "message": "Don't forget to create your back-to-school campaigns and share the codes with your students before November. More info for '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
+      "message": "Don't forget to create your back-to-school campaigns and share the codes with your students before November. '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'More info {faIcon}'</a>'"
     },
     "import": {
       "link-to": "import the students database",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -48,7 +48,7 @@
   },
   "banners": {
     "campaigns": {
-      "message": "'<strong>'Parcours de rentrée 2021'</strong>' : N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
+      "message": "'<strong>'Parcours de rentrée 2022 :'</strong>' N’oubliez pas de créer les campagnes de rentrée et de diffuser les codes aux élèves avant la Toussaint. '<'a href={documentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info {faIcon}'</a>'"
     },
     "import": {
       "link-to": "importer la base élèves",


### PR DESCRIPTION
## :unicorn: Problème
Les Organisations SCO de type Agriculture n'avait pas le même bandeau que les autres organisations SCO. Ce n'est plus la peine de gérer cette différence

## :robot: Solution
Unifier le message pour afficher l'incitation à la création de campagne de la Toussaint

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur Pix Orga, sco. admin@example.net, vérifier que le message est à jour