### PR TITLE
[FEATURE] Sortir les filtres des étudiants du tableau (PIX-5536).

### DIFF
--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -1,3 +1,43 @@
+<PixFilterBanner
+  @title={{t "pages.sup-organization-participants.table.filter.title"}}
+  class="participant-filter-banner hide-on-mobile"
+  aria-label={{t "pages.sup-organization-participants.table.filter.aria-label"}}
+  @details={{t "pages.sup-organization-participants.table.filter.students-count" count=@students.meta.rowCount}}
+  @clearFiltersLabel={{t "pages.sup-organization-participants.table.filter.actions.clear"}}
+  @onClearFilters={{@onResetFilter}}
+>
+  <Ui::SearchInputFilter
+    @field="studentNumber"
+    @value={{@studentNumberFilter}}
+    @placeholder={{t "pages.sup-organization-participants.table.filter.student-number.label"}}
+    @ariaLabel={{t "pages.sup-organization-participants.table.filter.student-number.aria-label"}}
+    @triggerFiltering={{@onFilter}}
+  />
+  <Ui::SearchInputFilter
+    @field="lastName"
+    @value={{@lastNameFilter}}
+    @placeholder={{t "pages.sup-organization-participants.table.filter.last-name.label"}}
+    @ariaLabel={{t "pages.sup-organization-participants.table.filter.last-name.aria-label"}}
+    @triggerFiltering={{@onFilter}}
+  />
+  <Ui::SearchInputFilter
+    @field="firstName"
+    @value={{@firstNameFilter}}
+    @placeholder={{t "pages.sup-organization-participants.table.filter.first-name.label"}}
+    @ariaLabel={{t "pages.sup-organization-participants.table.filter.first-name.aria-label"}}
+    @triggerFiltering={{@onFilter}}
+  />
+  <Ui::MultiSelectFilter
+    @field="groups"
+    @title={{t "pages.sup-organization-participants.table.column.group"}}
+    @onSelect={{@onFilter}}
+    @selectedOption={{@groupsFilter}}
+    @onLoadOptions={{this.loadGroups}}
+    @placeholder={{t "pages.sup-organization-participants.table.filter.group.label"}}
+    @ariaLabel={{t "pages.sup-organization-participants.table.filter.group.aria-label"}}
+    @emptyMessage={{t "pages.sup-organization-participants.table.filter.group.empty"}}
+  />
+</PixFilterBanner>
 <div class="panel">
   <table class="table content-text content-text--small">
     <thead>
@@ -18,43 +58,6 @@
           {{t "pages.sup-organization-participants.table.column.last-participation-date"}}
         </Table::Header>
         <Table::Header @size="medium" class="hide-on-mobile" />
-      </tr>
-      <tr class="hide-on-mobile">
-        <Table::HeaderFilterInput
-          @field="studentNumber"
-          @value={{@studentNumberFilter}}
-          @placeholder={{t "pages.sup-organization-participants.table.filter.student-number.label"}}
-          @ariaLabel={{t "pages.sup-organization-participants.table.filter.student-number.aria-label"}}
-          @triggerFiltering={{@onFilter}}
-        />
-        <Table::HeaderFilterInput
-          @field="lastName"
-          @value={{@lastNameFilter}}
-          @placeholder={{t "pages.sup-organization-participants.table.filter.last-name.label"}}
-          @ariaLabel={{t "pages.sup-organization-participants.table.filter.last-name.aria-label"}}
-          @triggerFiltering={{@onFilter}}
-        />
-        <Table::HeaderFilterInput
-          @field="firstName"
-          @value={{@firstNameFilter}}
-          @placeholder={{t "pages.sup-organization-participants.table.filter.first-name.label"}}
-          @ariaLabel={{t "pages.sup-organization-participants.table.filter.first-name.aria-label"}}
-          @triggerFiltering={{@onFilter}}
-        />
-        <Table::Header />
-        <Table::HeaderFilterMultiSelect
-          @field="groups"
-          @title={{t "pages.sup-organization-participants.table.column.group"}}
-          @onSelect={{@onFilter}}
-          @selectedOption={{@groupsFilter}}
-          @onLoadOptions={{this.loadGroups}}
-          @placeholder={{t "pages.sup-organization-participants.table.filter.group.label"}}
-          @ariaLabel={{t "pages.sup-organization-participants.table.filter.group.aria-label"}}
-          @emptyMessage={{t "pages.sup-organization-participants.table.filter.group.empty"}}
-        />
-        <Table::Header class="table__column--right" />
-        <Table::Header />
-        <Table::Header />
       </tr>
     </thead>
 

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -15,4 +15,12 @@ export default class ListController extends Controller {
     this[fieldName] = value || undefined;
     this.pageNumber = null;
   }
+
+  @action
+  onResetFilter() {
+    this.lastName = null;
+    this.firstName = null;
+    this.studentNumber = null;
+    this.groups = [];
+  }
 }

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -9,5 +9,6 @@
     @studentNumberFilter={{this.studentNumber}}
     @groupsFilter={{this.groups}}
     @onFilter={{this.triggerFiltering}}
+    @onResetFilter={{this.onResetFilter}}
   />
 </div>

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -892,6 +892,10 @@
         },
         "empty": "No students.",
         "filter": {
+          "actions": {
+            "clear": "Clear filters"
+          },
+          "aria-label":"Filters on students",
           "first-name": {
             "aria-label": "Enter a first name",
             "label": "Search by first name"
@@ -908,7 +912,9 @@
           "student-number": {
             "aria-label": "Enter a student number",
             "label": "Search by student number"
-          }
+          },
+          "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}",
+          "title": "Filters"
         },
         "row-title": "Student"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -892,6 +892,10 @@
         },
         "empty": "Aucun étudiant.",
         "filter": {
+          "aria-label":"Filtrer les étudiants",
+          "actions": {
+            "clear": "Effacer les filtres"
+          },
           "first-name": {
             "aria-label": "Entrer un prénom",
             "label": "Rechercher par prénom"
@@ -908,7 +912,9 @@
           "student-number": {
             "aria-label": "Entrer un numéro étudiant",
             "label": "Rechercher par numéro étudiant"
-          }
+          },
+          "students-count": "{count, plural, =0 {0 élève} =1 {1 élève} other {{count} élèves}}",
+          "title": "Filtres"
         },
         "row-title": "Étudiant"
       }


### PR DESCRIPTION
## :unicorn: Problème
Les filtres dans les colonnes tableaux ne sont plus d'actulité dans Pix Orga.
## :robot: Solution
Remplacer les filtres dans le tableaux de la page étudiants par un bandeau filtres

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter avec sup.admin@example.net, allez sur le menu étudiants, vérifiez que les filtres sont bien présent dans un bandeau et absent dans le tableau