### PR TITLE
[CLEANUP] Met à jour l'action commune d'automerge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,4 +1,5 @@
 name: automerge check
+
 on:
   pull_request:
     types:
@@ -7,11 +8,14 @@ on:
   check_suite:
     types:
       - completed
+  status:
+    types:
+      - success
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: 1024pix/pix-actions/auto-merge@v0.1.3
+      - uses: 1024pix/pix-actions/auto-merge@v0
         with:
           auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :unicorn: Problème
On utilise une version spécifique de l'action d'automerge plutôt que d'utiliser une version plus souple qui nous permet de la mettre à jour sans peine.

## :robot: Solution
Utilise la v0 de l'action commune d'automerge.
