### PR TITLE
[FEATURE] Ajouter un titre invisible pour les domaines dans l'affichage des compétences (PIX-5608).

### DIFF
--- a/mon-pix/app/components/profile-content.hbs
+++ b/mon-pix/app/components/profile-content.hbs
@@ -21,7 +21,7 @@
     {{#if @model.profile.scorecards}}
       <ProfileScorecards
         @interactive={{true}}
-        @areasCode={{@model.profile.areasCode}}
+        @areas={{@model.profile.areas}}
         @scorecards={{@model.profile.scorecards}}
       />
     {{else}}

--- a/mon-pix/app/components/profile-scorecards.hbs
+++ b/mon-pix/app/components/profile-scorecards.hbs
@@ -2,6 +2,7 @@
   <h2 class="sr-only">{{t "pages.profile.accessibility.user-skills"}}</h2>
   <div>
     {{#each @areas as |area|}}
+      <h3 class="sr-only">{{area.title}}</h3>
       <div class="rounded-panel-body__areas">
         {{#each @scorecards as |scorecard|}}
           {{#if (eq area.code scorecard.area.code)}}

--- a/mon-pix/app/components/profile-scorecards.hbs
+++ b/mon-pix/app/components/profile-scorecards.hbs
@@ -1,10 +1,10 @@
 <div class="rounded-panel-body">
   <h2 class="sr-only">{{t "pages.profile.accessibility.user-skills"}}</h2>
   <div>
-    {{#each @areasCode as |areaCode|}}
+    {{#each @areas as |area|}}
       <div class="rounded-panel-body__areas">
         {{#each @scorecards as |scorecard|}}
-          {{#if (eq areaCode scorecard.area.code)}}
+          {{#if (eq area.code scorecard.area.code)}}
             <div class="rounded-panel-body__competence-card">
               <CompetenceCard @interactive={{@interactive}} @scorecard={{scorecard}} />
             </div>

--- a/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
@@ -18,7 +18,7 @@
       <ProfileScorecards
         @interactive={{false}}
         class="send-profile-header__profile__cards"
-        @areasCode={{@user.profile.areasCode}}
+        @areas={{@user.profile.areas}}
         @scorecards={{@user.profile.scorecards}}
       />
     </div>
@@ -44,7 +44,7 @@
       <ProfileScorecards
         @interactive={{false}}
         class="send-profile-header__profile__cards"
-        @areasCode={{@user.profile.areasCode}}
+        @areas={{@user.profile.areas}}
         @scorecards={{@user.profile.scorecards}}
       />
     </div>

--- a/mon-pix/app/models/profile.js
+++ b/mon-pix/app/models/profile.js
@@ -5,7 +5,7 @@ export default class Profile extends Model {
 
   @hasMany('scorecard') scorecards;
 
-  get areasCode() {
-    return this.scorecards.mapBy('area.code').uniq();
+  get areas() {
+    return this.scorecards.mapBy('area').uniqBy('code');
   }
 }

--- a/mon-pix/app/models/shared-profile-for-campaign.js
+++ b/mon-pix/app/models/shared-profile-for-campaign.js
@@ -10,7 +10,7 @@ export default class SharedProfileForCampaign extends Model {
   @hasMany('scorecard') scorecards;
 
   @computed('scorecards.@each.area')
-  get areasCode() {
-    return this.scorecards.mapBy('area.code').uniq();
+  get areas() {
+    return this.scorecards.mapBy('area').uniqBy('code');
   }
 }

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -45,7 +45,7 @@
         <ProfileScorecards
           class="send-profile-header__profile__cards"
           @interactive={{false}}
-          @areasCode={{this.model.sharedProfile.areasCode}}
+          @areas={{this.model.sharedProfile.areas}}
           @scorecards={{this.model.sharedProfile.scorecards}}
         />
       </div>

--- a/mon-pix/tests/acceptance/competence-profile_test.js
+++ b/mon-pix/tests/acceptance/competence-profile_test.js
@@ -34,7 +34,7 @@ describe('Acceptance | Profile | Start competence', function () {
       await visit('/competences');
       await setBreakpoint('tablet');
       await click(
-        `.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__button`
+        `.rounded-panel-body__areas:nth-of-type(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-of-type(${competenceNumber}) .competence-card__button`
       );
 
       // then

--- a/mon-pix/tests/acceptance/profile_test.js
+++ b/mon-pix/tests/acceptance/profile_test.js
@@ -47,17 +47,17 @@ describe('Acceptance | Profile', function () {
         const competenceNumber = splitIndex[splitIndex.length - 1];
         expect(
           find(
-            `.rounded-panel-body__areas:nth-child(${scorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__area-name`
+            `.rounded-panel-body__areas:nth-of-type(${scorecard.area.code}) .rounded-panel-body__competence-card:nth-of-type(${competenceNumber}) .competence-card__area-name`
           ).textContent
         ).to.equal(scorecard.area.title);
         expect(
           find(
-            `.rounded-panel-body__areas:nth-child(${scorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__competence-name`
+            `.rounded-panel-body__areas:nth-of-type(${scorecard.area.code}) .rounded-panel-body__competence-card:nth-of-type(${competenceNumber}) .competence-card__competence-name`
           ).textContent
         ).to.equal(scorecard.name);
         expect(
           find(
-            `.rounded-panel-body__areas:nth-child(${scorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .score-value`
+            `.rounded-panel-body__areas:nth-of-type(${scorecard.area.code}) .rounded-panel-body__competence-card:nth-of-type(${competenceNumber}) .score-value`
           ).textContent
         ).to.equal(scorecard.level > 0 ? scorecard.level.toString() : scorecard.status === 'NOT_STARTED' ? '' : '–');
       });
@@ -69,7 +69,7 @@ describe('Acceptance | Profile', function () {
 
       // when
       await click(
-        '.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .competence-card__link'
+        '.rounded-panel-body__areas:nth-of-type(1) .rounded-panel-body__competence-card:first-child .competence-card__link'
       );
 
       // then

--- a/mon-pix/tests/integration/components/profile-content_test.js
+++ b/mon-pix/tests/integration/components/profile-content_test.js
@@ -30,7 +30,7 @@ describe('Integration | Component | Profile-content', function () {
       model = {
         profile: {
           pixScore: '34',
-          areasCode: [0, 1],
+          areas: [{ code: 0 }, { code: 1 }],
           scorecards: [
             {
               id: 1,

--- a/mon-pix/tests/unit/models/profile_test.js
+++ b/mon-pix/tests/unit/models/profile_test.js
@@ -17,7 +17,7 @@ describe('Unit | Model | Profile model', function () {
     expect(model).to.be.ok;
   });
 
-  describe('@areasCode', () => {
+  describe('@areas', () => {
     it('should return an array of unique areas code', function () {
       return run(() => {
         // given
@@ -32,10 +32,10 @@ describe('Unit | Model | Profile model', function () {
         model.scorecards = [scorecard1, scorecard2, scorecard3];
 
         // when
-        const areasCode = model.areasCode;
+        const areas = model.areas;
 
         // then
-        expect(areasCode).to.deep.equal([1, 2]);
+        expect(areas.map((area) => area.get('code'))).to.deep.equal([1, 2]);
       });
     });
   });

--- a/mon-pix/tests/unit/models/shared-profile-for-campaign_test.js
+++ b/mon-pix/tests/unit/models/shared-profile-for-campaign_test.js
@@ -11,7 +11,7 @@ describe('Unit | Model | SharedProfileForCampaign model', function () {
     store = this.owner.lookup('service:store');
   });
 
-  it('should return an array of unique areas code', function () {
+  it('should return an array of unique areas', function () {
     // given
     const area1 = store.createRecord('area', { code: 1 });
     const area2 = store.createRecord('area', { code: 2 });
@@ -24,9 +24,9 @@ describe('Unit | Model | SharedProfileForCampaign model', function () {
     model.scorecards = [scorecard1, scorecard2, scorecard3];
 
     // when
-    const areasCode = model.areasCode;
+    const areas = model.areas;
 
     // then
-    expect(areasCode).to.deep.equal([1, 2]);
+    expect(areas.map((area) => area.get('code'))).to.deep.equal([1, 2]);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, les compétences sont présentées par domaine, mais il n'est pas facile de naviguer entre ces derniers avec un lecteur d'écran.

## :robot: Solution
Ajouter le titre du domaine dans une balise `<h3>` en `sr-only`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App
- Se rendre sur la page `/competences`
- Vérifier dans le dom qu'un titre est bien présent avec le nom du domaine
