### PR TITLE
[FEATURE] Ramener les domaines et compétences dans les pages tutos sur Pix App (PIX-5605).

### DIFF
--- a/api/lib/application/frameworks/frameworks-controller.js
+++ b/api/lib/application/frameworks/frameworks-controller.js
@@ -18,4 +18,9 @@ module.exports = {
     const framework = await usecases.getFrameworkAreas({ frameworkId });
     return frameworkAreasSerializer.serialize(framework);
   },
+  async getPixFrameworkAreasWithoutThematics(request) {
+    const locale = extractLocaleFromRequest(request);
+    const framework = await usecases.getFrameworkAreas({ frameworkName: 'Pix', locale });
+    return frameworkAreasSerializer.serialize(framework, { withoutThematics: true });
+  },
 };

--- a/api/lib/application/frameworks/index.js
+++ b/api/lib/application/frameworks/index.js
@@ -71,6 +71,18 @@ exports.register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/frameworks/pix/areas-for-user',
+      config: {
+        handler: frameworkController.getPixFrameworkAreasWithoutThematics,
+        tags: ['api', 'framework'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle permet de récupérer tous les domaines du référentiel pix avec leurs compétences (sans les thématiques)',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/framework-areas-serializer.js
@@ -1,7 +1,7 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(framework) {
+  serialize(framework, { withoutThematics = false } = {}) {
     return new Serializer('area', {
       ref: 'id',
       attributes: ['code', 'title', 'color', 'competences'],
@@ -32,6 +32,9 @@ module.exports = {
       },
 
       transform(area) {
+        if (withoutThematics) {
+          return area;
+        }
         area.competences.forEach((competence) => {
           competence.thematics = framework.thematics
             .filter((thematic) => {

--- a/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
+++ b/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
@@ -205,4 +205,84 @@ describe('Acceptance | Controller | frameworks-controller', function () {
       });
     });
   });
+
+  describe('GET /api/frameworks/pix/areas-for-user', function () {
+    describe('User is authenticated', function () {
+      let userId;
+
+      beforeEach(async function () {
+        userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+        mockLearningContent(learningContent);
+      });
+
+      it('should return response code 200', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/frameworks/pix/areas-for-user`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+        };
+
+        const expectedResult = {
+          data: [
+            {
+              id: 'areaId',
+              type: 'areas',
+              attributes: {
+                code: 1,
+                title: 'Area fr',
+                color: 'some color',
+              },
+              relationships: {
+                competences: {
+                  data: [
+                    {
+                      id: 'competenceId',
+                      type: 'competences',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+          included: [
+            {
+              id: 'competenceId',
+              type: 'competences',
+              attributes: {
+                name: 'Competence name',
+                index: 0,
+              },
+            },
+          ],
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal(expectedResult);
+      });
+    });
+
+    describe('User is not authenticated', function () {
+      it('should return response code 401', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/frameworks/pix/areas-for-user`,
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/frameworks/frameworks-controller_test.js
+++ b/api/tests/unit/application/frameworks/frameworks-controller_test.js
@@ -85,4 +85,23 @@ describe('Unit | Controller | frameworks-controller', function () {
       expect(frameworkAreasSerializer.serialize).to.have.been.calledWithExactly(areas);
     });
   });
+
+  describe('#getPixFrameworkAreasWithoutThematics', function () {
+    it('should fetch and return framework, serialized as JSONAPI', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+
+      // when
+      const result = await frameworksController.getPixFrameworkAreasWithoutThematics(request);
+
+      // then
+      expect(result).to.equal(serializedAreas);
+      expect(usecases.getFrameworkAreas).to.have.been.calledWithExactly({ frameworkName: 'Pix', locale: 'en' });
+      expect(frameworkAreasSerializer.serialize).to.have.been.calledWithExactly(areas, { withoutThematics: true });
+    });
+  });
 });

--- a/api/tests/unit/application/frameworks/index_test.js
+++ b/api/tests/unit/application/frameworks/index_test.js
@@ -1,4 +1,4 @@
-const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const { expect, HttpTestServer, sinon, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const frameworksController = require('../../../../lib/application/frameworks/frameworks-controller');
@@ -106,6 +106,43 @@ describe('Unit | Application | Frameworks | Routes', function () {
 
       // then
       expect(statusCode).to.equal(403);
+    });
+  });
+
+  describe('GET /api/frameworks/pix/areas-for-user', function () {
+    const method = 'GET';
+    const url = '/api/frameworks/pix/areas-for-user';
+
+    it('should return a response with an HTTP status code 200 when user is logged in', async function () {
+      // given
+      sinon
+        .stub(frameworksController, 'getPixFrameworkAreasWithoutThematics')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(moduleUnderTest);
+      const headers = {
+        authorization: generateValidRequestAuthorizationHeader(),
+      };
+
+      // when
+      const { statusCode } = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(statusCode).to.equal(200);
+    });
+
+    it('should return a response with an HTTP status code 401 when user is not logged', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      httpTestServer.setupAuthentication();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const { statusCode } = await httpTestServer.request(method, url);
+
+      // then
+      expect(statusCode).to.equal(401);
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/framework-areas-serializer_test.js
@@ -111,5 +111,76 @@ describe('Unit | Serializer | JSONAPI | pix-framework-serializer', function () {
       // then
       expect(result).to.deep.equal(expectedSerializedResult);
     });
+
+    describe('when without thematics is true', function () {
+      it('should return a serialized JSON data object without thematics', function () {
+        // given
+        const withoutThematics = true;
+        const tube = domainBuilder.buildTube({
+          id: 'tubeId',
+        });
+
+        const thematicWithTube = domainBuilder.buildThematic({
+          id: 'recThem1',
+          tubeIds: ['tubeId'],
+        });
+
+        const thematicWithoutTube = domainBuilder.buildThematic({
+          id: 'recThem2',
+        });
+
+        const area = domainBuilder.buildArea({});
+
+        const competence = domainBuilder.buildCompetence({ thematicIds: ['recThem1', 'recThem2'] });
+        area.competences = [competence];
+
+        const expectedSerializedResult = {
+          data: [
+            {
+              id: 'recArea123',
+              type: 'areas',
+              attributes: {
+                code: 5,
+                color: 'red',
+                title: 'Super domaine',
+              },
+              relationships: {
+                competences: {
+                  data: [
+                    {
+                      id: 'recCOMP1',
+                      type: 'competences',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+          included: [
+            {
+              type: 'competences',
+              id: 'recCOMP1',
+              attributes: {
+                index: '1.1',
+                name: 'Manger des fruits',
+              },
+            },
+          ],
+        };
+
+        // when
+        const result = serializer.serialize(
+          {
+            tubes: [tube],
+            thematics: [thematicWithTube, thematicWithoutTube],
+            areas: [area],
+          },
+          { withoutThematics }
+        );
+
+        // then
+        expect(result).to.deep.equal(expectedSerializedResult);
+      });
+    });
   });
 });

--- a/mon-pix/app/adapters/area.js
+++ b/mon-pix/app/adapters/area.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class Area extends ApplicationAdapter {
+  urlForFindAll() {
+    return `${this.host}/${this.namespace}/frameworks/pix/areas-for-user`;
+  }
+}

--- a/mon-pix/app/models/area.js
+++ b/mon-pix/app/models/area.js
@@ -9,4 +9,9 @@ export default class Area extends Model {
 
   // includes
   @hasMany('resultCompetence') resultCompetences;
+  @hasMany('competence') competences;
+
+  get sortedCompetences() {
+    return this.competences.sortBy('code');
+  }
 }

--- a/mon-pix/app/models/competence.js
+++ b/mon-pix/app/models/competence.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Competence extends Model {
+  // attributes
+  @attr('string') name;
+}

--- a/mon-pix/app/routes/authenticated/user-tutorials.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class UserTutorialsRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.findAll('area');
+  }
+}

--- a/mon-pix/app/routes/authenticated/user-tutorials/recommended.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/recommended.js
@@ -10,8 +10,9 @@ export default class UserTutorialsRecommendedRoute extends Route {
     pageSize: { refreshModel: true },
   };
 
-  model(params) {
-    return this.store.query(
+  async model(params) {
+    const areas = this.modelFor('authenticated.user-tutorials');
+    const recommendedTutorials = await this.store.query(
       'tutorial',
       {
         type: 'recommended',
@@ -22,6 +23,10 @@ export default class UserTutorialsRecommendedRoute extends Route {
       },
       { reload: true }
     );
+    return {
+      areas,
+      recommendedTutorials,
+    };
   }
 
   resetController(controller, isExiting) {

--- a/mon-pix/app/routes/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/saved.js
@@ -11,8 +11,9 @@ export default class UserTutorialsSavedRoute extends Route {
     pageSize: { refreshModel: true },
   };
 
-  model(params) {
-    return this.store.query(
+  async model(params) {
+    const areas = this.modelFor('authenticated.user-tutorials');
+    const savedTutorials = await this.store.query(
       'tutorial',
       {
         type: 'saved',
@@ -23,6 +24,10 @@ export default class UserTutorialsSavedRoute extends Route {
       },
       { reload: true }
     );
+    return {
+      areas,
+      savedTutorials,
+    };
   }
 
   resetController(controller, isExiting) {

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -1,7 +1,11 @@
-{{#if @model.meta.rowCount}}
+{{#if @model.recommendedTutorials.meta.rowCount}}
   <div class="user-tutorials-content-v2__container">
-    <Tutorials::Cards @tutorials={{@model}} />
-    <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} @isCondensed="true" />
+    <Tutorials::Cards @tutorials={{@model.recommendedTutorials}} />
+    <PixPagination
+      @pagination={{@model.recommendedTutorials.meta}}
+      @pageOptions={{this.pageOptions}}
+      @isCondensed="true"
+    />
   </div>
 {{else}}
   <Tutorials::RecommendedEmpty />

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -1,7 +1,7 @@
-{{#if @model.meta.rowCount}}
+{{#if @model.savedTutorials.meta.rowCount}}
   <div class="user-tutorials-content-v2__container">
-    <Tutorials::Cards @tutorials={{@model}} @afterRemove={{this.refresh}} />
-    <PixPagination @pagination={{@model.meta}} @pageOptions={{this.pageOptions}} @isCondensed="true" />
+    <Tutorials::Cards @tutorials={{@model.savedTutorials}} @afterRemove={{this.refresh}} />
+    <PixPagination @pagination={{@model.savedTutorials.meta}} @pageOptions={{this.pageOptions}} @isCondensed="true" />
   </div>
 {{else}}
   <Tutorials::SavedEmpty />

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -1,3 +1,4 @@
+import getAreas from './routes/get-areas';
 import getCampaigns from './routes/get-campaigns';
 import getCertificationCandidatesSubscriptions from './routes/get-certification-candidates-subscriptions';
 import getCertifications from './routes/get-certifications';
@@ -66,6 +67,8 @@ export default function () {
   this.get('/challenges/:id', getChallenge);
 
   this.post('/competence-evaluations/start-or-resume', postCompetenceEvaluation);
+
+  this.get('/frameworks/pix/areas-for-user', getAreas);
 
   this.get('/progressions/:id', getProgression);
 

--- a/mon-pix/mirage/routes/get-areas.js
+++ b/mon-pix/mirage/routes/get-areas.js
@@ -1,0 +1,3 @@
+export default function (schema) {
+  return schema.areas.all();
+}

--- a/mon-pix/tests/unit/adapters/area_test.js
+++ b/mon-pix/tests/unit/adapters/area_test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | Area', function () {
+  setupTest();
+
+  describe('#urlForFindAll', function () {
+    it('should build url for find all', function () {
+      // given
+      const adapter = this.owner.lookup('adapter:area');
+
+      // when
+      const url = adapter.urlForFindAll();
+
+      // then
+      expect(url.endsWith('api/frameworks/pix/areas-for-user')).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, nous souhaitons pouvoir filtrer les tutoriels par compétences, cependant ces dernières ne sont pas disponibles.

## :robot: Solution
Proposer un endpoint API permettant de ramener les domaines et compétences.
Cette nouvelle route se nomme : `/frameworks/pix/areas-for-user`, car celle-ci est différente de celle proposée pour Pix Orga qui ramène aussi les thématiques alors que nous souhaitons pas exposer ces informations dans notre cas.

Ensuite, nous ajoutons les models nécessaires dans Pix App, puis ajoutons les areas dans le model des routes `user-tutorials`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App
- Se render sur `/mes-tutos/enregistres` et `/mes-tutos/recommandes`
- Constater un appel vers le nouvel endpoint `/frameworks/pix/areas-for-user` et constater dans l'extension Ember que les areas et les compétences sont disponibles
