### PR TITLE
[FEATURE] Ajouter l'id de l'utilisateur qui a archivé la campagne en BDD (PIX-5491)

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -182,6 +182,7 @@ __Plus d'infos :)__
     assessmentMethod: 'SMART_RANDOM',
     idPixLabel: 'identifiant entreprise',
     archivedAt: new Date('2020-01-02T15:00:34Z'),
+    archivedBy: 3,
     createdAt: new Date('2020-01-15'),
   });
 
@@ -200,6 +201,7 @@ __Plus d'infos :)__
     idPixLabel: 'identifiant entreprise',
     createdAt: new Date('2019-01-01'),
     archivedAt: new Date('2020-01-01T15:00:34Z'),
+    archivedBy: 2,
   });
 
   databaseBuilder.factory.buildCampaign({
@@ -217,6 +219,7 @@ __Plus d'infos :)__
     idPixLabel: 'identifiant entreprise',
     createdAt: new Date('2019-01-02'),
     archivedAt: new Date('2020-01-01T15:00:34Z'),
+    archivedBy: 2,
   });
 
   databaseBuilder.factory.buildCampaign({

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -13,6 +13,7 @@ class Campaign {
     createdAt,
     customLandingPageText,
     archivedAt,
+    archivedBy,
     type,
     isForAbsoluteNovice,
     targetProfile,
@@ -35,6 +36,7 @@ class Campaign {
     this.createdAt = createdAt;
     this.customLandingPageText = customLandingPageText;
     this.archivedAt = archivedAt;
+    this.archivedBy = archivedBy;
     this.type = type;
     this.isForAbsoluteNovice = isForAbsoluteNovice;
     this.targetProfile = targetProfile;

--- a/api/lib/domain/usecases/archive-campaign.js
+++ b/api/lib/domain/usecases/archive-campaign.js
@@ -12,5 +12,5 @@ module.exports = async function archiveCampaign({
     throw new UserNotAuthorizedToUpdateCampaignError();
   }
 
-  return campaignRepository.update({ id: campaignId, archivedAt: new Date() });
+  return campaignRepository.update({ id: campaignId, archivedAt: new Date(), archivedBy: userId });
 };

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -240,6 +240,7 @@ describe('Integration | Repository | Campaign', function () {
       campaign.title = 'New title';
       campaign.customLandingPageText = 'New text';
       campaign.archivedAt = new Date('2020-12-12T06:07:08Z');
+      campaign.archivedBy = databaseBuilder.factory.buildUser({ id: 3 }).id;
       campaign.ownerId = databaseBuilder.factory.buildUser({ id: 2 }).id;
       await databaseBuilder.commit();
 
@@ -252,6 +253,7 @@ describe('Integration | Repository | Campaign', function () {
       expect(campaignSaved.title).to.equal('New title');
       expect(campaignSaved.customLandingPageText).to.equal('New text');
       expect(campaignSaved.archivedAt).to.deep.equal(new Date('2020-12-12T06:07:08Z'));
+      expect(campaignSaved.archivedBy).to.equal(3);
       expect(campaignSaved.ownerId).to.equal(2);
     });
   });

--- a/api/tests/unit/domain/usecases/archive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign_test.js
@@ -31,6 +31,7 @@ describe('Unit | UseCase | archive-campaign', function () {
       expect(campaignRepository.update).to.have.been.calledWithExactly({
         id: campaignId,
         archivedAt: sinon.match.instanceOf(Date),
+        archivedBy: userId,
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La colonne archivedBy a été rajouté en base de donnée mais n'est pas encore utilisé

## :robot: Solution
Mette à jour le champs archivedBy par l'utilisateur effectuant l'action via Pix Orga

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur Pix Orga, archiver une campagne, vérifier que tout fonctionne. et le présence de l'id de l'utilisateur dans la colonne archivedBy de la campagne concernée.