### PR TITLE
[TECH] Script pour remplir la colonne `isCertifiable` pour toutes les participations déjà partagées (PIX-5479).

### DIFF
--- a/api/lib/domain/models/ParticipantResultsShared.js
+++ b/api/lib/domain/models/ParticipantResultsShared.js
@@ -15,7 +15,7 @@ class ParticipantResultsShared {
       this.isCertifiable = null;
     } else {
       this.masteryRate = this.pixScore / MAX_PIX_SCORE;
-      this.isCertifiable = placementProfile?.isCertifiable();
+      this.isCertifiable = placementProfile.isCertifiable();
     }
   }
 }

--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -13,6 +13,8 @@ const { knex } = require('../../db/knex-database-connection');
 const _ = require('lodash');
 const bluebird = require('bluebird');
 const constants = require('../../lib/infrastructure/constants');
+const placementProfileService = require('../../lib/domain/services/placement-profile-service');
+const competenceRepository = require('../../lib/infrastructure/repositories/competence-repository');
 
 let count;
 let total;
@@ -20,36 +22,57 @@ let logEnable;
 async function computeParticipantResultsShared(concurrency = 1, log = true) {
   logEnable = log;
   const campaigns = await knex('campaigns')
-    .distinct('campaigns.id')
     .select('campaigns.id')
     .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
-    .where({ status: SHARED, pixScore: null });
+    .where({ status: SHARED, pixScore: null, type: 'ASSESSMENT' })
+    .orWhere({ status: SHARED, isCertifiable: null, type: 'PROFILES_COLLECTION' });
+  const uniqueCampaigns = _.uniqBy(campaigns, 'id');
   count = 0;
-  total = campaigns.length;
+  total = uniqueCampaigns.length;
   _log(`Campagnes à traiter ${total}`);
 
-  await bluebird.map(campaigns, _updateCampaignParticipations, { concurrency });
+  await bluebird.map(uniqueCampaigns, _updateCampaignParticipations, { concurrency });
 }
 
 async function _updateCampaignParticipations(campaign) {
   const participationResults = await _computeCampaignParticipationResults(campaign);
 
-  // eslint-disable-next-line knex/avoid-injections
-  await knex.raw(`UPDATE "campaign-participations"
-  SET "validatedSkillsCount" = "participationSkillCounts"."validatedSkillsCount", "masteryRate" = "participationSkillCounts"."masteryRate", "pixScore" = "participationSkillCounts"."pixScore"
-  FROM (VALUES ${_toSQLValues(
-    participationResults
-  )}) AS "participationSkillCounts"(id, "validatedSkillsCount", "masteryRate", "pixScore")
-  WHERE "campaign-participations".id = "participationSkillCounts".id`);
+  const participationResultsWithIsCertifiable = participationResults.filter(
+    (participationResult) => !_.isNil(participationResult.isCertifiable)
+  );
 
+  if (!_.isEmpty(participationResultsWithIsCertifiable)) {
+    // eslint-disable-next-line knex/avoid-injections
+    await knex.raw(`UPDATE "campaign-participations"
+    SET "validatedSkillsCount" = "participationSkillCounts"."validatedSkillsCount", "masteryRate" = "participationSkillCounts"."masteryRate", "pixScore" = "participationSkillCounts"."pixScore", "isCertifiable" = "participationSkillCounts"."isCertifiable"
+    FROM (VALUES ${_toSQLValuesWithIsCertifiable(
+      participationResultsWithIsCertifiable
+    )}) AS "participationSkillCounts"(id, "validatedSkillsCount", "masteryRate", "pixScore", "isCertifiable")
+      WHERE "campaign-participations".id = "participationSkillCounts".id`);
+  }
+
+  const participationResultsWithIsCertifiableAsNull = _.difference(
+    participationResults,
+    participationResultsWithIsCertifiable
+  );
+  if (!_.isEmpty(participationResultsWithIsCertifiableAsNull)) {
+    // eslint-disable-next-line knex/avoid-injections
+    await knex.raw(`UPDATE "campaign-participations"
+    SET "validatedSkillsCount" = "participationSkillCounts"."validatedSkillsCount", "masteryRate" = "participationSkillCounts"."masteryRate", "pixScore" = "participationSkillCounts"."pixScore"
+    FROM (VALUES ${_toSQLValues(
+      participationResultsWithIsCertifiableAsNull
+    )}) AS "participationSkillCounts"(id, "validatedSkillsCount", "masteryRate", "pixScore")
+      WHERE "campaign-participations".id = "participationSkillCounts".id`);
+  }
   count++;
   _log(`${count} / ${total}`);
 }
 
 async function _computeCampaignParticipationResults(campaign) {
+  const competences = await competenceRepository.listPixCompetencesOnly();
   const campaignParticipationInfosChunks = await _getCampaignParticipationChunks(campaign);
   const targetedSkillIds = await _fetchTargetedSkillIds(campaign.id);
-  const computeResultsWithTargetedSkillIds = _.partial(_computeResults, targetedSkillIds);
+  const computeResultsWithTargetedSkillIds = _.partial(_computeResults, targetedSkillIds, competences);
 
   const participantsResults = await bluebird.mapSeries(
     campaignParticipationInfosChunks,
@@ -60,12 +83,11 @@ async function _computeCampaignParticipationResults(campaign) {
 }
 
 async function _getCampaignParticipationChunks(campaign) {
-  const campaignParticipations = await knex('campaign-participations').select(['userId', 'sharedAt', 'id']).where({
-    campaignId: campaign.id,
-    pixScore: null,
-    status: SHARED,
-  });
-
+  const campaignParticipations = await knex('campaign-participations')
+    .select(['userId', 'sharedAt', 'campaign-participations.id'])
+    .join('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
+    .where({ campaignId: campaign.id, status: SHARED, pixScore: null, 'campaigns.type': 'ASSESSMENT' })
+    .orWhere({ campaignId: campaign.id, status: SHARED, isCertifiable: null, 'campaigns.type': 'PROFILES_COLLECTION' });
   return _.chunk(campaignParticipations, constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING);
 }
 
@@ -80,14 +102,22 @@ async function _fetchTargetedSkillIds(campaignId) {
   return targetedSkillIds.map(({ id }) => id);
 }
 
-async function _computeResults(targetedSkillIds, campaignParticipation) {
-  const knowledgeElementByUser = await _getKnowledgeElementsByUser(campaignParticipation);
+async function _computeResults(targetedSkillIds, competences, campaignParticipations) {
+  const knowledgeElementByUser = await _getKnowledgeElementsByUser(campaignParticipations);
 
-  return campaignParticipation.map(({ userId, id }) => {
+  const userIdsAndDates = {};
+  campaignParticipations.forEach(({ userId, sharedAt }) => (userIdsAndDates[userId] = sharedAt));
+  const placementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
+    userIdsAndDates,
+    competences,
+    allowExcessPixAndLevels: false,
+  });
+  return campaignParticipations.map(({ userId, id }) => {
     return new ParticipantResultsShared({
       campaignParticipationId: id,
       knowledgeElements: knowledgeElementByUser[userId],
       targetedSkillIds,
+      placementProfile: placementProfiles.find((placementProfile) => placementProfile.userId === userId),
     });
   });
 }
@@ -106,6 +136,15 @@ function _toSQLValues(participantsResults) {
     .map(
       ({ id, validatedSkillsCount, masteryRate, pixScore }) =>
         `(${id}, ${validatedSkillsCount}, ${masteryRate}, ${pixScore})`
+    )
+    .join(', ');
+}
+
+function _toSQLValuesWithIsCertifiable(participantsResults) {
+  return participantsResults
+    .map(
+      ({ id, validatedSkillsCount, masteryRate, pixScore, isCertifiable }) =>
+        `(${id}, ${validatedSkillsCount}, ${masteryRate}, ${pixScore}, ${isCertifiable})`
     )
     .join(', ');
 }

--- a/api/tests/integration/infrastructure/repositories/participant-results-shared-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-results-shared-repository_test.js
@@ -146,7 +146,7 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
 
-        expect(participantResultsShared.isCertifiable).to.equal(false);
+        expect(participantResultsShared.isCertifiable).to.be.false;
       });
 
       it('computes isCertifiable as true', async function () {
@@ -183,7 +183,7 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
 
-        expect(participantResultsShared.isCertifiable).to.equal(true);
+        expect(participantResultsShared.isCertifiable).to.be.true;
       });
     });
 
