### PR TITLE
[TECH] Si on ne trouve pas un utilisateur, renvoyer une erreur générique (PIX-5538)

### DIFF
--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcrypt');
 const { bcryptNumberOfSaltRounds } = require('../../config');
-const PasswordNotMatching = require('../errors').PasswordNotMatching;
+const UserNotFoundError = require('../errors').UserNotFoundError;
 
 module.exports = {
   hashPassword: (password) => bcrypt.hash(password, bcryptNumberOfSaltRounds),
@@ -11,7 +11,7 @@ module.exports = {
   checkPassword: async ({ password, passwordHash }) => {
     const matching = await bcrypt.compare(password, passwordHash);
     if (!matching) {
-      throw new PasswordNotMatching();
+      throw new UserNotFoundError();
     }
   },
 };

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -2,7 +2,7 @@ const { catchErr, expect } = require('../../../test-helper');
 
 const bcrypt = require('bcrypt');
 const encryptionService = require('../../../../lib/domain/services/encryption-service');
-const PasswordNotMatching = require('../../../../lib/domain/errors').PasswordNotMatching;
+const UserNotFoundError = require('../../../../lib/domain/errors').UserNotFoundError;
 
 describe('Unit | Service | Encryption', function () {
   describe('#checkPassword', function () {
@@ -25,7 +25,7 @@ describe('Unit | Service | Encryption', function () {
     });
 
     describe('when password and hash are not matching', function () {
-      it('should reject a PasswordNotMatching error ', async function () {
+      it('should reject a UserNotFoundError error ', async function () {
         // given
         const password = 'my-expected-password';
         const passwordHash = 'ABCDEF1234';
@@ -37,12 +37,12 @@ describe('Unit | Service | Encryption', function () {
         });
 
         // then
-        expect(error).to.be.an.instanceof(PasswordNotMatching);
+        expect(error).to.be.an.instanceof(UserNotFoundError);
       });
     });
 
     describe('when password is not supplied', function () {
-      it('should reject, but not a PasswordNotMatching error ', async function () {
+      it('should reject, but not a UserNotFoundError error ', async function () {
         // given
         const password = undefined;
         // eslint-disable-next-line no-sync
@@ -54,7 +54,7 @@ describe('Unit | Service | Encryption', function () {
             passwordHash,
           });
         } catch (error) {
-          expect(error).not.to.be.an.instanceof(PasswordNotMatching);
+          expect(error).not.to.be.an.instanceof(UserNotFoundError);
         }
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la double mire de connexion des utilisateurs externes, le message d'erreur qui est affiché quand l'utilisateur se trompe dans son identifiant ou son mot de passe n'est pas la bonne : elle indique que la clé d'authentification n'est plus valide (or ce n'est pas le cas et pas le problème).
![image](https://user-images.githubusercontent.com/38167520/187214953-a00589ba-37c2-4010-b871-c108b62136d6.png)


## :robot: Solution
En regardant le code de retour de l'API, j'ai vu qu'en fait quand on remplissait un bon email et un mauvais mot de passe l'API renvoyait une 401 avec un detail "Mauvais mot de passe".
Pour des questions de sécurité il ne vaut mieux pas préciser que l'utilisateur a mis un mauvais mot de passe (car quelqu'un de mal intentionné pourrait ensuite faire du brute force vu qu'il sait que l'email est bon). 

Le service `api/lib/domain/services/authentication/pix-authentication-service.js` fait un appel à `encryptionService.checkPassword` et c'est ce dernier qui jete une erreur en cas de soucis. 
Ce service servant à chercher si l'utilisateur existe à partir d'un email et d'un mot de passe, ne devrait jamais renvoyer le fait qu'il n'y a que le mot de passe de mauvais et devrait rester générique. 

## :rainbow: Remarques
Ce changement a peut être d'autres impacts en dehors du scope du ticket je vais essayer de regarder les fonctionnalités impactées par le changement.

## :100: Pour tester
Lancer l'API avec : 
- `FT_SSO_ACCOUNT_RECONCILIATION=true npm run start:watch` 
Lancer mon-pix : 
- Aller sur `/connexion/cnav` 
- Se connecter avec un user CNAV (demander à l'équipe accès pour avoir les logins)
- Vous arrivez sur le double mire OIDC : remplisser un email valide et un mot de passe non valide 
- Constatez que vous avez un message d'erreur vous indiquant que vos identifiants ne sont pas bons
- Faire de même avec un email invalide, constatez la même erreur 
<img width="515" alt="image" src="https://user-images.githubusercontent.com/38167520/187217062-c98b263d-a184-47f2-958e-af9c4e6dd4e7.png">

