### PR TITLE
[TECH] Ajout d'un script de changement de méthode d'assessment pour les campagnes FLASH (PIX-5627).

### DIFF
--- a/api/scripts/switch-campaign-to-flash.js
+++ b/api/scripts/switch-campaign-to-flash.js
@@ -1,0 +1,28 @@
+'use strict';
+const _ = require('lodash');
+require('dotenv').config();
+const { knex } = require('../db/knex-database-connection');
+const Assessment = require('../lib/domain/models/Assessment');
+
+async function switchCampaignToFlash(id) {
+  await knex('campaigns').update({ assessmentMethod: Assessment.methods.FLASH }).where({ id });
+}
+
+async function main(id) {
+  if (!_.isFinite(id)) {
+    throw new Error("L'id de campagne est obligatoire, node switch-campaign-to-flash.js <:id>");
+  }
+
+  await switchCampaignToFlash(id);
+}
+
+if (require.main === module) {
+  const id = parseInt(process.argv[2]);
+
+  main(id).catch((err) => {
+    console.error(err);
+    process.exitCode = 1; // ou throw err
+  });
+}
+
+module.exports = { switchCampaignToFlash };

--- a/api/tests/integration/scripts/switch-campaign-to-flash_test.js
+++ b/api/tests/integration/scripts/switch-campaign-to-flash_test.js
@@ -1,0 +1,27 @@
+const { expect, databaseBuilder, knex } = require('../../test-helper');
+
+const { switchCampaignToFlash } = require('../../../scripts/switch-campaign-to-flash.js');
+
+describe('Integration | Scripts | switch-campaign-to-flash.js', function () {
+  describe('#switchCampaignToFlash', function () {
+    it('should switch campaign assessment-method from smart-random to flash', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ assessmentMethod: 'SMART_RANDOM' }).id;
+      const nonModifiedCampaignId = databaseBuilder.factory.buildCampaign({ assessmentMethod: 'SMART_RANDOM' }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      await switchCampaignToFlash(campaignId);
+
+      // then
+      const modifiedCampaign = await knex('campaigns').select('assessmentMethod').where({ id: campaignId }).first();
+      const nonModifiedCampaign = await knex('campaigns')
+        .select('assessmentMethod')
+        .where({ id: nonModifiedCampaignId })
+        .first();
+      expect(modifiedCampaign.assessmentMethod).to.equal('FLASH');
+      expect(nonModifiedCampaign.assessmentMethod).to.equal('SMART_RANDOM');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Afin de mener à bien l'expérimentation de l'algo flash se déroulant à Montpellier les 15 et 22 septembre prochains, nous devons modifier la valeur de la colonne `assessmentMethod` de `SMART_RANDOM` à `FLASH` sur la campagne voulue

## :robot: Solution

Création d'un script

## :rainbow: Remarques
N/A

## :100: Pour tester

Tester le script en RA sur une campagne et vérifier le changement de `SMART_RANDOM` à `FLASH` pour la campagne voulue.
