### PR TITLE
[FEATURE] Accéder à la page de réconciliation depuis la nouvelle double mire oidc sur Pix App (PIX-5486).

### DIFF
--- a/mon-pix/app/adapters/user-oidc-authentication-request.js
+++ b/mon-pix/app/adapters/user-oidc-authentication-request.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class ExternalUserAuthenticationRequest extends ApplicationAdapter {
+  buildURL() {
+    return `${this.host}/${this.namespace}/oidc/`;
+  }
+}

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -39,7 +39,7 @@
           </PixMessage>
         {{/if}}
 
-        <PixButton @type="submit" @triggerAction={{this.submit}}>
+        <PixButton @type="submit" @triggerAction={{this.register}}>
           {{t "pages.login-or-register-oidc.register-form.button"}}
         </PixButton>
       </div>

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -33,9 +33,9 @@
           </p>
         </div>
 
-        {{#if this.errorMessage}}
+        {{#if this.registerError}}
           <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
-            {{this.errorMessage}}
+            {{this.registerErrorMessage}}
           </PixMessage>
         {{/if}}
 
@@ -78,6 +78,12 @@
               {{t "pages.sign-in.forgotten-password"}}
             </LinkTo>
           </div>
+
+          {{#if this.loginError}}
+            <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
+              {{this.loginErrorMessage}}
+            </PixMessage>
+          {{/if}}
 
           <PixButton @type="submit" class="login-or-register-oidc-form__submit-button">
             {{t "pages.login-or-register-oidc.login-form.button"}}

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -72,6 +72,7 @@
               @label={{t "pages.login-or-register-oidc.login-form.password"}}
               autocomplete="off"
               required
+              {{on "change" this.setPassword}}
             />
             <LinkTo @route="password-reset-demand" class="login-or-register-oidc-form__forgotten-password-link">
               {{t "pages.sign-in.forgotten-password"}}

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -51,7 +51,7 @@
         <p class="login-or-register-oidc-form__description">
           {{t "pages.login-or-register-oidc.login-form.description"}}
         </p>
-        <form {{on "submit" this.confirmReconciliation}}>
+        <form {{on "submit" this.login}}>
           <p class="login-or-register-oidc-form__mandatory-description">{{t "common.form.mandatory-all-fields"}}</p>
 
           <PixInput

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -22,7 +22,6 @@ export default class LoginOrRegisterOidcComponent extends Component {
   @service store;
 
   @tracked isTermsOfServiceValidated = false;
-  @tracked isAuthenticationKeyExpired = false;
   @tracked errorMessage = null;
   @tracked email = '';
   @tracked password = '';

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -19,6 +19,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
   @service intl;
   @service session;
   @service currentDomain;
+  @service store;
 
   @tracked isTermsOfServiceValidated = false;
   @tracked isAuthenticationKeyExpired = false;
@@ -101,9 +102,21 @@ export default class LoginOrRegisterOidcComponent extends Component {
   }
 
   @action
-  confirmReconciliation() {
+  async login(event) {
+    event.preventDefault();
     if (this.isFormValid) {
-      // todo
+      const identityProvider = IdentityProviders[this.args.identityProviderSlug]?.code;
+      try {
+        const authenticationRequest = this.store.createRecord('user-oidc-authentication-request', {
+          password: this.password,
+          email: this.email,
+          authenticationKey: this.args.authenticationKey,
+          identityProvider,
+        });
+        await authenticationRequest.login();
+      } catch (error) {
+        return error;
+      }
     }
   }
 

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -55,7 +55,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
   }
 
   @action
-  async submit() {
+  async register() {
     if (this.isTermsOfServiceValidated) {
       this.errorMessage = null;
       try {

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -91,6 +91,11 @@ export default class LoginOrRegisterOidcComponent extends Component {
     }
   }
 
+  @action
+  setPassword(event) {
+    this.password = event.target.value;
+  }
+
   get isFormValid() {
     return isEmailValid(this.email) && !isEmpty(this.password);
   }

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -114,6 +114,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
           identityProvider,
         });
         await authenticationRequest.login();
+        this.args.toggleOidcReconciliation();
       } catch (error) {
         return error;
       }

--- a/mon-pix/app/components/authentication/oidc-reconciliation.hbs
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.hbs
@@ -1,0 +1,5 @@
+<PixBackgroundHeader>
+  <PixBlock @shadow="light">
+    <p>{{@authenticationKey}}</p>
+  </PixBlock>
+</PixBackgroundHeader>

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class LoginOrRegisterOidcRoute extends Controller {
+  queryParams = ['authenticationKey', 'identityProviderSlug'];
+
+  @tracked showOidcReconciliation = false;
+  @tracked authenticationKey = null;
+  @tracked identityProviderSlug = null;
+
+  @action toggleOidcReconciliation() {
+    this.showOidcReconciliation = !this.showOidcReconciliation;
+  }
+}

--- a/mon-pix/app/controllers/terms-of-service-oidc.js
+++ b/mon-pix/app/controllers/terms-of-service-oidc.js
@@ -1,18 +1,9 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 
 export default class TermsOfServiceOidcController extends Controller {
   queryParams = ['authenticationKey', 'identityProviderSlug'];
 
-  @tracked showOidcReconciliation = false;
   @tracked authenticationKey = null;
   @tracked identityProviderSlug = null;
-
-  @service featureToggles;
-
-  @action toggleOidcReconciliation() {
-    this.showOidcReconciliation = !this.showOidcReconciliation;
-  }
 }

--- a/mon-pix/app/controllers/terms-of-service-oidc.js
+++ b/mon-pix/app/controllers/terms-of-service-oidc.js
@@ -1,11 +1,18 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class TermsOfServiceOidcController extends Controller {
   queryParams = ['authenticationKey', 'identityProviderSlug'];
 
+  @tracked showOidcReconciliation = false;
   @tracked authenticationKey = null;
   @tracked identityProviderSlug = null;
+
   @service featureToggles;
+
+  @action toggleOidcReconciliation() {
+    this.showOidcReconciliation = !this.showOidcReconciliation;
+  }
 }

--- a/mon-pix/app/models/user-oidc-authentication-request.js
+++ b/mon-pix/app/models/user-oidc-authentication-request.js
@@ -1,0 +1,25 @@
+import Model, { attr } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
+
+export default class UserOidcAuthenticationRequest extends Model {
+  @attr('string') email;
+  @attr('string') password;
+  @attr('string') identityProvider;
+  @attr('string') authenticationKey;
+  @attr('string') accessToken;
+  @attr('string') logoutUrlUUID;
+
+  login = memberAction({
+    path: 'token-reconciliation',
+    type: 'post',
+    before() {
+      const payload = this.serialize();
+      delete payload.data.attributes['access-token'];
+      delete payload.data.attributes['logout-url-uuid'];
+      return payload;
+    },
+    after(response) {
+      return response?.data?.attributes;
+    },
+  });
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -117,6 +117,7 @@ Router.map(function () {
   this.route('authentication', { path: '/connexion' }, function () {
     this.route('login', { path: '' });
     this.route('login-oidc', { path: '/:identity_provider_slug' });
+    this.route('login-or-register-oidc', { path: '/oidc' });
   });
 
   this.route('sitemap', { path: '/plan-du-site' });

--- a/mon-pix/app/routes/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/routes/authentication/login-or-register-oidc.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class LoginOrRegisterOidcRoute extends Route {}

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -1,0 +1,14 @@
+{{page-title (t "pages.login-or-register-oidc.title")}}
+
+{{#if this.showOidcReconciliation}}
+  <Authentication::OidcReconciliation
+    @identityProviderSlug={{this.identityProviderSlug}}
+    @authenticationKey={{this.authenticationKey}}
+  />
+{{else}}
+  <Authentication::LoginOrRegisterOidc
+    @identityProviderSlug={{this.identityProviderSlug}}
+    @authenticationKey={{this.authenticationKey}}
+    @toggleOidcReconciliation={{this.toggleOidcReconciliation}}
+  />
+{{/if}}

--- a/mon-pix/app/templates/terms-of-service-oidc.hbs
+++ b/mon-pix/app/templates/terms-of-service-oidc.hbs
@@ -1,10 +1,18 @@
 {{page-title (t "pages.terms-of-service-oidc.title")}}
 
 {{#if this.featureToggles.featureToggles.isSsoAccountReconciliationEnabled}}
-  <Authentication::LoginOrRegisterOidc
-    @identityProviderSlug={{this.identityProviderSlug}}
-    @authenticationKey={{this.authenticationKey}}
-  />
+  {{#if this.showOidcReconciliation}}
+    <Authentication::OidcReconciliation
+      @identityProviderSlug={{this.identityProviderSlug}}
+      @authenticationKey={{this.authenticationKey}}
+    />
+  {{else}}
+    <Authentication::LoginOrRegisterOidc
+      @identityProviderSlug={{this.identityProviderSlug}}
+      @authenticationKey={{this.authenticationKey}}
+      @toggleOidcReconciliation={{this.toggleOidcReconciliation}}
+    />
+  {{/if}}
 {{else}}
   <Authentication::TermsOfServiceOidc
     @identityProviderSlug={{this.identityProviderSlug}}

--- a/mon-pix/app/templates/terms-of-service-oidc.hbs
+++ b/mon-pix/app/templates/terms-of-service-oidc.hbs
@@ -1,21 +1,6 @@
 {{page-title (t "pages.terms-of-service-oidc.title")}}
 
-{{#if this.featureToggles.featureToggles.isSsoAccountReconciliationEnabled}}
-  {{#if this.showOidcReconciliation}}
-    <Authentication::OidcReconciliation
-      @identityProviderSlug={{this.identityProviderSlug}}
-      @authenticationKey={{this.authenticationKey}}
-    />
-  {{else}}
-    <Authentication::LoginOrRegisterOidc
-      @identityProviderSlug={{this.identityProviderSlug}}
-      @authenticationKey={{this.authenticationKey}}
-      @toggleOidcReconciliation={{this.toggleOidcReconciliation}}
-    />
-  {{/if}}
-{{else}}
-  <Authentication::TermsOfServiceOidc
-    @identityProviderSlug={{this.identityProviderSlug}}
-    @authenticationKey={{this.authenticationKey}}
-  />
-{{/if}}
+<Authentication::TermsOfServiceOidc
+  @identityProviderSlug={{this.identityProviderSlug}}
+  @authenticationKey={{this.authenticationKey}}
+/>

--- a/mon-pix/tests/unit/adapters/user-oidc-authentication-request_test.js
+++ b/mon-pix/tests/unit/adapters/user-oidc-authentication-request_test.js
@@ -1,0 +1,18 @@
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import { expect } from 'chai';
+
+describe('Unit | Adapters | user-oidc-authentication-request', function () {
+  setupTest();
+
+  describe('#buildUrl', function () {
+    it('should build url', function () {
+      // when
+      const adapter = this.owner.lookup('adapter:user-oidc-authentication-request');
+      const url = adapter.buildURL();
+
+      // then
+      expect(url.endsWith('oidc/')).to.be.true;
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -145,4 +145,52 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
       });
     });
   });
+
+  context('#login', function () {
+    it('should request api for reconciliation', async function () {
+      // given
+      const email = 'glace.alo@example.net';
+      const password = 'pix123';
+      const identityProvider = 'CNAV';
+      const authenticationKey = '1234567azerty';
+      const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
+      const login = sinon.stub();
+      component.store = { createRecord: () => ({ login }) };
+      component.email = email;
+      component.password = password;
+      component.args.authenticationKey = authenticationKey;
+      component.args.identityProviderSlug = 'cnav';
+      sinon.spy(component.store, 'createRecord');
+
+      // when
+      await component.login();
+
+      // then
+      sinon.assert.calledWith(component.store.createRecord, 'user-oidc-authentication-request', {
+        password,
+        email,
+        authenticationKey,
+        identityProvider,
+      });
+      sinon.assert.calledOnce(login);
+    });
+
+    context('when form is invalid', function () {
+      it('should not request api for reconciliation', async function () {
+        // given
+        const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
+        const login = sinon.stub();
+        component.store = { createRecord: () => ({ login }) };
+        component.email = '';
+        sinon.spy(component.store, 'createRecord');
+
+        // when
+        await component.login();
+
+        // then
+        sinon.assert.notCalled(component.store.createRecord);
+        sinon.assert.notCalled(login);
+      });
+    });
+  });
 });

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -147,7 +147,7 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
   });
 
   context('#login', function () {
-    it('should request api for reconciliation', async function () {
+    it('should request api for login', async function () {
       // given
       const email = 'glace.alo@example.net';
       const password = 'pix123';
@@ -160,10 +160,12 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
       component.password = password;
       component.args.authenticationKey = authenticationKey;
       component.args.identityProviderSlug = 'cnav';
+      component.args.toggleOidcReconciliation = sinon.stub();
       sinon.spy(component.store, 'createRecord');
+      const eventStub = { preventDefault: sinon.stub() };
 
       // when
-      await component.login();
+      await component.login(eventStub);
 
       // then
       sinon.assert.calledWith(component.store.createRecord, 'user-oidc-authentication-request', {
@@ -173,6 +175,7 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
         identityProvider,
       });
       sinon.assert.calledOnce(login);
+      sinon.assert.calledOnce(component.args.toggleOidcReconciliation);
     });
 
     context('when form is invalid', function () {
@@ -183,9 +186,10 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
         component.store = { createRecord: () => ({ login }) };
         component.email = '';
         sinon.spy(component.store, 'createRecord');
+        const eventStub = { preventDefault: sinon.stub() };
 
         // when
-        await component.login();
+        await component.login(eventStub);
 
         // then
         sinon.assert.notCalled(component.store.createRecord);

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -18,14 +18,14 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
       component.errorMessage = null;
 
       // when
-      component.submit();
+      component.register();
 
       // then
       expect(component.errorMessage).to.equal(this.intl.t('pages.login-or-register-oidc.error.error-message'));
     });
   });
 
-  describe('#submit', function () {
+  describe('#register', function () {
     it('should create session', function () {
       // given
       const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
@@ -40,7 +40,7 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
       component.errorMessage = null;
 
       // when
-      component.submit();
+      component.register();
 
       // then
       sinon.assert.calledWith(authenticateStub, 'authenticator:oidc', {
@@ -65,7 +65,7 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
         component.errorMessage = null;
 
         // when
-        await component.submit();
+        await component.register();
 
         // then
         expect(component.errorMessage).to.equal(
@@ -89,7 +89,7 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
       component.errorMessage = null;
 
       // when
-      await component.submit();
+      await component.register();
 
       // then
       expect(component.errorMessage).to.equal(`${this.intl.t('common.error')} (some detail)`);
@@ -109,7 +109,7 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
       component.errorMessage = null;
 
       // when
-      await component.submit();
+      await component.register();
 
       // then
       expect(component.errorMessage).to.equal(this.intl.t('common.error'));

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -61,7 +61,6 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
         component.args.identityProviderSlug = 'super-idp';
         component.args.authenticationKey = 'super-key';
         component.isTermsOfServiceValidated = true;
-        component.isAuthenticationKeyExpired = false;
         component.errorMessage = null;
 
         // when
@@ -71,7 +70,6 @@ describe('Unit | Component | authentication::login-or-register-oidc', function (
         expect(component.errorMessage).to.equal(
           this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
         );
-        expect(component.isAuthenticationKeyExpired).to.be.true;
       });
     });
 

--- a/mon-pix/tests/unit/models/user-oidc-authentication-request_test.js
+++ b/mon-pix/tests/unit/models/user-oidc-authentication-request_test.js
@@ -1,0 +1,57 @@
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import { expect } from 'chai';
+import sinon from 'sinon/pkg/sinon-esm';
+import ENV from '../../../config/environment';
+
+describe('Unit | Model | user-oidc-authentication-request', function () {
+  setupTest();
+
+  describe('#login', function () {
+    it('should login and return attributes', async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('user-oidc-authentication-request');
+      sinon.stub(adapter, 'ajax');
+      adapter.ajax.resolves({
+        data: {
+          attributes: {
+            accessToken: 'accessToken',
+            logoutUrlUuid: 'url',
+          },
+        },
+      });
+
+      const userOidcAuthenticationRequest = store.createRecord('user-oidc-authentication-request', {
+        password: 'pix123',
+        email: 'glace.alo@example.net',
+        authenticationKey: '123456azerty',
+        identityProvider: 'oidc',
+      });
+
+      // when
+      const result = await userOidcAuthenticationRequest.login();
+
+      // then
+      const url = `${ENV.APP.API_HOST}/api/oidc/token-reconciliation`;
+      const payload = {
+        data: {
+          data: {
+            attributes: {
+              password: 'pix123',
+              email: 'glace.alo@example.net',
+              'authentication-key': '123456azerty',
+              'identity-provider': 'oidc',
+            },
+            type: 'user-oidc-authentication-requests',
+          },
+        },
+      };
+      sinon.assert.calledWith(adapter.ajax, url, 'POST', payload);
+      expect(result).to.deep.equal({
+        accessToken: 'accessToken',
+        logoutUrlUuid: 'url',
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -137,18 +137,47 @@ describe('Unit | Route | login-oidc', function () {
 
   describe('#afterModel', function () {
     describe('when user has no pix account', function () {
-      it("should redirect to cgu's oidc page", async function () {
-        // given
-        const route = this.owner.lookup('route:authentication/login-oidc');
-        route.router = { replaceWith: sinon.stub() };
-        const identityProviderSlug = 'super-idp-name';
+      describe('when sso account reconciliation enabled', function () {
+        it('should redirect to login or register oidc page', async function () {
+          // given
+          const route = this.owner.lookup('route:authentication/login-oidc');
+          route.router = { replaceWith: sinon.stub() };
+          const identityProviderSlug = 'super-idp-name';
 
-        // when
-        await route.afterModel({ authenticationKey: '123', shouldValidateCgu: true, identityProviderSlug });
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isSsoAccountReconciliationEnabled: true };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
 
-        // then
-        sinon.assert.calledWith(route.router.replaceWith, 'terms-of-service-oidc', {
-          queryParams: { authenticationKey: '123', identityProviderSlug },
+          // when
+          await route.afterModel({ authenticationKey: '123', shouldValidateCgu: true, identityProviderSlug });
+
+          // then
+          sinon.assert.calledWith(route.router.replaceWith, 'authentication.login-or-register-oidc', {
+            queryParams: { authenticationKey: '123', identityProviderSlug },
+          });
+        });
+      });
+
+      describe('when sso account reconciliation is not enabled', function () {
+        it("should redirect to cgu's oidc page", async function () {
+          // given
+          const route = this.owner.lookup('route:authentication/login-oidc');
+          route.router = { replaceWith: sinon.stub() };
+          const identityProviderSlug = 'super-idp-name';
+
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isSsoAccountReconciliationEnabled: false };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+          // when
+          await route.afterModel({ authenticationKey: '123', shouldValidateCgu: true, identityProviderSlug });
+
+          // then
+          sinon.assert.calledWith(route.router.replaceWith, 'terms-of-service-oidc', {
+            queryParams: { authenticationKey: '123', identityProviderSlug },
+          });
         });
       });
     });

--- a/mon-pix/tests/unit/routes/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-or-register-oidc_test.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Route | Authentication | login-or-register-oidc', function () {
+  setupTest();
+
+  it('exists', function () {
+    const route = this.owner.lookup('route:authentication/LoginOrRegisterOidc');
+    expect(route).to.be.ok;
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -945,7 +945,8 @@
       "error": {
         "error-message": "Please agree to the terms and conditions of use.",
         "expired-authentication-key": "Your authentication demand has expired. Please click to back button to log in",
-        "invalid-email": "Your email address is invalid."
+        "invalid-email": "Your email address is invalid.",
+        "login-unauthorized-error": "There was an error in the email address or password entered."
       }
     },
     "not-connected": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -945,7 +945,8 @@
       "error": {
         "error-message": "Vous devez accepter les conditions d’utilisation de Pix.",
         "expired-authentication-key": "Votre demande d'authentification a expiré, merci de renouveler votre connexion en cliquant sur le bouton retour.",
-        "invalid-email": "Votre adresse e-mail n’est pas valide."
+        "invalid-email": "Votre adresse e-mail n’est pas valide.",
+        "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects."
       }
     },
     "not-connected": {


### PR DESCRIPTION
## :unicorn: Problème
L'actuel scénario de réconciliation de compte n'est plus pertinent. Il permet entre autres de mauvaises réconciliation, comme un élève sco connecté sur Pix dont le parent va se connecter via Pôle Emploi en commençant une campagne.
Les deux comptes sont alors réconcilés.

Dans le nouveau scénario, nous avons désormais une double mire permettant à l'utilisateur de se connecter à un compte Pix qu'il possède déjà. 
[La route api](https://github.com/1024pix/pix/pull/4756) a été implémenté mais n'est pas connecté au front.

## :robot: Solution
Appeler la nouvelle route api et rediriger l'utilisateur vers la nouvelle page de confirmation de réconciliation

## :rainbow: Remarques
La page de réconciliation est créé mais n'est pas rempli. Ce sera fait dans une nouvelle PR. 
Il faut que le back transmette des infos (nom et prénom, méthodes de connexion, adresse email) au front pour les afficher dans cette page.


Le composant login-or-register-oidc était placé dans le template terms-of-service-oidc. Il a été déplacé dans un nouveau template plus approprié
## :100: Pour tester
ℹ️ Mettre le feature toggle à true en local

Aller sur Pix App
Aller sur /connexion/cnav
Accéder à la double mire oidc
Sur la partie droite, remplir email et mot de passe d'un utilisateur existant (sco.admin)
Constater que l'on est redirigé vers la page de confirmation de réconciliation

Tester les erreurs :

- Entrer un mauvais e-mail ou mot de passe
- Réduire la durée de la clé redis pour qu'elle expire, entrer un utilisateur existant