### PR TITLE
[FEATURE] Afficher la date de certificabilité dans la liste des élèves (PIX-5484).

### DIFF
--- a/api/lib/domain/read-models/ScoOrganizationParticipant.js
+++ b/api/lib/domain/read-models/ScoOrganizationParticipant.js
@@ -15,6 +15,7 @@ class ScoOrganizationParticipant {
     campaignType,
     participationStatus,
     isCertifiable,
+    certifiableAt,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -31,6 +32,7 @@ class ScoOrganizationParticipant {
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
     this.isCertifiable = isCertifiable;
+    this.certifiableAt = isCertifiable ? certifiableAt : null;
   }
 }
 

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -40,6 +40,9 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
       knex.raw(
         'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
       ),
+      knex.raw(
+        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"'
+      ),
     ])
     .from('organization-learners')
     .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
@@ -70,6 +73,7 @@ module.exports = {
         'users.email',
         'authentication-methods.externalIdentifier as samlId',
         'subquery.isCertifiable',
+        'subquery.certifiableAt',
         knex.raw(
           'FIRST_VALUE("name") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"'
         ),

--- a/api/lib/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer.js
@@ -19,6 +19,7 @@ module.exports = {
         'campaignType',
         'participationStatus',
         'isCertifiable',
+        'certifiableAt',
       ],
       meta: pagination,
     }).serialize(scoOrganizationParticipants);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -18,6 +18,7 @@ const Membership = require('../../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const CampaignTypes = require('../../../../lib/domain/models/CampaignTypes');
 
 describe('Acceptance | Application | organization-controller', function () {
   let server;
@@ -1057,7 +1058,10 @@ describe('Acceptance | Application | organization-controller', function () {
       let organizationLearner, campaign, participation;
 
       beforeEach(async function () {
-        campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+        campaign = databaseBuilder.factory.buildCampaign({
+          organizationId: organization.id,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        });
         organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
           organizationId: organization.id,
           userId: user.id,
@@ -1065,6 +1069,7 @@ describe('Acceptance | Application | organization-controller', function () {
         participation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: organizationLearner.id,
+          isCertifiable: true,
         });
 
         await databaseBuilder.commit();
@@ -1090,6 +1095,7 @@ describe('Acceptance | Application | organization-controller', function () {
                 'campaign-type': campaign.type,
                 'participation-status': participation.status,
                 'is-certifiable': participation.isCertifiable,
+                'certifiable-at': participation.sharedAt,
               },
               id: organizationLearner.id.toString(),
               type: 'sco-organization-participants',

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -281,46 +281,54 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
 
         it('should return sco participants filtered by "none" user connexion', async function () {
           // when
-          const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          const {
+            data: [{ lastName }],
+          } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
             filter: { connexionType: 'none' },
           });
 
           // then
-          expect(_.map(data, 'lastName')).to.deep.equal(['Lee']);
+          expect(lastName).to.equal('Lee');
         });
 
         it('should return sco participants filtered by "identifiant" user connexion', async function () {
           // when
-          const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          const {
+            data: [{ lastName }],
+          } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
             filter: { connexionType: 'identifiant' },
           });
 
           // then
-          expect(_.map(data, 'lastName')).to.deep.equal(['Willis']);
+          expect(lastName).to.deep.equal('Willis');
         });
 
         it('should return sco participants filtered by "email" user connexion', async function () {
           // when
-          const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          const {
+            data: [{ lastName }],
+          } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
             filter: { connexionType: 'email' },
           });
 
           // then
-          expect(_.map(data, 'lastName')).to.deep.equal(['Rambo']);
+          expect(lastName).to.deep.equal('Rambo');
         });
 
         it('should return sco participants filtered by "mediacentre" user connexion', async function () {
           // when
-          const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          const {
+            data: [{ lastName }],
+          } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
             filter: { connexionType: 'mediacentre' },
           });
 
           // then
-          expect(_.map(data, 'lastName')).to.deep.equal(['Norris']);
+          expect(lastName).to.equal('Norris');
         });
       });
 
@@ -341,13 +349,15 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ firstName }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId: organization.id,
           page: { number: 2, size: 1 },
         });
 
         // then
-        expect(_.map(data, 'firstName')).to.deep.equal(['Bar']);
+        expect(firstName).to.deep.equal('Bar');
       });
     });
 
@@ -380,12 +390,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [firstParticipant],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId: organization.id,
         });
 
         // then
-        expect(data[0]).to.deep.equal(expectedScoOrganizationParticipant);
+        expect(firstParticipant).to.deep.equal(expectedScoOrganizationParticipant);
       });
     });
 
