### PR TITLE
[FEATURE] Déplacer les filtres de la page élèves dans un bandeau dédié (PIX-5535)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -1,3 +1,48 @@
+<PixFilterBanner
+  @title={{t "pages.sco-organization-participants.filter.title"}}
+  class="participant-filter-banner hide-on-mobile"
+  aria-label={{t "pages.sco-organization-participants.filter.aria-label"}}
+  @details={{t "pages.sco-organization-participants.filter.students-count" count=@students.meta.rowCount}}
+  @clearFiltersLabel={{t "pages.sco-organization-participants.filter.actions.clear"}}
+  @onClearFilters={{@onResetFilter}}
+>
+  <Ui::SearchInputFilter
+    @field="firstName"
+    @value={{@firstNameFilter}}
+    @placeholder={{t "pages.sco-organization-participants.filter.first-name.label"}}
+    @ariaLabel={{t "pages.sco-organization-participants.filter.first-name.aria-label"}}
+    @triggerFiltering={{@onFilter}}
+  />
+
+  <Ui::SearchInputFilter
+    @field="lastName"
+    @value={{@lastNameFilter}}
+    @placeholder={{t "pages.sco-organization-participants.filter.last-name.label"}}
+    @ariaLabel={{t "pages.sco-organization-participants.filter.last-name.aria-label"}}
+    @triggerFiltering={{@onFilter}}
+  />
+
+  <Ui::MultiSelectFilter
+    @field="divisions"
+    @title={{t "pages.sco-organization-participants.filter.division.label"}}
+    @onSelect={{@onFilter}}
+    @selectedOption={{@divisionsFilter}}
+    @onLoadOptions={{this.loadDivisions}}
+    @placeholder={{t "pages.sco-organization-participants.filter.division.label"}}
+    @ariaLabel={{t "pages.sco-organization-participants.filter.division.aria-label"}}
+    @emptyMessage={{t "pages.sco-organization-participants.filter.division.empty"}}
+  />
+
+  <Ui::SelectFilter
+    @field="connexionType"
+    @options={{@connectionTypesOptions}}
+    @selectedOption={{@connexionTypeFilter}}
+    @triggerFiltering={{@onFilter}}
+    @ariaLabel={{t "pages.sco-organization-participants.filter.login-method.aria-label"}}
+    @emptyOptionLabel={{t "pages.sco-organization-participants.filter.login-method.empty-option"}}
+  />
+</PixFilterBanner>
+
 <div class="panel">
   <table class="table content-text content-text--small">
     <colgroup class="table__column">
@@ -48,45 +93,6 @@
           </div>
         </Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
-      </tr>
-      <tr class="hide-on-mobile">
-        <Table::HeaderFilterInput
-          @field="lastName"
-          @value={{@lastNameFilter}}
-          @placeholder={{t "pages.sco-organization-participants.table.filter.last-name.label"}}
-          @ariaLabel={{t "pages.sco-organization-participants.table.filter.last-name.aria-label"}}
-          @triggerFiltering={{@onFilter}}
-        />
-        <Table::HeaderFilterInput
-          @field="firstName"
-          @value={{@firstNameFilter}}
-          @placeholder={{t "pages.sco-organization-participants.table.filter.first-name.label"}}
-          @ariaLabel={{t "pages.sco-organization-participants.table.filter.first-name.aria-label"}}
-          @triggerFiltering={{@onFilter}}
-        />
-        <Table::Header />
-        <Table::HeaderFilterMultiSelect
-          @field="divisions"
-          @title={{t "pages.sco-organization-participants.table.column.division"}}
-          @onSelect={{@onFilter}}
-          @selectedOption={{@divisionsFilter}}
-          @onLoadOptions={{this.loadDivisions}}
-          @placeholder={{t "pages.sco-organization-participants.table.filter.division.label"}}
-          @ariaLabel={{t "pages.sco-organization-participants.table.filter.division.aria-label"}}
-          @emptyMessage={{t "pages.sco-organization-participants.table.filter.division.empty"}}
-        />
-        <Table::HeaderFilterSelect
-          @field="connexionType"
-          @options={{@connectionTypesOptions}}
-          @selectedOption={{@connexionTypeFilter}}
-          @triggerFiltering={{@onFilter}}
-          @ariaLabel={{t "pages.sco-organization-participants.table.filter.login-method.aria-label"}}
-          @emptyOptionLabel={{t "pages.sco-organization-participants.table.filter.login-method.empty-option"}}
-        />
-        <Table::Header class="table__column--right" />
-        <Table::Header />
-        <Table::Header />
-        <Table::Header />
       </tr>
     </thead>
 

