### PR TITLE
[FEATURE] Générer les acquis de campagne à la création de celle-ci en fonction du profil cible choisi (PIX-5582)

### DIFF
--- a/api/db/migrations/20220824131510_create-campaign-skill-relationship-table.js
+++ b/api/db/migrations/20220824131510_create-campaign-skill-relationship-table.js
@@ -1,0 +1,16 @@
+const CAMPAIGN_TABLE_NAME = 'campaigns';
+const CAMPAIGN_SKILL_TABLE_NAME = 'campaign_skills';
+const CAMPAIGN_ID_COLUMN = 'campaignId';
+const SKILL_ID_COLUMN = 'skillId';
+
+exports.up = async function (knex) {
+  await knex.schema.createTable(CAMPAIGN_SKILL_TABLE_NAME, (t) => {
+    t.integer(CAMPAIGN_ID_COLUMN).notNullable().references(`${CAMPAIGN_TABLE_NAME}.id`);
+    t.string(SKILL_ID_COLUMN).notNullable();
+    t.primary([CAMPAIGN_ID_COLUMN, SKILL_ID_COLUMN]);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.dropTable(CAMPAIGN_SKILL_TABLE_NAME);
+};

--- a/api/db/migrations/20220913085145_copy-target-profile-skills-in-campaign-skills.js
+++ b/api/db/migrations/20220913085145_copy-target-profile-skills-in-campaign-skills.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.raw(`
+      INSERT INTO "campaign_skills" ("campaignId", "skillId")
+      SELECT "campaigns"."id", "target-profiles_skills"."skillId"
+      FROM "campaigns"
+      JOIN "target-profiles" ON "target-profiles"."id" = "campaigns"."targetProfileId"
+      JOIN "target-profiles_skills" ON "target-profiles_skills"."targetProfileId" = "target-profiles"."id"
+   `);
+};
+
+exports.down = function (_knex) {};

--- a/api/lib/domain/models/CampaignCreator.js
+++ b/api/lib/domain/models/CampaignCreator.js
@@ -11,14 +11,14 @@ class CampaignCreator {
     const { type, targetProfileId } = campaignAttributes;
 
     if (type === CampaignTypes.ASSESSMENT) {
-      _checkAssessmentCampaignCreatationAllowed(targetProfileId, this.availableTargetProfileIds);
+      _checkAssessmentCampaignCreationAllowed(targetProfileId, this.availableTargetProfileIds);
     }
 
     return new CampaignForCreation(campaignAttributes);
   }
 }
 
