### PR TITLE
[BUGFIX] Des thématiques en dehors du profil-cible sont comprises dans le payload de lecture du profil-cible sur PixAdmin (PIX-5708)

### DIFF
--- a/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -145,9 +145,12 @@ async function _getLearningContent_new(targetProfileId, tubesData, locale) {
   const competenceIds = _.keys(_.groupBy(tubes, 'competenceId'));
   const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
 
-  const thematicIds = competences.map((competence) => competence.thematicIds).flat();
+  const thematicIds = competences.flatMap((competence) => competence.thematicIds);
   const uniqThematicIds = _.uniq(thematicIds);
-  const thematics = await thematicRepository.findByRecordIds(uniqThematicIds, locale);
+  const allCompetenceThematics = await thematicRepository.findByRecordIds(uniqThematicIds, locale);
+  const thematics = allCompetenceThematics.filter((thematic) =>
+    thematic.tubeIds.some((tubeId) => tubeIds.includes(tubeId))
+  );
 
   const areaIds = _.map(competences, (competence) => competence.areaId);
   const uniqAreaIds = _.uniq(areaIds);

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
@@ -493,7 +493,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
               index: '5',
               areaId: 'recAreaA',
               origin: 'Pix',
-              thematicIds: ['recThemC'],
+              thematicIds: ['recThemC', 'recThemD'],
             },
           ],
           thematics: [
@@ -518,6 +518,13 @@ describe('Integration | Repository | target-profile-for-admin', function () {
               competenceId: 'recCompB',
               tubeIds: ['recTube3'],
             },
+            {
+              id: 'recThemD',
+              name: 'nameFRD',
+              index: '4',
+              competenceId: 'recCompB',
+              tubeIds: ['recTube4'],
+            },
           ],
           tubes: [
             {
@@ -538,6 +545,12 @@ describe('Integration | Repository | target-profile-for-admin', function () {
               name: 'tubeName3',
               practicalTitleFrFr: 'practicalTitleFR3',
             },
+            {
+              id: 'recTube4',
+              competenceId: 'recCompB',
+              name: 'tubeName4',
+              practicalTitleFrFr: 'practicalTitleFR4',
+            },
           ],
           skills: [
             {
@@ -553,6 +566,11 @@ describe('Integration | Repository | target-profile-for-admin', function () {
             {
               id: 'recSkillTube3',
               tubeId: 'recTube3',
+              status: 'actif',
+            },
+            {
+              id: 'recSkillTube4',
+              tubeId: 'recTube4',
               status: 'actif',
             },
           ],
@@ -596,6 +614,13 @@ describe('Integration | Repository | target-profile-for-admin', function () {
               id: 'recChalBTube3',
               responsive: [],
               skillId: 'recSkillTube3',
+              status: 'validé',
+              genealogy: 'Prototype 1',
+            },
+            {
+              id: 'recChalTube4',
+              responsive: [],
+              skillId: 'recSkillTube4',
               status: 'validé',
               genealogy: 'Prototype 1',
             },


### PR DESCRIPTION
## :unicorn: Problème
Des thématiques qui ne sont pas supposées être dans le profil-cible sont malgré tout embarquée dans le TargetProfileForAdmin modèle (route GET /admin/target-profiles/id)

## :robot: Solution
Eviter de récupérer des thématiques dans lesquelles aucun tube du profil-cible ne sont compris.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Tester sur une autre PR et celle-ci :
- Créer un nouveau profil-cible
- Choisir toute la 2.1 Interagir
- Aller sur la page de détails / console du développeur et regarder le payload de réponse (ou bien le plugin ember storage)
- Constater que, contrairement à l'affichage sur PixAdmin, 5 thématiques sont reçues et non pas 4 (thématique workbench sans tubes)

Evidemment sur cette PR la thématique bonus a disparu
