### PR TITLE
[TECH] Retrait des warnings liés à l'usage déprécié de process.exit() dans les scripts (PIX-5585)

### DIFF
--- a/api/scripts/clean-anonymized-users-authentication-methods.js
+++ b/api/scripts/clean-anonymized-users-authentication-methods.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 const _ = require('lodash');
 const bluebird = require('bluebird');
-
+const { disconnect } = require('../db/knex-database-connection');
 const { parseCsvWithHeader } = require('./helpers/csvHelpers');
 const authenticationMethodRepository = require('../lib/infrastructure/repositories/authentication-method-repository');
 
@@ -20,44 +20,43 @@ async function cleanAnonymizedAuthenticationMethods({ arrayOfAnonymizedUsersIds 
   return anonymizedUserIdsWithAuthenticationMethodsDeleted;
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
 async function main() {
   console.log('Starting deleting anonymized users authentication methods');
 
-  try {
-    const filePath = process.argv[2];
+  const filePath = process.argv[2];
 
-    const anonymizedUsersIds = await parseCsvWithHeader(filePath);
-    const arrayOfAnonymizedUsersIds = _(anonymizedUsersIds)
-      .map((user) => user.ID)
-      .filter((userId) => !_.isNil(userId))
-      .value();
+  const anonymizedUsersIds = await parseCsvWithHeader(filePath);
+  const arrayOfAnonymizedUsersIds = _(anonymizedUsersIds)
+    .map((user) => user.ID)
+    .filter((userId) => !_.isNil(userId))
+    .value();
 
-    if (arrayOfAnonymizedUsersIds.length < 1) {
-      throw new Error('ID column must be present in CSV');
-    }
-    const anonymizedUserIdsWithAllAuthenticationMethodsDeleted = await cleanAnonymizedAuthenticationMethods({
-      arrayOfAnonymizedUsersIds,
-    });
-
-    console.log(
-      "\nDone. Here the list of user's id which authentication methods were deleted : ",
-      anonymizedUserIdsWithAllAuthenticationMethodsDeleted
-    );
-  } catch (error) {
-    console.error(error);
-
-    process.exit(1);
+  if (arrayOfAnonymizedUsersIds.length < 1) {
+    throw new Error('ID column must be present in CSV');
   }
-}
+  const anonymizedUserIdsWithAllAuthenticationMethodsDeleted = await cleanAnonymizedAuthenticationMethods({
+    arrayOfAnonymizedUsersIds,
+  });
 
-if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
-      console.error(err);
-      process.exit(1);
-    }
+  console.log(
+    "\nDone. Here the list of user's id which authentication methods were deleted : ",
+    anonymizedUserIdsWithAllAuthenticationMethodsDeleted
   );
 }
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
 
 module.exports = { cleanAnonymizedAuthenticationMethods };

--- a/api/scripts/create-pro-organizations-with-tags.js
+++ b/api/scripts/create-pro-organizations-with-tags.js
@@ -12,6 +12,7 @@ const organizationInvitationRepository = require('../lib/infrastructure/reposito
 const organizationRepository = require('../lib/infrastructure/repositories/organization-repository');
 const organizationTagRepository = require('../lib/infrastructure/repositories/organization-tag-repository');
 const tagRepository = require('../lib/infrastructure/repositories/tag-repository');
+const { disconnect } = require('../db/knex-database-connection');
 
 const REQUIRED_FIELD_NAMES = [
   'externalId',
@@ -63,27 +64,26 @@ async function createOrganizationWithTags(filePath) {
   return 'Organizations created with success !';
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
 async function main() {
   console.log('Starting creating PRO organizations.');
   const filePath = process.argv[2];
-
-  try {
-    await createOrganizationWithTags(filePath);
-  } catch (error) {
-    console.error(error);
-    process.exit(1);
-  }
+  await createOrganizationWithTags(filePath);
 }
 
-if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
-      console.error(err);
-      process.exit(1);
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
     }
-  );
-}
+  }
+})();
 
 module.exports = {
   createOrganizationWithTags,

--- a/api/scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js
+++ b/api/scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const randomString = require('randomstring');
 const OrganizationLearner = require('../../lib/domain/models/OrganizationLearner');
 const { OrganizationLearnersCouldNotBeSavedError } = require('../../lib/domain/errors');
-const { knex } = require('../../lib/infrastructure/bookshelf');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 
 function _buildOrganizationLearner(division, organizationId, iteration) {
   const birthdates = ['2001-01-05', '2002-11-15', '1995-06-25'];
@@ -48,6 +48,8 @@ async function addManyDivisionsAndStudentsToScoCertificationCenter(numberOfDivis
   }
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
 async function main() {
   console.log('Starting adding SCO students to certification center.');
 
@@ -59,15 +61,18 @@ async function main() {
   console.log('\nDone.');
 }
 
-if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
-      console.error(err);
-      process.exit(1);
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
     }
-  );
-}
+  }
+})();
 
 module.exports = {
   addManyDivisionsAndStudentsToScoCertificationCenter,

--- a/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
+++ b/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const { SCO_MIDDLE_SCHOOL_ID } = require('../../db/seeds/data/organizations-sco-builder');
 const OrganizationLearner = require('../../lib/domain/models/OrganizationLearner');
 const { OrganizationLearnersCouldNotBeSavedError } = require('../../lib/domain/errors');
-const { knex } = require('../../lib/infrastructure/bookshelf');
 const DomainTransaction = require('../../lib/infrastructure/DomainTransaction');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 
 function _buildOrganizationLearner(iteration) {
   const birthdates = ['2001-01-05', '2002-11-15', '1995-06-25'];
@@ -28,6 +28,8 @@ async function addManyStudentsToScoCertificationCenter(numberOfStudents) {
   }
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
 async function main() {
   console.log('Starting adding SCO students to certification center.');
 
@@ -38,15 +40,18 @@ async function main() {
   console.log('\nDone.');
 }
 
-if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
-      console.error(err);
-      process.exit(1);
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
     }
-  );
-}
+  }
+})();
 
 module.exports = {
   addManyStudentsToScoCertificationCenter,

--- a/api/scripts/populate-organizations-email.js
+++ b/api/scripts/populate-organizations-email.js
@@ -1,7 +1,6 @@
 const bluebird = require('bluebird');
-
+const { disconnect } = require('../db/knex-database-connection');
 const { parseCsvWithHeader } = require('../scripts/helpers/csvHelpers');
-
 const BookshelfOrganization = require('../lib/infrastructure/orm-models/Organization');
 
 async function updateOrganizationEmailByExternalId(externalId, email) {
@@ -22,38 +21,37 @@ async function populateOrganizations(objectsFromFile) {
   });
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
 async function main() {
   console.log("Start populating organization's email");
+  const filePath = process.argv[2];
 
-  try {
-    const filePath = process.argv[2];
-
-    if (!filePath) {
-      console.log('Usage: populate-organizations-email.js <FILE_NAME>.csv');
-      process.exit(1);
-    }
-
-    console.log('Reading and parsing csv file (checking headers)... ');
-    const csvData = await parseCsvWithHeader(filePath);
-    console.log(`Successfully read ${csvData.length} records.`);
-
-    console.log('Populating organizations (existing emails will be updated)... ');
-    await populateOrganizations(csvData);
-    console.log('\nOrganization successfully populated.');
-  } catch (error) {
-    console.error('\n', error);
+  if (!filePath) {
+    console.log('Usage: populate-organizations-email.js <FILE_NAME>.csv');
     process.exit(1);
   }
+
+  console.log('Reading and parsing csv file (checking headers)... ');
+  const csvData = await parseCsvWithHeader(filePath);
+  console.log(`Successfully read ${csvData.length} records.`);
+
+  console.log('Populating organizations (existing emails will be updated)... ');
+  await populateOrganizations(csvData);
+  console.log('\nOrganization successfully populated.');
 }
 
-if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
-      console.error(err);
-      process.exit(1);
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
     }
-  );
-}
+  }
+})();
 
 module.exports = populateOrganizations;

