### PR TITLE
[FEATURE] Pouvoir identifier les organisations qui utilisent le GAR (PIX-5139)

### DIFF
--- a/api/db/migrations/20220830082750_add-gar-identity-provider-for-campaigns-in-organizations-table.js
+++ b/api/db/migrations/20220830082750_add-gar-identity-provider-for-campaigns-in-organizations-table.js
@@ -1,0 +1,13 @@
+exports.up = async function (knex) {
+  await knex.raw('ALTER TABLE "organizations" DROP CONSTRAINT "organizations_identityProviderForCampaigns_check" ');
+  return knex.raw(
+    'ALTER TABLE "organizations" ADD CONSTRAINT "organizations_identityProviderForCampaigns_check" CHECK ( "identityProviderForCampaigns" IN (\'POLE_EMPLOI\', \'CNAV\', \'GAR\') )'
+  );
+};
+
+exports.down = async function (knex) {
+  await knex.raw('ALTER TABLE "organizations" DROP CONSTRAINT "organizations_identityProviderForCampaigns_check" ');
+  return knex.raw(
+    'ALTER TABLE "organizations" ADD CONSTRAINT "organizations_identityProviderForCampaigns_check" CHECK ( "identityProviderForCampaigns" IN (\'POLE_EMPLOI\', \'CNAV\') )'
+  );
+};


### PR DESCRIPTION
## :unicorn: Problème

Actuellement il est possible d'identifier facilement les organisations liées à la CNAV ou Pôle Emploi. Ce qui n'est pas le cas pour le GAR.

## :robot: Solution

Il faut mettre à jour la contrainte sur la colonne `identityProviderForCampaigns` de la table `organizations` pour y ajouter le `GAR`.

## :rainbow: Remarques

RAS

## :100: Pour tester

##### En local

- Se mettre sur la branche de cette PR
- Se connecter à la base de données (via votre outil favoris)
- Vérifiez la contrainte `organizations_identityProviderForCampaigns_check` sur la table `organizations` qu'elle contienne bien `POLE_EMPLOI` et `CNAV`
- Exécutez la migration `npm run db:migrate`
- Vérifiez la contrainte `organizations_identityProviderForCampaigns_check` sur la table `organizations` qu'elle contienne bien `POLE_EMPLOI`, `CNAV` et `GAR`
- Exécutez un rollback de la migration précédente `npm run db:rollback:latest`
- Vérifiez la contrainte `organizations_identityProviderForCampaigns_check` sur la table `organizations` qu'elle contienne bien `POLE_EMPLOI` et `CNAV`
