### PR TITLE
[FEATURE] Afficher le label plutôt que la valeur pour les formations (PIX-5597)

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -8,7 +8,7 @@
   <div class="training-card__content">
     <h3 class="training-card__title">{{@training.title}}</h3>
     <ul class="training-card__infos">
-      <li class="training-card__type">{{@training.type}}</li>
+      <li class="training-card__type">{{this.type}}</li>
       <li class="training-card__duration">
         <FaIcon @icon="clock" @prefix="far" aria-hidden="true" />
         <time>{{this.durationFormatted}}</time>

--- a/mon-pix/app/components/training/card.js
+++ b/mon-pix/app/components/training/card.js
@@ -1,8 +1,14 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class Card extends Component {
+  @service intl;
   get durationFormatted() {
     const hours = this.args.training.duration.hours + 'h';
     return hours;
+  }
+
+  get type() {
+    return this.intl.t(`pages.training.type.${this.args.training.type}`);
   }
 }

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -30,7 +30,7 @@ describe('Integration | Component | Training | Card', function () {
     expect(find('.training-card__content')).to.exist;
     expect(find('.training-card__title').textContent.trim()).to.equal('Mon super training');
     expect(find('.training-card__infos')).to.exist;
-    expect(find('.training-card__type').textContent.trim()).to.equal('webinaire');
+    expect(find('.training-card__type').textContent.trim()).to.equal('Webinaire');
     expect(find('.training-card__duration').textContent.trim()).to.equal('6h');
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1389,6 +1389,12 @@
       "primary": "You have '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' to complete the next question.",
       "secondary": "You can continue answering after this, but the question will not be marked as correct."
     },
+    "training" : {
+      "type": {
+        "autoformation": "Autoformation course",
+        "webinaire": "Webinar"
+      }
+    },
     "tutorial": {
       "title": "Campaign tutorial",
       "next": "Next",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1389,6 +1389,12 @@
       "primary": "Vous disposerez de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' pour réussir la question suivante.",
       "secondary": "Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie."
     },
+    "training" : {
+      "type": {
+        "autoformation": "Parcours d'autoformation",
+        "webinaire": "Webinaire"
+      }
+    },
     "tutorial": {
       "title": "Didacticiel de la campagne",
       "next": "Suivant",


### PR DESCRIPTION
## :unicorn: Problème
On affiche la value du `type=“autoformation”` au lieu du `label="parcours d’autoformation"`.

## :robot: Solution
Ajout des traductions et implémentation dans le composant Card des `trainings`.

## :100: Pour tester
- Cliquez sur `J'ai un code`
- Entrez le code campagne `PIXEDUINI`
- Cliquez sur `Accéder au parcours` et allez jusqu'à la fin de parcours
- Constater que les formations sont soit "Webinaire" soit "Parcours d'autoformation"