### PR TITLE
[BUGFIX] Ne pas afficher la "pop-up connecte toi au GAR" si l'utilisateur est déjà connecté (PIX-5649)

### DIFF
--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -11,7 +11,7 @@ import ENV from 'mon-pix/config/environment';
 
 const SCOPE_MON_PIX = 'mon-pix';
 const ERROR_PASSWORD_MESSAGE = 'pages.update-expired-password.fields.error';
-const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
 const VALIDATION_MAP = {
   default: {
@@ -76,7 +76,7 @@ export default class UpdateExpiredPasswordForm extends Component {
         });
 
         if (this.session.get('data.externalUser')) {
-          this.session.data.authenticated.source = AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+          this.session.data.authenticated.source = AUTHENTICATED_SOURCE_FROM_GAR;
         }
       } catch (errorResponse) {
         const error = get(errorResponse, 'errors[0]');

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -13,7 +13,7 @@ export default class FillInCampaignCodeController extends Controller {
   campaignCode = null;
 
   @tracked errorMessage = null;
-  @tracked showMediacentreStartCampaignModal = false;
+  @tracked showGARModal = false;
   @tracked campaign = null;
 
   get isUserAuthenticated() {
@@ -55,7 +55,7 @@ export default class FillInCampaignCodeController extends Controller {
       const externalUser = this.session.get('data.externalUser');
 
       if (!externalUser && this.campaign.identityProvider === 'GAR') {
-        this.showMediacentreStartCampaignModal = true;
+        this.showGARModal = true;
         return;
       }
 
@@ -88,7 +88,7 @@ export default class FillInCampaignCodeController extends Controller {
 
   @action
   closeModal() {
-    this.showMediacentreStartCampaignModal = false;
+    this.showGARModal = false;
   }
 
   @action

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -2,6 +2,10 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
+const IDENTITY_PROVIDER_ID_GAR = 'GAR';
 
 export default class FillInCampaignCodeController extends Controller {
   @service store;
@@ -52,9 +56,13 @@ export default class FillInCampaignCodeController extends Controller {
       this.campaign = await this.store.queryRecord('campaign', {
         filter: { code: campaignCode },
       });
+      const isGARCampaign = this.campaign.identityProvider === IDENTITY_PROVIDER_ID_GAR;
       const externalUser = this.session.get('data.externalUser');
+      const isUserAlreadyAuthenticatedWithGAR =
+        this.session.get('data.authenticated.source') === AUTHENTICATED_SOURCE_FROM_GAR;
+      const shouldShowGARModal = isGARCampaign && !isUserAlreadyAuthenticatedWithGAR && !externalUser;
 
-      if (!externalUser && this.campaign.identityProvider === 'GAR') {
+      if (shouldShowGARModal) {
         this.showGARModal = true;
         return;
       }

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ENV from 'mon-pix/config/environment';
 
-const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
 export default class LogoutRoute extends Route {
   @service session;
@@ -15,7 +15,7 @@ export default class LogoutRoute extends Route {
     this.campaignStorage.clearAll();
 
     if (this.session.isAuthenticated) {
-      if (this.session.data.authenticated.source === AUTHENTICATED_SOURCE_FROM_MEDIACENTRE) {
+      if (this.session.data.authenticated.source === AUTHENTICATED_SOURCE_FROM_GAR) {
         this.session.alternativeRootURL = '/nonconnecte';
       } else if (this.session.data.authenticated.source !== 'pole_emploi_connect') {
         this.session.alternativeRootURL = null;

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -79,7 +79,7 @@
 <PixModal
   @title={{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.title"}}
   @onCloseButtonClick={{this.closeModal}}
-  @showModal={{this.showMediacentreStartCampaignModal}}
+  @showModal={{this.showGARModal}}
 >
   <:content>
     <p>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -105,7 +105,7 @@ module.exports = function (environment) {
           MESSAGE: 'api-error-messages.internal-server-error',
         },
       },
-      AUTHENTICATED_SOURCE_FROM_MEDIACENTRE: 'external',
+      AUTHENTICATED_SOURCE_FROM_GAR: 'external',
       NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD: _getEnvironmentVariableAsNumber({
         environmentVariableName: 'NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD',
         defaultValue: 48,

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -17,7 +17,7 @@ import ENV from 'mon-pix/config/environment';
 import setupIntl from '../helpers/setup-intl';
 import { t } from 'ember-intl/test-support';
 
-const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
 describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
   setupApplicationTest();
@@ -831,7 +831,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           let garUser;
 
           beforeEach(async function () {
-            garUser = server.create('user', AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
+            garUser = server.create('user', AUTHENTICATED_SOURCE_FROM_GAR);
             await authenticateByGAR(garUser);
             server.create('sco-organization-learner', {
               campaignCode: campaign.code,
@@ -922,7 +922,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
             await click('#submit-connexion');
 
             const session = currentSession();
-            expect(session.data.authenticated.source).to.equal(AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
+            expect(session.data.authenticated.source).to.equal(AUTHENTICATED_SOURCE_FROM_GAR);
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -70,7 +70,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
 
           // then
           sinon.assert.notCalled(controller.router.transitionTo);
-          expect(controller.showMediacentreStartCampaignModal).to.equal(true);
+          expect(controller.showGARModal).to.equal(true);
         });
       });
     });

--- a/mon-pix/tests/unit/routes/logout_test.js
+++ b/mon-pix/tests/unit/routes/logout_test.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 import ENV from 'mon-pix/config/environment';
 import { expect } from 'chai';
 
-const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
 describe('Unit | Route | logout', () => {
   setupTest();
@@ -50,7 +50,7 @@ describe('Unit | Route | logout', () => {
         invalidate: invalidateStub,
         data: {
           authenticated: {
-            source: AUTHENTICATED_SOURCE_FROM_MEDIACENTRE,
+            source: AUTHENTICATED_SOURCE_FROM_GAR,
           },
         },
       });
@@ -101,7 +101,7 @@ describe('Unit | Route | logout', () => {
         invalidate: invalidateStub,
         data: {
           authenticated: {
-            source: AUTHENTICATED_SOURCE_FROM_MEDIACENTRE,
+            source: AUTHENTICATED_SOURCE_FROM_GAR,
           },
         },
       });


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'un utilisateur GAR est connecté sur Pix et que ce dernier clique sur le bouton `J'ai un code` pour débuter un parcours, il aura l'affichage d'une pop-up lui demandant de se connecter à son Médiacentre.

Cette pop-up ne devrait pas s'afficher car l'utilisateur est déjà connecté.

## :robot: Solution

En plus des vérifications déjà présentes, il faut également vérifier que l'utilisateur s'est bien connecté en passant par son Médiacentre via la propriété `source` se trouvant dans les données de sa session.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter via le GAR factice avec un utilisateur faisant partie d'une organisation de type GAR
- Acceptez les CGUs pour créer le compte
- Se déconnecter
- Se connecter de nouveau avec le même compte
- Cliquez sur `J'ai un code`
- Entrez le code campagne `SCOBADGE1`
- Cliquez sur `Accéder au parcours`
- Constatez que la pop-up ne s'affiche pas
- Se déconnecter
- Allez sur la page `/campagnes` de l'application Pix
- Entrez le code campagne `SCOBADGE1`
- Constatez l'affiche de la pop-up
