### PR TITLE
[FEATURE] Ajout du lien menant au détail de ma participation même si celle ci est désactivée par l'organisateur (PIX-5519)

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -10,10 +10,8 @@
     </time>
   </header>
   <section class="campaign-participation-overview-card-content">
-    <div
-      class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content__content-archived"
-    >
-      {{#if @model.isShared}}
+    {{#if @model.isShared}}
+      <div class="campaign-participation-overview-card-content__content">
         {{#if this.hasStages}}
           <PixStars
             @count={{@model.validatedStagesCount}}
@@ -30,11 +28,23 @@
             {{t "pages.campaign-participation-overview.card.results" result=@model.masteryRate}}
           </p>
         {{/if}}
-      {{else}}
+      </div>
+      <LinkTo
+        class="link campaign-participation-overview-card-content__see-more campaign-participation-overview-card-content__action"
+        @route="campaigns.entry-point"
+        @model={{@model.campaignCode}}
+      >
+        <FaIcon @icon="arrow-right" aria-hidden="true" />
+        {{t "pages.campaign-participation-overview.card.see-more"}}
+      </LinkTo>
+    {{else}}
+      <div
+        class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content__archived-and-not-shared"
+      >
         <p class="campaign-participation-overview-card-content--archived">
           {{t "pages.campaign-participation-overview.card.text-disabled" htmlSafe=true}}
         </p>
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
   </section>
 </article>

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -35,7 +35,7 @@
     color: $pix-neutral-60;
   }
 
-  &__content-archived {
+  &__archived-and-not-shared {
     margin-bottom: 32px;
   }
 

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
@@ -69,9 +69,52 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' })))
           .to.exist;
       });
+
+      it('should not display go to details link', async function () {
+        // given
+        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+          createdAt: '2020-01-01',
+          disabledAt: '2020-01-03',
+          status: 'TO_SHARE',
+          campaignTitle: 'My campaign',
+          organizationName: 'My organization',
+          masteryRate: null,
+        });
+        this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+        // when
+        await render(
+          hbs`<CampaignParticipationOverview::Card::Disabled @model={{this.campaignParticipationOverview}} />`
+        );
+
+        // then
+        expect(contains('Voir le détail')).to.not.exist;
+      });
     });
 
     context('when the participation is completed', function () {
+      it('should display go to details link', async function () {
+        // given
+        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+          createdAt: '2020-01-01',
+          disabledAt: '2020-01-03',
+          status: 'SHARED',
+          isShared: true,
+          campaignTitle: 'My campaign',
+          organizationName: 'My organization',
+          masteryRate: 0.56,
+        });
+        this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+        // when
+        await render(
+          hbs`<CampaignParticipationOverview::Card::Disabled @model={{this.campaignParticipationOverview}} />`
+        );
+
+        // then
+        expect(contains('Voir le détail')).to.exist;
+      });
+
       context('when the participation has a mastery percentage', () => {
         it('should render the result with percentage', async function () {
           // given


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous avons réalisé l’onglet Mes parcours nous avions voulu ne plus permettre à l’utilisateur de voir le détail de son parcours.
Hors, nous avons eu des retours d’utilisateurs (du support, du PRO et de Benoit) qui ne comprennent pas pourquoi ces parcours ne sont plus consultables, alors que c’est une action du prescripteur qui ne devrait pas cacher les résultats d’un parcours.

## :robot: Solution
Laisser le lien “Voir le détail” les cartes de parcours en statut INACTIF.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter à mon pix
- aller dans l'onglet `/mes-parcours`
- verifier la présence des liens et leur redirection
