### PR TITLE
[TECH] Migrer de Bookshelf vers knex le repository des paliers (PIX-5548)

### DIFF
--- a/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/lib/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -37,9 +37,11 @@ module.exports = {
   },
 
   async updateParticipantExternalId({ campaignParticipationId, participantExternalId }) {
-    try {
-      await knex('campaign-participations').where('id', campaignParticipationId).update({ participantExternalId });
-    } catch (error) {
+    const updatedRows = await knex('campaign-participations')
+      .where('id', campaignParticipationId)
+      .update({ participantExternalId });
+
+    if (!updatedRows) {
       throw new NotFoundError(`La participation avec l'id ${campaignParticipationId} n'existe pas.`);
     }
   },

--- a/api/tests/integration/infrastructure/repositories/participations-for-campaign-management-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participations-for-campaign-management-repository_test.js
@@ -261,7 +261,7 @@ describe('Integration | Repository | Participations-For-Campaign-Management', fu
         const newParticipantExternalId = 'newExternal';
 
         const error = await catchErr(participationsForCampaignManagementRepository.updateParticipantExternalId)({
-          unexistingCampaignParticipationId,
+          campaignParticipationId: unexistingCampaignParticipationId,
           participantExternalId: newParticipantExternalId,
         });
 

--- a/api/tests/integration/infrastructure/repositories/stage-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-repository_test.js
@@ -155,14 +155,18 @@ describe('Integration | Repository | StageRepository', function () {
     });
 
     it('should not update the stage when the id is unknown and throw an error', async function () {
+      // given
+      const id = 999999;
+
       // when
       const error = await catchErr(stageRepository.updateStage)({
-        id: 999999,
+        id,
         prescriberTitle: 'palier bof',
       });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`Le palier avec l'id ${id} n'existe pas`);
     });
   });
 
@@ -198,6 +202,7 @@ describe('Integration | Repository | StageRepository', function () {
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`Not found stage for ID ${unknownId}`);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le repository des paliers utilise encore Bookshelf

## :robot: Solution
Migrer vers knex

## :rainbow: Remarques
La méthode `updateParticipantExternalId` a été fixé car knex renvoi le nombre de ligne mise à jour et par conséquent ne throw pas d'erreur. Le test fonctionnait car on ne passait pas le bon argument à la fonction

## :100: Pour tester
- Vérifier la non regression
