### PR TITLE
[FEATURE] Ajout d'un tooltip sur l'en-tête de la colonne certificabilité dans le tableau sur la page des élèves (PIX-5476)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -29,7 +29,23 @@
           {{t "pages.sco-organization-participants.table.column.last-participation-date"}}
         </Table::Header>
         <Table::Header @size="medium" @align="center">
-          {{t "pages.sco-organization-participants.table.column.is-certifiable.label"}}
+          <div class="sco-organization-participant-list-page__certificability-header">
+            {{t "pages.sco-organization-participants.table.column.is-certifiable.label"}}
+            <div class="sco-organization-participant-list-page__certificability-header__tooltip">
+              <PixTooltip
+                @position="top-left"
+                @isWide={{true}}
+                aria-label={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip"}}
+              >
+                <:triggerElement>
+                  <FaIcon @icon="question-circle" tabindex="0" />
+                </:triggerElement>
+                <:tooltip>
+                  {{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip"}}
+                </:tooltip>
+              </PixTooltip>
+            </div>
+          </div>
         </Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />
       </tr>

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -5,5 +5,17 @@
       margin: 0;
     }
   }
+  &__certificability-header {
+    display: flex;
+
+    &__tooltip {
+      padding-left: 6px;
+      color: $pix-neutral-30;
+
+      [role="tooltip"] {
+        font-weight: $font-light;
+      }
+    }
+  }
 }
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -823,7 +823,8 @@
             "eligible": "Eligible",
             "label": "Eligibility for certification",
             "non-eligible": "Non-eligible",
-            "not-available": "Not available"
+            "not-available": "Not available",
+            "tooltip": "To know if a student is eligible for certification, their Pix profile needs to be submitted through a profile collection campaign. If the student has already submitted their profile, the date and status of the last submission are displayed."
           },
           "last-name": "Last name",
           "last-participation-date": "Latest participation",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -823,7 +823,8 @@
             "eligible": "Certifiable",
             "label": "Certificabilité",
             "non-eligible": "Non Certifiable",
-            "not-available": "Non communiqué"
+            "not-available": "Non communiqué",
+            "tooltip": "L’information de certificabilité remonte des campagnes de collecte de profils réalisées par l'élève. Si l'élève a déjà envoyé son profil, on affiche la date d’envoi ainsi que le statut du dernier envoi."
           },
           "last-name": "Nom",
           "last-participation-date": "Dernière participation",


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.

## :robot: Solution
Ajout du tooltip dans l’entête de colonne pour expliquer comment cette colonne était calculée.

Texte a afficher en Français : “L’information de certificabilité remonte des campagnes de collecte de profil réalisées par le participant. Si le participant a déjà envoyé son profil, on affiche la date d’envoi ainsi que le statut du dernier envoi.”


Texte a afficher pour l’EN : “To know if a participant is eligible for certification, their Pix profile needs to be submitted through a profile collection campaign. If the participant has already submitted their profile, the date and status of the last submission are displayed.”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter à pix orga pour sco
- aller sur la page Eleves
- observer l'icône fa-circle-interrogation
- survoler ce dernier et observer le tooltip
- tada 🎉 
