### PR TITLE
[FEATURE] Ajouter le filtre par certificabilité sur la liste des participants (Pix-5482)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -750,6 +750,7 @@ exports.register = async (server) => {
             'page[size]': Joi.number().integer().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'page[certificability]': [Joi.string()],
           }).options({ allowUnknown: true }),
         },
         handler: organizationController.findPaginatedFilteredScoParticipants,

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -31,6 +31,12 @@ const certificationResultUtils = require('../../infrastructure/utils/csv/certifi
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
 const organizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/organization-for-admin-serializer');
 
+const certificabilityByLabel = {
+  'not-available': null,
+  eligible: true,
+  'non-eligible': false,
+};
+
 module.exports = {
   async getOrganizationDetails(request) {
     const organizationId = request.params.id;
@@ -261,7 +267,12 @@ module.exports = {
     if (filter.divisions && !Array.isArray(filter.divisions)) {
       filter.divisions = [filter.divisions];
     }
-
+    if (filter.certificability) {
+      if (!Array.isArray(filter.certificability)) {
+        filter.certificability = [filter.certificability];
+      }
+      filter.certificability = filter.certificability.map((value) => certificabilityByLabel[value]);
+    }
     const { data: scoOrganizationParticipants, pagination } = await usecases.findPaginatedFilteredScoParticipants({
       organizationId,
       filter,

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -7,7 +7,7 @@ const ScoOrganizationParticipant = require('../../domain/read-models/ScoOrganiza
 const CampaignTypes = require('../../domain/models/CampaignTypes');
 const CampaignParticipationStatuses = require('../../domain/models/CampaignParticipationStatuses');
 
-function _setFilters(qb, { lastName, firstName, divisions, connexionType } = {}) {
+function _setFilters(qb, { lastName, firstName, divisions, connexionType, certificability } = {}) {
   if (lastName) {
     qb.whereRaw('LOWER("organization-learners"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
@@ -29,6 +29,14 @@ function _setFilters(qb, { lastName, firstName, divisions, connexionType } = {})
   } else if (connexionType === 'mediacentre') {
     // we only retrieve GAR authentication method in join clause
     qb.whereRaw('"authentication-methods"."externalIdentifier" IS NOT NULL');
+  }
+  if (certificability) {
+    qb.where(function (query) {
+      query.whereInArray('subquery.isCertifiable', certificability);
+      if (certificability.includes(null)) {
+        query.orWhereRaw('"subquery"."isCertifiable" IS NULL');
+      }
+    });
   }
 }
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -902,14 +902,110 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
     it('should return the serialized sco participants belonging to the organization', async function () {
       // given
-      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [scoOrganizationParticipant] });
-      scoOrganizationParticipantsSerializer.serialize.returns(serializedScoOrganizationParticipant);
+      const pagination = { page: 1 };
+      const scoOrganizationParticipants = [scoOrganizationParticipant];
+      usecases.findPaginatedFilteredScoParticipants.resolves({ data: scoOrganizationParticipants, pagination });
+      scoOrganizationParticipantsSerializer.serialize
+        .withArgs({ scoOrganizationParticipants, pagination })
+        .returns(serializedScoOrganizationParticipant);
 
       // when
       const response = await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
 
       // then
       expect(response).to.deep.equal(serializedScoOrganizationParticipant);
+    });
+
+    it('map the certificability eligible value', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': 'eligible',
+        },
+      };
+      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
+      scoOrganizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
+
+      // then
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+        organizationId,
+        filter: { certificability: [true] },
+        page: {},
+      });
+    });
+
+    it('map the certificability non-eligible value', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': 'non-eligible',
+        },
+      };
+      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
+      scoOrganizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
+
+      // then
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+        organizationId,
+        filter: { certificability: [false] },
+        page: {},
+      });
+    });
+
+    it('map the certificability not-available value', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': 'not-available',
+        },
+      };
+      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
+      scoOrganizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
+
+      // then
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+        organizationId,
+        filter: { certificability: [null] },
+        page: {},
+      });
+    });
+
+    it('map the all certificability values', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': ['eligible', 'not-available'],
+        },
+      };
+      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
+      scoOrganizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
+
+      // then
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+        organizationId,
+        filter: { certificability: [true, null] },
+        page: {},
+      });
     });
   });
 

