### PR TITLE
[FEATURE] Afficher une sidebar pour filtrer les tutoriels par compétences (PIX-5606).

### DIFF
--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -7,7 +7,11 @@
 
     <div class="user-tutorials-banner-v2__filters">
       {{#if this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled}}
-        <PixButton @backgroundColor="transparent-light" @isBorderVisible={{false}}>
+        <PixButton
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{false}}
+          @triggerAction={{@onTriggerFilterButton}}
+        >
           {{t "pages.user-tutorials.filter"}}
         </PixButton>
       {{/if}}

--- a/mon-pix/app/components/user-tutorials/filters/item-checkbox.hbs
+++ b/mon-pix/app/components/user-tutorials/filters/item-checkbox.hbs
@@ -1,0 +1,8 @@
+<li class="tutorials-filters-areas-competences__item-checkbox">
+  <PixCheckbox
+    @id={{@item.id}}
+    @label={{@item.name}}
+    {{on "input" (fn @handleFilterChange @type @item.id)}}
+    @checked={{this.isChecked}}
+  />
+</li>

--- a/mon-pix/app/components/user-tutorials/filters/item-checkbox.js
+++ b/mon-pix/app/components/user-tutorials/filters/item-checkbox.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+
+export default class ItemCheckbox extends Component {
+  constructor() {
+    super(...arguments);
+
+    if (!this.args.type) {
+      throw new Error('ERROR in UserTutorials::Filters::ItemCheckbox component, you must provide @type params');
+    }
+  }
+
+  get isChecked() {
+    return this.args.currentFilters[this.args.type].includes(this.args.item.id);
+  }
+}

--- a/mon-pix/app/components/user-tutorials/filters/sidebar.hbs
+++ b/mon-pix/app/components/user-tutorials/filters/sidebar.hbs
@@ -1,0 +1,39 @@
+<PixSidebar
+  @title={{t "pages.user-tutorials.filter"}}
+  @showSidebar={{@isVisible}}
+  @onClose={{@onClose}}
+  class="tutorials-filters"
+>
+  <:content>
+    {{#each this.sortedAreas as |area|}}
+      <div class="area-border-container">
+        <div class="area-border {{area.color}}"></div>
+        <PixCollapsible @title="{{area.title}}" class="tutorials-filters__areas {{area.color}}">
+          <ul class="tutorials-filters-areas__competences">
+            {{#each area.sortedCompetences as |competence|}}
+              <UserTutorials::Filters::ItemCheckbox
+                @type="competences"
+                @item={{competence}}
+                @handleFilterChange={{this.handleFilterChange}}
+                @currentFilters={{this.filters}}
+              />
+            {{/each}}
+          </ul>
+        </PixCollapsible>
+      </div>
+    {{/each}}
+  </:content>
+  <:footer>
+    <div class="tutorials-filters__footer">
+      <PixButton
+        @triggerAction={{this.handleResetFilters}}
+        @size="small"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+      >
+        {{t "pages.user-tutorials.sidebar.reset"}}
+      </PixButton>
+      <PixButton @size="small">{{t "pages.user-tutorials.sidebar.see-results"}}</PixButton>
+    </div>
+  </:footer>
+</PixSidebar>

--- a/mon-pix/app/components/user-tutorials/filters/sidebar.js
+++ b/mon-pix/app/components/user-tutorials/filters/sidebar.js
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+
+class Filters {
+  @tracked competences = A([]);
+}
+
+export default class Sidebar extends Component {
+  @tracked filters = new Filters();
+
+  get sortedAreas() {
+    return this.args.areas?.sortBy('code');
+  }
+
+  @action
+  handleFilterChange(type, id) {
+    if (!this.filters[type].includes(id)) {
+      this.filters[type].pushObject(id);
+    } else {
+      this.filters[type].removeObject(id);
+    }
+  }
+
+  @action
+  handleResetFilters() {
+    this.filters = new Filters();
+  }
+}

--- a/mon-pix/app/controllers/authenticated/user-tutorials/recommended.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/recommended.js
@@ -1,10 +1,24 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class RecommendedController extends Controller {
+  @tracked isSidebarVisible = false;
+
   pageOptions = [
     { label: '10', value: 10 },
     { label: '20', value: 20 },
     { label: '50', value: 50 },
     { label: '100', value: 100 },
   ];
+
+  @action
+  showSidebar() {
+    this.isSidebarVisible = true;
+  }
+
+  @action
+  closeSidebar() {
+    this.isSidebarVisible = false;
+  }
 }

--- a/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
@@ -1,7 +1,10 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class SavedController extends Controller {
+  @tracked isSidebarVisible = false;
+
   pageOptions = [
     { label: '10', value: 10 },
     { label: '20', value: 20 },
@@ -12,5 +15,15 @@ export default class SavedController extends Controller {
   @action
   refresh() {
     this.send('refreshModel');
+  }
+
+  @action
+  showSidebar() {
+    this.isSidebarVisible = true;
+  }
+
+  @action
+  closeSidebar() {
+    this.isSidebarVisible = false;
   }
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -114,6 +114,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/user-certification-hexagon-score';
 @import 'components/user-certifications-detail-result';
 @import 'components/user-logged-menu';
+@import 'components/user-tutorials/sidebar';
 @import 'components/communication-banner';
 @import 'components/pix-toggle';
 @import 'components/skip-link';

--- a/mon-pix/app/styles/components/user-tutorials/_sidebar.scss
+++ b/mon-pix/app/styles/components/user-tutorials/_sidebar.scss
@@ -1,0 +1,66 @@
+.tutorials-filters {
+
+  .pix-collapsible {
+
+    &__title {
+      align-items: center;
+      font-family: $font-open-sans;
+      font-size: 0.875rem;
+      font-weight: 500;
+      position: relative;
+      padding-left: 2rem;
+      color: $pix-neutral-70;
+      text-transform: uppercase;
+      text-align: left;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 10%;
+        left: 1rem;
+        border-left: 4px solid;
+        border-radius: 5px;
+        height: 80%;
+      }
+
+      &.jaffa::before {
+        border-color: $pix-information-light;
+      }
+
+      &.emerald::before {
+        border-color: $pix-content-light;
+      }
+
+      &.cerulean::before {
+        border-color: $pix-communication-light;
+      }
+
+      &.wild-strawberry::before {
+        border-color: $pix-security-light;
+      }
+
+      &.butterfly-bush::before {
+        border-color: $pix-environment-light;
+      }
+    }
+  }
+
+  &__footer {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.tutorials-filters-areas-competences {
+
+  &__item-checkbox {
+
+    .pix-checkbox__label {
+      flex-grow: 1;
+    }
+  }
+
+  &__item-checkbox + &__item-checkbox {
+    margin-top: 20px;
+  }
+}

--- a/mon-pix/app/templates/authenticated/user-tutorials.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials.hbs
@@ -1,17 +1,2 @@
 {{page-title (t "pages.user-tutorials.title")}}
-<BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
-  <burger.outlet>
-
-    <header role="banner">
-      <NavbarHeader @burger={{burger}} />
-      <Tutorials::Header />
-    </header>
-
-    <main id="main" class="main" role="main">
-      <div class="user-tutorials-content-v2">
-        {{outlet}}
-      </div>
-    </main>
-    <Footer />
-  </burger.outlet>
-</BurgerMenu>
+{{outlet}}

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -2,10 +2,15 @@
   <burger.outlet>
     <header role="banner">
       <NavbarHeader @burger={{burger}} />
-      <Tutorials::Header />
+      <Tutorials::Header @onTriggerFilterButton={{this.showSidebar}} />
     </header>
 
     <main id="main" class="main" role="main">
+      <UserTutorials::Filters::Sidebar
+        @isVisible={{this.isSidebarVisible}}
+        @areas={{this.model.areas}}
+        @onClose={{this.closeSidebar}}
+      />
       <div class="user-tutorials-content-v2">
         {{#if @model.recommendedTutorials.meta.rowCount}}
           <div class="user-tutorials-content-v2__container">

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -1,12 +1,27 @@
-{{#if @model.recommendedTutorials.meta.rowCount}}
-  <div class="user-tutorials-content-v2__container">
-    <Tutorials::Cards @tutorials={{@model.recommendedTutorials}} />
-    <PixPagination
-      @pagination={{@model.recommendedTutorials.meta}}
-      @pageOptions={{this.pageOptions}}
-      @isCondensed="true"
-    />
-  </div>
-{{else}}
-  <Tutorials::RecommendedEmpty />
-{{/if}}
+<BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
+  <burger.outlet>
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+      <Tutorials::Header />
+    </header>
+
+    <main id="main" class="main" role="main">
+      <div class="user-tutorials-content-v2">
+        {{#if @model.recommendedTutorials.meta.rowCount}}
+          <div class="user-tutorials-content-v2__container">
+            <Tutorials::Cards @tutorials={{@model.recommendedTutorials}} />
+            <PixPagination
+              @pagination={{@model.recommendedTutorials.meta}}
+              @pageOptions={{this.pageOptions}}
+              @isCondensed="true"
+            />
+          </div>
+        {{else}}
+          <Tutorials::RecommendedEmpty />
+        {{/if}}
+      </div>
+    </main>
+
+    <Footer />
+  </burger.outlet>
+</BurgerMenu>

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -2,10 +2,15 @@
   <burger.outlet>
     <header role="banner">
       <NavbarHeader @burger={{burger}} />
-      <Tutorials::Header />
+      <Tutorials::Header @onTriggerFilterButton={{this.showSidebar}} />
     </header>
 
     <main id="main" class="main" role="main">
+      <UserTutorials::Filters::Sidebar
+        @isVisible={{this.isSidebarVisible}}
+        @areas={{this.model.areas}}
+        @onClose={{this.closeSidebar}}
+      />
       <div class="user-tutorials-content-v2">
         {{#if @model.savedTutorials.meta.rowCount}}
           <div class="user-tutorials-content-v2__container">

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -1,8 +1,27 @@
-{{#if @model.savedTutorials.meta.rowCount}}
-  <div class="user-tutorials-content-v2__container">
-    <Tutorials::Cards @tutorials={{@model.savedTutorials}} @afterRemove={{this.refresh}} />
-    <PixPagination @pagination={{@model.savedTutorials.meta}} @pageOptions={{this.pageOptions}} @isCondensed="true" />
-  </div>
-{{else}}
-  <Tutorials::SavedEmpty />
-{{/if}}
+<BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
+  <burger.outlet>
+    <header role="banner">
+      <NavbarHeader @burger={{burger}} />
+      <Tutorials::Header />
+    </header>
+
+    <main id="main" class="main" role="main">
+      <div class="user-tutorials-content-v2">
+        {{#if @model.savedTutorials.meta.rowCount}}
+          <div class="user-tutorials-content-v2__container">
+            <Tutorials::Cards @tutorials={{@model.savedTutorials}} @afterRemove={{this.refresh}} />
+            <PixPagination
+              @pagination={{@model.savedTutorials.meta}}
+              @pageOptions={{this.pageOptions}}
+              @isCondensed="true"
+            />
+          </div>
+        {{else}}
+          <Tutorials::SavedEmpty />
+        {{/if}}
+      </div>
+    </main>
+
+    <Footer />
+  </burger.outlet>
+</BurgerMenu>

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -76,39 +76,38 @@
   </burger.outlet>
 </BurgerMenu>
 
-{{#if this.showMediacentreStartCampaignModal}}
-  <PixModal
-    @title={{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.title"}}
-    @onCloseButtonClick={{this.closeModal}}
-  >
-    <:content>
-      <p>
-        {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.message"}}
-        <p class="pix-text--small">
-          <div class="pix-text--small"><b>{{this.campaign.targetProfileName}}</b></div>
-          {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.organised-by"}}
-          <b>{{this.campaign.organizationName}}</b>
-        </p>
-        <p class="pix-text--small">
-          <b>{{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.message-footer"}}</b>
-        </p>
+<PixModal
+  @title={{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.title"}}
+  @onCloseButtonClick={{this.closeModal}}
+  @showModal={{this.showMediacentreStartCampaignModal}}
+>
+  <:content>
+    <p>
+      {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.message"}}
+      <p class="pix-text--small">
+        <div class="pix-text--small"><b>{{this.campaign.targetProfileName}}</b></div>
+        {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.organised-by"}}
+        <b>{{this.campaign.organizationName}}</b>
       </p>
-    </:content>
+      <p class="pix-text--small">
+        <b>{{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.message-footer"}}</b>
+      </p>
+    </p>
+  </:content>
 
-    <:footer>
-      <div class="mediacentre-start-campaign-modal__action-buttons">
-        <LinkTo
-          class="pix-text--link pix-text--small"
-          @route="campaigns.entry-point"
-          @model={{this.campaign.code}}
-          @backgroundColor="transparent-light"
-        >
-          {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.actions.continue"}}
-        </LinkTo>
-        <PixButton @triggerAction={{this.closeModal}}>
-          {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.actions.quit"}}
-        </PixButton>
-      </div>
-    </:footer>
-  </PixModal>
-{{/if}}
+  <:footer>
+    <div class="mediacentre-start-campaign-modal__action-buttons">
+      <LinkTo
+        class="pix-text--link pix-text--small"
+        @route="campaigns.entry-point"
+        @model={{this.campaign.code}}
+        @backgroundColor="transparent-light"
+      >
+        {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.actions.continue"}}
+      </LinkTo>
+      <PixButton @triggerAction={{this.closeModal}}>
+        {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.actions.quit"}}
+      </PixButton>
+    </div>
+  </:footer>
+</PixModal>

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -22,6 +22,8 @@ module.exports = function () {
       'image',
       'link',
       'lock',
+      'minus',
+      'plus',
       'power-off',
       'right-from-bracket',
       'right-long',

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^16.1.0",
+        "@1024pix/pix-ui": "^18.0.2",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -457,9 +457,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.1.0.tgz",
-      "integrity": "sha512-4BCdL/sEcLC0ko5/X8Ou8JhA9cb9YZkvg9K0Wmts7iVPUFR8W5tmeCPf4XX1exN/m8FFI/c3wqXBlqVMSsnoUA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.2.tgz",
+      "integrity": "sha512-1qZVEXze048T7uZYUoKYIDBuEN9SDHrRGv5vqrNx8DNSFlu7ve4Edrw1JYtKcOcDgK1R7t/wfbrUh3M89upIag==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -38698,9 +38698,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.1.0.tgz",
-      "integrity": "sha512-4BCdL/sEcLC0ko5/X8Ou8JhA9cb9YZkvg9K0Wmts7iVPUFR8W5tmeCPf4XX1exN/m8FFI/c3wqXBlqVMSsnoUA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.2.tgz",
+      "integrity": "sha512-1qZVEXze048T7uZYUoKYIDBuEN9SDHrRGv5vqrNx8DNSFlu7ve4Edrw1JYtKcOcDgK1R7t/wfbrUh3M89upIag==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^16.1.0",
+    "@1024pix/pix-ui": "^18.0.2",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",

--- a/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
@@ -8,6 +8,7 @@ import { authenticateByEmail } from '../helpers/authentication';
 import { contains } from '../helpers/contains';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
+import { waitForDialog } from '../helpers/wait-for';
 
 describe('Acceptance | Fill in campaign code page', function () {
   setupApplicationTest();
@@ -89,6 +90,7 @@ describe('Acceptance | Fill in campaign code page', function () {
           const screen = await visit(`/campagnes`);
           await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.description')), campaign.code);
           await click(screen.getByRole('button', { name: 'Accéder au parcours' }));
+          await waitForDialog();
           await click(screen.getByRole('link', { name: 'Continuer' }));
 
           // then
@@ -109,6 +111,7 @@ describe('Acceptance | Fill in campaign code page', function () {
           const screen = await visit(`/campagnes`);
           await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.description')), campaign.code);
           await click(screen.getByRole('button', { name: 'Accéder au parcours' }));
+          await waitForDialog();
           await click(screen.getByRole('button', { name: 'Quitter' }));
 
           // then

--- a/mon-pix/tests/helpers/wait-for.js
+++ b/mon-pix/tests/helpers/wait-for.js
@@ -1,0 +1,15 @@
+import { getScreen } from '@1024pix/ember-testing-library';
+import { waitUntil } from '@ember/test-helpers';
+
+export async function waitForDialog() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+describe('Integration | Component | User-Tutorials | Filters | ItemCheckbox', function () {
+  setupIntlRenderingTest();
+
+  describe('when currentFilters contains item', function () {
+    it('should show checked checkbox', async function () {
+      // given
+      this.set('item', { id: 'competencesId', name: 'Ma super compétence' });
+      this.set('currentFilters', { competences: ['competencesId'] });
+      this.set('handleFilterChange', () => {});
+
+      // when
+      await render(
+        hbs`<UserTutorials::Filters::ItemCheckbox
+              @type="competences"
+              @item={{item}}
+              @currentFilters={{currentFilters}}
+              @handleFilterChange={{handleFilterChange}}
+            />`
+      );
+
+      // then
+      expect(find('input').checked).to.be.true;
+    });
+  });
+
+  describe('when currentFilters not contains item', function () {
+    it('should show not checked checkbox', async function () {
+      // given
+      this.set('item', { id: 'competencesId', name: 'Ma super compétence' });
+      this.set('currentFilters', { competences: [] });
+      this.set('handleFilterChange', () => {});
+
+      // when
+      await render(
+        hbs`<UserTutorials::Filters::ItemCheckbox
+              @type="competences"
+              @item={{item}}
+              @currentFilters={{currentFilters}}
+              @handleFilterChange={{handleFilterChange}}
+            />`
+      );
+
+      // then
+      expect(find('input').checked).to.be.false;
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
@@ -1,0 +1,87 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { find, findAll, render, click } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+describe('Integration | Component | User-Tutorials | Filters | Sidebar', function () {
+  setupIntlRenderingTest();
+
+  describe('when isVisible param is true', function () {
+    it('should show sidebar with areas', async function () {
+      // given
+      this.set('isVisible', true);
+      this.set('areas', [
+        { id: 'area1', title: 'Area 1' },
+        { id: 'area2', title: 'Area 2' },
+        { id: 'area3', title: 'Area 3' },
+      ]);
+
+      // when
+      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} @areas={{areas}} />`);
+
+      // then
+      expect(find('.tutorials-filters')).to.exist;
+      expect(findAll('.tutorials-filters__areas')).to.have.lengthOf(3);
+    });
+
+    describe('when filters is clicked', function () {
+      it('should add it on selected filters', async function () {
+        // given
+        this.set('isVisible', true);
+        this.set('areas', [
+          { id: 'area1', title: 'Area 1', sortedCompetences: [{ id: 'competence1', name: 'Ma superbe compétence' }] },
+        ]);
+        const screen = await renderScreen(
+          hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} @areas={{areas}} />`
+        );
+        await click(screen.getByRole('button', { name: 'Area 1' }));
+        const checkbox = screen.getByRole('checkbox', { name: 'Ma superbe compétence' });
+
+        // when
+        await click(checkbox);
+
+        // then
+        expect(checkbox.checked).to.be.true;
+      });
+    });
+
+    describe('when filters is selected', function () {
+      describe('when reset button is clicked', function () {
+        it('should reset all filters', async function () {
+          // given
+          this.set('isVisible', true);
+          this.set('areas', [
+            { id: 'area1', title: 'Area 1', sortedCompetences: [{ id: 'competence1', name: 'Ma superbe compétence' }] },
+          ]);
+          const screen = await renderScreen(
+            hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} @areas={{areas}} />`
+          );
+          await click(screen.getByRole('button', { name: 'Area 1' }));
+          const checkbox = screen.getByRole('checkbox', { name: 'Ma superbe compétence' });
+          await click(checkbox);
+
+          // when
+          await click(screen.getByRole('button', { name: 'Réinitialiser' }));
+
+          // then
+          expect(checkbox.checked).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('when isVisible param is false', function () {
+    it('should not show sidebar', async function () {
+      // given
+      this.set('isVisible', false);
+
+      // when
+      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} />`);
+
+      // then
+      expect(find('.pix-sidebar--hidden')).to.exist;
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/user-tutorials/filters/item-checkbox_test.js
+++ b/mon-pix/tests/unit/components/user-tutorials/filters/item-checkbox_test.js
@@ -1,0 +1,57 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-mocha';
+import { A } from '@ember/array';
+
+describe('Unit | Component | User-Tutorials | Filters | ItemCheckbox', function () {
+  setupTest();
+
+  it('should throw an error if component has no type param', async function () {
+    // given & when
+    const componentParams = { item: { name: 'item' } };
+
+    // then
+    expect(() => {
+      createGlimmerComponent('component:user-tutorials/filters/item-checkbox', componentParams);
+    }).to.throw('ERROR in UserTutorials::Filters::ItemCheckbox component, you must provide @type params');
+  });
+
+  describe('#isChecked', function () {
+    describe('when element is in currentFilters', function () {
+      it('should return true', function () {
+        // given
+        const componentParams = {
+          type: 'competences',
+          item: { id: 'competenceId1' },
+          currentFilters: { competences: A(['competenceId1']) },
+        };
+        const component = createGlimmerComponent('component:user-tutorials/filters/item-checkbox', componentParams);
+
+        // when
+        const result = component.isChecked;
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    describe('when element is not in currentFilters', function () {
+      it('should return false', function () {
+        // given
+        const componentParams = {
+          type: 'competences',
+          item: { id: 'competenceId1' },
+          currentFilters: { competences: A([]) },
+        };
+        const component = createGlimmerComponent('component:user-tutorials/filters/item-checkbox', componentParams);
+
+        // when
+        const result = component.isChecked;
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/unit/components/user-tutorials/filters/sidebar_test.js
@@ -1,0 +1,56 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Component | User-Tutorials | Filters | Sidebar', function () {
+  setupTest();
+
+  describe('#handleFilterChange', function () {
+    describe('when element is not in array', function () {
+      it('should add id on corresponding type array', function () {
+        // given
+        const type = 'competences';
+        const id = 'competenceId1';
+        const component = createGlimmerComponent('component:user-tutorials/filters/sidebar');
+
+        // when
+        component.handleFilterChange(type, id);
+
+        // then
+        expect(component.filters[type].includes(id)).to.be.true;
+      });
+    });
+
+    describe('when element is already in list', function () {
+      it('should remove it', function () {
+        // given
+        const type = 'competences';
+        const id = 'competenceId1';
+        const component = createGlimmerComponent('component:user-tutorials/filters/sidebar');
+        component.filters[type].pushObject(id);
+
+        // when
+        component.handleFilterChange(type, id);
+
+        // then
+        expect(component.filters[type].includes(id)).to.be.false;
+      });
+    });
+  });
+
+  describe('#handleResetFilters', function () {
+    it('should reset all filters', async function () {
+      // given
+      const component = createGlimmerComponent('component:user-tutorials/filters/sidebar');
+      component.filters.competences = ['competence1', 'competence2'];
+
+      // when
+      component.handleResetFilters();
+
+      // then
+      expect(component.filters).to.have.property('competences');
+      expect(component.filters.competences).to.have.lengthOf(0);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1546,6 +1546,10 @@
         "image-link": "images/illustrations/user-tutorials/illustration-en.svg"
       },
       "filter": "Filter",
+      "sidebar": {
+        "reset": "Reset",
+        "see-results": "See the results"
+      },
       "label": "Tutorials",
       "list": {
         "title": "My list",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1547,6 +1547,10 @@
       },
       "filter": "Filtrer",
       "label": "tutoriels",
+      "sidebar": {
+        "reset": "Réinitialiser",
+        "see-results": "Voir les résultats"
+      },
       "list": {
         "title": "Ma liste",
         "tutorial": {


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons trier les tutoriels par compétence, cependant nous n'avons pas d'endroit pour le faire.

## :robot: Solution
Ajouter une sidebar proposant les compétences disponibles pour filtrer les tutoriels.

![Screenshot 2022-09-06 at 12 53 49](https://user-images.githubusercontent.com/26384707/188617738-65e7da11-9be3-41e4-9e13-439ad9cd1825.gif)

## :rainbow: Remarques
- [ ] Vider les filtres quand on sort de la sidebar ? 

## :100: Pour tester
- Se connecter sur Pix App
- Se rendre sur la page : `/mes-tutos/enregistres` ou `/mes-tutos/recommandes`
- Cliquer le bouton filtrer
- Constater que tous les domaines sont présent
- Selectionner quelques compétences 
- Cliquer sur le bouton rénitialiser et constater que les compétences ne sont plus sélectionnées.
