### PR TITLE
[TECH] Conserver l'expiration lors de la MàJ d'une clé dans le stockage temporaire en mémoire

### DIFF
--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -17,7 +17,8 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
 
   update(key, value) {
     const storageKey = trim(key);
-    this._client.set(storageKey, value);
+    const ttl = (this._client.getTtl(storageKey) - Date.now()) / 1000;
+    this._client.set(storageKey, value, ttl);
   }
 
   get(key) {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'on met à jour une clé dans le stockage temporaire en mémoire, la date d'expiration de cette clé n'est pas conservée.

## :robot: Solution

Conserver la date d'expiration.

## :rainbow: Remarques

N/A

## :100: Pour tester

Des TUs ont été ajoutés.