--- a/orga/app/components/ui/multi-select-filter.hbs
+++ b/orga/app/components/ui/multi-select-filter.hbs
@@ -1,0 +1,17 @@
+<PixMultiSelect
+  @id="multi-select-{{@field}}"
+  @title={{@title}}
+  @placeholder={{@placeholder}}
+  @loadingMessage={{t "common.filters.loading"}}
+  @emptyMessage={{@emptyMessage}}
+  aria-label={{@ariaLabel}}
+  @showOptionsOnInput={{true}}
+  @isSearchable={{true}}
+  @onSelect={{this.onSelect}}
+  @selected={{@selectedOption}}
+  @options={{@options}}
+  @onLoadOptions={{@onLoadOptions}}
+  as |option|
+>
+  {{option.label}}
+</PixMultiSelect>

--- a/orga/app/components/ui/multi-select-filter.js
+++ b/orga/app/components/ui/multi-select-filter.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class MultiSelectFilter extends Component {
+  @action
+  onSelect(value) {
+    const { onSelect, field } = this.args;
+    onSelect(field, value);
+  }
+}

--- a/orga/app/components/ui/select-filter.hbs
+++ b/orga/app/components/ui/select-filter.hbs
@@ -1,0 +1,8 @@
+<PixSelect
+  id="select-{{@field}}"
+  aria-label={{@ariaLabel}}
+  @onChange={{this.onChange}}
+  @options={{@options}}
+  @selectedOption={{@selectedOption}}
+  @emptyOptionLabel={{@emptyOptionLabel}}
+/>

--- a/orga/app/components/ui/select-filter.js
+++ b/orga/app/components/ui/select-filter.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class SelectFilter extends Component {
+  @action
+  onChange(event) {
+    const { triggerFiltering, field } = this.args;
+    triggerFiltering(field, event.target.value);
+  }
+}

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -26,6 +26,15 @@ export default class ListController extends Controller {
     this.pageNumber = null;
   }
 