-function _checkAssessmentCampaignCreatationAllowed(targetProfileId, availableTargetProfileIds) {
+function _checkAssessmentCampaignCreationAllowed(targetProfileId, availableTargetProfileIds) {
   if (targetProfileId && !availableTargetProfileIds.includes(targetProfileId)) {
     throw new UserNotAuthorizedToCreateCampaignError(
       `Organization does not have an access to the profile ${targetProfileId}`

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -5,6 +5,8 @@ const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-convert
 const { knex } = require('../../../db/knex-database-connection');
 const Campaign = require('../../domain/models/Campaign');
 
+const CAMPAIGNS_TABLE = 'campaigns';
+
 module.exports = {
   isCodeAvailable(code) {
     return BookshelfCampaign.where({ code })
@@ -54,8 +56,8 @@ module.exports = {
       'multipleSendings',
     ]);
 
-    const createdCampaign = await new BookshelfCampaign(campaignAttributes).save();
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfCampaign, createdCampaign);
+    const [createdCampaign] = await knex(CAMPAIGNS_TABLE).insert(campaignAttributes).returning('*');
+    return new Campaign(createdCampaign);
   },
 
   async update(campaign) {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, domainBuilder, databaseBuilder, knex } = require('../../../test-helper');
+const { expect, domainBuilder, databaseBuilder, knex, mockLearningContent } = require('../../../test-helper');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const CampaignTypes = require('../../../../lib/domain/models/CampaignTypes');
@@ -62,66 +62,207 @@ describe('Integration | Repository | Campaign', function () {
       expect(_.pick(actualCampaign, checkedAttributes)).to.deep.equal(_.pick(campaign, checkedAttributes));
     });
 
-    it('should resolve null if the code do not correspond to any campaign ', function () {
+    it('should resolve null if the code do not correspond to any campaign ', async function () {
       // when
-      const promise = campaignRepository.getByCode('BIDULEFAUX');
+      const result = await campaignRepository.getByCode('BIDULEFAUX');
 
       // then
-      return promise.then((result) => {
-        expect(result).to.be.null;
-      });
+      expect(result).to.be.null;
     });
   });
 
   describe('#save', function () {
-    afterEach(function () {
+    afterEach(async function () {
+      await knex('campaign_skills').delete();
       return knex('campaigns').delete();
     });
 
-    it('should save the given campaign with type ASSESSMENT', async function () {
-      // given
-      const user = databaseBuilder.factory.buildUser();
-      const creatorId = user.id;
-      const ownerId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      await databaseBuilder.commit();
+    context('when campaign is of type ASSESSMENT', function () {
+      it('should save the given campaign with type ASSESSMENT', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const creatorId = user.id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        await databaseBuilder.commit();
 
-      const campaignToSave = {
-        name: 'Evaluation niveau 1 recherche internet',
-        code: 'BCTERD153',
-        customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
-        creatorId,
-        ownerId,
-        organizationId,
-        multipleSendings: true,
-        type: CampaignTypes.ASSESSMENT,
-        targetProfileId,
-        title: 'Parcours recherche internet',
-      };
+        const campaignToSave = {
+          name: 'Evaluation niveau 1 recherche internet',
+          code: 'BCTERD153',
+          customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+          creatorId,
+          ownerId,
+          organizationId,
+          multipleSendings: true,
+          type: CampaignTypes.ASSESSMENT,
+          targetProfileId,
+          title: 'Parcours recherche internet',
+        };
 
-      // when
-      const savedCampaign = await campaignRepository.save(campaignToSave);
+        // when
+        const savedCampaign = await campaignRepository.save(campaignToSave);
 
-      // then
-      expect(savedCampaign).to.be.instanceof(Campaign);
-      expect(savedCampaign.id).to.exist;
+        // then
+        expect(savedCampaign).to.be.instanceof(Campaign);
+        expect(savedCampaign.id).to.exist;
 
-      expect(savedCampaign).to.deep.include(
-        _.pick(campaignToSave, [
-          'name',
-          'code',
-          'title',
-          'type',
-          'customLandingPageText',
-          'creator',
-          'organization',
-          'targetProfile',
-          'multipleSendings',
-          'ownerId',
-        ])
-      );
+        expect(savedCampaign).to.deep.include(
+          _.pick(campaignToSave, [
+            'name',
+            'code',
+            'title',
+            'type',
+            'customLandingPageText',
+            'creator',
+            'organization',
+            'targetProfile',
+            'multipleSendings',
+            'ownerId',
+          ])
+        );
+      });
+
+      it('should save the active skills of the target profile as campaign skills', async function () {
+        // given
+        const learningContent = {
+          areas: [{ id: 'recArea1', competenceIds: ['recCompetence1'] }],
+          competences: [
+            {
+              id: 'recCompetence1',
+              areaId: 'recArea1',
+              tubeIds: ['recTube1', 'recTube2', 'recTube3'],
+            },
+          ],
+          tubes: [
+            {
+              id: 'recTube1',
+              skillIds: ['recArchivedSkill1Tube1', 'recActiveSkill2Tube1', 'recActiveSkill3Tube1'],
+            },
+            {
+              id: 'recTube2',
+              skillIds: ['recActiveSkill2Tube2', 'recArchivedSkill4Tube2', 'recActiveSkill6Tube2'],
+            },
+            {
+              id: 'recTube3',
+              skillIds: ['recArchivedSkill1Tube3', 'recArchivedSkill3Tube3', 'recActiveSkill8Tube3'],
+            },
+            {
+              id: 'recTube4',
+              skillIds: ['recSkillTube4'],
+            },
+          ],
+          skills: [
+            {
+              id: 'recArchivedSkill1Tube1',
+              name: 'archivedSkill1Tube1_1',
+              status: 'archivé',
+              level: 1,
+              tubeId: 'recTube1',
+            },
+            {
+              id: 'recActiveSkill2Tube1',
+              name: 'activeSkill2Tube1_2',
+              status: 'actif',
+              level: 2,
+              tubeId: 'recTube1',
+            },
+            {
+              id: 'recActiveSkill3Tube1',
+              name: 'activeSkill3Tube1_3',
+              status: 'actif',
+              level: 3,
+              tubeId: 'recTube1',
+            },
+            {
+              id: 'recActiveSkill2Tube2',
+              name: 'activeSkill2Tube2_2',
+              status: 'actif',
+              level: 2,
+              tubeId: 'recTube2',
+            },
+            {
+              id: 'recArchivedSkill4Tube2',
+              name: 'archivedSkill4Tube2_4',
+              status: 'archivé',
+              level: 4,
+              tubeId: 'recTube2',
+            },
+            {
+              id: 'recActiveSkill6Tube2',
+              name: 'activeSkill6Tube2_6',
+              status: 'actif',
+              level: 6,
+              tubeId: 'recTube2',
+            },
+            {
+              id: 'recArchivedSkill1Tube3',
+              name: 'archivedSkill1Tube3_1',
+              status: 'archivé',
+              level: 1,
+              tubeId: 'recTube3',
+            },
+            {
+              id: 'recArchivedSkill3Tube3',
+              name: 'archivedSkill3Tube3_3',
+              status: 'archivé',
+              level: 3,
+              tubeId: 'recTube3',
+            },
+            {
+              id: 'recActiveSkill8Tube3',
+              name: 'activeSkill8Tube3_8',
+              status: 'actif',
+              level: 8,
+              tubeId: 'recTube3',
+            },
+            {
+              id: 'recSkillTube4',
+              name: 'skillTube4_1',
+              status: 'actif',
+              level: 1,
+              tubeId: 'recTube4',
+            },
+          ],
+        };
+        mockLearningContent(learningContent);
+        const user = databaseBuilder.factory.buildUser();
+        const creatorId = user.id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 8 });
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube3', level: 3 });
+        // random tube
+        databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'recTube4' });
+        await databaseBuilder.commit();
+
+        const campaignToSave = {
+          name: 'Evaluation niveau 1 recherche internet',
+          code: 'BCTERD153',
+          customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+          creatorId,
+          ownerId,
+          organizationId,
+          multipleSendings: true,
+          type: CampaignTypes.ASSESSMENT,
+          targetProfileId,
+          title: 'Parcours recherche internet',
+        };
+
+        // when
+        const savedCampaign = await campaignRepository.save(campaignToSave);
+
+        // then
+        const skillIds = await knex('campaign_skills')
+          .pluck('skillId')
+          .where('campaignId', savedCampaign.id)
+          .orderBy('skillId', 'ASC');
+        expect(skillIds).to.deepEqualArray(['recActiveSkill2Tube1', 'recActiveSkill2Tube2', 'recActiveSkill6Tube2']);
+      });
     });
 
     it('should save the given campaign with type PROFILES_COLLECTION', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la grosse Epix de refonte de fonctionnement des profil-cibles, il a été décidé que les profil-cibles seraient maintenant définis par des sujets cappés en niveau (et non plus par des acquis). En revanche, on a toujours besoin d'avoir une liste d'acquis définie et commune à tous les participants d'une campagne.

## :robot: Solution
Au moment de la création de campagne, faire une "capture" des acquis actifs correspondant aux critères de sujets cappés en niveau du profil cible choisi.

## :rainbow: Remarques
J'ai cherry-pick le premier commit pour avoir la migration depuis la branche du ticket pix-5247

## :100: Pour tester
Créer des campagnes et vérifier en base de données que les acquis sont bien capturés dans la table "campaign_skills"
