### PR TITLE
[FEATURE] Retourner le contexte du tutoriel dans la page `/mes-tutos/enregistres` (PIX-5545).

### DIFF
--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -67,7 +67,7 @@ module.exports = {
       const tutorials = await _findByRecordIds({ ids: skill.tutorialIds, locale });
 
       tutorialsForUser.push(
-        ..._toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials, skillId: skill.id })
+        ..._toTutorialsForUserForRecommandation({ tutorials, tutorialEvaluations, userTutorials, skillId: skill.id })
       );
     }
 
@@ -86,7 +86,15 @@ function _toDomain(tutorialData) {
   });
 }
 
-function _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials, skillId }) {
+function _toTutorialsForUser({ tutorials, tutorialEvaluations, userTutorials }) {
+  return tutorials.map((tutorial) => {
+    const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
+    const tutorialEvaluation = tutorialEvaluations.find(({ tutorialId }) => tutorialId === tutorial.id);
+    return new TutorialForUser({ ...tutorial, userTutorial, tutorialEvaluation, skillId: userTutorial?.skillId });
+  });
+}
+
+function _toTutorialsForUserForRecommandation({ tutorials, tutorialEvaluations, userTutorials, skillId }) {
   return tutorials.map((tutorial) => {
     const userTutorial = userTutorials.find(({ tutorialId }) => tutorialId === tutorial.id);
     const tutorialEvaluation = tutorialEvaluations.find(({ tutorialId }) => tutorialId === tutorial.id);

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -570,6 +570,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
           id: 101,
           userId: 4444,
           tutorialId: 'tuto1',
+          skillId: 'skill123',
         });
 
         await databaseBuilder.commit();
@@ -582,7 +583,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example.html',
               source: 'tuto.com',
               title: 'tuto1',
-              'skill-id': undefined,
+              'skill-id': 'skill123',
             },
             relationships: {
               'user-tutorial': { data: { id: '101', type: 'user-tutorial' } },
@@ -627,6 +628,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
           id: 102,
           userId: 4444,
           tutorialId: 'tuto2',
+          skillId: 'skill123',
           createdAt: new Date('2022-05-04'),
         });
         databaseBuilder.factory.buildUserSavedTutorial({
@@ -646,7 +648,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example3.html',
               source: 'tuto.com',
               title: 'tuto3',
-              'skill-id': undefined,
+              'skill-id': null,
             },
             id: 'tuto3',
             relationships: {
@@ -669,7 +671,7 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               link: 'http://www.example.com/this-is-an-example2.html',
               source: 'tuto.com',
               title: 'tuto2',
-              'skill-id': undefined,
+              'skill-id': 'skill123',
             },
             id: 'tuto2',
             relationships: {

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -164,6 +164,7 @@ describe('Integration | Repository | tutorial-repository', function () {
         const lastUserSavedTutorial = databaseBuilder.factory.buildUserSavedTutorial({
           tutorialId: tutorialId2,
           userId,
+          skillId: 'skill123',
           createdAt: new Date('2022-05-02'),
         });
         await databaseBuilder.commit();
@@ -182,6 +183,8 @@ describe('Integration | Repository | tutorial-repository', function () {
           lastUserSavedTutorial.createdAt,
           firstUserSavedTutorial.createdAt,
         ]);
+        expect(tutorialsForUser[0].skillId).to.equal(lastUserSavedTutorial.skillId);
+        expect(tutorialsForUser[1].skillId).to.be.null;
       });
 
       context('when user has evaluated tutorial ', function () {


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, nous souhaitons mettre en place des filtres sur les tutoriels et faire un affichage spécifique en fonction de la compétence de ceux-ci.


## :robot: Solution
- Renvoyer le `skillId` dans la réponse de la route permettant de récupérer les tutoriels enregistrés

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix APP
- Passer des compétences 
- Enregistrer un tutoriel
- Aller sur la page `/mes-tutos/enregistres`
- Recharger l'app
- Constater que dans la réponse les skillId sont fournis 
