### PR TITLE
[FEATURE] Affichage de la certificabilité dans l'onglet élèves de Pix Orga (PIX-5481).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -67,5 +67,6 @@ module.exports = function buildCampaignParticipation({
     isImproved,
     deletedAt,
     deletedBy,
+    isCertifiable,
   };
 };

--- a/api/db/seeds/data/campaigns-sco-builder.js
+++ b/api/db/seeds/data/campaigns-sco-builder.js
@@ -5,7 +5,7 @@ const {
 } = require('./target-profiles-builder');
 const { PRO_BASICS_BADGE_ID, PRO_TOOLS_BADGE_ID } = require('./badges-builder');
 const { SCO_MIDDLE_SCHOOL_ID, SCO_HIGH_SCHOOL_ID, SCO_AGRI_ID, SCO_AEFE_ID } = require('./organizations-sco-builder');
-const { SCO_STUDENT_ID, SCO_FRENCH_USER_ID, SCO_FOREIGNER_USER_ID, SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION, SCO_DISABLED_USER_ID } = require('./organizations-sco-builder');
+const { SCO_STUDENT_ID, SCO_FRENCH_USER_ID, SCO_FOREIGNER_USER_ID, SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION, SCO_DISABLED_USER_ID, SCO_STUDENT_NOT_CERTIFIABLE_ID } = require('./organizations-sco-builder');
 const { participateToAssessmentCampaign, participateToProfilesCollectionCampaign } = require('./campaign-participations-builder');
 const CampaignParticipationStatuses = require('../../../lib/domain/models/CampaignParticipationStatuses');
 const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;
@@ -138,9 +138,11 @@ function _buildScoProfilesCollectionParticipations({ databaseBuilder }) {
   const scoStudentFrench = { id: SCO_FRENCH_USER_ID, createdAt: new Date('2022-02-06') };
   const scoStudentForeigner = { id: SCO_FOREIGNER_USER_ID, createdAt: new Date('2022-02-07') };
   const scoStudentDisabled = { id: SCO_DISABLED_USER_ID, createdAt: new Date('2022-02-07') };
+  const scoStudentNotCertifiable = { id: SCO_STUDENT_NOT_CERTIFIABLE_ID, createdAt: new Date('2022-02-08') };
 
   participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 7, user: scoStudent, organizationLearnerId: SCO_STUDENT_ID, status: SHARED });
   participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 7, user: scoStudentFrench, organizationLearnerId: SCO_FRENCH_USER_ID, status: SHARED });
   participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 7, user: scoStudentForeigner, organizationLearnerId: SCO_FOREIGNER_USER_ID, status: TO_SHARE });
   participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 7, user: scoStudentDisabled, organizationLearnerId: SCO_DISABLED_USER_ID, status: SHARED });
+  participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 7, user: scoStudentNotCertifiable, organizationLearnerId: SCO_STUDENT_NOT_CERTIFIABLE_ID, status: SHARED });
 }

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -8,6 +8,7 @@ const SCO_STUDENT_ID = 99;
 const CANADA_INSEE_CODE = '401';
 const SCO_FOREIGNER_USER_ID = 301;
 const SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION = 302;
+const SCO_STUDENT_NOT_CERTIFIABLE_ID = 303;
 const SCO_FRENCH_USER_ID = 311;
 const SCO_DISABLED_USER_ID = 321;
 const SCO_ADMIN_ID = 4;
