### PR TITLE
[TECH] Supprimer la configuration de branche obsolète des tests automatisés

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,6 @@ workflows:
     jobs:
       - checkout:
           context: Pix
-          filters:
-            branches:
-              ignore:
-                - gh-pages
-                - master
-                - prod
-                - /release-.*/
 
       - api_build_and_test:
           context: Pix


### PR DESCRIPTION
## :unicorn: Problème
Des branches n'existant plus sont mentionnées dans la configuration CircleCi

## :robot: Solution
Supprimer les références.

## :100: Pour tester
Vérifier que la CI passe
