### PR TITLE
[FEATURE] Ajout du FT pour la récupération des résultats CleA par les CDC habilités (PIX-5373).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -194,6 +194,9 @@ module.exports = (function () {
     featureToggles: {
       isPixAppTutoFiltersEnabled: isFeatureEnabled(process.env.FT_TUTOS_V2_1_FILTERS),
       isSsoAccountReconciliationEnabled: isFeatureEnabled(process.env.FT_SSO_ACCOUNT_RECONCILIATION),
+      isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(
+        process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
+      ),
     },
 
     infra: {
@@ -317,6 +320,7 @@ module.exports = (function () {
 
     config.featureToggles.isPixAppTutoFiltersEnabled = false;
     config.featureToggles.isSsoAccountReconciliationEnabled = false;
+    config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/sample.env
+++ b/api/sample.env
@@ -718,6 +718,13 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 # default: false
 # FT_SSO_ACCOUNT_RECONCILIATION=true
 
+# Allow habilitated certifications centers to retrieve clea results
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS=true
+
 # =====
 # CPF
 # =====

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-pix-app-tuto-filters-enabled': false,
             'is-sso-account-reconciliation-enabled': false,
+            'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
           },
         },
       };

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isCertificationFreeFieldsDeletionEnabled;
+  @attr('boolean') isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled;
 }


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de cette nouvelle EPIX dédiée à la récupération des résultats CleA par les centres de certification habilités, nous souhaitons avancer à l'aide d'un feature-toggle

## :robot: Solution

Ajout d'un feature toggle
- [x] Ajout du FT sur les différents environnements

## :rainbow: Remarques

Le nom de ce FT est un peu long mais transmet je pense l'information nécessaire.
Preneur de meilleures options. 🤷‍♂️

## :100: Pour tester

Vérifier que les tests passent.
