### PR TITLE
[CLEANUP] Abaisse le niveau du log lorsque le rate limit est atteint

### DIFF
--- a/api/lib/infrastructure/plugins/rate-limit.js
+++ b/api/lib/infrastructure/plugins/rate-limit.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     redisClient: config.rateLimit.redisUrl ? createRedisRateLimit : null,
     overLimitError: (rate, request, h) => {
-      logger.error({ request_id: request.headers['x-request-id'], overLimit: rate.overLimit }, 'Rate limit exceeded');
+      logger.info({ request_id: request.headers['x-request-id'], overLimit: rate.overLimit }, 'Rate limit exceeded');
       if (config.rateLimit.logOnly) {
         return h.continue;
       } else {


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que le rate limit est activé en production, nous ne voulons plus être pollué les erreurs de rate limit atteint.

## :robot: Solution
Baisse le niveau du log a `info`.

## :100: Pour tester
Avec le rate limit activé `RATE_LIMIT_ENABLED=true`:
- sur la page de connexion, entrer un email et mot de passe quelconque et cliquer 11 fois sur le bouton de connexion
- Dans les logs API, voir le message "Rate limit exceeded" en info.
