### PR TITLE
[FEATURE] Améliorer l'accessibilité de l'affichage des tutoriels (PIX-5610).

### DIFF
--- a/mon-pix/app/components/learning-more-panel.hbs
+++ b/mon-pix/app/components/learning-more-panel.hbs
@@ -2,12 +2,12 @@
   <div class="learning-more-panel">
     <div class="learning-more-panel__container">
       <h3 class="learning-more-panel__hint-title"><span>{{t "pages.learning-more.title"}}</span></h3>
-      <div class="learning-more-panel__list-container">
+      <ul class="learning-more-panel__list-container">
         {{#each @learningMoreTutorials as |learningMoreTutorial|}}
           <Tutorials::Card @tutorial={{learningMoreTutorial}} />
         {{/each}}
         <div class="learning-more-panel__tutorial-info">{{t "pages.learning-more.info"}}</div>
-      </div>
+      </ul>
     </div>
   </div>
 {{/if}}

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -138,11 +138,11 @@
           {{#each this.tutorialsGroupedByTubeName as |tube|}}
             <div class="tube">
               <h4 class="tube__title">{{tube.practicalTitle}}</h4>
-              <div class="tube__content">
+              <ul class="tube__content">
                 {{#each tube.tutorials as |tutorial|}}
                   <Tutorials::Card @tutorial={{tutorial}} />
                 {{/each}}
-              </div>
+              </ul>
             </div>
           {{/each}}
         </div>

--- a/mon-pix/app/components/tutorial-panel.hbs
+++ b/mon-pix/app/components/tutorial-panel.hbs
@@ -19,11 +19,11 @@
       {{/if}}
 
       {{#if this.shouldDisplayTutorial}}
-        <div class="tutorial-panel__tutorials-container">
+        <ul class="tutorial-panel__tutorials-container">
           {{#each this.limitedTutorials as |tutorial|}}
             <Tutorials::Card @tutorial={{tutorial}} />
           {{/each}}
-        </div>
+        </ul>
         <div class="tutorial-panel__tutorial-info">{{t "pages.tutorial-panel.info"}}</div>
       {{/if}}
 

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,40 +1,42 @@
-<article class="tutorial-card-v2" role="article">
-  <div class="tutorial-card-v2__content">
-    <a
-      target="_blank"
-      rel="noopener noreferrer"
-      href="{{@tutorial.link}}"
-      class="tutorial-card-v2-content__link"
-      title="{{@tutorial.title}}"
-    >
-      {{@tutorial.title}}
-    </a>
-    <p class="tutorial-card-v2-content__details">
-      {{@tutorial.source}}
-      •
-      {{@tutorial.format}}
-      •
-      {{moment-duration @tutorial.duration}}
-    </p>
-    {{#if this.shouldShowActions}}
-      <ul class="tutorial-card-v2-content__actions">
-        <li>
-          <ActionChip
-            @title={{this.evaluateInformation}}
-            @isCompleted={{this.isTutorialEvaluated}}
-            @triggerAction={{this.evaluateTutorial}}
-            @icon="thumbs-up"
-          />
-        </li>
-        <li>
-          <ActionChip
-            @title={{this.saveInformation}}
-            @isCompleted={{this.isTutorialSaved}}
-            @triggerAction={{this.toggleSaveTutorial}}
-            @icon="bookmark"
-          />
-        </li>
-      </ul>
-    {{/if}}
-  </div>
-</article>
+<li>
+  <article class="tutorial-card-v2" role="article">
+    <div class="tutorial-card-v2__content">
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{@tutorial.link}}"
+        class="tutorial-card-v2-content__link"
+        title="{{@tutorial.title}}"
+      >
+        {{@tutorial.title}}
+      </a>
+      <p class="tutorial-card-v2-content__details">
+        {{@tutorial.source}}
+        •
+        {{@tutorial.format}}
+        •
+        {{moment-duration @tutorial.duration}}
+      </p>
+      {{#if this.shouldShowActions}}
+        <ul class="tutorial-card-v2-content__actions">
+          <li>
+            <ActionChip
+              @title={{this.evaluateInformation}}
+              @isCompleted={{this.isTutorialEvaluated}}
+              @triggerAction={{this.evaluateTutorial}}
+              @icon="thumbs-up"
+            />
+          </li>
+          <li>
+            <ActionChip
+              @title={{this.saveInformation}}
+              @isCompleted={{this.isTutorialSaved}}
+              @triggerAction={{this.toggleSaveTutorial}}
+              @icon="bookmark"
+            />
+          </li>
+        </ul>
+      {{/if}}
+    </div>
+  </article>
+</li>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -17,20 +17,24 @@
       {{moment-duration @tutorial.duration}}
     </p>
     {{#if this.shouldShowActions}}
-      <div class="tutorial-card-v2-content__actions">
-        <ActionChip
-          @title={{this.evaluateInformation}}
-          @isCompleted={{this.isTutorialEvaluated}}
-          @triggerAction={{this.evaluateTutorial}}
-          @icon="thumbs-up"
-        />
-        <ActionChip
-          @title={{this.saveInformation}}
-          @isCompleted={{this.isTutorialSaved}}
-          @triggerAction={{this.toggleSaveTutorial}}
-          @icon="bookmark"
-        />
-      </div>
+      <ul class="tutorial-card-v2-content__actions">
+        <li>
+          <ActionChip
+            @title={{this.evaluateInformation}}
+            @isCompleted={{this.isTutorialEvaluated}}
+            @triggerAction={{this.evaluateTutorial}}
+            @icon="thumbs-up"
+          />
+        </li>
+        <li>
+          <ActionChip
+            @title={{this.saveInformation}}
+            @isCompleted={{this.isTutorialSaved}}
+            @triggerAction={{this.toggleSaveTutorial}}
+            @icon="bookmark"
+          />
+        </li>
+      </ul>
     {{/if}}
   </div>
 </article>

--- a/mon-pix/app/components/tutorials/cards.hbs
+++ b/mon-pix/app/components/tutorials/cards.hbs
@@ -1,5 +1,5 @@
-<div class="user-tutorials-content-v2__cards">
+<ul class="user-tutorials-content-v2__cards">
   {{#each @tutorials as |tutorial|}}
     <Tutorials::Card @tutorial={{tutorial}} @afterRemove={{@afterRemove}} />
   {{/each}}
-</div>
+</ul>

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -5,22 +5,28 @@
       {{t "pages.user-tutorials.description"}}
     </p>
 
-    <div class="user-tutorials-banner-v2__filters">
+    <ul class="user-tutorials-banner-v2__filters">
       {{#if this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled}}
-        <PixButton
-          @backgroundColor="transparent-light"
-          @isBorderVisible={{false}}
-          @triggerAction={{@onTriggerFilterButton}}
-        >
-          {{t "pages.user-tutorials.filter"}}
-        </PixButton>
+        <li class="user-tutorials-banner-v2-filters__filter">
+          <PixButton
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{false}}
+            @triggerAction={{@onTriggerFilterButton}}
+          >
+            {{t "pages.user-tutorials.filter"}}
+          </PixButton>
+        </li>
       {{/if}}
-      <ChoiceChip @route="authenticated.user-tutorials.recommended">
-        {{t "pages.user-tutorials.recommended"}}
-      </ChoiceChip>
-      <ChoiceChip @route="authenticated.user-tutorials.saved">
-        {{t "pages.user-tutorials.saved"}}
-      </ChoiceChip>
-    </div>
+      <li class="user-tutorials-banner-v2-filters__filter">
+        <ChoiceChip @route="authenticated.user-tutorials.recommended">
+          {{t "pages.user-tutorials.recommended"}}
+        </ChoiceChip>
+      </li>
+      <li class="user-tutorials-banner-v2-filters__filter">
+        <ChoiceChip @route="authenticated.user-tutorials.saved">
+          {{t "pages.user-tutorials.saved"}}
+        </ChoiceChip>
+      </li>
+    </ul>
   </div>
 </div>

--- a/mon-pix/app/components/user-tutorials/filters/sidebar.hbs
+++ b/mon-pix/app/components/user-tutorials/filters/sidebar.hbs
@@ -24,18 +24,22 @@
     {{/each}}
   </:content>
   <:footer>
-    <div class="tutorials-filters__footer">
-      <PixButton
-        @triggerAction={{this.handleResetFilters}}
-        @size="small"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-      >
-        {{t "pages.user-tutorials.sidebar.reset"}}
-      </PixButton>
-      <PixButton @size="small" @triggerAction={{fn @onSubmit this.filters}}>
-        {{t "pages.user-tutorials.sidebar.see-results"}}
-      </PixButton>
-    </div>
+    <ul class="tutorials-filters__footer">
+      <li>
+        <PixButton
+          @triggerAction={{this.handleResetFilters}}
+          @size="small"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+        >
+          {{t "pages.user-tutorials.sidebar.reset"}}
+        </PixButton>
+      </li>
+      <li>
+        <PixButton @size="small" @triggerAction={{fn @onSubmit this.filters}}>
+          {{t "pages.user-tutorials.sidebar.see-results"}}
+        </PixButton>
+      </li>
+    </ul>
   </:footer>
 </PixSidebar>

--- a/mon-pix/app/styles/components/_choice-chip.scss
+++ b/mon-pix/app/styles/components/_choice-chip.scss
@@ -1,6 +1,7 @@
 .pix-choice-chip {
   border-radius: 50px;
   font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: $font-medium;
   white-space: nowrap;
   letter-spacing: 0.028rem;

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -27,3 +27,9 @@
   line-height: 1.25rem;
   margin: 5px;
 }
+
+.learning-more-panel__list-container {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -36,8 +36,11 @@
   }
 
   &__content {
+    list-style: none;
+    margin: 0;
+    padding: 0;
 
-    > .tutorial-card-v2 {
+    & .tutorial-card-v2 {
       margin-bottom: 16px;
     }
   }

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -46,6 +46,9 @@
   }
 
   &__actions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     justify-content: space-between;
     align-items: end;
     display: flex;

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -29,6 +29,9 @@
 }
 
 .tutorial-panel__tutorials-container {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
 

--- a/mon-pix/app/styles/components/user-tutorials/_sidebar.scss
+++ b/mon-pix/app/styles/components/user-tutorials/_sidebar.scss
@@ -46,6 +46,9 @@
   }
 
   &__footer {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: flex;
     gap: 8px;
   }

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -112,12 +112,14 @@
   }
 
   &__cards {
+    list-style: none;
+    padding: 0;
     display: grid;
     grid-template-columns: 1fr;
     grid-auto-rows: min-content;
     row-gap: 16px;
     width: 100%;
-    margin-bottom: 32px;
+    margin: 0 0 32px;
 
     @include device-is('desktop') {
       grid-template-columns: 1fr 1fr;

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -87,6 +87,10 @@
     display: flex;
     gap: 16px;
     flex-wrap: wrap;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix App, les boutons de filtres des tutoriels, ainsi que les cartes des tutoriels ne sont pas inclus dans une liste, ce qui peut perdre l'utilisateur. 

## :robot: Solution
- Déplacer les boutons de filtres sur les pages : `/mes-tutos/recommandes` et `/mes-tutos/enregistres` dans une liste
- Déplacer les boutons de la sidebar de filtres dans une liste
- Déplacer les cards des tutos dans une liste

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App 

### Détails d'une compétence
- Aller dans la page de détails d'une compétence 
- Constater le bon affichage des tutos

### Checkpoint 
- Passer une compétence 
- Au moment d'un checkpoint, cliquer sur `Réponses & tutos` 
- Constater le bon affichage

### Pages mes-tutos
- Aller sur `/mes-tutos/recommandes`
- Constater le bon affichage 
- Aller sur `/mes-tutos/enregistres`
- Constater le bon affichage
