### PR TITLE
[FEATURE] Ajouter le nombre de participants/étudiants/élèves dans le titre de la page (PIX-5568).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -273,12 +273,15 @@ module.exports = {
       }
       filter.certificability = filter.certificability.map((value) => certificabilityByLabel[value]);
     }
-    const { data: scoOrganizationParticipants, pagination } = await usecases.findPaginatedFilteredScoParticipants({
+    const { data: scoOrganizationParticipants, meta } = await usecases.findPaginatedFilteredScoParticipants({
       organizationId,
       filter,
       page,
     });
-    return scoOrganizationParticipantsSerializer.serialize({ scoOrganizationParticipants, pagination });
+    return scoOrganizationParticipantsSerializer.serialize({
+      scoOrganizationParticipants,
+      meta,
+    });
   },
 
   async findPaginatedFilteredSupParticipants(request) {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -291,12 +291,12 @@ module.exports = {
       filter.groups = [filter.groups];
     }
 
-    const { data: supOrganizationParticipants, pagination } = await usecases.findPaginatedFilteredSupParticipants({
+    const { data: supOrganizationParticipants, meta } = await usecases.findPaginatedFilteredSupParticipants({
       organizationId,
       filter,
       page,
     });
-    return supOrganizationParticipantsSerializer.serialize({ supOrganizationParticipants, pagination });
+    return supOrganizationParticipantsSerializer.serialize({ supOrganizationParticipants, meta });
   },
 
   async importOrganizationLearnersFromSIECLE(request, h) {

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -64,6 +64,12 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
 
 module.exports = {
   async findPaginatedFilteredScoParticipants({ organizationId, filter, page = {} }) {
+    const { totalScoParticipants } = await knex
+      .count('id', { as: 'totalScoParticipants' })
+      .from('organization-learners')
+      .where({ organizationId: organizationId, isDisabled: false })
+      .first();
+
     const query = knex
       .with('subquery', (qb) => _buildIsCertifiable(qb, organizationId))
       .distinct('organization-learners.id')
@@ -136,7 +142,7 @@ module.exports = {
     });
     return {
       data: scoOrganizationParticipants,
-      pagination,
+      meta: { ...pagination, participantCount: totalScoParticipants },
     };
   },
 };

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -21,6 +21,12 @@ function _setFilters(qb, { lastName, firstName, studentNumber, groups } = {}) {
 }
 module.exports = {
   async findPaginatedFilteredSupParticipants({ organizationId, filter, page = {} }) {
+    const { totalScoParticipants } = await knex
+      .count('id', { as: 'totalScoParticipants' })
+      .from('organization-learners')
+      .where({ organizationId: organizationId, isDisabled: false })
+      .first();
+
     const query = knex
       .distinct('organization-learners.id')
       .select([
@@ -76,7 +82,7 @@ module.exports = {
     });
     return {
       data: supOrganizationParticipants,
-      pagination,
+      meta: { ...pagination, participantCount: totalScoParticipants },
     };
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer.js
@@ -1,7 +1,7 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize({ scoOrganizationParticipants, pagination }) {
+  serialize({ scoOrganizationParticipants, meta }) {
     return new Serializer('sco-organization-participants', {
       id: 'id',
       attributes: [
@@ -21,7 +21,7 @@ module.exports = {
         'isCertifiable',
         'certifiableAt',
       ],
-      meta: pagination,
+      meta,
     }).serialize(scoOrganizationParticipants);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer.js
@@ -1,7 +1,7 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize({ supOrganizationParticipants, pagination }) {
+  serialize({ supOrganizationParticipants, meta }) {
     return new Serializer('sup-organization-participants', {
       id: 'id',
       attributes: [
@@ -16,7 +16,7 @@ module.exports = {
         'campaignType',
         'participationStatus',
       ],
-      meta: pagination,
+      meta,
     }).serialize(supOrganizationParticipants);
   },
 };

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -790,6 +790,64 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
       });
     });
 
+    context('#participantCount', function () {
+      it('should only count sco participants in currentOrganization', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        const otherOrganization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({ isDisabled: false, organizationId: otherOrganization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(meta.participantCount).to.equal(1);
+      });
+
+      it('should not count disabled sco participants', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        databaseBuilder.factory.buildOrganizationLearner({
+          isDisabled: false,
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({ isDisabled: true, organizationId: organization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(meta.participantCount).to.equal(1);
+      });
+
+      it('should count all participants when several exist', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(meta.participantCount).to.equal(2);
+      });
+    });
+
     context('#lastParticipationDate', function () {
       it('should take the last participation date', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -509,6 +509,64 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
       });
     });
 
+    context('#participantCount', function () {
+      it('should only count SUP participants in currentOrganization', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+        const otherOrganization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({ isDisabled: false, organizationId: otherOrganization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(meta.participantCount).to.equal(1);
+      });
+
+      it('should not count disabled SUP participants', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+        databaseBuilder.factory.buildOrganizationLearner({
+          isDisabled: false,
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({ isDisabled: true, organizationId: organization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(meta.participantCount).to.equal(1);
+      });
+
+      it('should count all participants when several exist', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+        });
+        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId: organization.id,
+        });
+
+        // then
+        expect(meta.participantCount).to.equal(2);
+      });
+    });
+
     context('#lastParticipationDate', function () {
       it('should take the last participation date', async function () {
         // given

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -842,6 +842,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
             isAuthenticatedFromGAR: false,
           },
         ],
+        meta: { pagination: { page: 1 } },
       };
     });
 
@@ -902,16 +903,15 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
     it('should return the serialized sco participants belonging to the organization', async function () {
       // given
-      const pagination = { page: 1 };
+      const meta = { pagination: { page: 1 } };
       const scoOrganizationParticipants = [scoOrganizationParticipant];
-      usecases.findPaginatedFilteredScoParticipants.resolves({ data: scoOrganizationParticipants, pagination });
+      usecases.findPaginatedFilteredScoParticipants.resolves({ data: scoOrganizationParticipants, meta });
       scoOrganizationParticipantsSerializer.serialize
-        .withArgs({ scoOrganizationParticipants, pagination })
+        .withArgs({ scoOrganizationParticipants, meta })
         .returns(serializedScoOrganizationParticipant);
 
       // when
       const response = await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
-
       // then
       expect(response).to.deep.equal(serializedScoOrganizationParticipant);
     });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1033,6 +1033,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
             ...supOrganizationParticipant,
           },
         ],
+        meta: { pagination: { page: 1 } },
       };
     });
 
@@ -1092,8 +1093,12 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
     it('should return the serialized sup participants belonging to the organization', async function () {
       // given
-      usecases.findPaginatedFilteredSupParticipants.resolves({ data: [supOrganizationParticipant] });
-      supOrganizationParticipantsSerializer.serialize.returns(serializedSupOrganizationParticipant);
+      const meta = { pagination: { page: 1 } };
+      const supOrganizationParticipants = [supOrganizationParticipant];
+      usecases.findPaginatedFilteredSupParticipants.resolves({ data: supOrganizationParticipants, meta });
+      supOrganizationParticipantsSerializer.serialize
+        .withArgs({ supOrganizationParticipants, meta })
+        .returns(serializedSupOrganizationParticipant);
 
       // when
       const response = await organizationController.findPaginatedFilteredSupParticipants(request, hFake);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/sco-organization-participants-serializer_test.js
@@ -46,6 +46,8 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
+      const participantCount = 10;
+      const meta = { ...pagination, participantCount };
 
       const expectedJSON = {
         data: [
@@ -92,11 +94,11 @@ describe('Unit | Serializer | JSONAPI | sco-organization-participants-serializer
             },
           },
         ],
-        meta: pagination,
+        meta,
       };
 
       // when
-      const json = serializer.serialize({ scoOrganizationParticipants, pagination });
+      const json = serializer.serialize({ scoOrganizationParticipants, meta });
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer_test.js
@@ -36,6 +36,8 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
+      const participantCount = 10;
+      const meta = { ...pagination, participantCount };
 
       const expectedJSON = {
         data: [
@@ -72,11 +74,11 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
             },
           },
         ],
-        meta: pagination,
+        meta,
       };
 
       // when
