### PR TITLE
[FEATURE] Changer la traduction pour "Afficher une alternative textuelle" (PIX-5596).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -551,8 +551,8 @@
       "statement": {
         "alternative-instruction": {
           "actions": {
-            "display": "Show alternative instruction",
-            "hide": "Hide alternative instruction"
+            "display": "Show alternative text",
+            "hide": "Hide alternative text"
           }
         },
         "external-link-title": "new window",


### PR DESCRIPTION
## :unicorn: Problème
La traduction de : "Afficher une alternative textuelle" n'est pas correcte.

## :robot: Solution
La changer pour : "Show alternative text""

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App en `.org` 
- Mettre sa langue en anglais
- Accéder à une épreuve ayant une alternative textuelle et constater que la traduction est bien la nouvelle 