### PR TITLE
[FEATURE] Permettre l'import de candidats avec un nom de commune contenant Saint/Sainte (PIX-5303)

### DIFF
--- a/api/tests/unit/scripts/import-certification-cpf-cities_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-cities_test.js
@@ -13,25 +13,25 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
         const csvData = [
           {
             code_commune_insee: '30288',
-            nom_de_la_commune: 'ST NAZAIRE',
+            nom_de_la_commune: 'NAZAIRE',
             code_postal: '30200',
             ligne_5: null,
           },
           {
             code_commune_insee: '44184',
-            nom_de_la_commune: 'ST NAZAIRE',
+            nom_de_la_commune: 'NAZAIRE',
             code_postal: '44600',
             ligne_5: 'ST MARC SUR MER',
           },
           {
             code_commune_insee: '66186',
-            nom_de_la_commune: 'ST NAZAIRE',
+            nom_de_la_commune: 'NAZAIRE',
             code_postal: '66570',
             ligne_5: null,
           },
           {
             code_commune_insee: '44184',
-            nom_de_la_commune: 'ST NAZAIRE',
+            nom_de_la_commune: 'NAZAIRE',
             code_postal: '44600',
             ligne_5: null,
           },
@@ -45,13 +45,13 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
           {
             INSEECode: '30288',
             isActualName: true,
-            name: 'ST NAZAIRE',
+            name: 'NAZAIRE',
             postalCode: '30200',
           },
           {
             INSEECode: '44184',
             isActualName: true,
-            name: 'ST NAZAIRE',
+            name: 'NAZAIRE',
             postalCode: '44600',
           },
           {
@@ -63,7 +63,7 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
           {
             INSEECode: '66186',
             isActualName: true,
-            name: 'ST NAZAIRE',
+            name: 'NAZAIRE',
             postalCode: '66570',
           },
         ]);

--- a/api/tests/unit/scripts/import-certification-cpf-cities_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-cities_test.js
@@ -95,5 +95,46 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
         ]);
       });
     });
+
+    describe('#when there is a word to replace in the city name', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        { cityName: 'STE CECILE', expectedCityName: 'SAINTE CECILE' },
+        { cityName: 'ST NAZAIRE', expectedCityName: 'SAINT NAZAIRE' },
+        { cityName: 'NAZAIRE STE CECILE', expectedCityName: 'NAZAIRE SAINTE CECILE' },
+        { cityName: 'CECILE ST NAZAIRE', expectedCityName: 'CECILE SAINT NAZAIRE' },
+      ].forEach(({ cityName, expectedCityName }) => {
+        it('should return 2 lines with both long and short city names', function () {
+          // given
+          const csvData = [
+            {
+              code_commune_insee: '50453',
+              nom_de_la_commune: cityName,
+              code_postal: '50800',
+              ligne_5: null,
+            },
+          ];
+
+          // when
+          const cities = buildCities({ csvData });
+
+          // then
+          expect(cities).to.deep.equal([
+            {
+              INSEECode: '50453',
+              isActualName: true,
+              name: cityName,
+              postalCode: '50800',
+            },
+            {
+              INSEECode: '50453',
+              isActualName: false,
+              name: expectedCityName,
+              postalCode: '50800',
+            },
+          ]);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, lorsqu’un utilisateur Pix certif importe une liste de candidat avec un nom de commune contenant Saint/Sainte, il obtient un message d’erreur si celui-ci n’est pas écrit spécifiquement St ou Ste, ce qui crée de la frustration.

## :robot: Solution
Autoriser pour tous les noms de commune contenant Saint/Sainte les 2 écritures : 

Ste ou Sainte

St ou Saint

## :100: Pour tester
- Lancer le script avec le fichier 'laposte_hexasma.csv' (Attention au casing des colonnes)
- Se connecter à pix-certif
- Inscrire des candidats à 'St Nazaire' et 'Saint Nazaire'
- Constater que les inscriptions se font correctement