### PR TITLE
[FEATURE] Ajouter la traduction anglaise pour l'aide sur l'utilisation d'un code parcours (PIX-5581)

### DIFF
--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -59,7 +59,7 @@
 
           <div class="fill-in-campaign-code__explanation">
             <a
-              href="https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-"
+              href={{t "pages.fill-in-campaign-code.explanation-link"}}
               class="link"
               target="_blank"
               rel="noopener noreferrer"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -769,7 +769,8 @@
         "missing-code": "Please enter a code.",
         "not-found": "Your code is incorrect. Please check it or contact the organiser."
       },
-      "explanation-message": "Qu’est-ce qu’un code parcours et comment l’utiliser ?",
+      "explanation-message": "What is a customised test code and how do I use it?",
+      "explanation-link": "https://support.pix.org/en/support/solutions/articles/15000029147-what-is-a-customised-test-code-and-how-do-i-use-it-",
       "first-title-connected": "{ firstName }, enter your code",
       "first-title-not-connected": "Enter your code",
       "start": "Start the customised test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -770,6 +770,7 @@
         "not-found": "Votre code est erroné, veuillez vérifier ou contacter l’organisateur."
       },
       "explanation-message": "Qu’est-ce qu’un code parcours et comment l’utiliser ?",
+      "explanation-link": "https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-",
       "first-title-connected": "{ firstName }, saisissez votre code",
       "first-title-not-connected": "Saisissez votre code",
       "start": "Accéder au parcours",


### PR DESCRIPTION
## :unicorn: Problème
La traducation pour le code parcours n'existe pas en Anglais, ni le lien pour le support

## :robot: Solution
Ajouter la trad en anglais ainsi que le lien vers le support en anglais.

## :rainbow: Remarques
RAS

## :100: Pour tester
Allez sur la page J'ai un code en FR, vérifiez que le lien est en français.
Allez sur la page i have a code en EN, vérifiez que le lien et la traduction est en anglais