### PR TITLE
[FEATURE] Supprimer les filtres sur la pages des tutoriels enregistrés (PIX-5684).

### DIFF
--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -6,6 +6,16 @@
     </p>
 
     <ul class="user-tutorials-banner-v2__filters">
+      <li class="user-tutorials-banner-v2-filters__filter">
+        <ChoiceChip @route="authenticated.user-tutorials.recommended">
+          {{t "pages.user-tutorials.recommended"}}
+        </ChoiceChip>
+      </li>
+      <li class="user-tutorials-banner-v2-filters__filter">
+        <ChoiceChip @route="authenticated.user-tutorials.saved">
+          {{t "pages.user-tutorials.saved"}}
+        </ChoiceChip>
+      </li>
       {{#if (and this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled @shouldShowFilterButton)}}
         <li class="user-tutorials-banner-v2-filters__filter">
           <PixButton
@@ -17,16 +27,6 @@
           </PixButton>
         </li>
       {{/if}}
-      <li class="user-tutorials-banner-v2-filters__filter">
-        <ChoiceChip @route="authenticated.user-tutorials.recommended">
-          {{t "pages.user-tutorials.recommended"}}
-        </ChoiceChip>
-      </li>
-      <li class="user-tutorials-banner-v2-filters__filter">
-        <ChoiceChip @route="authenticated.user-tutorials.saved">
-          {{t "pages.user-tutorials.saved"}}
-        </ChoiceChip>
-      </li>
     </ul>
   </div>
 </div>

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -6,7 +6,7 @@
     </p>
 
     <ul class="user-tutorials-banner-v2__filters">
-      {{#if this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled}}
+      {{#if (and this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled @shouldShowFilterButton)}}
         <li class="user-tutorials-banner-v2-filters__filter">
           <PixButton
             @backgroundColor="transparent-light"

--- a/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/controllers/authenticated/user-tutorials/saved.js
@@ -1,12 +1,9 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class SavedController extends Controller {
   @service router;
-
-  @tracked isSidebarVisible = false;
 
   pageOptions = [
     { label: '10', value: 10 },
@@ -18,26 +15,5 @@ export default class SavedController extends Controller {
   @action
   refresh() {
     this.send('refreshModel');
-  }
-
-  @action
-  showSidebar() {
-    this.isSidebarVisible = true;
-  }
-
-  @action
-  closeSidebar() {
-    this.isSidebarVisible = false;
-  }
-
-  @action
-  handleSubmitFilters(filters) {
-    this.router.replaceWith({
-      queryParams: {
-        competences: filters.competences.length ? filters.competences : undefined,
-        pageNumber: 1,
-      },
-    });
-    this.closeSidebar();
   }
 }

--- a/mon-pix/app/routes/authenticated/user-tutorials/saved.js
+++ b/mon-pix/app/routes/authenticated/user-tutorials/saved.js
@@ -9,7 +9,6 @@ export default class UserTutorialsSavedRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
-    competences: { refreshModel: true },
   };
 
   async model(params) {
@@ -18,9 +17,6 @@ export default class UserTutorialsSavedRoute extends Route {
       'tutorial',
       {
         type: 'saved',
-        filter: {
-          competences: params.competences,
-        },
         page: {
           number: params.pageNumber,
           size: params.pageSize,
@@ -37,7 +33,6 @@ export default class UserTutorialsSavedRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.set('pageNumber', null);
-      controller.set('competences', null);
     }
   }
 

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -91,6 +91,7 @@
     list-style: none;
     margin: 0;
     padding: 0;
+    height: 45px;
   }
 }
 

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -2,7 +2,7 @@
   <burger.outlet>
     <header role="banner">
       <NavbarHeader @burger={{burger}} />
-      <Tutorials::Header @onTriggerFilterButton={{this.showSidebar}} />
+      <Tutorials::Header @onTriggerFilterButton={{this.showSidebar}} @shouldShowFilterButton={{true}} />
     </header>
 
     <main id="main" class="main" role="main">

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -2,16 +2,10 @@
   <burger.outlet>
     <header role="banner">
       <NavbarHeader @burger={{burger}} />
-      <Tutorials::Header @onTriggerFilterButton={{this.showSidebar}} />
+      <Tutorials::Header @onTriggerFilterButton={{this.showSidebar}} @shouldShowFilterButton={{false}} />
     </header>
 
     <main id="main" class="main" role="main">
-      <UserTutorials::Filters::Sidebar
-        @onSubmit={{this.handleSubmitFilters}}
-        @isVisible={{this.isSidebarVisible}}
-        @areas={{this.model.areas}}
-        @onClose={{this.closeSidebar}}
-      />
       <div class="user-tutorials-content-v2">
         {{#if @model.savedTutorials.meta.rowCount}}
           <div class="user-tutorials-content-v2__container">

--- a/mon-pix/mirage/handlers/find-paginated-and-filtered-saved-tutorials.js
+++ b/mon-pix/mirage/handlers/find-paginated-and-filtered-saved-tutorials.js
@@ -2,17 +2,8 @@ import { getPaginationFromQueryParams, applyPagination } from './pagination-util
 
 export function findPaginatedAndFilteredSavedTutorials(schema, request) {
   const queryParams = request.queryParams;
-  const competenceFilters = queryParams['filter[competences]'];
 
-  let tutorials;
-
-  if (competenceFilters) {
-    tutorials = [schema.tutorials.create({ name: `Le tuto de la compétence ${competenceFilters[0]}` })];
-    schema.userSavedTutorials.create({ tutorial: tutorials[0] });
-  } else {
-    tutorials = schema.tutorials.all().models;
-  }
-
+  const tutorials = schema.tutorials.all().models;
   const userSavedTutorialIds = schema.userSavedTutorials
     .all()
     .models.map((userSavedTutorial) => userSavedTutorial.tutorialId);

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -2,10 +2,9 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { find, findAll, click, currentURL } from '@ember/test-helpers';
+import { find, findAll, click } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticateByEmail } from '../../helpers/authentication';
-import { waitForDialog } from '../../helpers/wait-for';
 
 describe('Acceptance | User-tutorials-v2 | Saved', function () {
   setupApplicationTest();
@@ -43,46 +42,6 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
 
         // then
         expect(findAll('.tutorial-card-v2')).to.be.lengthOf(9);
-      });
-    });
-
-    describe('when user is filtering by competences', function () {
-      it('should filter tutorial by competence and close sidebar', async function () {
-        // given
-        await server.db.tutorials.remove();
-        await server.db.userSavedTutorials.remove();
-
-        server.create('area', 'withCompetences');
-        server.createList('tutorial', 10, 'withUserSavedTutorial');
-        const screen = await visit('/mes-tutos/enregistres');
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(10);
-
-        await click(screen.getByRole('button', { name: 'Filtrer' }));
-        await waitForDialog();
-        await click(screen.getByRole('button', { name: 'Mon super domaine' }));
-        await click(screen.getByRole('checkbox', { name: 'Ma superbe compétence' }));
-
-        // when
-        await click(screen.getByRole('button', { name: 'Voir les résultats' }));
-
-        // then
-        expect(currentURL()).to.equal('/mes-tutos/enregistres?competences=1&pageNumber=1');
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);
-        expect(find('.pix-sidebar--hidden')).to.exist;
-      });
-
-      describe('when user access again to tutorials saved page', function () {
-        it('should reset competences filters', async function () {
-          // given
-          const screen = await visit('/mes-tutos/enregistres?competences=1&pageNumber=1');
-
-          // when
-          await click(screen.getByRole('link', { name: 'Recommandés' }));
-          await click(screen.getByRole('link', { name: 'Enregistrés' }));
-
-          // then
-          expect(currentURL()).to.equal('/mes-tutos/enregistres');
-        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/tutorials/header_test.js
+++ b/mon-pix/tests/integration/components/tutorials/header_test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { find, findAll } from '@ember/test-helpers';
+import { contains } from '../../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
@@ -18,30 +18,44 @@ describe('Integration | Component | Tutorials | Header', function () {
 
   it('renders the header', async function () {
     // when
-    await render(hbs`<Tutorials::Header />`);
-
-    // then
-    expect(find('.user-tutorials-banner-v2__title')).to.exist;
-    expect(find('.user-tutorials-banner-v2__description')).to.exist;
-    expect(find('.user-tutorials-banner-v2__filters')).to.exist;
-    expect(findAll('a.pix-choice-chip')).to.have.lengthOf(2);
-    expect(find('a.pix-choice-chip,a.pix-choice-chip--active')).to.exist;
-    expect(find('a.pix-choice-chip,a.pix-choice-chip--active'))
-      .to.have.property('textContent')
-      .that.contains('Recommandés');
-  });
-
-  it('should render filter button when tutorial filter feature toggle is activate', async function () {
-    // given
-    class FeatureTogglesStub extends Service {
-      featureToggles = { isPixAppTutoFiltersEnabled: true };
-    }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
-
-    // when
     const screen = await render(hbs`<Tutorials::Header />`);
 
     // then
-    expect(screen.getByRole('button', { name: 'Filtrer' })).to.exist;
+    expect(contains(this.intl.t('pages.user-tutorials.title'))).to.exist;
+    expect(contains(this.intl.t('pages.user-tutorials.description'))).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('pages.user-tutorials.recommended') })).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('pages.user-tutorials.saved') })).to.exist;
+  });
+
+  describe('when shouldShowFilterButton is true', function () {
+    it('should render filter button when tutorial filter feature toggle is activate', async function () {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isPixAppTutoFiltersEnabled: true };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+      // when
+      const screen = await render(hbs`<Tutorials::Header @shouldShowFilterButton={{true}}/>`);
+
+      // then
+      expect(screen.getByRole('button', { name: 'Filtrer' })).to.exist;
+    });
+  });
+
+  describe('when shouldShowFilterButton is false', function () {
+    it('should render filter button when tutorial filter feature toggle is activate', async function () {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isPixAppTutoFiltersEnabled: true };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+      // when
+      const screen = await render(hbs`<Tutorials::Header @shouldShowFilterButton={{false}}/>`);
+
+      // then
+      expect(screen.queryByRole('button', { name: 'Filtrer' })).to.not.exist;
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur Pix App, nous pouvons filtrer par compétences les tutoriels enregistrés. Cependant, nous n'avons pas le contexte du tutoriel dans tous les cas ce qui ne permet pas toujours filtrer par compétences.

## :robot: Solution
Supprimer la possibilité de filtrer sur cette page

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix App
- Enregistrer des tutoriels
- Aller sur la page `/mes-tutos/enregistres` et constater qu'il n'y a pas le bouton "Filtrer"
- Aller sur la page `/mes-tutos/recommandes` et constater qu'il y a toujours la bouton "Filtrer"