--- a/api/scripts/prod/create-assessment-campaigns-for-sco.js
+++ b/api/scripts/prod/create-assessment-campaigns-for-sco.js
@@ -2,7 +2,7 @@
 // To use on file with columns |targetProfileId, name, externalId, title, customLandingPageText, creatorId|, those headers included
 const bluebird = require('bluebird');
 const _ = require('lodash');
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const CampaignTypes = require('../../lib/domain/models/CampaignTypes');
 const campaignCodeGenerator = require('../../lib/domain/services/campaigns/campaign-code-generator');
 const campaignValidator = require('../../lib/domain/validators/campaign-validator');
@@ -72,38 +72,38 @@ function createAssessmentCampaignsForSco(campaigns) {
   return knex.batchInsert('campaigns', campaigns);
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
 async function main() {
-  try {
-    const filePath = process.argv[2];
+  const filePath = process.argv[2];
 
-    console.log('Lecture et parsing du fichier csv... ');
-    const csvData = await parseCsvWithHeader(filePath);
+  console.log('Lecture et parsing du fichier csv... ');
+  const csvData = await parseCsvWithHeader(filePath);
 
-    console.log('Vérification des données du fichier csv...');
-    const checkedData = checkData(csvData);
+  console.log('Vérification des données du fichier csv...');
+  const checkedData = checkData(csvData);
 
-    console.log('Création des modèles campagne...');
-    const campaigns = await prepareCampaigns(checkedData);
+  console.log('Création des modèles campagne...');
+  const campaigns = await prepareCampaigns(checkedData);
 
-    console.log('Création des campagnes...');
-    await createAssessmentCampaignsForSco(campaigns);
+  console.log('Création des campagnes...');
+  await createAssessmentCampaignsForSco(campaigns);
 
-    console.log('FIN');
-  } catch (error) {
-    console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
-    process.exit(1);
-  }
+  console.log('FIN');
 }
 
-if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
-      console.error(err);
-      process.exit(1);
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
     }
