### PR TITLE
[FEATURE] Améliorer l'accessibilité de nos menus (PIX-5527)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -46,11 +46,11 @@ describe('a11y', () => {
   describe('Authenticated pages', () => {
     const authenticatedPages = [
       { url: '/accueil', skipFailures: true },
-      { url: '/competences', skipFailures: true },
+      { url: '/competences' },
       { url: '/certifications', skipFailures: true },
       { url: '/mon-profil', skipFailures: true },
-      { url: '/mes-tutos/recommandes', skipFailures: true },
-      { url: '/mes-certifications', skipFailures: true },
+      { url: '/mes-tutos/recommandes' },
+      { url: '/mes-certifications' },
       { url: '/campagnes/NERA/evaluation/resultats' },
     ];
 

--- a/mon-pix/app/components/footer.hbs
+++ b/mon-pix/app/components/footer.hbs
@@ -14,7 +14,7 @@
     </div>
 
     <div class="footer-container__content">
-      <nav class="footer-container-content__navigation" role="navigation">
+      <nav class="footer-container-content__navigation" role="navigation" aria-label={{t "navigation.footer.label"}}>
         <ul class="footer-container-content__navigation-list">
           <li>
             <a href="{{this.supportHomeUrl}}" target="_blank" class="footer-navigation__item" rel="noopener noreferrer">

--- a/mon-pix/app/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/components/navbar-desktop-header.hbs
@@ -13,7 +13,7 @@
     </div>
 
     {{#if this.showHeaderMenuItem}}
-      <nav class="navbar-desktop-header-container__menu" role="navigation">
+      <nav class="navbar-desktop-header-container__menu" role="navigation" aria-label={{t "navigation.main.label"}}>
         <ul class="navbar-desktop-header-menu__list">
           <li class="navbar-desktop-header-menu__item">
             <LinkTo @route="user-dashboard" class="navbar-desktop-header-menu__link">

--- a/mon-pix/app/components/navbar-header.hbs
+++ b/mon-pix/app/components/navbar-header.hbs
@@ -1,10 +1,10 @@
 <Skiplink @href="#main" @label={{t "common.skip-links.skip-to-content"}} />
 <Skiplink @href="#footer" @label={{t "common.skip-links.skip-to-footer"}} />
 
-<nav class="navbar-header" role="navigation">
+<div class="navbar-header">
   {{#if (media "isDesktop")}}
     <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}} />
   {{else}}
     <NavbarMobileHeader @burger={{@burger}} @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}} />
   {{/if}}
-</nav>
+</div>

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -3,11 +3,17 @@
   <div class="navbar-mobile-header__container">
     {{#if @burger}}
       {{#if this.isUserLogged}}
-        <button class="navbar-mobile-header__burger-icon" {{on "click" @burger.state.actions.toggle}} type="button">
-          {{#unless @burger.state.open}}
+        {{#unless @burger.state.open}}
+          <button
+            class="navbar-mobile-header__burger-icon"
+            {{on "click" @burger.state.actions.toggle}}
+            type="button"
+            aria-labelledby="nav-mobile-button"
+          >
+            <span id="nav-mobile-button" class="sr-only">{{t "navigation.mobile-button-title"}}</span>
             <FaIcon @icon="bars" />
-          {{/unless}}
-        </button>
+          </button>
+        {{/unless}}
 
         {{#@burger.menu as |menu|}}
           <NavbarBurgerMenu class="navbar-burger-menu-content" @burger={{@burger}} />

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -97,6 +97,7 @@
     "copyrights": "©",
     "error": "Error",
     "footer": {
+      "label": "Secondary navigation",
       "a11y": "Accessibility",
       "data-protection-policy": "Personal data protection policy",
       "eula": "Terms and conditions",
@@ -105,6 +106,7 @@
     },
     "homepage": "Pix's Homepage",
     "main": {
+      "label": "Main navigation",
       "code": "I have a code",
       "dashboard": "Home",
       "help": "Help",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -126,7 +126,8 @@
     },
     "user-logged-menu": {
       "details": "Check my details"
-    }
+    },
+    "mobile-button-title": "Open menu"
   },
   "pages": {
     "assessment-banner": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -97,6 +97,7 @@
     "copyrights": "©",
     "error": "Erreur",
     "footer": {
+      "label": "Menu secondaire",
       "a11y": "Accessibilité : partiellement conforme",
       "data-protection-policy": "Politique de protection des données",
       "eula": "CGU",
@@ -105,6 +106,7 @@
     },
     "homepage": "Page d'accueil de Pix",
     "main": {
+      "label": "Menu principal",
       "code": "J'ai un code",
       "dashboard": "Accueil",
       "help": "Aide",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -126,7 +126,8 @@
     },
     "user-logged-menu": {
       "details": "Consulter mes informations"
-    }
+    },
+    "mobile-button-title": "Ouvrir le menu"
   },
   "pages": {
     "assessment-banner": {


### PR DESCRIPTION
## :unicorn: Problème
Les tests axe relevaient un problème d'accessibilité [`landmark-unique`](https://dequeuniversity.com/rules/axe/4.4/landmark-unique). Ce problème résulte du fait que nos navigations ont bien : `role="navigation"`, mais que rien différencie les 2 navigations présentes dans les pages sur Pix App. 

## :robot: Solution
Pour résoudre ce problème, il a fallu simplement ajouter des `aria-label` sur chaque nav. 

## :rainbow: Remarques
Une condition permet de ne pas afficher l'icon du bouton permettant d'ouvrir le menu sur mobile lorsque ce dernier est ouvert. Nous avons décidé de supprimer complétement le bouton lorsque le menu est ouvert au lieu de simplement l'icone. 

3 nouvelles pages ont désormais les tests axes qui passent : 
- `/competences`
- `/mes-tutos/recommandes`
- `/mes-certifications`

## :100: Pour tester
- Constater que la CI passe

- Vérifier le bon fonctionnement des barres de navigations 