@@ -323,7 +323,7 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
         //when
         const participantResultsShared = await participantResultsSharedRepository.get(participation.id);
 
-        expect(participantResultsShared.isCertifiable).to.equal(null);
+        expect(participantResultsShared.isCertifiable).to.be.null;
       });
     });
 

--- a/api/tests/integration/scripts/prod/compute-participation-results_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-results_test.js
@@ -11,14 +11,26 @@ describe('computeParticipationResults', function () {
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
 
       _buildParticipationWithSnapshot({ campaignId, sharedAt: new Date('2020-01-02') }, [
-        { skillId: 'skill_1', status: 'invalidated', earnedPix: 0 },
-        { skillId: 'skill_2', status: 'validated', earnedPix: 3 },
-        { skillId: 'skill_3', status: 'validated', earnedPix: 1 },
+        { skillId: 'skill_1', competenceId: 'competence_1', status: 'invalidated', earnedPix: 0 },
+        { skillId: 'skill_2', competenceId: 'competence_2', status: 'validated', earnedPix: 3 },
+        { skillId: 'skill_3', competenceId: 'competence_3', status: 'validated', earnedPix: 1 },
       ]);
 
       await databaseBuilder.commit();
 
-      mockLearningContent({ skills: [] });
+      const learningContent = {
+        skills: [
+          { id: 'skill_1', competenceId: 'competence_1', status: 'actif' },
+          { id: 'skill_2', competenceId: 'competence_2', status: 'actif' },
+          { id: 'skill_3', competenceId: 'competence_3', status: 'actif' },
+        ],
+        competences: [
+          { id: 'competence_1', origin: 'Pix' },
+          { id: 'competence_2', origin: 'Pix' },
+          { id: 'competence_3', origin: 'Pix' },
+        ],
+      };
+      mockLearningContent(learningContent);
 
       await computeParticipationResults(1, false);
 
@@ -27,6 +39,7 @@ describe('computeParticipationResults', function () {
       expect(campaignParticipation.masteryRate).to.equals('0.01');
       expect(campaignParticipation.pixScore).to.equals(4);
       expect(campaignParticipation.validatedSkillsCount).to.equals(2);
+      expect(campaignParticipation.isCertifiable).to.be.false;
     });
   });
 
