### PR TITLE
[FEATURE] Remplacer les modales dépréciées dans Pix-App (PIX-5711).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.hbs
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.hbs
@@ -1,64 +1,56 @@
-<PixModalDeprecated @containerClass="join-error-modal" @onClickOverlay={{@closeModal}} role="dialog">
-  <div class="join-error-modal__header">
-    <div class="join-error-modal-header__title">
-      <h1 class="join-error-modal-header-title__text">{{t "pages.join.sco.login-information-title"}}</h1>
-    </div>
-    <PixIconButton
-      id="pix-modal__close-button"
-      @withBackground={{true}}
-      @ariaLabel={{t "common.actions.close"}}
-      @icon="xmark"
-      @triggerAction={{@closeModal}}
-    />
-  </div>
-
-  <div class="join-error-modal__body" {{on-key "Escape" @closeModal}}>
-    {{#if this.message}}
-      <div class="join-error-modal-body__message" aria-live="polite">{{this.message}}</div>
-    {{/if}}
-    {{#if this.isAccountBelongingToAnotherUser}}
-      <p>
-        {{t "api-error-messages.join-error.r90.account-belonging-to-another-user"}}
-        <ul class="join-error-modal-body__list">
-          <li>
-            {{t "api-error-messages.join-error.r90.details.if-account-belonging-to-user"}}
-            <a
-              href="{{t 'api-error-messages.join-error.r90.details.contact-support.link-url'}}"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{t "api-error-messages.join-error.r90.details.contact-support.link-text"}}
-            </a>
-            {{t "api-error-messages.join-error.r90.details.code"}}
-          </li>
-          <li>{{t "api-error-messages.join-error.r90.details.disconnect-user"}}</li>
-        </ul>
-      </p>
-    {{/if}}
-  </div>
-
-  <div class="join-error-modal__footer">
-    {{#if this.isInformationMode}}
-      <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.goToHome}}>
-        {{t "common.actions.sign-out"}}
-      </PixButton>
-
-      <PixButton @triggerAction={{@associate}}>
-        {{t "pages.join.sco.associate"}}
-      </PixButton>
-    {{else}}
-      <PixButton
-        @backgroundColor="{{if this.displayContinueButton 'transparent-light' 'blue'}}"
-        @isBorderVisible={{true}}
-        @triggerAction={{this.goToHome}}
-      >
-        {{t "common.actions.quit"}}
-      </PixButton>
-      {{#if this.displayContinueButton}}
-        <PixButton @triggerAction={{this.goToCampaignConnectionForm}}>
-          {{t "pages.join.sco.continue-with-pix"}}
-        </PixButton>
+<PixModal @title={{t "pages.join.sco.login-information-title"}} @onCloseButtonClick={{@closeModal}} @showModal={{true}}>
+  <:content>
+    <div class="join-error-modal__body">
+      {{#if this.message}}
+        <div class="join-error-modal-body__message" aria-live="polite">
+          <p>{{this.message}}</p>
+        </div>
       {{/if}}
-    {{/if}}
-  </div>
-</PixModalDeprecated>
+      {{#if this.isAccountBelongingToAnotherUser}}
+        <p>
+          {{t "api-error-messages.join-error.r90.account-belonging-to-another-user"}}
+          <ul class="join-error-modal-body__list">
+            <li>
+              {{t "api-error-messages.join-error.r90.details.if-account-belonging-to-user"}}
+              <a
+                href="{{t 'api-error-messages.join-error.r90.details.contact-support.link-url'}}"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{t "api-error-messages.join-error.r90.details.contact-support.link-text"}}
+              </a>
+              {{t "api-error-messages.join-error.r90.details.code"}}
+            </li>
+            <li>{{t "api-error-messages.join-error.r90.details.disconnect-user"}}</li>
+          </ul>
+        </p>
+      {{/if}}
+    </div>
+  </:content>
+  <:footer>
+    <div class="join-error-modal__footer">
+      {{#if this.isInformationMode}}
+        <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.goToHome}}>
+          {{t "common.actions.sign-out"}}
+        </PixButton>
+
+        <PixButton @triggerAction={{@associate}}>
+          {{t "pages.join.sco.associate"}}
+        </PixButton>
+      {{else}}
+        <PixButton
+          @backgroundColor="{{if this.displayContinueButton 'transparent-light' 'blue'}}"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.goToHome}}
+        >
+          {{t "common.actions.quit"}}
+        </PixButton>
+        {{#if this.displayContinueButton}}
+          <PixButton @triggerAction={{this.goToCampaignConnectionForm}}>
+            {{t "pages.join.sco.continue-with-pix"}}
+          </PixButton>
+        {{/if}}
+      {{/if}}
+    </div>
+  </:footer>
+</PixModal>

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -150,64 +150,52 @@
     </div>
   {{/if}}
 </div>
-{{#if this.showResetModal}}
-  <PixModalDeprecated
-    @containerClass="scorecard-details__reset-modal pix-modal-dialog--wide"
-    @onClickOverlay={{this.closeModal}}
-    @originId="#reset-button"
-    role="dialog"
-  >
-    <button
-      id="pix-modal__close-button"
-      class="pix-modal__close-link"
-      type="button"
-      aria-label="{{t 'common.actions.close'}}"
-      {{on "click" this.closeModal}}
-    >
-      <span>{{t "common.actions.close"}}</span>
-      <FaIcon @icon="circle-xmark" class="logged-user-menu__icon" />
-    </button>
-
-    <div
-      class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding"
-      {{on-key "Escape" this.closeModal}}
-    >
-      <div class="pix-modal-header">
-        <h1 class="pix-modal-header__title pix-modal-header__title--thin">{{t
-            "pages.competence-details.actions.reset.modal.title"
-          }}</h1>
-        <h2 class="pix-modal-header__subtitle">{{@scorecard.name}}</h2>
-      </div>
-
-      <div class="pix-modal-body pix-modal-body--with-padding">
-        <div class="scorecard-details-reset-modal__important-message">
-          {{#if @scorecard.hasNotReachLevelOne}}
-            {{t "pages.competence-details.actions.reset.modal.important-message" earnedPix=@scorecard.earnedPix}}
-          {{else if @scorecard.hasReachAtLeastLevelOne}}
-            {{t
-              "pages.competence-details.actions.reset.modal.important-message-above-level-one"
-              level=@scorecard.level
-              earnedPix=@scorecard.earnedPix
-            }}
-          {{/if}}
-        </div>
-        <div class="scorecard-details-reset-modal__warning">
-          <p>{{t "pages.competence-details.actions.reset.modal.warning.header"}}</p>
-          <ul>
-            <li>{{t "pages.competence-details.actions.reset.modal.warning.ongoing-assessment"}}</li>
-            <li>{{t "pages.competence-details.actions.reset.modal.warning.certification"}}</li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
-        <PixButton id="pix-mdoal-footer__button-reset" @backgroundColor="red" @triggerAction={{this.reset}}>
-          {{t "pages.competence-details.actions.reset.label"}}
-        </PixButton>
+<PixModal
+  @title={{t "pages.competence-details.actions.reset.modal.title" scoreCardName=@scorecard.name}}
+  @onCloseButtonClick={{this.closeModal}}
+  @showModal={{this.showResetModal}}
+>
+  <:content>
+    <h2 class="scorecard-details-reset-modal__important-message">
+      {{#if @scorecard.hasNotReachLevelOne}}
+        {{t
+          "pages.competence-details.actions.reset.modal.important-message"
+          earnedPix=@scorecard.earnedPix
+          scoreCardName=@scorecard.name
+        }}
+      {{else if @scorecard.hasReachAtLeastLevelOne}}
+        {{t
+          "pages.competence-details.actions.reset.modal.important-message-above-level-one"
+          level=@scorecard.level
+          earnedPix=@scorecard.earnedPix
+          scoreCardName=@scorecard.name
+        }}
+      {{/if}}
+    </h2>
+    <div class="scorecard-details-reset-modal__warning">
+      <p>{{t "pages.competence-details.actions.reset.modal.warning.header"}}</p>
+      <ul class="scorecard-details-reset-modal__list">
+        <li class="scorecard-details-reset-modal-list__item">{{t
+            "pages.competence-details.actions.reset.modal.warning.ongoing-assessment"
+          }}</li>
+        <li class="scorecard-details-reset-modal-list__item">{{t
+            "pages.competence-details.actions.reset.modal.warning.certification"
+          }}</li>
+      </ul>
+    </div>
+  </:content>
+  <:footer>
+    <ul class="scorecard-details-reset-modal__footer">
+      <li>
         <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.closeModal}}>
           {{t "common.actions.cancel"}}
         </PixButton>
-      </div>
-    </div>
-  </PixModalDeprecated>
-{{/if}}
+      </li>
+      <li>
+        <PixButton id="pix-modal-footer__button-reset" @backgroundColor="red" @triggerAction={{this.reset}}>
+          {{t "pages.competence-details.actions.reset.label"}}
+        </PixButton>
+      </li>
+    </ul>
+  </:footer>
+</PixModal>

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -212,15 +212,11 @@
 .scorecard-details-reset-modal {
 
   &__important-message {
-    padding: 20px 0;
+    margin-bottom: $spacing-s;
     color: $pix-neutral-110;
     font-family: $font-roboto;
     font-weight: $font-medium;
     font-size: 1.375rem;
-
-    @include device-is('desktop') {
-      padding: 50px 0 20px 0;
-    }
   }
 
   &__warning {
@@ -234,8 +230,18 @@
       font-weight: bold;
     }
 
-    li:first-child {
-      margin-bottom: 12px;
+    .scorecard-details-reset-modal__list {
+      padding-left: $spacing-l;
+    }
+
+    .scorecard-details-reset-modal-list__item {
+      list-style: initial;
+    }
+  }
+
+  &__footer {
+    @include device-is('tablet') {
+      display: flex;
     }
   }
 }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -140,7 +140,6 @@
   }
 
   &__body {
-    padding: 24px 30px 0;
     background-color: $pix-neutral-10;
     display: flex;
     flex-direction: column;
@@ -148,7 +147,6 @@
   }
 
   &__footer {
-    padding: 24px 30px;
     background-color: $pix-neutral-10;
     display: flex;
     justify-content: center;

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^18.1.0",
+        "@1024pix/pix-ui": "^18.2.0",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -33,6 +33,7 @@
         "dotenv": "^16.0.1",
         "ember-api-actions": "^0.2.9",
         "ember-auto-import": "^1.12.2",
+        "ember-burger-menu": "^3.3.4",
         "ember-cli": "^3.28.5",
         "ember-cli-app-version": "^5.0.0",
         "ember-cli-autoprefixer": "^2.0.0",
@@ -456,9 +457,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.1.0.tgz",
-      "integrity": "sha512-7o/WwwRty1X/NvUvoA5C1rUkoeMKMji0qlMjzKY0M3f/AuSixCnLdK/oKYK1oPn6rodHPzvcjZ6TAjuhnwVfgw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.2.0.tgz",
+      "integrity": "sha512-lpObapOsP4L26fKv9XAoVT6df+t1fRzWuvTLBgSqRm0O9CQt7HJO4N0CT6uqJtdSPt74Z4qFiUn7NnOVke0Pdg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -37977,9 +37978,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.1.0.tgz",
-      "integrity": "sha512-7o/WwwRty1X/NvUvoA5C1rUkoeMKMji0qlMjzKY0M3f/AuSixCnLdK/oKYK1oPn6rodHPzvcjZ6TAjuhnwVfgw==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.2.tgz",
+      "integrity": "sha512-1qZVEXze048T7uZYUoKYIDBuEN9SDHrRGv5vqrNx8DNSFlu7ve4Edrw1JYtKcOcDgK1R7t/wfbrUh3M89upIag==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^18.1.0",
+    "@1024pix/pix-ui": "^18.2.0",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -160,17 +160,17 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
 
           // then
           expect(find('.scorecard-details-reset-modal__important-message').textContent).to.contain(
-            `Votre niveau ${scorecardWithPoints.level} et vos ${scorecardWithPoints.earnedPix} Pix vont être supprimés.`
+            `Votre niveau ${scorecardWithPoints.level} et vos ${scorecardWithPoints.earnedPix} Pix vont être supprimés de la compétence : ${scorecardWithPoints.name}.`
           );
         });
 
         it('should reset competence when user clicks on reset', async function () {
           // given
           await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
-          await click('.scorecard-details__reset-button');
 
+          await click('.scorecard-details__reset-button');
           // when
-          await click('#pix-mdoal-footer__button-reset');
+          await click('#pix-modal-footer__button-reset');
 
           // then
           expect(findAll('.competence-card__level .score-value')).to.have.lengthOf(0);
@@ -186,7 +186,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
           await click('.scorecard-details__reset-button');
 
           // when
-          await click('#pix-mdoal-footer__button-reset');
+          await click('#pix-modal-footer__button-reset');
 
           // then
           expect(findAll('.competence-card__level .score-value')).to.have.lengthOf(0);

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -1,4 +1,5 @@
-import { click, fillIn, currentURL, find, visit } from '@ember/test-helpers';
+import { click, fillIn, currentURL, find } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
@@ -199,7 +200,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collection
 
             it('should display error modal when fields are filled in', async function () {
               // given
-              await visit(`/campagnes/${campaign.code}`);
+              const screen = await visit(`/campagnes/${campaign.code}`);
               await clickByLabel("C'est parti !");
 
               // when
@@ -211,7 +212,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collection
               await clickByLabel(this.intl.t('pages.join.button'));
 
               //then
-              expect(find('.join-error-modal')).to.exist;
+              expect(screen.getByRole('dialog', { name: this.intl.t('pages.join.sco.login-information-title') }));
             });
 
             it('should redirect to connection form when continue button is clicked', async function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -682,8 +682,8 @@
           "label": "Reset",
           "modal": {
             "title": "Competence reset",
-            "important-message": "Your Pix { earnedPix } will be deleted.",
-            "important-message-above-level-one": "Your level { level } and your Pix { earnedPix } will be deleted.",
+            "important-message": "Your Pix { earnedPix } will be deleted from { scoreCardName }.",
+            "important-message-above-level-one": "Your level { level } and your Pix { earnedPix } will be deleted from { scoreCardName }.",
             "warning": {
               "certification": "If you are planning to certify your profile and results, this could affect your certification.",
               "header": "NB: ",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -682,8 +682,8 @@
           "label": "Remettre à zéro",
           "modal": {
             "title": "Remise à zéro de la compétence",
-            "important-message": "Vos { earnedPix } Pix vont être supprimés.",
-            "important-message-above-level-one": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+            "important-message": "Vos { earnedPix } Pix vont être supprimés de la compétence : { scoreCardName }.",
+            "important-message-above-level-one": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés de la compétence : { scoreCardName }.",
             "warning": {
               "certification": "si vous souhaitez faire certifier votre profil et vos différents résultats, cela pourrait altérer votre certification.",
               "header": "Attention : ",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, `PixApp` n'utilise pas les modales de  `Pix UI`dans certaines vues.
## :robot: Solution
- Mettre à jour le package de `Pix UI` (v18.2.0)
- Implémenter les modales dans les vues concernées

## :rainbow: Remarques
- Nous avons remarqués que le composant 'Pix-Modal' ne permet pas d'utiliser des icônes dans son header. Ce qui implique qu'il reste une modal dépréciée tant qu'on a pas mis à jour `Pix UI`

## :100: Pour tester

**Cas 1**
- Se connecter à PixApp
- Cliquer sur la compétence : `Mener une recherche et une veille d’information`
- Cliquer sur le bouton `Remettre à zéro`
- Vérifier via la console que la classe `pix-modal__overlay` existe

