### PR TITLE
[DOC] Expliciter le choix de support des navigateurs web

### DIFF
--- a/docs/adr/0034-support-des-navigateurs.md
+++ b/docs/adr/0034-support-des-navigateurs.md
@@ -1,0 +1,43 @@
+# Support navigateur
+
+Date : 2022-08-??
+
+## État
+
+En cours
+
+## Contexte
+
+Pix est un service en ligne accessible via des navigateurs web. Pix n'a pas la possibilité d'imposer un navigateur à ces utilisateurs, et doit pouvoir répondre à un large public, avec des navigateurs desktop/mobiles, obsolètes/à jour.
+
+Nos frameworks et nos packages permettent de supporter les anciens navigateurs jusqu'à une certaine version.
+
+Enfin, il faut pouvoir aider au mieux nos utilisateurs et le support Pix à répondre aux problèmes liés à l'utilisation de la plateforme.
+
+Le support navigateur se fait via le fichier `/config/target.js` disponible dans les différents projets front. C'est Babel qui s'occupe de la rétrocompatibilité, en utilisant [BrowserList](https://github.com/browserslist/browserslist) et [Can I Use](https://caniuse.com/).
+Ces sites utilisent les statistiques d'utilisations des navigateurs dans le monde.
+
+Il faut donc pouvoir continuer à mettre à jour nos frameworks, supporter les navigateurs anciens mais aussi les nouveaux navigateurs très utilisés sur nos publics.
+
+## Décision
+
+Pour être au clair sur les navigateurs supportés, le fichier `/config/target.js` doit indiquer :
+- la version minimum à supporter pour les navigateurs les plus communs :
+  - Chrome
+  - Firefox
+  - Safari
+  - Edge
+- les navigateurs utilisés à 1% dans le monde.
+
+Par conséquent, la liste des navigateurs est du type :
+```
+"browserslist": [
+  "> 1%",
+  "Firefox > 52",
+  "Chrome > 55",
+  "Edge > 88",
+]
+```
+
+Les versions minimums sont mise à jour régulièrement suite à une analyse des utilisateurs de Pix (environ tous les 6 mois).
+Les versions supportées sont les mêmes pour toutes les applications du repository.

--- a/docs/adr/0034-support-des-navigateurs.md
+++ b/docs/adr/0034-support-des-navigateurs.md
@@ -22,7 +22,7 @@ Il faut donc pouvoir continuer à mettre à jour nos frameworks, supporter les n
 ## Décision
 
 Pour être au clair sur les navigateurs supportés, le fichier `/config/target.js` doit indiquer :
-- la version minimum à supporter pour les navigateurs les plus communs :
+- la version minimale à supporter pour les navigateurs les plus communs :
   - Chrome
   - Firefox
   - Safari
@@ -39,5 +39,5 @@ Par conséquent, la liste des navigateurs est du type :
 ]
 ```
 
-Les versions minimums sont mise à jour régulièrement suite à une analyse des utilisateurs de Pix (environ tous les 6 mois).
+Les versions minimales sont mise à jour régulièrement suite à une analyse des utilisateurs de Pix (environ tous les 6 mois).
 Les versions supportées sont les mêmes pour toutes les applications du repository.


### PR DESCRIPTION
## :unicorn: Problème
Le support des navigateurs n'a pas changé depuis longtemps, nous supportons actuellement toujours IE11 (surtout pour supporter de vieille version de Firefox, comme la 52).

TODO : 
- [] Une fois qu'on est OK, faire les changements sur les fichiers
- [] Une première sortie de nos stats pour décider des versions minimales
## :robot: Solution
Se mettre d'accord sur notre gestion des navigateurs supportés via un ADR.

## :rainbow: Remarques
En plus de la partie technique, de la documentation sera faite avec le support Pix pour aider au mieux nos utilisateurs.

## :100: Pour tester
