### PR TITLE
[BUGFIX] Ne pas remonter l'erreur de Pole Emploi au renvoie des informations de l'utilisateur (PIX-5599).

### DIFF
--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -117,6 +117,12 @@ class OidcAuthenticationService {
       );
     }
 
+    if (!userInfoContent || typeof userInfoContent !== 'object') {
+      const message = 'Les informations utilisateur récupérées ne sont pas au format attendu.';
+      logger.error(message);
+      throw new InvalidExternalAPIResponseError(message);
+    }
+
     if (!userInfoContent.family_name || !userInfoContent.given_name || !userInfoContent.sub) {
       logger.error(`Un des champs obligatoires n'a pas été renvoyé : ${JSON.stringify(userInfoContent)}.`);
       throw new InvalidExternalAPIResponseError('Les informations utilisateurs récupérées sont incorrectes.');

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -320,6 +320,31 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
+    describe('when returned value by external API is not a json object', function () {
+      it('should throw error', async function () {
+        // given
+        sinon.stub(httpAgent, 'get').resolves({
+          isSuccessful: true,
+          data: '',
+        });
+        sinon.stub(logger, 'error');
+        const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl: 'userInfoUrl' });
+
+        // when
+        const error = await catchErr(oidcAuthenticationService._getContentFromUserInfoEndpoint)({
+          accessToken: 'accessToken',
+          userInfoUrl: 'userInfoUrl',
+        });
+
+        // then
+        expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
+        expect(error.message).to.be.equal('Les informations utilisateur récupérées ne sont pas au format attendu.');
+        expect(logger.error).to.have.been.calledWith(
+          'Les informations utilisateur récupérées ne sont pas au format attendu.'
+        );
+      });
+    });
+
     describe('when call to external API fails', function () {
       it('should throw error', async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Quand on demande les informations de l'utilisateur a Pole Emploi. Parfois le retour n'est pas dans le bon format et ça crée des erreurs de notre côté.

## :robot: Solution
Vérifiez que le retour est dans le bon format.

## :rainbow: Remarques
RAS

## :100: Pour tester
Le seul moyen de vraiment tester c'est de modifier le code de l'API et stubber le retour de Pole Emploi. Sinon juste valider que les tests passent et puis on vérifiera les logs dans Datadog
