### PR TITLE
[FEATURE] Afficher les informations sur la page de réconciliation - Pix App (PIX-5506).

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -115,7 +115,7 @@ exports.register = async (server) => {
     },
     {
       method: 'POST',
-      path: '/api/oidc/token-reconciliation',
+      path: '/api/oidc/user/check-reconciliation',
       config: {
         auth: false,
         pre: [

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -37,10 +37,7 @@ module.exports = {
       oidcAuthenticationService,
     });
 
-    if (result.isAuthenticationComplete) {
-      return h.response(oidcSerializer.serialize(result)).code(200);
-    }
-    return h.response().code(204);
+    return h.response(oidcSerializer.serialize(result)).code(200);
   },
 
   async getAuthenticationUrl(request, h) {

--- a/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
+++ b/api/lib/domain/usecases/find-user-for-oidc-reconciliation.js
@@ -30,7 +30,16 @@ module.exports = async function findUserForOidcReconciliation({
   if (!oidcAuthenticationMethod) {
     sessionContentAndUserInfo.userInfo.userId = foundUser.id;
     await authenticationSessionService.update(authenticationKey, sessionContentAndUserInfo);
-    return { isAuthenticationComplete: false };
+
+    const fullNameFromPix = `${foundUser.firstName} ${foundUser.lastName}`;
+    const fullNameFromExternalIdentityProvider = `${sessionContentAndUserInfo.userInfo.firstName} ${sessionContentAndUserInfo.userInfo.lastName}`;
+
+    return {
+      fullNameFromPix,
+      fullNameFromExternalIdentityProvider,
+      email: foundUser.email,
+      username: foundUser.username,
+    };
   }
 
   const isSameExternalIdentifier =
@@ -57,7 +66,7 @@ module.exports = async function findUserForOidcReconciliation({
 
   userRepository.updateLastLoggedAt({ userId: foundUser.id });
 
-  return { accessToken, logoutUrlUUID, isAuthenticationComplete: true };
+  return { accessToken, logoutUrlUUID };
 };
 
 async function _updateAuthenticationComplement({

--- a/api/lib/infrastructure/serializers/jsonapi/oidc-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/oidc-serializer.js
@@ -3,7 +3,15 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(authenticationContent) {
     return new Serializer('user-oidc-authentication-requests', {
-      attributes: ['accessToken', 'logoutUrlUUID'],
+      attributes: [
+        'accessToken',
+        'logoutUrlUUID',
+        'fullNameFromPix',
+        'fullNameFromExternalIdentityProvider',
+        'email',
+        'username',
+        'authenticationMethods',
+      ],
     }).serialize(authenticationContent);
   },
 };

--- a/api/tests/acceptance/application/authentication/oidc/oidc-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/oidc-route-post_test.js
@@ -5,7 +5,7 @@ const authenticationSessionService = require('../../../../../lib/domain/services
 const { featureToggles } = require('../../../../../lib/config');
 
 describe('Acceptance | Application | Oidc | Routes', function () {
-  describe('POST /api/oidc/token-reconciliation', function () {
+  describe('POST /api/oidc/user/check-reconciliation', function () {
     let server;
 
     beforeEach(async function () {
@@ -45,7 +45,7 @@ describe('Acceptance | Application | Oidc | Routes', function () {
         // when
         const response = await server.inject({
           method: 'POST',
-          url: `/api/oidc/token-reconciliation`,
+          url: `/api/oidc/user/check-reconciliation`,
           payload: {
             data: {
               attributes: {
@@ -99,7 +99,7 @@ describe('Acceptance | Application | Oidc | Routes', function () {
         // when
         const response = await server.inject({
           method: 'POST',
-          url: `/api/oidc/token-reconciliation`,
+          url: `/api/oidc/user/check-reconciliation`,
           payload: {
             data: {
               attributes: {
@@ -152,7 +152,7 @@ describe('Acceptance | Application | Oidc | Routes', function () {
           // when
           const response = await server.inject({
             method: 'POST',
-            url: `/api/oidc/token-reconciliation`,
+            url: `/api/oidc/user/check-reconciliation`,
             payload: {
               data: {
                 attributes: {

--- a/api/tests/acceptance/application/authentication/oidc/oidc-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/oidc-route-post_test.js
@@ -18,7 +18,7 @@ describe('Acceptance | Application | Oidc | Routes', function () {
     });
 
     context('when user has no oidc authentication method', function () {
-      it('should return 204 HTTP status', async function () {
+      it('should return 200 HTTP status', async function () {
         // given
         databaseBuilder.factory.buildUser.withRawPassword({ email: 'eva.poree@example.net', rawPassword: 'pix123' });
         await databaseBuilder.commit();
@@ -59,7 +59,11 @@ describe('Acceptance | Application | Oidc | Routes', function () {
         });
 
         // then
-        expect(response.statusCode).to.equal(204);
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes['full-name-from-pix']).to.exist;
+        expect(response.result.data.attributes['full-name-from-external-identity-provider']).to.exist;
+        expect(response.result.data.attributes['email']).to.exist;
+        expect(response.result.data.attributes['authentication-methods']).to.exist;
       });
     });
 

--- a/api/tests/integration/application/authentication/oidc/index_test.js
+++ b/api/tests/integration/application/authentication/oidc/index_test.js
@@ -90,7 +90,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
     });
   });
 
-  describe('POST /api/oidc/token-reconciliation', function () {
+  describe('POST /api/oidc/user/check-reconciliation', function () {
     context('error cases', function () {
       context('when user is not found', function () {
         it('should return a response with HTTP status code 404', async function () {
@@ -103,7 +103,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
 
           const response = await httpTestServer.requestObject({
             method: 'POST',
-            url: '/api/oidc/token-reconciliation',
+            url: '/api/oidc/user/check-reconciliation',
             payload: {
               data: {
                 attributes: {
@@ -131,7 +131,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
           httpTestServer.setupAuthentication();
           await httpTestServer.register(moduleUnderTest);
 
-          const response = await httpTestServer.request('POST', `/api/oidc/token-reconciliation`, {
+          const response = await httpTestServer.request('POST', `/api/oidc/user/check-reconciliation`, {
             data: {
               attributes: {
                 email: 'eva.poree@example.net',
@@ -157,7 +157,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
           httpTestServer.setupAuthentication();
           await httpTestServer.register(moduleUnderTest);
 
-          const response = await httpTestServer.request('POST', `/api/oidc/token-reconciliation`, {
+          const response = await httpTestServer.request('POST', `/api/oidc/user/check-reconciliation`, {
             data: {
               attributes: {
                 email: 'eva.poree@example.net',

--- a/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
+++ b/api/tests/unit/domain/usecases/find-user-for-oidc-reconciliation_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
 
   beforeEach(function () {
     authenticationMethodRepository = {
-      findOneByUserIdAndIdentityProvider: sinon.stub(),
+      findByUserId: sinon.stub(),
       updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
     };
     userRepository = { updateLastLoggedAt: sinon.stub() };
@@ -24,6 +24,10 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
 
   it('should find pix user and their oidc authentication method', async function () {
     // given
+    const pixAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword(
+      {}
+    );
+    authenticationMethodRepository.findByUserId.resolves([pixAuthenticationMethod]);
     pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
     authenticationSessionService.getByKey.resolves({
       sessionContent: { idToken: 'idToken' },
@@ -48,14 +52,17 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
       userRepository,
     });
 
-    expect(authenticationMethodRepository.findOneByUserIdAndIdentityProvider).to.be.calledOnceWith({
+    expect(authenticationMethodRepository.findByUserId).to.be.calledOnceWith({
       userId: 2,
-      identityProvider: 'oidc',
     });
   });
 
   it('should retrieve user session content', async function () {
     // given
+    const pixAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword(
+      {}
+    );
+    authenticationMethodRepository.findByUserId.resolves([pixAuthenticationMethod]);
     pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
     authenticationSessionService.getByKey.resolves({
       sessionContent: { idToken: 'idToken' },
@@ -103,7 +110,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
   });
 
   context('when user has no oidc authentication method', function () {
-    it('should return full names', async function () {
+    it('should return authentication methods and full names', async function () {
       // given
       const firstName = 'Sarah';
       const lastName = 'Pix';
@@ -113,7 +120,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
       };
       const pixAuthenticationMethod =
         domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({});
-      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(null);
+      authenticationMethodRepository.findByUserId.resolves([pixAuthenticationMethod]);
       pixAuthenticationService.getUserByUsernameAndPassword.resolves({
         id: 2,
         firstName,
@@ -142,6 +149,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
         fullNameFromExternalIdentityProvider: 'Sarah Idp',
         email: 'sarahcroche@example.net',
         username: 'sarahcroche123',
+        authenticationMethods: [pixAuthenticationMethod],
       });
     });
   });
@@ -154,7 +162,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
           externalIdentifier: '789fge',
         });
         pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
-        authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(oidcAuthenticationMethod);
+        authenticationMethodRepository.findByUserId.resolves([oidcAuthenticationMethod]);
         authenticationSessionService.getByKey.resolves({
           sessionContent: {},
           userInfo: { externalIdentityId: '123abc' },
@@ -192,7 +200,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
           });
 
           pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
-          authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(oidcAuthenticationMethod);
+          authenticationMethodRepository.findByUserId.resolves([oidcAuthenticationMethod]);
           authenticationSessionService.getByKey.resolves({
             sessionContent,
             userInfo: { externalIdentityId: '123abc' },
@@ -230,7 +238,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
             externalIdentifier: '123abc',
           });
           pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
-          authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(oidcAuthenticationMethod);
+          authenticationMethodRepository.findByUserId.resolves([oidcAuthenticationMethod]);
           authenticationSessionService.getByKey.resolves({
             sessionContent: { idToken: 'idToken' },
             userInfo: { externalIdentityId: '123abc' },
@@ -263,7 +271,7 @@ describe('Unit | UseCase | find-user-for-oidc-reconciliation', function () {
           externalIdentifier: '123abc',
         });
         pixAuthenticationService.getUserByUsernameAndPassword.resolves({ id: 2 });
-        authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(oidcAuthenticationMethod);
+        authenticationMethodRepository.findByUserId.resolves([oidcAuthenticationMethod]);
         authenticationSessionService.getByKey.resolves({
           sessionContent: { idToken: 'idToken' },
           userInfo: { externalIdentityId: '123abc' },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/oidc-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/oidc-serializer_test.js
@@ -5,9 +5,19 @@ describe('Unit | Serializer | JSONAPI | oidc-serializer', function () {
   describe('#serialize()', function () {
     it('should format into JSON API data', function () {
       // given
+      const authenticationMethods = [
+        { identityProvider: 'PIX', userId: 1 },
+        { identityProvider: 'PIX', userId: 1 },
+        { identityProvider: 'CNAV', userId: 1 },
+      ];
       const authenticationContent = {
         accessToken: 'access.token',
         logoutUrlUUID: 'logout.url.uuid',
+        fullNameFromPix: 'Sarah Pix',
+        fullNameFromExternalIdentityProvider: 'Sarah Idp',
+        username: 'sarahcroche123',
+        email: 'sarahcroche@example.net',
+        authenticationMethods,
       };
 
       // when
@@ -19,6 +29,15 @@ describe('Unit | Serializer | JSONAPI | oidc-serializer', function () {
           attributes: {
             'access-token': 'access.token',
             'logout-url-uuid': 'logout.url.uuid',
+            'full-name-from-pix': 'Sarah Pix',
+            'full-name-from-external-identity-provider': 'Sarah Idp',
+            username: 'sarahcroche123',
+            email: 'sarahcroche@example.net',
+            'authentication-methods': [
+              { identityProvider: 'PIX', userId: 1 },
+              { identityProvider: 'PIX', userId: 1 },
+              { identityProvider: 'CNAV', userId: 1 },
+            ],
           },
           type: 'user-oidc-authentication-requests',
         },

--- a/mon-pix/app/adapters/user-oidc-authentication-request.js
+++ b/mon-pix/app/adapters/user-oidc-authentication-request.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class ExternalUserAuthenticationRequest extends ApplicationAdapter {
   buildURL() {
-    return `${this.host}/${this.namespace}/oidc/`;
+    return `${this.host}/${this.namespace}/oidc/user/`;
   }
 }

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -24,7 +24,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
     };
     const host = `${ENV.APP.API_HOST}/api/oidc/`;
     let hostSlug, body;
-    const identityProvider = this.oidcIdentityProviders[identityProviderSlug] || {};
+    const identityProvider = this.oidcIdentityProviders[identityProviderSlug];
 
     if (authenticationKey) {
       hostSlug = 'users';

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -1,95 +1,88 @@
-<PixBackgroundHeader>
-  <PixBlock @shadow="light" class="login-or-register-oidc-form">
-    <a href={{this.homeUrl}} class="login-or-register-oidc-form__logo">
-      <img src="/images/pix-logo.svg" alt="{{t 'common.pix'}}" />
-    </a>
-    <h1 class="login-or-register-oidc-form__title">{{t "pages.login-or-register-oidc.title"}}</h1>
-    <div class="login-or-register-oidc-form__container">
-      <div class="login-or-register-oidc-form__register-container">
-        <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.register-form.title"}}</h2>
-        <p class="login-or-register-oidc-form__description">
-          {{t
-            "pages.login-or-register-oidc.register-form.description"
-            identityProviderOrganizationName=this.identityProviderOrganizationName
-          }}
-        </p>
-        <div class="login-or-register-oidc-form__cgu-container">
-          <PixCheckbox
-            @id="checkbox"
-            @label={{t "common.cgu.label"}}
-            @screenReaderOnly="true"
-            {{on "change" this.onChange}}
-          />
-          <p class="login-or-register-oidc-form__cgu-label">
-            {{t "common.cgu.accept"}}
-            <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
-              {{t "common.cgu.cgu"}}
-            </a>
-            {{t "common.cgu.and"}}
-            <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
-              {{t "common.cgu.data-protection-policy"}}
-            </a>
-            {{t "common.cgu.pix"}}
-          </p>
-        </div>
-
-        {{#if this.registerError}}
-          <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
-            {{this.registerErrorMessage}}
-          </PixMessage>
-        {{/if}}
-
-        <PixButton @type="submit" @triggerAction={{this.register}}>
-          {{t "pages.login-or-register-oidc.register-form.button"}}
-        </PixButton>
-      </div>
-
-      <div class="login-or-register-oidc-form__divider"></div>
-
-      <div class="login-or-register-oidc-form__login-container">
-        <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.login-form.title"}}</h2>
-        <p class="login-or-register-oidc-form__description">
-          {{t "pages.login-or-register-oidc.login-form.description"}}
-        </p>
-        <form {{on "submit" this.login}}>
-          <p class="login-or-register-oidc-form__mandatory-description">{{t "common.form.mandatory-all-fields"}}</p>
-
-          <PixInput
-            @id="email"
-            @label={{t "pages.login-or-register-oidc.login-form.email"}}
-            @errorMessage={{this.emailValidationMessage}}
-            @value={{this.email}}
-            type="email"
-            {{on "change" this.validateEmail}}
-            autocomplete="off"
-            required
-          />
-
-          <div class="login-or-register-oidc-form__password-container">
-            <PixInputPassword
-              @id="password"
-              @value={{this.password}}
-              @label={{t "pages.login-or-register-oidc.login-form.password"}}
-              autocomplete="off"
-              required
-              {{on "change" this.setPassword}}
-            />
-            <LinkTo @route="password-reset-demand" class="login-or-register-oidc-form__forgotten-password-link">
-              {{t "pages.sign-in.forgotten-password"}}
-            </LinkTo>
-          </div>
-
-          {{#if this.loginError}}
-            <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
-              {{this.loginErrorMessage}}
-            </PixMessage>
-          {{/if}}
-
-          <PixButton @type="submit" class="login-or-register-oidc-form__submit-button">
-            {{t "pages.login-or-register-oidc.login-form.button"}}
-          </PixButton>
-        </form>
-      </div>
+<h1 class="login-or-register-oidc-form__title">{{t "pages.login-or-register-oidc.title"}}</h1>
+<div class="login-or-register-oidc-form__container">
+  <div class="login-or-register-oidc-form__register-container">
+    <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.register-form.title"}}</h2>
+    <p class="login-or-register-oidc-form__description">
+      {{t
+        "pages.login-or-register-oidc.register-form.description"
+        identityProviderOrganizationName=this.identityProviderOrganizationName
+      }}
+    </p>
+    <div class="login-or-register-oidc-form__cgu-container">
+      <PixCheckbox
+        @id="checkbox"
+        @label={{t "common.cgu.label"}}
+        @screenReaderOnly="true"
+        {{on "change" this.onChange}}
+      />
+      <p class="login-or-register-oidc-form__cgu-label">
+        {{t "common.cgu.accept"}}
+        <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t "common.cgu.cgu"}}
+        </a>
+        {{t "common.cgu.and"}}
+        <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t "common.cgu.data-protection-policy"}}
+        </a>
+        {{t "common.cgu.pix"}}
+      </p>
     </div>
-  </PixBlock>
-</PixBackgroundHeader>
+
+    {{#if this.registerError}}
+      <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
+        {{this.registerErrorMessage}}
+      </PixMessage>
+    {{/if}}
+
+    <PixButton @type="submit" @triggerAction={{this.register}}>
+      {{t "pages.login-or-register-oidc.register-form.button"}}
+    </PixButton>
+  </div>
+
+  <div class="login-or-register-oidc-form__divider"></div>
+
+  <div class="login-or-register-oidc-form__login-container">
+    <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.login-form.title"}}</h2>
+    <p class="login-or-register-oidc-form__description">
+      {{t "pages.login-or-register-oidc.login-form.description"}}
+    </p>
+    <form {{on "submit" this.login}}>
+      <p class="login-or-register-oidc-form__mandatory-description">{{t "common.form.mandatory-all-fields"}}</p>
+
+      <PixInput
+        @id="email"
+        @label={{t "pages.login-or-register-oidc.login-form.email"}}
+        @errorMessage={{this.emailValidationMessage}}
+        @value={{this.email}}
+        type="email"
+        {{on "change" this.validateEmail}}
+        autocomplete="off"
+        required
+      />
+
+      <div class="login-or-register-oidc-form__password-container">
+        <PixInputPassword
+          @id="password"
+          @value={{this.password}}
+          @label={{t "pages.login-or-register-oidc.login-form.password"}}
+          autocomplete="off"
+          required
+          {{on "change" this.setPassword}}
+        />
+        <LinkTo @route="password-reset-demand" class="login-or-register-oidc-form__forgotten-password-link">
+          {{t "pages.sign-in.forgotten-password"}}
+        </LinkTo>
+      </div>
+
+      {{#if this.loginError}}
+        <PixMessage @type="error" class="login-or-register-oidc-form__cgu-error">
+          {{this.loginErrorMessage}}
+        </PixMessage>
+      {{/if}}
+
+      <PixButton @type="submit" class="login-or-register-oidc-form__submit-button">
+        {{t "pages.login-or-register-oidc.login-form.button"}}
+      </PixButton>
+    </form>
+  </div>
+</div>

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -15,7 +15,6 @@ const ERROR_INPUT_MESSAGE_MAP = {
 };
 
 export default class LoginOrRegisterOidcComponent extends Component {
-  @service url;
   @service intl;
   @service session;
   @service currentDomain;
@@ -37,10 +36,6 @@ export default class LoginOrRegisterOidcComponent extends Component {
 
   get currentLanguage() {
     return this.intl.t('current-lang');
-  }
-
-  get homeUrl() {
-    return this.url.homeUrl;
   }
 
   get cguUrl() {
@@ -115,17 +110,8 @@ export default class LoginOrRegisterOidcComponent extends Component {
 
     if (!this.isFormValid) return;
 
-    const identityProvider = this.oidcIdentityProviders[this.args.identityProviderSlug]?.code;
-
     try {
-      const authenticationRequest = this.store.createRecord('user-oidc-authentication-request', {
-        password: this.password,
-        email: this.email,
-        authenticationKey: this.args.authenticationKey,
-        identityProvider,
-      });
-      await authenticationRequest.login();
-      this.args.toggleOidcReconciliation();
+      await this.args.onLogin({ enteredEmail: this.email, enteredPassword: this.password });
     } catch (error) {
       this.loginError = true;
       const status = get(error, 'errors[0].status', 'unknown');

--- a/mon-pix/app/components/authentication/oidc-reconciliation.hbs
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.hbs
@@ -1,5 +1,65 @@
-<PixBackgroundHeader>
-  <PixBlock @shadow="light">
-    <p>{{@authenticationKey}}</p>
-  </PixBlock>
-</PixBackgroundHeader>
+<h1 class="oidc-reconciliation__title">
+  {{t "pages.oidc-reconciliation.title"}}
+  <span class="oidc-reconciliation__subtitle">{{t "pages.oidc-reconciliation.sub-title"}}</span>
+</h1>
+<p class="oidc-reconciliation__information">{{t "pages.oidc-reconciliation.information"}}</p>
+<div class="oidc-reconciliation__container">
+  <div class="oidc-reconciliation__user-information">
+    <FaIcon @icon="circle-user" />
+    <p>{{@fullNameFromPix}}</p>
+    <div class="oidc-reconciliation__user-authentication-methods">
+      <p>{{t "pages.oidc-reconciliation.current-authentication-methods"}}</p>
+      <dl
+        class="oidc-reconciliation__user-authentication-methods-list"
+        title={{t "pages.oidc-reconciliation.current-authentication-methods"}}
+      >
+        {{#if this.shouldShowEmail}}
+          <dt>{{t "pages.oidc-reconciliation.email"}}</dt>
+          <dd>{{@email}}</dd>
+        {{/if}}
+        {{#if this.shouldShowUsername}}
+          <dt>{{t "pages.oidc-reconciliation.username"}}</dt>
+          <dd>{{@username}}</dd>
+        {{/if}}
+        {{#if this.shouldShowGarAuthenticationMethod}}
+          <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
+          <dd>{{t "pages.user-account.connexion-methods.authentication-methods.gar"}}</dd>
+        {{/if}}
+        {{#if this.shouldShowPoleEmploiAuthenticationMethod}}
+          <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
+          <dd>{{t "pages.user-account.connexion-methods.authentication-methods.pole-emploi"}}</dd>
+        {{/if}}
+        {{#if this.shouldShowCnavAuthenticationMethod}}
+          <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
+          <dd>{{t "pages.user-account.connexion-methods.authentication-methods.cnav"}}</dd>
+        {{/if}}
+      </dl>
+    </div>
+  </div>
+
+  <div class="oidc-reconciliation__switch-account-button">
+    <PixButton @triggerAction={{this.backToLoginOrRegisterForm}} @backgroundColor="transparent-light">{{t
+        "pages.oidc-reconciliation.switch-account"
+      }}</PixButton>
+  </div>
+
+  <FaIcon class="oidc-reconciliation__arrow" @icon="arrow-up" />
+  <div class="oidc-reconciliation__new-authentication-method">
+    <p>{{t "pages.oidc-reconciliation.authentication-method-to-add"}}</p>
+    <PixBlock class="oidc-reconciliation__authentication-method-to-add">
+      <dl title={{t "pages.oidc-reconciliation.authentication-method-to-add"}}>
+        <dt>{{t "pages.oidc-reconciliation.external-connection-via"}} {{this.identityProviderOrganizationName}}</dt>
+        <dd>{{@fullNameFromExternalIdentityProvider}}</dd>
+      </dl>
+    </PixBlock>
+  </div>
+
+  <div class="oidc-reconciliation__action-buttons">
+    <PixButton
+      @triggerAction={{this.backToLoginOrRegisterForm}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+    >{{t "pages.oidc-reconciliation.return"}}</PixButton>
+    <PixButton @triggerAction={{this.reconcile}}>{{t "pages.oidc-reconciliation.confirm"}}</PixButton>
+  </div>
+</div>

--- a/mon-pix/app/components/authentication/oidc-reconciliation.js
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.js
@@ -1,0 +1,47 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class OidcReconciliationComponent extends Component {
+  @service oidcIdentityProviders;
+
+  get identityProviderOrganizationName() {
+    return this.oidcIdentityProviders[this.args.identityProviderSlug]?.organizationName;
+  }
+
+  get shouldShowEmail() {
+    return !!this.args.email;
+  }
+
+  get shouldShowUsername() {
+    return !!this.args.username;
+  }
+
+  get shouldShowGarAuthenticationMethod() {
+    return this.args.authenticationMethods.any(
+      (authenticationMethod) => authenticationMethod.identityProvider === 'GAR'
+    );
+  }
+
+  get shouldShowPoleEmploiAuthenticationMethod() {
+    return this.args.authenticationMethods.any(
+      (authenticationMethod) => authenticationMethod.identityProvider === 'POLE_EMPLOI'
+    );
+  }
+
+  get shouldShowCnavAuthenticationMethod() {
+    return this.args.authenticationMethods.any(
+      (authenticationMethod) => authenticationMethod.identityProvider === 'CNAV'
+    );
+  }
+
+  @action
+  backToLoginOrRegisterForm() {
+    this.args.toggleOidcReconciliation();
+  }
+
+  @action
+  reconcile() {
+    // todo
+  }
+}

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -1,15 +1,36 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import IdentityProviders from 'mon-pix/identity-providers';
 
-export default class LoginOrRegisterOidcRoute extends Controller {
+export default class LoginOrRegisterOidcController extends Controller {
   queryParams = ['authenticationKey', 'identityProviderSlug'];
 
+  @service url;
   @tracked showOidcReconciliation = false;
   @tracked authenticationKey = null;
   @tracked identityProviderSlug = null;
 
+  get homeUrl() {
+    return this.url.homeUrl;
+  }
+
   @action toggleOidcReconciliation() {
     this.showOidcReconciliation = !this.showOidcReconciliation;
+  }
+
+  @action
+  async onLogin({ enteredEmail, enteredPassword }) {
+    const identityProvider = IdentityProviders[this.identityProviderSlug]?.code;
+
+    const authenticationRequest = this.store.createRecord('user-oidc-authentication-request', {
+      password: enteredPassword,
+      email: enteredEmail,
+      authenticationKey: this.authenticationKey,
+      identityProvider,
+    });
+    await authenticationRequest.login();
+    this.toggleOidcReconciliation();
   }
 }

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -28,7 +28,7 @@ export default class LoginOrRegisterOidcController extends Controller {
 
   @action
   async onLogin({ enteredEmail, enteredPassword }) {
-    const identityProvider = this.oidcIdentityProviders[this.identityProviderSlug]?.code;
+    const identityProvider = this.oidcIdentityProviders[this.identityProviderSlug].code;
 
     const authenticationRequest = this.store.createRecord('user-oidc-authentication-request', {
       password: enteredPassword,

--- a/mon-pix/app/models/user-oidc-authentication-request.js
+++ b/mon-pix/app/models/user-oidc-authentication-request.js
@@ -10,7 +10,7 @@ export default class UserOidcAuthenticationRequest extends Model {
   @attr('string') logoutUrlUUID;
 
   login = memberAction({
-    path: 'token-reconciliation',
+    path: 'check-reconciliation',
     type: 'post',
     before() {
       const payload = this.serialize();

--- a/mon-pix/app/models/user-oidc-authentication-request.js
+++ b/mon-pix/app/models/user-oidc-authentication-request.js
@@ -3,11 +3,15 @@ import { memberAction } from 'ember-api-actions';
 
 export default class UserOidcAuthenticationRequest extends Model {
   @attr('string') email;
+  @attr('string') username;
   @attr('string') password;
   @attr('string') identityProvider;
   @attr('string') authenticationKey;
   @attr('string') accessToken;
   @attr('string') logoutUrlUUID;
+  @attr('string') fullNameFromPix;
+  @attr('string') fullNameFromExternalIdentityProvider;
+  @attr() authenticationMethods;
 
   login = memberAction({
     path: 'check-reconciliation',
@@ -16,10 +20,23 @@ export default class UserOidcAuthenticationRequest extends Model {
       const payload = this.serialize();
       delete payload.data.attributes['access-token'];
       delete payload.data.attributes['logout-url-uuid'];
+      delete payload.data.attributes['username'];
+      delete payload.data.attributes['full-name-from-pix'];
+      delete payload.data.attributes['full-name-from-external-identity-provider'];
+      delete payload.data.attributes['authentication-methods'];
       return payload;
     },
     after(response) {
-      return response?.data?.attributes;
+      if (!response.data?.attributes) return response;
+
+      const attributes = response.data.attributes;
+      return {
+        fullNameFromPix: attributes['full-name-from-pix'],
+        fullNameFromExternalIdentityProvider: attributes['full-name-from-external-identity-provider'],
+        email: attributes['email'],
+        username: attributes['username'],
+        authenticationMethods: attributes['authentication-methods'],
+      };
     },
   });
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -28,6 +28,7 @@
 
 /* components */
 @import 'components/authentication/login-or-register-oidc';
+@import 'components/authentication/oidc-reconciliation';
 @import 'components/assessment-banner';
 @import 'components/background-banner';
 @import 'components/badge-card';

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -1,0 +1,151 @@
+.oidc-reconciliation {
+
+  &__title,
+  &__subtitle,
+  &__information {
+    text-align: center;
+    color: $pix-neutral-90;
+  }
+
+  &__title {
+    @include h2;
+
+    text-align: center;
+    padding-top: $spacing-l;
+  }
+
+  &__subtitle {
+    @include h4;
+
+    padding: $spacing-s 0 $spacing-xxs 0;
+    margin: 0;
+    display: block;
+  }
+
+  &__information {
+    @include subheading;
+
+    font-weight: 400;
+    margin-bottom: $spacing-xxl;
+  }
+
+  &__container {
+    display: flex;
+    min-height: 500px;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  &__user-information {
+    background-color: $pix-neutral-10;
+    width: 570px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border-radius: $spacing-xs;
+    padding-top: $spacing-l;
+
+    svg {
+      color: $pix-neutral-50;
+      height: 120px;
+      min-width: 120px;
+    }
+
+    p {
+      @include h4;
+
+      color: $pix-neutral-90;
+      padding-top: $spacing-xs;
+      margin: 0;
+    }
+  }
+
+  &__user-authentication-methods {
+    width: 100%;
+    padding: $spacing-l;
+
+    p {
+      @include subheading;
+
+      font-weight: 400;
+    }
+  }
+
+  &__new-authentication-method {
+    width: 506px;
+    padding-top: $spacing-s;
+
+    p {
+      @include subheading;
+
+      font-weight: 400;
+      color: $pix-neutral-90;
+    }
+  }
+
+  &__user-authentication-methods-list {
+    background-color: $pix-neutral-0;
+    border-radius: $spacing-xs;
+    padding: $spacing-l $spacing-xl;
+
+    dd,
+    dt {
+      display: inline;
+
+      @include text-large;
+
+      color: $pix-neutral-90;
+    }
+
+    dt {
+      display: inline-block;
+      font-weight: 500;
+      width: 38%;
+      padding: $spacing-xxs 0;
+    }
+  }
+
+  &__switch-account-button {
+    display: flex;
+    justify-content: right;
+    width: 570px;
+    margin-top: $spacing-xs;
+  }
+
+  &__arrow {
+    height: 70px;
+    min-width: 50px;
+    color: $pix-neutral-15;
+  }
+
+  &__authentication-method-to-add {
+    border-radius: 8px;
+    padding: 0;
+
+    dl {
+      margin: 0;
+      padding: $spacing-l $spacing-xl;
+
+      @include text-large;
+
+      color: $pix-neutral-90;
+    }
+
+    dd,
+    dt {
+      display: inline;
+    }
+
+    dt {
+      font-weight: 500;
+    }
+  }
+
+  &__action-buttons {
+    padding-top: $spacing-l;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: $spacing-m;
+  }
+}

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -10,6 +10,13 @@
       <Authentication::OidcReconciliation
         @identityProviderSlug={{this.identityProviderSlug}}
         @authenticationKey={{this.authenticationKey}}
+        @email={{this.email}}
+        @username={{this.username}}
+        @username={{this.username}}
+        @fullNameFromPix={{this.fullNameFromPix}}
+        @fullNameFromExternalIdentityProvider={{this.fullNameFromExternalIdentityProvider}}
+        @authenticationMethods={{this.authenticationMethods}}
+        @toggleOidcReconciliation={{this.toggleOidcReconciliation}}
       />
     {{else}}
       <Authentication::LoginOrRegisterOidc

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -3,7 +3,7 @@
 <PixBackgroundHeader>
   <PixBlock @shadow="light" class="login-or-register-oidc-form">
     <a href={{this.homeUrl}} class="login-or-register-oidc-form__logo">
-      <img src="/images/pix-logo.svg" alt="{{t "common.pix"}}" />
+      <img src="/images/pix-logo.svg" alt="{{t 'common.pix'}}" />
     </a>
 
     {{#if this.showOidcReconciliation}}
@@ -11,7 +11,6 @@
         @identityProviderSlug={{this.identityProviderSlug}}
         @authenticationKey={{this.authenticationKey}}
         @email={{this.email}}
-        @username={{this.username}}
         @username={{this.username}}
         @fullNameFromPix={{this.fullNameFromPix}}
         @fullNameFromExternalIdentityProvider={{this.fullNameFromExternalIdentityProvider}}

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -1,14 +1,23 @@
 {{page-title (t "pages.login-or-register-oidc.title")}}
 
-{{#if this.showOidcReconciliation}}
-  <Authentication::OidcReconciliation
-    @identityProviderSlug={{this.identityProviderSlug}}
-    @authenticationKey={{this.authenticationKey}}
-  />
-{{else}}
-  <Authentication::LoginOrRegisterOidc
-    @identityProviderSlug={{this.identityProviderSlug}}
-    @authenticationKey={{this.authenticationKey}}
-    @toggleOidcReconciliation={{this.toggleOidcReconciliation}}
-  />
-{{/if}}
+<PixBackgroundHeader>
+  <PixBlock @shadow="light" class="login-or-register-oidc-form">
+    <a href={{this.homeUrl}} class="login-or-register-oidc-form__logo">
+      <img src="/images/pix-logo.svg" alt="{{t "common.pix"}}" />
+    </a>
+
+    {{#if this.showOidcReconciliation}}
+      <Authentication::OidcReconciliation
+        @identityProviderSlug={{this.identityProviderSlug}}
+        @authenticationKey={{this.authenticationKey}}
+      />
+    {{else}}
+      <Authentication::LoginOrRegisterOidc
+        @identityProviderSlug={{this.identityProviderSlug}}
+        @authenticationKey={{this.authenticationKey}}
+        @onLogin={{this.onLogin}}
+      />
+    {{/if}}
+
+  </PixBlock>
+</PixBackgroundHeader>

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -4,6 +4,7 @@ module.exports = function () {
     'free-solid-svg-icons': [
       'arrow-left',
       'arrow-right',
+      'arrow-up',
       'bars',
       'bookmark',
       'chevron-down',

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -76,4 +76,13 @@ export default function (config) {
         'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion',
     };
   });
+
+  config.post('/oidc/user/check-reconciliation', () => {
+    return {
+      'full-name-from-pix': 'LLoyd Cé',
+      'full-name-from-external-identity-provider': 'LLoyd Idp',
+      email: 'lloyd.ce@example.net',
+      'authentication-methods': [{ identityProvider: 'PIX' }],
+    };
+  });
 }

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
@@ -2,31 +2,126 @@
 
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import setupIntl from '../../helpers/setup-intl';
 import { expect } from 'chai';
+import { Response } from 'miragejs';
 
 describe('Acceptance | OIDC | authentication flow', function () {
   setupApplicationTest();
   setupMirage();
   setupIntl();
 
-  context('when user is logged in to external provider with logout url and logs out', function () {
-    it('should redirect the user to logout url', async function () {
-      // given
-      const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+  context('when user is logged in to external provider', function () {
+    context('when user logs out with logout url', function () {
+      context('when sso account reconciliation feature toggle is enabled', function () {
+        it('should redirect the user to logout url', async function () {
+          // given
+          const response = new Response(
+            200,
+            {},
+            {
+              data: {
+                type: 'feature-toggles',
+                id: '0',
+                attributes: {
+                  'is-sso-account-reconciliation-enabled': true,
+                },
+              },
+            }
+          );
+          server.get('/feature-toggles', () => response);
+          const screen = await visit('/connexion/oidc-partner?code=code&state=state');
 
-      // when
-      await click(
-        screen.getByLabelText("J'accepte les conditions d'utilisation et la politique de confidentialité de Pix")
-      );
-      await click(screen.getByRole('button', { name: 'Je continue' }));
-      await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
-      await click(screen.getByRole('link', { name: 'Se déconnecter' }));
+          // when
+          await click(
+            screen.getByLabelText('Accepter les conditions d’utilisation de Pix et la politique de confidentialité')
+          );
+          await click(screen.getByRole('button', { name: 'Je créé mon compte' }));
+          await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
+          await click(screen.getByRole('link', { name: 'Se déconnecter' }));
 
-      // then
-      expect(currentURL()).to.equal('/deconnexion');
+          // then
+          expect(currentURL()).to.equal('/deconnexion');
+        });
+      });
+
+      context('when sso account feature toggle is disabled', function () {
+        it('should redirect the user to logout url', async function () {
+          // given
+          const response = new Response(
+            200,
+            {},
+            {
+              data: {
+                type: 'feature-toggles',
+                id: '0',
+                attributes: {
+                  'is-sso-account-reconciliation-enabled': false,
+                },
+              },
+            }
+          );
+          server.get('/feature-toggles', () => response);
+          const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+          // when
+          await click(
+            screen.getByLabelText("J'accepte les conditions d'utilisation et la politique de confidentialité de Pix")
+          );
+          await click(screen.getByRole('button', { name: 'Je continue' }));
+          await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
+          await click(screen.getByRole('link', { name: 'Se déconnecter' }));
+
+          // then
+          expect(currentURL()).to.equal('/deconnexion');
+        });
+      });
+    });
+
+    context('when user have a pix account', function () {
+      it('should redirect user to reconciliation page', async function () {
+        // given
+        server.create('user', {
+          email: 'lloyd.ce@example.net',
+          password: 'pix123',
+          cgu: true,
+          mustValidateTermsOfService: false,
+          lastTermsOfServiceValidatedAt: new Date(),
+        });
+
+        const response = new Response(
+          200,
+          {},
+          {
+            data: {
+              type: 'feature-toggles',
+              id: '0',
+              attributes: {
+                'is-sso-account-reconciliation-enabled': true,
+              },
+            },
+          }
+        );
+        server.get('/feature-toggles', () => response);
+        const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+        // when
+        await fillIn(
+          screen.getByRole('textbox', { name: this.intl.t('pages.login-or-register-oidc.login-form.email') }),
+          'lloyd.ce@example.net'
+        );
+        await fillIn(screen.getByLabelText(this.intl.t('pages.login-or-register-oidc.login-form.password')), 'pix123');
+        await click(screen.getByRole('button', { name: 'Je me connecte' }));
+
+        // then
+        expect(
+          screen.getByRole('heading', {
+            name: "Attention ! Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
+          })
+        ).to.exist;
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
@@ -24,7 +24,7 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
     this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
   });
 
-  it('should display elements for OIDC identity provider', async function () {
+  it('should display heading', async function () {
     // given & when
     const screen = await render(
       hbs`<Authentication::LoginOrRegisterOidc @identityProviderSlug={{this.identityProviderSlug}} />`
@@ -37,8 +37,6 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
         level: 1,
       })
     ).to.exist;
-    expect(screen.getByRole('img', { name: this.intl.t('common.pix') })).to.exist;
-    expect(screen.getByRole('link', { name: this.intl.t('common.pix') })).to.exist;
   });
 
   context('on login form', function () {

--- a/mon-pix/tests/integration/components/authentication/oidc-reconciliation_test.js
+++ b/mon-pix/tests/integration/components/authentication/oidc-reconciliation_test.js
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import Service from '@ember/service';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+describe('Integration | Component |  authentication | oidc-reconciliation', function () {
+  setupIntlRenderingTest();
+
+  it('should display reconciliation page elements', async function () {
+    // given
+    const oidcPartner = {
+      organizationName: 'Partenaire OIDC',
+    };
+    class OidcIdentityProvidersStub extends Service {
+      'oidc-partner' = oidcPartner;
+      list = [oidcPartner];
+    }
+    this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+    this.set('fullNameFromPix', 'Lloyd Pix');
+    this.set('fullNameFromExternalIdentityProvider', 'Lloyd Cé');
+    this.set('email', 'lloyidce@example.net');
+    this.set('identityProviderSlug', 'oidc-partner');
+    this.set('authenticationMethods', [{ identityProvider: 'CNAV' }]);
+
+    //  when
+    const screen = await render(
+      hbs`<Authentication::OidcReconciliation @identityProviderSlug={{this.identityProviderSlug}} @authenticationMethods={{this.authenticationMethods}} @fullNameFromPix={{this.fullNameFromPix}} @fullNameFromExternalIdentityProvider={{this.fullNameFromExternalIdentityProvider}} @email={{this.email}}/>`
+    );
+
+    // then
+    expect(
+      screen.getByRole('heading', {
+        name: `${this.intl.t('pages.oidc-reconciliation.title')} ${this.intl.t('pages.oidc-reconciliation.sub-title')}`,
+      })
+    ).to.exist;
+    expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.information'))).to.exist;
+    expect(screen.getByText('Lloyd Cé')).to.exist;
+    expect(screen.getByText('Lloyd Pix')).to.exist;
+    expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.current-authentication-methods'))).to.exist;
+    expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.email'))).to.exist;
+    expect(screen.getByText('lloyidce@example.net')).to.exist;
+
+    expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.authentication-method-to-add'))).to.exist;
+    expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.external-connection'))).to.exist;
+    expect(screen.getByText(`${this.intl.t('pages.oidc-reconciliation.external-connection-via')} Partenaire OIDC`)).to
+      .exist;
+
+    expect(screen.getByRole('button', { name: this.intl.t('pages.oidc-reconciliation.switch-account') })).to.exist;
+    expect(screen.getByRole('button', { name: this.intl.t('pages.oidc-reconciliation.return') })).to.exist;
+    expect(screen.getByRole('button', { name: this.intl.t('pages.oidc-reconciliation.confirm') })).to.exist;
+  });
+});

--- a/mon-pix/tests/integration/components/authentication/oidc-reconciliation_test.js
+++ b/mon-pix/tests/integration/components/authentication/oidc-reconciliation_test.js
@@ -22,7 +22,7 @@ describe('Integration | Component |  authentication | oidc-reconciliation', func
     this.set('fullNameFromExternalIdentityProvider', 'Lloyd Cé');
     this.set('email', 'lloyidce@example.net');
     this.set('identityProviderSlug', 'oidc-partner');
-    this.set('authenticationMethods', [{ identityProvider: 'CNAV' }]);
+    this.set('authenticationMethods', [{ identityProvider: 'CNAV' }, { identityProvider: 'POLE_EMPLOI' }]);
 
     //  when
     const screen = await render(
@@ -41,9 +41,11 @@ describe('Integration | Component |  authentication | oidc-reconciliation', func
     expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.current-authentication-methods'))).to.exist;
     expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.email'))).to.exist;
     expect(screen.getByText('lloyidce@example.net')).to.exist;
+    expect(screen.getByText(this.intl.t('pages.user-account.connexion-methods.authentication-methods.cnav'))).to.exist;
+    expect(screen.getByText(this.intl.t('pages.user-account.connexion-methods.authentication-methods.pole-emploi'))).to
+      .exist;
 
     expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.authentication-method-to-add'))).to.exist;
-    expect(screen.getByText(this.intl.t('pages.oidc-reconciliation.external-connection'))).to.exist;
     expect(screen.getByText(`${this.intl.t('pages.oidc-reconciliation.external-connection-via')} Partenaire OIDC`)).to
       .exist;
 

--- a/mon-pix/tests/unit/adapters/user-oidc-authentication-request_test.js
+++ b/mon-pix/tests/unit/adapters/user-oidc-authentication-request_test.js
@@ -12,7 +12,7 @@ describe('Unit | Adapters | user-oidc-authentication-request', function () {
       const url = adapter.buildURL();
 
       // then
-      expect(url.endsWith('oidc/')).to.be.true;
+      expect(url.endsWith('user/')).to.be.true;
     });
   });
 });

--- a/mon-pix/tests/unit/authenticators/oidc_test.js
+++ b/mon-pix/tests/unit/authenticators/oidc_test.js
@@ -223,6 +223,7 @@ describe('Unit | Authenticator | oidc', function () {
 
         // then
         expect(authenticator.session.alternativeRootURL).to.equal(redirectLogoutUrl);
+        sinon.restore();
       });
     });
   });

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -161,49 +161,35 @@ describe('Unit | Component | authentication | login-or-register-oidc', function 
       // given
       const email = 'glace.alo@example.net';
       const password = 'pix123';
-      const identityProvider = 'OIDC_PARTNER';
-      const authenticationKey = '1234567azerty';
       const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
-      const login = sinon.stub();
-      component.store = { createRecord: () => ({ login }) };
       component.email = email;
       component.password = password;
-      component.args.authenticationKey = authenticationKey;
-      component.args.identityProviderSlug = 'oidc-partner';
-      component.args.toggleOidcReconciliation = sinon.stub();
-      sinon.spy(component.store, 'createRecord');
+      component.args.onLogin = sinon.stub();
       const eventStub = { preventDefault: sinon.stub() };
 
       // when
       await component.login(eventStub);
 
       // then
-      sinon.assert.calledWith(component.store.createRecord, 'user-oidc-authentication-request', {
-        password,
-        email,
-        authenticationKey,
-        identityProvider,
+      sinon.assert.calledWith(component.args.onLogin, {
+        enteredPassword: password,
+        enteredEmail: email,
       });
-      sinon.assert.calledOnce(login);
-      sinon.assert.calledOnce(component.args.toggleOidcReconciliation);
     });
 
     context('when form is invalid', function () {
       it('should not request api for reconciliation', async function () {
         // given
         const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
-        const login = sinon.stub();
-        component.store = { createRecord: () => ({ login }) };
         component.email = '';
-        sinon.spy(component.store, 'createRecord');
         const eventStub = { preventDefault: sinon.stub() };
+        component.args.onLogin = sinon.stub();
 
         // when
         await component.login(eventStub);
 
         // then
-        sinon.assert.notCalled(component.store.createRecord);
-        sinon.assert.notCalled(login);
+        sinon.assert.notCalled(component.args.onLogin);
       });
     });
 
@@ -211,11 +197,7 @@ describe('Unit | Component | authentication | login-or-register-oidc', function 
       it('should display error', async function () {
         // given
         const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
-        const login = sinon.stub().rejects({ errors: [{ status: '401' }] });
-        component.store = { createRecord: () => ({ login }) };
-        sinon.spy(component.store, 'createRecord');
-        component.args.identityProviderSlug = 'super-idp';
-        component.args.authenticationKey = 'super-key';
+        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '401' }] });
         component.email = 'glace.alo@example.net';
         component.password = 'pix123';
         const eventStub = { preventDefault: sinon.stub() };
@@ -234,11 +216,7 @@ describe('Unit | Component | authentication | login-or-register-oidc', function 
       it('should display error', async function () {
         // given
         const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
-        const login = sinon.stub().rejects({ errors: [{ status: '404' }] });
-        component.store = { createRecord: () => ({ login }) };
-        sinon.spy(component.store, 'createRecord');
-        component.args.identityProviderSlug = 'super-idp';
-        component.args.authenticationKey = 'super-key';
+        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '404' }] });
         component.email = 'glace.alo@example.net';
         component.password = 'pix123';
         const eventStub = { preventDefault: sinon.stub() };
@@ -256,11 +234,7 @@ describe('Unit | Component | authentication | login-or-register-oidc', function 
     it('it should display generic error', async function () {
       // given
       const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
-      const login = sinon.stub().rejects({ errors: [{ status: '500' }] });
-      component.store = { createRecord: () => ({ login }) };
-      sinon.spy(component.store, 'createRecord');
-      component.args.identityProviderSlug = 'super-idp';
-      component.args.authenticationKey = 'super-key';
+      component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '500' }] });
       component.email = 'glace.alo@example.net';
       component.password = 'pix123';
       const eventStub = { preventDefault: sinon.stub() };

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -6,7 +6,7 @@ import setupIntl from '../../../helpers/setup-intl';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-describe('Unit | Component | authentication | login-or-register-oidc', function () {
+describe('Unit | Component | authentication | oidc-reconciliation', function () {
   setupTest();
   setupIntl();
 

--- a/mon-pix/tests/unit/components/authentication/oidc-reconciliation_test.js
+++ b/mon-pix/tests/unit/components/authentication/oidc-reconciliation_test.js
@@ -1,0 +1,165 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+import Service from '@ember/service';
+import EmberObject from '@ember/object';
+
+describe('Unit | Component | authentication | login-or-register-oidc', function () {
+  setupTest();
+
+  describe('#backToLoginOrRegisterForm', function () {
+    it('should redirect back to login or register page', function () {
+      // given
+      const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+      component.args.toggleOidcReconciliation = sinon.stub();
+
+      // when
+      component.backToLoginOrRegisterForm();
+
+      // then
+      sinon.assert.called(component.args.toggleOidcReconciliation);
+    });
+  });
+
+  describe('#shouldShowPoleEmploiAuthenticationMethod', function () {
+    context('when pole emploi authentication method exist', function () {
+      it('should display authentication method', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.authenticationMethods = [EmberObject.create({ identityProvider: 'POLE_EMPLOI' })];
+
+        // then
+        expect(component.shouldShowPoleEmploiAuthenticationMethod).to.be.true;
+      });
+    });
+
+    context('when pole emploi authentication method does not exist', function () {
+      it('should not display authentication method', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.authenticationMethods = [EmberObject.create({ identityProvider: 'OIDC' })];
+
+        // then
+        expect(component.shouldShowPoleEmploiAuthenticationMethod).to.be.false;
+      });
+    });
+  });
+
+  describe('#shouldShowGarAuthenticationMethod', function () {
+    context('when gar authentication method exist', function () {
+      it('should display authentication method', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.authenticationMethods = [EmberObject.create({ identityProvider: 'GAR' })];
+
+        // then
+        expect(component.shouldShowGarAuthenticationMethod).to.be.true;
+      });
+    });
+
+    context('when gar authentication method does not exist', function () {
+      it('should not display authentication method', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.authenticationMethods = [EmberObject.create({ identityProvider: 'OIDC' })];
+
+        // then
+        expect(component.shouldShowGarAuthenticationMethod).to.be.false;
+      });
+    });
+  });
+
+  describe('#shouldShowCnavAuthenticationMethod', function () {
+    context('when cnav authentication method exist', function () {
+      it('should display authentication method', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.authenticationMethods = [EmberObject.create({ identityProvider: 'CNAV' })];
+
+        // then
+        expect(component.shouldShowCnavAuthenticationMethod).to.be.true;
+      });
+    });
+
+    context('when cnav authentication method does not exist', function () {
+      it('should not display authentication method', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.authenticationMethods = [EmberObject.create({ identityProvider: 'OIDC' })];
+
+        // then
+        expect(component.shouldShowCnavAuthenticationMethod).to.be.false;
+      });
+    });
+  });
+
+  describe('#identityProviderOrganizationName', function () {
+    it('should display identity provider organization name', function () {
+      // given & when
+      const oidcPartner = {
+        id: 'oidc-partner',
+        organizationName: 'Partenaire OIDC',
+      };
+      class OidcIdentityProvidersStub extends Service {
+        'oidc-partner' = oidcPartner;
+        list = [oidcPartner];
+      }
+      this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+      const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+      component.args.identityProviderSlug = 'oidc-partner';
+
+      // then
+      expect(component.identityProviderOrganizationName).to.equal('Partenaire OIDC');
+    });
+  });
+
+  describe('#shouldShowEmail', function () {
+    context('when email exist', function () {
+      it('should display email', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.email = 'lloyd.ce@example.net';
+
+        // then
+        expect(component.shouldShowEmail).to.be.true;
+      });
+    });
+
+    context('when email does not exist', function () {
+      it('should not display email', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.email = null;
+
+        // then
+        expect(component.shouldShowEmail).to.be.false;
+      });
+    });
+  });
+
+  describe('#shouldShowUsername', function () {
+    context('when username exist', function () {
+      it('should display username', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.username = 'lloyd.ce1122';
+
+        // then
+        expect(component.shouldShowUsername).to.be.true;
+      });
+    });
+
+    context('when username does not exist', function () {
+      it('should not display username', function () {
+        // given & when
+        const component = createGlimmerComponent('component:authentication/oidc-reconciliation');
+        component.args.username = null;
+
+        // then
+        expect(component.shouldShowUsername).to.be.false;
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import setupIntl from '../../../helpers/setup-intl';
+import sinon from 'sinon';
+
+describe('Unit | Controller | authentication::login-or-register-oidc', function () {
+  setupTest();
+  setupIntl();
+
+  describe('#onLogin', function () {
+    it('should request api for login', async function () {
+      // given
+      const email = 'glace.alo@example.net';
+      const password = 'pix123';
+      const identityProvider = 'CNAV';
+      const authenticationKey = '1234567azerty';
+      const controller = this.owner.lookup('controller:authentication/login-or-register-oidc');
+      const login = sinon.stub();
+      controller.store = { createRecord: () => ({ login }) };
+      controller.authenticationKey = authenticationKey;
+      controller.identityProviderSlug = 'cnav';
+      sinon.spy(controller.store, 'createRecord');
+
+      // when
+      await controller.onLogin({ enteredEmail: email, enteredPassword: password });
+
+      // then
+      sinon.assert.calledWith(controller.store.createRecord, 'user-oidc-authentication-request', {
+        password,
+        email,
+        authenticationKey,
+        identityProvider,
+      });
+      sinon.assert.calledOnce(login);
+    });
+
+    it('should redirect to oidc reconciliation page', async function () {
+      // given
+      const email = 'glace.alo@example.net';
+      const password = 'pix123';
+      const controller = this.owner.lookup('controller:authentication/login-or-register-oidc');
+      const login = sinon.stub();
+      controller.store = { createRecord: () => ({ login }) };
+      controller.email = email;
+      controller.password = password;
+      controller.showOidcReconciliation = false;
+      sinon.spy(controller.store, 'createRecord');
+
+      // when
+      await controller.onLogin({ enteredEmail: email, enteredPassword: password });
+
+      // then
+      expect(controller.showOidcReconciliation).to.equal(true);
+    });
+  });
+});

--- a/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
@@ -3,23 +3,40 @@ import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import setupIntl from '../../../helpers/setup-intl';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
-describe('Unit | Controller | authentication::login-or-register-oidc', function () {
+describe('Unit | Controller | authentication | login-or-register-oidc', function () {
   setupTest();
   setupIntl();
 
   describe('#onLogin', function () {
     it('should request api for login', async function () {
       // given
+      const oidcPartner = {
+        id: 'oidc-partner',
+        code: 'OIDC_PARTNER',
+      };
+      class OidcIdentityProvidersStub extends Service {
+        'oidc-partner' = oidcPartner;
+        list = [oidcPartner];
+      }
+      this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+
       const email = 'glace.alo@example.net';
       const password = 'pix123';
-      const identityProvider = 'CNAV';
+      const identityProvider = 'OIDC_PARTNER';
       const authenticationKey = '1234567azerty';
       const controller = this.owner.lookup('controller:authentication/login-or-register-oidc');
-      const login = sinon.stub();
+      const login = sinon.stub().resolves({
+        email,
+        username: 'glace.alo345',
+        fullNameFromExternalIdentityProvider: 'Glace Idp',
+        fullNameFromPix: 'Glace Alo',
+        authenticationMethods: [{ identityProvider: 'OIDC_PARTNER' }],
+      });
       controller.store = { createRecord: () => ({ login }) };
       controller.authenticationKey = authenticationKey;
-      controller.identityProviderSlug = 'cnav';
+      controller.identityProviderSlug = 'oidc-partner';
       sinon.spy(controller.store, 'createRecord');
 
       // when
@@ -33,6 +50,11 @@ describe('Unit | Controller | authentication::login-or-register-oidc', function 
         identityProvider,
       });
       sinon.assert.calledOnce(login);
+      expect(controller.email).to.equal('glace.alo@example.net');
+      expect(controller.username).to.equal('glace.alo345');
+      expect(controller.fullNameFromExternalIdentityProvider).to.equal('Glace Idp');
+      expect(controller.fullNameFromPix).to.equal('Glace Alo');
+      expect(controller.authenticationMethods).to.deep.equal([{ identityProvider: 'OIDC_PARTNER' }]);
     });
 
     it('should redirect to oidc reconciliation page', async function () {
@@ -40,7 +62,13 @@ describe('Unit | Controller | authentication::login-or-register-oidc', function 
       const email = 'glace.alo@example.net';
       const password = 'pix123';
       const controller = this.owner.lookup('controller:authentication/login-or-register-oidc');
-      const login = sinon.stub();
+      const login = sinon.stub().resolves({
+        email,
+        username: 'glace.alo345',
+        fullNameFromExternalIdentityProvider: 'Glace Idp',
+        fullNameFromPix: 'Glace Alo',
+        authenticationMethods: [{ identityProvider: 'oidc' }],
+      });
       controller.store = { createRecord: () => ({ login }) };
       controller.email = email;
       controller.password = password;

--- a/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
@@ -59,6 +59,16 @@ describe('Unit | Controller | authentication | login-or-register-oidc', function
 
     it('should redirect to oidc reconciliation page', async function () {
       // given
+      const oidcPartner = {
+        id: 'oidc-partner',
+        code: 'OIDC_PARTNER',
+      };
+      class OidcIdentityProvidersStub extends Service {
+        'oidc-partner' = oidcPartner;
+        list = [oidcPartner];
+      }
+      this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+
       const email = 'glace.alo@example.net';
       const password = 'pix123';
       const controller = this.owner.lookup('controller:authentication/login-or-register-oidc');
@@ -73,6 +83,7 @@ describe('Unit | Controller | authentication | login-or-register-oidc', function
       controller.email = email;
       controller.password = password;
       controller.showOidcReconciliation = false;
+      controller.identityProviderSlug = 'oidc-partner';
       sinon.spy(controller.store, 'createRecord');
 
       // when

--- a/mon-pix/tests/unit/models/user-oidc-authentication-request_test.js
+++ b/mon-pix/tests/unit/models/user-oidc-authentication-request_test.js
@@ -33,7 +33,7 @@ describe('Unit | Model | user-oidc-authentication-request', function () {
       const result = await userOidcAuthenticationRequest.login();
 
       // then
-      const url = `${ENV.APP.API_HOST}/api/oidc/token-reconciliation`;
+      const url = `${ENV.APP.API_HOST}/api/oidc/user/check-reconciliation`;
       const payload = {
         data: {
           data: {

--- a/mon-pix/tests/unit/models/user-oidc-authentication-request_test.js
+++ b/mon-pix/tests/unit/models/user-oidc-authentication-request_test.js
@@ -16,8 +16,11 @@ describe('Unit | Model | user-oidc-authentication-request', function () {
       adapter.ajax.resolves({
         data: {
           attributes: {
-            accessToken: 'accessToken',
-            logoutUrlUuid: 'url',
+            'full-name-from-pix': 'Loyd Pix',
+            'full-name-from-external-identity-provider': 'Loyd Cé',
+            username: 'loyd.ce123',
+            email: 'loyd.ce@example.net',
+            'authentication-methods': [{ identityProvider: 'oidc' }],
           },
         },
       });
@@ -48,10 +51,11 @@ describe('Unit | Model | user-oidc-authentication-request', function () {
         },
       };
       sinon.assert.calledWith(adapter.ajax, url, 'POST', payload);
-      expect(result).to.deep.equal({
-        accessToken: 'accessToken',
-        logoutUrlUuid: 'url',
-      });
+      expect(result.email).to.deep.equal('loyd.ce@example.net');
+      expect(result.fullNameFromPix).to.deep.equal('Loyd Pix');
+      expect(result.fullNameFromExternalIdentityProvider).to.deep.equal('Loyd Cé');
+      expect(result.username).to.deep.equal('loyd.ce123');
+      expect(result.authenticationMethods).to.deep.equal([{ identityProvider: 'oidc' }]);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -33,30 +33,15 @@ describe('Unit | Route | login-oidc', function () {
       const nonce = '555c86fe-ed0a-4a80-80f3-45b1f7c2df8c';
 
       beforeEach(function () {
-        sinon.stub(fetch, 'default').resolves({
-          json: sinon.stub().resolves({
-            redirectTarget: `https://oidc/connexion`,
-            state,
-            nonce,
-          }),
-        });
         const oidcPartner = {
           id: 'oidc-partner',
           code: 'OIDC_PARTNER',
-          organizationName: 'Partenaire OIDC',
-          hasLogoutUrl: false,
-          source: 'oidc-externe',
         };
         class OidcIdentityProvidersStub extends Service {
           'oidc-partner' = oidcPartner;
           list = [oidcPartner];
-          load = sinon.stub().resolves();
         }
         this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
-      });
-
-      afterEach(function () {
-        sinon.restore();
       });
 
       context('when identity provider is not supported', function () {
@@ -114,6 +99,13 @@ describe('Unit | Route | login-oidc', function () {
 
       it('should direct user to identity provider login page and set state and nonce', async function () {
         // given
+        sinon.stub(fetch, 'default').resolves({
+          json: sinon.stub().resolves({
+            redirectTarget: `https://oidc/connexion`,
+            state,
+            nonce,
+          }),
+        });
         const sessionStub = Service.create({
           attemptedTransition: { intent: { url: '/campagnes/PIXOIDC01/acces' } },
           authenticate: sinon.stub().resolves(),
@@ -129,6 +121,7 @@ describe('Unit | Route | login-oidc', function () {
         // then
         sinon.assert.calledWithMatch(route.location.replace, 'https://oidc/connexion');
         expect(sessionStub.data).to.deep.equal({ nextURL: '/campagnes/PIXOIDC01/acces', state, nonce });
+        sinon.restore();
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -952,6 +952,20 @@
         "login-unauthorized-error": "There was an error in the email address or password entered."
       }
     },
+    "oidc-reconciliation": {
+      "title": "Attention",
+      "sub-title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
+      "information": "L'évaluation des compétences étant personnalisée, votre compte doit rester strictement personnel",
+      "current-authentication-methods": "Mes méthodes de connexion actuelles :",
+      "authentication-method-to-add": "Méthode de connexion ajoutée :",
+      "external-connection": "Connexion externe",
+      "external-connection-via": "Connexion via",
+      "switch-account": "Changer de compte",
+      "confirm": "Continuer",
+      "return": "Retour",
+      "email": "Adresse e-mail",
+      "username": "Identifiant"
+    },
     "not-connected": {
       "title": "Logged out",
       "message": "You've been logged out.'<br>'Thanks! See you soon"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -952,6 +952,20 @@
         "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects."
       }
     },
+    "oidc-reconciliation": {
+      "title": "Attention !",
+      "sub-title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
+      "information": "L'évaluation des compétences étant personnalisée, votre compte doit rester strictement personnel",
+      "current-authentication-methods": "Mes méthodes de connexion actuelles :",
+        "authentication-method-to-add": "Connexion ajoutée :",
+      "external-connection": "Connexion externe",
+      "external-connection-via": "Connexion via",
+      "switch-account": "Changer de compte",
+      "return": "Retour",
+      "confirm": "Continuer",
+      "email": "Adresse e-mail",
+      "username": "Identifiant"
+    },
     "not-connected": {
       "title": "Déconnecté",
       "message": "Vous êtes bien déconnecté(e).'<br>'Merci, à bientôt."


### PR DESCRIPTION
## :unicorn: Problème
L'actuel scénario de réconciliation de compte n'est plus pertinent. Il permet entre autres de mauvaises réconciliation, comme un élève sco connecté sur Pix dont le parent va se connecter via Pôle Emploi en commençant une campagne.
Les deux comptes sont alors réconcilés.

Dans le nouveau scénario, nous avons désormais une double mire permettant à l'utilisateur de se connecter à un compte Pix qu'il possède déjà. 
La page de réconciliation a été créé dans un précédent ticket mais il manquait des informations de l'api pour la remplir.

## :robot: Solution
API : retourner le nom complet de l'utilisateur provenant de la BDD, le nom complet fournit par le partenaire et les méthodes de connexion.

FRONT : Créer les éléments de la page de réconciliation

## :rainbow: Remarques
API : Le nom de la route a été changé pour /user/check-reconciliation

FRONT: l'action appelant l'API a été déplacé dans le controller.

## :100: Pour tester
ℹ️ Mettre le feature toggle à true en local

Aller sur Pix App
Aller sur /connexion/cnav
Accéder à la double mire oidc
Sur la partie droite, remplir email et mot de passe d'un utilisateur existant (sco.admin)
Constater que l'on est redirigé vers la page de confirmation de réconciliation
Constater que l'on dispose de toutes les informations : 
- le nom et prénom de l'utilisateur en BDD
- le nom et prénom de l'utilisateur venant du partenaire
- les méthodes de connexion actuelles
- La méthode que l'on va ajouter

Tester les deux boutons : Retour et Changer de compte, qui ramènerons  l'utilisateur à la page de double mire.

⚠️ Attention le bouton confirmer ne fait rien, ce sera implémenté dans une prochaine PR
