### PR TITLE
[TECH] Suppression des warnings de lint des scripts certifications (PIX-5654).

### DIFF
--- a/api/scripts/certification/cancel-certifications-and-publish-sessions.js
+++ b/api/scripts/certification/cancel-certifications-and-publish-sessions.js
@@ -7,9 +7,10 @@ const sessionRepository = require('../../lib/infrastructure/repositories/session
 const certificationRepository = require('../../lib/infrastructure/repositories/certification-repository');
 const sessionPublicationService = require('../../lib/domain/services/session-publication-service');
 const { parseCsvWithHeader } = require('../helpers/csvHelpers');
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 
 let progression = 0;
+
 function _logProgression(totalCount) {
   ++progression;
   process.stdout.cursorTo(0);
@@ -33,7 +34,7 @@ async function main() {
   } catch (error) {
     console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
     yargs.showHelp();
-    process.exit(1);
+    throw new Error(error);
   }
 }
 
@@ -186,11 +187,10 @@ async function _findAlreadyPublishedSessions(sessionIdsToPublish) {
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
+  main()
+    .catch((err) => {
       console.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }

--- a/api/scripts/certification/generate-certification-results.js
+++ b/api/scripts/certification/generate-certification-results.js
@@ -1,4 +1,4 @@
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
 const bluebird = require('bluebird');
 const scoringCertificationService = require('../../lib/domain/services/scoring/scoring-certification-service');
@@ -47,16 +47,15 @@ async function main() {
     scores.forEach((score) => console.log(score));
   } catch (error) {
     console.error(error);
-    process.exit(1);
+    throw new Error(error);
   }
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
+  main()
+    .catch((err) => {
       console.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }

--- a/api/scripts/certification/generate-certification-test-statistics.js
+++ b/api/scripts/certification/generate-certification-test-statistics.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 const _ = require('lodash');
 const fp = require('lodash/fp').convert({ cap: false });
 const bluebird = require('bluebird');
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const competenceRepository = require('../../lib/infrastructure/repositories/competence-repository');
 const challengeRepository = require('../../lib/infrastructure/repositories/challenge-repository');
 const placementProfileService = require('../../lib/domain/services/placement-profile-service');
@@ -128,16 +128,15 @@ async function main() {
     console.log(_.fromPairs(challengeCountByCompetenceTotal));
   } catch (error) {
     console.error(error);
-    process.exit(1);
+    throw new Error(error);
   }
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
+  main()
+    .catch((err) => {
       console.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }

--- a/api/scripts/certification/import-certification-cpf-countries.js
+++ b/api/scripts/certification/import-certification-cpf-countries.js
@@ -6,7 +6,7 @@
 
 'use strict';
 const { parseCsv } = require('../helpers/csvHelpers');
-const { knex } = require('../../lib/infrastructure/bookshelf');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const { normalizeAndSortChars } = require('../../lib/infrastructure/utils/string-utils');
 const _ = require('lodash');
 
@@ -104,19 +104,18 @@ async function main(filePath) {
       trx.rollback();
     }
     console.error(error);
-    process.exit(1);
+    throw new Error(error);
   }
 }
 
 if (require.main === module) {
   const filePath = process.argv[2];
-  main(filePath).then(
-    () => process.exit(0),
-    (err) => {
+  main(filePath)
+    .catch((err) => {
       console.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }
 
 module.exports = {

--- a/api/scripts/certification/import-certifications-from-csv.js
+++ b/api/scripts/certification/import-certifications-from-csv.js
@@ -137,7 +137,7 @@ function main() {
     });
   } catch (err) {
     console.error(err.message);
-    process.exit(1);
+    throw new Error(err);
   }
 }
 

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -1,6 +1,6 @@
 'use strict';
 require('dotenv').config();
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const SessionFinalized = require('../../lib/domain/events/SessionFinalized');
 const certificationAssessmentRepository = require('../../lib/infrastructure/repositories/certification-assessment-repository');
 const challengeRepository = require('../../lib/infrastructure/repositories/challenge-repository');
@@ -49,11 +49,10 @@ async function main() {
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
+  main()
+    .catch((err) => {
       logger.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }

--- a/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
+++ b/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
@@ -1,4 +1,4 @@
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const bluebird = require('bluebird');
 const handleAutoJury = require('../../lib/domain/events/handle-auto-jury');
 const certificationIssueReportRepository = require('../../lib/infrastructure/repositories/certification-issue-report-repository');
@@ -140,7 +140,7 @@ async function main() {
     await _printAudit();
   } catch (error) {
     console.error(error);
-    process.exit(1);
+    throw new Error(error);
   }
 }
 
@@ -163,11 +163,10 @@ async function _toRetry(sessionId, error) {
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
+  main()
+    .catch((err) => {
       console.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }

--- a/api/scripts/certification/trigger-session-finalized-handler.js
+++ b/api/scripts/certification/trigger-session-finalized-handler.js
@@ -1,4 +1,4 @@
-const { knex } = require('../../db/knex-database-connection');
+const { knex, disconnect } = require('../../db/knex-database-connection');
 const bluebird = require('bluebird');
 const AutoJuryDone = require('../../lib/domain/events/AutoJuryDone');
 const { eventDispatcher } = require('../../lib/domain/events');
@@ -13,7 +13,7 @@ async function main() {
     logger.info('Fin');
   } catch (error) {
     logger.error(error);
-    process.exit(1);
+    throw new Error(error);
   }
 }
 
@@ -69,13 +69,12 @@ async function _dispatch(events) {
 }
 
 if (require.main === module) {
-  main().then(
-    () => process.exit(0),
-    (err) => {
+  main()
+    .catch((err) => {
       logger.error(err);
-      process.exit(1);
-    }
-  );
+      process.codeExit = 1;
+    })
+    .finally(disconnect);
 }
 
 module.exports = main;

--- a/api/scripts/switch-campaign-to-flash.js
+++ b/api/scripts/switch-campaign-to-flash.js
@@ -1,7 +1,7 @@
 'use strict';
 const _ = require('lodash');
 require('dotenv').config();
-const { knex } = require('../db/knex-database-connection');
+const { knex, disconnect } = require('../db/knex-database-connection');
 const Assessment = require('../lib/domain/models/Assessment');
 
 async function switchCampaignToFlash(id) {
@@ -19,10 +19,12 @@ async function main(id) {
 if (require.main === module) {
   const id = parseInt(process.argv[2]);
 
-  main(id).catch((err) => {
-    console.error(err);
-    process.exitCode = 1; // ou throw err
-  });
+  main(id)
+    .catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    })
+    .finally(disconnect);
 }
 
 module.exports = { switchCampaignToFlash };


### PR DESCRIPTION
## :unicorn: Problème

Lors du lancement des tests dans la CI, celle-ci est polluée de messages de `warning` liés au linter qui remonte l'interdiction d'utiliser `process.exit()` dans le code. 

## :robot: Solution

| Syntaxe actuelle     | Remplacement |
| ----------- | ----------- |
| `process.exit(1)` dans la fonction `main`    | `process.codeExit = 1`       |
| `process.exit(1)` hors de la fonction `main`    | `throw new Error(err)`       |
| `process.exit(0)`  dans la fonction `main` | Supprimé (fait par défaut)       |

## :rainbow: Remarques

Puisque nous ne forçons plus la sortie du script, il faut clore toutes les connexion ouvertes, fautes de quoi, le script ne s'arretera pas. Dans la majorité des cas, il est necessaire de clore les connexion à la BDD via  `disconnect` disponible dans `db/knex-database-connection` .

Nous nous occupons ici seulement des scripts de certifs afin de ne pas rendre la review plus pénible qu'elle ne l'est déjà.

## :100: Pour tester

Lancer chacun des scripts modifiés en vérifiant que ceux-ci fonctionnent toujours.
