### PR TITLE
[BUGFIX][ADMIN] Corriger l'affichage de l'identifiant du créateur de l'organisation (PIX-5586)

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -15,7 +15,7 @@ export default class Organization extends Model {
   @attr('string') formNPSUrl;
   @attr('number') credit;
   @attr('nullable-string') email;
-  @attr('date') createdBy;
+  @attr() createdBy;
   @attr('date') createdAt;
   @attr('nullable-string') documentationUrl;
   @attr('boolean') showSkills;

--- a/api/db/seeds/data/campaigns-sco-builder.js
+++ b/api/db/seeds/data/campaigns-sco-builder.js
@@ -4,8 +4,7 @@ const {
   TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
 } = require('./target-profiles-builder');
 const { PRO_BASICS_BADGE_ID, PRO_TOOLS_BADGE_ID } = require('./badges-builder');
-const { SCO_MIDDLE_SCHOOL_ID, SCO_HIGH_SCHOOL_ID, SCO_AGRI_ID, SCO_AEFE_ID } = require('./organizations-sco-builder');
-const { SCO_STUDENT_ID, SCO_FRENCH_USER_ID, SCO_FOREIGNER_USER_ID, SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION, SCO_DISABLED_USER_ID, SCO_STUDENT_NOT_CERTIFIABLE_ID } = require('./organizations-sco-builder');
+const { SCO_MIDDLE_SCHOOL_ID, SCO_HIGH_SCHOOL_ID, SCO_AGRI_ID, SCO_AEFE_ID, SCO_STUDENT_ID, SCO_FRENCH_USER_ID, SCO_FOREIGNER_USER_ID, SCO_FOREIGNER_USER_ID_IN_ANOTHER_ORGANIZATION, SCO_DISABLED_USER_ID, SCO_STUDENT_NOT_CERTIFIABLE_ID } = require('./organizations-sco-builder');
 const { participateToAssessmentCampaign, participateToProfilesCollectionCampaign } = require('./campaign-participations-builder');
 const CampaignParticipationStatuses = require('../../../lib/domain/models/CampaignParticipationStatuses');
 const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;

--- a/api/db/seeds/data/campaigns-sup-builder.js
+++ b/api/db/seeds/data/campaigns-sup-builder.js
@@ -2,8 +2,7 @@ const {
   TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
   TARGET_PROFILE_PIX_DROIT_ID,
 } = require('./target-profiles-builder');
-const { SUP_UNIVERSITY_ID } = require('./organizations-sup-builder');
-const { SUP_STUDENT_ASSOCIATED_ID, SUP_STUDENT_DISABLED_ID } = require('./organizations-sup-builder');
+const { SUP_UNIVERSITY_ID, SUP_STUDENT_ASSOCIATED_ID, SUP_STUDENT_DISABLED_ID } = require('./organizations-sup-builder');
 const { participateToAssessmentCampaign, participateToProfilesCollectionCampaign } = require('./campaign-participations-builder');
 const CampaignParticipationStatuses = require('../../../lib/domain/models/CampaignParticipationStatuses');
 const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -19,7 +19,6 @@ function organizationsProBuilder({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
     lastPixOrgaTermsOfServiceValidatedAt: new Date(),
   });
-
   const proUser2 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 3,
     firstName: 'Thorgo',
@@ -30,12 +29,19 @@ function organizationsProBuilder({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
     lastPixOrgaTermsOfServiceValidatedAt: new Date(),
   });
+  const privateCompanyCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Gormadoc',
+    lastName: 'Fleetfoot',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
 
   databaseBuilder.factory.buildOrganization({
     id: PRO_COMPANY_ID,
     type: 'PRO',
     name: 'Dragon & Co',
     logoUrl: require('../src/dragonAndCoBase64'),
+    createdBy: privateCompanyCreator.id,
     credit: 100,
     externalId: null,
     provinceCode: null,
@@ -69,6 +75,13 @@ function organizationsProBuilder({ databaseBuilder }) {
   });
 
   /* POLE EMPLOI */
+  const poleEmploiCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Paul',
+    lastName: 'Emploi',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
+
   databaseBuilder.factory.buildOrganization({
     id: PRO_POLE_EMPLOI_ID,
     type: 'PRO',
@@ -76,6 +89,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     externalId: null,
     provinceCode: null,
     email: null,
+    createdBy: poleEmploiCreator.id,
     identityProviderForCampaigns: 'POLE_EMPLOI',
   });
   databaseBuilder.factory.buildOrganizationTag({ organizationId: PRO_POLE_EMPLOI_ID, tagId: 4 });
@@ -87,6 +101,12 @@ function organizationsProBuilder({ databaseBuilder }) {
   });
 
   /* CNAV */
+  const cnavCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Timothy',
+    lastName: 'Chaney',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
   databaseBuilder.factory.buildOrganization({
     id: PRO_CNAV_ID,
     type: 'PRO',
@@ -94,6 +114,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     externalId: null,
     provinceCode: null,
     email: null,
+    createdBy: cnavCreator.id,
     identityProviderForCampaigns: 'CNAV',
   });
 
@@ -104,6 +125,12 @@ function organizationsProBuilder({ databaseBuilder }) {
   });
 
   /* MEDIATION NUMERIQUE */
