### PR TITLE
[BUGFIX] Ne pas poser deux fois les mêmes challenges en certif si un badge est acquis plusieurs fois (PIx-5720)

### DIFF
--- a/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -25,6 +25,7 @@ module.exports = {
         'complementary-certifications.key as complementaryCertificationKey',
         'campaign-participations.campaignId'
       )
+      .distinctOn('complementary-certifications.id')
       .join('badges', 'badges.id', 'badge-acquisitions.badgeId')
       .join('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
       .join(


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un candidat a acquis 'n' fois un badge certifiable, les challenges associés sont posés autant de fois

## :robot: Solution
Ne proposer les challenges lié à un badge acquis plusieurs fois qu'une fois en certification

## :100: Pour tester
- Passer une certification ayant du référentiel Pix+ pour un utilisateur ayant deux badge acquisition pointants vers le même badge
- Constater que les chllenges Pix+ N'ont pas été posés en double