### PR TITLE
[BUGFIX] Instancier Badge au lieu de Stage dans TargetProfileAdapter

### DIFF
--- a/api/lib/infrastructure/adapters/target-profile-adapter.js
+++ b/api/lib/infrastructure/adapters/target-profile-adapter.js
@@ -1,5 +1,6 @@
 const TargetProfile = require('../../domain/models/TargetProfile');
 const Stage = require('../../domain/models/Stage');
+const Badge = require('../../domain/models/Badge');
 const skillAdapter = require('./skill-adapter');
 
 module.exports = {
@@ -8,7 +9,7 @@ module.exports = {
     const targetProfileStages = bookshelfTargetProfile.related('stages');
     const stages = targetProfileStages?.models?.map((stage) => new Stage(stage.attributes)) ?? [];
     const targetProfileBadges = bookshelfTargetProfile.related('badges');
-    const badges = targetProfileBadges?.models?.map((stage) => new Stage(stage.attributes)) ?? [];
+    const badges = targetProfileBadges?.models?.map((badge) => new Badge(badge.attributes)) ?? [];
 
     return new TargetProfile({
       id: bookshelfTargetProfile.get('id'),


### PR DESCRIPTION
## :unicorn: Problème

Le `TargetProfileAdapter` instancie un `Stage` au lieu d'un `Badge`.

## :robot: Solution

Instancier un `Badge`.

## :rainbow: Remarques

A priori ça n'a pas eu d'impact.

## :100: Pour tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