+  const digitalMediationCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Fanchon',
+    lastName: 'Ricard',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
   databaseBuilder.factory.buildOrganization({
     id: PRO_MED_NUM_ID,
     type: 'PRO',
@@ -112,6 +139,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     externalId: null,
     provinceCode: null,
     email: null,
+    createdBy: digitalMediationCreator.id,
   });
   databaseBuilder.factory.buildOrganizationTag({ organizationId: PRO_MED_NUM_ID, tagId: 7 });
 
@@ -140,6 +168,12 @@ function organizationsProBuilder({ databaseBuilder }) {
     email: 'mimi.lasouris@example.net',
     rawPassword: DEFAULT_PASSWORD,
   });
+  const archivedCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Sébastien',
+    lastName: 'Rouleau',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
 
   const archivedAt = new Date('2022-02-02');
 
@@ -149,6 +183,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     name: 'Orga archivée',
     archivedAt,
     archivedBy: pixSuperAdmin.id,
+    createdBy: archivedCreator.id,
   });
   databaseBuilder.factory.buildMembership({
     userId: membership1.id,

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,5 +1,6 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const { DEFAULT_PASSWORD } = require('./users-builder');
+
 const SCO_MIDDLE_SCHOOL_ID = 3;
 const SCO_HIGH_SCHOOL_ID = 6;
 const SCO_AGRI_ID = 7;
@@ -17,7 +18,7 @@ const SCO_MEMBER_ID = 5;
 function organizationsScoBuilder({ databaseBuilder }) {
   _buildMiddleSchools({ databaseBuilder });
   _buildHighSchools({ databaseBuilder });
-  _buildAgri({ databaseBuilder });
+  _buildFarmingSchools({ databaseBuilder });
   _buildAEFE({ databaseBuilder });
 }
 
@@ -34,7 +35,6 @@ function _buildMiddleSchools({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
     lastPixOrgaTermsOfServiceValidatedAt: new Date(),
   });
-
   databaseBuilder.factory.buildUser.withRawPassword({
     id: SCO_MEMBER_ID,
     firstName: 'Aemon',
@@ -44,6 +44,13 @@ function _buildMiddleSchools({ databaseBuilder }) {
     cgu: true,
     pixOrgaTermsOfServiceAccepted: true,
     lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+  });
+
+  const middleSchoolsCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Iven',
+    lastName: 'Patry',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
   });
 
   databaseBuilder.factory.buildOrganization({
@@ -56,6 +63,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
     identityProviderForCampaigns: 'GAR',
+    createdBy: middleSchoolsCreator.id,
   });
 
   databaseBuilder.factory.buildMembership({
@@ -291,6 +299,12 @@ function _buildMiddleSchools({ databaseBuilder }) {
 
 function _buildHighSchools({ databaseBuilder }) {
   const SCO_LYCEE_EXTERNAL_ID = '1237457B';
+  const highSchoolsCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'France',
+    lastName: 'Guernon',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
 
   databaseBuilder.factory.buildOrganization({
     id: SCO_HIGH_SCHOOL_ID,
@@ -300,6 +314,7 @@ function _buildHighSchools({ databaseBuilder }) {
     email: 'sco2.generic.account@example.net',
     externalId: SCO_LYCEE_EXTERNAL_ID,
     provinceCode: '12',
+    createdBy: highSchoolsCreator.id,
   });
 
   databaseBuilder.factory.buildOrganizationTag({ organizationId: SCO_HIGH_SCHOOL_ID, tagId: 9 });
@@ -384,8 +399,15 @@ function _buildHighSchools({ databaseBuilder }) {
   });
 }
 
-function _buildAgri({ databaseBuilder }) {
+function _buildFarmingSchools({ databaseBuilder }) {
   const SCO_AGRI_EXTERNAL_ID = '1237457C';
+
+  const farmingSchoolsCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Maryse',
+    lastName: 'Marceau',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
 
   databaseBuilder.factory.buildOrganization({
     id: SCO_AGRI_ID,
@@ -395,6 +417,7 @@ function _buildAgri({ databaseBuilder }) {
     email: 'sco3.generic.account@example.net',
     externalId: SCO_AGRI_EXTERNAL_ID,
     provinceCode: '12',
+    createdBy: farmingSchoolsCreator.id,
   });
 
   databaseBuilder.factory.buildOrganizationTag({ organizationId: SCO_AGRI_ID, tagId: 1 });
@@ -415,6 +438,13 @@ function _buildAgri({ databaseBuilder }) {
 function _buildAEFE({ databaseBuilder }) {
   const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
 
+  const aefeCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Bevis',
+    lastName: 'Bellefeuille',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
+
   databaseBuilder.factory.buildOrganization({
     id: SCO_AEFE_ID,
     type: 'SCO',
@@ -422,6 +452,7 @@ function _buildAEFE({ databaseBuilder }) {
     email: 'sco4.generic.account@example.net',
     externalId: SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID,
     provinceCode: '12',
+    createdBy: aefeCreator.id,
   });
 
   databaseBuilder.factory.buildOrganizationTag({ organizationId: SCO_AEFE_ID, tagId: 6 });

--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -1,5 +1,6 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const { DEFAULT_PASSWORD } = require('./users-builder');
+
 const SUP_UNIVERSITY_ID = 2;
 const SUP_STUDENT_ASSOCIATED_ID = 888;
 const SUP_STUDENT_DISABLED_ID = 889;
@@ -15,12 +16,17 @@ function organizationsSupBuilder({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
     lastPixOrgaTermsOfServiceValidatedAt: new Date(),
   });
-
   const supUser2 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 8,
     firstName: 'Jaime',
     lastName: 'Lannister',
     email: 'sup.member@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+  });
+  const universityCreator = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Talon',
+    lastName: 'Maheu',
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
@@ -34,6 +40,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     provinceCode: null,
     email: null,
     showSkills: true,
+    createdBy: universityCreator.id,
   });
 
   databaseBuilder.factory.buildMembership({


### PR DESCRIPTION
## :unicorn: Problème

Une date s'affiche à la place de l'identifiant du créateur de l'organisation sur la page de détails d'une organisation. Ce qui ne devrait pas être le cas. Nous devons voir à la place l'identifiant du créateur de l'organisation.

## :robot: Solution

Retirer le type `date` sur l'attribut `createdBy` du modèle `Organization`.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter à Pix admin avec le compte superadmin
- Cliquez sur l'onglet `Organisations`
- Cherchez l'organisation `Dragon & Co (ID = 1)` et ouvrir la page de détails de cette organisation
- Constatez que le nom du créateur s'affiche ainsi que l'identifiant de ce dernier