-  );
-}
+  }
+})();
 
 module.exports = {
   prepareCampaigns,

--- a/api/scripts/prod/hide-skills-in-csv-export.js
+++ b/api/scripts/prod/hide-skills-in-csv-export.js
@@ -1,18 +1,28 @@
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 
 async function hideSkills() {
   await knex('organizations').where('showSkills', true).update({ showSkills: false });
 }
 
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  await hideSkills();
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
 module.exports = {
   hideSkills,
 };
-
-if (require.main === module) {
-  hideSkills()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error(err);
-      process.exit(1);
-    });
-}

--- a/api/scripts/prod/update-documentation-url.js
+++ b/api/scripts/prod/update-documentation-url.js
@@ -1,4 +1,4 @@
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 
 async function updateDocumentationUrl() {
   await _updateProOrganizations();
@@ -96,11 +96,21 @@ async function _updateAGRIOrganizations() {
   await knex('organizations').whereIn('id', ids).update({ documentationUrl: URL.AGRI });
 }
 
-if (require.main === module) {
-  updateDocumentationUrl()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error(err);
-      process.exit(1);
-    });
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  await updateDocumentationUrl();
 }
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();


### PR DESCRIPTION
## :unicorn: Problème
Des warnings apparaissent dans le linter sur l'API car, dans les scripts, on utilise encore `process.exit()`. 

## :robot: Solution
@octo-topi a décrit dans cette PR (https://github.com/1024pix/pix/pull/4599) par quoi les remplacer. Mieux, il a même ajouté un template de script qu'il faut utiliser afin d'homogénéiser ces fichiers.
Je m'efforce de faire ressembler les scripts existants au template, tout en remplaçant les `process.exit()`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Exécuter quelques scripts en local