@@ -158,6 +159,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
 
   // organization learner associated with email
   const userWithEmail = databaseBuilder.factory.buildUser.withRawPassword({
+    id: SCO_STUDENT_NOT_CERTIFIABLE_ID,
     firstName: 'Lyanna',
     lastName: 'Mormont',
     email: 'mormont.lyanna@example.net',
@@ -166,13 +168,14 @@ function _buildMiddleSchools({ databaseBuilder }) {
   });
 
   databaseBuilder.factory.buildOrganizationLearner({
+    id: SCO_STUDENT_NOT_CERTIFIABLE_ID,
     firstName: userWithEmail.firstName,
     lastName: userWithEmail.lastName,
     birthdate: '2002-01-07',
     division: '5D',
     group: null,
     organizationId: SCO_MIDDLE_SCHOOL_ID,
-    userId: userWithEmail.id,
+    userId: SCO_STUDENT_NOT_CERTIFIABLE_ID,
     nationalStudentId: '123456789EE',
   });
 
@@ -446,4 +449,5 @@ module.exports = {
   SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION,
   SCO_FRENCH_USER_ID,
   SCO_DISABLED_USER_ID,
+  SCO_STUDENT_NOT_CERTIFIABLE_ID,
 };

--- a/api/lib/domain/read-models/ScoOrganizationParticipant.js
+++ b/api/lib/domain/read-models/ScoOrganizationParticipant.js
@@ -14,6 +14,7 @@ class ScoOrganizationParticipant {
     campaignName,
     campaignType,
     participationStatus,
+    isCertifiable,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -29,6 +30,7 @@ class ScoOrganizationParticipant {
     this.campaignName = campaignName;
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
+    this.isCertifiable = isCertifiable;
   }
 }
 

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -4,6 +4,8 @@ const AuthenticationMethod = require('../../domain/models/AuthenticationMethod')
 const { knex } = require('../../../db/knex-database-connection');
 const { fetchPage } = require('../utils/knex-utils');
 const ScoOrganizationParticipant = require('../../domain/read-models/ScoOrganizationParticipant');
+const CampaignTypes = require('../../domain/models/CampaignTypes');
+const CampaignParticipationStatuses = require('../../domain/models/CampaignParticipationStatuses');
 
 function _setFilters(qb, { lastName, firstName, divisions, connexionType } = {}) {
   if (lastName) {
@@ -30,9 +32,29 @@ function _setFilters(qb, { lastName, firstName, divisions, connexionType } = {})
   }
 }
 
+function _buildIsCertifiable(queryBuilder, organizationId) {
+  queryBuilder
+    .distinct('organization-learners.id')
+    .select([
+      'organization-learners.id as organizationLearnerId',
+      knex.raw(
+        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
+      ),
+    ])
+    .from('organization-learners')
+    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where('campaign-participations.status', CampaignParticipationStatuses.SHARED)
+    .where('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
+    .where('organization-learners.organizationId', organizationId)
+    .where('campaigns.organizationId', organizationId)
+    .where('campaign-participations.deletedAt', null);
+}
+
 module.exports = {
   async findPaginatedFilteredScoParticipants({ organizationId, filter, page = {} }) {
     const query = knex
+      .with('subquery', (qb) => _buildIsCertifiable(qb, organizationId))
       .distinct('organization-learners.id')
       .select([
         'organization-learners.id',
@@ -47,23 +69,25 @@ module.exports = {
         'users.username',
         'users.email',
         'authentication-methods.externalIdentifier as samlId',
+        'subquery.isCertifiable',
         knex.raw(
-          'FIRST_VALUE("name") OVER(PARTITION BY "organizationLearnerId" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"'
+          'FIRST_VALUE("name") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"'
         ),
         knex.raw(
-          'FIRST_VALUE("campaign-participations"."status") OVER(PARTITION BY "organizationLearnerId" ORDER BY "campaign-participations"."createdAt" DESC) AS "participationStatus"'
+          'FIRST_VALUE("campaign-participations"."status") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "participationStatus"'
         ),
         knex.raw(
-          'FIRST_VALUE("type") OVER(PARTITION BY "organizationLearnerId" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignType"'
+          'FIRST_VALUE("type") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignType"'
         ),
         knex.raw(
-          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organizationLearnerId") AS "participationCount"'
+          'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organization-learners"."id") AS "participationCount"'
         ),
         knex.raw(
-          'max("campaign-participations"."createdAt") OVER(PARTITION BY "organizationLearnerId") AS "lastParticipationDate"'
+          'max("campaign-participations"."createdAt") OVER(PARTITION BY "organization-learners"."id") AS "lastParticipationDate"'
         ),
       ])
       .from('organization-learners')
+      .leftJoin('subquery', 'subquery.organizationLearnerId', 'organization-learners.id')
       .leftJoin('campaign-participations', 'campaign-participations.organizationLearnerId', 'organization-learners.id')
       .leftJoin('users', 'users.id', 'organization-learners.userId')
       .leftJoin('authentication-methods', function () {

--- a/api/lib/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer.js
@@ -18,6 +18,7 @@ module.exports = {
         'campaignName',
         'campaignType',
         'participationStatus',
+        'isCertifiable',
       ],
       meta: pagination,
     }).serialize(scoOrganizationParticipants);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1085,6 +1085,7 @@ describe('Acceptance | Application | organization-controller', function () {
                 'campaign-name': campaign.name,
                 'campaign-type': campaign.type,
                 'participation-status': participation.status,
+                'is-certifiable': participation.isCertifiable,
               },
               id: organizationLearner.id.toString(),
               type: 'sco-organization-participants',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer_test.js
@@ -23,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
           campaignName: 'King Karam',
           campaignType: 'ASSESSMENT',
           participationStatus: campaignParticipationsStatuses.TO_SHARE,
+          isCertifiable: null,
         }),
         new ScoOrganizationParticipant({
           id: 778,
@@ -39,6 +40,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
           campaignName: 'King Xavier',
           campaignType: 'PROFILES_COLLECTION',
           participationStatus: campaignParticipationsStatuses.SHARED,
+          isCertifiable: true,
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -62,6 +64,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
               'campaign-name': scoOrganizationParticipants[0].campaignName,
               'campaign-type': scoOrganizationParticipants[0].campaignType,
               'participation-status': scoOrganizationParticipants[0].participationStatus,
+              'is-certifiable': scoOrganizationParticipants[0].isCertifiable,
             },
           },
           {
@@ -81,6 +84,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
               'campaign-name': scoOrganizationParticipants[1].campaignName,
               'campaign-type': scoOrganizationParticipants[1].campaignType,
               'participation-status': scoOrganizationParticipants[1].participationStatus,
+              'is-certifiable': scoOrganizationParticipants[1].isCertifiable,
             },
           },
         ],

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -8,6 +8,7 @@
       <col />
       <col class="table__column--right" />
       <col class="table__column--center" />
+      <col class="table__column--center" />
       <col class="hide-on-mobile" />
     </colgroup>
     <thead>
@@ -26,6 +27,9 @@
         </Table::Header>
         <Table::Header @size="medium" @align="center">
           {{t "pages.sco-organization-participants.table.column.last-participation-date"}}
+        </Table::Header>
+        <Table::Header @size="medium" @align="center">
+          {{t "pages.sco-organization-participants.table.column.is-certifiable.label"}}
         </Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
       </tr>
@@ -66,6 +70,7 @@
         <Table::Header class="table__column--right" />
         <Table::Header />
         <Table::Header />
+        <Table::Header />
       </tr>
     </thead>
 
@@ -95,6 +100,9 @@
                   />
                 </div>
               {{/if}}
+            </td>
+            <td class="table__column--center">
+              <Ui::IsCertifiable @isCertifiable={{student.isCertifiable}} />
             </td>
             <td class="organization-participant-list-page__actions hide-on-mobile">
               {{#if student.isAssociated}}

--- a/orga/app/components/ui/is-certifiable.hbs
+++ b/orga/app/components/ui/is-certifiable.hbs
@@ -1,0 +1,11 @@
+{{#if this.isCertifiableNotAvailable}}
+  {{t "pages.sco-organization-participants.table.column.is-certifiable.not-available"}}
+{{else if @isCertifiable}}
+  <PixTag @color="green-light">
+    {{t "pages.sco-organization-participants.table.column.is-certifiable.eligible"}}
+  </PixTag>
+{{else}}
+  <PixTag @color="yellow-light">
+    {{t "pages.sco-organization-participants.table.column.is-certifiable.non-eligible"}}
+  </PixTag>
+{{/if}}

--- a/orga/app/components/ui/is-certifiable.js
+++ b/orga/app/components/ui/is-certifiable.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class IsCertifiable extends Component {
+  get isCertifiableNotAvailable() {
+    return this.args.isCertifiable === null;
+  }
+}

--- a/orga/app/models/sco-organization-participant.js
+++ b/orga/app/models/sco-organization-participant.js
@@ -21,7 +21,7 @@ export default class ScoOrganizationParticipant extends Model {
   @attr('string') campaignName;
   @attr('string') campaignType;
   @attr('string') participationStatus;
-  @attr() isCertifiable;
+  @attr('nullable-boolean') isCertifiable;
   @belongsTo('organization') organization;
 
   get hasUsername() {

--- a/orga/app/models/sco-organization-participant.js
+++ b/orga/app/models/sco-organization-participant.js
@@ -21,6 +21,7 @@ export default class ScoOrganizationParticipant extends Model {
   @attr('string') campaignName;
   @attr('string') campaignType;
   @attr('string') participationStatus;
+  @attr() isCertifiable;
   @belongsTo('organization') organization;
 
   get hasUsername() {

--- a/orga/app/transforms/nullable-boolean.js
+++ b/orga/app/transforms/nullable-boolean.js
@@ -1,0 +1,12 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class NullableBoolean extends Transform {
+  serialize(boolean) {
+    if (typeof boolean !== 'boolean') return null;
+    return boolean;
+  }
+
+  deserialize(boolean) {
+    return boolean;
+  }
+}

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import { click } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
-import { render } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
@@ -90,6 +89,21 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         )
       )
       .exists();
+  });
+
+  test('it should display participant as eligible for certification when the participant is certifiable', async function (assert) {
+    // given
+    this.set('students', [
+      store.createRecord('sco-organization-participant', {
+        isCertifiable: true,
+      }),
+    ]);
+
+    // when
+    await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+    // then
+    assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
   });
 
   module('when user is filtering some users', function () {

--- a/orga/tests/integration/components/ui/is-certifiable_test.js
+++ b/orga/tests/integration/components/ui/is-certifiable_test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Ui | IsCertifiable', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display participant as eligible for certification', async function (assert) {
+    // when
+    await render(hbs`<Ui::IsCertifiable @isCertifiable={{true}} />`);
+
+    // then
+    assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
+  });
+
+  test('it should display participant as non eligible for certification', async function (assert) {
+    // when
+    await render(hbs`<Ui::IsCertifiable @isCertifiable={{false}} />`);
+
+    // then
+    assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.non-eligible'));
+  });
+
+  test('it should display participant with not available information about eligibility for certification', async function (assert) {
+    // when
+    await render(hbs`<Ui::IsCertifiable @isCertifiable={{null}} />`);
+
+    // then
+    assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.not-available'));
+  });
+});

--- a/orga/tests/unit/transforms/nullable-boolean_test.js
+++ b/orga/tests/unit/transforms/nullable-boolean_test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import NullableBooleanTransform from 'pix-orga/transforms/nullable-boolean';
+
+module('Unit | Transformer | Nullable Boolean', function (hooks) {
+  setupTest(hooks);
+
+  module('#serialize', function () {
+    test('should return null when undefined', function (assert) {
+      // given
+      const transform = NullableBooleanTransform.create();
+      const boolean = undefined;
+
+      // when
+      const serialized = transform.serialize(boolean);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+
+    test('should return true', function (assert) {
+      // given
+      const transform = NullableBooleanTransform.create();
+      const boolean = true;
+
+      // when
+      const serialized = transform.serialize(boolean);
+
+      // then
+      assert.true(serialized);
+    });
+
+    test('should return false', function (assert) {
+      // given
+      const transform = NullableBooleanTransform.create();
+      const boolean = false;
+
+      // when
+      const serialized = transform.serialize(boolean);
+
+      // then
+      assert.false(serialized);
+    });
+
+    test('should return null', function (assert) {
+      // given
+      const transform = NullableBooleanTransform.create();
+      const boolean = null;
+
+      // when
+      const serialized = transform.serialize(boolean);
+
+      // then
+      assert.strictEqual(serialized, null);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -819,6 +819,12 @@
           "date-of-birth": "Date of birth",
           "division": "Class",
           "first-name": "First name",
+          "is-certifiable": {
+            "eligible": "Eligible",
+            "label": "Eligibility for certification",
+            "non-eligible": "Non-eligible",
+            "not-available": "Not available"
+          },
           "last-name": "Last name",
           "last-participation-date": "Latest participation",
           "login-method": "Log in method(s)",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -819,6 +819,12 @@
           "date-of-birth": "Date de naissance",
           "division": "Classe",
           "first-name": "Prénom",
+          "is-certifiable": {
+            "eligible": "Certifiable",
+            "label": "Certificabilité",
+            "non-eligible": "Non Certifiable",
+            "not-available": "Non communiqué"
+          },
           "last-name": "Nom",
           "last-participation-date": "Dernière participation",
           "login-method": "Méthode(s) de connexion",


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.

## :robot: Solution
Maintenant que nous avons créé et enrichi la colonne IsCertifiable, nous pouvons exploiter cette donnée et l’afficher dans l’onglet Eleves :
- si l'élève est “certifiable” on affiche la flag Certifiable
- si l’lève ne l’est pas on affiche “Non certifiable” 
- si non n’avons pas d’information affiché “Non communiqué”

## :rainbow: Remarques
Un benchmark avec la requête d'avant et la requête d'après a été fait pour comparaison, voici les résultats :

**AVANT**
organisation comportant 1000 `organization-learners` : 20ms
organisation comportant 15000 `organization-learners` : 450ms

requête testée (celle servant à la pagination et devant récupérer toutes les lignes) :
```
explain analyze select count(*) as "rowCount" from (
select distinct "organization-learners"."id", 
"organization-learners"."id", 
"organization-learners"."firstName", 
"organization-learners"."lastName", 
LOWER("organization-learners"."firstName") AS "lowerFirstName", 
LOWER("organization-learners"."lastName") AS "lowerLastName", 
"organization-learners"."birthdate", 
"organization-learners"."division", 
"organization-learners"."userId", 
"organization-learners"."organizationId", 
"users"."username", 
"users"."email", 
"authentication-methods"."externalIdentifier" as "samlId", 
FIRST_VALUE("name") OVER(PARTITION BY "organizationLearnerId" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName", 
FIRST_VALUE("campaign-participations"."status") OVER(PARTITION BY "organizationLearnerId" ORDER BY "campaign-participations"."createdAt" DESC) AS "participationStatus", 
FIRST_VALUE("type") OVER(PARTITION BY "organizationLearnerId" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignType", 
COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organizationLearnerId") AS "participationCount", 
max("campaign-participations"."createdAt") OVER(PARTITION BY "organizationLearnerId") AS "lastParticipationDate" 
from "organization-learners" 
left join "campaign-participations" on "campaign-participations"."organizationLearnerId" = "organization-learners"."id" 
left join "users" on "users"."id" = "organization-learners"."userId" 
left join "authentication-methods" on "users"."id" = "authentication-methods"."userId" and "authentication-methods"."identityProvider" = 'GAR' 
left join "campaigns" on "campaigns"."id" = "campaign-participations"."campaignId" and "campaigns"."organizationId" = "organization-learners"."organizationId" 
where ("campaign-participations"."id" is null or ("campaign-participations"."isImproved" = false and "campaign-participations"."deletedAt" is null))
and "organization-learners"."isDisabled" = false 
and "organization-learners"."organizationId" = ID_ORGA
order by "lowerLastName" ASC, "lowerFirstName" ASC 
) as "query_all_results" limit 1
```

**APRES**
organisation comportant 1000 `organization-learners` : 20ms
organisation comportant 15000 `organization-learners` : 600ms

requête testée (celle servant à la pagination et devant récupérer toutes les lignes) :
```
explain analyse select count(*) as "rowCount" from (
with "subquery" as (
select distinct "organization-learners"."id", 
"organization-learners"."id" as "organizationLearnerId", 
FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable" 
from "organization-learners" 
inner join "campaign-participations" on "organization-learners"."id" = "campaign-participations"."organizationLearnerId" 
inner join "campaigns" on "campaigns"."id" = "campaign-participations"."campaignId" 
where "campaign-participations"."status" = 'SHARED' 
and "campaigns"."type" = 'PROFILES_COLLECTION' 
and "organization-learners"."organizationId" = ID_ORGA 
and "campaigns"."organizationId" = ID_ORGA 
and "campaign-participations"."deletedAt" is null)
select distinct "organization-learners"."id", 
"organization-learners"."id", 
"organization-learners"."firstName", 
"organization-learners"."lastName", 
LOWER("organization-learners"."firstName") AS "lowerFirstName", 
LOWER("organization-learners"."lastName") AS "lowerLastName",
"organization-learners"."birthdate", 
"organization-learners"."division", 
"organization-learners"."userId", 
"organization-learners"."organizationId", 
"users"."username", "users"."email", 
"authentication-methods"."externalIdentifier" as "samlId", 
"subquery"."isCertifiable", 
FIRST_VALUE("name") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName", 
FIRST_VALUE("campaign-participations"."status") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "participationStatus", 
FIRST_VALUE("type") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignType", 
COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organization-learners"."id") AS "participationCount", 
max("campaign-participations"."createdAt") OVER(PARTITION BY "organization-learners"."id") AS "lastParticipationDate" 
from "organization-learners" 
left join "subquery" on "subquery"."organizationLearnerId" = "organization-learners"."id" 
left join "campaign-participations" on "campaign-participations"."organizationLearnerId" = "organization-learners"."id" 
left join "users" on "users"."id" = "organization-learners"."userId" 
left join "authentication-methods" on "users"."id" = "authentication-methods"."userId" and "authentication-methods"."identityProvider" = 'GAR'
left join "campaigns" on "campaigns"."id" = "campaign-participations"."campaignId" and "campaigns"."organizationId" = "organization-learners"."organizationId" 
where ("campaign-participations"."id" is null or ("campaign-participations"."isImproved" = false and "campaign-participations"."deletedAt" is null)) 
and "organization-learners"."isDisabled" = false
and "organization-learners"."organizationId" = ID_ORGA 
order by "lowerLastName" ASC, "lowerFirstName" ASC
) as "query_all_results" limit 1
```

Ces temps sont tout à fait acceptables.

## :100: Pour tester
- se connecter à pix orga en tant que sco.admin@example.net et aller dans l'onglet élèves. Vérifier qu'on voit pour "Student Certified" et "George De Cambdridge" certifiables, "Lyanna Mormont" non certifiable et les autres non communiqué.
- tester aussi la version anglais en mettant le .org et `?lang=en` dans l'url
- tester en faisant une campagne `SCOCOLECT` en tant que userpix1@exampl.net, se réconcilier avec `first last 10/10/2010`, partager son profil et vérifier que l'info a été mise à jour dans Pix Orga.
