### PR TITLE
[FEATURE] Implémenter la version définitive de la traduction des compétences Pix en compétences DigComp (PIX-5600)

### DIFF
--- a/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
@@ -1,4 +1,5 @@
 const uniqBy = require('lodash/uniqBy');
+const remove = require('lodash/remove');
 const EuropeanNumericLevel = require('./EuropeanNumericLevel');
 
 class EuropeanNumericLevelFactory {
@@ -62,6 +63,8 @@ class EuropeanNumericLevelFactory {
         new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: averageGlobalScore })
       );
     }
+
+    remove(europeanNumericLevels, ({ level }) => level === 0);
 
     return europeanNumericLevels;
   }

--- a/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
@@ -1,3 +1,4 @@
+const uniqBy = require('lodash/uniqBy');
 const EuropeanNumericLevel = require('./EuropeanNumericLevel');
 
 class EuropeanNumericLevelFactory {
@@ -53,12 +54,14 @@ class EuropeanNumericLevelFactory {
     });
     if (europeanNumericLevel3_1) europeanNumericLevels.push(europeanNumericLevel3_1);
 
-    const averageGlobalScore = Math.round(
-      europeanNumericLevels.reduce((total, { level }) => total + level, 0) / europeanNumericLevels.length
-    );
-    europeanNumericLevels.push(
-      new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: averageGlobalScore })
-    );
+    if (_areAtLeastOneCompetenceByDomain(competenceMarks)) {
+      const averageGlobalScore = Math.round(
+        europeanNumericLevels.reduce((total, { level }) => total + level, 0) / europeanNumericLevels.length
+      );
+      europeanNumericLevels.push(
+        new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: averageGlobalScore })
+      );
+    }
 
     return europeanNumericLevels;
   }
@@ -82,6 +85,10 @@ function _buildEuropeanNumericLevelFromMergedCompetenceMarks({
     foundCompetenceMarks.reduce((total, { level }) => total + level, 0) / foundCompetenceMarks.length
   );
   return EuropeanNumericLevel.from({ competenceCode: mergedCompetenceCode, level });
+}
+
+function _areAtLeastOneCompetenceByDomain(competenceMarks) {
+  return uniqBy(competenceMarks, 'areaCode').length === 5;
 }
 
 module.exports = EuropeanNumericLevelFactory;

--- a/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
@@ -75,7 +75,8 @@ function _buildEuropeanNumericLevelFromMergedCompetenceMarks({
     if (foundCompetenceMark) foundCompetenceMarks.push(foundCompetenceMark);
   });
 
-  if (foundCompetenceMarks.length !== competenceCodesToMerge.length) return null;
+  const areAllCompetenceCodesToMergeFound = foundCompetenceMarks.length === competenceCodesToMerge.length;
+  if (!areAllCompetenceCodesToMergeFound) return null;
 
   const level = Math.round(
     foundCompetenceMarks.reduce((total, { level }) => total + level, 0) / foundCompetenceMarks.length

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -28,6 +28,7 @@ function _selectCpfCertificationResults() {
       knex.raw(`
         json_agg(json_build_object(
           'competenceCode', "competence-marks"."competence_code",
+          'areaCode', "competence-marks"."area_code",
           'level', "competence-marks"."level"
         ) ORDER BY "competence-marks"."competence_code" asc) as "competenceMarks"`)
     )

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -46,5 +46,6 @@ function _selectCpfCertificationResults() {
     .where('certification-courses.isPublished', true)
     .where('certification-courses.isCancelled', false)
     .where('assessment-results.status', AssessmentResult.status.VALIDATED)
+    .where('competence-marks.level', '>', -1)
     .groupBy('certification-courses.id', 'assessment-results.pixScore', 'sessions.publishedAt');
 }

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -185,6 +185,71 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       ]);
     });
 
