### PR TITLE
[BUGFIX] Ne pas afficher les boutons d'actions des tutoriels lorsque l'utilisateur n'est pas connecté (PIX-5547).

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -16,19 +16,21 @@
       •
       {{moment-duration @tutorial.duration}}
     </p>
-    <div class="tutorial-card-v2-content__actions">
-      <ActionChip
-        @title={{this.evaluateInformation}}
-        @isCompleted={{this.isTutorialEvaluated}}
-        @triggerAction={{this.evaluateTutorial}}
-        @icon="thumbs-up"
-      />
-      <ActionChip
-        @title={{this.saveInformation}}
-        @isCompleted={{this.isTutorialSaved}}
-        @triggerAction={{this.toggleSaveTutorial}}
-        @icon="bookmark"
-      />
-    </div>
+    {{#if this.shouldShowActions}}
+      <div class="tutorial-card-v2-content__actions">
+        <ActionChip
+          @title={{this.evaluateInformation}}
+          @isCompleted={{this.isTutorialEvaluated}}
+          @triggerAction={{this.evaluateTutorial}}
+          @icon="thumbs-up"
+        />
+        <ActionChip
+          @title={{this.saveInformation}}
+          @isCompleted={{this.isTutorialSaved}}
+          @triggerAction={{this.toggleSaveTutorial}}
+          @icon="bookmark"
+        />
+      </div>
+    {{/if}}
   </div>
 </article>

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 export default class Card extends Component {
   @service intl;
   @service store;
+  @service currentUser;
 
   @tracked savingStatus;
   @tracked evaluationStatus;
@@ -15,6 +16,10 @@ export default class Card extends Component {
     super(owner, args);
     this.savingStatus = args.tutorial.isSaved ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
     this.evaluationStatus = args.tutorial.isEvaluated ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
+  }
+
+  get shouldShowActions() {
+    return !!this.currentUser.user;
   }
 
   get saveInformation() {

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -42,19 +42,17 @@ describe('Integration | Component | Tutorial Panel', function () {
       });
 
       context('when the user is logged in', function () {
-        class StoreStub extends Service {
-          user = {
-            firstName: 'Banana',
-            email: 'banana.split@example.net',
-            fullName: 'Banana Split',
-          };
-        }
-
-        beforeEach(function () {
-          this.owner.register('service:currentUser', StoreStub);
-        });
-
         it('should render the tutorial with actions', async function () {
+          // given
+          class CurrentUserStub extends Service {
+            user = {
+              firstName: 'Banana',
+              email: 'banana.split@example.net',
+              fullName: 'Banana Split',
+            };
+          }
+          this.owner.register('service:currentUser', CurrentUserStub);
+
           // when
           await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);
 
@@ -71,6 +69,12 @@ describe('Integration | Component | Tutorial Panel', function () {
 
       context('when the user is not logged in', function () {
         it('should render the tutorial without actions', async function () {
+          // given
+          class CurrentUserStub extends Service {
+            user = null;
+          }
+          this.owner.register('service:currentUser', CurrentUserStub);
+
           // when
           await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);
 
@@ -78,7 +82,7 @@ describe('Integration | Component | Tutorial Panel', function () {
           expect(find('.tutorial-card-v2')).to.exist;
           expect(find('.tutorial-card-v2__content')).to.exist;
           expect(find('.tutorial-card-v2-content__details')).to.exist;
-          expect(find('.tutorial-card-v2-content__actions')).to.exist;
+          expect(find('.tutorial-card-v2-content__actions')).to.not.exist;
         });
       });
     });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -2,39 +2,84 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 describe('Integration | Component | Tutorials | Card', function () {
   setupIntlRenderingTest();
 
-  it('renders component', async function () {
-    // given
-    this.set('tutorial', {
-      title: 'Mon super tutoriel',
-      link: 'https://exemple.net/',
-      source: 'mon-tuto',
-      format: 'vidéo',
-      duration: '00:01:00',
-      isEvaluated: true,
-      isSaved: true,
+  describe('when user is logged', function () {
+    it('should render the component with actions', async function () {
+      // given
+      class CurrentUserStub extends Service {
+        user = { firstName: 'John' };
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
+      this.set('tutorial', {
+        title: 'Mon super tutoriel',
+        link: 'https://exemple.net/',
+        source: 'mon-tuto',
+        format: 'vidéo',
+        duration: '00:01:00',
+        isEvaluated: true,
+        isSaved: true,
+      });
+
+      // when
+      await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+
+      // then
+      expect(find('.tutorial-card-v2')).to.exist;
+      expect(find('.tutorial-card-v2__content')).to.exist;
+      expect(find('.tutorial-card-v2-content__link'))
+        .to.have.property('textContent')
+        .that.contains('Mon super tutoriel');
+      expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
+      expect(find('.tutorial-card-v2-content__details'))
+        .to.have.property('textContent')
+        .that.contains('mon-tuto')
+        .and.contains('vidéo')
+        .and.contains('une minute');
+      expect(find('.tutorial-card-v2-content__actions')).to.exist;
+      expect(find('[aria-label="Ne plus considérer ce tuto comme utile"]')).to.exist;
+      expect(find('[aria-label="Retirer de ma liste de tutos"]')).to.exist;
+      expect(find('[title="Ne plus considérer ce tuto comme utile"]')).to.exist;
     });
+  });
 
-    // when
-    await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+  describe('when user is not logged', function () {
+    it('should render the component without actions', async function () {
+      // given
+      class CurrentUserStub extends Service {
+        user = null;
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
+      this.set('tutorial', {
+        title: 'Mon super tutoriel',
+        link: 'https://exemple.net/',
+        source: 'mon-tuto',
+        format: 'vidéo',
+        duration: '00:01:00',
+        isEvaluated: true,
+        isSaved: true,
+      });
 
-    // then
-    expect(find('.tutorial-card-v2')).to.exist;
-    expect(find('.tutorial-card-v2__content')).to.exist;
-    expect(find('.tutorial-card-v2-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
-    expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
-    expect(find('.tutorial-card-v2-content__details'))
-      .to.have.property('textContent')
-      .that.contains('mon-tuto')
-      .and.contains('vidéo')
-      .and.contains('une minute');
-    expect(find('.tutorial-card-v2-content__actions')).to.exist;
-    expect(find('[aria-label="Ne plus considérer ce tuto comme utile"]')).to.exist;
-    expect(find('[aria-label="Retirer de ma liste de tutos"]')).to.exist;
-    expect(find('[title="Ne plus considérer ce tuto comme utile"]')).to.exist;
+      // when
+      await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+
+      // then
+      expect(find('.tutorial-card-v2')).to.exist;
+      expect(find('.tutorial-card-v2__content')).to.exist;
+      expect(find('.tutorial-card-v2-content__link'))
+        .to.have.property('textContent')
+        .that.contains('Mon super tutoriel');
+      expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
+      expect(find('.tutorial-card-v2-content__details'))
+        .to.have.property('textContent')
+        .that.contains('mon-tuto')
+        .and.contains('vidéo')
+        .and.contains('une minute');
+      expect(find('.tutorial-card-v2-content__actions')).to.not.exist;
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix App, lorsqu'un utilisateur passe un test statique (démo), nous lui affichons en fin de test ses résultats ainsi que des tutoriels. Cependant, les tutoriels comportent des boutons d'actions : liker et enregistrer et ces derniers nécessitent d'être connecté pour être fonctionnel alors qu'un test démo peut-être fait sans être connecté. 

## :robot: Solution
- Ne pas afficher les boutons d'action quand l'utilisateur n'est pas connecté. 

### Avec les boutons d'actions
![Screenshot 2022-08-26 at 15 56 54@2x](https://user-images.githubusercontent.com/26384707/186920328-42f7c3dd-51e2-477b-95b9-69e9db0f4093.png)

### Sans les boutons d'actions
![Screenshot 2022-08-26 at 15 57 41@2x](https://user-images.githubusercontent.com/26384707/186920345-6cd271ab-54a5-4f2e-883a-b85deb138a11.png)

## :rainbow: Remarques
Cette solution a été envisagé car c'était la plus simple à mettre en place. 

## :100: Pour tester

### Connecté
- Se connecter sur Pix App
- Passer une démo (ex: `/courses/recBCwxarnE8QntZr`
- Constater en fin de test que les tutos ont les boutons d'actions et qu'ils sont fonctionnels

### Non Connecté
- Arriver sur Pix App sans être connecté
- Passer une démo (ex: `/courses/recBCwxarnE8QntZr`
- Constater en fin de test que les tutos n'ont pas les boutons d'actions
