### PR TITLE
[TECH] Il manque un test pour la méthode update du campaign repository (Pix 5679).

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -215,6 +215,19 @@ describe('Integration | Repository | Campaign', function () {
       expect(campaignSaved).to.be.an.instanceof(Campaign);
     });
 
+    it('should update the correct campaign', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ title: 'MASH' }).id;
+      await databaseBuilder.commit();
+
+      // when
+      await campaignRepository.update({ id: campaign.id, title: 'Title' });
+      const row = await knex.from('campaigns').where({ id: campaignId }).first();
+
+      // then
+      expect(row.title).to.equal('MASH');
+    });
+
     it('should not add row in table "campaigns"', async function () {
       // given
       const rowsCountBeforeUpdate = await knex.select('id').from('campaigns');


### PR DESCRIPTION
## :unicorn: Problème
Il manque un test pour la méthode update du campaign repository

## :robot: Solution
Rajouter un test

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Si je supprime le where campaign-repository.js:71 un des tests d'intégrations ne passe pas.
