### PR TITLE
[TECH] Rendre la colonne campaignParticipationId de la table badge-acquisitions non nulle (PIX-5573)

### DIFF
--- a/api/db/database-builder/factory/build-badge-acquisition.js
+++ b/api/db/database-builder/factory/build-badge-acquisition.js
@@ -1,10 +1,11 @@
 const databaseBuffer = require('../database-buffer');
+const buildCampaignParticipation = require('./build-campaign-participation');
 
 module.exports = function buildBadgeAcquisition({
   id = databaseBuffer.getNextId(),
   badgeId,
   userId,
-  campaignParticipationId,
+  campaignParticipationId = buildCampaignParticipation().id,
   createdAt = new Date('2000-01-01'),
 } = {}) {
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20220830193152_make-campaignParticipationId-column-in-table-badge-acquisitions-not-nullable.js
+++ b/api/db/migrations/20220830193152_make-campaignParticipationId-column-in-table-badge-acquisitions-not-nullable.js
@@ -1,0 +1,66 @@
+const BADGE_ACQUISITIONS_TABLE = 'badge-acquisitions';
+const CAMPAIGN_PARTICIPATION_ID_COLUMN = 'campaignParticipationId';
+
+exports.up = async function (knex) {
+  const badgeAcquisitionsToResolve = await knex(BADGE_ACQUISITIONS_TABLE)
+    .select('id', 'userId', 'badgeId', 'createdAt')
+    .whereNull(CAMPAIGN_PARTICIPATION_ID_COLUMN);
+  let allDone = true;
+  for (const badgeAcquisition of badgeAcquisitionsToResolve) {
+    const targetProfileId = await _findTargetProfileIdFromBadgeId(badgeAcquisition.badgeId, knex);
+    const eligibleParticipations = await _findParticipations({
+      userId: badgeAcquisition.userId,
+      targetProfileId,
+      knex,
+    });
+    if (eligibleParticipations.length) {
+      const participation = _findParticipationClosestToTimestamp(eligibleParticipations, badgeAcquisition.createdAt);
+      await _updateBadgeAcquisitionWithParticipation(badgeAcquisition.id, participation.id, knex);
+    } else {
+      allDone = false;
+    }
+  }
+  if (allDone) {
+    await knex.schema.alterTable(BADGE_ACQUISITIONS_TABLE, (table) => {
+      table.integer(CAMPAIGN_PARTICIPATION_ID_COLUMN).notNullable().alter();
+    });
+  }
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable(BADGE_ACQUISITIONS_TABLE, (table) => {
+    table.integer(CAMPAIGN_PARTICIPATION_ID_COLUMN).nullable().alter();
+  });
+};
+
+async function _findTargetProfileIdFromBadgeId(badgeId, knex) {
+  return (await knex('badges').pluck('targetProfileId').where('id', badgeId))[0];
+}
+
+async function _findParticipations({ userId, targetProfileId, knex }) {
+  return knex('campaign-participations')
+    .select({
+      id: 'campaign-participations.id',
+      completedAt: 'assessments.updatedAt',
+    })
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .join('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
+    .where('campaign-participations.userId', userId)
+    .where('campaigns.targetProfileId', targetProfileId)
+    .where('assessments.state', 'completed');
+}
+
+function _findParticipationClosestToTimestamp(participations, timestamp) {
+  // sorting participations by date distance
+  const sortByClosestDateFromTimestamp = function (participationA, participationB) {
+    const distance_a = Math.abs(timestamp - participationA.completedAt);
+    const distance_b = Math.abs(timestamp - participationB.completedAt);
+    return distance_a - distance_b;
+  };
+  participations.sort(sortByClosestDateFromTimestamp);
+  return participations[0];
+}
+
+async function _updateBadgeAcquisitionWithParticipation(badgeAcquisitionId, campaignParticipationId, knex) {
+  await knex(BADGE_ACQUISITIONS_TABLE).update({ campaignParticipationId }).where('id', badgeAcquisitionId);
+}

--- a/api/db/seeds/data/certification/badge-acquisition-builder.js
+++ b/api/db/seeds/data/certification/badge-acquisition-builder.js
@@ -17,41 +17,109 @@ const {
   CERTIF_EDU_FORMATION_CONTINUE_1ER_DEGRE_USER_ID,
 } = require('./users');
 
+const { participateToAssessmentCampaign } = require('../campaign-participations-builder');
+const {
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V2,
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
+  TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
+  TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE,
+  TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE,
+} = require('../target-profiles-builder');
+const { PRO_COMPANY_ID, PRO_LEARNER_ASSOCIATED_ID } = require('../organizations-pro-builder');
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+const { SHARED } = CampaignParticipationStatuses;
+
 function badgeAcquisitionBuilder({ databaseBuilder }) {
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V1',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
     userId: CERTIF_REGULAR_USER1_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V1,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V2',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V2,
     userId: CERTIF_SUCCESS_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V2,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V3',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     userId: CERTIF_SUCCESS_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V3',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     userId: CERTIF_FAILURE_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Initiale 2nd degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
     userId: CERTIF_EDU_FORMATION_INITIALE_2ND_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME_BADGE_ID,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Continue 2nd degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
     userId: CERTIF_EDU_FORMATION_CONTINUE_2ND_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE_BADGE_ID,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Initiale 1er degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE,
     userId: CERTIF_EDU_FORMATION_INITIALE_1ER_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME_BADGE_ID,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Continue 1er degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE,
     userId: CERTIF_EDU_FORMATION_CONTINUE_1ER_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE_BADGE_ID,
+    databaseBuilder,
   });
 }
 
 module.exports = {
   badgeAcquisitionBuilder,
 };
