### PR TITLE
[FEATURE] Ne prends plus en compte les places supprimées (PIX-5344)

### DIFF
--- a/api/db/database-builder/factory/build-organization-place.js
+++ b/api/db/database-builder/factory/build-organization-place.js
@@ -12,6 +12,8 @@ const buildOrganizationPlace = function buildOrganizationPlace({
   category = 'T0',
   createdBy,
   createdAt = new Date('1997-07-01'),
+  deletedBy,
+  deletedAt,
 } = {}) {
   organizationId = organizationId || buildOrganization().id;
   createdBy = createdBy || buildUser.withRole({ firstName: 'Gareth', lastName: 'Edwards' }).id;
@@ -26,6 +28,8 @@ const buildOrganizationPlace = function buildOrganizationPlace({
     category,
     createdBy,
     createdAt,
+    deletedBy,
+    deletedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20220816125246_add-deleted-at-and-deleted-by-to-organization-places.js
+++ b/api/db/migrations/20220816125246_add-deleted-at-and-deleted-by-to-organization-places.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'organization-places';
+const DELETEDAT_COLUMN = 'deletedAt';
+const DELETEDBY_COLUMN = 'deletedBy';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dateTime(DELETEDAT_COLUMN).nullable();
+    table.bigInteger(DELETEDBY_COLUMN).index().references('users.id').nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(DELETEDAT_COLUMN);
+    table.dropColumn(DELETEDBY_COLUMN);
+  });
+};

--- a/api/db/seeds/data/organization-places-pro-builder.js
+++ b/api/db/seeds/data/organization-places-pro-builder.js
@@ -5,6 +5,20 @@ function organizationPlacesProBuilder({ databaseBuilder }) {
   const expirationDate = new Date();
   const createdDate = new Date();
 
+  // Deleted
+  databaseBuilder.factory.buildOrganizationPlace({
+    organizationId: PRO_COMPANY_ID,
+    count: 40,
+    activationDate: new Date(activationDate.setMonth(activationDate.getMonth() - 1)),
+    expirationDate: new Date(expirationDate.setMonth(expirationDate.getMonth() + 8)),
+    reference: 'TheOfficeDeleted',
+    category: 'T1',
+    createdBy: PIX_SUPER_ADMIN_ID,
+    createdAt: new Date('2019-12-01'),
+    deletedBy: PIX_SUPER_ADMIN_ID,
+    deletedAt: new Date('2020-01-12'),
+  });
+
   // Expired
   databaseBuilder.factory.buildOrganizationPlace({
     organizationId: PRO_COMPANY_ID,

--- a/api/lib/infrastructure/repositories/organization-places-capacity-repository.js
+++ b/api/lib/infrastructure/repositories/organization-places-capacity-repository.js
@@ -7,6 +7,7 @@ async function findByOrganizationId(organizationId) {
     .select('category', 'count')
     .where({ organizationId })
     .where('activationDate', '<', now)
+    .whereNull('deletedAt')
     .where(function () {
       this.where('expirationDate', '>', now).orWhereNull('expirationDate');
     });

--- a/api/lib/infrastructure/repositories/organizations/organization-places-lot-repository.js
+++ b/api/lib/infrastructure/repositories/organizations/organization-places-lot-repository.js
@@ -16,6 +16,7 @@ async function findByOrganizationId(organizationId) {
     )
     .join('users', 'users.id', 'createdBy')
     .where({ organizationId })
+    .whereNull('deletedAt')
     .orderBy('activationDate', 'desc')
     .orderBy('expirationDate', 'desc')
     .orderBy('organization-places.createdAt', 'desc');

--- a/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-places-capacity-repository_test.js
@@ -32,6 +32,28 @@ describe('Integration | Infrastructure | Repository | OrganizationPlacesCapacity
       ]);
     });
 
+    it('should not take into acccount deleted places', async function () {
+      databaseBuilder.factory.buildOrganizationPlace({
+        category: categories.T0,
+        count: 10,
+        deletedAt: new Date('2020-01-01'),
+        organizationId,
+      });
+      await databaseBuilder.commit();
+
+      const organizationPlacesCapacity = await organizationPlacesCapacityRepository.findByOrganizationId(
+        organizationId
+      );
+
+      expect(organizationPlacesCapacity.categories).to.have.deep.members([
+        { category: categories.FREE_RATE, count: 0 },
+        { category: categories.PUBLIC_RATE, count: 0 },
+        { category: categories.REDUCE_RATE, count: 0 },
+        { category: categories.SPECIAL_REDUCE_RATE, count: 0 },
+        { category: categories.FULL_RATE, count: 0 },
+      ]);
+    });
+
     it('should return count if there are places', async function () {
       databaseBuilder.factory.buildOrganizationPlace({ category: categories.T0, count: 10, organizationId });
       databaseBuilder.factory.buildOrganizationPlace({ category: categories.T1, count: 5, organizationId });

--- a/api/tests/integration/infrastructure/repositories/organizations/organization-places-lot-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organizations/organization-places-lot-repository_test.js
@@ -84,6 +84,25 @@ describe('Integration | Repository | Organization Place', function () {
       expect(foundOrganizationPlace.length).to.equal(0);
     });
 
+    it('should not take into account deleted places', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.buildOrganizationPlace({
+        organizationId,
+        reference: 'Stargate SG-1',
+        deletedAt: new Date('2020-01-10'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundOrganizationPlace = await organizationPlacesLotRepository.findByOrganizationId(organizationId);
+
+      // then
+      expect(foundOrganizationPlace.length).to.equal(0);
+    });
+
     it("should return creator place's name for given id", async function () {
       // given
       const user = databaseBuilder.factory.buildUser({ firstName: 'Jack', lastName: "O'Neill" });


### PR DESCRIPTION
## :unicorn: Problème
Dans l'épix création des places et calcul d’une capacité d’une organisation, nous avons créé une gestion de places dans pix admin. 
Actuellement il y a un tableau avec chaque ligne représentant un lot de place, et une liste de la capacité actuelle. Les utilisateurs voudrait pouvoir supprimer de lots de places.

## :robot: Solution
Dans un premier temps, nous ajoutons deux colonnes dans la table organization-places : 
- deletedAt
- deletedBy

On met aussi à jour les repositories qui renvoient en les lots de places et calcul la capacité.
Dans un second temps une PR ajoutera la possibilité de supprimer en lot de places depuis PixAdmin.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixAdmin
- Se rendre sur la page de [gestion des places](http://localhost:4202/organizations/1/places) de l'organisation 1 
- Constater que le lot de places de référence "TheOfficeDeleted" n'est pas présent et qu'il n'y a pas 40 places "Tarif public" dans la capacité actuelle
