### PR TITLE
[BUGFIX] Charger toutes les données quand on accède à la page de détail d'un utilisateur depuis la liste des membres d'une organisation (PIX-5726)

### DIFF
--- a/admin/app/components/organizations/member-item.hbs
+++ b/admin/app/components/organizations/member-item.hbs
@@ -1,4 +1,4 @@
-<td><LinkTo @route="authenticated.users.get" @model={{@membership.user}}>
+<td><LinkTo @route="authenticated.users.get" @model={{@membership.user.id}}>
     {{@membership.user.id}}
   </LinkTo></td>
 <td>{{@membership.user.firstName}}</td>


### PR DESCRIPTION
## :unicorn: Problème
Quand on accède à la page de détail d'un utilisateur depuis la page qui liste les membres d'une organisation, toutes les informations de l'utilisateur ne sont pas affichées.

## :robot: Solution
En fait la linkto `<LinkTo @route="authenticated.users.get" @model={{@membership.user}}>` donnait tout un model à la route. Ce qui fait que cette route n'allait pas chercher d'information supplémentaire car on lui avait passé ce qu'on estimait être nécessaire.
Il vaut mieux dans ce cas ne donner que l'id à `@model` , ce qui aura pour conséquence qu'Ember rechargera les données en lien avec cet id là. 

## :rainbow: Remarques
Plus d'info sur LinkTo : https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo
Voir l'article en lien : https://emberigniter.com/force-store-reload-data-api-backend/ 

## :100: Pour tester
- Se connecter sur Pix Admin
- Aller sur la page de détail d'une organisation
- Scroller vers la section des membres
- Cliquer sur l'id d'un des membres
- Constater qu'on est bien redirigé vers la page de détail du membre et que aucune info ne manque (ex “Langue”, “Date de dernière connexion” sont remplis et  l’onglet “Profil” et “Participations” ne restent pas vides)