+    it('should only return competence marks with level greater than -1', async function () {
+      // given
+      const startDate = new Date('2022-01-01');
+      const endDate = new Date('2022-01-10');
+
+      const sessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 545,
+        firstName: 'Barack',
+        lastName: 'Afritt',
+        birthdate: '2004-10-22',
+        sex: 'M',
+        birthINSEECode: '75116',
+        birthPostalCode: null,
+        isPublished: true,
+        sessionId,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 2244,
+        pixScore: 132,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 545,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 5,
+        competence_code: '1.2',
+        area_code: '1',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 0,
+        competence_code: '2.3',
+        area_code: '2',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: -1,
+        competence_code: '4.1',
+        area_code: '4',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByTimeRange({
+        startDate,
+        endDate,
+      });
+
+      // then
+      expect(cpfCertificationResult.competenceMarks).to.deep.equal([
+        {
+          competenceCode: '1.2',
+          areaCode: '1',
+          level: 5,
+        },
+        {
+          competenceCode: '2.3',
+          areaCode: '2',
+          level: 0,
+        },
+      ]);
+    });
+
     context('when the certification course is not published', function () {
       it('should return an empty array', async function () {
         // given
@@ -332,8 +397,8 @@ describe('Integration | Repository | CpfCertificationResult', function () {
   describe('#findByIdRange', function () {
     it('should return an array of CpfCertificationResult ordered by session publication date, last name and first name', async function () {
       // given
-      const startId = 200;
-      const endId = 600;
+      const startId = 245;
+      const endId = 545;
 
       const firstPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
       databaseBuilder.factory.buildCertificationCourse({
@@ -508,6 +573,71 @@ describe('Integration | Repository | CpfCertificationResult', function () {
             },
           ],
         }),
+      ]);
+    });
+
+    it('should only return competence marks with level greater than -1', async function () {
+      // given
+      const startId = 245;
+      const endId = 545;
+
+      const sessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 545,
+        firstName: 'Barack',
+        lastName: 'Afritt',
+        birthdate: '2004-10-22',
+        sex: 'M',
+        birthINSEECode: '75116',
+        birthPostalCode: null,
+        isPublished: true,
+        sessionId,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 2244,
+        pixScore: 132,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 545,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 5,
+        competence_code: '1.2',
+        area_code: '1',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 0,
+        competence_code: '2.3',
+        area_code: '2',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: -1,
+        competence_code: '4.1',
+        area_code: '4',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByIdRange({
+        startId,
+        endId,
+      });
+
+      // then
+      expect(cpfCertificationResult.competenceMarks).to.deep.equal([
+        {
+          competenceCode: '1.2',
+          areaCode: '1',
+          level: 5,
+        },
+        {
+          competenceCode: '2.3',
+          areaCode: '2',
+          level: 0,
+        },
       ]);
     });
 

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -32,11 +32,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         assessmentResultId: 2244,
         level: 5,
         competence_code: '1.2',
+        area_code: '1',
       });
       databaseBuilder.factory.buildCompetenceMark({
         assessmentResultId: 2244,
         level: 5,
         competence_code: '2.3',
+        area_code: '2',
       });
 
       databaseBuilder.factory.buildCertificationCourse({
@@ -61,11 +63,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         assessmentResultId: 4466,
         level: 5,
         competence_code: '3.1',
+        area_code: '3',
       });
       databaseBuilder.factory.buildCompetenceMark({
         assessmentResultId: 4466,
         level: 4,
         competence_code: '2.3',
+        area_code: '2',
       });
 
       const secondPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-10') }).id;
@@ -91,11 +95,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         assessmentResultId: 4467,
         level: 2,
         competence_code: '2.1',
+        area_code: '2',
       });
       databaseBuilder.factory.buildCompetenceMark({
         assessmentResultId: 4467,
         level: 4,
         competence_code: '3.1',
+        area_code: '3',
       });
       await databaseBuilder.commit();
 
@@ -120,10 +126,12 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           competenceMarks: [
             {
               competenceCode: '2.3',
+              areaCode: '2',
               level: 4,
             },
             {
               competenceCode: '3.1',
+              areaCode: '3',
               level: 5,
             },
           ],
@@ -141,10 +149,12 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           competenceMarks: [
             {
               competenceCode: '2.1',
+              areaCode: '2',
               level: 2,
             },
             {
               competenceCode: '3.1',
+              areaCode: '3',
               level: 4,
             },
           ],
@@ -162,10 +172,12 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           competenceMarks: [
             {
               competenceCode: '1.2',
+              areaCode: '1',
               level: 5,
             },
             {
               competenceCode: '2.3',
+              areaCode: '2',
               level: 5,
             },
           ],
@@ -346,11 +358,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         assessmentResultId: 2244,
         level: 5,
         competence_code: '1.2',
+        area_code: '1',
       });
       databaseBuilder.factory.buildCompetenceMark({
         assessmentResultId: 2244,
         level: 5,
         competence_code: '2.3',
+        area_code: '2',
       });
 
       databaseBuilder.factory.buildCertificationCourse({
@@ -375,11 +389,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         assessmentResultId: 4466,
         level: 5,
         competence_code: '3.1',
+        area_code: '3',
       });
       databaseBuilder.factory.buildCompetenceMark({
         assessmentResultId: 4466,
         level: 4,
         competence_code: '2.3',
+        area_code: '2',
       });
 
       const secondPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-10') }).id;
@@ -405,11 +421,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         assessmentResultId: 4467,
         level: 2,
         competence_code: '2.1',
+        area_code: '2',
       });
       databaseBuilder.factory.buildCompetenceMark({
         assessmentResultId: 4467,
         level: 4,
         competence_code: '3.1',
+        area_code: '3',
       });
       await databaseBuilder.commit();
 
