### PR TITLE
[FEATURE] Ajouter la colonne Certificabilité dans l'onglet Étudiants (Pix-5562)

### DIFF
--- a/api/db/seeds/data/campaigns-sup-builder.js
+++ b/api/db/seeds/data/campaigns-sup-builder.js
@@ -2,7 +2,7 @@ const {
   TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
   TARGET_PROFILE_PIX_DROIT_ID,
 } = require('./target-profiles-builder');
-const { SUP_UNIVERSITY_ID, SUP_STUDENT_ASSOCIATED_ID, SUP_STUDENT_DISABLED_ID } = require('./organizations-sup-builder');
+const { SUP_UNIVERSITY_ID, SUP_STUDENT_ASSOCIATED_ID, SUP_STUDENT_DISABLED_ID, SUP_STUDENT_CERTIFIABLE } = require('./organizations-sup-builder');
 const { participateToAssessmentCampaign, participateToProfilesCollectionCampaign } = require('./campaign-participations-builder');
 const CampaignParticipationStatuses = require('../../../lib/domain/models/CampaignParticipationStatuses');
 const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;
@@ -75,6 +75,8 @@ function _buildSupAssessmentParticipations({ databaseBuilder }) {
 function _buildSupProfilesCollectionParticipations({ databaseBuilder }) {
   const supStudentAssociated = { id: SUP_STUDENT_ASSOCIATED_ID, createdAt: new Date('2022-02-06') };
   const supStudentDisabled = { id: SUP_STUDENT_DISABLED_ID, createdAt: new Date('2022-02-07') };
+  const supStudentCertifiable = { id: SUP_STUDENT_CERTIFIABLE, createdAt: new Date('2022-02-08') };
   participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 10, user: supStudentAssociated, organizationLearnerId: SUP_STUDENT_ASSOCIATED_ID, status: SHARED });
   participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 10, user: supStudentDisabled, organizationLearnerId: SUP_STUDENT_DISABLED_ID, status: TO_SHARE });
+  participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 10, user: supStudentCertifiable, organizationLearnerId: SUP_STUDENT_CERTIFIABLE, status: SHARED, isCertifiable: true });
 }

--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -5,6 +5,7 @@ const { DEFAULT_PASSWORD } = require('./users-builder');
 const SUP_UNIVERSITY_ID = 2;
 const SUP_STUDENT_ASSOCIATED_ID = 888;
 const SUP_STUDENT_DISABLED_ID = 889;
+const SUP_STUDENT_CERTIFIABLE = 999;
 
 function organizationsSupBuilder({ databaseBuilder }) {
   const supUser1 = databaseBuilder.factory.buildUser.withRawPassword({
@@ -103,6 +104,28 @@ function organizationsSupBuilder({ databaseBuilder }) {
     division: null,
   });
 
+  // student certifiable
+  const studentCertfiable = databaseBuilder.factory.buildUser.withRawPassword({
+    id: SUP_STUDENT_CERTIFIABLE,
+    firstName: 'Certi',
+    lastName: 'Fiable',
+    email: 'certi.fiable@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    id: SUP_STUDENT_CERTIFIABLE,
+    firstName: studentCertfiable.firstName,
+    lastName: studentCertfiable.lastName,
+    birthdate: '2005-03-28',
+    organizationId: SUP_UNIVERSITY_ID,
+    userId: SUP_STUDENT_CERTIFIABLE,
+    studentNumber: 'c3rt1f',
+    group: 'L3',
+    division: null,
+  });
+
   // disabled student
   const studentDisabled = databaseBuilder.factory.buildUser.withRawPassword({
     id: SUP_STUDENT_DISABLED_ID,
@@ -130,4 +153,6 @@ module.exports = {
   SUP_UNIVERSITY_ID,
   SUP_STUDENT_ASSOCIATED_ID,
   SUP_STUDENT_DISABLED_ID,
+  SUP_STUDENT_CERTIFIABLE,
+
 };

--- a/api/lib/domain/read-models/SupOrganizationParticipant.js
+++ b/api/lib/domain/read-models/SupOrganizationParticipant.js
@@ -11,6 +11,7 @@ class SupOrganizationParticipant {
     campaignName,
     campaignType,
     participationStatus,
+    isCertifiable,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -23,6 +24,7 @@ class SupOrganizationParticipant {
     this.campaignName = campaignName;
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
+    this.isCertifiable = isCertifiable;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer.js
@@ -15,6 +15,7 @@ module.exports = {
         'campaignName',
         'campaignType',
         'participationStatus',
+        'isCertifiable',
       ],
       meta,
     }).serialize(supOrganizationParticipants);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1082,6 +1082,7 @@ describe('Acceptance | Application | organization-controller', function () {
                 'campaign-name': campaign.name,
                 'campaign-type': campaign.type,
                 'participation-status': participation.status,
+                'is-certifiable': participation.isCertifiable,
               },
               id: organizationLearner.id.toString(),
               type: 'sup-organization-participants',

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -705,5 +705,280 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         expect(lastParticipationDate).to.deep.equal(null);
       });
     });
+
+    context('#isCertifiable', function () {
+      it('should take the shared participation', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: false,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.STARTED,
+          sharedAt: null,
+          isCertifiable: true,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
+      });
+
+      it('should be null when sup participant has a not shared participation', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.STARTED,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(null);
+      });
+
+      it('should take the last shared participation', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: true,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: false,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
+      });
+
+      it('should take the last shared participation of profile collection campaign', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const profileCollectionCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const assessmentCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.ASSESSMENT,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: profileCollectionCampaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: assessmentCampaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
+      });
+
+      it('should take the last shared participation not deleted', async function () {
+        // given
+        const deletedBy = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: false,
+          deletedAt: new Date(),
+          deletedBy,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
+      });
+
+      it('should take the last shared participation even if isImproved is true', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: true,
+          isImproved: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
+      });
+
+      it('should take the last shared participation for campaign of given organization', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({
+          organizationId: otherOrganizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: true,
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2022-01-01'),
+          isCertifiable: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          data: [{ isCertifiable }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -17,12 +17,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
       await databaseBuilder.commit();
 
       // when
-      const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+      const {
+        data: [participant],
+      } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
         organizationId: organization.id,
       });
 
       // then
-      expect(data[0]).to.be.an.instanceOf(SupOrganizationParticipant);
+      expect(participant).to.be.an.instanceOf(SupOrganizationParticipant);
     });
 
     it('should return all the SupOrganizationParticipant for a given organization ID', async function () {
@@ -327,13 +329,15 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         };
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ campaignName, campaignType }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].campaignName).to.deep.equal(expectedAttributes.campaignName);
-        expect(data[0].campaignType).to.deep.equal(expectedAttributes.campaignType);
+        expect(campaignName).to.deep.equal(expectedAttributes.campaignName);
+        expect(campaignType).to.deep.equal(expectedAttributes.campaignType);
       });
 
       it('should return null when there is no participation', async function () {
@@ -344,13 +348,15 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ campaignName, campaignType }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].campaignName).to.deep.equal(null);
-        expect(data[0].campaignType).to.deep.equal(null);
+        expect(campaignName).to.deep.equal(null);
+        expect(campaignType).to.deep.equal(null);
       });
 
       it('should return campaign name and type only for a campaign in the given organization', async function () {
@@ -365,12 +371,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ campaignName }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].campaignName).to.equal(null);
+        expect(campaignName).to.equal(null);
       });
     });
 
