### PR TITLE
[FEATURE] Ajouter la possibilité de supprimer la méthode d'authentification CNAV (PIX-5633)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -189,6 +189,18 @@
           />
         {{/if}}
       </td>
+      <td>
+        {{#if this.accessControl.hasAccessToUsersActionsScope}}
+          {{#if @user.isAllowedToRemoveCnavAuthenticationMethod}}
+            <PixButton
+              class="user-authentication-method__remove-button"
+              @size="small"
+              @backgroundColor="red"
+              @triggerAction={{fn @toggleDisplayRemoveAuthenticationMethodModal "CNAV"}}
+            >Supprimer</PixButton>
+          {{/if}}
+        {{/if}}
+      </td>
     </tr>
   </tbody>
 </table>

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -75,6 +75,7 @@ export default class User extends Model {
         this.hasUsernameAuthenticationMethod,
         this.hasGarAuthenticationMethod,
         this.hasPoleEmploiAuthenticationMethod,
+        this.hasCnavAuthenticationMethod,
       ].filter((hasAuthenticationMethod) => hasAuthenticationMethod).length === 1
     );
   }
@@ -93,6 +94,10 @@ export default class User extends Model {
 
   get isAllowedToRemoveGarAuthenticationMethod() {
     return this.hasGarAuthenticationMethod && !this.hasOnlyOneAuthenticationMethod;
+  }
+
+  get isAllowedToRemoveCnavAuthenticationMethod() {
+    return this.hasCnavAuthenticationMethod && !this.hasOnlyOneAuthenticationMethod;
   }
 
   get isAllowedToAddEmailAuthenticationMethod() {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -270,6 +270,11 @@ export default function () {
       user.update({ email: null });
     }
 
+    if (type === 'CNAV') {
+      const authenticationMethod = schema.authenticationMethods.findBy({ identityProvider: 'CNAV' });
+      authenticationMethod.destroy();
+    }
+
     return new Response(204);
   });
 

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -259,6 +259,30 @@ module('Integration | Component | users | user-detail-personal-information/authe
 
       module('cnav authentication method', function () {
         module('when user has cnav authentication method', function () {
+          module('and another authentication method', function () {
+            test('it should display a delete button', async function (assert) {
+              // given
+              this.set('user', {
+                hasCnavAuthenticationMethod: true,
+                hasEmailAuthenticationMethod: true,
+                isAllowedToRemoveCnavAuthenticationMethod: true,
+              });
+              this.set('toggleDisplayRemoveAuthenticationMethodModal', function () {});
+              this.owner.register('service:access-control', AccessControlStub);
+
+              // when
+              const screen = await render(hbs`
+              <Users::UserDetailPersonalInformation::AuthenticationMethod
+                @user={{this.user}}
+                @toggleDisplayRemoveAuthenticationMethodModal={{this.toggleDisplayRemoveAuthenticationMethodModal}}
+              />
+              `);
+
+              // then
+              assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+            });
+          });
+
           test('should display information', async function (assert) {
             // given
             this.set('user', { hasCnavAuthenticationMethod: true });

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -179,7 +179,15 @@ exports.register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                type: Joi.string().valid('GAR', 'EMAIL', 'USERNAME', OidcIdentityProviders.POLE_EMPLOI.code).required(),
+                type: Joi.string()
+                  .valid(
+                    'GAR',
+                    'EMAIL',
+                    'USERNAME',
+                    OidcIdentityProviders.POLE_EMPLOI.code,
+                    OidcIdentityProviders.CNAV.code
+                  )
+                  .required(),
               },
             },
           }),

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -43,6 +43,10 @@ module.exports = async function removeAuthenticationMethod({
   if (type === OidcIdentityProviders.POLE_EMPLOI.code) {
     await _removeAuthenticationMethod(userId, OidcIdentityProviders.POLE_EMPLOI.code, authenticationMethodRepository);
   }
+
+  if (type === OidcIdentityProviders.CNAV.code) {
+    await _removeAuthenticationMethod(userId, OidcIdentityProviders.CNAV.code, authenticationMethodRepository);
+  }
 };
 
 async function _removeAuthenticationMethod(userId, identityProvider, authenticationMethodRepository) {

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -74,42 +74,6 @@ describe('Integration | Application | Users | Routes', function () {
     });
   });
 
-  describe('GET /api/admin/users/{id}', function () {
-    it('should exist', async function () {
-      // given
-      securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
-      const url = '/api/admin/users/123';
-
-      // when
-      const response = await httpTestServer.request(methodGET, url);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('should return BAD_REQUEST (400) when id in param is not a number"', async function () {
-      // given
-      const url = '/api/admin/users/NOT_A_NUMBER';
-
-      // when
-      const response = await httpTestServer.request(methodGET, url);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return BAD_REQUEST (400) when id in param is out of range"', async function () {
-      // given
-      const url = '/api/admin/users/0';
-
-      // when
-      const response = await httpTestServer.request(methodGET, url);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-
   describe('POST /api/users/{userId}/competences/{competenceId}/reset', function () {
     it('should return OK (200) when params are valid', async function () {
       // given
@@ -137,89 +101,6 @@ describe('Integration | Application | Users | Routes', function () {
     });
   });
 
-  describe('PATCH /api/admin/users/{id}', function () {
-    it('should update user when payload is valid', async function () {
-      // given
-      securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
-      const url = '/api/admin/users/123';
-
-      const payload = {
-        data: {
-          id: '123',
-          attributes: {
-            'first-name': 'firstNameUpdated',
-            'last-name': 'lastNameUpdated',
-            email: 'emailUpdated@example.net',
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(methodPATCH, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('should return bad request when firstName is missing', async function () {
-      // given
-      securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
-      const url = '/api/admin/users/123';
-
-      const payload = {
-        data: {
-          id: '123',
-          attributes: {
-            'last-name': 'lastNameUpdated',
-            email: 'emailUpdated@example.net',
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(methodPATCH, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-      const firstError = response.result.errors[0];
-      expect(firstError.detail).to.equal('"data.attributes.first-name" is required');
-    });
-
-    it('should return bad request when lastName is missing', async function () {
-      // given
-      securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
-      const url = '/api/admin/users/123';
-      const payload = {
-        data: {
-          id: '123',
-          attributes: {
-            'first-name': 'firstNameUpdated',
-            email: 'emailUpdated',
-          },
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request(methodPATCH, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-      const firstError = response.result.errors[0];
-      expect(firstError.detail).to.equal('"data.attributes.last-name" is required');
-    });
-
-    it('should return a 400 when id in param is not a number"', async function () {
-      // given
-      const url = '/api/admin/users/NOT_A_NUMBER';
-
-      // when
-      const response = await httpTestServer.request(methodGET, url);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-
   describe('PATCH /api/users/{id}/has-seen-challenge-tooltip/{challengeType}', function () {
     it('should return 400 - Bad request when challengeType is not valid', async function () {
       // given
@@ -241,6 +122,127 @@ describe('Integration | Application | Users | Routes', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  context('Routes /admin', function () {
+    describe('GET /api/admin/users/{id}', function () {
+      it('should exist', async function () {
+        // given
+        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        const url = '/api/admin/users/123';
+
+        // when
+        const response = await httpTestServer.request(methodGET, url);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return BAD_REQUEST (400) when id in param is not a number"', async function () {
+        // given
+        const url = '/api/admin/users/NOT_A_NUMBER';
+
+        // when
+        const response = await httpTestServer.request(methodGET, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return BAD_REQUEST (400) when id in param is out of range"', async function () {
+        // given
+        const url = '/api/admin/users/0';
+
+        // when
+        const response = await httpTestServer.request(methodGET, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    describe('PATCH /api/admin/users/{id}', function () {
+      it('should update user when payload is valid', async function () {
+        // given
+        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        const url = '/api/admin/users/123';
+
+        const payload = {
+          data: {
+            id: '123',
+            attributes: {
+              'first-name': 'firstNameUpdated',
+              'last-name': 'lastNameUpdated',
+              email: 'emailUpdated@example.net',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(methodPATCH, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return bad request when firstName is missing', async function () {
+        // given
+        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        const url = '/api/admin/users/123';
+
+        const payload = {
+          data: {
+            id: '123',
+            attributes: {
+              'last-name': 'lastNameUpdated',
+              email: 'emailUpdated@example.net',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(methodPATCH, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        const firstError = response.result.errors[0];
+        expect(firstError.detail).to.equal('"data.attributes.first-name" is required');
+      });
+
+      it('should return bad request when lastName is missing', async function () {
+        // given
+        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+        const url = '/api/admin/users/123';
+        const payload = {
+          data: {
+            id: '123',
+            attributes: {
+              'first-name': 'firstNameUpdated',
+              email: 'emailUpdated',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(methodPATCH, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        const firstError = response.result.errors[0];
+        expect(firstError.detail).to.equal('"data.attributes.last-name" is required');
+      });
+
+      it('should return a 400 when id in param is not a number"', async function () {
+        // given
+        const url = '/api/admin/users/NOT_A_NUMBER';
+
+        // when
+        const response = await httpTestServer.request(methodGET, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
     });
   });
 });

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -898,61 +898,65 @@ describe('Unit | Router | user-router', function () {
 
     describe('POST /api/admin/users/{id}/remove-authentication', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
-      ['GAR', 'EMAIL', 'USERNAME', OidcIdentityProviders.POLE_EMPLOI.code].forEach((type) => {
-        it(`should return 200 when user is "SUPER_ADMIN" and type is ${type}`, async function () {
-          // given
-          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response(true));
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
+      ['GAR', 'EMAIL', 'USERNAME', OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.CNAV.code].forEach(
+        (type) => {
+          it(`should return 200 when user is "SUPER_ADMIN" and type is ${type}`, async function () {
+            // given
+            sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+              .callsFake((request, h) => h.response(true));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
 
-          // when
-          const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
-            data: {
-              attributes: {
-                type,
+            // when
+            const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+              data: {
+                attributes: {
+                  type,
+                },
               },
-            },
+            });
+
+            // then
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+            sinon.assert.calledOnce(userController.removeAuthenticationMethod);
+            expect(result.statusCode).to.equal(200);
           });
 
-          // then
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-          sinon.assert.calledOnce(userController.removeAuthenticationMethod);
-          expect(result.statusCode).to.equal(200);
-        });
+          it(`should return 200 when user is "SUPPORT" and type is ${type}`, async function () {
+            // given
+            sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+            sinon
+              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+              .callsFake((request, h) => h.response(true));
+            const httpTestServer = new HttpTestServer();
+            await httpTestServer.register(moduleUnderTest);
 
-        it(`should return 200 when user is "SUPPORT" and type is ${type}`, async function () {
-          // given
-          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
-          sinon
-            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(true));
-          const httpTestServer = new HttpTestServer();
-          await httpTestServer.register(moduleUnderTest);
-
-          // when
-          const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
-            data: {
-              attributes: {
-                type,
+            // when
+            const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+              data: {
+                attributes: {
+                  type,
+                },
               },
-            },
-          });
+            });
 
-          // then
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-          sinon.assert.calledOnce(userController.removeAuthenticationMethod);
-          expect(result.statusCode).to.equal(200);
-        });
-      });
+            // then
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+            sinon.assert.calledOnce(userController.removeAuthenticationMethod);
+            expect(result.statusCode).to.equal(200);
+          });
+        }
+      );
 
       it('should return 400 when id is not a number', async function () {
         // given
@@ -972,7 +976,7 @@ describe('Unit | Router | user-router', function () {
         expect(result.statusCode).to.equal(400);
       });
 
-      it('should return 400 when type is not GAR or EMAIL or USERNAME or POLE_EMPLOI', async function () {
+      it('should return 400 when type is not GAR or EMAIL or USERNAME or POLE_EMPLOI or CNAV', async function () {
         // given
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -24,7 +24,25 @@ describe('Unit | UseCase | remove-authentication-method', function () {
     return [
       domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId }),
       domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
-      domainBuilder.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId }),
+      domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+        userId,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      }),
+    ];
+  }
+
+  function buildAllAuthenticationMethodsForUser(userId) {
+    return [
+      domainBuilder.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId }),
+      domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
+      domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+        userId,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      }),
+      domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+        userId,
+        identityProvider: OidcIdentityProviders.CNAV.code,
+      }),
     ];
   }
 
@@ -171,6 +189,26 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
         userId: user.id,
         identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      });
+    });
+  });
+
+  context('When type is CNAV', function () {
+    it('should remove CNAV authentication method', async function () {
+      // given
+      const type = OidcIdentityProviders.CNAV.code;
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildAllAuthenticationMethodsForUser(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+        userId: user.id,
+        identityProvider: OidcIdentityProviders.CNAV.code,
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, après avoir rattaché une méthode de connexion CNAV à un compte Pix existant, il n'est pas possible de supprimer cette méthode de connexion.

## :robot: Solution

Ajouter la possibilité de supprimer la méthode de connexion CNAV pour un utilisateur ayant plusieurs méthodes de connexions.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter avec un compte CNAV n'aillant pas encore de compte Pix
- A la double mire, choisir de se connecter avec un compte Pix existant
- Sur la page de réconciliation, choisir de rattacher le compte CNAV au compte Pix
- Une fois le rattachement effectué, ouvrir `Pix Admin`
- Se connecter avec un compte ayant le rôle `SUPERADMIN` ou `SUPPORT`
- Cliquez sur l'onglet `Utilisateurs`
- Faire une recherche pour trouver votre utilisateur
- Ouvrir la page de détails de cette utilisateur
- Constatez qu'il a bien 2 méthodes de connexions
- Constatez qu'un bouton `Supprimer` se trouve sur la ligne de la méthode de connexion CNAV
- Supprimez la méthode de connexion CNAV
- Constatez que la méthode de connexion n'est plus disponible
- Tentez de se connecter via la CNAV
- Constatez que l'on arrive sur la double mire car le compte CNAV n'est plus rattaché au précédent utilisateur
