### PR TITLE
[FEATURE] Ajouter un champ de recherche par nom ou prénom à la liste des candidats dans l'espace surveillant (PIX-5452)

### DIFF
--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -4,6 +4,7 @@
       <h1 class="session-supervising-candidate-list__title">Candidats</h1>
       <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test
         pour l'autoriser à commencer son test de certification.</span>
+      <PixInput @id="search-candidate" @ariaLabel="Rechercher un candidat" placeholder="Rechercher un candidat" />
       <ul class="session-supervising-candidate-list__candidates">
         {{#each @candidates as |candidate|}}
           <SessionSupervising::CandidateInList

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -4,12 +4,16 @@
       <h1 class="session-supervising-candidate-list__title">Candidats</h1>
       <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test
         pour l'autoriser à commencer son test de certification.</span>
-      <PixInput
-        @id="search-candidate"
-        @ariaLabel="Rechercher un candidat"
-        placeholder="Rechercher un candidat"
-        {{on "input" this.setFilter}}
-      />
+      <div class="session-supervising-candidate-list__search">
+        <FaIcon @icon="search" class="search-icon" />
+        <PixInput
+          class="search-input"
+          @id="search-candidate"
+          @ariaLabel="Rechercher un candidat"
+          placeholder="Rechercher un candidat"
+          {{on "input" this.setFilter}}
+        />
+      </div>
       <p class="session-supervising-candidate-list__description">{{t
           "pages.session-supervising.candidate-list.authorized-to-start-candidates"
           authorizedToStartCandidates=this.authorizedToStartCandidates

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -11,8 +11,19 @@
           @id="search-candidate"
           @ariaLabel="Rechercher un candidat"
           placeholder="Rechercher un candidat"
+          @value={{this.filter}}
           {{on "input" this.setFilter}}
         />
+        <PixButton
+          @size="small"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{false}}
+          @triggerAction={{this.emptySearchInput}}
+          aria-label="Vider le champ"
+          class="empty-button"
+        >
+          <FaIcon @icon="times" />
+        </PixButton>
       </div>
       <p class="session-supervising-candidate-list__description">{{t
           "pages.session-supervising.candidate-list.authorized-to-start-candidates"

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -2,8 +2,8 @@
   {{#if @candidates}}
     <div class="session-supervising-candidate-list">
       <h1 class="session-supervising-candidate-list__title">Candidats</h1>
-      <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test
-        pour l'autoriser à commencer son test de certification.</span>
+      <p class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test
+        pour l'autoriser à commencer son test de certification.</p>
       <div class="session-supervising-candidate-list__search">
         <FaIcon @icon="search" class="search-icon" />
         <PixInput
@@ -25,7 +25,7 @@
           <FaIcon @icon="times" />
         </PixButton>
       </div>
-      <p class="session-supervising-candidate-list__description">{{t
+      <p class="session-supervising-candidate-list__candidates-count">{{t
           "pages.session-supervising.candidate-list.authorized-to-start-candidates"
           authorizedToStartCandidates=this.authorizedToStartCandidates
           totalCandidates=@candidates.length

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -4,9 +4,14 @@
       <h1 class="session-supervising-candidate-list__title">Candidats</h1>
       <span class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test
         pour l'autoriser à commencer son test de certification.</span>
-      <PixInput @id="search-candidate" @ariaLabel="Rechercher un candidat" placeholder="Rechercher un candidat" />
+      <PixInput
+        @id="search-candidate"
+        @ariaLabel="Rechercher un candidat"
+        placeholder="Rechercher un candidat"
+        {{on "input" this.setFilter}}
+      />
       <ul class="session-supervising-candidate-list__candidates">
-        {{#each @candidates as |candidate|}}
+        {{#each this.filteredCandidates as |candidate|}}
           <SessionSupervising::CandidateInList
             @candidate={{candidate}}
             @toggleCandidate={{this.toggleCandidate}}

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -10,6 +10,11 @@
         placeholder="Rechercher un candidat"
         {{on "input" this.setFilter}}
       />
+      <p class="session-supervising-candidate-list__description">{{t
+          "pages.session-supervising.candidate-list.authorized-to-start-candidates"
+          authorizedToStartCandidates=this.authorizedToStartCandidates
+          totalCandidates=@candidates.length
+        }}</p>
       <ul class="session-supervising-candidate-list__candidates">
         {{#each this.filteredCandidates as |candidate|}}
           <SessionSupervising::CandidateInList

--- a/certif/app/components/session-supervising/candidate-list.js
+++ b/certif/app/components/session-supervising/candidate-list.js
@@ -25,6 +25,13 @@ export default class CandidateList extends Component {
     this.filter = event.target.value;
   }
 
+  get authorizedToStartCandidates() {
+    return this.args.candidates.reduce((authorizedToStartCandidates, candidate) => {
+      if (candidate.authorizedToStart == true) return authorizedToStartCandidates + 1;
+      return authorizedToStartCandidates;
+    }, 0);
+  }
+
   get filteredCandidates() {
     return this.args.candidates.filter(
       (candidate) =>

--- a/certif/app/components/session-supervising/candidate-list.js
+++ b/certif/app/components/session-supervising/candidate-list.js
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class CandidateList extends Component {
+  @tracked filter = '';
+
   @action
   async toggleCandidate(candidate) {
     await this.args.toggleCandidate(candidate);
@@ -15,5 +18,18 @@ export default class CandidateList extends Component {
   @action
   async endAssessmentBySupervisor(candidate) {
     await this.args.endAssessmentBySupervisor(candidate);
+  }
+
+  @action
+  setFilter(event) {
+    this.filter = event.target.value;
+  }
+
+  get filteredCandidates() {
+    return this.args.candidates.filter(
+      (candidate) =>
+        candidate.firstName.toLowerCase().indexOf(this.filter.toLowerCase()) === 0 ||
+        candidate.lastName.toLowerCase().indexOf(this.filter.toLowerCase()) === 0
+    );
   }
 }

--- a/certif/app/components/session-supervising/candidate-list.js
+++ b/certif/app/components/session-supervising/candidate-list.js
@@ -25,6 +25,11 @@ export default class CandidateList extends Component {
     this.filter = event.target.value;
   }
 
+  @action
+  emptySearchInput() {
+    this.filter = '';
+  }
+
   get authorizedToStartCandidates() {
     return this.args.candidates.reduce((authorizedToStartCandidates, candidate) => {
       if (candidate.authorizedToStart == true) return authorizedToStartCandidates + 1;

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -2,7 +2,7 @@
   background: $pix-neutral-100;
   border-radius: 18px 18px 0 0;
   flex-grow: 1;
-  padding: 24px 8px;
+  padding: 32px 16px;
 
   .session-supervising-candidate-list {
     @include device-is("tablet") {
@@ -19,21 +19,19 @@
       display: flex;
       justify-content: flex-start;
       color: $pix-neutral-15;
-      font-size: 12px;
+      font-size: 0.875rem;
       font-weight: normal;
-      height: 14px;
+      min-height: 14px;
       letter-spacing: 0;
-      padding: 0 8px;
-      margin-bottom: 2rem;
+      margin: 0 0 24px;
     }
 
     &__title {
       font-weight: 600;
-      margin-top: 0;
+      margin: 0 0 8px;
       font-family: $font-open-sans;
       color: $pix-neutral-15;
-      font-size: 1.125rem;
-      padding: 0 8px;
+      font-size: 1.25rem;
     }
 
     &__candidates {
@@ -77,6 +75,17 @@
       width: 100%;
     }
 
+    &__candidates-count {
+      display: flex;
+      justify-content: flex-start;
+      color: $pix-neutral-15;
+      font-size: 0.875rem;
+      font-weight: normal;
+      height: 14px;
+      letter-spacing: 0;
+      margin: 16px 0 24px;
+    }
+
     .search-icon {
       color: $pix-neutral-30;
     }
@@ -98,11 +107,6 @@
 
     .pix-input {
       flex: 1;
-    }
-
-    .empty-button {
-      margin-left: auto;
-      margin-right: 4px;
     }
   }
 }

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -99,5 +99,10 @@
     .pix-input {
       flex: 1;
     }
+
+    .empty-button {
+      margin-left: auto;
+      margin-right: 4px;
+    }
   }
 }

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -63,5 +63,41 @@
       max-width: 225px;
       text-align: center;
     }
+
+    &__search {
+      align-items: center;
+      background-color: white;
+      border: 1px solid #7A869A;
+      border-radius: 4px;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: row;
+      height: 44px;
+      padding-left: 15px;
+      width: 100%;
+    }
+
+    .search-icon {
+      color: $pix-neutral-30;
+    }
+
+    .search-input {
+      border: none;
+      box-shadow: none;
+      color: $pix-neutral-90;
+      font-family: $font-roboto;
+      font-size: 1rem;
+      padding: 0 10px;
+      width: 100%;
+    }
+
+    .empty-button {
+      margin-left: auto;
+      margin-right: 4px;
+    }
+
+    .pix-input {
+      flex: 1;
+    }
   }
 }

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | SessionSupervising::CandidateList', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 
@@ -114,6 +114,58 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
         assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
         assert.dom(screen.getByText('Rocket Gammvert')).exists();
         assert.dom(screen.queryByText('Lord Star')).doesNotExist();
+      });
+    });
+
+    module('when some candidates are authorized to start', function () {
+      test('it renders the number of authorized to start candidates', async function (assert) {
+        // given
+        this.certificationCandidates = [
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 123,
+            firstName: 'Gamora',
+            lastName: 'Zen Whoberi Ben Titan',
+            birthdate: '1984-05-28',
+            extraTimePercentage: '8',
+            authorizedToStart: true,
+            assessmentStatus: null,
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 456,
+            firstName: 'Star',
+            lastName: 'Lord',
+            birthdate: '1983-06-28',
+            extraTimePercentage: '12',
+            authorizedToStart: true,
+            assessmentStatus: null,
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 789,
+            firstName: 'Gammvert',
+            lastName: 'Rocket',
+            birthdate: '1982-06-06',
+            extraTimePercentage: '12',
+            authorizedToStart: false,
+            assessmentStatus: null,
+          }),
+        ];
+
+        // when
+        const screen = await renderScreen(
+          hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}}  />`
+        );
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              this.intl.t('pages.session-supervising.candidate-list.authorized-to-start-candidates', {
+                authorizedToStartCandidates: 2,
+                totalCandidates: this.certificationCandidates.length,
+              })
+            )
+          )
+          .exists();
       });
     });
   });

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { fillIn } from '@ember/test-helpers';
+import { fillIn, click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import hbs from 'htmlbars-inline-precompile';
@@ -114,6 +114,34 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
         assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
         assert.dom(screen.getByText('Rocket Gammvert')).exists();
         assert.dom(screen.queryByText('Lord Star')).doesNotExist();
+      });
+
+      module('when the empty input button is clicked', function () {
+        test('it empties the input field', async function (assert) {
+          // given
+          this.certificationCandidates = [
+            store.createRecord('certification-candidate-for-supervising', {
+              id: 123,
+              firstName: 'Gamora',
+              lastName: 'Zen Whoberi Ben Titan',
+              birthdate: '1984-05-28',
+              extraTimePercentage: '8',
+              authorizedToStart: true,
+              assessmentStatus: null,
+            }),
+          ];
+          const screen = await renderScreen(
+            hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}}  />`
+          );
+          await fillIn(screen.getByRole('textbox', { name: 'Rechercher un candidat' }), 'Champs rempli');
+
+          // when
+          await click(screen.getByRole('button', { name: 'Vider le champ' }));
+
+          // then
+          assert.dom(screen.queryByRole('Champ rempli')).doesNotExist();
+          assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
+        });
       });
     });
 

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -46,13 +46,33 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
       assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
       assert.dom(screen.getByText('Lord Star')).exists();
     });
+
+    test('it renders a search input', async function (assert) {
+      // given
+      this.certificationCandidates = [
+        store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          firstName: 'Gamora',
+          lastName: 'Zen Whoberi Ben Titan',
+          birthdate: '1984-05-28',
+          extraTimePercentage: '8',
+          authorizedToStart: true,
+          assessmentStatus: null,
+        }),
+      ];
+
+      // when
+      const screen = await renderScreen(
+        hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}}  />`
+      );
+
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Rechercher un candidat' })).exists();
+    });
   });
 
   module('when there is no candidate', function () {
     test('it renders a message', async function (assert) {
-      // given
-      this.certificationCandidates = [];
-
       // when
       const screen = await renderScreen(
         hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}} />`
@@ -60,6 +80,19 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
 
       // then
       assert.dom(screen.getByText('Aucun candidat inscrit à cette session')).exists();
+    });
+
+    test('it does not render a search input', async function (assert) {
+      // given
+      this.certificationCandidates = [];
+
+      // when
+      const screen = await renderScreen(
+        hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}}  />`
+      );
+
+      // then
+      assert.dom(screen.queryByRole('textbox', { name: 'Rechercher un candidat' })).doesNotExist();
     });
   });
 });

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -16,64 +16,50 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
   module('when there are candidates', function () {
     test('it renders the candidates information', async function (assert) {
       // given
-      this.sessionForSupervising = store.createRecord('session-for-supervising', {
-        certificationCandidates: [
-          store.createRecord('certification-candidate-for-supervising', {
-            id: 123,
-            firstName: 'Gamora',
-            lastName: 'Zen Whoberi Ben Titan',
-            birthdate: '1984-05-28',
-            extraTimePercentage: '8',
-            authorizedToStart: true,
-            assessmentStatus: null,
-          }),
-          store.createRecord('certification-candidate-for-supervising', {
-            id: 456,
-            firstName: 'Star',
-            lastName: 'Lord',
-            birthdate: '1983-06-28',
-            extraTimePercentage: '12',
-            authorizedToStart: false,
-            assessmentStatus: null,
-          }),
-          store.createRecord('certification-candidate-for-supervising', {
-            id: 789,
-            firstName: 'Rocket',
-            lastName: 'Racoon',
-            birthdate: '1982-07-28',
-            extraTimePercentage: null,
-            authorizedToStart: true,
-            assessmentStatus: 'started',
-          }),
-        ],
-      });
+      this.certificationCandidates = [
+        store.createRecord('certification-candidate-for-supervising', {
+          id: 123,
+          firstName: 'Gamora',
+          lastName: 'Zen Whoberi Ben Titan',
+          birthdate: '1984-05-28',
+          extraTimePercentage: '8',
+          authorizedToStart: true,
+          assessmentStatus: null,
+        }),
+        store.createRecord('certification-candidate-for-supervising', {
+          id: 456,
+          firstName: 'Star',
+          lastName: 'Lord',
+          birthdate: '1983-06-28',
+          extraTimePercentage: '12',
+          authorizedToStart: false,
+          assessmentStatus: null,
+        }),
+      ];
 
       // when
       const screen = await renderScreen(
-        hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}}  />`
+        hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}}  />`
       );
 
       // then
       assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
       assert.dom(screen.getByText('Lord Star')).exists();
-      assert.dom(screen.getByText('Racoon Rocket')).exists();
     });
+  });
 
-    module('when there is no candidate', function () {
-      test('it renders a message', async function (assert) {
-        // given
-        this.sessionForSupervising = store.createRecord('session-for-supervising', {
-          certificationCandidates: [],
-        });
+  module('when there is no candidate', function () {
+    test('it renders a message', async function (assert) {
+      // given
+      this.certificationCandidates = [];
 
-        // when
-        const screen = await renderScreen(
-          hbs`<SessionSupervising::CandidateList @candidates={{this.sessionForSupervising.certificationCandidates}} />`
-        );
+      // when
+      const screen = await renderScreen(
+        hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}} />`
+      );
 
-        // then
-        assert.dom(screen.getByText('Aucun candidat inscrit à cette session')).exists();
-      });
+      // then
+      assert.dom(screen.getByText('Aucun candidat inscrit à cette session')).exists();
     });
   });
 });

