### PR TITLE
[FEATURE] Filtrer les badges perdus sur la page de détails de fin de parcours (PIX-5422)

### DIFF
--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -5,15 +5,16 @@ const constants = require('../../constants');
 const moment = require('moment');
 
 class AssessmentResult {
-  constructor(
+  constructor({
     participationResults,
-    targetProfile,
     isCampaignMultipleSendings,
     isOrganizationLearnerActive,
-    isCampaignArchived
-  ) {
+    isCampaignArchived,
+    competences,
+    badgeResultsDTO,
+    stages,
+  }) {
     const { knowledgeElements, sharedAt, assessmentCreatedAt } = participationResults;
-    const { competences } = targetProfile;
 
     this.id = participationResults.campaignParticipationId;
     this.isCompleted = participationResults.isCompleted;
@@ -32,11 +33,11 @@ class AssessmentResult {
     );
 
     this.competenceResults = competences.map((competence) => _buildCompetenceResults(competence, knowledgeElements));
-    this.badgeResults = targetProfile.badges.map((badge) => new BadgeResult(badge, participationResults));
+    this.badgeResults = badgeResultsDTO.map((badge) => new BadgeResult(badge, participationResults));
 
-    this.stageCount = targetProfile.stages.length;
-    if (targetProfile.stages.length > 0) {
-      this.reachedStage = new ReachedStage(this.masteryRate, targetProfile.stages);
+    this.stageCount = stages.length;
+    if (stages.length > 0) {
+      this.reachedStage = new ReachedStage(this.masteryRate, stages);
     }
     this.canImprove = this._computeCanImprove(knowledgeElements, assessmentCreatedAt, this.isShared);
     this.isDisabled = this._computeIsDisabled(isCampaignArchived, participationResults.isDeleted);

--- a/api/lib/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/lib/domain/usecases/get-user-campaign-assessment-result.js
@@ -5,18 +5,29 @@ module.exports = async function getUserCampaignAssessmentResult({
   campaignId,
   locale,
   participantResultRepository,
+  knowledgeElementRepository,
+  badgeCriteriaService,
   targetProfileRepository,
   badgeRepository,
 }) {
   try {
     const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId });
     const badges = await badgeRepository.findByTargetProfileId(targetProfile.id);
+    const stillValidBadges = badges.filter((badge) =>
+      badgeCriteriaService.areBadgeCriteriaFulfilled({
+        knowledgeElements,
+        targetProfile,
+        badge,
+      })
+    );
+
     const assessmentResult = await participantResultRepository.getByUserIdAndCampaignId({
       userId,
       campaignId,
       locale,
       targetProfile,
-      badges,
+      badges: stillValidBadges,
     });
 
     return assessmentResult;

--- a/api/lib/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/lib/domain/usecases/get-user-campaign-assessment-result.js
@@ -5,9 +5,21 @@ module.exports = async function getUserCampaignAssessmentResult({
   campaignId,
   locale,
   participantResultRepository,
+  targetProfileRepository,
+  badgeRepository,
 }) {
   try {
-    return await participantResultRepository.getByUserIdAndCampaignId({ userId, campaignId, locale });
+    const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
+    const badges = await badgeRepository.findByTargetProfileId(targetProfile.id);
+    const assessmentResult = await participantResultRepository.getByUserIdAndCampaignId({
+      userId,
+      campaignId,
+      locale,
+      targetProfile,
+      badges,
+    });
+
+    return assessmentResult;
   } catch (error) {
     if (error instanceof NotFoundError) throw new NoCampaignParticipationForUserAndCampaign();
     throw error;

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -10,23 +10,13 @@ const { NotFoundError } = require('../../domain/errors');
 
 const ParticipantResultRepository = {
   async getByUserIdAndCampaignId({ userId, campaignId, targetProfile, badges, locale }) {
-    const [
-      participationResults,
-      isCampaignMultipleSendings,
-      isOrganizationLearnerActive,
-      isCampaignArchived,
-      competences,
-      badgeResultsDTO,
-      stages,
-    ] = await Promise.all([
-      _getParticipationResults(userId, campaignId, targetProfile.id),
-      _isCampaignMultipleSendings(campaignId),
-      _isOrganizationLearnerActive(userId, campaignId),
-      _isCampaignArchived(campaignId),
-      _findTargetedCompetences(targetProfile.id, locale),
-      _getBadgeResults(badges),
-      _getStages(targetProfile.id),
-    ]);
+    const participationResults = await _getParticipationResults(userId, campaignId, targetProfile.id);
+    const isCampaignMultipleSendings = await _isCampaignMultipleSendings(campaignId);
+    const isOrganizationLearnerActive = await _isOrganizationLearnerActive(userId, campaignId);
+    const isCampaignArchived = await _isCampaignArchived(campaignId);
+    const competences = await _findTargetedCompetences(targetProfile.id, locale);
+    const badgeResultsDTO = await _getBadgeResults(badges);
+    const stages = await _getStages(targetProfile.id);
 
     return new AssessmentResult({
       participationResults,

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -7,6 +7,7 @@ const {
   generateValidRequestAuthorizationHeader,
 } = require('../../../test-helper');
 const _ = require('lodash');
+const BadgeCriterion = require('../../../../lib/domain/models/BadgeCriterion');
 
 describe('Acceptance | API | Campaign Assessment Result', function () {
   const JAFFA_COLOR = 'jaffa';
@@ -68,6 +69,11 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       title: 'Banana',
       key: 'PIX_BANANA',
       targetProfileId: targetProfile.id,
+    });
+    databaseBuilder.factory.buildBadgeCriterion({
+      badgeId: 1,
+      scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+      threshold: 0,
     });
 
     skillSet = databaseBuilder.factory.buildSkillSet({

--- a/api/tests/integration/application/users/user-controller_test.js
+++ b/api/tests/integration/application/users/user-controller_test.js
@@ -109,11 +109,13 @@ describe('Integration | Application | Users | user-controller', function () {
     const auth = { credentials: {}, strategy: {} };
 
     context('Success cases', function () {
-      const campaignAssessmentResult = new AssessmentResult(
-        { knowledgeElements: [] },
-        { competences: [], badges: [], stages: [] },
-        false
-      );
+      const campaignAssessmentResult = new AssessmentResult({
+        participationResults: { knowledgeElements: [] },
+        competences: [],
+        badgeResultsDTO: [],
+        stages: [],
+        isCampaignMultipleSendings: false,
+      });
 
       beforeEach(function () {
         securityPreHandlers.checkRequestedUserIsAuthenticatedUser.returns(true);

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -1,4 +1,4 @@
-const { catchErr, expect, databaseBuilder, mockLearningContent } = require('../../../test-helper');
+const { catchErr, expect, databaseBuilder, mockLearningContent, domainBuilder } = require('../../../test-helper');
 const participantResultRepository = require('../../../../lib/infrastructure/repositories/participant-result-repository');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const { NotFoundError } = require('../../../../lib/domain/errors');
@@ -9,15 +9,17 @@ const { STARTED } = CampaignParticipationStatuses;
 
 describe('Integration | Repository | ParticipantResultRepository', function () {
   describe('#getByUserIdAndCampaignId', function () {
-    let targetProfileId;
+    let targetProfile;
 
     beforeEach(function () {
-      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill1' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill2' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill3' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill4' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill6' });
+      domainBuilder.buildAssessment();
+      targetProfile = domainBuilder.buildTargetProfile({ ownerOrganizationId: null });
+      databaseBuilder.factory.buildTargetProfile(targetProfile);
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill2' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill3' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill4' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill6' });
 
       const learningContent = {
         areas: [
@@ -64,7 +66,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
     it('use the most recent assessment to define if the participation is completed', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
-      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -88,6 +90,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
         userId,
         campaignId,
+        targetProfile,
+        badges: [],
         locale: 'FR',
       });
 
@@ -99,7 +103,10 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     context('computes canRetry', function () {
       it('returns true when there is no organization-learner and all other conditions are filled', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId, multipleSendings: true });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          tagetProfileId: targetProfile.id,
+          multipleSendings: true,
+        });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -112,6 +119,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -124,7 +133,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId });
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           organizationId,
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           multipleSendings: true,
         });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
@@ -139,6 +148,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -147,7 +158,10 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
       it('returns false when multipleSendings is false', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId, multipleSendings: false });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          tagetProfileId: targetProfile.id,
+          multipleSendings: false,
+        });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -158,6 +172,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -169,7 +185,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: organizationId } = databaseBuilder.factory.buildOrganization();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           organizationId,
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           multipleSendings: true,
         });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
@@ -183,6 +199,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -193,7 +211,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({
           organizationId,
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           multipleSendings: true,
         }).id;
         const userId = databaseBuilder.factory.buildUser().id;
@@ -217,6 +235,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId: otherUserId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -229,7 +249,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId, isDisabled: true });
         const campaignId = databaseBuilder.factory.buildCampaign({
           organizationId,
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           multipleSendings: true,
         }).id;
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
@@ -247,7 +267,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         });
         const otherCampaignId = databaseBuilder.factory.buildCampaign({
           organizationId: otherOrganizationId,
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           multipleSendings: true,
         }).id;
         const otherCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
@@ -258,8 +278,10 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         await databaseBuilder.commit();
 
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
-          userId,
           campaignId: otherCampaignId,
+          targetProfile,
+          badges: [],
+          userId,
           locale: 'FR',
         });
 
@@ -286,6 +308,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -309,6 +333,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -332,6 +358,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -342,7 +370,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
     it('compute the number of skills, the number of skill tested and the number of skill validated', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
-      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -379,6 +407,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
         userId,
         campaignId,
+        targetProfile,
+        badges: [],
         locale: 'FR',
       });
 
@@ -392,7 +422,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
     it('compute the number of skills, the number of skill tested and the number of skill validated using operative skills', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
-      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -422,6 +452,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
         userId,
         campaignId,
+        targetProfile,
+        badges: [],
         locale: 'FR',
       });
 
@@ -434,7 +466,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
     it('computes the results for each competence assessed', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
-      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -480,6 +512,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
         userId,
         campaignId,
+        targetProfile,
+        badges: [],
         locale: 'FR',
       });
       const competenceResult1 = participantResult.competenceResults.find(({ id }) => id === 'rec1');
@@ -512,7 +546,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       it('returns the stage reached', async function () {
         const { id: otherTargetProfileId } = databaseBuilder.factory.buildTargetProfile();
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -525,32 +559,31 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           id: 10,
           title: 'StageO',
           message: 'Message0',
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           threshold: 0,
         });
         databaseBuilder.factory.buildStage({
           id: 1,
           title: 'Stage1',
           message: 'Message1',
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           threshold: 10,
         });
         databaseBuilder.factory.buildStage({
           id: 2,
           title: 'Stage2',
           message: 'Message2',
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           threshold: 50,
         });
         databaseBuilder.factory.buildStage({
           id: 3,
           title: 'Stage3',
           message: 'Message3',
-          targetProfileId,
+          targetProfileId: targetProfile.id,
           threshold: 100,
         });
         databaseBuilder.factory.buildStage({ targetProfileId: otherTargetProfileId });
-
         const knowledgeElementsAttributes = [
           {
             userId,
@@ -588,6 +621,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
         expect(participantResult.reachedStage).to.deep.include({
@@ -604,35 +639,36 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     context('when the participation has badges', function () {
       it('computes the results for each badge', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
           sharedAt: new Date('2020-01-02'),
         });
 
-        databaseBuilder.factory.buildBadge({
-          id: 1,
-          message: 'Badge1 Message',
-          altMessage: 'Badge1 AltMessage',
-          title: 'Badge1 Title',
-          imageUrl: 'Badge1 ImgUrl',
-          key: 'Badge1 Key',
-          targetProfileId,
-        });
-
-        databaseBuilder.factory.buildBadge({
-          id: 2,
-          altMessage: 'Badge2 AltMessage',
-          message: 'Badge2 Message',
-          title: 'Badge2 Title',
-          imageUrl: 'Badge2 ImgUrl',
-          key: 'Badge2 Key',
-          targetProfileId,
-          isAlwaysVisible: true,
-        });
-
-        databaseBuilder.factory.buildBadge();
+        const badges = [
+          domainBuilder.buildBadge({
+            id: 1,
+            message: 'Badge1 Message',
+            altMessage: 'Badge1 AltMessage',
+            title: 'Badge1 Title',
+            imageUrl: 'Badge1 ImgUrl',
+            key: 'Badge1 Key',
+            targetProfileId: targetProfile.id,
+          }),
+          domainBuilder.buildBadge({
+            id: 2,
+            altMessage: 'Badge2 AltMessage',
+            message: 'Badge2 Message',
+            title: 'Badge2 Title',
+            imageUrl: 'Badge2 ImgUrl',
+            key: 'Badge2 Key',
+            targetProfileId: targetProfile.id,
+            isAlwaysVisible: true,
+          }),
+          domainBuilder.buildBadge({ id: 3, targetProfileId: null }),
+        ];
+        badges.forEach(databaseBuilder.factory.buildBadge);
 
         databaseBuilder.factory.buildBadgeAcquisition({ badgeId: 1, userId, campaignParticipationId });
 
@@ -643,6 +679,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges,
           locale: 'FR',
         });
         const badgeResult1 = participantResult.badgeResults.find(({ id }) => id === 1);
@@ -671,8 +709,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
       it('computes the results for each badge earned during the current campaign participation', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
-        const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -684,27 +722,28 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           sharedAt: new Date('2020-01-02'),
         });
 
-        databaseBuilder.factory.buildBadge({
-          id: 1,
-          message: 'Badge1 Message',
-          altMessage: 'Badge1 AltMessage',
-          title: 'Badge1 Title',
-          imageUrl: 'Badge1 ImgUrl',
-          key: 'Badge1 Key',
-          targetProfileId,
-        });
-
-        databaseBuilder.factory.buildBadge({
-          id: 2,
-          altMessage: 'Badge2 AltMessage',
-          message: 'Badge2 Message',
-          title: 'Badge2 Title',
-          imageUrl: 'Badge2 ImgUrl',
-          key: 'Badge2 Key',
-          targetProfileId,
-        });
-
-        databaseBuilder.factory.buildBadge();
+        const badges = [
+          domainBuilder.buildBadge({
+            id: 1,
+            message: 'Badge1 Message',
+            altMessage: 'Badge1 AltMessage',
+            title: 'Badge1 Title',
+            imageUrl: 'Badge1 ImgUrl',
+            key: 'Badge1 Key',
+            targetProfileId: targetProfile.id,
+          }),
+          domainBuilder.buildBadge({
+            id: 2,
+            altMessage: 'Badge2 AltMessage',
+            message: 'Badge2 Message',
+            title: 'Badge2 Title',
+            imageUrl: 'Badge2 ImgUrl',
+            key: 'Badge2 Key',
+            targetProfileId: targetProfile.id,
+          }),
+          domainBuilder.buildBadge({ id: 3, targetProfileId: null }),
+        ];
+        badges.forEach(databaseBuilder.factory.buildBadge);
 
         const badgeObtainedInAnotherCampaign = databaseBuilder.factory.buildBadgeAcquisition({
           badgeId: 1,
@@ -719,12 +758,13 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         });
 
         databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
-
         await databaseBuilder.commit();
 
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges,
           locale: 'FR',
         });
         const badgeResult1 = participantResult.badgeResults.find(
@@ -756,15 +796,15 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       context('when the target profile has skillsets (CleaNumerique)', function () {
         it('computes the buildSkillSet for each competence of badge', async function () {
           const { id: userId } = databaseBuilder.factory.buildUser();
-          const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+          const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
           const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId,
             sharedAt: new Date('2020-01-02'),
           });
 
-          const badge = databaseBuilder.factory.buildBadge({ id: 1, targetProfileId });
-          const skillSet1 = databaseBuilder.factory.buildSkillSet({
+          const badge = databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id });
+          databaseBuilder.factory.buildSkillSet({
             id: 1,
             badgeId: 1,
             name: 'BadgeCompt1',
@@ -772,7 +812,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
             color: 'BadgeCompt1Color',
             skillIds: ['skill1', 'skill2'],
           });
-          const skillSet2 = databaseBuilder.factory.buildSkillSet({
+          databaseBuilder.factory.buildSkillSet({
             id: 2,
             badgeId: 1,
             name: 'BadgeCompt2',
@@ -820,12 +860,15 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           );
 
           await databaseBuilder.commit();
-          badge.skillSets = [skillSet1, skillSet2];
+
           const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
             userId,
             campaignId,
+            targetProfile,
+            badges: [badge],
             locale: 'FR',
           });
+
           const skillSetResult1 = participantResult.badgeResults[0].skillSetResults.find(({ id }) => id === 1);
           const skillSetResult2 = participantResult.badgeResults[0].skillSetResults.find(({ id }) => id === 2);
           expect(participantResult.competenceResults).to.have.lengthOf(2);
@@ -853,12 +896,14 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     context('when no participation for given user and campaign', function () {
       it('should throw a not found error', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         await databaseBuilder.commit();
 
         const error = await catchErr(participantResultRepository.getByUserIdAndCampaignId)({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 
@@ -869,7 +914,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     context('when the participation is shared', function () {
       it('returns the mastery rate for the participation using the mastery rate stocked', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -883,6 +928,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
         expect(participantResult.masteryRate).to.equal(0.6);
@@ -892,7 +939,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     context('when the participation is not shared', function () {
       it('returns the mastery rate for the participation using knowledge elements', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -906,6 +953,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
         expect(participantResult.masteryRate).to.equal(0);
@@ -915,7 +964,10 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     context('when there are several participations', function () {
       it('use the participation not improved yet', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId, multipleSendings: true });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({
+          tagetProfileId: targetProfile.id,
+          multipleSendings: true,
+        });
         const { id: oldCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -946,6 +998,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
         expect(participantResult.id).to.equal(campaignParticipationId);
@@ -977,6 +1031,8 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
           userId,
           campaignId,
+          targetProfile,
+          badges: [],
           locale: 'FR',
         });
 

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -38,9 +38,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       participantExternalId: 'greg@lafleche.fr',
     };
 
-    const targetProfile = { competences, stages: [], badges: [] };
-
-    const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+    const assessmentResult = new AssessmentResult({
+      participationResults,
+      competences,
+      stages: [],
+      badgeResultsDTO: [],
+      isCampaignMultipleSendings: false,
+      isOrganizationLearnerActive: false,
+      isCampaignArchived: false,
+    });
 
     expect(assessmentResult).to.deep.include({
       id: 12,
@@ -91,9 +97,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             sharedAt: null,
           };
 
-          const targetProfile = { competences, stages: [], badges: [] };
-
-          const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+          const assessmentResult = new AssessmentResult({
+            participationResults,
+            competences,
+            stages: [],
+            badgeResultsDTO: [],
+            isCampaignMultipleSendings: false,
+            isOrganizationLearnerActive: false,
+            isCampaignArchived: false,
+          });
 
           expect(assessmentResult.masteryRate).to.equal(0.67);
         });
@@ -118,9 +130,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             sharedAt: null,
           };
 
-          const targetProfile = { competences, stages: [], badges: [] };
-
-          const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+          const assessmentResult = new AssessmentResult({
+            participationResults,
+            competences,
+            stages: [],
+            badgeResultsDTO: [],
+            isCampaignMultipleSendings: false,
+            isOrganizationLearnerActive: false,
+            isCampaignArchived: false,
+          });
 
           expect(assessmentResult.masteryRate).to.equal(0);
         });
@@ -149,10 +167,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           masteryRate: 0.5,
         };
 
-        const targetProfile = { competences, stages: [], badges: [] };
-
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
-
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences,
+          stages: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: false,
+          isCampaignArchived: false,
+        });
         expect(assessmentResult.masteryRate).to.equal(0.5);
       });
     });
@@ -179,9 +202,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
 
     const participationResults = { knowledgeElements, acquiredBadgeIds: [] };
 
-    const targetProfile = { competences, stages: [], badges: [] };
-
-    const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+    const assessmentResult = new AssessmentResult({
+      participationResults,
+      competences,
+      stages: [],
+      badgeResultsDTO: [],
+      isCampaignMultipleSendings: false,
+      isOrganizationLearnerActive: false,
+      isCampaignArchived: false,
+    });
 
     const competenceResults1 = assessmentResult.competenceResults.find(({ id }) => competences[0].id === id);
     const competenceResults2 = assessmentResult.competenceResults.find(({ id }) => competences[1].id === id);
@@ -190,7 +219,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     expect(competenceResults2).to.deep.include({ name: 'C2', masteryPercentage: 100 });
   });
 
-  describe('when the targetProfile has stages', function () {
+  describe('when the target profile has stages', function () {
     it('gives the reached stage', function () {
       const competences = [
         {
@@ -216,16 +245,21 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         { id: 3, title: 'Stage3', message: 'message3', threshold: 90 },
       ];
 
-      const targetProfile = { competences, stages, badges: [] };
-
-      const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+      const assessmentResult = new AssessmentResult({
+        participationResults,
+        stages,
+        badgeResultsDTO: [],
+        competences,
+        isCampaignMultipleSendings: false,
+        isOrganizationLearnerActive: false,
+      });
 
       expect(assessmentResult.reachedStage).to.deep.include({ id: 2, title: 'Stage2', starCount: 2 });
       expect(assessmentResult.stageCount).to.equal(3);
     });
   });
 
-  describe('when the targetProfile has badges', function () {
+  describe('when the target profile has badges', function () {
     it('computes results for each badge', function () {
       const competences = [
         {
@@ -239,7 +273,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       ];
       const participationResults = { knowledgeElements: [], acquiredBadgeIds: [1] };
 
-      const badges = [
+      const badgeResultsDTO = [
         {
           id: 2,
           title: 'Badge Blue',
@@ -260,9 +294,14 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         },
       ];
 
-      const targetProfile = { competences, stages: [], badges };
-
-      const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+      const assessmentResult = new AssessmentResult({
+        participationResults,
+        stages: [],
+        badgeResultsDTO,
+        competences,
+        isCampaignMultipleSendings: false,
+        isOrganizationLearnerActive: false,
+      });
       const badgeResult1 = assessmentResult.badgeResults.find(({ id }) => id === 1);
       const badgeResult2 = assessmentResult.badgeResults.find(({ id }) => id === 2);
       expect(badgeResult1).to.deep.include({ title: 'Badge Yellow', isAcquired: true });
@@ -297,14 +336,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: new Date('2020-01-01T05:06:07Z'),
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(
+        const assessmentResult = new AssessmentResult({
           participationResults,
-          targetProfile,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
-          isCampaignArchived
-        );
+          isCampaignArchived,
+        });
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -322,14 +362,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: new Date('2020-01-01T05:06:07Z'),
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(
+        const assessmentResult = new AssessmentResult({
           participationResults,
-          targetProfile,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
-          isCampaignArchived
-        );
+          isCampaignArchived,
+        });
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -347,14 +388,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: null,
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(
+        const assessmentResult = new AssessmentResult({
           participationResults,
-          targetProfile,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
-          isCampaignArchived
-        );
+          isCampaignArchived,
+        });
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -372,14 +414,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: new Date('2020-01-01T05:06:07Z'),
           isDeleted: true,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(
+        const assessmentResult = new AssessmentResult({
           participationResults,
-          targetProfile,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
-          isCampaignArchived
-        );
+          isCampaignArchived,
+        });
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -397,14 +440,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: new Date('2020-01-01T05:06:07Z'),
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(
+        const assessmentResult = new AssessmentResult({
           participationResults,
-          targetProfile,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
-          isCampaignArchived
-        );
+          isCampaignArchived,
+        });
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -424,14 +468,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             sharedAt: new Date('2020-01-03T05:06:07Z'),
             isDeleted: false,
           };
-          const targetProfile = { competences: [], stages: [], badges: [] };
-          const assessmentResult = new AssessmentResult(
+          const assessmentResult = new AssessmentResult({
             participationResults,
-            targetProfile,
+            competences: [],
+            stages: [],
+            badgeResultsDTO: [],
             isCampaignMultipleSendings,
             isOrganizationLearnerActive,
-            isCampaignArchived
-          );
+            isCampaignArchived,
+          });
 
           expect(assessmentResult.canRetry).to.be.false;
         });
@@ -450,15 +495,17 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           sharedAt: new Date('2020-01-01T05:06:07Z'),
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
 
-        const assessmentResult = new AssessmentResult(
+        const assessmentResult = new AssessmentResult({
           participationResults,
-          targetProfile,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+
           isCampaignMultipleSendings,
           isOrganizationLearnerActive,
-          isCampaignArchived
-        );
+          isCampaignArchived,
+        });
 
         expect(assessmentResult.canRetry).to.be.false;
       });
@@ -478,14 +525,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             sharedAt: new Date('2019-12-12'),
             isDeleted: false,
           };
-          const targetProfile = { competences: [], stages: [], badges: [] };
-          const assessmentResult = new AssessmentResult(
+          const assessmentResult = new AssessmentResult({
             participationResults,
-            targetProfile,
+            competences: [],
+            stages: [],
+            badgeResultsDTO: [],
             isCampaignMultipleSendings,
             isOrganizationLearnerActive,
-            isCampaignArchived
-          );
+            isCampaignArchived,
+          });
 
           expect(assessmentResult.canRetry).to.be.true;
         });
@@ -506,14 +554,16 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             sharedAt: new Date('2020-01-01T05:06:07Z'),
             isDeleted: false,
           };
-          const targetProfile = { competences: [], stages: [], badges: [] };
-          const assessmentResult = new AssessmentResult(
+
+          const assessmentResult = new AssessmentResult({
             participationResults,
-            targetProfile,
+            competences: [],
+            stages: [],
+            badgeResultsDTO: [],
             isCampaignMultipleSendings,
             isOrganizationLearnerActive,
-            isCampaignArchived
-          );
+            isCampaignArchived,
+          });
 
           expect(assessmentResult.canRetry).to.be.true;
         });
@@ -557,9 +607,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             acquiredBadgeIds: [],
             assessmentCreatedAt,
           };
-          const targetProfile = { competences: [], stages: [], badges: [] };
 
-          const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+          const assessmentResult = new AssessmentResult({
+            participationResults,
+            competences: [],
+            stages: [],
+            badgeResultsDTO: [],
+            isCampaignMultipleSendings: false,
+            isOrganizationLearnerActive: false,
+          });
 
           expect(assessmentResult.canImprove).to.be.false;
         });
@@ -577,9 +633,14 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           acquiredBadgeIds: [],
           assessmentCreatedAt,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: false,
+        });
 
         expect(assessmentResult.canImprove).to.be.false;
       });
