### PR TITLE
[TECH] Refactorer le scoring des certifications complémentaires hors CléA (PIX-5574) 

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -7,6 +7,7 @@ module.exports = function buildComplementaryCertification({
   createdAt = new Date('2020-01-01'),
   minimumReproducibilityRate = 70.0,
   minimumEarnedPix,
+  hasComplementaryReferential = false,
 } = {}) {
   const values = {
     id,
@@ -15,6 +16,7 @@ module.exports = function buildComplementaryCertification({
     createdAt,
     minimumReproducibilityRate,
     minimumEarnedPix,
+    hasComplementaryReferential,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'complementary-certifications',

--- a/api/db/migrations/20220830132314_add-column-has-complementary-referential-to-complementary-certifications.js
+++ b/api/db/migrations/20220830132314_add-column-has-complementary-referential-to-complementary-certifications.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'complementary-certifications';
+const COLUMN_NAME = 'hasComplementaryReferential';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME);
+  });
+
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'DROIT' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'EDU_1ER_DEGRE' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'EDU_2ND_DEGRE' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, false).where({ key: 'CLEA' });
+
+  await knex.schema.alterTable(TABLE_NAME, async (table) => {
+    await table.boolean(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/ComplementaryCertificationScoringCriteria.js
+++ b/api/lib/domain/models/ComplementaryCertificationScoringCriteria.js
@@ -3,10 +3,14 @@ class ComplementaryCertificationScoringCriteria {
     complementaryCertificationCourseId,
     minimumReproducibilityRate,
     complementaryCertificationBadgeKeys,
+    hasComplementaryReferential,
+    minimumEarnedPix,
   } = {}) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
     this.minimumReproducibilityRate = minimumReproducibilityRate;
     this.complementaryCertificationBadgeKeys = complementaryCertificationBadgeKeys;
+    this.hasComplementaryReferential = hasComplementaryReferential;
+    this.minimumEarnedPix = minimumEarnedPix;
   }
 }
 

--- a/api/lib/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
@@ -8,6 +8,8 @@ module.exports = {
         complementaryCertificationCourseId: 'complementary-certification-courses.id',
         minimumReproducibilityRate: 'complementary-certifications.minimumReproducibilityRate',
         complementaryCertificationBadgeKeys: knex.raw('json_agg("badges"."key")'),
+        hasComplementaryReferential: 'complementary-certifications.hasComplementaryReferential',
+        minimumEarnedPix: 'complementary-certifications.minimumEarnedPix',
       })
       .join(
         'complementary-certifications',
@@ -25,11 +27,19 @@ module.exports = {
       .where({ certificationCourseId });
 
     return results.map(
-      ({ complementaryCertificationCourseId, minimumReproducibilityRate, complementaryCertificationBadgeKeys }) =>
+      ({
+        complementaryCertificationCourseId,
+        minimumReproducibilityRate,
+        complementaryCertificationBadgeKeys,
+        hasComplementaryReferential,
+        minimumEarnedPix,
+      }) =>
         new ComplementaryCertificationScoringCriteria({
           complementaryCertificationCourseId,
           minimumReproducibilityRate: Number(minimumReproducibilityRate),
           complementaryCertificationBadgeKeys,
+          hasComplementaryReferential,
+          minimumEarnedPix,
         })
     );
   },

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-scoring-criteria-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-scoring-criteria-repository_test.js
@@ -11,11 +11,14 @@ describe('Integration | Repository | complementary certification scoring criteri
         key: 'PIX+_TEST_1',
         label: 'label pour PIX+ TEST 1',
         minimumReproducibilityRate: 50,
+        hasComplementaryReferential: true,
       });
       const complementaryCertification2 = databaseBuilder.factory.buildComplementaryCertification({
         key: 'PIX+_TEST_2',
         label: 'label pour PIX+ TEST 2',
         minimumReproducibilityRate: 30,
+        hasComplementaryReferential: false,
+        minimumEarnedPix: 42,
       });
 
       const complementaryCertificationCourse1 = databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -62,11 +65,14 @@ describe('Integration | Repository | complementary certification scoring criteri
           complementaryCertificationCourseId: complementaryCertificationCourse1.id,
           minimumReproducibilityRate: complementaryCertification1.minimumReproducibilityRate,
           complementaryCertificationBadgeKeys: [badge1.key, badge2.key],
+          hasComplementaryReferential: complementaryCertification1.hasComplementaryReferential,
         }),
         domainBuilder.buildComplementaryCertificationScoringCriteria({
           complementaryCertificationCourseId: complementaryCertificationCourse2.id,
           minimumReproducibilityRate: complementaryCertification2.minimumReproducibilityRate,
           complementaryCertificationBadgeKeys: [badge3.key, badge4.key],
+          hasComplementaryReferential: complementaryCertification2.hasComplementaryReferential,
+          minimumEarnedPix: complementaryCertification2.minimumEarnedPix,
         }),
       ]);
     });

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-scoring-criteria.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-scoring-criteria.js
@@ -4,11 +4,15 @@ function buildComplementaryCertificationScoringCriteria({
   complementaryCertificationCourseId = 123,
   minimumReproducibilityRate = 70,
   complementaryCertificationBadgeKeys = [],
+  hasComplementaryReferential = false,
+  minimumEarnedPix = null,
 } = {}) {
   return new ComplementaryCertificationScoringCriteria({
     complementaryCertificationCourseId,
     minimumReproducibilityRate,
     complementaryCertificationBadgeKeys,
+    hasComplementaryReferential,
+    minimumEarnedPix,
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Il existe une classe de scoring par certification complementaire. Dans le cadre du refactoring de ces certifications on souhaite ne plus faire de spécifique pour CléA

## :robot: Solution
Refactorer pour avoir un unique scoring configurable.

## :rainbow: Remarques
Ajout de seeds à l'image de la production.

## :100: Pour tester
Passer les certifications pour tester le scoring sur 
- clea
- droit
- edu 1er degres
- edu 2nd degres
