### PR TITLE
[TECH] db(api): Make databaseBuilder.factory.buildUser create email without spaces

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -71,7 +71,7 @@ const buildUser = function buildUser({
   lastLoggedAt = new Date(),
   emailConfirmedAt = null,
 } = {}) {
-  email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
+  email = generateAnEmailIfNecessary(email, id, lastName, firstName);
 
   const values = {
     id,
@@ -126,7 +126,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   lastLoggedAt = new Date('2022-04-28T02:42:00Z'),
   emailConfirmedAt = new Date('2021-04-28T02:42:00Z'),
 } = {}) {
-  email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
+  email = generateAnEmailIfNecessary(email, id, lastName, firstName);
 
   const values = {
     id,
@@ -186,7 +186,7 @@ buildUser.withRole = function buildUserWithRole({
   rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
 } = {}) {
-  email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
+  email = generateAnEmailIfNecessary(email, id, lastName, firstName);
 
   const values = {
     id,
@@ -243,7 +243,7 @@ buildUser.withMembership = function buildUserWithMemberships({
   rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
 } = {}) {
-  email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
+  email = generateAnEmailIfNecessary(email, id, lastName, firstName);
 
   const values = {
     id,
@@ -304,7 +304,7 @@ buildUser.withCertificationCenterMembership = function buildUserWithCertificatio
   updatedAt = new Date(),
   certificationCenterId = null,
 } = {}) {
-  email = isUndefined(email) ? `${firstName}.${lastName}${id}@example.net`.toLowerCase() : email || null;
+  email = generateAnEmailIfNecessary(email, id, lastName, firstName);
 
   const user = buildUser({
     id,
@@ -334,5 +334,15 @@ buildUser.withCertificationCenterMembership = function buildUserWithCertificatio
 
   return user;
 };
+
+function generateAnEmailIfNecessary(email, id, lastName, firstName) {
+  if (isUndefined(email)) {
+    return `${firstName}.${lastName}${id}@example.net`.replaceAll(/\s+/g, '_').toLowerCase();
+  }
+  if (email) {
+    return email;
+  }
+  return null;
+}
 
 module.exports = buildUser;


### PR DESCRIPTION
## :unicorn: Problème

Some test user accounts are created with spaces in their email, namely `george.de cambridgeXXX@example.net`, which prevents developers to log in with them because the email address is invalid.

## :robot: Solution

Have databaseBuilder.factory.buildUser replace spaces with an email-valid character.

## :rainbow: Remarques

None

## :100: Pour tester

Run `npm run db:reset` and check that there is no more `george.de cambridgeXXX@example.net` but a `george.de_cambridgeXXX@example.net` instead (the space has been replaced by an underscore).

Before the modification:

```sql
pix=# select id, email, username from users where id=311;
 id  |               email                |        username
-----+------------------------------------+------------------------
 311 | george.de cambridge311@example.net | george.decambridge2207
```

After the modification:

```sql
pix=# select id, email, username from users where id=311;
 id  |               email                |        username
-----+------------------------------------+------------------------
 311 | george.de_cambridge311@example.net | george.decambridge2207
```

And also:

`forster.gillay djonesXXX@example.net` → `forster.gillay_djonesXXX@example.net`
