### PR TITLE
[TECH] Ajouter des rôles d'administration aux créateurs des organisations dans les seeds

### DIFF
--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -1,5 +1,6 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
+const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 const { DEFAULT_PASSWORD } = require('./users-builder');
 const PRO_COMPANY_ID = 1;
 const PRO_POLE_EMPLOI_ID = 4;
@@ -35,6 +36,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: privateCompanyCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: PRO_COMPANY_ID,
@@ -81,6 +83,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: poleEmploiCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: PRO_POLE_EMPLOI_ID,
@@ -107,6 +110,8 @@ function organizationsProBuilder({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: cnavCreator.id, role: ROLES.SUPER_ADMIN });
+
   databaseBuilder.factory.buildOrganization({
     id: PRO_CNAV_ID,
     type: 'PRO',
@@ -131,6 +136,8 @@ function organizationsProBuilder({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: digitalMediationCreator.id, role: ROLES.SUPER_ADMIN });
+
   databaseBuilder.factory.buildOrganization({
     id: PRO_MED_NUM_ID,
     type: 'PRO',
@@ -174,6 +181,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: archivedCreator.id, role: ROLES.SUPER_ADMIN });
 
   const archivedAt = new Date('2022-02-02');
 

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,5 +1,6 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const { DEFAULT_PASSWORD } = require('./users-builder');
+const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 
 const SCO_MIDDLE_SCHOOL_ID = 3;
 const SCO_HIGH_SCHOOL_ID = 6;
@@ -52,6 +53,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: middleSchoolsCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: SCO_MIDDLE_SCHOOL_ID,
@@ -305,6 +307,7 @@ function _buildHighSchools({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: highSchoolsCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: SCO_HIGH_SCHOOL_ID,
@@ -408,6 +411,7 @@ function _buildFarmingSchools({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: farmingSchoolsCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: SCO_AGRI_ID,
@@ -444,6 +448,7 @@ function _buildAEFE({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+  databaseBuilder.factory.buildPixAdminRole({ userId: aefeCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: SCO_AEFE_ID,

--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -1,4 +1,5 @@
 const Membership = require('../../../lib/domain/models/Membership');
+const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 const { DEFAULT_PASSWORD } = require('./users-builder');
 
 const SUP_UNIVERSITY_ID = 2;
@@ -30,6 +31,8 @@ function organizationsSupBuilder({ databaseBuilder }) {
     rawPassword: DEFAULT_PASSWORD,
     cgu: true,
   });
+
+  databaseBuilder.factory.buildPixAdminRole({ userId: universityCreator.id, role: ROLES.SUPER_ADMIN });
 
   databaseBuilder.factory.buildOrganization({
     id: SUP_UNIVERSITY_ID,


### PR DESCRIPTION
## :unicorn: Problème

Actuellement les créateurs des organisations sont des utilisateurs standards, donc n'ayant pas accès à l'application `admin`. Il est impossible pour un utilisateur standard de créer une organisation. Seul des administrateurs, ayant les permissions nécessaires, peuvent créer une organisation.

## :robot: Solution

Ajouter un rôle d'administrateur à tous les créateurs des organisations.

## :rainbow: Remarques

Il y a 2 organisations (Observatoire de Pix) qui ne sont pas créées directement par les scripts qui ont été modifiés, et qui n'auront pas d'identifiant de créateur.

## :100: Pour tester

- Exécutez la commande `npm run db:reset` en local dans le répertoire de l'api
- Vérifiez en base de données l'ajout de l'identifiant du créateur des organisations
