### PR TITLE
[FEATURE] Ajout de logs associé a la requête lors de l'import siecle

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -1,5 +1,5 @@
 const settings = require('../config');
-const { get, set, update } = require('lodash');
+const { get, set, update, omit } = require('lodash');
 const logger = require('../infrastructure/logger');
 const requestUtils = require('../infrastructure/utils/request-response-utils');
 
@@ -14,7 +14,7 @@ function logInfoWithCorrelationIds(data) {
       {
         user_id: extractUserIdFromRequest(request),
         request_id: `${get(request, 'info.id', '-')}`,
-        ...get(data, 'metrics', {}),
+        ...omit(data, 'message'),
       },
       get(data, 'message', '-')
     );
@@ -36,7 +36,7 @@ function logErrorWithCorrelationIds(data) {
       {
         user_id: extractUserIdFromRequest(request),
         request_id: `${get(request, 'info.id', '-')}`,
-        ...get(data, 'metrics', {}),
+        ...omit(data, 'message'),
       },
       get(data, 'message', '-')
     );

--- a/api/tests/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
+++ b/api/tests/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
@@ -37,11 +37,9 @@ describe('SiecleFileStreamer', function () {
 
         it('log only the first sax error', async function () {
           const path = `${__dirname}/files/xml/garbage.xml`;
-          const logger = {
-            error: sinon.stub(),
-          };
+          const logError = sinon.stub();
 
-          const streamer = await SiecleFileStreamer.create(path, logger);
+          const streamer = await SiecleFileStreamer.create(path, logError);
 
           await catchErr(
             streamer.perform,
@@ -53,7 +51,7 @@ describe('SiecleFileStreamer', function () {
             saxStream.on('end', resolve);
           });
 
-          expect(logger.error).to.have.been.calledOnce;
+          expect(logError).to.have.been.calledOnce;
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
En cas d'erreurs lors de l'import siecle, nous n'avons pas de contexte associé au logs d'erreurs.

## :robot: Solution
Utilisation de `logErrorWithCorrelationIds` pour avoir des logs avec le `request_id`/`user_id`. 

## :100: Pour tester
1. En étant connecter sur pix-orga avec une orga sco
2. Importer un fichier siecle avec un caractère quelconque avec les données (n'importe quel caractère sauf espace)
3. Voir dans les logs le message similaire à "Text data outside of root node.\nLine: 1\nColumn: 1\nChar: a" avec le request_id et le user_id
