### PR TITLE
[FEATURE] Remonter les compétences Pix+ en plus des compétences Pix. (PIX-5647).

### DIFF
--- a/api/lib/infrastructure/repositories/certified-profile-repository.js
+++ b/api/lib/infrastructure/repositories/certified-profile-repository.js
@@ -13,7 +13,6 @@ const tubeDatasource = require('../datasources/learning-content/tube-datasource'
 const competenceDatasource = require('../datasources/learning-content/competence-datasource');
 const areaDatasource = require('../datasources/learning-content/area-datasource');
 const knowledgeElementRepository = require('./knowledge-element-repository');
-const competenceRepository = require('./competence-repository');
 
 module.exports = {
   async get(certificationCourseId) {
@@ -39,16 +38,9 @@ module.exports = {
       limitDate: createdAt,
     });
 
-    const pixCompetences = await competenceRepository.listPixCompetencesOnly();
-    const pixCompetenceIds = pixCompetences.map((pixCompetence) => pixCompetence.id);
     const isKnowledgeElementValidated = (knowledgeElement) => knowledgeElement.status === 'validated';
-    const isKnowledgeElementFromPixCompetences = (knowledgeElement) =>
-      pixCompetenceIds.includes(knowledgeElement.competenceId);
     const skillIds = knowledgeElements
-      .filter(
-        (knowledgeElement) =>
-          isKnowledgeElementValidated(knowledgeElement) && isKnowledgeElementFromPixCompetences(knowledgeElement)
-      )
+      .filter((knowledgeElement) => isKnowledgeElementValidated(knowledgeElement))
       .map((pixKnowledgeElement) => pixKnowledgeElement.skillId);
 
     const certifiedSkills = await _createCertifiedSkills(skillIds, askedSkillIds);

--- a/api/tests/integration/infrastructure/repositories/certified-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certified-profile-repository_test.js
@@ -32,7 +32,7 @@ describe('Integration | Repository | Certified Profile', function () {
             index: 'competence1_2_index',
             areaId: 'recArea1',
             skillIds: ['recArea1_Competence2_Tube1_Skill1'],
-            origin: 'Pix',
+            origin: 'Edu',
           },
         ],
         tubes: [
@@ -98,12 +98,39 @@ describe('Integration | Repository | Certified Profile', function () {
         id: 'recArea1',
         name: 'area1_Title',
       });
-      const userId = databaseBuilder.factory.buildUser().id;
+
+      const skill1_2_1_1 = domainBuilder.buildCertifiedSkill({
+        id: 'recArea1_Competence2_Tube1_Skill1',
+        name: 'skill1_2_1_1_name',
+        hasBeenAskedInCertif: false,
+        tubeId: 'recArea1_Competence2_Tube1',
+        difficulty: 3,
+      });
+      const tube1_2_1 = domainBuilder.buildCertifiedTube({
+        id: 'recArea1_Competence2_Tube1',
+        name: 'tube1_2_1_practicalTitle',
+        competenceId: 'recArea1_Competence2',
+      });
+      const competence1_2 = domainBuilder.buildCertifiedCompetence({
+        id: 'recArea1_Competence2',
+        name: 'competence1_2_name',
+        areaId: 'recArea1',
+      });
+
+      const userId = databaseBuilder.factory.buildUser({ id: 123 }).id;
+      databaseBuilder.factory.buildUser({ id: 456 });
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+        id: 1234,
         userId,
         createdAt: new Date('2020-01-01'),
       }).id;
-      databaseBuilder.factory.buildCertificationCourse({ userId });
+
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 4567,
+        userId: 456,
+        createdAt: new Date('2020-01-01'),
+      }).id;
+
       databaseBuilder.factory.buildKnowledgeElement({
         userId,
         createdAt: new Date('2019-01-01'),
@@ -121,17 +148,18 @@ describe('Integration | Repository | Certified Profile', function () {
       databaseBuilder.factory.buildKnowledgeElement({
         userId,
         createdAt: new Date('2019-01-01'),
-        status: KnowledgeElement.StatusType.INVALIDATED,
+        status: KnowledgeElement.StatusType.VALIDATED,
         skillId: 'recArea1_Competence2_Tube1_Skill1',
         competenceId: 'recArea1_Competence2',
       });
+      databaseBuilder.factory.buildCertificationChallenge({ courseId: 4567 });
       databaseBuilder.factory.buildCertificationChallenge({ courseId: certificationCourseId });
       const expectedCertifiedProfile = domainBuilder.buildCertifiedProfile({
         id: certificationCourseId,
         userId,
-        certifiedSkills: [skill1_1_1_2],
-        certifiedTubes: [tube1_1_1],
-        certifiedCompetences: [competence1_1],
+        certifiedSkills: [skill1_1_1_2, skill1_2_1_1],
+        certifiedTubes: [tube1_1_1, tube1_2_1],
+        certifiedCompetences: [competence1_1, competence1_2],
         certifiedAreas: [area1],
       });
       mockLearningContent(learningContent);
@@ -171,7 +199,7 @@ describe('Integration | Repository | Certified Profile', function () {
             index: 'competence1_2_index',
             areaId: 'recArea1',
             skillIds: ['recArea1_Competence2_Tube1_Skill1'],
-            origin: 'Pix',
+            origin: 'Edu',
           },
         ],
         tubes: [
@@ -215,10 +243,17 @@ describe('Integration | Repository | Certified Profile', function () {
       };
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+        id: 12345,
         userId,
         createdAt: new Date('2020-01-01'),
       }).id;
-      databaseBuilder.factory.buildCertificationCourse({ userId });
+
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 1234,
+        userId,
+        createdAt: new Date('2020-01-01'),
+      });
+
       databaseBuilder.factory.buildKnowledgeElement({
         userId,
         createdAt: new Date('2019-01-01'),
@@ -237,6 +272,7 @@ describe('Integration | Repository | Certified Profile', function () {
         courseId: certificationCourseId,
         associatedSkillId: 'recArea1_Competence1_Tube1_Skill2',
       });
+
       mockLearningContent(learningContent);
       await databaseBuilder.commit();
 


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix-Admin, les compétences Pix+ ne sont pas remontées dans l'écran de profil.

## :robot: Solution

Ne plus effectuer de tri  des compétences dans l'API.

## :rainbow: Remarques
N/A

## :100: Pour tester
Sur Pix-Admin, vérifier que les compétences Pix+ s'affichent sur la page de profil.
