### PR TITLE
[TECH] Refactorer le script permettant de remplir la colonne `skillId` de la table `user-saved-tutorials` (PIX-5642).

### DIFF
--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -25,7 +25,9 @@ async function main() {
       continue;
     }
 
-    const skillId = await getMostRelevantSkillId(userSavedTutorial);
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: userSavedTutorial.userId });
+
+    const skillId = await getMostRelevantSkillId(userSavedTutorial, knowledgeElements);
 
     if (!skillId) {
       continue;
@@ -86,13 +88,10 @@ function associateTutorialToUserSavedTutorial(userSavedTutorial, tutorials) {
   return new UserSavedTutorialWithTutorial({ ...userSavedTutorial, tutorial });
 }
 
-async function getMostRelevantSkillId(userSavedTutorialWithTutorial) {
-  const userId = userSavedTutorialWithTutorial.userId;
+function getMostRelevantSkillId(userSavedTutorialWithTutorial, knowledgeElements) {
   const tutorialSkillIds = userSavedTutorialWithTutorial.tutorial.skillIds;
   const tutorialReferenceBySkillsIdsForLearningMore =
     userSavedTutorialWithTutorial.tutorial.referenceBySkillsIdsForLearningMore;
-
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });
 
   const invalidatedDirectKnowledgeElements = knowledgeElements.filter(_isInvalidatedAndDirect);
 

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -19,7 +19,12 @@ async function main() {
 
   const userSavedTutorialsWithoutSkillIdGroupedByUserId = groupBy(userSavedTutorialsWithoutSkillId, 'userId');
 
-  for (const userId in userSavedTutorialsWithoutSkillIdGroupedByUserId) {
+  const userIds = Object.keys(userSavedTutorialsWithoutSkillIdGroupedByUserId);
+  const numberOfUsers = userIds.length;
+
+  for (const userId of userIds) {
+    console.log(`User ${userIds.findIndex((id) => id === userId) + 1} of ${numberOfUsers}`);
+
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });
     await fillSkillIdForGivenUserSavedTutorials(
       userSavedTutorialsWithoutSkillIdGroupedByUserId[userId],
@@ -88,12 +93,14 @@ async function fillSkillIdForGivenUserSavedTutorials(
       tutorialsWithSkills
     );
     if (!userSavedTutorial.tutorial) {
+      console.log(`Outdated tutorial ${userSavedTutorial.tutorialId}`);
       continue;
     }
 
     const skillId = await getMostRelevantSkillId(userSavedTutorial, knowledgeElements);
 
     if (!skillId) {
+      console.log(`Not found skillId for this user-saved-tutorials id : ${userSavedTutorial.id}`);
       continue;
     }
 


### PR DESCRIPTION
## :unicorn: Problème
Le script permettant de remplir la colonne `skillId` de la table `user-saved-tutorials` fait des appels inutiles aux `knowledge-element-repository`, car un utilisateur peut enregistrer plusieurs tutoriel. Il n'est donc pas nécessaire de faire un appel pour chaque enregistrement.

## :robot: Solution
Sortir l'appel au `knowledge-element-repository` à l'extérieur de la fonction `getMostRelevantSkillId` et grouper les `user-saved-tutorials` par utilisateur. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Enregistrer des tutoriels
- Se connecter à la base de la RA et supprimer les valeurs de la colonne `skillId` : 
```sql
update "user-saved-tutorials" set "skillId" = null; 
```
- Lancer le script et constater que la colonne est à nouveau remplie. 