@@ -393,12 +401,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ participationStatus }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].participationStatus).to.deep.equal(CampaignParticipationStatuses.TO_SHARE);
+        expect(participationStatus).to.equal(CampaignParticipationStatuses.TO_SHARE);
       });
 
       it('should return null when there is no participation', async function () {
@@ -409,12 +419,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ participationStatus }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        expect(data[0].participationStatus).to.deep.equal(null);
+        expect(participationStatus).to.deep.equal(null);
       });
     });
 
@@ -431,13 +443,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([2]);
+        expect(participationCount).to.equal(2);
       });
 
       it('should count only participations not deleted', async function () {
@@ -463,13 +476,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([1]);
+        expect(participationCount).to.deep.equal(1);
       });
 
       it('should count only participations not improved', async function () {
@@ -483,13 +497,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([1]);
+        expect(participationCount).to.deep.equal(1);
       });
 
       it('should count 0 participation when sup participant has no participation', async function () {
@@ -499,13 +514,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ participationCount }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const participationCountAsArray = data.map((result) => result.participationCount);
-        expect(participationCountAsArray).to.deep.equal([0]);
+        expect(participationCount).to.deep.equal(0);
       });
     });
 
@@ -521,12 +537,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { meta } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          meta: { participantCount },
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId: organization.id,
         });
 
         // then
-        expect(meta.participantCount).to.equal(1);
+        expect(participantCount).to.equal(1);
       });
 
       it('should not count disabled SUP participants', async function () {
@@ -540,12 +558,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { meta } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          meta: { participantCount },
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId: organization.id,
         });
 
         // then
-        expect(meta.participantCount).to.equal(1);
+        expect(participantCount).to.equal(1);
       });
 
       it('should count all participants when several exist', async function () {
@@ -558,12 +578,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { meta } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          meta: { participantCount },
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId: organization.id,
         });
 
         // then
-        expect(meta.participantCount).to.equal(2);
+        expect(participantCount).to.equal(2);
       });
     });
 
@@ -588,13 +610,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([campaignParticipation.createdAt]);
+        expect(lastParticipationDate).to.deep.equal(campaignParticipation.createdAt);
       });
 
       it('should take the last participation date not deleted', async function () {
@@ -622,13 +645,15 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([campaignParticipation.createdAt]);
+
+        expect(lastParticipationDate).to.deep.equal(campaignParticipation.createdAt);
       });
 
       it('should take the last participation date not improved', async function () {
@@ -652,13 +677,15 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([campaignParticipation.createdAt]);
+
+        expect(lastParticipationDate).to.deep.equal(campaignParticipation.createdAt);
       });
 
       it('should be null when sup participant has no participation', async function () {
@@ -668,13 +695,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         await databaseBuilder.commit();
 
         // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        const {
+          data: [{ lastParticipationDate }],
+        } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
           organizationId,
         });
 
         // then
