### PR TITLE
Ajout d'un message informatif sur la suppression des participations dans l'onglet d'un utilisateur (PIX-5453)

### DIFF
--- a/admin/app/components/users/campaign-participations.hbs
+++ b/admin/app/components/users/campaign-participations.hbs
@@ -1,8 +1,11 @@
 <header class="page-section__header">
   <h2 class="page-section__title">Participations à des campagnes</h2>
 </header>
+<p class="participations-section__subtitle">
+  Attention toute modification sur une participation nécessite un accord écrit du prescripteur et du prescrit
+</p>
 
-<div class="campaign-participations-table content-text content-text--small">
+<div class="content-text content-text--small">
   <table class="table-admin">
     <thead>
       <tr>


### PR DESCRIPTION
## :unicorn: Problème
Nous avons rajouté des actions depuis l’onglet utilisateur sur les participations : pouvoir supprimer.
Cependant, il est interdit de réaliser ces actions à part si nous avons reçu une demande écrite du prescrit et du prescripteur (par la hotline, par mail etc..).

## :robot: Solution
Rajouter une phrase explicative, au dessus de la liste des participations (voir capture d'écran).

Phrase à rajouter : “Attention toute modification sur une participation nécessite un accord écrit du prescripteur et du prescrit”.

Récupérer le style de la phrase dans le détail d’une campagne d’une organisation (voir capture d'écran).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Admin
- Aller sur l'onglet utilisateur
- Chercher un utilisateur (exemple : Jaune)
- Aller sur sa page en cliquant sur son id dans le tableau
- Aller dans l'onglet participations de l'utilisateur
- Observer, juste en dessous du titre le sous-titre préventif
- Vérifier son style
- Tada 🎉 
