### PR TITLE
[TECH] Script pour convertir les profil-cibles existants dans le nouveau format. Conversion acquis vers sujets cappés par niveau (PIX-5502)

### DIFF
--- a/api/scripts/prod/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/convert-target-profiles-into-new-format.js
@@ -1,0 +1,113 @@
+const _ = require('lodash');
+const { knex } = require('../../db/knex-database-connection');
+const logger = require('../../lib/infrastructure/logger');
+
+let allSkills;
+let allTubes;
+async function _cacheLearningContentData() {
+  const skillRepository = require('../../lib/infrastructure/repositories/skill-repository');
+  allSkills = await skillRepository.list();
+  const tubeRepository = require('../../lib/infrastructure/repositories/tube-repository');
+  allTubes = await tubeRepository.list();
+}
+
+async function main() {
+  try {
+    await doJob();
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+}
+
+async function doJob() {
+  await _cacheLearningContentData();
+  const targetProfileIds = await _findTargetProfileIdsToConvert();
+  if (targetProfileIds.length === 0) {
+    logger.info('Aucun profil cible à convertir.');
+    return;
+  }
+  logger.info(`${targetProfileIds.length} à convertir...`);
+  for (const targetProfileId of targetProfileIds) {
+    const trx = await knex.transaction();
+    try {
+      logger.info(`Conversion de ${targetProfileId}...`);
+      await _convertTargetProfile(targetProfileId, trx);
+      await trx.commit();
+    } catch (err) {
+      logger.error(`${targetProfileId} Echec. Raison : ${err}`);
+      await trx.rollback();
+    }
+  }
+}
+
+async function _findTargetProfileIdsToConvert() {
+  const ids = await knex('target-profiles')
+    .pluck('target-profiles.id')
+    .leftJoin('target-profile_tubes', 'target-profile_tubes.targetProfileId', 'target-profiles.id')
+    .whereNull('target-profile_tubes.id');
+  return _.uniq(ids);
+}
+
+async function _convertTargetProfile(targetProfileId, trx) {
+  const skillIds = await _findSkillIds(targetProfileId, trx);
+  if (skillIds.length === 0) throw new Error("Le profil cible n'a pas d'acquis.");
+
+  const tubes = await _computeTubeIdsAndLevelsForSkills(skillIds);
+
+  await _createTargetProfileTubes(targetProfileId, tubes, trx);
+  logger.info(`${targetProfileId} OK. ${tubes.length} tubes créés.`);
+}
+
+async function _findSkillIds(targetProfileId, trx) {
+  return trx('target-profiles_skills').pluck('skillId').where('targetProfileId', targetProfileId);
+}
+
+async function _computeTubeIdsAndLevelsForSkills(skillIds) {
+  const skills = _findSkills(skillIds);
+  const skillsGroupedByTubeId = _.groupBy(skills, 'tubeId');
+  const tubes = [];
+  for (const [tubeId, skills] of Object.entries(skillsGroupedByTubeId)) {
+    const skillWithHighestDifficulty = _.maxBy(skills, 'difficulty');
+    tubes.push({
+      tubeId,
+      level: skillWithHighestDifficulty.difficulty,
+    });
+  }
+  return tubes;
+}
+
+function _findSkills(skillIds) {
+  return skillIds.map((skillId) => {
+    const foundSkill = allSkills.find((skill) => skill.id === skillId);
+    if (!foundSkill) throw new Error(`L'acquis "${skillId}" n'existe pas dans le référentiel.`);
+    if (!foundSkill.tubeId) throw new Error(`L'acquis "${skillId}" n'appartient à aucun sujet.`);
+    const tubeExists = _doesTubeExist(foundSkill.tubeId);
+    if (!tubeExists) throw new Error(`Le sujet "${foundSkill.tubeId}" n'existe pas dans le référentiel.`);
+    return foundSkill;
+  });
+}
+
+function _doesTubeExist(tubeId) {
+  return Boolean(allTubes.find((tube) => tube.id === tubeId));
+}
+
+async function _createTargetProfileTubes(targetProfileId, tubes, trx) {
+  const completeTubes = tubes.map((tube) => {
+    return { ...tube, targetProfileId };
+  });
+  await trx.batchInsert('target-profile_tubes', completeTubes);
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    () => {
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  doJob,
+};

--- a/api/scripts/prod/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/convert-target-profiles-into-new-format.js
@@ -1,6 +1,8 @@
+require('dotenv').config();
 const _ = require('lodash');
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const logger = require('../../lib/infrastructure/logger');
+const cache = require('../../lib/infrastructure/caches/learning-content-cache');
 
 let allSkills;
 let allTubes;
@@ -16,7 +18,10 @@ async function main() {
     await doJob();
   } catch (err) {
     logger.error(err);
-    process.exit(1);
+    throw err;
+  } finally {
+    await disconnect();
+    cache.quit();
   }
 }
 
@@ -100,12 +105,7 @@ async function _createTargetProfileTubes(targetProfileId, tubes, trx) {
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    () => {
-      process.exit(1);
-    }
-  );
+  main();
 }
 
 module.exports = {

--- a/api/tests/acceptance/scripts/convert-target-profiles-into-new-format_test.js
+++ b/api/tests/acceptance/scripts/convert-target-profiles-into-new-format_test.js
@@ -1,0 +1,173 @@
+const { expect, databaseBuilder, sinon, mockLearningContent } = require('../../test-helper');
+const { knex } = require('../../../db/knex-database-connection');
+const logger = require('../../../lib/infrastructure/logger');
+
+const { doJob } = require('../../../scripts/prod/convert-target-profiles-into-new-format');
+
+describe('Acceptance | Scripts | convert-target-profiles-into-new-format', function () {
+  it('should execute the script as expected', async function () {
+    // given
+    sinon.stub(logger, 'info');
+    const loggerErrorStub = sinon.stub(logger, 'error');
+    const targetProfileAlreadyConvertedId = 1;
+    const targetProfileToConvertId = 2;
+    const targetProfileConversionErrorNoSkillsId = 3;
+    const targetProfileConversionErrorUnknownSkillsId = 4;
+    const targetProfileConversionErrorNoCorrespondingTubeId = 5;
+    const learningContent = {
+      skills: [],
+      tubes: [],
+    };
+    _buildTargetProfileAlreadyConverted(targetProfileAlreadyConvertedId);
+    _buildTargetProfileToConvert(targetProfileToConvertId, learningContent);
+    _buildTargetProfileConversionErrorNoSkills(targetProfileConversionErrorNoSkillsId);
+    _buildTargetProfileConversionErrorUnknownSkills(targetProfileConversionErrorUnknownSkillsId);
+    _buildTargetProfileConversionErrorNoCorrespondingTube(
+      targetProfileConversionErrorNoCorrespondingTubeId,
+      learningContent
+    );
+
+    mockLearningContent(learningContent);
+    await databaseBuilder.commit();
+
+    // when
+    await doJob();
+
+    // then
+    const tubesForAlreadyConverted = await _getTubes(targetProfileAlreadyConvertedId);
+    const tubesForToConvert = await _getTubes(targetProfileToConvertId);
+    const tubesForErrorNoSkills = await _getTubes(targetProfileConversionErrorNoSkillsId);
+    const tubesForErrorUnknownSkills = await _getTubes(targetProfileConversionErrorUnknownSkillsId);
+    const tubesForErrorNoCorrespondingTube = await _getTubes(targetProfileConversionErrorNoCorrespondingTubeId);
+    expect(tubesForAlreadyConverted).to.deep.equal([{ tubeId: 'recAlreadyConvertedTubeId', level: 9000 }]);
+    expect(tubesForToConvert).to.deep.equal([
+      { tubeId: 'recTubeA', level: 3 },
+      { tubeId: 'recTubeB', level: 5 },
+    ]);
+    expect(tubesForErrorNoSkills).to.deep.equal([]);
+    expect(tubesForErrorUnknownSkills).to.deep.equal([]);
+    expect(tubesForErrorNoCorrespondingTube).to.deep.equal([]);
+    expect(loggerErrorStub).to.have.been.calledWith("3 Echec. Raison : Error: Le profil cible n'a pas d'acquis.");
+    expect(loggerErrorStub).to.have.been.calledWith(
+      `4 Echec. Raison : Error: L'acquis "recSomeUnknownSkill" n'existe pas dans le référentiel.`
+    );
+    expect(loggerErrorStub).to.have.been.calledWith(
+      `5 Echec. Raison : Error: Le sujet "recSomeUnknownTube" n'existe pas dans le référentiel.`
+    );
+  });
+});
+
+async function _getTubes(targetProfileId) {
+  return knex('target-profile_tubes')
+    .select('tubeId', 'level')
+    .where('targetProfileId', targetProfileId)
+    .orderBy('tubeId', 'ASC');
+}
+
+function _buildTargetProfileAlreadyConverted(id) {
+  databaseBuilder.factory.buildTargetProfile({ id });
+  databaseBuilder.factory.buildTargetProfileTube({
+    tubeId: 'recAlreadyConvertedTubeId',
+    level: 9000,
+    targetProfileId: id,
+  });
+}
+
+function _buildTargetProfileToConvert(id, learningContent) {
+  databaseBuilder.factory.buildTargetProfile({ id });
+  databaseBuilder.factory.buildTargetProfileSkill({
+    skillId: 'recSkill1TubeA',
+    targetProfileId: id,
+  });
+  databaseBuilder.factory.buildTargetProfileSkill({
+    skillId: 'recSkill2TubeA',
+    targetProfileId: id,
+  });
+  databaseBuilder.factory.buildTargetProfileSkill({
+    skillId: 'recSkill3TubeA',
+    targetProfileId: id,
+  });
+  databaseBuilder.factory.buildTargetProfileSkill({
+    skillId: 'recSkill5TubeB',
+    targetProfileId: id,
+  });
+
+  const skill1TubeA = {
+    id: 'recSkill1TubeA',
+    name: '@skill1TubeA',
+    tubeId: 'recTubeA',
+    level: 1,
+  };
+  const skill3TubeA = {
+    id: 'recSkill3TubeA',
+    name: '@skill3TubeA',
+    tubeId: 'recTubeA',
+    level: 3,
+  };
+  const skill2TubeA = {
+    id: 'recSkill2TubeA',
+    name: '@skill2TubeA',
+    tubeId: 'recTubeA',
+    level: 2,
+  };
+  const skill5TubeB = {
+    id: 'recSkill5TubeB',
+    name: '@skill5TubeB',
+    tubeId: 'recTubeB',
+    level: 5,
+  };
+  const skill7TubeB = {
+    id: 'recSkill7TubeB',
+    name: '@skill7TubeB',
+    tubeId: 'recTubeB',
+    level: 7,
+  };
+  const skill3TubeC = {
+    id: 'recSkill3TubeC',
+    name: '@skill3TubeC',
+    tubeId: 'recTubeC',
+    level: 3,
+  };
+  const tubeA = {
+    id: 'recTubeA',
+    skills: [skill1TubeA, skill3TubeA, skill2TubeA],
+  };
+  const tubeB = {
+    id: 'recTubeB',
+    skills: [skill5TubeB, skill7TubeB],
+  };
+  const tubeC = {
+    id: 'recTubeC',
+    skills: [skill3TubeC],
+  };
+  learningContent.skills.push(skill1TubeA, skill3TubeA, skill2TubeA, skill5TubeB, skill7TubeB, skill3TubeC);
+  learningContent.tubes.push(tubeA, tubeB, tubeC);
+}
+
+function _buildTargetProfileConversionErrorNoSkills(id) {
+  databaseBuilder.factory.buildTargetProfile({ id });
+}
+
+function _buildTargetProfileConversionErrorUnknownSkills(id) {
+  databaseBuilder.factory.buildTargetProfile({ id });
+  databaseBuilder.factory.buildTargetProfileSkill({
+    skillId: 'recSomeUnknownSkill',
+    targetProfileId: id,
+  });
+}
+
+function _buildTargetProfileConversionErrorNoCorrespondingTube(id, learningContent) {
+  databaseBuilder.factory.buildTargetProfile({ id });
+  databaseBuilder.factory.buildTargetProfileSkill({
+    skillId: 'recSkillWithoutTube',
+    targetProfileId: id,
+  });
+
+  const skill = {
+    id: 'recSkillWithoutTube',
+    name: '@skillWithoutTube',
+    tubeId: 'recSomeUnknownTube',
+    level: 2,
+  };
+  learningContent.skills.push(skill);
+}


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Epix d'amélioration des profil-cibles, ces derniers vont être amenés à ne plus être défini par des acquis, mais par des sujets et des niveaux max. Il faut donc harmoniser tous les profil-cibles, y compris les anciens.


## :robot: Solution
Il s'agit donc de convertir les anciens profil-cibles existants déjà dans la BDD, à savoir transformer une liste d'acquis en liste de sujets cappés par niveau.
Ecriture d'un script pour ce faire. Afin d'avoir un suivi propre, ajout d'une colonne booléenne temporaire dans la table des profil-cibles. Si un seul problème intervient pendant la conversion d'un profil cible, la conversion pour ce profil cible est annulée.

## :rainbow: Remarques


## :100: Pour tester
Comparer l'affichage de détails d'un profil cible ancien sur PixAdmin avant et après exécution du script