-      const json = serializer.serialize({ supOrganizationParticipants, pagination });
+      const json = serializer.serialize({ supOrganizationParticipants, meta });
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/orga/app/components/organization-participant/header.hbs
+++ b/orga/app/components/organization-participant/header.hbs
@@ -1,0 +1,2 @@
+<h1 class="page__title page-title">{{t "pages.organization-participants.title" count=@participantCount}}
+</h1>

--- a/orga/app/components/sco-organization-participant/header-actions.hbs
+++ b/orga/app/components/sco-organization-participant/header-actions.hbs
@@ -1,5 +1,5 @@
 <div class="organization-participant-list-page__header">
-  <h1 class="page__title page-title">{{t "pages.sco-organization-participants.title"}}</h1>
+  <h1 class="page__title page-title">{{t "pages.sco-organization-participants.title" count=@participantCount}}</h1>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="organization-participant-list-page__import-students-button hide-on-mobile">
       <PixButtonUpload @id="students-file-upload" @onChange={{@onImportStudents}} accept={{this.acceptedFileType}}>

--- a/orga/app/components/sup-organization-participant/header-actions.hbs
+++ b/orga/app/components/sup-organization-participant/header-actions.hbs
@@ -1,5 +1,5 @@
 <div class="organization-participant-list-page__header">
