### PR TITLE
[BUGFIX] Supprimer l'appel au helper text-with-multiple-lang dans la page d'affichage des résultats (PIX-5703).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -40,7 +40,7 @@
                 {{text-with-multiple-lang this.reachedStage.title}}
               </div>
               <div class="stage-congrats__message">
-                <MarkdownToHtml @markdown={{text-with-multiple-lang this.reachedStage.message}} />
+                <MarkdownToHtml @markdown={{this.reachedStage.message}} />
               </div>
             </div>
           {{else}}

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -120,6 +120,37 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     });
   });
 
+  context('when the the campaign has stage', function () {
+    it('displays the stage message', async function () {
+      const reachedStage = {
+        get: sinon.stub(),
+        message: 'Bravo !',
+      };
+      reachedStage.get.withArgs('threshold').returns([75]);
+      campaign = {
+        customResultPageButtonUrl: 'http://www.my-url.net/resultats',
+        customResultPageButtonText: 'Next step',
+        organizationName: 'Dragon & Co',
+        organizationShowNPS: false,
+      };
+      const campaignParticipationResult = {
+        isShared: true,
+        masteryRate: '0.5',
+        participantExternalId: '1234G56',
+        reachedStage,
+        campaignParticipationBadges: [],
+        stageCount: 1,
+      };
+      this.set('model', { campaign, campaignParticipationResult });
+
+      // When
+      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+      // Then
+      expect(contains('Bravo !')).to.exist;
+    });
+  });
+
   describe('The trainings block', function () {
     context('When they does not have trainings', function () {
       it('should not display the block', async function () {


### PR DESCRIPTION
## :unicorn: Problème
L'affichage de la page des résultats ne marche plus pour les campagne avec des paliers.

## :robot: Solution
Supprimer l'appel au helper text-with-multiple-lang 

## :rainbow: Remarques
L'utilisation text-with-multiple-lang n'est pas nécéssaire puisque le message du palier est toujours une chaine de caractère dans une seule langue.   

## :100: Pour tester
Participer à une campagne d'évaluation qui a des paliers et aller jusqu'à la page de partage des résultats.