### PR TITLE
[FEATURE] Assouplir l'import des candidats sur les villes de naissance à arrondissements (PIX-5304)

### DIFF
--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -3,8 +3,15 @@
 
 require('dotenv').config();
 const logger = require('../../lib/infrastructure/logger');
-// Usage: node scripts/import-certification-cpf-cities path/file.csv
-// File downloaded from https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/
+
+/**
+ * Usage: node scripts/import-certification-cpf-cities path/file.csv
+ * File is semi-colon separated values, headers being:
+ * code_commune_insee;nom_de_la_commune;code_postal;ligne_5
+ * ligne_5 is used for potential alternative city name
+ *
+ * File downloaded from https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/ (Export au format CSV)
+ **/
 
 ('use strict');
 const { parseCsv, checkCsvHeader } = require('../helpers/csvHelpers');
@@ -421,5 +428,5 @@ function _buildCityNameWithWordReplaced(cityName) {
 
 module.exports = {
   buildCities,
-  getCitiesWithDistricts
+  getCitiesWithDistricts,
 };

--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -23,12 +23,132 @@ const wordsToReplace = [
   },
 ];
 
-const specificCities = [
+const districtCities = [
   {
     name: 'PARIS',
     postalCode: 75000,
     INSEECode: 75056,
     isActualName: true,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75001,
+    INSEECode: 75101,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75002,
+    INSEECode: 75102,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75003,
+    INSEECode: 75103,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75004,
+    INSEECode: 75104,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75005,
+    INSEECode: 75106,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75006,
+    INSEECode: 75106,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75007,
+    INSEECode: 75107,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75008,
+    INSEECode: 75108,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75009,
+    INSEECode: 75109,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75010,
+    INSEECode: 75110,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 750011,
+    INSEECode: 75111,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75012,
+    INSEECode: 75112,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75013,
+    INSEECode: 75113,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75014,
+    INSEECode: 75114,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75015,
+    INSEECode: 75115,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75016,
+    INSEECode: 75116,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75017,
+    INSEECode: 75117,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75018,
+    INSEECode: 75118,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75019,
+    INSEECode: 75119,
+    isActualName: false,
+  },
+  {
+    name: 'PARIS',
+    postalCode: 75020,
+    INSEECode: 75120,
+    isActualName: false,
   },
   {
     name: 'LYON',
@@ -37,10 +157,160 @@ const specificCities = [
     isActualName: true,
   },
   {
+    name: 'LYON',
+    postalCode: 69001,
+    INSEECode: 69381,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69002,
+    INSEECode: 69382,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69003,
+    INSEECode: 69383,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69004,
+    INSEECode: 69384,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69005,
+    INSEECode: 69385,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69006,
+    INSEECode: 69386,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69007,
+    INSEECode: 69387,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69008,
+    INSEECode: 69388,
+    isActualName: false,
+  },
+  {
+    name: 'LYON',
+    postalCode: 69009,
+    INSEECode: 69389,
+    isActualName: false,
+  },
+  {
     name: 'MARSEILLE',
     postalCode: 13000,
     INSEECode: 13055,
     isActualName: true,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13001,
+    INSEECode: 13201,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13002,
+    INSEECode: 13202,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13003,
+    INSEECode: 13203,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13004,
+    INSEECode: 13204,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13005,
+    INSEECode: 13205,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13006,
+    INSEECode: 13206,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13007,
+    INSEECode: 13207,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13008,
+    INSEECode: 13208,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13009,
+    INSEECode: 13209,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13010,
+    INSEECode: 13210,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13011,
+    INSEECode: 13211,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13012,
+    INSEECode: 13212,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13013,
+    INSEECode: 13213,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13014,
+    INSEECode: 13214,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13015,
+    INSEECode: 13215,
+    isActualName: false,
+  },
+  {
+    name: 'MARSEILLE',
+    postalCode: 13016,
+    INSEECode: 13216,
+    isActualName: false,
   },
 ];
 
@@ -50,6 +320,10 @@ const headers = {
   inseeCode: 'code_commune_insee',
   cityAlternateName: 'ligne_5',
 };
+
+function getCitiesWithDistricts() {
+  return districtCities;
+}
 
 function buildCities({ csvData }) {
   const citiesWithAlternates = csvData.flatMap((data) => {
@@ -100,7 +374,7 @@ async function main(filePath) {
     logger.info('✅ ');
 
     logger.info('Retrieving postal code, INSEE code and city name... ');
-    const cities = buildCities({ csvData }).concat(specificCities);
+    const cities = buildCities({ csvData }).concat(getCitiesWithDistricts());
     logger.info('✅ ');
 
     logger.info('Inserting cities in database... ');
@@ -110,7 +384,7 @@ async function main(filePath) {
     const insertedLines = _getInsertedLineNumber(batchInfo);
     logger.info('✅ ');
     trx.commit();
-    logger.info(`Added lines: ${insertedLines} (${specificCities.length} exception cases)`);
+    logger.info(`Added lines: ${insertedLines} (${districtCities.length} exception cases)`);
     logger.info('Done.');
   } catch (error) {
     if (trx) {
@@ -147,4 +421,5 @@ function _buildCityNameWithWordReplaced(cityName) {
 
 module.exports = {
   buildCities,
+  getCitiesWithDistricts
 };

--- a/api/tests/unit/scripts/import-certification-cpf-cities_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-cities_test.js
@@ -1,5 +1,8 @@
 const { expect, sinon } = require('../../test-helper');
-const { buildCities } = require('../../../scripts/certification/import-certification-cpf-cities');
+const {
+  buildCities,
+  getCitiesWithDistricts,
+} = require('../../../scripts/certification/import-certification-cpf-cities');
 const { noop } = require('lodash/noop');
 
 describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
@@ -135,6 +138,308 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
           ]);
         });
       });
+    });
+  });
+
+  describe('#getCitiesWithDistricts', function () {
+    it('should return the list of cities with districts', function () {
+      // when
+      const cities = getCitiesWithDistricts();
+
+      // then
+      expect(cities.filter(({ name }) => name === 'PARIS').length).to.equal(21);
+      expect(cities.filter(({ name }) => name === 'LYON').length).to.equal(10);
+      expect(cities.filter(({ name }) => name === 'MARSEILLE').length).to.equal(17);
+      expect(cities).to.deep.equal([
+        {
+          name: 'PARIS',
+          postalCode: 75000,
+          INSEECode: 75056,
+          isActualName: true,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75001,
+          INSEECode: 75101,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75002,
+          INSEECode: 75102,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75003,
+          INSEECode: 75103,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75004,
+          INSEECode: 75104,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75005,
+          INSEECode: 75106,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75006,
+          INSEECode: 75106,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75007,
+          INSEECode: 75107,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75008,
+          INSEECode: 75108,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75009,
+          INSEECode: 75109,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75010,
+          INSEECode: 75110,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 750011,
+          INSEECode: 75111,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75012,
+          INSEECode: 75112,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75013,
+          INSEECode: 75113,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75014,
+          INSEECode: 75114,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75015,
+          INSEECode: 75115,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75016,
+          INSEECode: 75116,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75017,
+          INSEECode: 75117,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75018,
+          INSEECode: 75118,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75019,
+          INSEECode: 75119,
+          isActualName: false,
+        },
+        {
+          name: 'PARIS',
+          postalCode: 75020,
+          INSEECode: 75120,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69000,
+          INSEECode: 69123,
+          isActualName: true,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69001,
+          INSEECode: 69381,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69002,
+          INSEECode: 69382,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69003,
+          INSEECode: 69383,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69004,
+          INSEECode: 69384,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69005,
+          INSEECode: 69385,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69006,
+          INSEECode: 69386,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69007,
+          INSEECode: 69387,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69008,
+          INSEECode: 69388,
+          isActualName: false,
+        },
+        {
+          name: 'LYON',
+          postalCode: 69009,
+          INSEECode: 69389,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13000,
+          INSEECode: 13055,
+          isActualName: true,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13001,
+          INSEECode: 13201,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13002,
+          INSEECode: 13202,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13003,
+          INSEECode: 13203,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13004,
+          INSEECode: 13204,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13005,
+          INSEECode: 13205,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13006,
+          INSEECode: 13206,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13007,
+          INSEECode: 13207,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13008,
+          INSEECode: 13208,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13009,
+          INSEECode: 13209,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13010,
+          INSEECode: 13210,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13011,
+          INSEECode: 13211,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13012,
+          INSEECode: 13212,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13013,
+          INSEECode: 13213,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13014,
+          INSEECode: 13214,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13015,
+          INSEECode: 13215,
+          isActualName: false,
+        },
+        {
+          name: 'MARSEILLE',
+          postalCode: 13016,
+          INSEECode: 13216,
+          isActualName: false,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, lorsqu’un utilisateur Pix Certif importe un candidat en utilisant le code postal pour le lieu de naissance, si celui-ci correspond à une ville avec arrondissement (Paris, Marseille ou Lyon), il doit absolument indiquer le numéro de l’arrondissement sinon il obtient un message d’erreur. Ex : 75001 Paris 01 (Paris, Paris 1 etc ne passent pas).

## :robot: Solution
Pour les CP des villes à arrondissement, autoriser le nom générique de la ville lors de l’import

## :rainbow: Remarques
Solution effectuée dans le script d'import

## :100: Pour tester

Importer le fichier 
```shell
scalingo --app pix-api-review-pr4809 run node ./scripts/certification/import-certification-cpf-cities.js /tmp/uploads/laposte_hexasmal.csv --file ~/Downloads/laposte_hexasmal.csv
```

Ajouter des candidats de certification pour Lyon/Marseille/Paris sans spécifier le numero d'arrondissement dans le nom (PARIS au lieu de PARIS 01)
S'assurer que le candidat est bien inscrit.