### PR TITLE
[TECH] Ne plus utiliser de routes dépréciées sur les prescrits dans Pix Certif (Pix-5499).

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -228,7 +228,7 @@ module.exports = {
   async enrollStudentsToSession(request, h) {
     const referentId = requestResponseUtils.extractUserIdFromRequest(request);
     const sessionId = request.params.id;
-    const studentIds = request.payload.data.attributes['student-ids'];
+    const studentIds = request.deserializedPayload.studentIds || request.deserializedPayload.organizationLearnerIds;
 
     await usecases.enrollStudentsToSession({ sessionId, referentId, studentIds });
     const certificationCandidates = await usecases.getSessionCertificationCandidates({ sessionId });

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -14,7 +14,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
     server = await createServer();
   });
 
-  describe('#enrollStudentsToSession', function () {
+  describe('#enrollStudentsToSession with studentIds', function () {
     let options;
     let payload;
     let userId;
@@ -106,6 +106,148 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
           data: {
             attributes: {
               'student-ids': [organizationLearner.id],
+            },
+          },
+        };
+        options = {
+          method: 'PUT',
+          url: `/api/sessions/${sessionId}/enroll-students-to-session`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          payload,
+        };
+      });
+
+      it('should respond with a 201', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+        sinon.assert.match(response.result, {
+          data: [
+            {
+              attributes: {
+                'billing-mode': '',
+                'prepayment-code': null,
+                'birth-city': organizationLearner.birthCity,
+                birthdate: organizationLearner.birthdate,
+                'first-name': organizationLearner.firstName,
+                'birth-country': country.commonName,
+                'is-linked': false,
+                'last-name': organizationLearner.lastName,
+                'birth-province-code': null,
+                'birth-insee-code': birthCityCode,
+                'birth-postal-code': null,
+                email: null,
+                'external-id': null,
+                'extra-time-percentage': null,
+                'result-recipient-email': null,
+                'schooling-registration-id': organizationLearner.id,
+                'organization-learner-id': organizationLearner.id,
+                sex: 'M',
+                'complementary-certifications': [],
+              },
+              id: sinon.match.string,
+              type: 'certification-candidates',
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  describe('#enrollStudentsToSession with organizationLearnerIds', function () {
+    let options;
+    let payload;
+    let userId;
+
+    beforeEach(function () {
+      userId = databaseBuilder.factory.buildUser().id;
+      options = {
+        method: 'POST',
+        url: '/api/sessions/1/enroll-students-to-session',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+      return databaseBuilder.commit();
+    });
+
+    context('when user is not authenticated', function () {
+      beforeEach(function () {
+        options = {
+          method: 'PUT',
+          url: '/api/sessions/1/enroll-students-to-session',
+          headers: { authorization: 'invalid.access.token' },
+        };
+      });
+
+      it('should respond with a 401 - unauthorized access', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    context('when session id is not an integer', function () {
+      beforeEach(function () {
+        options = {
+          method: 'PUT',
+          url: '/api/sessions/2.1/enroll-students-to-session',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+      });
+
+      it('should respond with a 400 - Bad Request', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        expect(response.result.errors[0].title).to.equal('Bad Request');
+      });
+    });
+
+    context('when user is authenticated', function () {
+      let sessionId;
+      let organizationLearner;
+      let country;
+      const birthCityCode = 'Detroit313';
+      const FRANCE_INSEE_CODE = '99100';
+      const FRANCE_ORGANIZATION_LEARNER_INSEE_CODE = '100';
+
+      afterEach(function () {
+        return knex('certification-candidates').delete();
+      });
+
+      beforeEach(async function () {
+        const { id: certificationCenterId, externalId } = databaseBuilder.factory.buildCertificationCenter({
+          type: 'SCO',
+        });
+
+        sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          externalId,
+        });
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+        country = databaseBuilder.factory.buildCertificationCpfCountry({
+          code: FRANCE_INSEE_CODE,
+          commonName: 'FRANCE',
+          originalName: 'FRANCE',
+        });
+
+        organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          birthCityCode,
+          birthCountryCode: FRANCE_ORGANIZATION_LEARNER_INSEE_CODE,
+        });
+
+        await databaseBuilder.commit();
+        payload = {
+          data: {
+            attributes: {
+              'organization-learner-ids': [organizationLearner.id],
             },
           },
         };

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -36,11 +36,11 @@ export default class SessionAdapter extends ApplicationAdapter {
 
       if (snapshot.adapterOptions.studentListToAdd) {
         const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/enroll-students-to-session';
-        const studentIds = snapshot.adapterOptions.studentListToAdd.map((student) => student.id);
+        const organizationLearnerIds = snapshot.adapterOptions.studentListToAdd.map((student) => student.id);
         const data = {
           data: {
             attributes: {
-              'student-ids': studentIds,
+              'organization-learner-ids': organizationLearnerIds,
             },
           },
         };

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -14,7 +14,7 @@ export default class CertificationCandidate extends Model {
   @attr('string') externalId;
   @attr('number') extraTimePercentage;
   @attr('boolean') isLinked;
-  @attr('string') schoolingRegistrationId;
+  @attr('string') organizationLearnerId;
   @attr('string') sex;
   @attr('string') billingMode;
   @attr('string') prepaymentCode;

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -177,7 +177,7 @@ export default function () {
   this.put('/sessions/:id/enroll-students-to-session', (schema, request) => {
     const requestBody = JSON.parse(request.requestBody);
     const sessionId = request.params.id;
-    const studentListToAdd = requestBody.data.attributes['student-ids'];
+    const studentListToAdd = requestBody.data.attributes['organization-learner-ids'];
     const numberOfStudents = studentListToAdd.length;
     if (numberOfStudents > 0) {
       server.createList('certification-candidate', numberOfStudents, { sessionId });

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -279,7 +279,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
           server.create('student', { isSelected: false, isEnrolled: false });
           const enrolledStudent = server.create('student', { isSelected: false, isEnrolled: true });
           server.create('certification-candidate', {
-            schoolingRegistrationId: enrolledStudent.id,
+            organizationLearnerId: enrolledStudent.id,
             sessionId: sessionWithEnrolledStudent.id,
           });
           const screen = await visitScreen(`/sessions/${sessionWithEnrolledStudent.id}/candidats`);

--- a/certif/tests/unit/adapters/session_test.js
+++ b/certif/tests/unit/adapters/session_test.js
@@ -49,7 +49,7 @@ module('Unit | Adapter | session', function (hooks) {
           data: {
             data: {
               attributes: {
-                'student-ids': expectedStudentIdList,
+                'organization-learner-ids': expectedStudentIdList,
               },
             },
           },


### PR DESCRIPTION
## :unicorn: Problème
On utilise encore des paramètres dépréciés dans Pix Certif.

## :robot: Solution
Ne plus les utiliser mais utiliser leurs remplaçants.

## :rainbow: Remarques
RAS

## :100: Pour tester
Sur Pix Certif exclusivement :
- en tant que certifsco@example.net :
  - inscrire des candidats à une session de certification
  - lister les candidats
- en tant que certifsup@example.net :
  - inscrire un candidat manuellement (saisie des informations, pour le lieu de naissance : choisir Nantes 44000)