--- a/certif/tests/integration/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-list_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import hbs from 'htmlbars-inline-precompile';
@@ -68,6 +69,52 @@ module('Integration | Component | SessionSupervising::CandidateList', function (
 
       // then
       assert.dom(screen.getByRole('textbox', { name: 'Rechercher un candidat' })).exists();
+    });
+
+    module('when the candidate search filter is filled', function () {
+      test('it renders the filtered candidates information', async function (assert) {
+        // given
+        this.certificationCandidates = [
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 123,
+            firstName: 'Gamora',
+            lastName: 'Zen Whoberi Ben Titan',
+            birthdate: '1984-05-28',
+            extraTimePercentage: '8',
+            authorizedToStart: true,
+            assessmentStatus: null,
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 456,
+            firstName: 'Star',
+            lastName: 'Lord',
+            birthdate: '1983-06-28',
+            extraTimePercentage: '12',
+            authorizedToStart: false,
+            assessmentStatus: null,
+          }),
+          store.createRecord('certification-candidate-for-supervising', {
+            id: 789,
+            firstName: 'Gammvert',
+            lastName: 'Rocket',
+            birthdate: '1982-06-06',
+            extraTimePercentage: '12',
+            authorizedToStart: false,
+            assessmentStatus: null,
+          }),
+        ];
+        const screen = await renderScreen(
+          hbs`<SessionSupervising::CandidateList @candidates={{this.certificationCandidates}}  />`
+        );
+
+        // when
+        await fillIn(screen.getByRole('textbox', { name: 'Rechercher un candidat' }), 'Gam');
+
+        // then
+        assert.dom(screen.getByText('Zen Whoberi Ben Titan Gamora')).exists();
+        assert.dom(screen.getByText('Rocket Gammvert')).exists();
+        assert.dom(screen.queryByText('Lord Star')).doesNotExist();
+      });
     });
   });
 

