### PR TITLE
[BUGFIX] Ajout de scopes manquants pour pole emploi(PIX-5616)

### DIFF
--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -9,11 +9,12 @@ const logoutUrlTemporaryStorage = require('../../../infrastructure/temporary-sto
 class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   constructor() {
     const clientId = settings.poleEmploi.clientId;
+    // Attention, les scopes serviceDigitauxExposition api_peconnect-servicesdigitauxv1 ne sont pas présents dans la documentation de Pole Emploi mais ils sont nécessaires à l'envoi des résultats
     const authenticationUrlParameters = [
       { key: 'realm', value: '/individu' },
       {
         key: 'scope',
-        value: `application_${clientId} api_peconnect-individuv1 openid profile`,
+        value: `application_${clientId} api_peconnect-individuv1 openid profile serviceDigitauxExposition api_peconnect-servicesdigitauxv1`,
       },
     ];
 

--- a/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
@@ -76,7 +76,7 @@ describe('Acceptance | Route | oidc authentication url', function () {
         expect(redirectTargetUrl.searchParams.get('response_type')).to.equal('code');
         expect(redirectTargetUrl.searchParams.get('realm')).to.equal('/individu');
         expect(redirectTargetUrl.searchParams.get('scope')).to.equal(
-          'application_PIX_POLE_EMPLOI_CLIENT_ID api_peconnect-individuv1 openid profile'
+          'application_PIX_POLE_EMPLOI_CLIENT_ID api_peconnect-individuv1 openid profile serviceDigitauxExposition api_peconnect-servicesdigitauxv1'
         );
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur connecté avec Pole Emploi veut soumettre ses résultats à la fin de sa campagne, l'appel api effectué renvoit une 403 indiquant que l'utilisateur n'a pas les droits pour le faire.

## :robot: Solution
Il manquait des scopes

## :rainbow: Remarques
Nous avons ajouté un commentaire rappelant de ne pas supprimer ces scopes, en effet, ils sont actuellement manquant dans la documentation pole emploi.

## :100: Pour tester
- aller sur localhost.fr:4200/campagnes et suivre la campagne  `PIXEMPLOI` jusqu'au bout
- observer dans les logs de l'api que la requête POST sur `https://api-r.es-qvr.fr/partenaire/peconnect-servicesdigitaux/v1/resultat-service` ne renvoie plus de 403
