### PR TITLE
[BUGFIX] Corriger l'édition d'une organisation sur Pix Admin (PIX-5520).

### DIFF
--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -109,7 +109,8 @@ module.exports = {
 
     const tagsDB = await knex('tags')
       .select(['tags.id', 'tags.name'])
-      .join('organization-tags', 'organization-tags.organizationId', knex.raw('?', [organization.id]));
+      .join('organization-tags', 'organization-tags.tagId', 'tags.id')
+      .where('organization-tags.organizationId', organizationDB.id);
 
     const tags = tagsDB.map((tagDB) => new Tag(tagDB));
 
@@ -124,7 +125,8 @@ module.exports = {
 
     const tagsDB = await knex('tags')
       .select(['tags.id', 'tags.name'])
-      .join('organization-tags', 'organization-tags.organizationId', knex.raw('?', [id]));
+      .join('organization-tags', 'organization-tags.tagId', 'tags.id')
+      .where('organization-tags.organizationId', id);
 
     const tags = tagsDB.map((tagDB) => new Tag(tagDB));
     return _toDomain({ ...organizationDB, tags });


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'edition d'une organisation sur Pix Admin, une erreur est levée.
<img width="1666" alt="image" src="https://user-images.githubusercontent.com/38167520/186168205-cea77827-749d-465b-ad8a-8640f1025854.png">


## :robot: Solution
En fait le soucis est que lorsqu'on va récupérer l'organisation en BDD, on retourne avec elles TOUS les tags existant au lieu des tags qui sont liés à cette organisation. 

Ensuite lors de la mises à jour de l'organisation (ainsi que de ses tags), on relève les tags de l'organisation et on compare avec ceux que fournis le front pour savoir s'il y en a à ajouter ou à supprimer. Or comme on récupère tous les tags quand on va chercher l'organisation, on en vient à essayer de supprimer des tags non existant pour cette organisation. 

## :rainbow: Remarques
Ce soucis est en lien avec la suppression de bookshelf : https://github.com/1024pix/pix/pull/4800

## :100: Pour tester
Lancer Pix Admin : 
- Aller sur, par exemple, l'organisation "Médiation Numérique" (id= 5)
- Cliquer sur le bouton "Editer"
- Modifier n'importe quel champ
- Sauvegarder et constater qu'il n'y a plus d'erreur et que l'API ne renvoie pas d'erreur
