### PR TITLE
[TECH] Nettoyage du test de la version d'Hapi

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -88,10 +88,6 @@ function pushInContext(path, value) {
 function installHapiHook() {
   if (!settings.hapi.enableRequestMonitoring) return;
 
-  if (require('@hapi/hapi/package.json').version !== '20.2.2') {
-    throw new Error('Hapi version changed, please check if patch still works');
-  }
-
   const Request = require('@hapi/hapi/lib/request');
 
   const originalMethod = Request.prototype._execute;


### PR DESCRIPTION
## :unicorn: Problème
Le test de la version d'Hadi n'est plus utile, comme le code concerné par le patch est testé dans les tests du plugin pino

## :robot: Solution
Supprimer ce code.

## :100: Pour tester
Lancer les tests (notamment api/tests/integration/infrastructure/plugins/pino_test.js), et vérifier que tout est au vert.