@@ -425,12 +437,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [firstParticipant],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId: organization.id,
         });
 
         // then
-        expect(data[0]).to.deep.equal(expectedScoOrganizationParticipant);
+        expect(firstParticipant).to.deep.equal(expectedScoOrganizationParticipant);
       });
     });
 
@@ -463,12 +477,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [firstParticipant],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId: organization.id,
         });
 
         // then
-        expect(data[0]).to.deep.equal(expectedScoOrganizationParticipant);
+        expect(firstParticipant).to.deep.equal(expectedScoOrganizationParticipant);
       });
     });
 
@@ -492,13 +508,15 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         };
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ campaignName, campaignType }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].campaignName).to.deep.equal(expectedAttributes.campaignName);
-        expect(data[0].campaignType).to.deep.equal(expectedAttributes.campaignType);
+        expect(campaignName).to.equal(expectedAttributes.campaignName);
+        expect(campaignType).to.equal(expectedAttributes.campaignType);
       });
 
       it('should return null when there is no participation', async function () {
@@ -509,13 +527,15 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ campaignName, campaignType }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].campaignName).to.deep.equal(null);
-        expect(data[0].campaignType).to.deep.equal(null);
+        expect(campaignName).to.equal(null);
+        expect(campaignType).to.equal(null);
       });
 
       it('should return campaign name and type only for a campaign in the given organization', async function () {
@@ -530,12 +550,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ campaignName }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].campaignName).to.equal(null);
+        expect(campaignName).to.equal(null);
       });
     });
 
@@ -558,12 +580,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ participationStatus }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].participationStatus).to.deep.equal(CampaignParticipationStatuses.TO_SHARE);
+        expect(participationStatus).to.deep.equal(CampaignParticipationStatuses.TO_SHARE);
       });
 
       it('should return null when there is no participation', async function () {
@@ -574,12 +598,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ participationStatus }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].participationStatus).to.deep.equal(null);
+        expect(participationStatus).to.deep.equal(null);
       });
     });
 
@@ -596,13 +622,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([2]);
+        expect(participationCount).to.deep.equal(2);
       });
 
       it('should count only participations not deleted', async function () {
@@ -628,13 +655,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([1]);
+        expect(participationCount).to.deep.equal(1);
       });
 
       it('should count only participations not improved', async function () {
@@ -648,13 +676,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([1]);
+        expect(participationCount).to.deep.equal(1);
       });
 
       it('should count 0 participation when sco participant has no participation', async function () {
@@ -664,13 +693,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([0]);
+        expect(participationCount).to.deep.equal(0);
       });
     });
 
@@ -695,13 +725,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([campaignParticipation.createdAt]);
+        expect(lastParticipationDate).to.deep.equal(campaignParticipation.createdAt);
       });
 
       it('should take the last participation date not deleted', async function () {
@@ -729,13 +760,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([campaignParticipation.createdAt]);
+        expect(lastParticipationDate).to.deep.equal(campaignParticipation.createdAt);
       });
 
       it('should take the last participation date not improved', async function () {
@@ -759,13 +791,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([campaignParticipation.createdAt]);
+        expect(lastParticipationDate).to.deep.equal(campaignParticipation.createdAt);
       });
 
       it('should be null when sco participant has no participation', async function () {
@@ -775,13 +808,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([null]);
+        expect(lastParticipationDate).to.equal(null);
       });
     });
 
@@ -816,13 +850,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([campaignParticipation.isCertifiable]);
+        expect(isCertifiable).to.deep.equal(campaignParticipation.isCertifiable);
       });
 
       it('should take the last shared participation', async function () {
@@ -855,13 +890,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([campaignParticipation.isCertifiable]);
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
       });
 
       it('should take the last shared participation of profile collection campaign', async function () {
@@ -894,13 +930,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([campaignParticipation.isCertifiable]);
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
       });
 
       it('should take the last shared participation not deleted', async function () {
@@ -936,13 +973,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([campaignParticipation.isCertifiable]);
+        expect(isCertifiable).to.deep.equal(campaignParticipation.isCertifiable);
       });
 
       it('should take the last shared participation even if isImproved is true', async function () {
@@ -972,13 +1010,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([campaignParticipation.isCertifiable]);
+        expect(isCertifiable).to.deep.equal(campaignParticipation.isCertifiable);
       });
 
       it('should take the last shared participation for campaign of given organization', async function () {
@@ -1012,13 +1051,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([campaignParticipation.isCertifiable]);
+        expect(isCertifiable).to.deep.equal(campaignParticipation.isCertifiable);
       });
 
       it('should be null when sco participant has no participation', async function () {
@@ -1028,13 +1068,14 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        const {
+          data: [{ isCertifiable }],
+        } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
           organizationId,
         });
 
         // then