+  @action
+  resetFiltering() {
+    this.pageNumber = null;
+    this.divisions = [];
+    this.connexionType = null;
+    this.firstName = null;
+    this.lastName = null;
+  }
+
   get connectionTypesOptions() {
     return [
       { value: 'none', label: this.intl.t(CONNECTION_TYPES.none) },

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -11,6 +11,7 @@
     @divisionsFilter={{this.divisions}}
     @connexionTypeFilter={{this.connexionType}}
     @onFilter={{this.triggerFiltering}}
+    @onResetFilter={{this.resetFiltering}}
   />
 
   {{#if this.isLoading}}

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -27,7 +27,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     this.owner.register('service:current-user', CurrentUserStub);
   });
 
-  test('it should display the table headers', async function (assert) {
+  test('it should display the filter banner', async function (assert) {
     // given
     this.set('students', []);
 
@@ -176,6 +176,32 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
       // then
       sinon.assert.calledWithExactly(triggerFiltering, 'connexionType', 'email');
+      assert.ok(true);
+    });
+
+    test('it should call resetFiltered', async function (assert) {
+      // given
+      const resetFiltered = sinon.spy();
+      this.set('resetFiltered', resetFiltered);
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', [
+        store.createRecord('sco-organization-participant', {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          birthdate: '2010-01-01',
+        }),
+      ]);
+
+      await render(
+        hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{triggerFiltering}} @onResetFilter={{resetFiltered}}  />`
+      );
+
+      // when
+      await clickByName('Effacer les filtres');
+
+      // then
+      sinon.assert.called(resetFiltered);
       assert.ok(true);
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -814,6 +814,31 @@
           }
         }
       },
+      "filter": {
+        "division": {
+          "aria-label": "Enter a class",
+          "empty": "No class",
+          "label": "Search by class"
+        },
+        "first-name": {
+          "aria-label": "Enter a first name",
+          "label": "Search by first name"
+        },
+        "last-name": {
+          "aria-label": "Enter a last name",
+          "label": "Search by last name"
+        },
+        "login-method": {
+          "aria-label": "Search by log in method",
+          "empty-option": "login method"
+        },
+        "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}",
+        "title": "Filters",
+        "aria-label":"Filters on students",
+        "actions": {
+          "clear": "Clear filters"
+        }
+      },
       "table": {
         "column": {
           "date-of-birth": "Date of birth",
@@ -832,25 +857,6 @@
           "participation-count": "Number of participations"
         },
         "empty": "No students.",
-        "filter": {
-          "division": {
-            "aria-label": "Enter a class",
-            "empty": "No class",
-            "label": "Search by class"
-          },
-          "first-name": {
-            "aria-label": "Enter a first name",
-            "label": "Search by first name"
-          },
-          "last-name": {
-            "aria-label": "Enter a last name",
-            "label": "Search by last name"
-          },
-          "login-method": {
-            "aria-label": "Search by log in method",
-            "empty-option": "All"
-          }
-        },
         "row-title": "Student"
       }
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -814,6 +814,31 @@
           }
         }
       },
+      "filter": {
+        "division": {
+          "aria-label": "Entrer une classe",
+          "empty": "Aucune classe",
+          "label": "Rechercher par classe"
+        },
+        "first-name": {
+          "aria-label": "Entrer un prénom",
+          "label": "Rechercher par prénom"
+        },
+        "last-name": {
+          "aria-label": "Entrer un nom",
+          "label": "Rechercher par nom"
+        },
+        "login-method": {
+          "aria-label": "Rechercher par méthode de connexion",
+          "empty-option": "Méthode de connexion"
+        },
+        "students-count": "{count, plural, =0 {0 élève} =1 {1 élève} other {{count} élèves}}",
+        "title": "Filtres",
+        "aria-label":"Filtres sur les élèves",
+        "actions": {
+          "clear": "Effacer les filtres"
+        }
+      },
       "table": {
         "column": {
           "date-of-birth": "Date de naissance",
@@ -832,25 +857,6 @@
           "participation-count": "Nombre de participations"
         },
         "empty": "Aucun élève.",
-        "filter": {
-          "division": {
-            "aria-label": "Entrer une classe",
-            "empty": "Aucune classe",
-            "label": "Rechercher par classe"
-          },
-          "first-name": {
-            "aria-label": "Entrer un prénom",
-            "label": "Rechercher par prénom"
-          },
-          "last-name": {
-            "aria-label": "Entrer un nom",
-            "label": "Rechercher par nom"
-          },
-          "login-method": {
-            "aria-label": "Rechercher par méthode de connexion",
-            "empty-option": "Tous"
-          }
-        },
         "row-title": "Élève"
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Les filtres dans les colonnes tableaux ne sont plus d'actulité dans Pix Orga, de plus il porte un souci d'accessiblité en devenant des tableaux dit "complexes"

## :robot: Solution
Remplacer les filtres dans le tableaux de la page élèves par un bandeau filtres

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter avec sco.admin@example.net, allez sur le menu élèves, vérifiez que les filtres sont bien présent dans un bandeau et absent dans le tableau