### PR TITLE
[FEATURE] Ajout d'un point (PIX-5552)

### DIFF
--- a/admin/app/components/users/campaign-participations.hbs
+++ b/admin/app/components/users/campaign-participations.hbs
@@ -2,7 +2,7 @@
   <h2 class="page-section__title">Participations à des campagnes</h2>
 </header>
 <p class="participations-section__subtitle">
-  Attention toute modification sur une participation nécessite un accord écrit du prescripteur et du prescrit
+  Attention toute modification sur une participation nécessite un accord écrit du prescripteur et du prescrit.
 </p>
 
 <div class="content-text content-text--small">


### PR DESCRIPTION
## :unicorn: Problème
Dans la [PR precédente](https://github.com/1024pix/pix/pull/4808) le point en fin de phrase a été oublié
## :robot: Solution
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Admin
- Aller sur l'onglet utilisateur
- Chercher un utilisateur (exemple : Jaune)
- Aller sur sa page en cliquant sur son id dans le tableau
- Aller dans l'onglet participations de l'utilisateur
- Observer, juste en dessous du titre le sous-titre préventif **qui se termine par un point**
- Tada 🎉