### PR TITLE
[BUGFIX] Correction du téléchargement du contenu d'un profil cible

### DIFF
--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -5,6 +5,7 @@ const targetProfileSummaryForAdminSerializer = require('../../infrastructure/ser
 const targetProfileForAdminOldSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-for-admin-old-format-serializer');
 const targetProfileForAdminNewSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
 const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
 const badgeCreationSerializer = require('../../infrastructure/serializers/jsonapi/badge-creation-serializer');
@@ -58,10 +59,12 @@ module.exports = {
 
     const { jsonContent, fileName } = await usecases.getTargetProfileContentAsJson({ userId, targetProfileId });
 
+    const escapedFilename = requestResponseUtils.escapeFileName(fileName);
+
     return h
       .response(jsonContent)
       .header('Content-Type', 'text/json;charset=utf-8')
-      .header('Content-Disposition', `attachment; filename=${fileName}`);
+      .header('Content-Disposition', `attachment; filename=${escapedFilename}`);
   },
 
   async attachOrganizations(request, h) {

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -713,7 +713,7 @@ describe('Acceptance | Controller | target-profile-controller', function () {
       expect(response.statusCode).to.equal(200);
       expect(response.payload).to.equal('[{"id":"recTube","level":6,"frameworkId":"recFmwk","skills":["recSkill"]}]');
       expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename=20201101_profil_cible_Roxane est très jolie.json'
+        'attachment; filename=20201101_profil_cible_Roxane est tr_s jolie.json'
       );
       expect(response.headers['content-type']).to.equal('text/json;charset=utf-8');
     });


### PR DESCRIPTION
## :unicorn: Problème
Si le nom du profil contient des caractères invalide, l'API renvoit une 500 car le header `Content-Disposition` est invalide.

## :robot: Solution
Échapper les caractères du nom du fichier avant l'envoi a l'utilisateur.

## :100: Pour tester
- Avoir un profil cible avec un nom (coté admin) contenant une apostrophe
- Télécharger le contenu
- Voir que le caractère apostrophe a été remplacé par un `_`