@@ -597,8 +658,14 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           assessmentCreatedAt,
           sharedAt: new Date(),
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: false,
+        });
 
         expect(assessmentResult.canImprove).to.be.false;
       });
@@ -618,8 +685,14 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
             assessmentCreatedAt,
             sharedAt: null,
           };
-          const targetProfile = { competences: [], stages: [], badges: [] };
-          const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false);
+          const assessmentResult = new AssessmentResult({
+            participationResults,
+            competences: [],
+            stages: [],
+            badgeResultsDTO: [],
+            isCampaignMultipleSendings: false,
+            isOrganizationLearnerActive: false,
+          });
 
           expect(assessmentResult.canImprove).to.be.true;
         });
@@ -635,8 +708,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           acquiredBadgeIds: [],
           isDeleted: true,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false, false);
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: false,
+          isCampaignArchived: false,
+        });
 
         expect(assessmentResult.isDisabled).to.be.true;
       });
@@ -649,8 +729,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           acquiredBadgeIds: [],
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false, true);
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: false,
+          isCampaignArchived: true,
+        });
 
         expect(assessmentResult.isDisabled).to.be.true;
       });
@@ -663,8 +750,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
           acquiredBadgeIds: [],
           isDeleted: false,
         };
-        const targetProfile = { competences: [], stages: [], badges: [] };
-        const assessmentResult = new AssessmentResult(participationResults, targetProfile, false, false, false);
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages: [],
+          badgeResultsDTO: [],
+          isCampaignMultipleSendings: false,
+          isOrganizationLearnerActive: false,
+          isCampaignArchived: false,
+        });
 
         expect(assessmentResult.isDisabled).to.be.false;
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -52,7 +52,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         { id: 3, title: 'Stage2', message: 'Message2', threshold: 50 },
         { id: 4, title: 'Stage1', message: 'Message1', threshold: 100 },
       ];
