### PR TITLE
[BUGFIX] Retirer la taille défini du formulaire de saisie d'un code de campagne (PIX-5472)

### DIFF
--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -1,24 +1,21 @@
-/* stylelint-disable declaration-colon-newline-after */
-/* stylelint-disable function-parentheses-newline-inside */
-
 .fill-in-campaign-code {
 
   &__container {
-    padding-bottom: 30px;
+    padding-bottom: $spacing-s;
     display: flex;
     flex-direction: column;
     align-items: center;
     width: 100%;
 
     @include device-is('tablet') {
-      padding: 40px;
+      padding: $spacing-xl;
     }
   }
 
   &__title {
     font-weight: $font-light;
     text-align: center;
-    margin-bottom: 32px;
+    margin-bottom: $spacing-l;
   }
 
   &__instruction {
@@ -27,7 +24,7 @@
     font-size: 1.219rem;
     text-align: center;
     font-weight: $font-light;
-    margin-bottom: 16px;
+    margin-bottom: $spacing-s;
     max-width: 600px;
 
     @include device-is('tablet') {
@@ -42,6 +39,7 @@
   &__form-field {
     display: inline-block;
     text-align: left;
+    margin-bottom: $spacing-s;
 
     input {
       width: 13.6ch;
@@ -53,33 +51,33 @@
     flex-direction: column;
     justify-content: space-between;
     align-items: center;
-    height: 118px;
   }
 
   &__actions {
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-bottom: $spacing-s;
   }
 
   &__error {
     color: $pix-warning-60;
     font-size: 0.875rem;
-    padding: 16px 10px;
     text-align: center;
+    margin-bottom: $spacing-s;
   }
 
   &__warning {
     color: $pix-neutral-90;
     font-size: 0.875rem;
     text-align: center;
-    margin-top: 40px;
+    margin-bottom: $spacing-s;
+    margin-top: $spacing-s;
   }
 
   &__explanation {
     text-align: center;
     padding-top: 25px;
-    margin-top: 25px;
     border-top: 1px solid $pix-neutral-15;
     max-width: 600px;
 


### PR DESCRIPTION
## :unicorn: Problème
En non connecté, si nous affichons le message d'erreur sous l'input, l'élement empiète sur celui du dessous

## :robot: Solution
retirer la taille forcé du formulaire afin qu'il s'ajuste à son contenu

## :rainbow: Remarques
Ajout des spacings du design system sur cette page

## :100: Pour tester
Aller sur mon-pix/campagnes , valider le formulaire. vérifier que le formulaire ne dépasse pas

Se connecter avec jaune.attend@example.net , aller sur la page /campagnes , valider le formulaire, vérifier que le message ne dépasse pas non plus