### PR TITLE
[FEATURE] création du script d'archivage de campagne en masse (PIX-5489).

### DIFF
--- a/api/lib/domain/models/CampaignForArchiving.js
+++ b/api/lib/domain/models/CampaignForArchiving.js
@@ -1,7 +1,8 @@
 const { ArchivedCampaignError, ObjectValidationError } = require('../errors');
 
 class CampaignForArchiving {
-  constructor({ code, archivedAt, archivedBy } = {}) {
+  constructor({ id, code, archivedAt, archivedBy } = {}) {
+    this.id = id;
     this.code = code;
     this.archivedAt = archivedAt;
     this.archivedBy = archivedBy;
@@ -20,6 +21,11 @@ class CampaignForArchiving {
 
     this.archivedAt = archivedAt;
     this.archivedBy = archivedBy;
+  }
+
+  unarchive() {
+    this.archivedAt = null;
+    this.archivedBy = null;
   }
 }
 

--- a/api/lib/domain/models/CampaignForArchiving.js
+++ b/api/lib/domain/models/CampaignForArchiving.js
@@ -1,0 +1,26 @@
+const { ArchivedCampaignError, ObjectValidationError } = require('../errors');
+
+class CampaignForArchiving {
+  constructor({ code, archivedAt, archivedBy } = {}) {
+    this.code = code;
+    this.archivedAt = archivedAt;
+    this.archivedBy = archivedBy;
+  }
+
+  archive(archivedAt, archivedBy) {
+    if (!archivedAt) {
+      throw new ObjectValidationError('ArchivedAt Missing');
+    }
+    if (!archivedBy) {
+      throw new ObjectValidationError('ArchivedBy Missing');
+    }
+    if (this.archivedAt) {
+      throw new ArchivedCampaignError('Campaign Already Archived');
+    }
+
+    this.archivedAt = archivedAt;
+    this.archivedBy = archivedBy;
+  }
+}
+
+module.exports = CampaignForArchiving;

--- a/api/lib/domain/usecases/archive-campaign-from-campaign-code.js
+++ b/api/lib/domain/usecases/archive-campaign-from-campaign-code.js
@@ -1,0 +1,9 @@
+module.exports = async function archiveCampaignFromCampaignCode({
+  campaignCode,
+  userId,
+  campaignForArchivingRepository,
+}) {
+  const campaign = await campaignForArchivingRepository.getByCode(campaignCode);
+  campaign.archive(new Date(), userId);
+  await campaignForArchivingRepository.save(campaign);
+};

--- a/api/lib/domain/usecases/archive-campaign.js
+++ b/api/lib/domain/usecases/archive-campaign.js
@@ -1,16 +1,6 @@
-const { UserNotAuthorizedToUpdateCampaignError } = require('../errors');
-
-module.exports = async function archiveCampaign({
-  // Parameters
-  campaignId,
-  userId,
-  // Repositories
-  campaignRepository,
-}) {
-  const isUserCampaignAdmin = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
-  if (!isUserCampaignAdmin) {
-    throw new UserNotAuthorizedToUpdateCampaignError();
-  }
-
-  return campaignRepository.update({ id: campaignId, archivedAt: new Date(), archivedBy: userId });
+module.exports = async function archiveCampaign({ campaignId, userId, campaignForArchivingRepository }) {
+  const campaign = await campaignForArchivingRepository.get(campaignId);
+  campaign.archive(new Date(), userId);
+  await campaignForArchivingRepository.save(campaign);
+  return campaign;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -18,6 +18,7 @@ const dependencies = {
   campaignAssessmentParticipationResultListRepository: require('../../infrastructure/repositories/campaign-assessment-participation-result-list-repository'),
   campaignAssessmentParticipationResultRepository: require('../../infrastructure/repositories/campaign-assessment-participation-result-repository'),
   campaignCreatorRepository: require('../../infrastructure/repositories/campaign-creator-repository'),
+  campaignForArchivingRepository: require('../../infrastructure/repositories/campaign/campaign-for-archiving-repository'),
   campaignParticipantActivityRepository: require('../../infrastructure/repositories/campaign-participant-activity-repository'),
   campaignCollectiveResultRepository: require('../../infrastructure/repositories/campaign-collective-result-repository'),
   campaignManagementRepository: require('../../infrastructure/repositories/campaign-management-repository'),

--- a/api/lib/domain/usecases/unarchive-campaign.js
+++ b/api/lib/domain/usecases/unarchive-campaign.js
@@ -1,10 +1,6 @@
-const { UserNotAuthorizedToUpdateCampaignError } = require('../errors');
-
-module.exports = async function unarchiveCampaign({ campaignId, userId, campaignRepository }) {
-  const isUserCampaignAdmin = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
-  if (!isUserCampaignAdmin) {
-    throw new UserNotAuthorizedToUpdateCampaignError();
-  }
-
-  return campaignRepository.update({ id: campaignId, archivedAt: null, archivedBy: null });
+module.exports = async function unarchiveCampaign({ campaignId, campaignForArchivingRepository }) {
+  const campaign = await campaignForArchivingRepository.get(campaignId);
+  campaign.unarchive();
+  await campaignForArchivingRepository.save(campaign);
+  return campaign;
 };

--- a/api/lib/infrastructure/repositories/campaign/campaign-for-archiving-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/campaign-for-archiving-repository.js
@@ -1,0 +1,28 @@
+const { knex } = require('../../../../db/knex-database-connection');
+const Campaign = require('../../../domain/models/CampaignForArchiving');
+const knexUtils = require('../../utils/knex-utils');
+
+const { NotFoundError, UserNotFoundError } = require('../../../domain/errors');
+
+async function save(campaign) {
+  try {
+    await knex('campaigns').update(campaign).where({ code: campaign.code });
+  } catch (error) {
+    if (knexUtils.foreignKeyConstraintViolated(error)) {
+      throw new UserNotFoundError('User Not Found');
+    }
+  }
+}
+
+async function getByCode(code) {
+  const row = await knex('campaigns').select(['code', 'archivedAt', 'archivedBy']).where({ code }).first();
+  if (!row) {
+    throw new NotFoundError();
+  }
+  return new Campaign(row);
+}
+
+module.exports = {
+  save,
+  getByCode,
+};

--- a/api/lib/infrastructure/repositories/campaign/campaign-for-archiving-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/campaign-for-archiving-repository.js
@@ -15,7 +15,15 @@ async function save(campaign) {
 }
 
 async function getByCode(code) {
-  const row = await knex('campaigns').select(['code', 'archivedAt', 'archivedBy']).where({ code }).first();
+  const row = await knex('campaigns').select(['id', 'code', 'archivedAt', 'archivedBy']).where({ code }).first();
+  if (!row) {
+    throw new NotFoundError('Campaign Not Found');
+  }
+  return new Campaign(row);
+}
+
+async function get(id) {
+  const row = await knex('campaigns').select(['id', 'code', 'archivedAt', 'archivedBy']).where({ id }).first();
   if (!row) {
     throw new NotFoundError();
   }
@@ -25,4 +33,5 @@ async function getByCode(code) {
 module.exports = {
   save,
   getByCode,
+  get,
 };

--- a/api/lib/infrastructure/utils/progression-logger.js
+++ b/api/lib/infrastructure/utils/progression-logger.js
@@ -1,0 +1,23 @@
+class ProgressionLogger {
+  constructor(output) {
+    this.output = output;
+    this.count = 0;
+  }
+
+  setTotal(total) {
+    this.total = total;
+  }
+
+  log(data) {
+    this.output.write(data.toString());
+    this.output.write('\n');
+  }
+
+  logCount() {
+    this.count += 1;
+    this.output.cursorTo(0);
+    this.output.write(`progress : ${this.count}/${this.total}`);
+  }
+}
+
+module.exports = ProgressionLogger;

--- a/api/scripts/prod/archive-campaigns.js
+++ b/api/scripts/prod/archive-campaigns.js
@@ -1,0 +1,43 @@
+const { parseCsvWithHeader } = require('../helpers/csvHelpers');
+const archiveCampaignFromCampaignCode = require('../../lib/domain/usecases/archive-campaign-from-campaign-code');
+const campaignForArchivingRepository = require('../../lib/infrastructure/repositories/campaign/campaign-for-archiving-repository');
+const bluebird = require('bluebird');
+const ProgressionLogger = require('../../lib/infrastructure/utils/progression-logger');
+
+async function archiveCampaign(campaignData, logger) {
+  try {
+    await archiveCampaignFromCampaignCode({
+      campaignCode: campaignData.code,
+      userId: campaignData.userId,
+      campaignForArchivingRepository,
+    });
+  } catch (error) {
+    logger.log('');
+    logger.log(`campaign ${campaignData.code} cannot be archived !`);
+    logger.log(error.message);
+  } finally {
+    logger.logCount();
+  }
+}
+
+async function archiveCampaigns(file, logger, concurrency = 1) {
+  const data = await parseCsvWithHeader(file);
+  logger.setTotal(data.length);
+  await bluebird.mapSeries(data, (campaignData) => archiveCampaign(campaignData, logger), { concurrency });
+  logger.log('');
+  logger.log('DONE');
+}
+
+module.exports = archiveCampaigns;
+
+if (require.main === module) {
+  const logger = new ProgressionLogger(process.stdout);
+
+  archiveCampaigns(process.argv[2], logger, process.argv[3]).then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}

--- a/api/tests/integration/infrastructure/repositories/campaign/campaign-for-archiving-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign/campaign-for-archiving-repository_test.js
@@ -6,21 +6,26 @@ const { NotFoundError, UserNotFoundError } = require('../../../../../lib/domain/
 describe('Integration | Infrastructure | Repository | campaign-for-archiving-repository', function () {
   describe('#save', function () {
     it('updates the campaign', async function () {
-      databaseBuilder.factory.buildCampaign({ code: '123ABC', archivedAt: null, archivedBy: null });
+      databaseBuilder.factory.buildCampaign({ id: 1, code: '123ABC', archivedAt: null, archivedBy: null });
       databaseBuilder.factory.buildUser({ id: 12 });
       await databaseBuilder.commit();
-      const campaign = new Campaign({ code: '123ABC', archivedAt: '2022-01-22', archivedBy: 12 });
+      const campaign = new Campaign({ id: 1, code: '123ABC', archivedAt: '2022-01-22', archivedBy: 12 });
 
       await campaignForArchivingRepository.save(campaign);
       const actualCampaign = await campaignForArchivingRepository.getByCode('123ABC');
 
-      expect(actualCampaign).to.deep.equal({ code: '123ABC', archivedAt: new Date('2022-01-22'), archivedBy: 12 });
+      expect(actualCampaign).to.deep.equal({
+        id: 1,
+        code: '123ABC',
+        archivedAt: new Date('2022-01-22'),
+        archivedBy: 12,
+      });
     });
 
     context('when there is several campaign', function () {
       it('updates the campaign with the correct code', async function () {
-        databaseBuilder.factory.buildCampaign({ code: 'ABC123', archivedAt: null, archivedBy: null });
-        databaseBuilder.factory.buildCampaign({ code: 'ABC456', archivedAt: null, archivedBy: null });
+        databaseBuilder.factory.buildCampaign({ id: 1, code: 'ABC123', archivedAt: null, archivedBy: null });
+        databaseBuilder.factory.buildCampaign({ id: 2, code: 'ABC456', archivedAt: null, archivedBy: null });
         databaseBuilder.factory.buildUser({ id: 12 });
         await databaseBuilder.commit();
 
@@ -30,8 +35,8 @@ describe('Integration | Infrastructure | Repository | campaign-for-archiving-rep
         const campaign1 = await campaignForArchivingRepository.getByCode('ABC123');
         const campaign2 = await campaignForArchivingRepository.getByCode('ABC456');
 
-        expect(campaign1).to.deep.equal({ code: 'ABC123', archivedAt: new Date('2022-01-22'), archivedBy: 12 });
-        expect(campaign2).to.deep.equal({ code: 'ABC456', archivedAt: null, archivedBy: null });
+        expect(campaign1).to.deep.equal({ id: 1, code: 'ABC123', archivedAt: new Date('2022-01-22'), archivedBy: 12 });
+        expect(campaign2).to.deep.equal({ id: 2, code: 'ABC456', archivedAt: null, archivedBy: null });
       });
     });
 
@@ -51,18 +56,38 @@ describe('Integration | Infrastructure | Repository | campaign-for-archiving-rep
 
   describe('#getByCode', function () {
     it('find the campaign with the correct code', async function () {
-      databaseBuilder.factory.buildCampaign({ code: '123ABC', archivedAt: null, archivedBy: null });
+      databaseBuilder.factory.buildCampaign({ id: 1, code: '123ABC', archivedAt: null, archivedBy: null });
       databaseBuilder.factory.buildUser({ id: 12 });
       await databaseBuilder.commit();
 
       const actualCampaign = await campaignForArchivingRepository.getByCode('123ABC');
 
-      expect(actualCampaign).to.deep.equal({ code: '123ABC', archivedAt: null, archivedBy: null });
+      expect(actualCampaign).to.deep.equal({ id: 1, code: '123ABC', archivedAt: null, archivedBy: null });
     });
 
     context('when there the campaign does not exists', function () {
       it('throws an error', async function () {
         const error = await catchErr(campaignForArchivingRepository.getByCode)('ABC123');
+
+        expect(error).to.be.an.instanceOf(NotFoundError);
+      });
+    });
+  });
+
+  describe('#get', function () {
+    it('find the campaign with the correct id', async function () {
+      databaseBuilder.factory.buildCampaign({ id: 2, code: '123ABC', archivedAt: null, archivedBy: null });
+      databaseBuilder.factory.buildUser({ id: 12 });
+      await databaseBuilder.commit();
+
+      const actualCampaign = await campaignForArchivingRepository.get(2);
+
+      expect(actualCampaign).to.deep.equal({ id: 2, code: '123ABC', archivedAt: null, archivedBy: null });
+    });
+
+    context('when there the campaign does not exists', function () {
+      it('throws an error', async function () {
+        const error = await catchErr(campaignForArchivingRepository.get)(1);
 
         expect(error).to.be.an.instanceOf(NotFoundError);
       });

--- a/api/tests/integration/infrastructure/repositories/campaign/campaign-for-archiving-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign/campaign-for-archiving-repository_test.js
@@ -1,0 +1,71 @@
+const { expect, databaseBuilder, catchErr } = require('../../../../test-helper');
+const campaignForArchivingRepository = require('../../../../../lib/infrastructure/repositories/campaign/campaign-for-archiving-repository');
+const Campaign = require('../../../../../lib/domain/models/CampaignForArchiving');
+const { NotFoundError, UserNotFoundError } = require('../../../../../lib/domain/errors');
+
+describe('Integration | Infrastructure | Repository | campaign-for-archiving-repository', function () {
+  describe('#save', function () {
+    it('updates the campaign', async function () {
+      databaseBuilder.factory.buildCampaign({ code: '123ABC', archivedAt: null, archivedBy: null });
+      databaseBuilder.factory.buildUser({ id: 12 });
+      await databaseBuilder.commit();
+      const campaign = new Campaign({ code: '123ABC', archivedAt: '2022-01-22', archivedBy: 12 });
+
+      await campaignForArchivingRepository.save(campaign);
+      const actualCampaign = await campaignForArchivingRepository.getByCode('123ABC');
+
+      expect(actualCampaign).to.deep.equal({ code: '123ABC', archivedAt: new Date('2022-01-22'), archivedBy: 12 });
+    });
+
+    context('when there is several campaign', function () {
+      it('updates the campaign with the correct code', async function () {
+        databaseBuilder.factory.buildCampaign({ code: 'ABC123', archivedAt: null, archivedBy: null });
+        databaseBuilder.factory.buildCampaign({ code: 'ABC456', archivedAt: null, archivedBy: null });
+        databaseBuilder.factory.buildUser({ id: 12 });
+        await databaseBuilder.commit();
+
+        const campaignToArchived = new Campaign({ code: 'ABC123', archivedAt: '2022-01-22', archivedBy: 12 });
+
+        await campaignForArchivingRepository.save(campaignToArchived);
+        const campaign1 = await campaignForArchivingRepository.getByCode('ABC123');
+        const campaign2 = await campaignForArchivingRepository.getByCode('ABC456');
+
+        expect(campaign1).to.deep.equal({ code: 'ABC123', archivedAt: new Date('2022-01-22'), archivedBy: 12 });
+        expect(campaign2).to.deep.equal({ code: 'ABC456', archivedAt: null, archivedBy: null });
+      });
+    });
+
+    context('when the user does not exist', function () {
+      it('updates the campaign with the correct code', async function () {
+        databaseBuilder.factory.buildCampaign({ id: 1, code: 'ABC123', archivedAt: null, archivedBy: null });
+        await databaseBuilder.commit();
+
+        const campaignToArchived = new Campaign({ code: 'ABC123', archivedAt: '2022-01-22', archivedBy: 12 });
+
+        const error = await catchErr(campaignForArchivingRepository.save)(campaignToArchived);
+
+        expect(error).to.be.an.instanceOf(UserNotFoundError);
+      });
+    });
+  });
+
+  describe('#getByCode', function () {
+    it('find the campaign with the correct code', async function () {
+      databaseBuilder.factory.buildCampaign({ code: '123ABC', archivedAt: null, archivedBy: null });
+      databaseBuilder.factory.buildUser({ id: 12 });
+      await databaseBuilder.commit();
+
+      const actualCampaign = await campaignForArchivingRepository.getByCode('123ABC');
+
+      expect(actualCampaign).to.deep.equal({ code: '123ABC', archivedAt: null, archivedBy: null });
+    });
+
+    context('when there the campaign does not exists', function () {
+      it('throws an error', async function () {
+        const error = await catchErr(campaignForArchivingRepository.getByCode)('ABC123');
+
+        expect(error).to.be.an.instanceOf(NotFoundError);
+      });
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/archive-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/archive-campaigns_test.js
@@ -1,0 +1,52 @@
+const { expect, databaseBuilder, knex, sinon } = require('../../../test-helper');
+const archiveCampaigns = require('../../../../scripts/prod/archive-campaigns');
+
+describe('Script | Prod | Archive Campaign', function () {
+  let clock;
+  let now;
+
+  beforeEach(function () {
+    now = new Date('2022-01-01');
+    clock = sinon.useFakeTimers(now);
+  });
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#archiveCampaigns', function () {
+    it('archives all given campaigns', async function () {
+      const file = './tests/tooling/fixtures/campaigns-to-archive.csv';
+      const logger = { setTotal: () => {}, log: () => {}, logCount: () => {} };
+      databaseBuilder.factory.buildCampaign({ code: 'ABC123' });
+      databaseBuilder.factory.buildCampaign({ code: 'ABC456' });
+      databaseBuilder.factory.buildUser({ id: 1 });
+      databaseBuilder.factory.buildUser({ id: 2 });
+      await databaseBuilder.commit();
+
+      await archiveCampaigns(file, logger);
+
+      const rows = await knex('campaigns').select(['code', 'archivedAt', 'archivedBy']);
+      expect(rows).to.exactlyContain([
+        { code: 'ABC123', archivedAt: now, archivedBy: 1 },
+        { code: 'ABC456', archivedAt: now, archivedBy: 2 },
+      ]);
+    });
+
+    it('archives all archivable campaigns', async function () {
+      const file = './tests/tooling/fixtures/campaigns-unarchivable.csv';
+      const logger = { setTotal: () => {}, log: () => {}, logCount: () => {} };
+      databaseBuilder.factory.buildCampaign({ code: 'ARCHIVABLE' });
+      databaseBuilder.factory.buildCampaign({ code: 'UNARCHIVABLE' });
+      databaseBuilder.factory.buildUser({ id: 1 });
+      await databaseBuilder.commit();
+
+      await archiveCampaigns(file, logger);
+
+      const rows = await knex('campaigns').select(['code', 'archivedAt', 'archivedBy']);
+      expect(rows).to.exactlyContain([
+        { code: 'ARCHIVABLE', archivedAt: now, archivedBy: 1 },
+        { code: 'UNARCHIVABLE', archivedAt: null, archivedBy: null },
+      ]);
+    });
+  });
+});

--- a/api/tests/tooling/fixtures/campaigns-to-archive.csv
+++ b/api/tests/tooling/fixtures/campaigns-to-archive.csv
@@ -1,0 +1,3 @@
+code;userId
+ABC123;1
+ABC456;2

--- a/api/tests/tooling/fixtures/campaigns-unarchivable.csv
+++ b/api/tests/tooling/fixtures/campaigns-unarchivable.csv
@@ -1,0 +1,3 @@
+code;userId
+ARCHIVABLE;1
+NOTARCHIVABLE;2

--- a/api/tests/unit/domain/models/CampaignForArchiving_test.js
+++ b/api/tests/unit/domain/models/CampaignForArchiving_test.js
@@ -5,16 +5,16 @@ const { ArchivedCampaignError, ObjectValidationError } = require('../../../../li
 describe('Unit | Domain | Models | CampaignForArchiving', function () {
   describe('#archive', function () {
     it('archives the campaigns', function () {
-      const campaign = new Campaign({ code: 'ABC123', archivedAt: null, archivedBy: null });
+      const campaign = new Campaign({ id: 1, code: 'ABC123', archivedAt: null, archivedBy: null });
 
       campaign.archive('2023-02-27', 1);
 
-      expect(campaign).to.deep.equal({ code: 'ABC123', archivedAt: '2023-02-27', archivedBy: 1 });
+      expect(campaign).to.deep.equal({ id: 1, code: 'ABC123', archivedAt: '2023-02-27', archivedBy: 1 });
     });
 
     context('when the campaign is already archived', function () {
       it('archives the campaigns', async function () {
-        const campaign = new Campaign({ code: 'ABC123', archivedAt: '2023-01-01', archivedBy: 2 });
+        const campaign = new Campaign({ id: 1, code: 'ABC123', archivedAt: '2023-01-01', archivedBy: 2 });
 
         const error = await catchErr(campaign.archive, campaign)('2023-02-27', 1);
 
@@ -40,6 +40,16 @@ describe('Unit | Domain | Models | CampaignForArchiving', function () {
 
         expect(error).to.be.an.instanceOf(ObjectValidationError);
       });
+    });
+  });
+
+  describe('#unarchive', function () {
+    it('unarchives the campaigns', function () {
+      const campaign = new Campaign({ id: 1, code: 'ABC123', archivedAt: new Date('2022-01-01'), archivedBy: 1 });
+
+      campaign.unarchive();
+
+      expect(campaign).to.deep.equal({ id: 1, code: 'ABC123', archivedAt: null, archivedBy: null });
     });
   });
 });

--- a/api/tests/unit/domain/models/CampaignForArchiving_test.js
+++ b/api/tests/unit/domain/models/CampaignForArchiving_test.js
@@ -1,0 +1,45 @@
+const { expect, catchErr } = require('../../../test-helper');
+const Campaign = require('../../../../lib/domain/models/CampaignForArchiving');
+const { ArchivedCampaignError, ObjectValidationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Models | CampaignForArchiving', function () {
+  describe('#archive', function () {
+    it('archives the campaigns', function () {
+      const campaign = new Campaign({ code: 'ABC123', archivedAt: null, archivedBy: null });
+
+      campaign.archive('2023-02-27', 1);
+
+      expect(campaign).to.deep.equal({ code: 'ABC123', archivedAt: '2023-02-27', archivedBy: 1 });
+    });
+
+    context('when the campaign is already archived', function () {
+      it('archives the campaigns', async function () {
+        const campaign = new Campaign({ code: 'ABC123', archivedAt: '2023-01-01', archivedBy: 2 });
+
+        const error = await catchErr(campaign.archive, campaign)('2023-02-27', 1);
+
+        expect(error).to.be.an.instanceOf(ArchivedCampaignError);
+      });
+    });
+
+    context('when the given date is  null', function () {
+      it('throws an exception', async function () {
+        const campaign = new Campaign({ id: 1, code: 'ABC123', archivedAt: null, archivedBy: null });
+
+        const error = await catchErr(campaign.archive, campaign)(null, 1);
+
+        expect(error).to.be.an.instanceOf(ObjectValidationError);
+      });
+    });
+
+    context('when the given userId is null', function () {
+      it('throws an exception', async function () {
+        const campaign = new Campaign({ id: 1, code: 'ABC123', archivedAt: null, archivedBy: null });
+
+        const error = await catchErr(campaign.archive, campaign)('2023-02-27', null);
+
+        expect(error).to.be.an.instanceOf(ObjectValidationError);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/archive-campaign-from-campaign-code_test.js
+++ b/api/tests/unit/domain/usecases/archive-campaign-from-campaign-code_test.js
@@ -1,0 +1,35 @@
+const { expect, sinon } = require('../../../test-helper');
+const archiveCampaignFromCampaignCode = require('../../../../lib/domain/usecases/archive-campaign-from-campaign-code');
+const Campaign = require('../../../../lib/domain/models/CampaignForArchiving');
+
+describe('Unit | UseCase | archive-campaign', function () {
+  let campaignForArchivingRepository;
+  let clock;
+  let now;
+
+  beforeEach(function () {
+    now = new Date('2022-01-01');
+    clock = sinon.useFakeTimers(now);
+    campaignForArchivingRepository = {
+      getByCode: sinon.stub(),
+      save: sinon.stub(),
+    };
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('updates the campaign', async function () {
+    const userId = 1;
+    const campaignCode = 2;
+    const campaign = new Campaign({ id: 1, code: 'ABCD', archivedAt: null, archivedBy: null });
+    const expectedCampaign = new Campaign({ id: 1, code: 'ABCD', archivedAt: now, archivedBy: userId });
+    campaignForArchivingRepository.getByCode.resolves(campaign);
+
+    await archiveCampaignFromCampaignCode({ userId, campaignCode, campaignForArchivingRepository });
+
+    expect(campaignForArchivingRepository.getByCode).to.have.been.calledWithExactly(campaignCode);
+    expect(campaignForArchivingRepository.save).to.have.been.calledWith(expectedCampaign);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs organisations PRO et SCO souhaiteraient archiver leur campagne en masse.

## :robot: Solution
Création du script afin d’archiver en masse des campagnes à partir d’un fichier csv contenant pour chaque ligne un code campagne et un userID (archivedBy)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer le script en local avec un fichier
