### PR TITLE
[TECH] Alimenter la colonne "isReferer" dans certification-center-memberships (PIX-5374)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center-membership.js
+++ b/api/db/database-builder/factory/build-certification-center-membership.js
@@ -9,6 +9,7 @@ module.exports = function buildCertificationCenterMembership({
   certificationCenterId,
   createdAt = new Date('2020-01-01'),
   disabledAt,
+  isReferer = false,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   certificationCenterId = _.isUndefined(certificationCenterId) ? buildCertificationCenter().id : certificationCenterId;
@@ -19,6 +20,7 @@ module.exports = function buildCertificationCenterMembership({
     certificationCenterId,
     createdAt,
     disabledAt,
+    isReferer,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-center-memberships',

--- a/api/db/migrations/20220915083737_add-new-column-referer-to-certification-centers-memberships.js
+++ b/api/db/migrations/20220915083737_add-new-column-referer-to-certification-centers-memberships.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'certification-center-memberships';
+const COLUMN_NAME = 'isReferer';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/CertificationCenterMembership.js
+++ b/api/lib/domain/models/CertificationCenterMembership.js
@@ -1,10 +1,11 @@
 class CertificationCenterMembership {
-  constructor({ id, certificationCenter, user, createdAt, disabledAt } = {}) {
+  constructor({ id, certificationCenter, user, createdAt, disabledAt, isReferer } = {}) {
     this.id = id;
     this.certificationCenter = certificationCenter;
     this.user = user;
     this.createdAt = createdAt;
     this.disabledAt = disabledAt;
+    this.isReferer = isReferer;
   }
 }
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
@@ -17,6 +17,7 @@ module.exports = function buildCertificationCenterMembership({
   user = _buildUser(),
   createdAt = new Date('2020-01-01'),
   disabledAt,
+  isReferer = false,
 } = {}) {
   return new CertificationCenterMembership({
     id,
@@ -24,5 +25,6 @@ module.exports = function buildCertificationCenterMembership({
     user,
     createdAt,
     disabledAt,
+    isReferer,
   });
 };


### PR DESCRIPTION
## :unicorn: Problème
Les centres de certification habilités CléA numérique doivent importer les informations des candidats ayant obtenu leur “Cléa numérique by Pix” sur la plateforme mise à disposition par Certif Pro, notamment pour générer les parchemins (= certificat) de ces candidats. Pour le moment, nous leur avons indiqué dans le process, de se mettre en tant que “destinataire des résultats” pour chaque candidat Cléa, afin de recevoir le fichier csv des résultats à la publication de la session.

## :robot: Solution
Premiere étape : ajouter la colonne referer dans certification-center-memberships qui sera rempli par un boolean

## :100: Pour tester
Lancer les migrations et voir que la nouvelle colonne est bien ajoutée dans la table