### PR TITLE
[TECH] Améliorer le message d'information dans le script de remplissage de la colonne `skillId` de la table `user-saved-tutorials` (PIX-5651)

### DIFF
--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -93,7 +93,7 @@ async function fillSkillIdForGivenUserSavedTutorials(
       tutorialsWithSkills
     );
     if (!userSavedTutorial.tutorial) {
-      console.log(`Outdated tutorial ${userSavedTutorial.tutorialId}`);
+      console.log(`Outdated tutorial ${userSavedTutorialWithoutSkillId.tutorialId}`);
       continue;
     }
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le script permettant de remplir la colonne `skillId` de la table `user-saved-tutorials`, le message permettant de mettre en avant les tutoriels plus présent dans le référentiel ne logue pas l'id. 
En effet, il utilise un objet provenant du model qui n'a pas le champ `tutorialId`

## :robot: Solution
Utiliser le bon objet pour loguer 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Sauvegarder un tutoriel
- Changer en base dans la table `user-saved-tutorials`  le `tutorialId` pour quelque chose qui n'existe pas
- Lancer le script
- Constater le log
