### PR TITLE
[TECH] Ajout de script magiques pour aider à la conversion d'un fichier JS en Typescript

### DIFF
--- a/api/lib/domain/models/AdminMember.ts
+++ b/api/lib/domain/models/AdminMember.ts
@@ -1,0 +1,75 @@
+const Joi = require('joi').extend(require('@joi/date'));
+const { validateEntity } = require('../validators/entity-validator');
+const isNil = require('lodash/isNil');
+const { ROLES } = require('../constants').PIX_ADMIN;
+
+export type AdminMemberOptionsType = {
+  id: unknown;
+  userId: unknown;
+  firstName: unknown;
+  lastName: unknown;
+  email: unknown;
+  role: unknown;
+  createdAt: unknown;
+  updatedAt: unknown;
+  disabledAt: unknown;
+}
+
+export class AdminMember {
+  id;
+  userId;
+  firstName;
+  lastName;
+  email;
+  role;
+  createdAt;
+  updatedAt;
+  disabledAt;
+
+  constructor({ id, userId, firstName, lastName, email, role, createdAt, updatedAt, disabledAt }: AdminMemberOptionsType) {
+    this.id = id;
+    this.userId = userId;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.role = role;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.disabledAt = disabledAt;
+
+    validateEntity(
+      Joi.object({
+        id: Joi.number().integer().required(),
+        userId: Joi.number().optional(),
+        firstName: Joi.string().optional(),
+        lastName: Joi.string().optional(),
+        email: Joi.string().email().optional(),
+        role: Joi.string().valid(ROLES.SUPER_ADMIN, ROLES.SUPPORT, ROLES.METIER, ROLES.CERTIF).required(),
+        createdAt: Joi.date().allow(null).optional(),
+        updatedAt: Joi.date().allow(null).optional(),
+        disabledAt: Joi.date().allow(null).optional(),
+      }),
+      this
+    );
+  }
+
+  get hasAccessToAdminScope() {
+    return this.role in ROLES && isNil(this.disabledAt);
+  }
+
+  get isSuperAdmin() {
+    return this.role === ROLES.SUPER_ADMIN && isNil(this.disabledAt);
+  }
+
+  get isCertif() {
+    return this.role === ROLES.CERTIF && isNil(this.disabledAt);
+  }
+
+  get isMetier() {
+    return this.role === ROLES.METIER && isNil(this.disabledAt);
+  }
+
+  get isSupport() {
+    return this.role === ROLES.SUPPORT && isNil(this.disabledAt);
+  }
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -126,6 +126,7 @@
         "ts-migrate": "^0.1.30",
         "ts-migrate-plugins": "^0.1.30",
         "ts-migrate-server": "^0.1.29",
+        "ts-morph": "^16.0.0",
         "ts-node-dev": "^2.0.0"
       },
       "engines": {
@@ -6273,6 +6274,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true
     },
     "node_modules/code-excerpt": {
       "version": "3.0.0",
@@ -16360,6 +16367,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/ts-morph": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
+      "dev": true,
+      "dependencies": {
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
+      }
+    },
+    "node_modules/ts-morph/node_modules/@ts-morph/common": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.11",
+        "minimatch": "^5.1.0",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/ts-morph/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/ts-morph/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-morph/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -22177,6 +22239,12 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true
     },
     "code-excerpt": {
       "version": "3.0.0",
@@ -29855,6 +29923,54 @@
         "@ts-morph/bootstrap": "^0.16.0",
         "pretty-ms": "^7.0.1",
         "updatable-log": "^0.2.0"
+      }
+    },
+    "ts-morph": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
+      "dev": true,
+      "requires": {
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
+      },
+      "dependencies": {
+        "@ts-morph/common": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+          "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
+          "dev": true,
+          "requires": {
+            "fast-glob": "^3.2.11",
+            "minimatch": "^5.1.0",
+            "mkdirp": "^1.0.4",
+            "path-browserify": "^1.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
       }
     },
     "ts-node": {

--- a/api/package.json
+++ b/api/package.json
@@ -132,6 +132,7 @@
     "ts-migrate": "^0.1.30",
     "ts-migrate-plugins": "^0.1.30",
     "ts-migrate-server": "^0.1.29",
+    "ts-morph": "^16.0.0",
     "ts-node-dev": "^2.0.0"
   },
   "overrides": {

--- a/api/scripts/typescript/migrate-model-files-to-typescript.ts
+++ b/api/scripts/typescript/migrate-model-files-to-typescript.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S ts-node --files
+
+import * as path from "path";
+import {
+  ClassExpression,
+  ConstructorDeclaration,
+  ObjectBindingPattern,
+  ParameterDeclaration,
+  Project,
+  SourceFile,
+  Statement,
+  StructureKind,
+  SyntaxKind, TypeLiteralNode
+} from "ts-morph";
+
+async function main() {
+  console.log('Starting magic script to transform model file into sexy usecase file');
+
+  try {
+    const filePath = process.argv[2];
+    console.log({filePath});
+
+    console.log('Reading file... ');
+
+    const project = new Project({
+      tsConfigFilePath: path.join(__dirname, '..', '..', 'tsconfig.json'),
+    });
+    const sourceFile: SourceFile = project.addSourceFileAtPath(filePath);
+    const statements: Statement[] = sourceFile.getStatements();
+    const statement = statements.find(statement => statement.getKind() === SyntaxKind.ExpressionStatement);
+    const classExpression = statement?.getDescendantsOfKind(SyntaxKind.ClassExpression)[0] as ClassExpression;
+    const classExpressionConstructor = classExpression.getMembers().find(member => member.getKind() === SyntaxKind.Constructor) as ConstructorDeclaration;
+    const constructorParameter = classExpressionConstructor.getParameters()[0] as ParameterDeclaration;
+    const parameters = constructorParameter.getFirstDescendantByKind(SyntaxKind.ObjectBindingPattern) as ObjectBindingPattern;
+    const elements = parameters.getElements();
+
+    sourceFile.addTypeAlias({
+      type: `{\n${elements.map(element => `${element.getName()}: unknown;`).join('\n')}\n}`,
+      name: `${classExpression.getName()}OptionsType`,
+      isExported: true,
+    });
+
+    await project.save();
+
+    console.log('\nDone.');
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/api/scripts/typescript/migrate-repository-file-to-typescript.js
+++ b/api/scripts/typescript/migrate-repository-file-to-typescript.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config();
+const fs = require('fs');
+const { access, readFile, writeFile } = require('fs').promises;
+const { NotFoundError } = require('../../lib/domain/errors');
+
+async function _readFile({ filePath }) {
+  try {
+    await access(filePath, fs.constants.F_OK);
+  } catch (err) {
+    throw new NotFoundError(`File ${filePath} not found!`);
+  }
+
+  return await readFile(filePath, 'utf8');
+}
+
+function _insertAt(array, index, ...elementsArray) {
+  return array.splice(index, 0, ...elementsArray);
+}
+
+function _getRepositoryNameInCamelCaseWithUppercase({ filePath }) {
+  const filePathModified = filePath
+    .replace(/.*\//, '')
+    .replace(/-./g, (letter) => letter[1].toUpperCase())
+    .replace('.js', '')
+    .replace('.ts', '');
+  return filePathModified[0].toUpperCase() + filePathModified.slice(1);
+}
+
+function _insertInterface({ fileContent, repositoryName }) {
+  const _getInterfaceToInsertInString = ({ fileContentArray }) => {
+    const repositoryFunctionsSignatures = [];
+    fileContentArray.forEach((line, index) => {
+      if (isMethodStart(line)) {
+        repositoryFunctionsSignatures.push(getSignatureName(line, fileContentArray, index));
+      }
+    });
+
+    return `export interface ${repositoryName}Interface {\n\t` + repositoryFunctionsSignatures.join('\n\t') + '\n}\n';
+  };
+
+  const fileContentArray = fileContent.split('\n');
+  const interfaceToInsert = _getInterfaceToInsertInString({ fileContentArray });
+  const lineNumberOfModuleExport = fileContentArray.indexOf('module.exports = {');
+  _insertAt(fileContentArray, lineNumberOfModuleExport, interfaceToInsert);
+  return fileContentArray;
+}
+
+function isMethodStart(line) {
+  return line.includes('async');
+}
+
+function getSignatureName(line, fileContentArray, index) {
+  let resultLine = line;
+  if (!isACompleteMethodSignature(resultLine)) {
+    for (let i = index + 1; i < fileContentArray.length; i++) {
+      resultLine = resultLine + ' ' + fileContentArray[i];
+      if (isACompleteMethodSignature(resultLine)) {
+        break;
+      }
+    }
+    resultLine = resultLine.replaceAll(/ /g, '');
+  }
+  resultLine = resultLine.replace('async', '').trim().replace(/{$/, ': Promise<?>;');
+  if (!resultLine.includes('()')) {
+    resultLine = resultLine.replaceAll(/,/g, ': ?,').replace(/\)/, ': ?)');
+  }
+  return resultLine;
+}
+
+function isACompleteMethodSignature(line) {
+  return /^[ \t]{2}(async )[a-z]+(.*){$/.test(line);
+}
+
+function _transformRepositoryToAClass({ fileContent, repositoryName }) {
+  const indexOfModuleExport = fileContent.indexOf('module.exports = {');
+  fileContent[indexOfModuleExport] = `export class ${repositoryName} implements ${repositoryName}Interface {`;
+  fileContent.push(`\nexport const ${repositoryName} = new ${repositoryName}();`);
+  return fileContent;
+}
+
+function _convertFileContentToString(fileContentWithInterface) {
+  return fileContentWithInterface.join('\n');
+}
+
+async function _getNewFileContent({ filePath, currentfileContent }) {
+  const repositoryName = _getRepositoryNameInCamelCaseWithUppercase({ filePath });
+  const fileContentWithInterface = _insertInterface({ fileContent: currentfileContent, repositoryName });
+  const fileContentWithInterfaceAndClass = _transformRepositoryToAClass({
+    fileContent: fileContentWithInterface,
+    repositoryName,
+  });
+
+  const result = _convertFileContentToString(fileContentWithInterfaceAndClass);
+  return result;
+}
+
+async function _writeNewFileContent({ filePath, newFileContent }) {
+  try {
+    await writeFile(filePath, newFileContent);
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+async function main() {
+  console.log('Starting magic script to transform repository file into sexy repository file');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading file... ');
+    const currentfileContent = await _readFile({ filePath });
+    console.log('Constructing new file... ');
+    const newFileContent = await _getNewFileContent({ filePath, currentfileContent });
+    console.log('Saving new file content...');
+    await _writeNewFileContent({ filePath, newFileContent });
+
+    console.log('\nDone.');
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}

--- a/api/scripts/typescript/migrate-usecase-file-to-typescript.js
+++ b/api/scripts/typescript/migrate-usecase-file-to-typescript.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config();
+const fs = require('fs');
+const { isGeneratorFunction } = require('util/types');
+const { access, readFile, writeFile, rename } = require('fs').promises;
+const { NotFoundError } = require('../../lib/domain/errors');
+
+async function _readFile({ filePath }) {
+  try {
+    await access(filePath, fs.constants.F_OK);
+  } catch (err) {
+    throw new NotFoundError(`File ${filePath} not found!`);
+  }
+
+  return await readFile(filePath, 'utf8');
+}
+
+function _insertAt(array, index, ...elementsArray) {
+  return array.splice(index, 0, ...elementsArray);
+}
+
+function _getUsecaseNameInCamelCaseWithUppercase({ filePath }) {
+  const filePathModified = filePath
+    .replace(/.*\//, '')
+    .replace(/-./g, (letter) => letter[1].toUpperCase())
+    .replace('.js', '')
+    .replace('.ts', '');
+  return filePathModified[0].toUpperCase() + filePathModified.slice(1);
+}
+
+function _transformToKebabCase(string) {
+  const re = /[\W_]+|(?<=[a-z0-9])(?=[A-Z])/g;
+  return string.replace(re, '-').toLowerCase();
+}
+
+function _getRepositoryNames({ fileContent }) {
+  const matchingRepositoryNames = [];
+  fileContent.forEach((line, index) => {
+    const isLineModuleExport = /module\.exports = /.test(line);
+    if (isLineModuleExport) {
+      const moduleExportLine = line;
+
+      const repositoryNameRegex = /[a-zA-Z]+Repository/;
+      const endOfFunctionSignature = /}\) {/;
+      const repositoryNamesOnModuleExportLine = moduleExportLine.match(repositoryNameRegex);
+      if (repositoryNamesOnModuleExportLine) {
+        matchingRepositoryNames.push(...repositoryNamesOnModuleExportLine);
+      }
+
+      const isFunctionSignatureWrittenInMoreThanOneLine = /\({$/.test(line);
+      if (isFunctionSignatureWrittenInMoreThanOneLine) {
+        let indexOfNextLine = index + 1;
+        let nextLine = fileContent[indexOfNextLine];
+        let isNextLineTheEndOfFunctionSignature = endOfFunctionSignature.test(nextLine);
+        while (!isNextLineTheEndOfFunctionSignature) {
+          if (repositoryNameRegex.test(nextLine)) {
+            matchingRepositoryNames.push(nextLine.replace(',', '').trim());
+          }
+
+          indexOfNextLine += 1;
+          nextLine = fileContent[indexOfNextLine];
+          isNextLineTheEndOfFunctionSignature = endOfFunctionSignature.test(nextLine);
+        }
+      }
+    }
+  });
+  return matchingRepositoryNames;
+}
+
+function _getParametersNames({ fileContent }) {
+  const matchingParametersNames = [];
+  fileContent.forEach((line, index) => {
+    const isLineUsecaseSignature = /module\.exports = /.test(line);
+    if (isLineUsecaseSignature) {
+      const moduleExportLine = line;
+
+      const allParametersInString = moduleExportLine.match(/\({ .* }\)/g)?.toString();
+      if (allParametersInString) {
+        const allParameters = allParametersInString.replace('({', '').replace('})', '').trim().split(',');
+        const parametersWithoutRepositories = allParameters.filter((parameter) => {
+          const parameterIsARepository = /Repository/.test(parameter);
+          return !parameterIsARepository;
+        });
+        if (parametersWithoutRepositories) {
+          matchingParametersNames.push(...parametersWithoutRepositories);
+        }
+      }
+
+      const endOfFunctionSignature = /}\) {/;
+      const isFunctionSignatureWrittenInMoreThanOneLine = /\({$/.test(line);
+      if (isFunctionSignatureWrittenInMoreThanOneLine) {
+        let indexOfNextLine = index + 1;
+        let nextLine = fileContent[indexOfNextLine];
+        let isNextLineTheEndOfFunctionSignature = endOfFunctionSignature.test(nextLine);
+        while (!isNextLineTheEndOfFunctionSignature) {
+          const isLineARepository = /Repository/.test(nextLine);
+          const isLineAParameter = /[a-zA-Z]+/.test(nextLine);
+          if (!isLineARepository && isLineAParameter) {
+            matchingParametersNames.push(nextLine.replace(',', '').trim());
+          }
+
+          indexOfNextLine += 1;
+          nextLine = fileContent[indexOfNextLine];
+          isNextLineTheEndOfFunctionSignature = endOfFunctionSignature.test(nextLine);
+        }
+      }
+    }
+  });
+  return matchingParametersNames;
+}
+
+function _transformRepositoryNameIntoInterfaceName(repositoryName) {
+  return repositoryName[0].toUpperCase() + repositoryName.slice(1) + 'Interface';
+}
+
+function _insertRepositoryInterfacesImport({ fileContent, repositoryNames }) {
+  const repositoyInterfacesImports = repositoryNames.map((repositoryName) => {
+    return (
+      `import { ${_transformRepositoryNameIntoInterfaceName(repositoryName)} } from ` +
+      `'../../infrastructure/repositories/${_transformToKebabCase(repositoryName)}';`
+    );
+  });
+  repositoyInterfacesImports[repositoyInterfacesImports.length - 1] += '\n';
+  _insertAt(fileContent, 0, ...repositoyInterfacesImports);
+  return fileContent;
+}
+
+function _transformRequireToImport({ fileContent }) {
+  return fileContent.map((line) => {
+    const isLineARequire = /= require\(/.test(line);
+    if (isLineARequire) {
+      const newImportLine = line
+        .replace('const {', 'import {') // transform import with {} destructuration
+        .replace('} = require(', '} from ')
+        .replace('const', 'import {') // transform import without {} destructuration
+        .replace(' = require(', ' } from ')
+        .replace(')', '');
+      return newImportLine;
+    } else {
+      return line;
+    }
+  });
+}
+
+function _transformModuleExportIntoClass({ fileContent, usecaseName, repositoryNames, usecaseParametersNames }) {
+  const repositoriesInjection = repositoryNames
+    .map(
+      (repositoryName) =>
+        `private readonly ${repositoryName}: ${_transformRepositoryNameIntoInterfaceName(repositoryName)}`
+    )
+    .join(',');
+  const parametersList = usecaseParametersNames.join(': ?, ') + ': ?';
+  const beginningOfTheClass = [
+    `export class ${usecaseName} {`,
+    `\tconstructor(${repositoriesInjection}) {}\n`,
+    `\texecute(${parametersList}): Promise<?> {`,
+  ];
+
+  let newFileContent = [];
+
+  const _replaceModuleExportByClass = ({ fileContent, beginningOfTheClass }) => {
+    let isLineTheUsecaseFunctionSignature = false;
+    let isBeginningOfTheClassInserted = false;
+    fileContent.forEach((line) => {
+      const isLineModuleExport = /module\.exports = /.test(line);
+      const shouldChangeThisLine = isLineModuleExport || isLineTheUsecaseFunctionSignature;
+      if (shouldChangeThisLine) {
+        isLineTheUsecaseFunctionSignature = true;
+        const isLineTheEndOfFunctionSignature = /}\)/.test(line);
+        if (isLineTheEndOfFunctionSignature) {
+          isLineTheUsecaseFunctionSignature = false;
+          isBeginningOfTheClassInserted = true;
+          newFileContent.push(...beginningOfTheClass);
+        }
+      } else {
+        if(isBeginningOfTheClassInserted) {
+          const isLineContainingRepository = /Repository/.test(line);
+          if(isLineContainingRepository) {
+            const isLineJsonParameters = /Repository,/.test(line);
+            if(isLineJsonParameters) {
+              line = line.replace(/([a-zA-Z]+Repository)/, '$1: this.$1');
+            } else {
+              line = line.replace(/([a-zA-Z]+Repository)/, 'this.$1');
+            }
+          }
+        }
+        newFileContent.push(line);
+      }
+    });
+  };
+  const _removeSemiColons = ({ fileContent }) => {
+    return fileContent.map((line) => {
+      return line.replace('};', '}');
+    })
+  };
+
+  _replaceModuleExportByClass({ fileContent, beginningOfTheClass });
+  newFileContent = _removeSemiColons({ fileContent: newFileContent });
+  newFileContent.push('}');
+
+  return newFileContent;
+}
+
+function _convertFileContentToString(fileContentWithInterface) {
+  return fileContentWithInterface.join('\n');
+}
+
+async function _getNewFileContent({ filePath, currentFileContent }) {
+  const fileContentArray = currentFileContent.split('\n');
+
+  const usecaseName = _getUsecaseNameInCamelCaseWithUppercase({ filePath });
+  const repositoryNames = _getRepositoryNames({ fileContent: fileContentArray });
+  const usecaseParametersNames = _getParametersNames({ fileContent: fileContentArray });
+
+  const newFileContentWithInterfacesImport = _insertRepositoryInterfacesImport({
+    fileContent: fileContentArray,
+    repositoryNames,
+  });
+  const newFileContentWithImports = _transformRequireToImport({ fileContent: newFileContentWithInterfacesImport });
+  const newFileContentWithImportsAndExports = _transformModuleExportIntoClass({
+    fileContent: newFileContentWithImports,
+    usecaseName,
+    repositoryNames,
+    usecaseParametersNames,
+  });
+
+  return _convertFileContentToString(newFileContentWithImportsAndExports);
+}
+
+async function _writeNewFileContent({ filePath, newFileContent }) {
+  try {
+    await writeFile(filePath, newFileContent);
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+async function _renameJsFileToTs({ filePath }) {
+  try {
+    await rename(filePath, filePath.replace('.js', '.ts'));
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+async function main() {
+  console.log('Starting magic script to transform usecase file into sexy usecase file');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading file... ');
+    const currentFileContent = await _readFile({ filePath });
+    console.log('Constructing new file... ');
+    const newFileContent = await _getNewFileContent({ filePath, currentFileContent });
+    console.log('Saving new file content...');
+    await _writeNewFileContent({ filePath, newFileContent });
+    console.log('Renaming file js to ts...');
+    await _renameJsFileToTs({ filePath });
+
+    console.log('\nDone.');
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}


### PR DESCRIPTION
## :unicorn: Problème
Renommer à la main un fichier `.ts` en `.js` et ouvrir la PR de migration de Typescript pour savoir comment s'y prendre ... c'est long et on a souvent la flemme.

## :robot: Solution
Ajouter des scripts magiques pour aider à convertir un fichier .js en fichier .ts.


## 🌈 Remarques
Ces scripts sont là pour aider, faciliter la tâche mais ils requirent des modifications une fois le fichier transformé !
Vous devrez remplir les `?` , passer un coup de linter et évidemment relire le fichier en entier pour vérifier que tout s'est bien déroulé. 

**/!\ Ces scripts sont un peu simplet et risquent de ne pas fonctionner sur un fichier qui a une structure "classique". Utilisez les à vos risques et périls**

TODO :
- [ ] utiliser un parser JS (ex: https://ts-morph.com/, pour tester en ligne: https://astexplorer.net/#/gist/956e939ffa7672bf370285cec8e46a8b/latest) 

Lancer le script TS : `npx ts-node scripts/typescript/migrate-model-files-to-typescript.ts lib/domain/models/AdminMember.js`

## :100: Pour convertir vos fidèles 
**A partir du dossier API :** 
- `cd api`

**Lancer le script sur un usecase :** 
- `./scripts/typescript/migrate-usecase-file-to-typescript.js lib/domain/usecases/<fichier-à-convertir>.js`

**Lancer le script sur un repository :** 
- `./scripts/typescript/migrate-repository-file-to-typescript.js lib/infrastructure/repositories/<fichier-à-convertir>.js`

![image](https://user-images.githubusercontent.com/38167520/186945595-b26a0431-3c57-4c12-82fa-f3a19d46da2a.png)
