### PR TITLE
[FEATURE] Gérer un accès à durée spécifique, étendue et limitée, pour les comptes anonymes (en accès simplifié) (PIX-4633)

### DIFF
--- a/api/lib/application/pre-response-utils.js
+++ b/api/lib/application/pre-response-utils.js
@@ -11,7 +11,11 @@ function handleDomainAndHttpErrors(request, h) {
 
   // Ne devrait pas etre necessaire
   if (response.isBoom && response.output.statusCode === 401) {
-    return errorManager.handle(request, h, new UnauthorizedError(undefined, 401));
+    return errorManager.handle(
+      request,
+      h,
+      new UnauthorizedError(undefined, response.output.payload?.attributes?.code || 401)
+    );
   }
 
   return h.continue;

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -114,6 +114,10 @@ module.exports = (function () {
       passwordResetTokenLifespan: '1h',
     },
 
+    anonymous: {
+      accessTokenLifespanMs: ms(process.env.ANONYMOUS_ACCESS_TOKEN_LIFESPAN || '4h'),
+    },
+
     apiManager: {
       url: process.env.APIM_URL || 'https://gateway.pix.fr',
     },

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -19,6 +19,11 @@ function createAccessTokenFromUser(userId, source) {
   return { accessToken, expirationDelaySeconds };
 }
 
+function createAccessTokenFromAnonymousUser(userId) {
+  const expirationDelaySeconds = settings.anonymous.accessTokenLifespanMs / 1000;
+  return _createAccessToken({ userId, source: 'pix', expirationDelaySeconds });
+}
+
 function createAccessTokenForSaml(userId) {
   const expirationDelaySeconds = settings.saml.accessTokenLifespanMs / 1000;
   return _createAccessToken({ userId, source: 'external', expirationDelaySeconds });
@@ -192,6 +197,7 @@ module.exports = {
   createAccessTokenFromUser,
   createAccessTokenForSaml,
   createAccessTokenFromApplication,
+  createAccessTokenFromAnonymousUser,
   createTokenForCampaignResults,
   createIdTokenForUserReconciliation,
   createCertificationResultsByRecipientEmailLinkToken,

--- a/api/lib/domain/usecases/authenticate-anonymous-user.js
+++ b/api/lib/domain/usecases/authenticate-anonymous-user.js
@@ -16,6 +16,5 @@ module.exports = async function authenticateAnonymousUser({
   const userToAdd = UserToCreate.createAnonymous({ lang });
   const newUser = await userToCreateRepository.create({ user: userToAdd });
 
-  const accessToken = tokenService.createAccessTokenFromUser(newUser.id, 'pix').accessToken;
-  return accessToken;
+  return tokenService.createAccessTokenFromAnonymousUser(newUser.id);
 };

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -28,7 +28,9 @@ async function _checkIsAuthenticated(request, h, { key, validate }) {
     }
   }
 
-  return boom.unauthorized();
+  const error = boom.unauthorized();
+  error.output.payload.attributes = { code: 'SESSION_EXPIRED' };
+  return error;
 }
 
 function validateUser(decoded) {

--- a/api/sample.env
+++ b/api/sample.env
@@ -621,6 +621,12 @@ NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD=48
 # default: '20m'
 ACCESS_TOKEN_LIFESPAN=20m
 
+# Anonymous access token lifespan
+# presence: optional
+# type: String
+# default: '4h'
+# ANONYMOUS_ACCESS_TOKEN_LIFESPAN=
+
 # Refresh token lifespan
 # presence: optional
 # type: String

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -59,6 +59,28 @@ describe('Unit | Application | Controller | Authentication', function () {
     });
   });
 
+  describe('#authenticateAnonymousUser', function () {
+    it('should return an access token', async function () {
+      // given
+      const campaignCode = 'SIMPLIFIE';
+      const lang = 'fr';
+      const request = {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        payload: { campaign_code: campaignCode, lang },
+      };
+      sinon.stub(usecases, 'authenticateAnonymousUser').withArgs({ campaignCode, lang }).resolves('valid access token');
+
+      // when
+      const { statusCode, source } = await authenticationController.authenticateAnonymousUser(request, hFake);
+
+      // then
+      expect(statusCode).to.equal(200);
+      expect(source).to.deep.equal({ access_token: 'valid access token', token_type: 'bearer' });
+    });
+  });
+
   describe('#authenticateExternalUser', function () {
     it('should return an access token', async function () {
       // given

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -351,4 +351,23 @@ describe('Unit | Domain | Service | Token Service', function () {
       expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal({ user_id: userId });
     });
   });
+
+  describe('#createAccessTokenFromAnonymousUser', function () {
+    it('should create and return an access token and an expiration delay in seconds', function () {
+      // given
+      const userId = 1;
+      settings.authentication.secret = 'SECRET_KEY';
+      settings.anonymous.accessTokenLifespanMs = 10000;
+      const payload = { user_id: userId, source: 'pix' };
+      const secret = 'SECRET_KEY';
+      const options = { expiresIn: 10 };
+      sinon.stub(jsonwebtoken, 'sign').withArgs(payload, secret, options).returns('VALID_ACCESS_TOKEN');
+
+      // when
+      const result = tokenService.createAccessTokenFromAnonymousUser(userId);
+
+      // then
+      expect(result).to.equal('VALID_ACCESS_TOKEN');
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
@@ -20,7 +20,7 @@ describe('Unit | UseCase | authenticate-anonymous-user', function () {
       create: sinon.stub(),
     };
     tokenService = {
-      createAccessTokenFromUser: sinon.stub(),
+      createAccessTokenFromAnonymousUser: sinon.stub(),
     };
     campaignToJoinRepository.getByCode.withArgs(campaignCode).resolves({ isSimplifiedAccess: true });
   });
@@ -28,7 +28,7 @@ describe('Unit | UseCase | authenticate-anonymous-user', function () {
   it('should create an anonymous user', async function () {
     // given
     userToCreateRepository.create.resolves({ id: 1 });
-    tokenService.createAccessTokenFromUser.returns({ accessToken: 'access-token', expirationDelaySeconds: 123 });
+    tokenService.createAccessTokenFromAnonymousUser.returns('access-token');
 
     // when
     await authenticateAnonymousUser({
@@ -58,9 +58,7 @@ describe('Unit | UseCase | authenticate-anonymous-user', function () {
     const accessToken = 'access.token';
 
     userToCreateRepository.create.resolves({ id: userId });
-    tokenService.createAccessTokenFromUser
-      .withArgs(userId, 'pix')
-      .returns({ accessToken, expirationDelaySeconds: 1000 });
+    tokenService.createAccessTokenFromAnonymousUser.withArgs(userId).returns(accessToken);
 
     // when
     const result = await authenticateAnonymousUser({

--- a/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
@@ -14,7 +14,7 @@ Fonctionnalité: Connexion - Déconnexion
   Scénario: Je suis connecté et ma session expire puis je rejoins une nouvelle page
     Lorsque je suis connecté avec un compte dont le token expire bientôt
     Alors je suis redirigé vers la page d'accueil de "Daenerys"
-    Lorsque j'attends 3000 ms
+    Lorsque j'attends 5000 ms
     Et je vais sur la page "/mes-certifications"
     Alors je suis redirigé vers la page "/connexion"
 

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -102,7 +102,7 @@ Cypress.Commands.add('loginExternalPlatformForTheSecondTime', () => {
 Cypress.Commands.add('loginWithAlmostExpiredToken', () => {
   cy.intercept('/api/users/me').as('getCurrentUser');
   const token = jsonwebtoken.sign({ user_id: 1 }, Cypress.env('AUTH_SECRET'), {
-    expiresIn: '2s',
+    expiresIn: '4s',
   });
   cy.visitMonPix(`/?token=${token}`);
   cy.wait(['@getCurrentUser']);

--- a/high-level-tests/e2e/cypress/support/index.js
+++ b/high-level-tests/e2e/cypress/support/index.js
@@ -14,8 +14,8 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
-import 'cypress-axe'
+import './commands';
+import 'cypress-axe';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -25,5 +25,15 @@ beforeEach(() => {
 
   cy.window().then((win) => {
     win.sessionStorage.clear();
+  });
+
+  cy.on('uncaught:exception', (err) => {
+    if (
+      err.message.includes(
+        'You attempted to remove a function listener which did not exist on the instance, which means you may have attempted to remove it before it was added.'
+      )
+    ) {
+      return false;
+    }
   });
 });

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -35,4 +35,12 @@ export default class Application extends JSONAPIAdapter {
     }
     return currentLocale;
   }
+
+  handleResponse(status, headers, payload) {
+    if (status === 401 && payload.errors[0].code === 'SESSION_EXPIRED') {
+      return this.session.invalidate();
+    }
+
+    return super.handleResponse(...arguments);
+  }
 }

--- a/mon-pix/tests/acceptance/authentication_test.js
+++ b/mon-pix/tests/acceptance/authentication_test.js
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { setupApplicationTest } from 'ember-mocha';
-import { fillIn, currentURL, visit } from '@ember/test-helpers';
+import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { currentSession } from 'ember-simple-auth/test-support';
 import { authenticateByEmail, authenticateByUsername } from '../helpers/authentication';
+import { startCampaignByCode } from '../helpers/campaign';
 import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';
+import { Response } from 'miragejs';
 
 describe('Acceptance | Authentication', function () {
   setupApplicationTest();
@@ -64,6 +67,37 @@ describe('Acceptance | Authentication', function () {
 
         // then
         expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
+      });
+    });
+
+    context('REST API call returns 401', function () {
+      it('should disconnect user if 401 is a SESSION_EXPIRED error', async function () {
+        // given
+        const campaign = server.create('campaign', { isSimplifiedAccess: true });
+
+        // when
+        const screen = await startCampaignByCode(campaign.code);
+        const userId = currentSession().get('data.authenticated.user_id');
+        server.patch(
+          `/users/${userId}/remember-user-has-seen-assessment-instructions`,
+          () =>
+            new Response(
+              401,
+              {},
+              {
+                errors: [
+                  {
+                    status: '401',
+                    code: 'SESSION_EXPIRED',
+                  },
+                ],
+              }
+            )
+        );
+        await click(screen.getByRole('button', { name: this.intl.t('pages.tutorial.pass') }));
+
+        // then
+        expect(currentSession().get('isAuthenticated')).to.be.false;
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Les utilisateurs qui jouent des parcours simplifiés voient apparaître des erreurs 403 au bout de 20 minutes, ce qui correspond à la durée de vie de l'access token. En effet, ils utilisent des comptes anonymes qui sont gérés côté Ember par l’authenticator `anonymous`, lequel ne gère pas les refresh tokens.

## :robot: Solution

- Ne pas faire de gestion via un refresh token.
- Créer un access token avec une durée de vie spécifique, limitée mais plus longue que la durée de vie par défaut des access tokens, via une nouvelle configuration dédiée uniquement à l'authentification d'un compte anonyme (valeur de 4h).

## :rainbow: Remarques

- En prod le problème a été contourné temporairement par l’allongement de la durée de vie des access tokens (passée à 4 heures au lieu de 20 minutes).
- Au moment de la mise en production de cette branche il faudra, pour la durée de vie par défaut des access tokens, remettre une valeur plus basse.

## :100: Pour tester

1. Allez sur [Parcours simplifié](https://app-pr4807.review.pix.fr/campagnes/SIMPLIFIE).
2. Ouvrir la console développeur et se mettre sur l'onglet `Network|Réseau`.
3. Cliquez sur le bouton `Je commence`.
4. Constatez dans la liste des appels réseaux qu'une ligne `anonymous` est présente (POST /api/token/anonymous) avec une réponse 200 et un access token dans le body de la requête.

en local pour tester l'invalidation de la session

1. Réduisez le temps d'expiration de `ANONYMOUS_ACCESS_TOKEN_LIFESPAN` a 10s
2. Redémarrer votre api
3. Allez sur [Parcours simplifié](https://app-pr4807.review.pix.fr/campagnes/SIMPLIFIE)
4. Cliquez sur le bouton `Je commence`.
5. Parcourez la campagne et attendez que le token expire
7. Remarquez que vous êtes redirigé vers la page de connexion une fois le token expiré