@@ -48,6 +61,7 @@ describe('computeParticipationResults', function () {
           { id: 'skill_2', status: 'archivé' },
           { id: 'skill_3', status: 'périmé' },
         ],
+        competences: [],
       };
       mockLearningContent(learningContent);
 
@@ -58,6 +72,7 @@ describe('computeParticipationResults', function () {
       expect(campaignParticipation.masteryRate).to.equals('1.00');
       expect(campaignParticipation.pixScore).to.equals(5);
       expect(campaignParticipation.validatedSkillsCount).to.equals(1);
+      expect(campaignParticipation.isCertifiable).to.be.null;
     });
   });
 
@@ -67,25 +82,45 @@ describe('computeParticipationResults', function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
 
         _buildParticipationWithSnapshot({ id: 1, campaignId, sharedAt: new Date('2020-01-02') }, [
-          { skillId: 'skill_1', status: 'validated', earnedPix: 40 },
+          { skillId: 'skill_1', status: 'validated', earnedPix: 4 },
         ]);
 
-        _buildParticipationWithSnapshot({ id: 2, campaignId, sharedAt: new Date('2020-01-03') }, [
-          { skillId: 'skill_1', status: 'invalidated', earnedPix: 0 },
+        _buildParticipationWithSnapshot({ id: 2, campaignId, sharedAt: new Date('2020-01-02') }, [
+          { skillId: 'skill_1', competenceId: 'competence_1', status: 'validated', earnedPix: 8 },
+          { skillId: 'skill_2', competenceId: 'competence_2', status: 'validated', earnedPix: 8 },
+          { skillId: 'skill_3', competenceId: 'competence_3', status: 'validated', earnedPix: 8 },
+          { skillId: 'skill_4', competenceId: 'competence_4', status: 'validated', earnedPix: 8 },
+          { skillId: 'skill_5', competenceId: 'competence_5', status: 'validated', earnedPix: 8 },
         ]);
 
         await databaseBuilder.commit();
 
-        mockLearningContent({ skills: [] });
+        const learningContent = {
+          skills: [
+            { id: 'skill_1', competenceId: 'competence_1', status: 'actif' },
+            { id: 'skill_2', competenceId: 'competence_2', status: 'actif' },
+            { id: 'skill_3', competenceId: 'competence_3', status: 'actif' },
+            { id: 'skill_4', competenceId: 'competence_4', status: 'actif' },
+            { id: 'skill_5', competenceId: 'competence_5', status: 'actif' },
+          ],
+          competences: [
+            { id: 'competence_1', origin: 'Pix' },
+            { id: 'competence_2', origin: 'Pix' },
+            { id: 'competence_3', origin: 'Pix' },
+            { id: 'competence_4', origin: 'Pix' },
+            { id: 'competence_5', origin: 'Pix' },
+          ],
+        };
+        mockLearningContent(learningContent);
 
         await computeParticipationResults(1, false);
         const campaignParticipations = await knex('campaign-participations')
-          .select(['validatedSkillsCount', 'pixScore', 'masteryRate'])
+          .select(['validatedSkillsCount', 'pixScore', 'masteryRate', 'isCertifiable'])
           .orderBy('id');
 
         expect(campaignParticipations).to.deep.equals([
-          { validatedSkillsCount: 1, pixScore: 40, masteryRate: '0.06' },
-          { validatedSkillsCount: 0, pixScore: 0, masteryRate: '0.00' },
+          { validatedSkillsCount: 1, pixScore: 4, masteryRate: '0.01', isCertifiable: false },
+          { validatedSkillsCount: 5, pixScore: 40, masteryRate: '0.06', isCertifiable: true },
         ]);
       });
     });