--- a/certif/tests/unit/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/unit/components/session-supervising/candidate-list_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | session-supervising/candidate-list', function (hooks) {
+  setupTest(hooks);
+
+  module('filteredCandidates', function () {
+    test('it should return only the filtered candidate by its first name', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-list');
+      component.args.candidates = [
+        { firstName: 'Pierre', lastName: 'Quiroule' },
+        { firstName: 'Piegrièche', lastName: 'Ouicestunoiseau' },
+        { firstName: 'Paul', lastName: 'Ochon' },
+      ];
+      component.filter = 'Pie';
+
+      // when
+      const filteredCandidateList = component.filteredCandidates;
+
+      // then
+      assert.deepEqual(filteredCandidateList, [
+        { firstName: 'Pierre', lastName: 'Quiroule' },
+        { firstName: 'Piegrièche', lastName: 'Ouicestunoiseau' },
+      ]);
+    });
+
+    test('it should return only the filtered candidate by its last name', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-list');
+      component.args.candidates = [
+        { firstName: 'Pierre', lastName: 'Quiroule' },
+        { firstName: 'Paul', lastName: 'Ochon' },
+      ];
+      component.filter = 'Och';
+
+      // when
+      const filteredCandidateList = component.filteredCandidates;
+
+      // then
+      assert.deepEqual(filteredCandidateList, [{ firstName: 'Paul', lastName: 'Ochon' }]);
+    });
+  });
+});

