### PR TITLE
[FEATURE] Rendre la page de résultat d'une campagne accessible.

### DIFF
--- a/high-level-tests/e2e/cypress/fixtures/assessments.json
+++ b/high-level-tests/e2e/cypress/fixtures/assessments.json
@@ -26,5 +26,12 @@
     "state": "completed",
     "type": "CAMPAIGN",
     "userId": 5
+  },
+  {
+    "id": 5,
+    "campaignParticipationId": 7,
+    "state": "started",
+    "type": "CAMPAIGN",
+    "userId": 3
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/campaign-participations.json
+++ b/high-level-tests/e2e/cypress/fixtures/campaign-participations.json
@@ -48,5 +48,13 @@
     "status": "TO_SHARE",
     "userId": 5,
     "organizationLearnerId": 6
+  },
+  {
+    "id": 7,
+    "campaignId": 1,
+    "status": "TO_SHARE",
+    "participantExternalId": "a11y vérif",
+    "userId": 3,
+    "organizationLearnerId": 8
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/organization-learners.json
+++ b/high-level-tests/e2e/cypress/fixtures/organization-learners.json
@@ -54,5 +54,12 @@
     "lastName": "Lannister",
     "organizationId": 1,
     "userId": 6
+  },
+  {
+    "id": 8,
+    "firstName": "John",
+    "lastName": "Snow",
+    "organizationId": 1,
+    "userId": 3
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -57,13 +57,17 @@ describe('a11y', () => {
     ];
 
     authenticatedPages.forEach(({ url, skipFailures = false }) => {
-      it(`${url} should be accessible`, () => {
+      beforeEach(() => {
         // given
         cy.visitMonPix('/');
         cy.login('john.snow@pix.fr', 'pix123');
+      });
 
+      it(`${url} should be accessible`, () => {
         // when
         cy.visitMonPix(url);
+        cy.get('.app-loader').should('not.exist');
+
         cy.injectAxe();
 
         // then

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -53,6 +53,7 @@ describe('a11y', () => {
       { url: '/mon-profil', skipFailures: true },
       { url: '/mes-tutos/recommandes',skipFailures: true },
       { url: '/mes-certifications', skipFailures: true },
+      { url: '/campagnes/NERA/evaluation/resultats' },
     ];
 
     authenticatedPages.forEach(({ url, skipFailures = false }) => {

--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -13,7 +13,7 @@ Fonctionnalité: Gestion des Campagnes
     Lorsque je clique sur "Campagne de la Néra"
     Alors je vois le détail de la campagne "Campagne de la Néra"
     Lorsque je clique sur "Activité"
-    Alors je vois 3 participants
+    Alors je vois 4 participants
     Lorsque je clique sur "Cersei"
     Alors je vois "50 %" comme "Avancement"
     Alors je vois 0 résultats par compétence

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -1,244 +1,245 @@
 <div class="skill-review__banner">
-  <AssessmentBanner @title={{@model.campaign.title}} @displayHomeLink={{false}} />
+  <AssessmentBanner @title={{this.title}} @displayHomeLink={{false}} />
 </div>
 
-{{#if this.showDisabledBlock}}
-  <PixBlock class="skill-review__result-abstract-container">
-    <div class="skill-review__disabled-share">
-      <img
-        class="skill-review-disabled-share__image"
-        src="{{this.rootURL}}/images/illustrations/fat-bee.svg"
-        alt=""
-        role="none"
-      />
-      <p class="skill-review-disabled-share__text">
-        {{t "pages.skill-review.disabled-share" htmlSafe=true}}
-      </p>
-      <LinkTo @route="index" class="skill-review-share__back-to-home link">
-        {{t "pages.skill-review.actions.continue"}}
-      </LinkTo>
-    </div>
-  </PixBlock>
-{{else}}
-  <PixBlock class="skill-review__result-abstract-container">
-    <div class="skill-review__result-and-action">
-      <h2 class="sr-only">{{t "pages.skill-review.abstract-title"}}</h2>
-      {{#if this.showStages}}
-        <ReachedStage
-          @stageCount={{this.stageCount}}
-          @starCount={{this.reachedStage.starCount}}
-          @masteryRate={{this.masteryRate}}
-          @imageUrl={{@model.campaign.targetProfileImageUrl}}
+<main role="main">
+  {{#if this.showDisabledBlock}}
+    <PixBlock class="skill-review__result-abstract-container">
+      <div class="skill-review__disabled-share">
+        <img
+          class="skill-review-disabled-share__image"
+          src="{{this.rootURL}}/images/illustrations/fat-bee.svg"
+          alt=""
+          role="none"
         />
-      {{/if}}
-
-      <div class="skill-review__share">
+        <p class="skill-review-disabled-share__text">
+          {{t "pages.skill-review.disabled-share" htmlSafe=true}}
+        </p>
+        <LinkTo @route="index" class="skill-review-share__back-to-home link">
+          {{t "pages.skill-review.actions.continue"}}
+        </LinkTo>
+      </div>
+    </PixBlock>
+  {{else}}
+    <PixBlock class="skill-review__result-abstract-container">
+      <div class="skill-review__result-and-action">
+        <h2 class="sr-only">{{t "pages.skill-review.abstract-title"}}</h2>
         {{#if this.showStages}}
-          <div class="skill-review-share__stage-congrats">
-            <div class="stage-congrats__title">
-              {{text-with-multiple-lang this.reachedStage.title}}
-            </div>
-            <div class="stage-congrats__message">
-              <MarkdownToHtml @markdown={{text-with-multiple-lang this.reachedStage.message}} />
-            </div>
-          </div>
-        {{else}}
-          {{#if this.isFlashCampaign}}
-            <p class="rounded-panel-title skill-review-result-abstract__text">
-              {{t "pages.skill-review.flash.abstract"}}
-            </p>
-            <p class="rounded-panel-title skill-review-result-abstract__subtext">
-              {{t "pages.skill-review.flash.pixCount" count=this.flashPixCount}}
-              <br />
-              <span class="skill-review-result-abstract__nonDefinitive">
-                {{t "pages.skill-review.flash.nonDefinitive"}}
-              </span>
-            </p>
-          {{else}}
-            <p class="rounded-panel-title skill-review-result-abstract__text">
-              {{t "pages.skill-review.abstract" rate=this.masteryRate htmlSafe=true}}
-            </p>
-          {{/if}}
+          <ReachedStage
+            @stageCount={{this.stageCount}}
+            @starCount={{this.reachedStage.starCount}}
+            @masteryRate={{this.masteryRate}}
+            @imageUrl={{@model.campaign.targetProfileImageUrl}}
+          />
         {{/if}}
 
-        <h2 class="sr-only">{{t "pages.skill-review.send-title"}}</h2>
-
-        <div
-          class="skill-review-result-abstract__share-container
-            {{if this.showStages "skill-review-result-abstract__share-container--left"}}"
-        >
-          {{#if this.showNotFinishedYetMessage}}
-            <div class="skill-review-share__error-container">
-              <div class="skill-review-share-error__message" aria-live="polite">
-                {{t "pages.skill-review.not-finished"}}
+        <div class="skill-review__share">
+          {{#if this.showStages}}
+            <div class="skill-review-share__stage-congrats">
+              <div class="stage-congrats__title">
+                {{text-with-multiple-lang this.reachedStage.title}}
               </div>
-              <LinkTo
-                @route="campaigns.entry-point"
-                @model={{@model.campaign.code}}
-                class="skill-review-share-error__button button button--big button--link"
-              ><span class="sr-only">{{t "pages.profile.resume-campaign-banner.accessibility.resume"}}</span>{{t
-                  "pages.profile.resume-campaign-banner.actions.resume"
-                }}</LinkTo>
-            </div>
-          {{else if this.showGlobalErrorMessage}}
-            <div class="skill-review-share__error-container">
-              <div class="skill-review-share-error__message" aria-live="polite">
-                {{t "pages.skill-review.error"}}
+              <div class="stage-congrats__message">
+                <MarkdownToHtml @markdown={{text-with-multiple-lang this.reachedStage.message}} />
               </div>
-              <LinkTo
-                @route="authentication.login"
-                class="skill-review-share-error__button button button--big button--link"
-              >
-                {{t "navigation.back-to-homepage"}}
-              </LinkTo>
             </div>
           {{else}}
-            {{#if @model.campaign.isForAbsoluteNovice}}
-              <a
-                href="#"
-                {{on "click" this.redirectToSignupIfUserIsAnonymous}}
-                class="skill-review-share__back-to-home link"
-                data-link-to-continue-pix
-              >
-                {{t "pages.skill-review.actions.continue"}}
-              </a>
+            {{#if this.isFlashCampaign}}
+              <p class="rounded-panel-title skill-review-result-abstract__text">
+                {{t "pages.skill-review.flash.abstract"}}
+              </p>
+              <p class="rounded-panel-title skill-review-result-abstract__subtext">
+                {{t "pages.skill-review.flash.pixCount" count=this.flashPixCount}}
+                <br />
+                <span class="skill-review-result-abstract__nonDefinitive">
+                  {{t "pages.skill-review.flash.nonDefinitive"}}
+                </span>
+              </p>
             {{else}}
-              <CampaignShareButton
-                @isShared={{this.isShared}}
-                @displayPixLink={{this.displayPixLink}}
-                @shareCampaignParticipation={{this.shareCampaignParticipation}}
-                @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
-                @isFlashCampaign={{this.isFlashCampaign}}
-              />
+              <p class="rounded-panel-title skill-review-result-abstract__text">
+                {{t "pages.skill-review.abstract" rate=this.masteryRate htmlSafe=true}}
+              </p>
             {{/if}}
           {{/if}}
+
+          <h2 class="sr-only">{{t "pages.skill-review.send-title"}}</h2>
+
+          <div
+            class="skill-review-result-abstract__share-container
+              {{if this.showStages "skill-review-result-abstract__share-container--left"}}"
+          >
+            {{#if this.showNotFinishedYetMessage}}
+              <div class="skill-review-share__error-container">
+                <div class="skill-review-share-error__message" aria-live="polite">
+                  {{t "pages.skill-review.not-finished"}}
+                </div>
+                <LinkTo
+                  @route="campaigns.entry-point"
+                  @model={{@model.campaign.code}}
+                  class="skill-review-share-error__button button button--big button--link"
+                ><span class="sr-only">{{t "pages.profile.resume-campaign-banner.accessibility.resume"}}</span>{{t
+                    "pages.profile.resume-campaign-banner.actions.resume"
+                  }}</LinkTo>
+              </div>
+            {{else if this.showGlobalErrorMessage}}
+              <div class="skill-review-share__error-container">
+                <div class="skill-review-share-error__message" aria-live="polite">
+                  {{t "pages.skill-review.error"}}
+                </div>
+                <LinkTo
+                  @route="authentication.login"
+                  class="skill-review-share-error__button button button--big button--link"
+                >
+                  {{t "navigation.back-to-homepage"}}
+                </LinkTo>
+              </div>
+            {{else}}
+              {{#if @model.campaign.isForAbsoluteNovice}}
+                <a
+                  href="#"
+                  {{on "click" this.redirectToSignupIfUserIsAnonymous}}
+                  class="skill-review-share__back-to-home link"
+                  data-link-to-continue-pix
+                >
+                  {{t "pages.skill-review.actions.continue"}}
+                </a>
+              {{else}}
+                <CampaignShareButton
+                  @isShared={{this.isShared}}
+                  @displayPixLink={{this.displayPixLink}}
+                  @shareCampaignParticipation={{this.shareCampaignParticipation}}
+                  @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
+                  @isFlashCampaign={{this.isFlashCampaign}}
+                />
+              {{/if}}
+            {{/if}}
+          </div>
         </div>
       </div>
-    </div>
-    {{#if @model.campaignParticipationResult.canRetry}}
-      <div class="skill-review__retry">
-        <p class="skill-review-retry__message">{{t
-            "pages.skill-review.retry.message"
-            organizationName=@model.campaign.organizationName
-          }}</p>
-        <LinkTo
-          @route="campaigns.entry-point"
-          @model={{@model.campaign.code}}
-          @query={{hash retry=true}}
-          class="skill-review-retry__button button button--big button--link"
-        >{{t "pages.skill-review.retry.button"}}</LinkTo>
-      </div>
-    {{/if}}
-
-    {{#if @model.trainings}}
-      <section class="skill-review__trainings">
-        <h2 class="skill-review-trainings__title">{{t "pages.skill-review.trainings.title"}}</h2>
-        <p class="skill-review-trainings__description">{{t "pages.skill-review.trainings.description"}}</p>
-        {{#each @model.trainings as |training|}}
-          <Training::Card @training={{training}} />
-        {{/each}}
-      </section>
-    {{/if}}
-  </PixBlock>
-{{/if}}
-
-{{#if this.displayOrganizationCustomMessage}}
-  <PixBlock class="skill-review__organization-message">
-    {{#if @model.campaign.organizationLogoUrl}}
-      <div class="skill-review-organization-message__logo">
-        <img class="logo" src={{@model.campaign.organizationLogoUrl}} alt="{{@model.campaign.organizationName}}" />
-      </div>
-    {{/if}}
-    <div class="skill-review-organization-message__content">
-      <p class="skill-review-organization-message__title">{{t "pages.skill-review.organization-message"}}</p>
-      <p class="skill-review-organization-message__organization-name">{{@model.campaign.organizationName}}</p>
-      {{#if this.showOrganizationMessage}}
-        <div class="skill-review-organization-message__text">
-          <MarkdownToHtml @markdown={{@model.campaign.customResultPageText}} />
+      {{#if @model.campaignParticipationResult.canRetry}}
+        <div class="skill-review__retry">
+          <p class="skill-review-retry__message">{{t
+              "pages.skill-review.retry.message"
+              organizationName=@model.campaign.organizationName
+            }}</p>
+          <LinkTo
+            @route="campaigns.entry-point"
+            @model={{@model.campaign.code}}
+            @query={{hash retry=true}}
+            class="skill-review-retry__button button button--big button--link"
+          >{{t "pages.skill-review.retry.button"}}</LinkTo>
         </div>
       {{/if}}
-      {{#if this.showOrganizationButton}}
-        <a
-          class="skill-review-organization-message__link"
-          target="_blank"
-          rel="noopener noreferrer"
-          href={{this.customButtonUrl}}
-        >{{this.customButtonText}}<FaIcon @icon="up-right-from-square" aria-hidden="true" /></a>
+      {{#if @model.trainings}}
+        <section class="skill-review__trainings">
+          <h2 class="skill-review-trainings__title">{{t "pages.skill-review.trainings.title"}}</h2>
+          <p class="skill-review-trainings__description">{{t "pages.skill-review.trainings.description"}}</p>
+          {{#each @model.trainings as |training|}}
+            <Training::Card @training={{training}} />
+          {{/each}}
+        </section>
       {{/if}}
-    </div>
-  </PixBlock>
-{{/if}}
+    </PixBlock>
+  {{/if}}
 
-{{#if this.showNPS}}
-  <PixBlock class="skill-review__net-promoter-score">
-    <div class="skill-review-net-promoter-score__logo">
-      <img src="/images/illustrations/skill-review/net-promoter-score.svg" role="presentation" alt="" />
-    </div>
-    <div class="skill-review-net-promoter-score__content">
-      <h2>{{t "pages.skill-review.net-promoter-score.title"}}</h2>
-      <p>{{t "pages.skill-review.net-promoter-score.text"}}</p>
-      <PixButtonLink @href="{{@model.campaign.organizationFormNPSUrl}}" target="_blank">
-        {{t "pages.skill-review.net-promoter-score.link.label"}}
-      </PixButtonLink>
-    </div>
-  </PixBlock>
-{{/if}}
-
-{{#if this.showDetail}}
-  <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
-    {{#if this.showBadges}}
-      {{#unless this.hideBadgesTitle}}
-        <h2 class="skill-review-result-detail__badge-subtitle">
-          {{t "pages.skill-review.badges-title"}}
-        </h2>
-      {{/unless}}
-      <div class="badge-container">
-        {{#each this.orderedBadges as |badge|}}
-          <BadgeCard
-            @title={{badge.title}}
-            @message={{badge.message}}
-            @imageUrl={{badge.imageUrl}}
-            @altMessage={{badge.altMessage}}
-            @isAcquired={{badge.isAcquired}}
-          />
-        {{/each}}
+  {{#if this.displayOrganizationCustomMessage}}
+    <PixBlock class="skill-review__organization-message">
+      {{#if @model.campaign.organizationLogoUrl}}
+        <div class="skill-review-organization-message__logo">
+          <img class="logo" src={{@model.campaign.organizationLogoUrl}} alt="{{@model.campaign.organizationName}}" />
+        </div>
+      {{/if}}
+      <div class="skill-review-organization-message__content">
+        <p class="skill-review-organization-message__title">{{t "pages.skill-review.organization-message"}}</p>
+        <p class="skill-review-organization-message__organization-name">{{@model.campaign.organizationName}}</p>
+        {{#if this.showOrganizationMessage}}
+          <div class="skill-review-organization-message__text">
+            <MarkdownToHtml @markdown={{@model.campaign.customResultPageText}} />
+          </div>
+        {{/if}}
+        {{#if this.showOrganizationButton}}
+          <a
+            class="skill-review-organization-message__link"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={{this.customButtonUrl}}
+          >{{this.customButtonText}}<FaIcon @icon="up-right-from-square" aria-hidden="true" /></a>
+        {{/if}}
       </div>
-    {{/if}}
+    </PixBlock>
+  {{/if}}
 
-    {{#if this.showImproveButton}}
-      <SkillReviewImprove @improve={{this.improve}} />
-    {{/if}}
+  {{#if this.showNPS}}
+    <PixBlock class="skill-review__net-promoter-score">
+      <div class="skill-review-net-promoter-score__logo">
+        <img src="/images/illustrations/skill-review/net-promoter-score.svg" role="presentation" alt="" />
+      </div>
+      <div class="skill-review-net-promoter-score__content">
+        <h2>{{t "pages.skill-review.net-promoter-score.title"}}</h2>
+        <p>{{t "pages.skill-review.net-promoter-score.text"}}</p>
+        <PixButtonLink @href="{{@model.campaign.organizationFormNPSUrl}}" target="_blank">
+          {{t "pages.skill-review.net-promoter-score.link.label"}}
+        </PixButtonLink>
+      </div>
+    </PixBlock>
+  {{/if}}
 
-    {{#unless @model.campaign.isForAbsoluteNovice}}
-
-      <main class="skill-review-result-detail__content" role="main">
-        <div class="skill-review-result-detail__table-header">
-          <h2 class="skill-review-result-detail__subtitle">
-            {{t "pages.skill-review.details.title"}}
+  {{#if this.showDetail}}
+    <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
+      {{#if this.showBadges}}
+        {{#unless this.hideBadgesTitle}}
+          <h2 class="skill-review-result-detail__badge-subtitle">
+            {{t "pages.skill-review.badges-title"}}
           </h2>
-          <CircleChart @value={{this.masteryPercentage}}>
-            <span
-              aria-label="{{t "pages.skill-review.details.result"}}"
-              class="skill-review-table-header__circle-chart-value"
-            >
-              {{t "pages.skill-review.details.percentage" rate=this.masteryRate}}
-            </span>
-          </CircleChart>
+        {{/unless}}
+        <div class="badge-container">
+          {{#each this.orderedBadges as |badge|}}
+            <BadgeCard
+              @title={{badge.title}}
+              @message={{badge.message}}
+              @imageUrl={{badge.imageUrl}}
+              @altMessage={{badge.altMessage}}
+              @isAcquired={{badge.isAcquired}}
+            />
+          {{/each}}
         </div>
+      {{/if}}
 
-        <CampaignSkillReviewCompetenceResult
-          @showCleaCompetences={{this.showCleaCompetences}}
-          @competenceResults={{@model.campaignParticipationResult.competenceResults}}
-          @skillSetResults={{@model.campaignParticipationResult.cleaBadge.skillSetResults}}
-        />
-      </main>
+      {{#if this.showImproveButton}}
+        <SkillReviewImprove @improve={{this.improve}} />
+      {{/if}}
 
-      <div class="skill-review-result-detail__information">
-        <FaIcon @icon="circle-info" class="skill-review-information__info-icon" aria-hidden="true" />
-        <div class="skill-review-information__text">
-          {{t "pages.skill-review.information"}}
+      {{#unless @model.campaign.isForAbsoluteNovice}}
+
+        <section class="skill-review-result-detail__content">
+          <div class="skill-review-result-detail__table-header">
+            <h2 class="skill-review-result-detail__subtitle">
+              {{t "pages.skill-review.details.title"}}
+            </h2>
+            <CircleChart @value={{this.masteryPercentage}}>
+              <span
+                aria-label="{{t "pages.skill-review.details.result"}}"
+                class="skill-review-table-header__circle-chart-value"
+              >
+                {{t "pages.skill-review.details.percentage" rate=this.masteryRate}}
+              </span>
+            </CircleChart>
+          </div>
+
+          <CampaignSkillReviewCompetenceResult
+            @showCleaCompetences={{this.showCleaCompetences}}
+            @competenceResults={{@model.campaignParticipationResult.competenceResults}}
+            @skillSetResults={{@model.campaignParticipationResult.cleaBadge.skillSetResults}}
+          />
+        </section>
+
+        <div class="skill-review-result-detail__information">
+          <FaIcon @icon="circle-info" class="skill-review-information__info-icon" aria-hidden="true" />
+          <div class="skill-review-information__text">
+            {{t "pages.skill-review.information"}}
+          </div>
         </div>
-      </div>
-    {{/unless}}
-  </PixBlock>
-{{/if}}
+      {{/unless}}
+    </PixBlock>
+  {{/if}}
+</main>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -17,6 +17,10 @@ export default class SkillReview extends Component {
   @tracked showGlobalErrorMessage = false;
   @tracked isShareButtonClicked = false;
 
+  get title() {
+    return this.args.model.campaign.title || this.intl.t('pages.skill-review.title');
+  }
+
   get showCleaCompetences() {
     const cleaBadge = this.args.model.campaignParticipationResult.cleaBadge;
     return !!cleaBadge;

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -24,6 +24,18 @@
   font-weight: $font-light;
   margin: 0;
 
+  @include device-is('mobile') {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+    display: block;
+  }
+
   @include device-is('desktop') {
     font-weight: $font-normal;
   }

--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -14,10 +14,6 @@
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
     color: $pix-neutral-0;
   }
-
-  &__title {
-    display: none;
-  }
 }
 
 @include device-is('tablet') {


### PR DESCRIPTION
## :unicorn: Problème
Nous allons apporter des modifications à la page de résultat d'une campagne et nous souhaitons que celle-ci devienne accessible.

## :robot: Solution
Nous rendons la page accessible en 
- mettant un titre dans tous les cas même en mobile en utilisant les propriétés de la class `sr-only`.
- déplacant la balise main pour qu'il soit plus global. 

De plus, nous ajoutons la page aux tests axe présents pour que cette page le reste.

## :rainbow: Remarques
Nous avons fixé les tests Cypress qui testaient le loader

## :100: Pour tester
Vérifier que la CI passe 
