### PR TITLE
[FEATURE] Ajouter l'ID d'assessment dans les résultats d'assessment flash (PIX-5628)

### DIFF
--- a/api/db/database-builder/factory/build-flash-assessment-result.js
+++ b/api/db/database-builder/factory/build-flash-assessment-result.js
@@ -17,6 +17,7 @@ module.exports = function buildFlashAssessmentResult({
       answerId,
       estimatedLevel,
       errorRate,
+      assessmentId,
     },
   });
 };

--- a/api/db/migrations/20220906142048_add-assessmentId-in-flash-assessments-results.js
+++ b/api/db/migrations/20220906142048_add-assessmentId-in-flash-assessments-results.js
@@ -1,0 +1,23 @@
+const bluebird = require('bluebird');
+const TABLE_NAME = 'flash-assessment-results';
+const COLUMN_NAME = 'assessmentId';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => table.integer(COLUMN_NAME).references('assessments.id'));
+
+  const flashAssessmentResults = await knex(TABLE_NAME)
+    .select('answers.assessmentId', 'flash-assessment-results.id')
+    .join('answers', 'answers.id', 'flash-assessment-results.answerId');
+
+  await bluebird.each(flashAssessmentResults, async function ({ assessmentId, id }) {
+    await knex(TABLE_NAME).update({ assessmentId }).where({ id });
+  });
+
+  return knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, async (table) => table.dropColumn(COLUMN_NAME));
+};

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -106,6 +106,7 @@ module.exports = async function correctAnswerThenUpdateAssessment({
       answerId: answerSaved.id,
       estimatedLevel,
       errorRate,
+      assessmentId: assessment.id,
     });
   }
   return answerSaved;

--- a/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
@@ -8,12 +8,14 @@ module.exports = {
     answerId,
     estimatedLevel,
     errorRate,
+    assessmentId,
     domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
   }) {
     const query = knex(TABLE_NAME).insert({
       answerId,
       estimatedLevel,
       errorRate,
+      assessmentId,
     });
     if (knexTransaction) query.transacting(knexTransaction);
     return query;

--- a/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/flash-assessment-result-repository.js
@@ -22,12 +22,6 @@ module.exports = {
   },
 
   async getLatestByAssessmentId(assessmentId) {
-    return knex(TABLE_NAME)
-      .join('answers', 'answers.id', '=', `${TABLE_NAME}.answerId`)
-      .select(`${TABLE_NAME}.*`)
-      .where({ assessmentId })
-      .orderBy('createdAt', 'desc')
-      .limit(1)
-      .first();
+    return knex(TABLE_NAME).where({ assessmentId }).orderBy('id', 'desc').limit(1).first();
   },
 };

--- a/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
@@ -14,7 +14,7 @@ describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepos
       await databaseBuilder.commit();
     });
 
-    context('when assessment has no answers yet', function () {
+    context('when assessment has no assessment results yet', function () {
       it('should return undefined', async function () {
         // when
         const result = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
@@ -24,53 +24,32 @@ describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepos
       });
     });
 
-    context('when assessment has one answer', function () {
+    context('when assessment has several assessment results', function () {
       let expectedResult;
 
       beforeEach(async function () {
-        expectedResult = databaseBuilder.factory.buildFlashAssessmentResult({ assessmentId });
-        await databaseBuilder.commit();
-      });
-
-      it('should return flash result for this answer', async function () {
-        // when
-        const result = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
-
-        // then
-        expect(result).to.contain({
-          id: expectedResult.id,
-          estimatedLevel: expectedResult.estimatedLevel,
-          errorRate: expectedResult.errorRate,
-        });
-      });
-    });
-
-    context('when assessment has several answers', function () {
-      let expectedResult;
-
-      beforeEach(async function () {
-        const thirdAnswer = databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2022-01-03') });
-        const secondAnswer = databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2022-01-02') });
-        const firstAnswer = databaseBuilder.factory.buildAnswer({ assessmentId, createdAt: new Date('2022-01-01') });
         expectedResult = databaseBuilder.factory.buildFlashAssessmentResult({
-          answerId: thirdAnswer.id,
+          id: 125,
           estimatedLevel: 1,
           errorRate: 2,
+          assessmentId,
         });
         databaseBuilder.factory.buildFlashAssessmentResult({
-          answerId: secondAnswer.id,
+          id: 124,
           estimatedLevel: 3,
           errorRate: 4,
+          assessmentId,
         });
         databaseBuilder.factory.buildFlashAssessmentResult({
-          answerId: firstAnswer.id,
+          id: 123,
           estimatedLevel: 5,
           errorRate: 6,
+          assessmentId,
         });
         await databaseBuilder.commit();
       });
 
-      it('should return flash result for the latest answer', async function () {
+      it('should return the latest flash result', async function () {
         // when
         const result = await flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId);
 

--- a/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/flash-assessment-result-repository_test.js
@@ -85,19 +85,18 @@ describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepos
   });
 
   describe('#save', function () {
-    let answerId;
-
-    beforeEach(async function () {
-      answerId = databaseBuilder.factory.buildAnswer().id;
-      await databaseBuilder.commit();
-    });
-
     it('should create a result with estimated level and error rate', async function () {
+      // given
+      const answerId = databaseBuilder.factory.buildAnswer().id;
+      databaseBuilder.factory.buildAssessment({ id: 99 });
+      await databaseBuilder.commit();
+
       // when
       await flashAssessmentResultRepository.save({
         answerId,
         estimatedLevel: 1.9,
         errorRate: 1.3,
+        assessmentId: 99,
       });
 
       // then
@@ -106,6 +105,7 @@ describe('Integration | Infrastructure | Repository | FlashAssessmentResultRepos
         answerId,
         estimatedLevel: 1.9,
         errorRate: 1.3,
+        assessmentId: 99,
       });
     });
   });

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -647,6 +647,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           answerId: id,
           estimatedLevel,
           errorRate,
+          assessmentId: assessment.id,
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Afin d'aider l'équipe Data dans leurs analyses, nous devons rajouter une colonne `assessmentId` sur la table `flash-assessments-results`.

## :robot: Solution

Cette colonne sera enrichie lors de la création de flash-assessment-results (à récupérer à partir de l'assessment).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
?