### PR TITLE
[BUGFIX] Afficher la méthode de connexion CNAV dans la modale de suppression sur Pix Admin (PIX-5670).

### DIFF
--- a/admin/app/components/users/user-detail-personal-information.js
+++ b/admin/app/components/users/user-detail-personal-information.js
@@ -11,6 +11,7 @@ const typesLabel = {
   USERNAME: 'Identifiant',
   POLE_EMPLOI: 'Pôle Emploi',
   GAR: 'Médiacentre',
+  CNAV: 'CNAV',
 };
 
 export default class UserDetailPersonalInformationComponent extends Component {

--- a/admin/tests/integration/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information_test.js
@@ -126,7 +126,10 @@ module('Integration | Component | users | user-detail-personal-information', fun
       await clickByName('Supprimer');
 
       // then
-      assert.dom(screen.getByText('Confirmer la suppression')).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Confirmer la suppression' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Oui, je supprime' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      assert.dom(screen.getByText('Suppression de la méthode de connexion suivante : Adresse e-mail')).exists();
     });
 
     test('should close the modal on click on cancel button', async function (assert) {

--- a/admin/tests/unit/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information_test.js
@@ -49,4 +49,56 @@ module('Unit | Component | users | user-detail-personal-information', function (
       assert.ok(component.notifications.error.called);
     });
   });
+
+  module('#translatedType', function () {
+    module('when authentication method is GAR', function () {
+      test('it should display "Médiacentre"', function (assert) {
+        // given
+        component.authenticationMethodType = 'GAR';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'Médiacentre');
+      });
+    });
+
+    module('when authentication method is PIX with email', function () {
+      test('it should display "Adresse e-mail"', function (assert) {
+        // given
+        component.authenticationMethodType = 'EMAIL';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'Adresse e-mail');
+      });
+    });
+
+    module('when authentication method is PIX with username', function () {
+      test('it should display "Identifiant"', function (assert) {
+        // given
+        component.authenticationMethodType = 'USERNAME';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'Identifiant');
+      });
+    });
+
+    module('when authentication method is POLE EMPLOI', function () {
+      test('it should display "Pôle Emploi"', function (assert) {
+        // given
+        component.authenticationMethodType = 'POLE_EMPLOI';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'Pôle Emploi');
+      });
+    });
+
+    module('when authentication method is CNAV', function () {
+      test('it should display "CNAV"', function (assert) {
+        // given
+        component.authenticationMethodType = 'CNAV';
+
+        // when & then
+        assert.strictEqual(component.translatedType, 'CNAV');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite à cette PR: https://github.com/1024pix/pix/pull/4886 , on peut désormais supprimer la méthode de connexion CNAV d'un utilisateur sur Pix Admin.
Seulement lorsque l'on clique sur le bouton supprimer, la méthode de connexion n'apparaît pas dans la modale.

## :robot: Solution
Ajouter la méthode de connexion CNAV dans la liste de méthodes de connexion attendues dans la modale de suppression.

## :rainbow: Remarques
Ajout de tests unitaires pour le get qui affiche ces méthodes.

## :100: Pour tester
- En local: Créer un compte CNAV fonctionnellement (en passant sur Pix App) ou bien ajouter une méthode de connexion CNAV en BDD directement (authentication-methods)
- Se connecter sur Pix Admin (superadmin@example.net)
- Cliquer sur l'onglet Utilisateurs
- Chercher l'utilisateur ayant la méthode ( en RA : Jon Snow )
- Ouvrir la page de détails de cet utilisateur
- Supprimer la méthode de connexion CNAV
- Constater que la méthode de connexion s'affiche dans la modale