### PR TITLE
[TECH] Modifier la gestion du code HTTP 401 sur Pix App (PIX-5661)

### DIFF
--- a/api/lib/application/pre-response-utils.js
+++ b/api/lib/application/pre-response-utils.js
@@ -11,11 +11,7 @@ function handleDomainAndHttpErrors(request, h) {
 
   // Ne devrait pas etre necessaire
   if (response.isBoom && response.output.statusCode === 401) {
-    return errorManager.handle(
-      request,
-      h,
-      new UnauthorizedError(undefined, response.output.payload?.attributes?.code || 401)
-    );
+    return errorManager.handle(request, h, new UnauthorizedError(undefined, 401));
   }
 
   return h.continue;

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -28,9 +28,7 @@ async function _checkIsAuthenticated(request, h, { key, validate }) {
     }
   }
 
-  const error = boom.unauthorized();
-  error.output.payload.attributes = { code: 'SESSION_EXPIRED' };
-  return error;
+  return boom.unauthorized();
 }
 
 function validateUser(decoded) {

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -36,9 +36,10 @@ export default class Application extends JSONAPIAdapter {
     return currentLocale;
   }
 
-  handleResponse(status, headers, payload) {
-    if (status === 401 && payload.errors[0].code === 'SESSION_EXPIRED') {
-      return this.session.invalidate();
+  handleResponse(status) {
+    if (status === 401 && this.session.isAuthenticated) {
+      // no-await-on-purpose -- We want the session invalidation to happen in the background
+      this.session.invalidate();
     }
 
     return super.handleResponse(...arguments);

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class ApplicationRoute extends Route {
   @service splash;
@@ -21,5 +22,11 @@ export default class ApplicationRoute extends Route {
     await this.oidcIdentityProviders.load().catch();
 
     await this.session.handleUserLanguageAndLocale(transition);
+  }
+
+  @action
+  error(error) {
+    const isUnauthorizedError = error?.errors?.some((err) => err.status === '401');
+    return !isUnauthorizedError;
   }
 }

--- a/mon-pix/tests/acceptance/authentication_test.js
+++ b/mon-pix/tests/acceptance/authentication_test.js
@@ -57,7 +57,7 @@ describe('Acceptance | Authentication', function () {
       expect(currentURL()).to.equal('/connexion');
     });
 
-    describe('when user should change password', function () {
+    context('when user should change password', function () {
       it('should redirect to /update-expired-password', async function () {
         // given
         user = server.create('user', 'withUsername', 'shouldChangePassword');
@@ -70,30 +70,15 @@ describe('Acceptance | Authentication', function () {
       });
     });
 
-    context('REST API call returns 401', function () {
-      it('should disconnect user if 401 is a SESSION_EXPIRED error', async function () {
+    context('when user session is invalid', function () {
+      it('should disconnect user', async function () {
         // given
         const campaign = server.create('campaign', { isSimplifiedAccess: true });
 
         // when
         const screen = await startCampaignByCode(campaign.code);
         const userId = currentSession().get('data.authenticated.user_id');
-        server.patch(
-          `/users/${userId}/remember-user-has-seen-assessment-instructions`,
-          () =>
-            new Response(
-              401,
-              {},
-              {
-                errors: [
-                  {
-                    status: '401',
-                    code: 'SESSION_EXPIRED',
-                  },
-                ],
-              }
-            )
-        );
+        server.patch(`/users/${userId}/remember-user-has-seen-assessment-instructions`, () => new Response(401));
         await click(screen.getByRole('button', { name: this.intl.t('pages.tutorial.pass') }));
 
         // then

--- a/mon-pix/tests/unit/adapters/application_test.js
+++ b/mon-pix/tests/unit/adapters/application_test.js
@@ -98,18 +98,21 @@ describe('Unit | Adapters | ApplicationAdapter', function () {
   });
 
   describe('handleResponse()', function () {
-    context('when an HTTP status code 401 with code SESSION_EXPIRED is received', function () {
+    context('when an HTTP status code 401 is received', function () {
       it('should invalidate the current session', function () {
         // given
         const applicationAdapter = this.owner.lookup('adapter:application');
         const session = this.owner.lookup('service:session');
+        const status = 401;
+        const headers = {};
+        const payload = {};
+        const requestData = {};
 
         sinon.stub(session, 'invalidate');
+        session.isAuthenticated = true;
 
         // when
-        const headers = null;
-        const payload = { errors: [{ code: 'SESSION_EXPIRED' }] };
-        applicationAdapter.handleResponse(401, headers, payload);
+        applicationAdapter.handleResponse(status, headers, payload, requestData);
 
         // then
         sinon.assert.calledOnce(session.invalidate);


### PR DESCRIPTION
## :unicorn: Problème

Nous avons ajouté un code d’erreur `SESSION_EXPIRED` retourné par l’api lorsque l’accès à la ressource n’est pas possible par l’utilisateur, pour nous permettre de faire la différence entre les autres 401 possibles (différents codes d’erreurs).

Cette gestion par code d’erreur n’est pas nécessaire.

## :robot: Solution

Modifier le comportement actuel en vérifiant, à la place du code d'erreur `SESSION_EXPIRED`, que l'utilisateur est connecté. Si c'est le cas, on invalide sa session et le redirige vers la page de connexion (en fonction de l'`authenticator` sélectionné)

## :rainbow: Remarques

Après une connexion avec un compte Pôle Emploi, si l'`access_token` généré par Pix expire, l'utilisateur ne sera pas. redirigé vers le site de Pôle Emploi. Il se retrouvera sur la page de connexion de Pix. Ce cas sera traité par un autre ticket.

## :100: Pour tester

Il faudra modifier les valeurs des variables d'environnement suivantes pour faire les tests : 
- ANONYMOUS_ACCESS_TOKEN_LIFESPAN=10s
- ACCESS_TOKEN_LIFESPAN=10s
- REFRESH_TOKEN_LIFESPAN=10s

#### Accès avec un compte standard

- Allez sur https://app-pr4909.review.pix.fr/
- Ouvrir la console dévelopeur sur l'onglet `Network / Réseau`
- Se connecter avec un compte (voir seeds)
- Attendez le temps que vous avez renseigné pour la variable `REFRESH_TOKEN_LIFESPAN`
- Tentez de naviguer vers une nouvelle page de l'application
- Constatez que vous êtes redirigé vers la page de connexion

#### Accès avec un compte anonyme

- Allez sur https://app-pr4909.review.pix.fr/campagnes/SIMPLIFIE
- Ouvrir la console dévelopeur sur l'onglet `Network / Réseau`
- Cliquez sur `Je commence`
- Attendez le temps que vous avez renseigné pour la variable `ANONYMOUS_ACCESS_TOKEN_LIFESPAN`
- Cliquez sur `Ignorer`
- Constatez que vous êtes redirigé vers la page de connexion
