### PR TITLE
[BUGFIX] Corrige la redirection lorsqu'une certification a été terminé par le superviseur (PIX-5666)

### DIFF
--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -117,6 +117,7 @@ export default class Item extends Component {
 
       if (this._isAssessmentEndedBySupervisorOrByFinalization(error)) {
         this.router.transitionTo('authenticated.certifications.results', assessment.certificationCourse.get('id'));
+        return;
       }
 
       this.router.transitionTo('error', error);


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un candidat demande une nouvelle question sur une certification qui a été terminé par le superviseur, on obtient un vilain message d'erreur "oups"

## :robot: Solution
Remettre la redirection correcte vers la page "Le surveillant a mis fin à votre test de certification"

## :rainbow: Remarques
Breaking change d'ember?

## :100: Pour tester
[mon-pix] Lancer une certification avec un candidat lambda (pas besoin de répondre à la 1ere question)
[certif]      Terminer la certification via le portail surveillant
[mon-pix] Passer (ou répondre à ) la question et s'assurer d'avoir la page qui contient le message "Le surveillant a mis fin à votre test de certification"
