### PR TITLE
[FEATURE] Afficher un message d'erreur plus approprié quand il y a un conflit de compte (PIX-4991).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -443,7 +443,7 @@ function _mapToHttpError(error) {
   }
 
   if (error instanceof DomainErrors.DifferentExternalIdentifierError) {
-    return new HttpErrors.PreconditionFailedError(error.message);
+    return new HttpErrors.ConflictError(error.message);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/tests/integration/application/authentication/oidc/index_test.js
+++ b/api/tests/integration/application/authentication/oidc/index_test.js
@@ -169,7 +169,7 @@ describe('Integration | Application | Route | OidcRouter', function () {
           });
 
           // then
-          expect(response.statusCode).to.equal(412);
+          expect(response.statusCode).to.equal(409);
           expect(response.result.errors[0].detail).to.equal(
             "La valeur de l'externalIdentifier de la méthode de connexion ne correspond pas à celui reçu par le partenaire."
           );

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -467,17 +467,17 @@ describe('Unit | Application | ErrorManager', function () {
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
     });
 
-    it('should instantiate PreconditionFailedError when DifferentExternalIdentifierError', async function () {
+    it('should instantiate ConflictError when DifferentExternalIdentifierError', async function () {
       // given
       const error = new DifferentExternalIdentifierError();
-      sinon.stub(HttpErrors, 'PreconditionFailedError');
+      sinon.stub(HttpErrors, 'ConflictError');
       const params = { request: {}, h: hFake, error };
 
       // when
       await handle(params.request, params.h, params.error);
 
       // then
-      expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
+      expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
     });
   });
 });

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -11,6 +11,7 @@ const ERROR_INPUT_MESSAGE_MAP = {
   unknownError: 'common.error',
   expiredAuthenticationKey: 'pages.login-or-register-oidc.error.expired-authentication-key',
   invalidEmail: 'pages.login-or-register-oidc.error.invalid-email',
+  accountConflict: 'pages.login-or-register-oidc.error.account-conflict',
   loginUnauthorizedError: 'pages.login-or-register-oidc.error.login-unauthorized-error',
 };
 
@@ -115,11 +116,12 @@ export default class LoginOrRegisterOidcComponent extends Component {
       await this.args.onLogin({ enteredEmail: this.email, enteredPassword: this.password });
     } catch (error) {
       this.loginError = true;
-      const status = get(error, 'errors[0].status', 'unknown');
+      const status = get(error, 'errors[0].status');
 
       const errorsMapping = {
         401: this.intl.t(ERROR_INPUT_MESSAGE_MAP['expiredAuthenticationKey']),
         404: this.intl.t(ERROR_INPUT_MESSAGE_MAP['loginUnauthorizedError']),
+        409: this.intl.t(ERROR_INPUT_MESSAGE_MAP['accountConflict']),
       };
       this.loginErrorMessage = errorsMapping[status] || this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
     }

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -232,6 +232,25 @@ describe('Unit | Component | authentication | login-or-register-oidc', function 
       });
     });
 
+    context('when there is an account conflict', function () {
+      it('should display error', async function () {
+        // given
+        const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
+        component.args.onLogin = sinon.stub().rejects({ errors: [{ status: '409' }] });
+        component.email = 'glace.alo@example.net';
+        component.password = 'pix123';
+        const eventStub = { preventDefault: sinon.stub() };
+
+        // when
+        await component.login(eventStub);
+
+        // then
+        expect(component.loginErrorMessage).to.equal(
+          this.intl.t('pages.login-or-register-oidc.error.account-conflict')
+        );
+      });
+    });
+
     it('it should display generic error', async function () {
       // given
       const component = createGlimmerComponent('component:authentication/login-or-register-oidc');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -960,7 +960,8 @@
         "error-message": "Please agree to the terms and conditions of use.",
         "expired-authentication-key": "Your authentication demand has expired.",
         "invalid-email": "Your email address is invalid.",
-        "login-unauthorized-error": "There was an error in the email address or password entered."
+        "login-unauthorized-error": "There was an error in the email address or password entered.",
+        "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support."
       }
     },
     "oidc-reconciliation": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -960,7 +960,8 @@
         "error-message": "Vous devez accepter les conditions d’utilisation de Pix.",
         "expired-authentication-key": "Votre demande d'authentification a expiré.",
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
-        "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects."
+        "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
+        "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support."
       }
     },
     "oidc-reconciliation": {


### PR DESCRIPTION
## :unicorn: Problème
L'actuel scénario de réconciliation de compte n'est plus pertinent. Il permet entre autres de mauvaises réconciliation, comme un élève sco connecté sur Pix dont le parent va se connecter via Pôle Emploi en commençant une campagne.
Les deux comptes sont alors réconciliés.

Dans le nouveau scénario, nous avons désormais une double mire permettant à l'utilisateur de se connecter à un compte Pix qu'il possède déjà. Mais si l'utilisateur se log avec un compte Pix qui est déjà associé à un même organisme, une erreur générique est affichée. 

## :robot: Solution
Modifier le message de l'erreur pour que ce soit plus claire pour l'utilisateur.

## :rainbow: Remarques
RAS

## :100: Pour tester
ℹ️ Mettre le feature toggle à true en local

- Allez sur Pix App
- Allez sur /connexion/pole-emploi
- Accédez à la double mire oidc
- Sur la partie droite, remplissez email et mot de passe d'un utilisateur existant (sco.admin)
- Constatez que vous êtes redirigé vers la page de confirmation de réconciliation
- Validez les informations
- Constatez que vous êtes redirigé à la page d'accueil
- Déconnectez vous
- Allez sur /connexion/pole-emploi
- Connectez vous avec un différent compte
- Accédez à la double mire oidc
- Sur la partie droite, remplissez email et mot de passe avec le même utilisateur (sco.admin)
- Constatez que vous avez le bon message d'erreur
- Remplissez email et mot de passe avec un autre compte
- Constatez que vous êtes redirigé vers la page de confirmation de réconciliation