-      const badges = [
+      const badgeResultsDTO = [
         {
           id: 3,
           altMessage: 'Badge2 AltMessage',
@@ -65,14 +65,15 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         },
       ];
 
-      const targetProfile = { competences, stages, badges };
-      assessmentResult = new AssessmentResult(
+      assessmentResult = new AssessmentResult({
         participationResults,
-        targetProfile,
+        competences,
+        stages,
+        badgeResultsDTO,
         isCampaignMultipleSendings,
         isOrganizationLearnerActive,
-        isCampaignArchived
-      );
+        isCampaignArchived,
+      });
     });
 
     it('should convert a CampaignParticipationResult model object into JSON API data', function () {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du refacto des certif complémentaires, nous allons modifier la façon de fonctionner des badges certifiables. L’idée est que ce badge certifiable porte l'éligibilité à une certif complémentaire, qui peut être perdue à tout moment (en cas de remise à 0 d’une compétence).

Aujourd’hui, lorsqu’un utilisateur obtient au badge certifiable à l’issu d’un parcours, puis le perd et revient sur la page de fin de parcours (depuis son menu “Mes parcours” sur app, il voit toujours le badge certifiable alors qu’il n’est plus éligible).

## :robot: Solution
Ne plus afficher sur la page de fin de parcours un badge certifiable si l’utilisateur n’est plus éligible à la certification complémentaire concernée

## :rainbow: Remarques

On reprends le filtre qui vérifie que le badge est encore valide `badgeCriteriaService.areBadgeCriteriaFulfilled`

Le refacto est assez conséquent pour que le repository soit d'une part plus concis, moins orienté domain, et d'autre part pour ne pas avoir à faire des appels en doublons.

Pour allez plus loin, il faudrait limiter encore plus le scope du repository et faire faire le travail par un objet du domain.

## :100: Pour tester
Passer un badge via une campagne. Valider le badge puis verifier en revenant sur la campagne qu'il est bien present.
Supprimer ensuite les KE liés à ce badge via un reset de competence. 
Verifier que le badge disparait quand on reviens 

