### PR TITLE
[TECH] Mettre à jour le script de certification pour gérer les campagnes

### DIFF
--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -3,7 +3,7 @@ const {
   TARGET_PROFILE_STAGES_BADGES_ID,
   TARGET_PROFILE_ONE_COMPETENCE_ID,
   TARGET_PROFILE_SIMPLIFIED_ACCESS_ID,
-  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
   TARGET_PROFILE_PIX_DROIT_ID,
   TARGET_PROFILE_CNAV_ID,
 } = require('./target-profiles-builder');
@@ -86,13 +86,13 @@ __Plus d'infos :)__
 
   databaseBuilder.factory.buildCampaign({
     id: POLE_EMPLOI_CAMPAIGN_ID,
-    name: 'Pro - Campagne Pix Emploi',
+    name: 'Pro - Campagne Pix Emploi v3',
     code: 'PIXEMPLOI',
     type: 'ASSESSMENT',
     organizationId: PRO_POLE_EMPLOI_ID,
     creatorId: 2,
     ownerId: 2,
-    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     assessmentMethod: 'SMART_RANDOM',
     title: null,
     customLandingPageText: null,

--- a/api/db/seeds/data/certification/badge-acquisition-builder.js
+++ b/api/db/seeds/data/certification/badge-acquisition-builder.js
@@ -17,41 +17,109 @@ const {
   CERTIF_EDU_FORMATION_CONTINUE_1ER_DEGRE_USER_ID,
 } = require('./users');
 
+const { participateToAssessmentCampaign } = require('../campaign-participations-builder');
+const {
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V2,
+  TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
+  TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
+  TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE,
+  TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE,
+} = require('../target-profiles-builder');
+const { PRO_COMPANY_ID, PRO_LEARNER_ASSOCIATED_ID } = require('../organizations-pro-builder');
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+const { SHARED } = CampaignParticipationStatuses;
+
 function badgeAcquisitionBuilder({ databaseBuilder }) {
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V1',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
     userId: CERTIF_REGULAR_USER1_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V1,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V2',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V2,
     userId: CERTIF_SUCCESS_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V2,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V3',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     userId: CERTIF_SUCCESS_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne PixEmploiClea V3',
+    targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     userId: CERTIF_FAILURE_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Initiale 2nd degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
     userId: CERTIF_EDU_FORMATION_INITIALE_2ND_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME_BADGE_ID,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Continue 2nd degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
     userId: CERTIF_EDU_FORMATION_CONTINUE_2ND_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE_BADGE_ID,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Initiale 1er degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE,
     userId: CERTIF_EDU_FORMATION_INITIALE_1ER_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME_BADGE_ID,
+    databaseBuilder,
   });
-  databaseBuilder.factory.buildBadgeAcquisition({
+  _buildBadgeAcquisition({
+    campaignName: 'Campagne Edu Formation Continue 1er degré',
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE,
     userId: CERTIF_EDU_FORMATION_CONTINUE_1ER_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE_BADGE_ID,
+    databaseBuilder,
   });
 }
 
 module.exports = {
   badgeAcquisitionBuilder,
 };
+
+function _buildBadgeAcquisition({ campaignName, targetProfileId, userId, badgeId, databaseBuilder }) {
+  const campaignParticipationId = _buildRequiredCampaignData({
+    campaignName,
+    targetProfileId,
+    userId,
+    databaseBuilder,
+  });
+  databaseBuilder.factory.buildBadgeAcquisition({
+    userId,
+    badgeId,
+    campaignParticipationId,
+  });
+}
+
+function _buildRequiredCampaignData({ campaignName, targetProfileId, userId, databaseBuilder }) {
+  const campaignId = databaseBuilder.factory.buildCampaign({
+    name: campaignName,
+    type: 'ASSESSMENT',
+    targetProfileId,
+    organizationId: PRO_COMPANY_ID,
+  }).id;
+  return participateToAssessmentCampaign({
+    databaseBuilder,
+    campaignId,
+    user: { id: userId },
+    organizationLearnerId: PRO_LEARNER_ASSOCIATED_ID,
+    status: SHARED,
+  });
+}

--- a/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
+++ b/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
@@ -14,12 +14,30 @@ const {
   PIX_DROIT_MAITRE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_1ER_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
 } = require('./certification-centers-builder');
+const { participateToAssessmentCampaign } = require('../campaign-participations-builder');
+const { TARGET_PROFILE_PIX_DROIT_ID } = require('../target-profiles-builder');
+const { SUP_STUDENT_ASSOCIATED_ID, SUP_UNIVERSITY_ID } = require('../organizations-sup-builder');
+const CampaignParticipationStatuses = require('../../../../lib/domain/models/CampaignParticipationStatuses');
+const { SHARED } = CampaignParticipationStatuses;
 
 function complementaryCertificationCourseResultsBuilder({ databaseBuilder }) {
+  const campaignId = databaseBuilder.factory.buildCampaign({
+    name: 'Campagne Pix+Droit',
+    type: 'ASSESSMENT',
+    targetProfileId: TARGET_PROFILE_PIX_DROIT_ID,
+    organizationId: SUP_UNIVERSITY_ID,
+  }).id;
+  const campaignParticipationId = participateToAssessmentCampaign({
+    databaseBuilder,
+    campaignId,
+    user: { id: CERTIF_DROIT_USER5_ID },
+    organizationLearnerId: SUP_STUDENT_ASSOCIATED_ID,
+    status: SHARED,
+  });
   databaseBuilder.factory.buildBadgeAcquisition({
     badgeId: PIX_DROIT_MAITRE_BADGE_ID,
     userId: CERTIF_DROIT_USER5_ID,
-    campaignParticipationId: null,
+    campaignParticipationId,
   });
   const { id: complementaryCertifCourseSuccessCleaId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
     certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID,

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -7,6 +7,7 @@ const PRO_POLE_EMPLOI_ID = 4;
 const PRO_CNAV_ID = 17;
 const PRO_MED_NUM_ID = 5;
 const PRO_ARCHIVED_ID = 15;
+const PRO_LEARNER_ASSOCIATED_ID = 1200;
 
 function organizationsProBuilder({ databaseBuilder }) {
   /* PRIVATE COMPANY */
@@ -74,6 +75,25 @@ function organizationsProBuilder({ databaseBuilder }) {
     email: userInvited.email,
     status: OrganizationInvitation.StatusType.PENDING,
     organizationId: PRO_COMPANY_ID,
+  });
+
+  // learner associated
+  const userAssociated = databaseBuilder.factory.buildUser.withRawPassword({
+    id: PRO_LEARNER_ASSOCIATED_ID,
+    firstName: 'learnerPro',
+    lastName: 'Associated',
+    email: 'learnerpro.associated@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    id: PRO_LEARNER_ASSOCIATED_ID,
+    firstName: userAssociated.firstName,
+    lastName: userAssociated.lastName,
+    birthdate: '2005-03-28',
+    organizationId: PRO_COMPANY_ID,
+    userId: PRO_LEARNER_ASSOCIATED_ID,
   });
 
   /* POLE EMPLOI */
@@ -213,4 +233,5 @@ module.exports = {
   PRO_POLE_EMPLOI_ID,
   PRO_CNAV_ID,
   PRO_MED_NUM_ID,
+  PRO_LEARNER_ASSOCIATED_ID,
 };

--- a/api/package.json
+++ b/api/package.json
@@ -154,6 +154,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
+    "test:api:scripts": "npm run test:api:path -- tests/integration/scripts",
     "test:api:unit": "TEST_DATABASE_URL=postgres://should.not.reach.db.in.unit.tests REDIS_URL= npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -7,6 +7,7 @@ const bluebird = require('bluebird');
 const maxBy = require('lodash/maxBy');
 const logger = require('../../lib/infrastructure/logger');
 const { getNewSessionCode } = require('../../lib/domain/services/session-code-service');
+const temporaryStorage = require('../../lib/infrastructure/temporary-storage/index');
 const {
   makeUserPixCertifiable,
   makeUserPixDroitCertifiable,
@@ -431,5 +432,6 @@ async function _disconnect() {
   await disconnect();
   logger.info('Closing connexions to cache...');
   cache.quit();
+  temporaryStorage.quit();
   logger.info('Exiting process gracefully...');
 }

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -22,7 +22,9 @@ const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst: false });
 const cache = require('../../lib/infrastructure/caches/learning-content-cache');
 
 /**
- * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1 '[{"candidateNumber": 1, "name": "Pix+ Édu 2nd degré"}]'
+ * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1 '[{"candidateNumber": 1, "key": "EDU_1ER_DEGRE"}, {"candidateNumber": 1, "key": "EDU_2ND_DEGRE"}]'
+ * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'PRO' 2 '[{"candidateNumber": 1, "key": "CLEA"}, {"candidateNumber": 2, "key": "DROIT"}]'
+ * LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'PRO' 1'
  */
 
 const PIXCLEA = 'CLEA';
@@ -395,7 +397,7 @@ async function _createUser({ firstName, lastName, birthdate, email }, databaseBu
 }
 
 if (process.argv.length > 2 && process.env.NODE_ENV !== 'test') {
-  const [centerType, candidateNumber, complementaryCertifications] = process.argv.slice(2);
+  const [centerType, candidateNumber, complementaryCertifications = '[]'] = process.argv.slice(2);
 
   main({
     centerType,


### PR DESCRIPTION
## :unicorn: Problème
Suite à une modification de la recuperation des skillz d'une campagne. Le script de generation de données ne permettait plus de demarrer une certification

## :robot: Solution
Ajouter pour tout les candidats une participation à une campagne et lier le badge de certification complementaire à cette campagne

## :rainbow: Remarques
Le premier commit embarque un fix pour corriger les seeds (cherry pick du commit de @laura-bergoens )

## :100: Pour tester
- Lancer le script 
- via CLI: `LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js`
- ou directement: `LOG_LEVEL=info ./scripts/data-generation/generate-certif-cli.js 'SUP' 1` '[{"candidateNumber": 1, "key": "EDU_1ER_DEGRE"}, {"candidateNumber": 1, "key": "EDU_2ND_DEGRE"}]'
- démarrer une certification
- s'assurer que la certification démarre avec les certifications complementaires selectionnées