-  <div class="page__title page-title">{{t "pages.sup-organization-participants.title"}}</div>
+  <div class="page__title page-title">{{t "pages.sup-organization-participants.title" count=@participantCount}}</div>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="organization-participant-list-page__import-students-button hide-on-mobile">
       <PixButtonLink

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -1,7 +1,7 @@
-{{page-title (t "pages.organization-participants.title")}}
+{{page-title (t "pages.organization-participants.page-title")}}
 
 <div class="organization-participant-list-page">
-  <h1 class="page__title page-title">{{t "pages.organization-participants.title"}}</h1>
+  <OrganizationParticipant::Header @participantCount={{this.currentUser.prescriber.participantCount}} />
   {{#if this.currentUser.prescriber.hasParticipants}}
     <OrganizationParticipant::List
       @participants={{@model}}

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -1,8 +1,10 @@
-{{page-title (t "pages.sco-organization-participants.title")}}
+{{page-title (t "pages.sco-organization-participants.page-title")}}
 
 <div class="organization-participant-list-page sco-organization-participant-list-page">
-  <ScoOrganizationParticipant::HeaderActions @onImportStudents={{this.importStudents}} />
-
+  <ScoOrganizationParticipant::HeaderActions
+    @onImportStudents={{this.importStudents}}
+    @participantCount={{@model.meta.participantCount}}
+  />
   <ScoOrganizationParticipant::List
     @students={{@model}}
     @connectionTypesOptions={{this.connectionTypesOptions}}

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -1,6 +1,6 @@
-{{page-title (t "pages.sup-organization-participants.title")}}
+{{page-title (t "pages.sup-organization-participants.page-title")}}
 <div class="organization-participant-list-page sup-organization-participant-list-page">
-  <SupOrganizationParticipant::HeaderActions />
+  <SupOrganizationParticipant::HeaderActions @participantCount={{@model.meta.participantCount}} />
 
   <SupOrganizationParticipant::List
     @students={{@model}}

--- a/orga/tests/integration/components/organization-participant/header_test.js
+++ b/orga/tests/integration/components/organization-participant/header_test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | OrganizationParticipant::header', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display the header labels', async function (assert) {
+    // given
+    this.set('participantCount', 5);
+
+    // when
+    await render(hbs`<OrganizationParticipant::Header @participantCount={{participantCount}}/>`);
+
+    // then
+    assert.contains(this.intl.t('pages.organization-participants.title', { count: 5 }));
+  });
+});

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -7,14 +7,6 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | ScoOrganizationParticipant::HeaderActions', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should show title', async function (assert) {
-    // when
-    await render(hbs`<ScoOrganizationParticipant::HeaderActions />`);
-
-    // then
-    assert.contains('Élèves');
-  });
-
   test('it should show title with participant count', async function (assert) {
     //given
     this.set('participantCount', 10);
@@ -23,7 +15,7 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
     await render(hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`);
 
     // then
-    assert.contains('Élèves (10)');
+    assert.contains(this.intl.t('pages.sco-organization-participants.title', { count: 10 }));
   });
 
   module('user rights', () => {

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -15,6 +15,17 @@ module('Integration | Component | ScoOrganizationParticipant::HeaderActions', fu
     assert.contains('Élèves');
   });
 
+  test('it should show title with participant count', async function (assert) {
+    //given
+    this.set('participantCount', 10);
+
+    // when
+    await render(hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`);
+
+    // then
+    assert.contains('Élèves (10)');
+  });
+
   module('user rights', () => {
     module('when user is admin in organization', () => {
       module('when organization is SCO', (hooks) => {

--- a/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
@@ -15,6 +15,17 @@ module('Integration | Component | SupOrganizationParticipant::HeaderActions', fu
     assert.contains('Étudiants');
   });
 
+  test('it should show title with participant count', async function (assert) {
+    //given
+    this.set('participantCount', 10);
+
+    // when
+    await render(hbs`<SupOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`);
+
+    // then
+    assert.contains('Étudiants (10)');
+  });
+
   module('when user is admin', function (hooks) {
     hooks.beforeEach(function () {
       class CurrentUserStub extends Service {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -756,7 +756,8 @@
       }
     },
     "sco-organization-participants": {
-      "title": "Students",
+      "page-title": "Students",
+      "title": "{count, plural, =0 {Students} =1 {Student} other {Students ({count})}}",
       "actions": {
         "import-file": {
           "file-type-separator": " or ",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -867,7 +867,8 @@
       }
     },
     "sup-organization-participants": {
-      "title": "Students",
+      "title": "{count, plural, =0 {Students} =1 {Student} other {Students ({count})}}",
+      "page-title": "Students",
       "actions": {
         "download-template": "Download the template",
         "edit-student-number": "Edit the student number",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -653,6 +653,11 @@
       }
     },
     "organization-participants": {
+      "empty-state": {
+        "message": "No participants yet!",
+        "call-to-action": "Share with them a link to join an existing campaign or create a new campaign.",
+        "action": "See my campaigns"
+      },
       "filters": {
         "actions": {
           "clear": "Clear filters"
@@ -667,11 +672,6 @@
           }
         }
       },
-      "empty-state": {
-        "message": "No participants yet!",
-        "call-to-action": "Share with them a link to join an existing campaign or create a new campaign.",
-        "action": "See my campaigns"
-      },
       "table": {
         "column": {
           "first-name": "First name",
@@ -682,7 +682,8 @@
         "empty": "No participants",
         "row-title": "Participant"
       },
-      "title": "Participants"
+      "page-title": "Participants",
+      "title": "{count, plural, =0 {Participants} =1 {Participant} other {Participants ({count})}}"
     },
     "participants-list": {
       "latest-participation-information-tooltip": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -867,7 +867,8 @@
       }
     },
     "sup-organization-participants": {
-      "title": "Étudiants",
+      "title": "{count, plural, =0 {Étudiants} =1 {Étudiant} other {Étudiants ({count})}}",
+      "page-title": "Étudiants",
       "actions": {
         "download-template": "Télécharger le modèle",
         "edit-student-number": "Éditer le numéro étudiant",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -756,7 +756,8 @@
       }
     },
     "sco-organization-participants": {
-      "title": "Élèves",
+      "page-title": "Élèves",
+      "title": "{count, plural, =0 {Élèves} =1 {Élève} other {Élèves ({count})}}",
       "actions": {
         "import-file": {
           "file-type-separator": " ou ",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -653,6 +653,11 @@
       }
     },
     "organization-participants": {
+      "empty-state": {
+        "message": "Aucun participant pour l’instant !",
+        "call-to-action": "Invitez-les à rejoindre une campagne ou créez-en une nouvelle.",
+        "action": "Voir mes campagnes"
+      },
       "filters": {
         "actions": {
           "clear": "Effacer les filtres"
@@ -667,11 +672,6 @@
           }
         }
       },
-      "empty-state": {
-        "message": "Aucun participant pour l’instant !",
-        "call-to-action": "Invitez-les à rejoindre une campagne ou créez-en une nouvelle.",
-        "action": "Voir mes campagnes"
-      },
       "table": {
         "column": {
           "first-name": "Prénom",
@@ -682,7 +682,8 @@
         "empty": "Aucun participant",
         "row-title": "Participant"
       },
-      "title": "Participants"
+      "page-title": "Participants",
+      "title": "{count, plural, =0 {Participants} =1 {Participant} other {Participants ({count})}}"
     },
     "participants-list": {
       "latest-participation-information-tooltip": {


### PR DESCRIPTION
## :unicorn: Problème
Un besoin de pouvoir consulter le nombre total de participants pour l’ongle Étudiants, Élèves et participants a été  remonté.

## :robot: Solution
Ajouter le nombre total 'participantCount' de participants/étudiants/élèves à côté du titre de la page respectivement.

## :rainbow: Remarques
RAS

## :100: Pour tester
**Pour l'onglet Étudiants**

- Se connecter avec [sup.admin@example.net](url) puis aller dans l’onglet étudiant et constater que le nombre d'étudiants est affiché à côté du title. eg _Étudiantes (10)_

**Pour l'onglet Élèves** 

- Se connecter avec [sco.admin@example.net](url) puis aller dans l’onglet élèves  et constater que le nombre d'élèves  est affiché à côté du title. eg _Élèves (10)_

**Pour l'onglet Participants** 

- Se connecter avec [pro.admin@example.net](url)  ou n’import quelle Orga isManagingStudents. Puis aller dans l’onglet Participants  et constater que le nombre de participants  est affiché à côté du title. eg _Participants (10)_