### PR TITLE
[FEATURE] Mettre le archivedBy à null lors du désarchivage (PIX-5490)

### DIFF
--- a/api/lib/domain/usecases/unarchive-campaign.js
+++ b/api/lib/domain/usecases/unarchive-campaign.js
@@ -1,16 +1,10 @@
 const { UserNotAuthorizedToUpdateCampaignError } = require('../errors');
 
-module.exports = async function unarchiveCampaign({
-  // Parameters
-  campaignId,
-  userId,
-  // Repositories
-  campaignRepository,
-}) {
+module.exports = async function unarchiveCampaign({ campaignId, userId, campaignRepository }) {
   const isUserCampaignAdmin = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
   if (!isUserCampaignAdmin) {
     throw new UserNotAuthorizedToUpdateCampaignError();
   }
 
-  return campaignRepository.update({ id: campaignId, archivedAt: null });
+  return campaignRepository.update({ id: campaignId, archivedAt: null, archivedBy: null });
 };

--- a/api/tests/unit/domain/usecases/unarchive-campaign_test.js
+++ b/api/tests/unit/domain/usecases/unarchive-campaign_test.js
@@ -28,7 +28,11 @@ describe('Unit | UseCase | unarchive-campaign', function () {
     });
 
     it('should update the campaign', function () {
-      expect(campaignRepository.update).to.have.been.calledWithExactly({ id: campaignId, archivedAt: null });
+      expect(campaignRepository.update).to.have.been.calledWithExactly({
+        id: campaignId,
+        archivedAt: null,
+        archivedBy: null,
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour l'épix l'archivage en masse des campagnes, on souhaite garder en BDD par qui ont été archivées les campagnes. Mais lors du désarchivage on a aucun moyen de remettre cette donnée à null.

## :robot: Solution
Set à `null` le `archivedBy` lors du désarchivage d'une campagne.

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à Pix Orga
- Désarchiver une campagne, et constater en BDD que le `archivedBy ` est à `null`
