### PR TITLE
[BUGFIX] Corriger l'affichage de la liste des niveaux jury sélectionnables dans la page de détail d'une certification Pix+ Édu (PIX-5505)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -32,10 +32,7 @@ export default class CertificationInformationsController extends Controller {
   @tracked confirmAction = 'onCandidateResultsSave';
   @tracked isCandidateEditModalOpen = false;
   @tracked displayJuryLevelSelect = false;
-  @tracked juryLevelOptions = [
-    ...this.certification.complementaryCertificationCourseResultsWithExternal.get('allowedExternalLevels'),
-    { value: 'REJECTED', label: 'Rejetée' },
-  ];
+
   @tracked selectedJuryLevel = null;
 
   // private properties
@@ -83,6 +80,13 @@ export default class CertificationInformationsController extends Controller {
 
   get isModifyButtonDisabled() {
     return this.editingCandidateResults || this.certification.wasRegisteredBeforeCPF;
+  }
+
+  get juryLevelOptions() {
+    return [
+      ...this.certification.complementaryCertificationCourseResultsWithExternal.get('allowedExternalLevels'),
+      { value: 'REJECTED', label: 'Rejetée' },
+    ];
   }
 
   @action

--- a/admin/app/templates/authenticated/sessions/session.hbs
+++ b/admin/app/templates/authenticated/sessions/session.hbs
@@ -20,7 +20,12 @@
     <LinkTo @route="authenticated.sessions.session.informations" @model={{@model.id}} class="navbar-item">
       Informations
     </LinkTo>
-    <LinkTo @route="authenticated.sessions.session.certifications" @model={{@model.id}} class="navbar-item">
+    <LinkTo
+      @route="authenticated.sessions.session.certifications"
+      @model={{@model.id}}
+      class="navbar-item"
+      aria-label="Liste des certifications de la session"
+    >
       Certifications
     </LinkTo>
   </nav>

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -86,7 +86,7 @@ module('Acceptance | Session pages', function (hooks) {
         test('tab "Certifications" is clickable', async function (assert) {
           // when
           const screen = await visit('/sessions/1');
-          await click(screen.getAllByRole('link', { name: 'Certifications' })[1]);
+          await click(screen.getByLabelText('Liste des certifications de la session'));
 
           // then
           assert.dom(screen.getByRole('heading', { name: 'Certifications' })).exists();

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -228,6 +228,38 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
+  module('#juryLevelOptions', function () {
+    test('should return an array of labels and values', function (assert) {
+      // given
+      const complementaryCertificationCourseResultsWithExternal = EmberObject.create({
+        allowedExternalLevels: [
+          {
+            value: 'COMME',
+            label: 'je veux',
+          },
+        ],
+      });
+      controller.model = {
+        certification: EmberObject.create({
+          status: 'cancelled',
+          complementaryCertificationCourseResultsWithExternal,
+        }),
+      };
+
+      // when
+      const juryLevelOptions = controller.juryLevelOptions;
+
+      //then
+      assert.deepEqual(juryLevelOptions, [
+        {
+          value: 'COMME',
+          label: 'je veux',
+        },
+        { value: 'REJECTED', label: 'Rejetée' },
+      ]);
+    });
+  });
+
   module('#impactfulCertificationIssueReports', () => {
     test('it should return certification issue reports with action required', async function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, lorsque l'on se trouve sur la page de détail d'une certification Pix+ Édu, que l'on ouvre la liste des niveaux jury sélectionnables pour la certification complémentaire, que l'on ouvre ensuite le détail d'une autre certification complémentaire Pix+ Édu, la liste des niveaux jury sélectionnables et la liste de la première certification affichées et non pas celle de la certification courante.

## :robot: Solution
- Rafraîchir la liste des niveau jury sélectionnables afin qu'il correspondent à la certification complémentaire Pix+ Édu actuellement affichée. 

## :100: Pour tester
- Créer une session et y inscrire un certificat Pix+ Édu 1er degré et un candidat Pix+ Édu 2nd degré.
- Passer les deux certifications
- Finaliser la session
- Aller sur Pix Admin et afficher la liste des niveaux jury sélectionnables de la certification Pix+ Édu 1er degré
- Retourner sur la liste des certifications de la session et ouvrir le détail de la certification Pix+ Édu 2nd degré
- Ouvrir la liste des niveaux jury sélectionnables et vérifier que les niveau proposés correspondent bien à du 2nd degré.
