### PR TITLE
[TECH] Corriger le design de la section "Certification Pix+ Edu" dans Pix Admin (PIX-5366)

### DIFF
--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -39,6 +39,7 @@
     }
 
     &--pix-edu {
+      flex: 1;
       background-color: $pix-neutral-5;
       text-align: center;
       box-shadow: none;

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -123,7 +123,7 @@
               <div class="certification-informations__card certification-informations__card--pix-edu">
                 <p>VOLET JURY</p>
                 {{#if this.displayJuryLevelSelect}}
-                  <div class="certification-informations__complementary-certification__pix-edu__row__jury-level-editor">
+                  <div class="certification-informations__pix-edu__row__jury-level-editor">
                     <section>
                       <PixSelect
                         aria-label="Sélectionner un niveau"
@@ -155,8 +155,10 @@
                     </section>
                   </div>
                 {{else}}
-                  <div class="certification-informations__complementary-certification__pix-edu__row__jury-level">
-                    <p>{{this.certification.complementaryCertificationCourseResultsWithExternal.externalResult}}</p>
+                  <div class="certification-informations__pix-edu__row__jury-level">
+                    <p class="certification-informations__card__score">
+                      {{this.certification.complementaryCertificationCourseResultsWithExternal.externalResult}}
+                    </p>
                     {{#if this.shouldDisplayJuryLevelEditButton}}
                       <button
                         type="button"

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -189,7 +189,7 @@
     <section
       class="certification-informations__row certification-informations__card certification-informations__certification-issue-reports"
     >
-      <h2 class="card-title certification-informations__certification-issue-reports__title">Signalements</h2>
+      <h2 class="card-title certification-informations__card__title">Signalements</h2>
       <Certifications::IssueReports
         @hasImpactfulIssueReports={{this.hasImpactfulIssueReports}}
         @hasUnimpactfulIssueReports={{this.hasUnimpactfulIssueReports}}


### PR DESCRIPTION
## :unicorn: Problème
Le design de la section des resultats Pix+ Edu dans Pix Admin a été cassé

## :robot: Solution
Le réparer (rappeler les bonnes classes css aux bons endroits)

## :100: Pour tester
Aller sur les informations d'une certification Pix+ Edu dans Pix Admin et constater ces changements :

<img width="1389" alt="Capture d’écran 2022-08-16 à 18 46 50" src="https://user-images.githubusercontent.com/103997660/184934384-502d22cb-2986-4600-807f-e6320815305e.png">
(Réallignements des cards, taille du titre de la section Signalements homogène)

Et lorsque l'on clique sur le bouton édité :
<img width="1388" alt="Capture d’écran 2022-08-16 à 18 47 07" src="https://user-images.githubusercontent.com/103997660/184934411-75eb7574-60ed-451e-8d38-cdf715879eec.png">
