### PR TITLE
[BUGFIX] Réparer la connexion GAR (PIX-5646)

### DIFF
--- a/mon-pix/app/components/authentication/terms-of-service-oidc.hbs
+++ b/mon-pix/app/components/authentication/terms-of-service-oidc.hbs
@@ -2,7 +2,7 @@
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <a href={{this.homeUrl}}>
+      <a href={{this.showcaseUrl}}>
         <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt={{t "navigation.homepage"}} />
       </a>
     </div>

--- a/mon-pix/app/components/authentication/terms-of-service-oidc.js
+++ b/mon-pix/app/components/authentication/terms-of-service-oidc.js
@@ -20,8 +20,8 @@ export default class TermsOfServiceOidcComponent extends Component {
   @tracked isAuthenticationKeyExpired = false;
   @tracked errorMessage = null;
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   get identityProviderOrganizationName() {

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -1,6 +1,6 @@
 <main class="sign-form__container" role="main">
 
-  <a href={{this.homeUrl}} class="pix-logo__link">
+  <a href={{this.showcaseUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 
@@ -48,7 +48,7 @@
     </div>
 
     <div class="password-reset-demand-form__home-link">
-      <a href={{this.homeUrl}} class="link">{{t "pages.password-reset-demand.actions.back-home"}}</a>
+      <a href={{this.showcaseUrl}} class="link">{{t "pages.password-reset-demand.actions.back-home"}}</a>
     </div>
   {{else}}
     <form {{on "submit" this.savePasswordResetDemand}} class="sign-form__body">

--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -14,8 +14,8 @@ export default class PasswordResetDemandForm extends Component {
 
   email = '';
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   get error() {

--- a/mon-pix/app/components/reset-password-form.hbs
+++ b/mon-pix/app/components/reset-password-form.hbs
@@ -1,6 +1,6 @@
 <div class="sign-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link">
+  <a href={{this.showcaseUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -15,8 +15,8 @@ export default class ResetPasswordForm extends Component {
     @tracked message: null,
   };
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   @action

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -1,6 +1,6 @@
 <main class="sign-form__container" role="main">
 
-  <a href={{this.homeUrl}} class="pix-logo__link">
+  <a href={{this.showcaseUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -20,8 +20,8 @@ export default class SigninForm extends Component {
   login = '';
   password = '';
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   get displayPoleEmploiButton() {

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,5 +1,5 @@
 <main class="sign-form__container" role="main">
-  <a href={{this.homeUrl}} class="pix-logo__link">
+  <a href={{this.showcaseUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -48,8 +48,8 @@ export default class SignupForm extends Component {
   @tracked validation = new SignupFormValidation();
   _tokenHasBeenUsed = null;
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   get cguUrl() {

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -1,6 +1,6 @@
 <div class="update-expired-password-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link">
+  <a href={{this.showcaseUrl}} class="pix-logo__link">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -36,8 +36,8 @@ export default class UpdateExpiredPasswordForm extends Component {
 
   @tracked errorMessage = null;
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   get validationMessage() {

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -18,8 +18,8 @@ export default class LoginOrRegisterOidcController extends Controller {
   @tracked username = '';
   @tracked authenticationMethods = [];
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   @action toggleOidcReconciliation() {

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -11,8 +11,8 @@ export default class TermsOfServiceController extends Controller {
   @tracked isTermsOfServiceValidated = false;
   @tracked showErrorTermsOfServiceNotSelected = false;
 
-  get homeUrl() {
-    return this.url.homeUrl;
+  get showcaseUrl() {
+    return this.url.showcaseUrl;
   }
 
   @action

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -14,12 +14,11 @@ export default class Url extends Service {
     return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION;
   }
 
-  get homeUrl() {
-    const isProdEnv = ENV.APP.IS_PROD_ENVIRONMENT;
+  get showcaseUrl() {
+    return this._showcaseWebsiteUrl;
+  }
 
-    if (isProdEnv) {
-      return this._showcaseWebsiteUrl;
-    }
+  get homeUrl() {
     const currentLanguage = this.intl.t('current-lang');
     return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -2,7 +2,7 @@
 
 <PixBackgroundHeader>
   <PixBlock @shadow="light" class="login-or-register-oidc-form">
-    <a href={{this.homeUrl}} class="login-or-register-oidc-form__logo">
+    <a href={{this.showcaseUrl}} class="login-or-register-oidc-form__logo">
       <img src="/images/pix-logo.svg" alt="{{t 'common.pix'}}" />
     </a>
 

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -4,7 +4,7 @@
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <a href={{homeUrl}}>
+      <a href={{this.showcaseUrl}}>
         <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
       </a>
     </div>


### PR DESCRIPTION
## :unicorn: Problème

Nous avons eu des retours d'utilisateurs se connectant à Pix depuis leur ENT comme étant redirigés vers pix.fr au lieu d'arriver sur la page pour rejoindre une campagne.

En creusant, nous avons observé qu'après la génération de son token valide, l'utilisateur n'était pas redirigé correctement.

Le problème semble être dû au getter homeUrl du service url qui est utilisé après la connexion mais, en prod, renvoie l'url du site vitrine là où c'est la page d'accueil de Pix App qui devrait être utilisé.

## :robot: Solution

- Renommer le getter existant getHomeUrl par getShowcaseUrl et conserver le comportement en prod
- Ajouter un nouveau getter getHomeUrl qui renvoie toujours la page d'accueil

## :rainbow: Remarques

Ce problème est similaire aux problèmes rencontrés lors de la montée de version de Ember-simple-auth : https://github.com/1024pix/pix/pull/3541 

## :100: Pour tester

1. Se connecter à Pix App pour générer un token valide
2. Récupérer l'access_token et l'user_id dans le localStorage
3. En navigation privée, accéder à Pix App avec ces deux éléments en query param : [https://app.dev.pix.fr?token=[TOKEN_VALIDE]&user-id[ID_UTILISATEUR]](https://app.dev.pix.fr/?token=%5BTOKEN_VALIDE%5D&user-id%5BID_UTILISATEUR%5D)
4. Constater qu'on est authentifié