@@ -434,10 +452,12 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           competenceMarks: [
             {
               competenceCode: '1.2',
+              areaCode: '1',
               level: 5,
             },
             {
               competenceCode: '2.3',
+              areaCode: '2',
               level: 5,
             },
           ],
@@ -455,10 +475,12 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           competenceMarks: [
             {
               competenceCode: '2.3',
+              areaCode: '2',
               level: 4,
             },
             {
               competenceCode: '3.1',
+              areaCode: '3',
               level: 5,
             },
           ],
@@ -476,10 +498,12 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           competenceMarks: [
             {
               competenceCode: '2.1',
+              areaCode: '2',
               level: 2,
             },
             {
               competenceCode: '3.1',
+              areaCode: '3',
               level: 4,
             },
           ],

--- a/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
+++ b/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
@@ -289,13 +289,16 @@ describe('Unit | Domain | Read-models | EuropeanNumericLevelFactory', function (
       });
     });
 
-    context('when there are competence marks', function () {
+    context('when there are at least one competence by domain in competence marks', function () {
       it(`should return an EuropeanNumericLevel for competence '5.3' with level equal to the average of all competence marks levels`, function () {
         // given
         const competenceMarks = [
-          { competenceCode: '3.4', level: 8 },
-          { competenceCode: '4.1', level: 5 },
-          { competenceCode: '4.2', level: 3 },
+          { competenceCode: '1.1', areaCode: '1', level: 1 },
+          { competenceCode: '2.2', areaCode: '2', level: 3 },
+          { competenceCode: '3.4', areaCode: '3', level: 8 },
+          { competenceCode: '4.1', areaCode: '4', level: 5 },
+          { competenceCode: '4.2', areaCode: '4', level: 3 },
+          { competenceCode: '5.2', areaCode: '5', level: 0 },
         ];
 
         // when
@@ -303,7 +306,7 @@ describe('Unit | Domain | Read-models | EuropeanNumericLevelFactory', function (
 
         // then
         expect(europeanNumericLevels).to.deep.contains(
-          new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: 5 })
+          new EuropeanNumericLevel({ domainCompetenceId: '5', competenceId: '3', level: 3 })
         );
       });
     });

--- a/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
+++ b/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
@@ -310,5 +310,23 @@ describe('Unit | Domain | Read-models | EuropeanNumericLevelFactory', function (
         );
       });
     });
+
+    context('when there is european numeric levels with a level of 0 after computing', function () {
+      it('should remove these european numeric levels', function () {
+        // given
+        const competenceMarks = [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '2.1', level: 0 },
+          { competenceCode: '3.1', level: 0 },
+          { competenceCode: '3.2', level: 0 },
+        ];
+
+        // when
+        const europeanNumericLevels = EuropeanNumericLevelFactory.buildFromCompetenceMarks(competenceMarks);
+
+        // then
+        expect(europeanNumericLevels).to.be.empty;
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -155,17 +155,6 @@ function _getExpectedXmlExport() {
                         5
                       </cpf:competenceId>
                     </cpf:resultat>
-                    <cpf:resultat>
-                      <cpf:niveau>
-                        4
-                      </cpf:niveau>
-                      <cpf:domaineCompetenceId>
-                        5
-                      </cpf:domaineCompetenceId>
-                      <cpf:competenceId>
-                        3
-                      </cpf:competenceId>
-                    </cpf:resultat>
                   </cpf:resultats>
                 </cpf:niveauNumeriqueEuropeen>
                 <cpf:scoring>
@@ -262,17 +251,6 @@ function _getExpectedXmlExport() {
                       </cpf:domaineCompetenceId>
                       <cpf:competenceId>
                         2
-                      </cpf:competenceId>
-                    </cpf:resultat>
-                    <cpf:resultat>
-                      <cpf:niveau>
-                        1
-                      </cpf:niveau>
-                      <cpf:domaineCompetenceId>
-                        5
-                      </cpf:domaineCompetenceId>
-                      <cpf:competenceId>
-                        3
                       </cpf:competenceId>
                     </cpf:resultat>
                   </cpf:resultats>


### PR DESCRIPTION
## :unicorn: Problème
L'envoi des résultats de certification à mon compte formation implique de traduire les compétences Pix en compétences du référentiel européen DigComp. Une première version avait été réalisée mais elle ne prenait pas en compte tous les cas particuliers soulevés par le métier. 

## :robot: Solution
- Implémenter la version définitive de la traduction des compétences Pix en compétences DigComp

## :100: Pour tester
PR difficilement testable car nécessite de réaliser des fichiers d'exports CPF avaec des profils particuliers.
