### PR TITLE
[BUGFIX] Correction d'un bug d'affichage de PixMultiSelect

### DIFF
--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -4,15 +4,6 @@
     height: auto;
   }
 
-  label {
-    margin-bottom: 0.5rem;
-  }
-
-  label,
-  output {
-    display: inline-block;
-  }
-
   &__instructions {
     margin-bottom: 10px;
     font-size: 0.8rem;
@@ -101,4 +92,10 @@
   background-clip: padding-box;
   border: 1px solid $pix-neutral-22;
   border-radius: 0.25rem;
+}
+
+// FIXME: remove after upgrading to pix-ui v19.0.0
+label {
+  margin-bottom: 0.5rem;
+  display: inline-block;
 }


### PR DESCRIPTION
## :unicorn: Problème

Le PixMultiSelect a un bug d'affichage dans PixAdmin :

![image](https://user-images.githubusercontent.com/19571875/190645943-22790411-51b0-4a5d-b02c-4d1fbe27fca2.png)

## :robot: Solution

On revient temporairement en arrière sur [les modifs ayant introduit le bug](https://github.com/1024pix/pix/pull/4869/commits/41719f275f8e6be4ff0bc7e5bdfdb1fd03173344#diff-07a655b21866eabf47fbf79fb98eb90ff41962d6695c769a6971339fef4b829e), en attendant de pouvoir monter à la version 19.0.0 de pix-ui.

## :rainbow: Remarques

N/A

## :100: Pour tester

Aller sur la page de création d'un profil cible, vérifier que le multi select des référentiels s'affiche correctement.