### PR TITLE
[TECH] Supprimer du code qui gère un cas qui n'arrivera jamais.

### DIFF
--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -65,22 +65,11 @@ module.exports = async function authenticateOidcUser({
 };
 
 async function _updateAuthenticationMethodWithComplement({
-  userInfo,
   userId,
   sessionContent,
   oidcAuthenticationService,
   authenticationMethodRepository,
 }) {
-  const oidcAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
-    userId,
-    identityProvider: oidcAuthenticationService.identityProvider,
-  });
-
-  const isSameExternalIdentifier = oidcAuthenticationMethod.externalIdentifier === userInfo.externalIdentityId;
-  if (!isSameExternalIdentifier) {
-    throw new DifferentExternalIdentifierError();
-  }
-
   const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({ sessionContent });
   if (!authenticationComplement) return;
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le nouveau parcours OIDC, quand un utilisateur se connecte avec un provider, on vérifie si on trouve déjà un compte Pix associé (le user avec une méthode d'authentification avec le même provider et external id). Mais par la suite dans le code, on fait l'inverse et on cherche la méthode d'authentification avec le user id trouvé avant et le provider et puis on s'assure que les external ids sont les mêmes. Évidemment ils le seront toujours.

## :robot: Solution
Enlever la partie du code qui fait l'inverse et compare les external ids

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire des parcours pole emploi ou cnav
