### PR TITLE
[FEATURE] Ré-ordonner les champs d'édition d'une organisation (PIX-5648)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -57,21 +57,6 @@
     </div>
 
     <div class="form-field">
-      <label for="email" class="form-field__label">Adresse e-mail d'activation SCO</label>
-      {{#if (v-get this.form "email" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "email" "message"}}
-        </div>
-      {{/if}}
-      <Input
-        id="email"
-        @type="text"
-        class={{if (v-get this.form "email" "isInvalid") "form-control is-invalid" "form-control"}}
-        @value={{this.form.email}}
-      />
-    </div>
-
-    <div class="form-field">
       <label for="credits" class="form-field__label">Crédits</label>
       {{#if (v-get this.form "credit" "isInvalid")}}
         <div class="form-field__error">
@@ -101,23 +86,6 @@
       />
     </div>
 
-    {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
-      <div class="form-field organization-edit-form__checkbox">
-        <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
-        {{#if (v-get this.form "isManagingStudents" "isInvalid")}}
-          <div class="form-field__error">
-            {{v-get this.form "isManagingStudents" "message"}}
-          </div>
-        {{/if}}
-        <Input
-          id="isManagingStudents"
-          @type="checkbox"
-          class={{if (v-get this.form "isManagingStudents" "isInvalid") "form-control is-invalid" "form-control"}}
-          @checked={{this.form.isManagingStudents}}
-        />
-      </div>
-    {{/if}}
-
     <div class="form-field organization-edit-form__checkbox">
       <label for="showSkills" class="form-field__label">Affichage des acquis dans l'export de résultats</label>
       {{#if (v-get this.form "showSkills" "isInvalid")}}
@@ -143,6 +111,39 @@
         @emptyOptionNotSelectable={{true}}
       />
     </div>
+
+    <div class="form-field">
+      <label for="email" class="form-field__label">Adresse e-mail d'activation SCO</label>
+      {{#if (v-get this.form "email" "isInvalid")}}
+        <div class="form-field__error">
+          {{v-get this.form "email" "message"}}
+        </div>
+      {{/if}}
+      <Input
+        id="email"
+        @type="text"
+        class={{if (v-get this.form "email" "isInvalid") "form-control is-invalid" "form-control"}}
+        @value={{this.form.email}}
+      />
+    </div>
+
+    {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
+      <div class="form-field organization-edit-form__checkbox">
+        <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
+        {{#if (v-get this.form "isManagingStudents" "isInvalid")}}
+          <div class="form-field__error">
+            {{v-get this.form "isManagingStudents" "message"}}
+          </div>
+        {{/if}}
+        <Input
+          id="isManagingStudents"
+          @type="checkbox"
+          class={{if (v-get this.form "isManagingStudents" "isInvalid") "form-control is-invalid" "form-control"}}
+          @checked={{this.form.isManagingStudents}}
+        />
+      </div>
+    {{/if}}
+
     <div class="form-actions">
       <PixButton
         @size="small"

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -104,7 +104,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @tracked isEditMode = false;
   @tracked showArchivingConfirmationModal = false;
   noIdentityProviderOption = { label: 'Aucun', value: 'None' };
-  garIdentityProviderOption = { label: 'Médiacentre', value: 'GAR' };
+  garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
 
   constructor() {
     super(...arguments);

--- a/admin/app/components/organizations/information-section-view.js
+++ b/admin/app/components/organizations/information-section-view.js
@@ -7,7 +7,7 @@ export default class OrganizationInformationSection extends Component {
   @service accessControl;
 
   get identityProviderName() {
-    const GARIdentityProvider = { code: 'GAR', organizationName: 'Médiacentre' };
+    const GARIdentityProvider = { code: 'GAR', organizationName: 'GAR' };
     const allIdentityProviderList = [...this.oidcIdentityProviders.list, GARIdentityProvider];
     const identityProvider = allIdentityProviderList.findBy(
       'code',

--- a/admin/tests/unit/components/organizations/information-section-view_test.js
+++ b/admin/tests/unit/components/organizations/information-section-view_test.js
@@ -7,7 +7,7 @@ module('Unit | Component | organizations/information-section-view', function (ho
   setupTest(hooks);
 
   module('#identityProviderName', function () {
-    test('it should return "Médiacentre" when organization has GAR identityProvider', async function (assert) {
+    test('it should return "GAR" when organization has GAR identityProvider', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const oidcPartner = store.createRecord('oidc-identity-provider', {
@@ -25,7 +25,7 @@ module('Unit | Component | organizations/information-section-view', function (ho
       });
 
       // when / then
-      assert.strictEqual(component.identityProviderName, 'Médiacentre');
+      assert.strictEqual(component.identityProviderName, 'GAR');
     });
 
     test('it should return the organization SSO name when organization has an oidc identityProvider', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement l'ordre des données affichées pour une organisation n'est pas la même que lors d'une édition d'organisation.

## :robot: Solution

Ré-ordonner les champs d'édition d'une organisation.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter à Pix admin
- Ouvrir la page de détails d'une organisation SCO ou SUP
- Éditez cette organisation
- Constatez que l'ordre des champs est le suivant :
  1. Nom
  2. Identifiant externe
  3. Département (en 3 chiffres)
  4. Crédits
  5. Lien vers la documentation
  6. Affichage des acquis dans l'export de résultats
  7. SSO
  8. Adresse e-mail d'activation SCO
  9. Gestion d'élèves/étudiants
- Constatez dans la sélection d'un SSO que le terme `Médiacentre` a été remplacé par `GAR`