+
+function _buildBadgeAcquisition({ campaignName, targetProfileId, userId, badgeId, databaseBuilder }) {
+  const campaignParticipationId = _buildRequiredCampaignData({
+    campaignName,
+    targetProfileId,
+    userId,
+    databaseBuilder,
+  });
+  databaseBuilder.factory.buildBadgeAcquisition({
+    userId,
+    badgeId,
+    campaignParticipationId,
+  });
+}
+
+function _buildRequiredCampaignData({ campaignName, targetProfileId, userId, databaseBuilder }) {
+  const campaignId = databaseBuilder.factory.buildCampaign({
+    name: campaignName,
+    type: 'ASSESSMENT',
+    targetProfileId,
+    organizationId: PRO_COMPANY_ID,
+  }).id;
+  return participateToAssessmentCampaign({
+    databaseBuilder,
+    campaignId,
+    user: { id: userId },
+    organizationLearnerId: PRO_LEARNER_ASSOCIATED_ID,
+    status: SHARED,
+  });
+}

--- a/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
+++ b/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
@@ -11,12 +11,30 @@ const {
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 } = require('./certification-centers-builder');
+const { participateToAssessmentCampaign } = require('../campaign-participations-builder');
+const { TARGET_PROFILE_PIX_DROIT_ID } = require('../target-profiles-builder');
+const { SUP_STUDENT_ASSOCIATED_ID, SUP_UNIVERSITY_ID } = require('../organizations-sup-builder');
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+const { SHARED } = CampaignParticipationStatuses;
 
 function complementaryCertificationCourseResultsBuilder({ databaseBuilder }) {
+  const campaignId = databaseBuilder.factory.buildCampaign({
+    name: 'Campagne Pix+Droit',
+    type: 'ASSESSMENT',
+    targetProfileId: TARGET_PROFILE_PIX_DROIT_ID,
+    organizationId: SUP_UNIVERSITY_ID,
+  }).id;
+  const campaignParticipationId = participateToAssessmentCampaign({
+    databaseBuilder,
+    campaignId,
+    user: { id: CERTIF_DROIT_USER5_ID },
+    organizationLearnerId: SUP_STUDENT_ASSOCIATED_ID,
+    status: SHARED,
+  });
   databaseBuilder.factory.buildBadgeAcquisition({
     badgeId: PIX_DROIT_MAITRE_BADGE_ID,
     userId: CERTIF_DROIT_USER5_ID,
-    campaignParticipationId: null,
+    campaignParticipationId,
   });
   const { id: complementaryCertifCourseSuccessCleaId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
     certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID,

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -6,6 +6,7 @@ const PRO_POLE_EMPLOI_ID = 4;
 const PRO_CNAV_ID = 17;
 const PRO_MED_NUM_ID = 5;
 const PRO_ARCHIVED_ID = 15;
+const PRO_LEARNER_ASSOCIATED_ID = 1200;
 
 function organizationsProBuilder({ databaseBuilder }) {
   /* PRIVATE COMPANY */
@@ -66,6 +67,25 @@ function organizationsProBuilder({ databaseBuilder }) {
     email: userInvited.email,
     status: OrganizationInvitation.StatusType.PENDING,
     organizationId: PRO_COMPANY_ID,
+  });
+
+  // learner associated
+  const userAssociated = databaseBuilder.factory.buildUser.withRawPassword({
+    id: PRO_LEARNER_ASSOCIATED_ID,
+    firstName: 'learnerPro',
+    lastName: 'Associated',
+    email: 'learnerpro.associated@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    id: PRO_LEARNER_ASSOCIATED_ID,
+    firstName: userAssociated.firstName,
+    lastName: userAssociated.lastName,
+    birthdate: '2005-03-28',
+    organizationId: PRO_COMPANY_ID,
+    userId: PRO_LEARNER_ASSOCIATED_ID,
   });
 
   /* POLE EMPLOI */
@@ -170,4 +190,5 @@ module.exports = {
   PRO_POLE_EMPLOI_ID,
   PRO_CNAV_ID,
   PRO_MED_NUM_ID,
+  PRO_LEARNER_ASSOCIATED_ID,
 };

--- a/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/fill-campaign-participation-id-in-badge-acquisitions_test.js
@@ -7,7 +7,7 @@ const {
   updateBadgeAcquisitionWithCampaignParticipationId,
 } = require('../../../scripts/fill-campaign-participation-id-in-badge-acquisitions');
 
-describe('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions', function () {
+describe.skip('Integration | Scripts | fillCampaignParticipationIdInBadgeAcquisitions', function () {
   beforeEach(function () {
     sinon.stub(console, 'log');
   });


### PR DESCRIPTION
## :unicorn: Problème
Incohérence DB : un badge est toujours obtenu par le biais d'une campagne. De fait, on s'attend logiquement à ce que la colonne `campaignParticipationId` de la table `badge-acquisitions` soit toujours remplie.
Or, aujourd'hui le doute plane car la colonne est "nullable"

## :robot: Solution
Rendre la colonne non nullable. Il existe aujourd'hui en prod des badge-acquisitions pour lesquels il n'y a pas de `campaignParticipationId` associé :
- Dans les seeds, on associe les acquisitions de badge à une participation
- Dans la migration de la colonne, on fait d'abord un petit travail d'investigation et de correction pour trouver une participation aux acquisitions de badge qui en ont besoin. Si tout a été résolu, alors on rend la colonne non nullable
- Petite correction du builder pour les tests

## :rainbow: Remarques
Dans le dernier commit j'ai skip un test, car j'ai remarqué qu'il existe déjà un script pour remplir la colonne ??!! Mais apparemment il n'a pas fait le boulot OU n'a pas été exécuté en prod.

## :100: Pour tester
Faire des bidouilles en local, car les seeds sont "propres" de base désormais.