--- a/certif/tests/unit/components/session-supervising/candidate-list_test.js
+++ b/certif/tests/unit/components/session-supervising/candidate-list_test.js
@@ -42,4 +42,21 @@ module('Unit | Component | session-supervising/candidate-list', function (hooks)
       assert.deepEqual(filteredCandidateList, [{ firstName: 'Paul', lastName: 'Ochon' }]);
     });
   });
+
+  module('authorizedToStartCandidates', function () {
+    test('it should return the number of authorized to start candidates', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-list');
+      component.args.candidates = [
+        { firstName: 'Pierre', lastName: 'Quiroule', authorizedToStart: true },
+        { firstName: 'Paul', lastName: 'Ochon', authorizedToStart: false },
+      ];
+
+      // when
+      const authorizedToStartCandidates = component.authorizedToStartCandidates;
+
+      // then
+      assert.strictEqual(authorizedToStartCandidates, 1);
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -34,6 +34,11 @@
           "disclaimer": "Attention, cette action est irréversible."
         }
       }
+    },
+    "session-supervising": {
+      "candidate-list": {
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} authorized {authorizedToStartCandidates, plural,one {candidate} other {candidates}}"
+      }
     }
   }
 }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -34,6 +34,11 @@
           "disclaimer": "Attention, cette action est irréversible."
         }
       }
+    },
+    "session-supervising": {
+      "candidate-list": {
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}"
+      }
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
La liste des candidats inscrits à une session de certification est affiché dans l’Espace Surveillant avec des actions liées, notamment la possibilité d’autoriser le lancement du test des candidats. Retrouver un candidat peut être long ou compliqué. 

## :robot: Solution
Ajouter un champ de recherche par nom / prénom du candidat.

## :rainbow: Remarques
La maquette : [https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=705%3A11144 - Connect to preview](https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=705%3A11144)

Bonus de foufou: Ajout du nombre de candidats présents
<img width="238" alt="image" src="https://user-images.githubusercontent.com/3769147/189388501-2430fb63-831e-4d36-9857-b7316c6bbf7c.png">


## :100: Pour tester
- Créer une session de certifications comportant des candidats.
- Se connecter à l'espace surveillant.
- Constater la présence d'un champ au-dessus de la liste des candidats.
- Taper le nom ou prénom d'un candidat et voir que la liste affichée en-dessous se filtre sur cette recherche. 
- Cliquer sur la case à cocher d'un candidat et constater que le nombre de candidats autorisés évolue.
- Savourer ce nouvel ajout de valeur destiné à nos utilisateurs.