-        const lastParticipationDatesAsArray = data.map((result) => result.lastParticipationDate);
-        expect(lastParticipationDatesAsArray).to.deep.equal([null]);
+        expect(lastParticipationDate).to.deep.equal(null);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer_test.js
@@ -20,6 +20,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
           campaignName: 'King Karam',
           campaignType: 'ASSESSMENT',
           participationStatus: campaignParticipationsStatuses.TO_SHARE,
+          isCertifiable: true,
         }),
         new SupOrganizationParticipant({
           id: 778,
@@ -33,6 +34,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
           campaignName: 'King Xavier',
           campaignType: 'PROFILES_COLLECTION',
           participationStatus: campaignParticipationsStatuses.SHARED,
+          isCertifiable: false,
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -55,6 +57,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
               'campaign-name': supOrganizationParticipants[0].campaignName,
               'campaign-type': supOrganizationParticipants[0].campaignType,
               'participation-status': supOrganizationParticipants[0].participationStatus,
+              'is-certifiable': supOrganizationParticipants[0].isCertifiable,
             },
           },
           {
@@ -71,6 +74,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
               'campaign-name': supOrganizationParticipants[1].campaignName,
               'campaign-type': supOrganizationParticipants[1].campaignType,
               'participation-status': supOrganizationParticipants[1].participationStatus,
+              'is-certifiable': supOrganizationParticipants[1].isCertifiable,
             },
           },
         ],

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -57,6 +57,9 @@
         <Table::Header @size="medium" @align="center">
           {{t "pages.sup-organization-participants.table.column.last-participation-date"}}
         </Table::Header>
+        <Table::Header @size="medium" @align="center">
+          {{t "pages.sup-organization-participants.table.column.is-certifiable.label"}}
+        </Table::Header>
         <Table::Header @size="medium" class="hide-on-mobile" />
       </tr>
     </thead>
@@ -83,6 +86,9 @@
                   />
                 </div>
               {{/if}}
+            </td>
+            <td class="table__column--center">
+              <Ui::IsCertifiable @isCertifiable={{student.isCertifiable}} />
             </td>
             <td class="organization-participant-list-page__actions hide-on-mobile">
               {{#if this.currentUser.isAdminInOrganization}}

--- a/orga/app/models/sup-organization-participant.js
+++ b/orga/app/models/sup-organization-participant.js
@@ -12,4 +12,5 @@ export default class SupOrganizationParticipant extends Model {
   @attr('string') campaignType;
   @attr('string') participationStatus;
   @belongsTo('organization') organization;
+  @attr('boolean', { allowNull: true }) isCertifiable;
 }

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -104,6 +104,27 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     assert.contains('reçu');
   });
 
+  test('it should display participant as eligible for certification when the sup participant is certifiable', async function (assert) {
+    // given
+    const students = [
+      {
+        lastParticipationDate: new Date('2022-01-03'),
+        campaignName: 'SUP - Campagne de collecte de profils',
+        campaignType: 'PROFILES_COLLECTION',
+        participationStatus: 'SHARED',
+        isCertifiable: true,
+      },
+    ];
+
+    this.set('students', students);
+
+    // when
+    await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+    // then
+    assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
+  });
+
   module('when user is filtering some users', function () {
     test('it should trigger filtering with lastname', async function (assert) {
       const triggerFiltering = sinon.spy();

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -899,7 +899,10 @@
           "last-name": "Last name",
           "last-participation-date": "Latest participation",
           "participation-count": "Number of participations",
-          "student-number": "Student number"
+          "student-number": "Student number",
+          "is-certifiable": {
+            "label": "Certificabilité"
+          }
         },
         "empty": "No students.",
         "filter": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -899,7 +899,10 @@
           "last-name": "Nom",
           "last-participation-date": "Dernière participation",
           "participation-count": "Nombre de participations",
-          "student-number": "Numéro étudiant"
+          "student-number": "Numéro étudiant",
+          "is-certifiable": {
+            "label": "Certificabilité"
+          }
         },
         "empty": "Aucun étudiant.",
         "filter": {


### PR DESCRIPTION
## :unicorn: Problème
Dans la continuité de l'enrichissement des tableaux des prescrits, on n'avait aucun moyen de savoir si un prescrit était certifiable ou pas 

## :robot: Solution
Ajouter une colonne qui nous donne cette info

## :rainbow: Remarques


## :100: Pour tester
- Aller sur Pix Orga en tant qu'admin du SUP
- Aller sur l'onglet Étudiants et constater la présence de la colonne Certificabilité ainsi que du tag 
