### PR TITLE
[TECH] Remplissage de la nouvelle colonne `isCertifiable` au partage de profil (PIX-5478).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -22,6 +22,7 @@ module.exports = function buildCampaignParticipation({
   isImproved = false,
   deletedAt = null,
   deletedBy = null,
+  isCertifiable = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
@@ -44,6 +45,7 @@ module.exports = function buildCampaignParticipation({
     isImproved,
     deletedAt,
     deletedBy,
+    isCertifiable,
   };
   databaseBuffer.pushInsertable({
     tableName: 'campaign-participations',

--- a/api/db/migrations/20220816143731_add-isCertifiable-to-campaign-participations.js
+++ b/api/db/migrations/20220816143731_add-isCertifiable-to-campaign-participations.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'campaign-participations';
+const COLUMN = 'isCertifiable';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.boolean(COLUMN).nullable().defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(COLUMN);
+  });
+};

--- a/api/lib/domain/events/compute-campaign-participation-results.js
+++ b/api/lib/domain/events/compute-campaign-participation-results.js
@@ -1,13 +1,9 @@
 const CampaignParticipationResultShared = require('./CampaignParticipationResultsShared');
 
-module.exports = async function computeCampaignParticipationResults({
-  event,
-  participantResultsSharedRepository,
-  campaignParticipationRepository,
-}) {
+module.exports = async function computeCampaignParticipationResults({ event, participantResultsSharedRepository }) {
   const { campaignParticipationId } = event;
   const participantResultsShared = await participantResultsSharedRepository.get(campaignParticipationId);
-  await campaignParticipationRepository.update(participantResultsShared);
+  await participantResultsSharedRepository.save(participantResultsShared);
 };
 
 module.exports.eventTypes = [CampaignParticipationResultShared];

--- a/api/lib/domain/models/ParticipantResultsShared.js
+++ b/api/lib/domain/models/ParticipantResultsShared.js
@@ -4,7 +4,7 @@ const { MAX_REACHABLE_PIX_BY_COMPETENCE } = require('../constants');
 const MAX_PIX_SCORE = MAX_REACHABLE_PIX_BY_COMPETENCE * 16;
 
 class ParticipantResultsShared {
-  constructor({ campaignParticipationId, knowledgeElements, targetedSkillIds }) {
+  constructor({ campaignParticipationId, knowledgeElements, targetedSkillIds, placementProfile }) {
     const validatedKnowledgeElements = _getValidatedKnowledgeElements(knowledgeElements, targetedSkillIds);
 
     this.id = campaignParticipationId;
@@ -12,8 +12,10 @@ class ParticipantResultsShared {
     this.pixScore = calculatePixScore(validatedKnowledgeElements);
     if (targetedSkillIds.length > 0) {
       this.masteryRate = this.validatedSkillsCount / targetedSkillIds.length;
+      this.isCertifiable = null;
     } else {
       this.masteryRate = this.pixScore / MAX_PIX_SCORE;
+      this.isCertifiable = placementProfile?.isCertifiable();
     }
   }
 }

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -153,6 +153,25 @@ async function getPlacementProfilesWithSnapshotting({ userIdsAndDates, competenc
   return placementProfilesList;
 }
 
+async function getPlacementProfileWithSnapshotting({ userId, limitDate, competences, allowExcessPixAndLevels = true }) {
+  const snapshots = await knowledgeElementRepository.findSnapshotForUsers({
+    [userId]: limitDate,
+  });
+  const knowledgeElements = snapshots[userId];
+  const knowledgeElementsByCompetence = _.groupBy(knowledgeElements, 'competenceId');
+
+  const userCompetences = _createUserCompetencesV2({
+    knowledgeElementsByCompetence,
+    competences,
+    allowExcessPixAndLevels,
+  });
+  return new PlacementProfile({
+    userId,
+    profileDate: limitDate,
+    userCompetences,
+  });
+}
+
 function _matchingDirectlyValidatedSkillsForCompetence(knowledgeElementsForCompetence, skillMap) {
   const competenceSkills = knowledgeElementsForCompetence
     .filter((ke) => ke.isDirectlyValidated())
@@ -166,4 +185,5 @@ function _matchingDirectlyValidatedSkillsForCompetence(knowledgeElementsForCompe
 module.exports = {
   getPlacementProfile,
   getPlacementProfilesWithSnapshotting,
+  getPlacementProfileWithSnapshotting,
 };

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -107,26 +107,25 @@ function _createUserCompetencesV2({
 }
 
 async function _generatePlacementProfileV2({ userId, profileDate, competences, allowExcessPixAndLevels }) {
-  const placementProfile = new PlacementProfile({
-    userId,
-    profileDate,
-  });
-
   const knowledgeElementsByCompetence = await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
-    userId: placementProfile.userId,
-    limitDate: placementProfile.profileDate,
+    userId,
+    limitDate: profileDate,
   });
 
   const skills = await skillRepository.list();
 
-  placementProfile.userCompetences = _createUserCompetencesV2({
+  const userCompetences = _createUserCompetencesV2({
     knowledgeElementsByCompetence,
     competences,
     allowExcessPixAndLevels,
     skills,
   });
 
-  return placementProfile;
+  return new PlacementProfile({
+    userId,
+    profileDate,
+    userCompetences,
+  });
 }
 
 async function getPlacementProfilesWithSnapshotting({ userIdsAndDates, competences, allowExcessPixAndLevels = true }) {
@@ -136,15 +135,16 @@ async function getPlacementProfilesWithSnapshotting({ userIdsAndDates, competenc
   const placementProfilesList = [];
   for (const [strUserId, knowledgeElementsByCompetence] of Object.entries(knowledgeElementsByUserIdAndCompetenceId)) {
     const userId = parseInt(strUserId);
-    const placementProfile = new PlacementProfile({
-      userId,
-      profileDate: userIdsAndDates[userId],
-    });
 
-    placementProfile.userCompetences = _createUserCompetencesV2({
+    const userCompetences = _createUserCompetencesV2({
       knowledgeElementsByCompetence,
       competences,
       allowExcessPixAndLevels,
+    });
+    const placementProfile = new PlacementProfile({
+      userId,
+      profileDate: userIdsAndDates[userId],
+      userCompetences,
     });
 
     placementProfilesList.push(placementProfile);

--- a/api/lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js
+++ b/api/lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js
@@ -7,7 +7,7 @@ class ParticipationResultCalculationJobHandler {
   async handle(event) {
     const { campaignParticipationId } = event;
     const participantResultsShared = await this.participantResultsSharedRepository.get(campaignParticipationId);
-    await this.campaignParticipationRepository.update(participantResultsShared);
+    await this.participantResultsSharedRepository.save(participantResultsShared);
   }
 }
 

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -223,9 +223,6 @@ function _getAttributes(campaignParticipation) {
     status: campaignParticipation.status,
     campaignId: campaignParticipation.campaignId,
     userId: campaignParticipation.userId,
-    validatedSkillsCount: campaignParticipation.validatedSkillsCount,
-    pixScore: campaignParticipation.pixScore,
-    masteryRate: campaignParticipation.masteryRate,
     organizationLearnerId: campaignParticipation.organizationLearnerId,
   };
 }

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -2,17 +2,19 @@ const CampaignProfile = require('../../../lib/domain/read-models/CampaignProfile
 const placementProfileService = require('../../domain/services/placement-profile-service');
 const { NotFoundError } = require('../../../lib/domain/errors');
 const { knex } = require('../../../db/knex-database-connection');
+const competenceRepository = require('./competence-repository');
 
 module.exports = {
   async findProfile({ campaignId, campaignParticipationId, locale }) {
     const profile = await _fetchCampaignProfileAttributesFromCampaignParticipation(campaignId, campaignParticipationId);
+    const competences = await competenceRepository.listPixCompetencesOnly({ locale });
 
     const { sharedAt, userId } = profile;
-    const placementProfile = await placementProfileService.getPlacementProfile({
+    const placementProfile = await placementProfileService.getPlacementProfileWithSnapshotting({
       userId,
       limitDate: sharedAt,
       allowExcessPixAndLevels: false,
-      locale,
+      competences,
     });
 
     return new CampaignProfile({ ...profile, placementProfile });

--- a/api/lib/infrastructure/repositories/participant-results-shared-repository.js
+++ b/api/lib/infrastructure/repositories/participant-results-shared-repository.js
@@ -38,6 +38,10 @@ function _fetchUserIdAndSharedAt(campaignParticipationId) {
 }
 
 const participantResultsSharedRepository = {
+  async save(participantResultShared) {
+    await knex('campaign-participations').update(participantResultShared).where({ id: participantResultShared.id });
+  },
+
   async get(campaignParticipationId) {
     const targetedSkillIds = await _fetchTargetedSkillIds(campaignParticipationId);
     const knowledgeElements = await _fetchKnowledgeElements(campaignParticipationId);

--- a/api/lib/infrastructure/repositories/participant-results-shared-repository.js
+++ b/api/lib/infrastructure/repositories/participant-results-shared-repository.js
@@ -1,6 +1,8 @@
 const { knex } = require('../../../db/knex-database-connection');
 const skillDatasource = require('../datasources/learning-content/skill-datasource');
 const ParticipantResultsShared = require('../../../lib/domain/models/ParticipantResultsShared');
+const placementProfileService = require('../../domain/services/placement-profile-service');
+const competenceRepository = require('./competence-repository');
 
 async function _fetchTargetedSkillIds(campaignParticipationId) {
   const skillIds = await knex('campaign-participations')
@@ -28,12 +30,33 @@ async function _fetchKnowledgeElements(campaignParticipationId) {
   return knowledgeElements;
 }
 
+function _fetchUserIdAndSharedAt(campaignParticipationId) {
+  return knex('campaign-participations')
+    .select('userId', 'sharedAt')
+    .where('campaign-participations.id', campaignParticipationId)
+    .first();
+}
+
 const participantResultsSharedRepository = {
   async get(campaignParticipationId) {
     const targetedSkillIds = await _fetchTargetedSkillIds(campaignParticipationId);
     const knowledgeElements = await _fetchKnowledgeElements(campaignParticipationId);
+    const { userId, sharedAt } = await _fetchUserIdAndSharedAt(campaignParticipationId);
+    const competences = await competenceRepository.listPixCompetencesOnly();
 
-    return new ParticipantResultsShared({ campaignParticipationId, knowledgeElements, targetedSkillIds });
+    const placementProfile = await placementProfileService.getPlacementProfileWithSnapshotting({
+      userId,
+      limitDate: sharedAt,
+      allowExcessPixAndLevels: false,
+      competences,
+    });
+
+    return new ParticipantResultsShared({
+      campaignParticipationId,
+      knowledgeElements,
+      targetedSkillIds,
+      placementProfile,
+    });
   },
 };
 

--- a/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler_test.js
@@ -8,11 +8,9 @@ describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationRe
       // given
       const event = new CampaignParticipationResultsShared({ campaignParticipationId: 1 });
       const participationResultsShared = Symbol('participation results shared');
-      const participantResultsSharedRepository = { get: sinon.stub() };
-      const campaignParticipationRepository = { update: sinon.stub() };
+      const participantResultsSharedRepository = { get: sinon.stub(), save: sinon.stub() };
       const handler = new ParticipationResultCalculationJobHandler({
         participantResultsSharedRepository,
-        campaignParticipationRepository,
       });
       participantResultsSharedRepository.get.withArgs(1).resolves(participationResultsShared);
 
@@ -20,7 +18,7 @@ describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationRe
       await handler.handle(event);
 
       // then
-      expect(campaignParticipationRepository.update).to.have.been.calledWith(participationResultsShared);
+      expect(participantResultsSharedRepository.save).to.have.been.calledWith(participationResultsShared);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -309,7 +309,6 @@ describe('Integration | Repository | Campaign Participation', function () {
         id: campaignParticipationId,
         status: STARTED,
         sharedAt: null,
-        validatedSkillsCount: null,
       });
 
       await databaseBuilder.commit();
@@ -318,9 +317,6 @@ describe('Integration | Repository | Campaign Participation', function () {
         ...campaignParticipationToUpdate,
         sharedAt: new Date('2021-01-01'),
         status: SHARED,
-        validatedSkillsCount: 10,
-        pixScore: 10,
-        masteryRate: 0.9,
       });
       const campaignParticipation = await knex('campaign-participations')
         .where({ id: campaignParticipationId })
@@ -328,9 +324,6 @@ describe('Integration | Repository | Campaign Participation', function () {
 
       expect(campaignParticipation.sharedAt).to.deep.equals(new Date('2021-01-01'));
       expect(campaignParticipation.status).to.equals(SHARED);
-      expect(campaignParticipation.validatedSkillsCount).to.equals(10);
-      expect(campaignParticipation.pixScore).to.equals(10);
-      expect(campaignParticipation.masteryRate).to.equals('0.90');
     });
 
     it('should not update because the leaner can not have 2 active participations for the same campaign', async function () {

--- a/api/tests/unit/domain/events/compute-campaign-participation-results_test.js
+++ b/api/tests/unit/domain/events/compute-campaign-participation-results_test.js
@@ -22,18 +22,16 @@ describe('Unit | Domain | Events | compute-campaign-participation-results', func
     // given
     const participationResultsShared = Symbol('participation results shared');
     const event = new CampaignParticipationResultsShared({ campaignParticipationId: 1 });
-    const participantResultsSharedRepository = { get: sinon.stub() };
+    const participantResultsSharedRepository = { get: sinon.stub(), save: sinon.stub() };
     participantResultsSharedRepository.get.withArgs(1).resolves(participationResultsShared);
-    const campaignParticipationRepository = { update: sinon.stub() };
 
     // when
     await computeCampaignParticipationResults({
       event,
       participantResultsSharedRepository,
-      campaignParticipationRepository,
     });
 
     // then
-    expect(campaignParticipationRepository.update).to.have.been.calledWith(participationResultsShared);
+    expect(participantResultsSharedRepository.save).to.have.been.calledWith(participationResultsShared);
   });
 });

--- a/api/tests/unit/domain/models/ParticipantResultsShared_test.js
+++ b/api/tests/unit/domain/models/ParticipantResultsShared_test.js
@@ -48,10 +48,49 @@ describe('Unit | Domain | Models | ParticipantResultsShared', function () {
         const participantResultsShared = new ParticipantResultsShared({
           knowledgeElements,
           targetedSkillIds,
+          placementProfile: { isCertifiable: () => {} },
         });
 
         // then
         expect(participantResultsShared.masteryRate).to.be.equal(10 / (16 * MAX_REACHABLE_PIX_BY_COMPETENCE));
+      });
+    });
+  });
+
+  context('#isCertifiable', function () {
+    context('when there are targetSkills', function () {
+      it('computes isCertifiable as null', function () {
+        // given
+        const knowledgeElements = [];
+        const targetedSkillIds = ['skill1', 'skill2', 'skill3'];
+
+        // when
+        const participantResultsShared = new ParticipantResultsShared({
+          knowledgeElements,
+          targetedSkillIds,
+        });
+
+        // then
+        expect(participantResultsShared.isCertifiable).to.equal(null);
+      });
+    });
+
+    context('when there are no targetSkills', function () {
+      it('computes isCertifiable with placementProfile', function () {
+        // given
+        const knowledgeElements = [];
+        const targetedSkillIds = [];
+        const isCertifiable = Symbol('isCertifiable');
+
+        // when
+        const participantResultsShared = new ParticipantResultsShared({
+          knowledgeElements,
+          targetedSkillIds,
+          placementProfile: { isCertifiable: () => isCertifiable },
+        });
+
+        // then
+        expect(participantResultsShared.isCertifiable).to.equal(isCertifiable);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.

## :robot: Solution
Pour commencer nous allons créer la colonne “certificabilité” en base et la remplir au moment du partage d’un envoi profil.

## :rainbow: Remarques
RAS

## :100: Pour tester
- de base, tout doit être à null en base
- partager un profil non certifiable : s'assurer qu'on a bien false en base
- partager un profil certifiable (certif-success@example.net) : s'assurer qu'on a bien true en base
- non régression sur la page de détail d'un profil dans Pix Orga