@@ -106,23 +141,54 @@ describe('computeParticipationResults', function () {
 
         await databaseBuilder.commit();
 
-        mockLearningContent({ skills: [] });
+        mockLearningContent({ skills: [], competences: [] });
 
         await computeParticipationResults(1, false);
         const campaignParticipations = await knex('campaign-participations')
-          .select(['validatedSkillsCount', 'pixScore', 'masteryRate'])
+          .select(['validatedSkillsCount', 'pixScore', 'masteryRate', 'isCertifiable'])
           .orderBy('id');
 
         expect(campaignParticipations).to.deep.equals([
-          { validatedSkillsCount: 2, pixScore: 80, masteryRate: '0.13' },
-          { validatedSkillsCount: 1, pixScore: 40, masteryRate: '0.06' },
+          { validatedSkillsCount: 2, pixScore: 80, masteryRate: '0.13', isCertifiable: false },
+          { validatedSkillsCount: 1, pixScore: 40, masteryRate: '0.06', isCertifiable: false },
         ]);
       });
     });
 
-    context('when there are campaign participation with already pix score computed', function () {
+    context(
+      'when there are campaign participation on profiles collection campaign with isCertifiable already computed',
+      function () {
+        it('does not compute results', async function () {
+          const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            sharedAt: new Date('2020-01-02'),
+            validatedSkillsCount: 10,
+            masteryRate: 0.2,
+            pixScore: 10,
+            isCertifiable: true,
+          });
+
+          await databaseBuilder.commit();
+
+          mockLearningContent({ skills: [], competences: [] });
+
+          await computeParticipationResults(1, false);
+
+          const campaignParticipation = await knex('campaign-participations').first();
+
+          expect(campaignParticipation.masteryRate).to.equals('0.20');
+          expect(campaignParticipation.pixScore).to.equals(10);
+          expect(campaignParticipation.validatedSkillsCount).to.equals(10);
+          expect(campaignParticipation.isCertifiable).to.be.true;
+        });
+      }
+    );
+
+    context('when there are campaign participation on assessment campaign with pixScore already computed', function () {
       it('does not compute results', async function () {
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
 
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId,
@@ -130,11 +196,12 @@ describe('computeParticipationResults', function () {
           validatedSkillsCount: 10,
           masteryRate: 0.2,
           pixScore: 10,
+          isCertifiable: null,
         });
 
         await databaseBuilder.commit();
 
-        mockLearningContent({ skills: [] });
+        mockLearningContent({ skills: [], competences: [] });
 
         await computeParticipationResults(1, false);
 
@@ -143,6 +210,7 @@ describe('computeParticipationResults', function () {
         expect(campaignParticipation.masteryRate).to.equals('0.20');
         expect(campaignParticipation.pixScore).to.equals(10);
         expect(campaignParticipation.validatedSkillsCount).to.equals(10);
+        expect(campaignParticipation.isCertifiable).to.be.null;
       });
     });
 
@@ -163,6 +231,7 @@ describe('computeParticipationResults', function () {
         expect(campaignParticipation.masteryRate).to.equals(null);
         expect(campaignParticipation.pixScore).to.equals(null);
         expect(campaignParticipation.validatedSkillsCount).to.equals(null);
+        expect(campaignParticipation.isCertifiable).to.be.null;
       });
     });
   });

--- a/api/tests/unit/domain/models/ParticipantResultsShared_test.js
+++ b/api/tests/unit/domain/models/ParticipantResultsShared_test.js
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | ParticipantResultsShared', function () {
         });
 
         // then
-        expect(participantResultsShared.isCertifiable).to.equal(null);
+        expect(participantResultsShared.isCertifiable).to.be.null;
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.

## :robot: Solution
Afin de remplir la nouvelle colonne, nous devons faire un script pour calculer et enregistrer cette nouvelle information pour toutes les participations (envoi de profil) déjà partagées.

## :rainbow: Remarques
RAS

## :100: Pour tester
Pour les seeds le script est déjà passé, donc il faut modifier des données en base puis runner en local `node scripts/prod/compute-participation-results.js 10` ou `scalingo -a pix-api-review-pr4806 run node scripts/prod/compute-participation-results.js 10`