### PR TITLE
[FEATURE] Proposer les épreuves du référentiel Pix+ en début de test de certification (PIX-5448)

### DIFF
--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -516,7 +516,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         const certificationCourseToSave = CertificationCourse.from({
                           certificationCandidate: foundCertificationCandidate,
-                          challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                          challenges: [challengePlus1, challengePlus2, challengePlus3, challenge1, challenge2],
                           verificationCode,
                           maxReachableLevelOnCertificationDate: 5,
                           complementaryCertificationCourses: [complementaryCertificationCourse],
@@ -644,7 +644,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         const certificationCourseToSave = CertificationCourse.from({
                           certificationCandidate: foundCertificationCandidate,
-                          challenges: [challenge1, challenge2, challengePlus1, challengePlus2, challengePlus3],
+                          challenges: [challengePlus1, challengePlus2, challengePlus3, challenge1, challenge2],
                           verificationCode,
                           maxReachableLevelOnCertificationDate: 5,
                           complementaryCertificationCourses: [complementaryCertificationCourse],
@@ -689,11 +689,11 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                         // then
                         expect(result.certificationCourse._challenges).to.deep.equal([
-                          challenge1,
-                          challenge2,
                           challengePlus1,
                           challengePlus2,
                           challengePlus3,
+                          challenge1,
+                          challenge2,
                         ]);
                       });
 
@@ -1203,12 +1203,12 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     const certificationCourseToSave = CertificationCourse.from({
                       certificationCandidate: foundCertificationCandidate,
                       challenges: [
-                        challenge1,
-                        challenge2,
                         challenge1ForPixPlus1,
                         challenge2ForPixPlus1,
                         challenge1ForPixPlus2,
                         challenge2ForPixPlus2,
+                        challenge1,
+                        challenge2,
                       ],
                       verificationCode,
                       maxReachableLevelOnCertificationDate: 5,
@@ -1262,12 +1262,12 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                     // then
                     expect(result.certificationCourse._challenges).to.deep.equal([
-                      challenge1,
-                      challenge2,
                       challenge1ForPixPlus1,
                       challenge2ForPixPlus1,
                       challenge1ForPixPlus2,
                       challenge2ForPixPlus2,
+                      challenge1,
+                      challenge2,
                     ]);
                   });
                 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, lorsqu’un candidat passe une double certification Pix/Pix+ (Edu, Droit et d’autres demain), les questions du référentiel Pix+ sont proposées en fin de test

Les candidats à ce type de certification souhaitent se concentrer d’avantage sur la partie spécifique (Pix+) que sur le référentiel cœur afin de sécuriser l’obtention de cette certif Pix+ qui représente un enjeu plus important à leurs yeux (plusieurs REX dans ce sens).

## :robot: Solution
Pour toutes les certifications Pix+, poser les questions du référentiel Pix+ en début de test, puis terminer par celles du référentiel cœur.

## :100: Pour tester
- Passer une certification avec un candidat ellible à une certification complémentaire
- S'assurer que les questions concernant la certification complémentaire ont bien été posées en début de test de certification


Les questions du référentiel pix+ ne s'affichent pas dans la page 'détail' sur pix-admin. Ici un candidat ayant passé une certif Edu a bien eu 8 questions Edu en début de test, ses questions du référentiel :heart: commencent donc à partir de la 9eme question
![image](https://user-images.githubusercontent.com/37305474/189670389-02509290-4fab-4f16-8aff-bf9707539e49.png)
