### PR TITLE
[TECH] Ajout d'un test sur le message de log du plugin Pino (PIX-5504)

### DIFF
--- a/api/tests/integration/infrastructure/plugins/pino_test.js
+++ b/api/tests/integration/infrastructure/plugins/pino_test.js
@@ -54,7 +54,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
       monitoringTools.installHapiHook();
     });
 
-    it('should log version', async function () {
+    it('should log the datadog filtered message and version', async function () {
       // given
       let finish;
 
@@ -77,6 +77,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(messages).to.have.lengthOf(1);
+      expect(messages[0].msg).to.equal('request completed');
       expect(messages[0].req.version).to.equal('development');
       expect(messages[0].req.user_id).to.be.undefined;
       expect(messages[0].req.route).to.be.undefined;
@@ -90,7 +91,7 @@ describe('Integration | Infrastructure | plugins | pino', function () {
       monitoringTools.installHapiHook();
     });
 
-    it('should log version, user id, route and metrics', async function () {
+    it('should log the datadog filtered message, version, user id, route and metrics', async function () {
       // given
       let finish;
 
@@ -112,10 +113,10 @@ describe('Integration | Infrastructure | plugins | pino', function () {
       // when
       const response = await httpTestServer.request(method, url, null, null, headers);
       await done;
-
       // then
       expect(response.statusCode).to.equal(200);
       expect(messages).to.have.lengthOf(1);
+      expect(messages[0].msg).to.equal('request completed');
       expect(messages[0].req.version).to.equal('development');
       expect(messages[0].req.user_id).to.equal(1234);
       expect(messages[0].req.route).to.equal('/');


### PR DESCRIPTION
## :unicorn: Problème

Les logs hapi sont filtrés par notre outil de monitoring pour permettre leur analyse.
Lors de la dernière montée de version de hapi-pino, le message de log a changé, ce qui a provoqué un arrêt de l'enrichissement des logs.

## :robot: Solution

Ajouter un test pour valider que le filtre qui est configuré dans notre outil de monitoring contient bien le même message que celui renvoyé par l'API.

## :rainbow: Remarques

Les changements déjà constatés étaient de la forme : 

- hapi-pino 9.1.2 :  `msg=request completed`
- hapi-pino > 9.1.2 : `msg= [response] get /api/toto 200`

## :100: Pour tester

- Vérifier que les tests sont au vert
- Vérifier dans les pipelines de parsing de log que le filtre des logs hapi correspondent bien