--- a/api/tests/unit/domain/models/ParticipantResultsShared_test.js
+++ b/api/tests/unit/domain/models/ParticipantResultsShared_test.js
@@ -2,6 +2,7 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const ParticipantResultsShared = require('../../../../lib/domain/models/ParticipantResultsShared');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const { MAX_REACHABLE_PIX_BY_COMPETENCE } = require('../../../../lib/domain/constants');
+const noop = require('lodash/noop');
 
 describe('Unit | Domain | Models | ParticipantResultsShared', function () {
   context('#masteryRate', function () {
@@ -48,7 +49,7 @@ describe('Unit | Domain | Models | ParticipantResultsShared', function () {
         const participantResultsShared = new ParticipantResultsShared({
           knowledgeElements,
           targetedSkillIds,
-          placementProfile: { isCertifiable: () => {} },
+          placementProfile: { isCertifiable: noop },
         });
 
         // then

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -41,6 +41,16 @@
     @ariaLabel={{t "pages.sco-organization-participants.filter.login-method.aria-label"}}
     @emptyOptionLabel={{t "pages.sco-organization-participants.filter.login-method.empty-option"}}
   />
+  <Ui::MultiSelectFilter
+    @field="certificability"
+    @title={{t "pages.sco-organization-participants.filter.certificability.label"}}
+    @onSelect={{@onFilter}}
+    @selectedOption={{@certificabilityFilter}}
+    @options={{@certificabilityOptions}}
+    @placeholder={{t "pages.sco-organization-participants.filter.certificability.label"}}
+    @ariaLabel={{t "pages.sco-organization-participants.filter.certificability.aria-label"}}
+    @emptyMessage={{t "pages.sco-organization-participants.filter.certificability.empty"}}
+  />
 </PixFilterBanner>
 
 <div class="panel">

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -17,6 +17,7 @@ export default class ListController extends Controller {
   @tracked firstName = null;
   @tracked divisions = [];
   @tracked connexionType = null;
+  @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = null;
 
@@ -33,6 +34,7 @@ export default class ListController extends Controller {
     this.connexionType = null;
     this.firstName = null;
     this.lastName = null;
+    this.certificability = [];
   }
 
   get connectionTypesOptions() {
@@ -41,6 +43,23 @@ export default class ListController extends Controller {
       { value: 'email', label: this.intl.t(CONNECTION_TYPES.email) },
       { value: 'identifiant', label: this.intl.t(CONNECTION_TYPES.identifiant) },
       { value: 'mediacentre', label: this.intl.t(CONNECTION_TYPES.mediacentre) },
+    ];
+  }
+
+  get certificabilityOptions() {
+    return [
+      {
+        value: 'not-available',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.not-available'),
+      },
+      {
+        value: 'eligible',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'),
+      },
+      {
+        value: 'non-eligible',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.non-eligible'),
+      },
     ];
   }
 

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -9,6 +9,7 @@ export default class ListRoute extends Route {
     firstName: { refreshModel: true },
     divisions: { refreshModel: true },
     connexionType: { refreshModel: true },
+    certificability: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
   };
@@ -23,6 +24,7 @@ export default class ListRoute extends Route {
         firstName: params.firstName,
         divisions: params.divisions,
         connexionType: params.connexionType,
+        certificability: params.certificability,
       },
       page: {
         number: params.pageNumber,
@@ -37,6 +39,7 @@ export default class ListRoute extends Route {
       controller.firstName = null;
       controller.divisions = [];
       controller.connexionType = null;
+      controller.certificability = null;
       controller.pageNumber = null;
       controller.pageSize = null;
     }

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -6,10 +6,12 @@
   <ScoOrganizationParticipant::List
     @students={{@model}}
     @connectionTypesOptions={{this.connectionTypesOptions}}
+    @certificabilityOptions={{this.certificabilityOptions}}
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
     @divisionsFilter={{this.divisions}}
     @connexionTypeFilter={{this.connexionType}}
+    @certificabilityFilter={{this.certificability}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}
   />

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -181,6 +181,28 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       assert.ok(true);
     });
 
+    test('it should trigger filtering with certificability', async function (assert) {
+      // given
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+
+      const { getByPlaceholderText } = await render(
+        hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{triggerFiltering}} @certificabilityOptions={{certificabilityOptions}} @certificability={{certificability}} />`
+      );
+
+      // when
+      const select = await getByPlaceholderText('Rechercher par certificabilité');
+      await click(select);
+      await clickByName('Certifiable');
+
+      // then
+      sinon.assert.calledWithExactly(triggerFiltering, 'certificability', ['eligible']);
+      assert.ok(true);
+    });
+
     test('it should call resetFiltered', async function (assert) {
       // given
       const resetFiltered = sinon.spy();

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -815,6 +815,11 @@
         }
       },
       "filter": {
+        "certificability": {
+          "aria-label": "Enter a status for certificability",
+          "empty": "No status",
+          "label": "Search by certificability"
+        },
         "division": {
           "aria-label": "Enter a class",
           "empty": "No class",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -815,6 +815,11 @@
         }
       },
       "filter": {
+        "certificability": {
+          "aria-label": "Enter un statut de certification",
+          "empty": "Pas de status",
+          "label": "Rechercher par certificabilité"
+        },
         "division": {
           "aria-label": "Entrer une classe",
           "empty": "Aucune classe",


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs doivent passer par les campagnes de collecte pour savoir quel participant est certifiable.

## :robot: Solution
Chercher les participants et les filtrer en fonction de leur certificabilité

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter avec sco.admin@example.net
Aller sur la page élèves
Filtrer les participants par certificabilité