### PR TITLE
[FEATURE] Améliore l'accessiblité de la tooltip du score Pix sur Pix App (PIX-5428)

### DIFF
--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -1,29 +1,34 @@
-<PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
-  <:triggerElement>
-    <div class="hexagon-score" tabindex="0" aria-describedby="hexagon-score-tooltip">
-      <div class="hexagon-score__content">
-        <div class="hexagon-score-content__title">{{t "common.pix"}}</div>
-        <div class="hexagon-score-content__pix-score">{{this.score}}</div>
-        <div class="hexagon-score-content__pix-total">
-          1024
-          <div class="hexagon-score-content-pix-total__icon">
-            <FaIcon @icon="circle-info" />
+<div class="hexagon-score">
+  <div class="hexagon-score__content">
+    <div class="hexagon-score-content__title">{{t "common.pix"}}</div>
+    <div class="hexagon-score-content__pix-score">{{this.score}}</div>
+    <div class="hexagon-score-content__pix-total">
+      1024
+      <PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
+        <:triggerElement>
+          <button
+            aria-label={{t "score-tooltip-button-label"}}
+            type="button"
+            class="hexagon-score-content-pix-total__icon"
+            aria-describedby="hexagon-score-tooltip"
+          >
+            <FaIcon @icon="circle-info" aria-label={{t "pages.profile.total-score-helper.icon"}} />
+          </button>
+        </:triggerElement>
+        <:tooltip>
+          <div class="hexagon-score__information hexagon-score-information__text">
+            <p class="hexagon-score-information__text--strong">
+              {{t "pages.profile.total-score-helper.title"}}
+            </p>
+            {{t
+              "pages.profile.total-score-helper.explanation"
+              maxReachablePixCount=this.maxReachablePixCount
+              maxReachableLevel=this.maxReachableLevel
+              htmlSafe=true
+            }}
           </div>
-        </div>
-      </div>
+        </:tooltip>
+      </PixTooltip>
     </div>
-  </:triggerElement>
-  <:tooltip>
-    <div class="hexagon-score__information hexagon-score-information__text">
-      <p class="hexagon-score-information__text--strong">
-        {{t "pages.profile.total-score-helper.title"}}
-      </p>
-      {{t
-        "pages.profile.total-score-helper.explanation"
-        maxReachablePixCount=this.maxReachablePixCount
-        maxReachableLevel=this.maxReachableLevel
-        htmlSafe=true
-      }}
-    </div>
-  </:tooltip>
-</PixTooltip>
+  </div>
+</div>

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -99,6 +99,11 @@
   }
 }
 
-hexagon-score-content-pix-total__icon {
-  padding: 0 0 0 4px;
+.hexagon-score-content-pix-total__icon {
+  padding: 0;
+  margin-left: 4px;
+  line-height: 0;
+  background: none;
+  color: inherit;
+  border: none;
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1025,6 +1025,8 @@
         "reminder-send-campaign-with-title": "customised test \"{title}\" finished. Don’t forget to submit your results!"
       },
       "total-score-helper": {
+        "label": "Open tooltip",
+        "icon": "Pix information",
         "title": "Why 1,024 pix?",
         "explanation": "<p>That’s the maximum number of pix you can get when the 8 levels of the Pix framework will be available.'</p><p>'Today, '<span class=\"hexagon-score-information__text--strong\">'the maximum number available is {maxReachablePixCount} pix'</span>', corresponding to level {maxReachableLevel}.'</p>'"
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1025,6 +1025,8 @@
         "reminder-send-campaign-with-title": "Parcours \"{title}\" terminé. N'oubliez pas de finaliser votre envoi !"
       },
       "total-score-helper": {
+        "label": "Ouvrir l'infobulle",
+        "icon": "Information sur les pix",
         "title": "Pourquoi 1024 pix ?",
         "explanation": "<p>C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'</p><p>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de {maxReachablePixCount} pix'</span>', correspondant au niveau {maxReachableLevel}.'</p>'"
       }


### PR DESCRIPTION
## :unicorn: Problème
L'infobulle sur le score Pix n'était pas atteignable au clavier.

## :robot: Solution
- Encapsuler l'icône dans une balise `button`
- Ajouter un `aria-label` sur le bouton
- Ajouter un `aria-label` sur l'icône informative
- Ajouter un `aria-describedby `sur le bouton pour le relier à la tooltip

## :100: Pour tester
Accéder à la tooltip au clavier.
Utiliser le lecteur d'écran.