-        const isCertifiablesAsArray = data.map((result) => result.isCertifiable);
-        expect(isCertifiablesAsArray).to.deep.equal([null]);
+        expect(isCertifiable).to.deep.equal(null);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer_test.js
@@ -24,6 +24,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
           campaignType: 'ASSESSMENT',
           participationStatus: campaignParticipationsStatuses.TO_SHARE,
           isCertifiable: null,
+          certifiableAt: null,
         }),
         new ScoOrganizationParticipant({
           id: 778,
@@ -41,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
           campaignType: 'PROFILES_COLLECTION',
           participationStatus: campaignParticipationsStatuses.SHARED,
           isCertifiable: true,
+          certifiableAt: '2021-03-04',
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -65,6 +67,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
               'campaign-type': scoOrganizationParticipants[0].campaignType,
               'participation-status': scoOrganizationParticipants[0].participationStatus,
               'is-certifiable': scoOrganizationParticipants[0].isCertifiable,
+              'certifiable-at': scoOrganizationParticipants[0].certifiableAt,
             },
           },
           {
@@ -85,6 +88,7 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
               'campaign-type': scoOrganizationParticipants[1].campaignType,
               'participation-status': scoOrganizationParticipants[1].participationStatus,
               'is-certifiable': scoOrganizationParticipants[1].isCertifiable,
+              'certifiable-at': scoOrganizationParticipants[1].certifiableAt,
             },
           },
         ],

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -125,6 +125,13 @@
             </td>
             <td class="table__column--center">
               <Ui::IsCertifiable @isCertifiable={{student.isCertifiable}} />
+              {{#if student.certifiableAt}}
+                <span class="organization-participant-list-page__certifiable-at">{{moment-format
+                    student.certifiableAt
+                    "DD/MM/YYYY"
+                    allow-empty=true
+                  }}</span>
+              {{/if}}
             </td>
             <td class="organization-participant-list-page__actions hide-on-mobile">
               {{#if student.isAssociated}}

--- a/orga/app/models/sco-organization-participant.js
+++ b/orga/app/models/sco-organization-participant.js
@@ -22,6 +22,7 @@ export default class ScoOrganizationParticipant extends Model {
   @attr('string') campaignType;
   @attr('string') participationStatus;
   @attr('nullable-boolean') isCertifiable;
+  @attr('date') certifiableAt;
   @belongsTo('organization') organization;
 
   get hasUsername() {

--- a/orga/app/styles/pages/authenticated/organization-participants.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants.scss
@@ -12,6 +12,11 @@ $margin-right: 32px;
     justify-content: center;
   }
 
+  &__certifiable-at {
+    display: block;
+    margin-top: $spacing-xxs;
+  }
+
   &__header {
     display: flex;
     align-items: baseline;

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -58,7 +58,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     assert.dom('[aria-label="Élève"]').exists({ count: 2 });
   });
 
-  test('it should display the firstName, lastName, birthdate, division, participation count, last participation date of student and the last participation tooltip', async function (assert) {
+  test('it should display the firstName, lastName, birthdate, division, participation count, last participation date of student, the last participation tooltip and certifiableAt', async function (assert) {
     // given
     const students = [
       {
@@ -68,6 +68,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         birthdate: new Date('2010-02-01'),
         participationCount: 42,
         lastParticipationDate: new Date('2022-01-03'),
+        certifiableAt: new Date('2022-01-02'),
       },
     ];
     this.set('students', students);
@@ -82,6 +83,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     assert.contains('3B');
     assert.contains('42');
     assert.contains('03/01/2022');
+    assert.contains('02/01/2022');
     assert
       .dom(
         screen.getByLabelText(


### PR DESCRIPTION
## :unicorn: Problème
L'information de la certificabilité d'un élève n'est pas suffisante en soit car les utilisateurs de Pix peuvent réinitialiser les compétences perdant de fait la certificabilité.

## :robot: Solution
Pour rendre l'information précise, on ajoute la date à laquelle on est certain que l'élève était certifiable.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixOrga avec le compte admin Sco
- Aller dans l'onglet Élèves
- Constater la présence d'une date dans la colonne "Certificabilité" lorsque celle-ci est valorisé à "Certifiable"
