### PR TITLE
[FEATURE] Enregistrer les certifications qui ont été générées dans un fichier d'export CPF (PIX-5624).

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -26,6 +26,7 @@ module.exports = function buildCertificationCourse({
   maxReachableLevelOnCertificationDate = 5,
   isCancelled = false,
   abortReason = null,
+  cpfFilename = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
@@ -52,6 +53,7 @@ module.exports = function buildCertificationCourse({
     maxReachableLevelOnCertificationDate,
     isCancelled,
     abortReason,
+    cpfFilename,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/db/migrations/20220907144932_add-column-exported-in-file-in-table-certification-courses.js
+++ b/api/db/migrations/20220907144932_add-column-exported-in-file-in-table-certification-courses.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'cpfFilename';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -18,4 +18,6 @@ module.exports = async function createAndUpload({
   const now = moment().tz('Europe/Paris').format('YYYYMMDD-HHmmssSSS');
   const filename = `pix-cpf-export-${now}.xml`;
   await cpfExternalStorage.upload({ filename, writableStream });
+
+  await cpfCertificationResultRepository.markCertificationCoursesAsExported({ certificationCourseIds, filename });
 };

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -1,4 +1,5 @@
 const { PassThrough } = require('stream');
+const moment = require('moment-timezone');
 
 module.exports = async function createAndUpload({
   data,
@@ -6,15 +7,15 @@ module.exports = async function createAndUpload({
   cpfCertificationXmlExportService,
   cpfExternalStorage,
 }) {
-  const { startId, endId } = data;
-  const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-    startId,
-    endId,
+  const { certificationCourseIds } = data;
+  const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+    certificationCourseIds,
   });
 
   const writableStream = new PassThrough();
   cpfCertificationXmlExportService.buildXmlExport({ cpfCertificationResults, writableStream });
 
-  const filename = `pix-cpf-export-from-${startId}-to-${endId}.xml`;
+  const now = moment().tz('Europe/Paris').format('YYYYMMDD-HHmmssSSS');
+  const filename = `pix-cpf-export-${now}.xml`;
   await cpfExternalStorage.upload({ filename, writableStream });
 };

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
@@ -12,9 +12,7 @@ module.exports = async function planner({ pgBoss, cpfCertificationResultReposito
   const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({ startDate, endDate });
 
   chunk(cpfCertificationResults, plannerJob.chunkSize).forEach((chunk) => {
-    const firstId = chunk[0].id;
-    const lastId = chunk[chunk.length - 1].id;
-
-    pgBoss.send('CpfExportBuilderJob', { startId: firstId, endId: lastId });
+    const certificationCourseIds = chunk.map(({ id }) => id);
+    pgBoss.send('CpfExportBuilderJob', { certificationCourseIds });
   });
 };

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -19,6 +19,10 @@ module.exports = {
 
     return certificationCourses.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
   },
+
+  async markCertificationCoursesAsExported({ certificationCourseIds, filename }) {
+    return knex('certification-courses').update({ cpfFilename: filename }).whereIn('id', certificationCourseIds);
+  },
 };
 
 function _selectCpfCertificationResults() {

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -12,9 +12,9 @@ module.exports = {
     return certificationCourses.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
   },
 
-  async findByIdRange({ startId, endId }) {
+  async findByCertificationCourseIds({ certificationCourseIds }) {
     const certificationCourses = await _selectCpfCertificationResults()
-      .whereBetween('certification-courses.id', [startId, endId])
+      .whereIn('certification-courses.id', certificationCourseIds)
       .orderBy(['sessions.publishedAt', 'certification-courses.lastName', 'certification-courses.firstName']);
 
     return certificationCourses.map((certificationCourse) => new CpfCertificationResult(certificationCourse));

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -49,6 +49,7 @@ function _selectCpfCertificationResults() {
     )
     .where('certification-courses.isPublished', true)
     .where('certification-courses.isCancelled', false)
+    .whereNull('certification-courses.cpfFilename')
     .whereNotNull('certification-courses.sex')
     .where('assessment-results.status', AssessmentResult.status.VALIDATED)
     .where('competence-marks.level', '>', -1)

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -352,6 +352,26 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         expect(cpfCertificationResults).to.be.empty;
       });
     });
+
+    context('when the certification course has already been exported', function () {
+      it('should return an empty array', async function () {
+        // given
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+
+        createCertificationCourseWithCompetenceMarks({ sessionDate: '2022-01-08', cpfFilename: 'file.xml' });
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
   });
 
   describe('#findByCertificationCourseIds', function () {
@@ -695,6 +715,24 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         expect(cpfCertificationResults).to.be.empty;
       });
     });
+
+    context('when the certification course has already been exported', function () {
+      it('should return an empty array', async function () {
+        // given
+        const certificationCourseIds = [101];
+
+        createCertificationCourseWithCompetenceMarks({ certificationCourseId: 101, cpfFilename: 'file.xml' });
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+          certificationCourseIds,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
   });
 
   describe('#markCertificationCoursesAsExported', function () {
@@ -726,6 +764,7 @@ function createCertificationCourseWithCompetenceMarks({
   certificationCourseCancelled = false,
   isPublished = true,
   sessionDate = '2022-01-08',
+  cpfFilename = null,
 }) {
   const publishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date(sessionDate) }).id;
   databaseBuilder.factory.buildCertificationCourse({
@@ -739,6 +778,7 @@ function createCertificationCourseWithCompetenceMarks({
     isPublished: isPublished,
     sessionId: publishedSessionId,
     isCancelled: certificationCourseCancelled,
+    cpfFilename,
   }).id;
   databaseBuilder.factory.buildAssessmentResult({
     id: 2244,

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -354,11 +354,10 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     });
   });
 
-  describe('#findByIdRange', function () {
+  describe('#findByCertificationCourseIds', function () {
     it('should return an array of CpfCertificationResult ordered by session publication date, last name and first name', async function () {
       // given
-      const startId = 245;
-      const endId = 545;
+      const certificationCourseIds = [245, 345, 545];
 
       const firstPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
       databaseBuilder.factory.buildCertificationCourse({
@@ -457,9 +456,8 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await databaseBuilder.commit();
 
       // when
-      const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-        startId,
-        endId,
+      const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+        certificationCourseIds,
       });
 
       // then
@@ -538,8 +536,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
 
     it('should only return competence marks with level greater than -1', async function () {
       // given
-      const startId = 245;
-      const endId = 545;
+      const certificationCourseIds = [545];
 
       const sessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
       databaseBuilder.factory.buildCertificationCourse({
@@ -581,9 +578,8 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await databaseBuilder.commit();
 
       // when
-      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByIdRange({
-        startId,
-        endId,
+      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByCertificationCourseIds({
+        certificationCourseIds,
       });
 
       // then
@@ -604,8 +600,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the certification course is not published', function () {
       it('should return an empty array', async function () {
         // given
-        const startId = 100;
-        const endId = 200;
+        const certificationCourseIds = [101];
 
         createCertificationCourseWithCompetenceMarks({
           certificationCourseId: 101,
@@ -614,9 +609,8 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-          startId,
-          endId,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+          certificationCourseIds,
         });
 
         // then
@@ -627,8 +621,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the certification course is cancelled', function () {
       it('should return an empty array', async function () {
         // given
-        const startId = 100;
-        const endId = 200;
+        const certificationCourseIds = [101];
 
         createCertificationCourseWithCompetenceMarks({
           certificationCourseId: 101,
@@ -637,9 +630,8 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-          startId,
-          endId,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+          certificationCourseIds,
         });
 
         // then
@@ -650,8 +642,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the latest assessment result is not validated', function () {
       it('should return an empty array', async function () {
         // given
-        const startId = 100;
-        const endId = 200;
+        const certificationCourseIds = [101];
 
         createCertificationCourseWithCompetenceMarks({
           certificationCourseId: 101,
@@ -660,9 +651,8 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-          startId,
-          endId,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+          certificationCourseIds,
         });
 
         // then
@@ -670,19 +660,17 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       });
     });
 
-    context('when the session publication index is ouf of bounds', function () {
+    context('when the certification course id is not in the array', function () {
       it('should return an empty array', async function () {
         // given
-        const startId = 100;
-        const endId = 200;
+        const certificationCourseIds = [101];
 
         createCertificationCourseWithCompetenceMarks({ certificationCourseId: 201 });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-          startId,
-          endId,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+          certificationCourseIds,
         });
 
         // then
@@ -693,16 +681,14 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the certification course sex is not defined', function () {
       it('should return an empty array', async function () {
         // given
-        const startId = 100;
-        const endId = 200;
+        const certificationCourseIds = [101];
 
-        createCertificationCourseWithCompetenceMarks({ sex: null });
+        createCertificationCourseWithCompetenceMarks({ certificationCourseId: 101, sex: null });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByIdRange({
-          startId,
-          endId,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
+          certificationCourseIds,
         });
 
         // then

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -13,6 +13,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
 
     cpfCertificationResultRepository = {
       findByCertificationCourseIds: sinon.stub(),
+      markCertificationCoursesAsExported: sinon.stub(),
     };
     cpfCertificationXmlExportService = {
       buildXmlExport: sinon.stub(),
@@ -59,6 +60,10 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
     expect(cpfExternalStorage.upload).to.have.been.calledWith({
       filename: 'pix-cpf-export-20220101-114327000.xml',
       writableStream: sinon.match(PassThrough),
+    });
+    expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
+      certificationCourseIds,
+      filename: 'pix-cpf-export-20220101-114327000.xml',
     });
   });
 });

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -6,10 +6,13 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
   let cpfCertificationResultRepository;
   let cpfCertificationXmlExportService;
   let cpfExternalStorage;
+  let clock;
 
   beforeEach(function () {
+    clock = sinon.useFakeTimers(new Date('2022-01-01T10:43:27Z'));
+
     cpfCertificationResultRepository = {
-      findByIdRange: sinon.stub(),
+      findByCertificationCourseIds: sinon.stub(),
     };
     cpfCertificationXmlExportService = {
       buildXmlExport: sinon.stub(),
@@ -19,10 +22,13 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
     };
   });
 
+  afterEach(function () {
+    clock.restore();
+  });
+
   it('should build an xml export file and upload it to an external storage', async function () {
     // given
-    const startId = 12;
-    const endId = 120;
+    const certificationCourseIds = [12, 20, 33, 98, 114];
 
     const cpfCertificationResults = [
       domainBuilder.buildCpfCertificationResult({ id: 12 }),
@@ -32,24 +38,26 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
       domainBuilder.buildCpfCertificationResult({ id: 114 }),
     ];
 
-    cpfCertificationResultRepository.findByIdRange.resolves(cpfCertificationResults);
+    cpfCertificationResultRepository.findByCertificationCourseIds.resolves(cpfCertificationResults);
 
     // when
     await createAndUpload({
-      data: { startId, endId },
+      data: { certificationCourseIds },
       cpfCertificationResultRepository,
       cpfCertificationXmlExportService,
       cpfExternalStorage,
     });
 
     // then
-    expect(cpfCertificationResultRepository.findByIdRange).to.have.been.calledWith({ startId, endId });
+    expect(cpfCertificationResultRepository.findByCertificationCourseIds).to.have.been.calledWith({
+      certificationCourseIds,
+    });
     expect(cpfCertificationXmlExportService.buildXmlExport).to.have.been.calledWith({
       cpfCertificationResults,
       writableStream: sinon.match(PassThrough),
     });
     expect(cpfExternalStorage.upload).to.have.been.calledWith({
-      filename: 'pix-cpf-export-from-12-to-120.xml',
+      filename: 'pix-cpf-export-20220101-114327000.xml',
       writableStream: sinon.match(PassThrough),
     });
   });

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
@@ -16,7 +16,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
     };
   });
 
-  it('should send to CpfExportBuilderJob chunks of cpf certification results', async function () {
+  it('should send to CpfExportBuilderJob chunks of certification course ids', async function () {
     // given
     sinon.stub(cpf.plannerJob, 'chunkSize').value(2);
     sinon.stub(cpf.plannerJob, 'monthsToProcess').value(2);
@@ -40,17 +40,8 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
 
     // then
     expect(cpfCertificationResultRepository.findByTimeRange).to.have.been.calledWith({ startDate, endDate });
-    expect(pgBoss.send.firstCall).to.have.been.calledWith('CpfExportBuilderJob', {
-      startId: 1,
-      endId: 2,
-    });
-    expect(pgBoss.send.secondCall).to.have.been.calledWith('CpfExportBuilderJob', {
-      startId: 3,
-      endId: 4,
-    });
-    expect(pgBoss.send.thirdCall).to.have.been.calledWith('CpfExportBuilderJob', {
-      startId: 5,
-      endId: 5,
-    });
+    expect(pgBoss.send.firstCall).to.have.been.calledWith('CpfExportBuilderJob', { certificationCourseIds: [1, 2] });
+    expect(pgBoss.send.secondCall).to.have.been.calledWith('CpfExportBuilderJob', { certificationCourseIds: [3, 4] });
+    expect(pgBoss.send.thirdCall).to.have.been.calledWith('CpfExportBuilderJob', { certificationCourseIds: [5] });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible d’exporter dans un fichier xml les certifications obtenues chez Pix pour pouvoir ensuite les envoyer au CPF. Certaines certifications ne seront cependant pas exportés comme celles dont le sexe du candidat n’est pas connu. Cependant, nous ne conservons pas l'information comme quoi une certification a été générée dans un fichier.

## :robot: Solution
- Stocker le nom du fichier dans lequel une certification a été exportée.
- Empêcher d'exporter une certification déjà exportée auparavant. 

## :100: Pour tester
- Programmer un export de certifications
- Vérifier que les certifications présentes dans la fichier ont bien la colonne "cpfFilename" renseignée.

Résultats:

Les certifications dont la colonne "sex" n'est pas null ont bien le fichier d'export de renseigné:

![Selection_081](https://user-images.githubusercontent.com/1216570/189348680-06870e85-4475-467a-9ed8-f53b74404370.png)
