### PR TITLE
[TECH] Nettoyer les données d'une précédente session (PIX-5658)

### DIFF
--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -12,6 +12,12 @@ export default class LoginOidcRoute extends Route {
   @service oidcIdentityProviders;
   @service featureToggles;
 
+  _unsetOidcProperties() {
+    this.session.set('data.nextURL', undefined);
+    this.session.set('data.nonce', undefined);
+    this.session.set('data.state', undefined);
+  }
+
   beforeModel(transition) {
     const queryParams = transition.to.queryParams;
     if (queryParams.error) {
@@ -19,6 +25,8 @@ export default class LoginOidcRoute extends Route {
     }
 
     if (!queryParams.code) {
+      this._unsetOidcProperties();
+
       const identityProviderSlug = transition.to.params.identity_provider_slug.toString();
       const isSupportedIdentityProvider = this.oidcIdentityProviders[identityProviderSlug] ?? null;
       if (isSupportedIdentityProvider) return this._handleRedirectRequest(identityProviderSlug);

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -33,6 +33,13 @@ describe('Unit | Route | login-oidc', function () {
       const nonce = '555c86fe-ed0a-4a80-80f3-45b1f7c2df8c';
 
       beforeEach(function () {
+        sinon.stub(fetch, 'default').resolves({
+          json: sinon.stub().resolves({
+            redirectTarget: `https://oidc/connexion`,
+            state,
+            nonce,
+          }),
+        });
         const oidcPartner = {
           id: 'oidc-partner',
           code: 'OIDC_PARTNER',
@@ -42,6 +49,10 @@ describe('Unit | Route | login-oidc', function () {
           list = [oidcPartner];
         }
         this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+      });
+
+      afterEach(function () {
+        sinon.restore();
       });
 
       context('when identity provider is not supported', function () {
@@ -97,19 +108,16 @@ describe('Unit | Route | login-oidc', function () {
         });
       });
 
-      it('should direct user to identity provider login page and set state and nonce', async function () {
+      it('should clear previous session data, redirect user to identity provider login page and set state and nonce', async function () {
         // given
-        sinon.stub(fetch, 'default').resolves({
-          json: sinon.stub().resolves({
-            redirectTarget: `https://oidc/connexion`,
-            state,
-            nonce,
-          }),
-        });
         const sessionStub = Service.create({
           attemptedTransition: { intent: { url: '/campagnes/PIXOIDC01/acces' } },
           authenticate: sinon.stub().resolves(),
-          data: {},
+          data: {
+            nextURL: '/previous-url',
+            state: 'previous-state',
+            nonce: 'previous-nonce',
+          },
         });
         const route = this.owner.lookup('route:authentication/login-oidc');
         route.set('session', sessionStub);
@@ -121,7 +129,6 @@ describe('Unit | Route | login-oidc', function () {
         // then
         sinon.assert.calledWithMatch(route.location.replace, 'https://oidc/connexion');
         expect(sessionStub.data).to.deep.equal({ nextURL: '/campagnes/PIXOIDC01/acces', state, nonce });
-        sinon.restore();
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Il peut arriver que des informations d'une session précédente, liée à une connexion à un partenaire, viennent modifier le comportement attendu d'un utilisateur sur une nouvelle session liée à une connexion avec un autre partenaire, sur la même machine et le même navigateur.

## :robot: Solution

Nettoyer toutes données (state, nonce, nextURL) concernant une authentification dans les données de session.

## :rainbow: Remarques

Le problème est difficilement reproductible, voir impossible dû au changement effectué sur la brique générique de connexion aux différents partenaires.

## :100: Pour tester

- Se connecter avec un compte Pôle Emploi via le sso du partenaire
- Tentez de commencer un parcours CNAV via le code `PIXCNAV01`
- Se connecter avec un compte CNAV
- Constatez que l'on arrive bien sur le parcours
- Quitter le parcours
- Constatez que le compte Pôle Emploi n'est plus connecté
- Tentez de commencer un parcours Pôle Emploi via le code `PIXEMPLOI`
- Se connecter avec un compte Pôle Emploi
- Constatez que l'on arrive bien sur le parcours
- Quitter le parcours
- Constatez que le compte CNAV n'est plus connecté
