### PR TITLE
[FEATURE] N'afficher que le résultat de la certif Pix+ Edu correspondant au volet Pix (PIX-5425)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/certification-result-repository.js
@@ -1,4 +1,5 @@
 const { knex } = require('../../../db/knex-database-connection');
+const ComplementaryCertificationCourseResult = require('../../domain/models/ComplementaryCertificationCourseResult');
 const CertificationResult = require('../../domain/models/CertificationResult');
 const isEmpty = require('lodash/isEmpty');
 
@@ -116,6 +117,7 @@ function _selectComplementaryCertificationCourseResultsBySessionId({ sessionId }
       'complementary-certification-courses.certificationCourseId'
     )
     .where({ sessionId })
+    .where('complementary-certification-course-results.source', ComplementaryCertificationCourseResult.sources.PIX)
     .groupBy('certification-courses.id');
 }
 


### PR DESCRIPTION
Co-authored-by: Mathieu Gilet <mathieu.gilet@zenika.com>

## :unicorn: Problème
Pour le moment, lorsque la session est publiée APRES que le niveau obtenu au volet jury ait été renseigné depuis Pix Admin, le système prend au hasard un niveau entre le niveau obtenu au volet Pix et celui obtenu au volet jury. Dans un premier temps, on souhaite tout le temps afficher le niveau obtenu au volet Pix, ce qui peut potentiellement ne pas être le cas.

## :robot: Solution
N’afficher que le niveau obtenu au volet Pix dans le fichier csv des résultats, même si le niveau volet jury a été renseigné

## :100: Pour tester
- passer une certif edu
- mettre un niveau jury
- télécharger les résultats