### PR TITLE
[FEATURE] Cacher l'URL des campagnes pour les orgas qui sont rattachés au SSO GAR(PIX-5235)

### DIFF
--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -2,6 +2,8 @@ const Membership = require('../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
 const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 const { DEFAULT_PASSWORD } = require('./users-builder');
+const OidcIdentityProviders = require('../../../lib/domain/constants/oidc-identity-providers');
+
 const PRO_COMPANY_ID = 1;
 const PRO_POLE_EMPLOI_ID = 4;
 const PRO_CNAV_ID = 17;
@@ -113,7 +115,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     provinceCode: null,
     email: null,
     createdBy: poleEmploiCreator.id,
-    identityProviderForCampaigns: 'POLE_EMPLOI',
+    identityProviderForCampaigns: OidcIdentityProviders.POLE_EMPLOI.code,
   });
   databaseBuilder.factory.buildOrganizationTag({ organizationId: PRO_POLE_EMPLOI_ID, tagId: 4 });
 
@@ -140,7 +142,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     provinceCode: null,
     email: null,
     createdBy: cnavCreator.id,
-    identityProviderForCampaigns: 'CNAV',
+    identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
   });
 
   databaseBuilder.factory.buildMembership({

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,5 +1,6 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const { DEFAULT_PASSWORD } = require('./users-builder');
+const { SamlIdentityProviders } = require('../../../lib/domain/constants/saml-identity-providers');
 const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 
 const SCO_MIDDLE_SCHOOL_ID = 3;
@@ -64,7 +65,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     externalId: SCO_COLLEGE_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
-    identityProviderForCampaigns: 'GAR',
+    identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
 

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -30,6 +30,7 @@ module.exports = {
     NOT_LINKED_ORGANIZATION_MSG:
       "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
   },
+
   PIX_ADMIN: {
     SCOPE: 'pix-admin',
     NOT_ALLOWED_MSG: "Vous n'avez pas les droits pour vous connecter.",

--- a/api/lib/domain/constants/saml-identity-providers.js
+++ b/api/lib/domain/constants/saml-identity-providers.js
@@ -1,0 +1,7 @@
+module.exports = {
+  SamlIdentityProviders: {
+    GAR: {
+      code: 'GAR',
+    },
+  },
+};

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -19,6 +19,7 @@ class Organization {
     externalId,
     provinceCode,
     isManagingStudents,
+    identityProviderForCampaigns,
     credit = defaultValues.credit,
     email,
     targetProfileShares = [],
@@ -37,6 +38,7 @@ class Organization {
     this.logoUrl = logoUrl;
     this.externalId = externalId;
     this.provinceCode = provinceCode;
+    this.identityProviderForCampaigns = identityProviderForCampaigns;
     this.isManagingStudents = isManagingStudents;
     this.credit = credit;
     this.email = email;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -15,6 +15,7 @@ function _toDomain(rawOrganization) {
     externalId: rawOrganization.externalId,
     provinceCode: rawOrganization.provinceCode,
     isManagingStudents: Boolean(rawOrganization.isManagingStudents),
+    identityProviderForCampaigns: rawOrganization.identityProviderForCampaigns,
     credit: rawOrganization.credit,
     email: rawOrganization.email,
     documentationUrl: rawOrganization.documentationUrl,

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -49,6 +49,7 @@ module.exports = {
             'credit',
             'isManagingStudents',
             'isAgriculture',
+            'identityProviderForCampaigns',
             'targetProfiles',
             'memberships',
             'students',

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -3,6 +3,8 @@ const { NotFoundError, MissingAttributesError } = require('../../../../lib/domai
 const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const organizationForAdminRepository = require('../../../../lib/infrastructure/repositories/organization-for-admin-repository');
+const { SamlIdentityProviders } = require('../../../../lib/domain/constants/saml-identity-providers');
+const OidcIdentityProviders = require('../../../../lib/domain/constants/oidc-identity-providers');
 
 describe('Integration | Repository | Organization-for-admin', function () {
   let clock;
@@ -36,7 +38,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         showNPS: true,
         formNPSUrl: 'https://pix.fr/',
         showSkills: false,
-        identityProviderForCampaigns: 'CNAV',
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
       });
 
       await databaseBuilder.commit();
@@ -70,7 +72,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         archivistLastName: null,
         creatorFirstName: 'Cécile',
         creatorLastName: 'Encieux',
-        identityProviderForCampaigns: 'CNAV',
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
       });
       expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
     });
@@ -203,7 +205,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
         archivedAt: null,
-        identityProviderForCampaigns: 'GAR',
+        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
       });
       const organizationSaved = await organizationForAdminRepository.update(organizationToUpdate);
 
@@ -230,7 +232,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         archivistLastName: undefined,
         creatorFirstName: undefined,
         creatorLastName: undefined,
-        identityProviderForCampaigns: 'GAR',
+        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
         tags: [{ id: tagId, name: 'orga tag' }],
       });
       expect(organizationSaved.tags[0].id).to.be.equal(tagId);

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -1,8 +1,9 @@
+const _ = require('lodash');
 const { catchErr, expect, knex, domainBuilder, databaseBuilder } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const Organization = require('../../../../lib/domain/models/Organization');
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
-const _ = require('lodash');
+const { SamlIdentityProviders } = require('../../../../lib/domain/constants/saml-identity-providers');
 
 describe('Integration | Repository | Organization', function () {
   describe('#create', function () {
@@ -81,6 +82,7 @@ describe('Integration | Repository | Organization', function () {
         logoUrl: 'http://new.logo.url',
         externalId: '999Z527F',
         provinceCode: '999',
+        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
         isManagingStudents: true,
         credit: 50,
         email: 'email@example.net',
@@ -107,6 +109,7 @@ describe('Integration | Repository | Organization', function () {
         externalId: '999Z527F',
         provinceCode: '999',
         isManagingStudents: true,
+        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
         credit: 50,
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
@@ -139,7 +142,7 @@ describe('Integration | Repository | Organization', function () {
 
   describe('#get', function () {
     describe('success management', function () {
-      it('should return a organization by provided id', async function () {
+      it('should return an organization by provided id', async function () {
         // given
         const superAdminUserId = databaseBuilder.factory.buildUser().id;
 
@@ -150,6 +153,7 @@ describe('Integration | Repository | Organization', function () {
           credit: 154,
           externalId: '100',
           provinceCode: '75',
+          identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
           isManagingStudents: 'true',
           email: 'sco.generic.account@example.net',
           documentationUrl: 'https://pix.fr/',
@@ -158,6 +162,7 @@ describe('Integration | Repository | Organization', function () {
           formNPSUrl: 'https://pix.fr/',
           showSkills: false,
         });
+
         const tag = databaseBuilder.factory.buildTag({ name: 'SUPER-TAG' });
         databaseBuilder.factory.buildTag({ name: 'OTHER-TAG' });
         databaseBuilder.factory.buildOrganizationTag({ organizationId: insertedOrganization.id, tagId: tag.id });
@@ -180,6 +185,7 @@ describe('Integration | Repository | Organization', function () {
           email: 'sco.generic.account@example.net',
           targetProfileShares: [],
           organizationInvitations: [],
+          identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
           tags: [{ id: tag.id, name: 'SUPER-TAG' }],
           documentationUrl: 'https://pix.fr/',
           createdBy: insertedOrganization.createdBy,

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -41,6 +41,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', fun
           'targetProfileShares',
           'tags',
           'createdBy',
+          'identityProviderForCampaigns',
         ])
       ).to.deep.equal(expectedOrganization);
     });

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -4,6 +4,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 const Tag = require('../../../../lib/domain/models/Tag');
 const OrganizationTag = require('../../../../lib/domain/models/OrganizationTag');
 const OrganizationForAdmin = require('../../../../lib/domain/models/OrganizationForAdmin');
+const OidcIdentityProviders = require('../../../../lib/domain/constants/oidc-identity-providers');
 
 describe('Unit | UseCase | update-organization-information', function () {
   let organizationForAdminRepository;
@@ -33,7 +34,7 @@ describe('Unit | UseCase | update-organization-information', function () {
       const givenOrganization = _buildOrganizationWithNullAttributes({
         id: organizationId,
         name: newName,
-        identityProviderForCampaigns: 'super-idp',
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
       });
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
@@ -46,7 +47,7 @@ describe('Unit | UseCase | update-organization-information', function () {
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
         ...originalOrganization,
         name: newName,
-        identityProviderForCampaigns: 'super-idp',
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -3,6 +3,7 @@ const serializer = require('../../../../../lib/infrastructure/serializers/jsonap
 const Organization = require('../../../../../lib/domain/models/Organization');
 const OrganizationForAdmin = require('../../../../../lib/domain/models/OrganizationForAdmin');
 const Tag = require('../../../../../lib/domain/models/Tag');
+const { SamlIdentityProviders } = require('../../../../../lib/domain/constants/saml-identity-providers');
 
 describe('Unit | Serializer | organization-for-admin-serializer', function () {
   describe('#serialize', function () {
@@ -19,7 +20,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         documentationUrl: 'https://pix.fr/',
         archivistFirstName: 'John',
         archivistLastName: 'Doe',
-        identityProviderForCampaigns: 'super-idp',
+        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
       });
       const meta = { some: 'meta' };
 
@@ -49,7 +50,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'archived-at': organization.archivedAt,
             'archivist-full-name': organization.archivistFullName,
             'creator-full-name': organization.creatorFullName,
-            'identity-provider-for-campaigns': 'super-idp',
+            'identity-provider-for-campaigns': SamlIdentityProviders.GAR.code,
           },
           relationships: {
             memberships: {
@@ -121,7 +122,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         createdBy: 10,
         documentationUrl: 'https://pix.fr/',
         showSkills: false,
-        identityProviderForCampaigns: 'external-OIDC',
+        identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
       };
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -2,6 +2,7 @@ const { expect, domainBuilder } = require('../../../../test-helper');
 
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/prescriber-serializer');
 const Membership = require('../../../../../lib/domain/models/Membership');
+const { SamlIdentityProviders } = require('../../../../../lib/domain/constants/saml-identity-providers');
 
 describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
   describe('#serialize', function () {
@@ -91,6 +92,41 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', function () {
           organization,
           serializedField: 'is-agriculture',
           field: 'isAgriculture',
+        });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when organization has an identity provider for campaigns', function () {
+      it('should serialize prescriber with identityProviderForCampaigns', function () {
+        // given
+        const organization = domainBuilder.buildOrganization({
+          identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        });
+        const membership = domainBuilder.buildMembership({ organization });
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({
+          prescriber,
+          membership,
+          userOrgaSettings,
+          organization,
+          serializedField: 'identity-provider-for-campaigns',
+          field: 'identityProviderForCampaigns',
         });
 
         // when

--- a/orga/app/components/campaign/settings/view.hbs
+++ b/orga/app/components/campaign/settings/view.hbs
@@ -54,17 +54,19 @@
           <dd class="content-text campaign-settings-content__text">{{@campaign.idPixLabel}}</dd>
         </div>
       {{/if}}
-      <div class="campaign-settings-content">
-        <dt class="label-text campaign-settings-content__label">{{t "pages.campaign-settings.direct-link"}}</dt>
-        <dd class="campaign-settings-content__clipboard">
-          <span class="content-text campaign-settings-content__text">{{this.campaignsRootUrl}}</span>
-          <Campaign::CopyPasteButton
-            @clipBoardtext={{this.campaignsRootUrl}}
-            @successMessage={{t "pages.campaign.copy.link.success"}}
-            @defaultMessage={{t "pages.campaign.copy.link.default"}}
-          />
-        </dd>
-      </div>
+      {{#if this.displayCampaignsRootUrl}}
+        <div class="campaign-settings-content">
+          <dt class="label-text campaign-settings-content__label">{{t "pages.campaign-settings.direct-link"}}</dt>
+          <dd class="campaign-settings-content__clipboard">
+            <span class="content-text campaign-settings-content__text">{{this.campaignsRootUrl}}</span>
+            <Campaign::CopyPasteButton
+              @clipBoardtext={{this.campaignsRootUrl}}
+              @successMessage={{t "pages.campaign.copy.link.success"}}
+              @defaultMessage={{t "pages.campaign.copy.link.default"}}
+            />
+          </dd>
+        </div>
+      {{/if}}
     </div>
     {{#if @campaign.isTypeAssessment}}
       <div class="campaign-settings-row">

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -19,6 +19,10 @@ export default class CampaignView extends Component {
     return campaignIsNotArchived && isCurrentUserAllowedToUpdateCampaign;
   }
 
+  get displayCampaignsRootUrl() {
+    return !this.currentUser.prescriber.hasCurrentOrganizationWithGARAsIdentityProvider;
+  }
+
   get campaignsRootUrl() {
     return `${this.url.campaignsRootUrl}${this.args.campaign.code}`;
   }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -8,6 +8,7 @@ export default class Organization extends Model {
   @attr('boolean') isManagingStudents;
   @attr('boolean') isAgriculture;
   @attr('string') documentationUrl;
+  @attr('string') identityProviderForCampaigns;
 
   @hasMany('campaign') campaigns;
   @hasMany('target-profile') targetProfiles;

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -14,6 +14,10 @@ export default class Prescriber extends Model {
     return `${this.firstName} ${this.lastName}`;
   }
 
+  get hasCurrentOrganizationWithGARAsIdentityProvider() {
+    return this.userOrgaSettings.get('organization').get('identityProviderForCampaigns') === 'GAR';
+  }
+
   get isAdminOfTheCurrentOrganization() {
     const memberships = this.memberships.toArray();
     return memberships.some(

--- a/orga/tests/unit/models/prescriber_test.js
+++ b/orga/tests/unit/models/prescriber_test.js
@@ -5,11 +5,44 @@ import { run } from '@ember/runloop';
 module('Unit | Model | prescriber', function (hooks) {
   setupTest(hooks);
 
+  module('#hasCurrentOrganizationWithGARAsIdentityProvider', function () {
+    test('it should return false if the current organization has not GAR as identity provider', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = run(() => store.createRecord('organization', { name: 'Willow school' }));
+      const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization }));
+      const membership = run(() => store.createRecord('membership', { organizationRole: 'MEMBER', organization }));
+      const memberships = [membership];
+      const model = run(() => store.createRecord('prescriber', { memberships, userOrgaSettings }));
+
+      // when / then
+      assert.false(model.hasCurrentOrganizationWithGARAsIdentityProvider);
+    });
+
+    test('it should return true if the current organization has GAR as identity provider', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const organization = run(() =>
+        store.createRecord('organization', {
+          name: 'Willow school',
+          identityProviderForCampaigns: 'GAR',
+        })
+      );
+      const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization }));
+      const membership = run(() => store.createRecord('membership', { organizationRole: 'MEMBER', organization }));
+      const memberships = [membership];
+      const model = run(() => store.createRecord('prescriber', { memberships, userOrgaSettings }));
+
+      // when / then
+      assert.true(model.hasCurrentOrganizationWithGARAsIdentityProvider);
+    });
+  });
+
   module('#isAdminOfTheCurrentOrganization', function () {
     test('it should return true if prescriber is ADMIN of the current organization', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const organization = store.createRecord('organization', { name: 'Willow school' });
+      const organization = run(() => store.createRecord('organization', { name: 'Willow school' }));
       const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization }));
       const membership = run(() => store.createRecord('membership', { organizationRole: 'ADMIN', organization }));
       const memberships = [membership];
@@ -22,7 +55,7 @@ module('Unit | Model | prescriber', function (hooks) {
     test('it should return false if prescriber is MEMBER of the current organization', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const organization = store.createRecord('organization', { name: 'Willow school' });
+      const organization = run(() => store.createRecord('organization', { name: 'Willow school' }));
       const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization }));
       const membership = run(() => store.createRecord('membership', { organizationRole: 'MEMBER', organization }));
       const memberships = [membership];
@@ -35,8 +68,8 @@ module('Unit | Model | prescriber', function (hooks) {
     test('it should return false if prescriber is MEMBER of the current organization and ADMIN in another', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const currentOrganization = store.createRecord('organization', { id: 7, name: 'Willow school' });
-      const otherOrganization = store.createRecord('organization', { id: 123, name: 'Tanglewood school' });
+      const currentOrganization = run(() => store.createRecord('organization', { id: 7, name: 'Willow school' }));
+      const otherOrganization = run(() => store.createRecord('organization', { id: 123, name: 'Tanglewood school' }));
       const userOrgaSettings = run(() => store.createRecord('userOrgaSetting', { organization: currentOrganization }));
       const membership = run(() =>
         store.createRecord('membership', { organizationRole: 'MEMBER', currentOrganization })


### PR DESCRIPTION
## :unicorn: Problème
L'URL d'accès direct aux campagnes est disponible dans Pix Orga. Il se peut que les enseignants donnent cette URL direct aux élèves.
MAIS, dans les établissements où le GAR est mis en place, si les élèves accèdent aux campagnes via cette URL direct, ils vont potentiellement oublier de se connecter en amont à Pix via leur ENT. Et le risque c'est qu'ils se créent donc un compte avec adresse email ou identifiant. Chose qu'on ne veut pas. 
Le GAR a justement été mis en place pour éviter cela.
Pour réduire le risque d'erreur, nous allons donc cacher cette URL de Pix Orga pour éviter que les enseignants ne le partagent.


## :robot: Solution
Récupérer  identityProviderForCampaigns de l'organization à laquelle est rattachée l'organisation de la campagne, si c'est le 'GAR' alors le lien de la campagne n'est pas affiché

## :rainbow: Remarques
Vue avec la team prescription pour ne pas ajouter identityProviderForCampaigns au modèle Campaign

## :100: Pour tester

- Se connecter sur orga (ex avec sco.admin@example.net), vous arrivez sur la page qui liste les campagnes du collège "The Night Watch"
- Aller sur le détail de la  campagne en cliquant sur son nom **Sco - Collège - Campagne d’évaluation Badges** et cliquer sur l'onglet Paramètres
- observer que le lien vers l'url de la campagne ne s'affiche pas 
- choisir une autre organisation, ex 'Lycée Agricole'
- Aller sur le détail de la  campagne en cliquant sur son nom **Sco - Agriculture - Campagne d’évaluation Badges**  et cliquer sur l'onglet Paramètres
- observer que le lien vers l'url de la campagne s'affiche http://localhost:4200/campagnes/SCOBADGE3
