### PR TITLE
[FEATURE] Dans pix-admin ajouter un onglet Centres de certification dans la fiche des utilisateurs (PIX-5583)

### DIFF
--- a/admin/app/components/certification-centers/memberships-section.hbs
+++ b/admin/app/components/certification-centers/memberships-section.hbs
@@ -30,7 +30,11 @@
                 "
               >
                 <td>{{certificationCenterMembership.id}}</td>
-                <td>{{certificationCenterMembership.user.id}}</td>
+                <td>
+                  <LinkTo @route="authenticated.users.get" @model={{certificationCenterMembership.user.id}}>
+                    {{certificationCenterMembership.user.id}}
+                  </LinkTo>
+                </td>
                 <td>{{certificationCenterMembership.user.firstName}}</td>
                 <td>{{certificationCenterMembership.user.lastName}}</td>
                 <td>{{certificationCenterMembership.user.email}}</td>

--- a/admin/app/components/users/certification-center-memberships.hbs
+++ b/admin/app/components/users/certification-center-memberships.hbs
@@ -1,0 +1,43 @@
+<header class="page-section__header">
+  <h2 class="page-section__title">Centres de certification de l’utilisateur</h2>
+</header>
+<div class="content-text content-text--small">
+  <div class="table-admin">
+    <table>
+      <thead>
+        <tr>
+          <th class="table__column table__column--id">Membre ID</th>
+          <th>Centre ID</th>
+          <th>Nom</th>
+          <th>Type</th>
+          <th>Identifiant externe</th>
+        </tr>
+      </thead>
+
+      {{#if this.orderedCertificationCenterMemberships}}
+        <tbody>
+          {{#each this.orderedCertificationCenterMemberships as |certificationCenterMembership|}}
+            <tr>
+              <td>{{certificationCenterMembership.id}}</td>
+              <td class="table__column table__column--id">
+                <LinkTo
+                  @route="authenticated.certification-centers.get"
+                  @model={{certificationCenterMembership.certificationCenter.id}}
+                >
+                  {{certificationCenterMembership.certificationCenter.id}}
+                </LinkTo>
+              </td>
+              <td>{{certificationCenterMembership.certificationCenter.name}}</td>
+              <td>{{certificationCenterMembership.certificationCenter.type}}</td>
+              <td>{{certificationCenterMembership.certificationCenter.externalId}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      {{/if}}
+    </table>
+
+  </div>
+  {{#unless this.orderedCertificationCenterMemberships}}
+    <div class="table__empty">Aucun centre de certification</div>
+  {{/unless}}
+</div>

--- a/admin/app/components/users/certification-center-memberships.js
+++ b/admin/app/components/users/certification-center-memberships.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class CertificationCenterMemberships extends Component {
+  get orderedCertificationCenterMemberships() {
+    return this.args.certificationCenterMemberships.sortBy('certificationCenter.name');
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -51,6 +51,7 @@ Router.map(function () {
         this.route('profile');
         this.route('campaign-participations', { path: '/participations' });
         this.route('organizations');
+        this.route('certification-center-memberships');
       });
     });
 

--- a/admin/app/routes/authenticated/users/get/certification-centers.js
+++ b/admin/app/routes/authenticated/users/get/certification-centers.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class UserCertificationCentersRoute extends Route {
+  async model() {
+    const user = this.modelFor('authenticated.users.get');
+    return user;
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -63,6 +63,7 @@
 @import 'components/users/user-detail-personal-information-section';
 @import 'components/users/user-detail-personal-information/authentication-method';
 @import 'components/users/user-profile';
+@import 'components/users/get';
 @import 'components/target-profiles/badges';
 @import 'components/target-profiles/target-profile';
 @import 'components/target-profiles/badge-form';

--- a/admin/app/styles/components/users/get.scss
+++ b/admin/app/styles/components/users/get.scss
@@ -1,0 +1,3 @@
+.certification-center-navbar {
+  width: 200px;
+}

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -9,12 +9,13 @@
 
 <main class="page-body">
   <section class="page-section">
+    <h1 class="page-section__title">Informations de l'utilisateur</h1>
     <Users::UserOverview @user={{@model}} />
   </section>
 
-  <nav class="navbar">
+  <nav class="navbar" aria-label="Navigation de la section détails d'un utilisateur">
     <LinkTo @route="authenticated.users.get.information" @model={{@model}} class="navbar-item">
-      Informations
+      Détails
     </LinkTo>
 
     <LinkTo @route="authenticated.users.get.profile" @model={{@model}} class="navbar-item">

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -34,6 +34,14 @@
     >
       Organisations
     </LinkTo>
+
+    <LinkTo
+      @route="authenticated.users.get.certification-center-memberships"
+      class="navbar-item certification-center-navbar"
+      aria-label="Centres de certification auxquels appartient l´utilisateur"
+    >
+      Centres de certification
+    </LinkTo>
   </nav>
 
   {{outlet}}

--- a/admin/app/templates/authenticated/users/get/certification-center-memberships.hbs
+++ b/admin/app/templates/authenticated/users/get/certification-center-memberships.hbs
@@ -1,0 +1,3 @@
+<section class="page-section">
+  <Users::CertificationCenterMemberships @certificationCenterMemberships={{@model.certificationCenterMemberships}} />
+</section>

--- a/admin/mirage/serializers/certification-center-membership.js
+++ b/admin/mirage/serializers/certification-center-membership.js
@@ -1,6 +1,6 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
-const relationshipsToInclude = ['certification-center', 'user'];
+const relationshipsToInclude = ['certificationCenter', 'user'];
 
 export default JSONAPISerializer.extend({
   include: relationshipsToInclude,

--- a/admin/mirage/serializers/user.js
+++ b/admin/mirage/serializers/user.js
@@ -1,6 +1,11 @@
 import ApplicationSerializer from './application';
 
-const _includes = ['organizationLearners', 'authenticationMethods', 'organizationMemberships'];
+const _includes = [
+  'organizationLearners',
+  'authenticationMethods',
+  'organizationMemberships',
+  'certificationCenterMemberships',
+];
 
 export default ApplicationSerializer.extend({
   include: _includes,

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -97,13 +97,15 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       externalId: 'ABCDEF',
       type: 'SCO',
     });
+    const user1 = server.create('user', { firstName: 'Eric', lastName: 'Hochet' });
     server.create('certification-center-membership', {
       certificationCenter,
-      user: server.create('user', { firstName: 'Eric', lastName: 'Hochet' }),
+      user: user1,
     });
+    const user2 = server.create('user', { firstName: 'Gilles', lastName: 'Parbal' });
     server.create('certification-center-membership', {
       certificationCenter,
-      user: server.create('user', { firstName: 'Gilles', lastName: 'Parbal' }),
+      user: user2,
     });
 
     // when
@@ -111,7 +113,10 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
     // then
     assert.dom(screen.getByLabelText('Informations du membre Gilles Parbal')).exists();
+    assert.dom(screen.getByRole('link', { name: user1.id })).exists();
+
     assert.dom(screen.getByLabelText('Informations du membre Eric Hochet')).exists();
+    assert.dom(screen.getByRole('link', { name: user2.id })).exists();
   });
 
   test('should be possible to desactive a certification center membership', async function (assert) {

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -41,6 +41,21 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     assert.deepEqual(currentURL(), `/users/${user.id}`);
   });
 
+  test('should display user detail information page', async function (assert) {
+    // when
+    const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
+    const screen = await visit(`/users/${user.id}`);
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: "Informations de l'utilisateur" })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Méthodes de connexion' })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Informations prescrit' })).exists();
+    assert.dom(screen.getByLabelText("Navigation de la section détails d'un utilisateur")).exists();
+    assert.dom(screen.getByRole('link', { name: 'Informations' })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Profil' })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Participations' })).exists();
+  });
+
   test('should redirect to list users page when click page title', async function (assert) {
     // given
     const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -42,8 +42,10 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   test('should display user detail information page', async function (assert) {
-    // when
+    // given
     const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
+
+    // when
     const screen = await visit(`/users/${user.id}`);
 
     // then

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { click, currentURL } from '@ember/test-helpers';
-import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
@@ -50,10 +50,14 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     assert.dom(screen.getByRole('heading', { name: "Informations de l'utilisateur" })).exists();
     assert.dom(screen.getByRole('heading', { name: 'Méthodes de connexion' })).exists();
     assert.dom(screen.getByRole('heading', { name: 'Informations prescrit' })).exists();
-    assert.dom(screen.getByLabelText("Navigation de la section détails d'un utilisateur")).exists();
-    assert.dom(screen.getByRole('link', { name: 'Informations' })).exists();
-    assert.dom(screen.getByRole('link', { name: 'Profil' })).exists();
-    assert.dom(screen.getByRole('link', { name: 'Participations' })).exists();
+
+    const userNavigation = within(screen.getByLabelText("Navigation de la section détails d'un utilisateur"));
+    assert.dom(userNavigation.getByRole('link', { name: 'Détails' })).exists();
+    assert.dom(userNavigation.getByRole('link', { name: 'Profil' })).exists();
+    assert.dom(userNavigation.getByRole('link', { name: 'Participations' })).exists();
+    assert
+      .dom(userNavigation.getByRole('link', { name: 'Centres de certification auxquels appartient l´utilisateur' }))
+      .exists();
   });
 
   test('should redirect to list users page when click page title', async function (assert) {

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -249,4 +249,38 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       assert.dom(screen.getByText('Modifier le rôle')).exists();
     });
   });
+
+  module('when administrator clicks on certification centers tab', function () {
+    test('should display user’s certification centers', async function (assert) {
+      // given
+      const certificationCenter = this.server.create('certification-center', {
+        name: 'Centre Kaede',
+        externalId: 'ABCDEF12345',
+        type: 'SCO',
+      });
+      const certificationCenterMembership = this.server.create('certification-center-membership', {
+        certificationCenter,
+      });
+      const user = this.server.create('user', {
+        email: 'john.harry@example.net',
+        certificationCenterMemberships: [certificationCenterMembership],
+      });
+
+      const adminUser = this.server.create('user');
+      this.server.create('admin-member', {
+        userId: adminUser.id,
+        isSuperAdmin: true,
+      });
+      await createAuthenticateSession({ userId: adminUser.id });
+
+      const screen = await visit(`/users/${user.id}`);
+
+      // when
+      await click(screen.getByLabelText('Centres de certification auxquels appartient l´utilisateur'));
+
+      // then
+      assert.deepEqual(currentURL(), `/users/${user.id}/certification-center-memberships`);
+      assert.dom(screen.getByText('Centre Kaede')).exists();
+    });
+  });
 });

--- a/admin/tests/integration/components/users/certification-center-memberships_test.js
+++ b/admin/tests/integration/components/users/certification-center-memberships_test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | users | certification-center-memberships', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('When user isn’t member of any certification center', function () {
+    test('it should display an empty table', async function (assert) {
+      // given
+      this.set('certificationCenterMemberships', []);
+
+      // when
+      const screen = await render(
+        hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{certificationCenterMemberships}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText('Aucun centre de certification')).exists();
+    });
+  });
+
+  module('When user is member of some certification centers', function () {
+    test('it should display a table of the certification centers the user is member of', async function (assert) {
+      // given
+      const certificationCenter = EmberObject.create('certification-center', {
+        id: '123',
+        name: 'Centre Kaede',
+        externalId: 'ABCDEF12345',
+        type: 'SCO',
+      });
+      const certificationCenterMembership = EmberObject.create('certification-center-membership', {
+        id: '456',
+        certificationCenter,
+      });
+
+      this.set('certificationCenterMemberships', [certificationCenterMembership]);
+
+      // when
+      const screen = await render(
+        hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{certificationCenterMemberships}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText('Centre Kaede')).exists();
+    });
+  });
+});

--- a/admin/tests/unit/components/users/certification-center-memberships_test.js
+++ b/admin/tests/unit/components/users/certification-center-memberships_test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | users | certification-center-memberships', function (hooks) {
+  setupTest(hooks);
+
+  module('#orderedCertificationCenterMemberships', function () {
+    test('it returns certification center memberships in alphabetical order', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:users/certification-center-memberships');
+      const certificationCenterMemberships = [
+        { certificationCenter: { name: 'ZZZ' } },
+        { certificationCenter: { name: 'AAA' } },
+        { certificationCenter: { name: 'BBB' } },
+      ];
+      component.args.certificationCenterMemberships = certificationCenterMemberships;
+
+      // when & then
+      assert.deepEqual(component.orderedCertificationCenterMemberships, [
+        { certificationCenter: { name: 'AAA' } },
+        { certificationCenter: { name: 'BBB' } },
+        { certificationCenter: { name: 'ZZZ' } },
+      ]);
+    });
+  });
+});

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -66,7 +66,6 @@ exports.register = async function (server) {
         tags: ['api', 'admin', 'user'],
       },
     },
-
     {
       method: 'POST',
       path: '/api/admin/users/{id}/anonymize',
@@ -318,6 +317,34 @@ exports.register = async function (server) {
             '- Elle permet à un administrateur de lister les organisations auxquelles appartient l´utilisateur',
         ],
         tags: ['api', 'admin', 'user', 'organizations'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/users/{id}/certification-center-memberships',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        handler: userController.findCertificationCenterMembershipsByUser,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet à un administrateur de lister les centres de certification auxquels appartient l´utilisateur',
+        ],
+        tags: ['api', 'admin', 'user', 'certification-centers'],
       },
     },
   ];

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -16,6 +16,8 @@ const updateEmailSerializer = require('../../infrastructure/serializers/jsonapi/
 const authenticationMethodsSerializer = require('../../infrastructure/serializers/jsonapi/authentication-methods-serializer');
 const campaignParticipationForUserManagementSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer');
 const userOrganizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-organization-for-admin-serializer');
+const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
+
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
@@ -331,5 +333,13 @@ module.exports = {
       userId,
     });
     return h.response(userOrganizationForAdminSerializer.serialize(organizations));
+  },
+
+  async findCertificationCenterMembershipsByUser(request, h) {
+    const userId = request.params.id;
+    const certificationCenterMemberships = await usecases.findCertificationCenterMembershipsByUser({
+      userId,
+    });
+    return h.response(certificationCenterMembershipSerializer.serializeForAdmin(certificationCenterMemberships));
   },
 };

--- a/api/lib/domain/usecases/find-certification-center-memberships-by-user.js
+++ b/api/lib/domain/usecases/find-certification-center-memberships-by-user.js
@@ -1,0 +1,6 @@
+module.exports = async function findCertificationCenterMembershipsByUser({
+  userId,
+  certificationCenterMembershipRepository,
+}) {
+  return certificationCenterMembershipRepository.findByUserId(userId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -283,6 +283,7 @@ module.exports = injectDependencies(
     findTargetProfileStages: require('./find-target-profile-stages'),
     findTutorials: require('./find-tutorials'),
     findUserCampaignParticipationOverviews: require('./find-user-campaign-participation-overviews'),
+    findCertificationCenterMembershipsByUser: require('./find-certification-center-memberships-by-user'),
     findUserForOidcReconciliation: require('./find-user-for-oidc-reconciliation'),
     findUserPrivateCertificates: require('./find-user-private-certificates'),
     flagSessionResultsAsSentToPrescriber: require('./flag-session-results-as-sent-to-prescriber'),

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -42,17 +42,27 @@ function _toDomain(certificationCenterMembershipDTO) {
 
 module.exports = {
   async findByUserId(userId) {
-    const certificationCenterMemberships = await BookshelfCertificationCenterMembership.where({
-      userId,
-      disabledAt: null,
-    }).fetchAll({
-      withRelated: ['certificationCenter'],
-    });
+    const certificationCenterMemberships = await knex
+      .select(
+        'certification-center-memberships.*',
+        'certification-centers.name',
+        'certification-centers.type',
+        'certification-centers.externalId',
+        'certification-centers.createdAt AS certificationCenterCreatedAt',
+        'certification-centers.updatedAt AS certificationCenterUpdatedAt'
+      )
+      .from('certification-center-memberships')
+      .leftJoin(
+        'certification-centers',
+        'certification-centers.id',
+        'certification-center-memberships.certificationCenterId'
+      )
+      .where({
+        userId,
+        disabledAt: null,
+      });
 
-    return bookshelfToDomainConverter.buildDomainObjects(
-      BookshelfCertificationCenterMembership,
-      certificationCenterMemberships
-    );
+    return certificationCenterMemberships.map(_toDomain);
   },
 
   async findActiveByCertificationCenterIdSortedByNames({ certificationCenterId }) {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -40,4 +40,20 @@ module.exports = {
       attributes: ['firstName', 'lastName'],
     }).serialize(certificationCenterMemberships);
   },
+
+  serializeForAdmin(certificationCenterMemberships) {
+    return new Serializer('certification-center-memberships', {
+      attributes: ['createdAt', 'certificationCenter', 'user'],
+      certificationCenter: {
+        ref: 'id',
+        included: true,
+        attributes: ['name', 'type', 'externalId'],
+      },
+      user: {
+        ref: 'id',
+        included: true,
+        attributes: ['firstName', 'lastName', 'email'],
+      },
+    }).serialize(certificationCenterMemberships);
+  },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -8,6 +8,7 @@ module.exports = {
         record.profile = null;
         record.participations = null;
         record.organizationMemberships = null;
+        record.certificationCenterMemberships = null;
         return record;
       },
       attributes: [
@@ -30,6 +31,7 @@ module.exports = {
         'profile',
         'participations',
         'organizationMemberships',
+        'certificationCenterMemberships',
       ],
       organizationLearners: {
         ref: 'id',
@@ -77,6 +79,15 @@ module.exports = {
         relationshipLinks: {
           related: function (record, current, parent) {
             return `/api/admin/users/${parent.id}/organizations`;
+          },
+        },
+      },
+      certificationCenterMemberships: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/admin/users/${parent.id}/certification-center-memberships`;
           },
         },
       },

--- a/api/lib/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer.js
@@ -4,7 +4,6 @@ module.exports = {
   serialize(organization) {
     return new Serializer('organization-membership', {
       attributes: [
-        'id',
         'updatedAt',
         'organizationRole',
         'organizationId',

--- a/api/tests/acceptance/application/users/find-user-certification-centers-for-admin-route-get_test.js
+++ b/api/tests/acceptance/application/users/find-user-certification-centers-for-admin-route-get_test.js
@@ -1,0 +1,42 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Route | Users', function () {
+  describe('GET /api/admin/users/{id}/certification-center-memberships', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const adminUser = databaseBuilder.factory.buildUser.withRole();
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        name: 'Centre Takeo',
+        type: 'SCO',
+        externalId: '1234',
+      });
+
+      const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId,
+        disabledAt: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/admin/users/${userId}/certification-center-memberships`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.be.instanceOf(Array);
+      expect(response.result.data).to.have.length(1);
+      expect(response.result.data[0]).to.have.property('id', certificationCenterMembership.id.toString());
+    });
+  });
+});

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -23,6 +23,7 @@ const validationErrorSerializer = require('../../../../lib/infrastructure/serial
 const updateEmailSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/update-email-serializer');
 const authenticationMethodsSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/authentication-methods-serializer');
 const userOrganizationForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer');
+const certificationCenterMembershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 
 const userController = require('../../../../lib/application/users/user-controller');
 const UserOrganizationForAdmin = require('../../../../lib/domain/read-models/UserOrganizationForAdmin');
@@ -1143,6 +1144,37 @@ describe('Unit | Controller | user-controller', function () {
 
       // then
       expect(usecases.findUserOrganizationsForAdmin).to.have.been.calledWith({ userId: 1 });
+    });
+  });
+
+  describe('#findCertificationCenterMembershipsByUser', function () {
+    it("should return user's certification centers", async function () {
+      // given
+      const certificationCenterMemberships = Symbol("a list of user's certification center memberships");
+      const certificationCenterMembershipsSerialized = Symbol(
+        "a list of user's certification center memberships serialized"
+      );
+
+      sinon
+        .stub(certificationCenterMembershipSerializer, 'serializeForAdmin')
+        .withArgs(certificationCenterMemberships)
+        .returns(certificationCenterMembershipsSerialized);
+
+      sinon
+        .stub(usecases, 'findCertificationCenterMembershipsByUser')
+        .withArgs({ userId: 12345 })
+        .resolves(certificationCenterMemberships);
+
+      // when
+      const request = {
+        params: {
+          id: 12345,
+        },
+      };
+      const result = await userController.findCertificationCenterMembershipsByUser(request, hFake);
+
+      // then
+      expect(result.source).to.equal(certificationCenterMembershipsSerialized);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/find-certification-center-memberships-by-user_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-center-memberships-by-user_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon } = require('../../../test-helper');
+const findCertificationCenterMembershipsByUser = require('../../../../lib/domain/usecases/find-certification-center-memberships-by-user');
+
+describe('Unit | UseCase | find-certification-center-memberships-by-user', function () {
+  let certificationCenterMembershipRepository;
+
+  beforeEach(function () {
+    certificationCenterMembershipRepository = { findByUserId: sinon.stub() };
+  });
+
+  it('should return the list of the user’s certification centers', async function () {
+    // given
+    const certificationCenterMemberships = Symbol('A certification center membership list');
+    certificationCenterMembershipRepository.findByUserId.withArgs(123).resolves(certificationCenterMemberships);
+
+    // when
+    const result = await findCertificationCenterMembershipsByUser({
+      userId: 123,
+      certificationCenterMembershipRepository,
+    });
+
+    // then
+    expect(result).to.equal(certificationCenterMemberships);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -106,4 +106,72 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
       expect(serializedMember).to.deep.equal(expectedSerializedMember);
     });
   });
+
+  describe('#serializeForAdmin', function () {
+    it('should convert into JSON API data', function () {
+      // given
+      const user = domainBuilder.buildUser();
+      const certificationCenter = domainBuilder.buildCertificationCenter({
+        name: 'Centre Shigeru',
+        type: 'SCO',
+        externalId: '12345ABC',
+      });
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+        certificationCenter,
+        user,
+      });
+
+      // when
+      const serializedCertificationCenterMembership = certificationCenterMembershipSerializer.serializeForAdmin([
+        certificationCenterMembership,
+      ]);
+
+      // then
+      expect(serializedCertificationCenterMembership).to.deep.equal({
+        data: [
+          {
+            id: certificationCenterMembership.id.toString(),
+            type: 'certification-center-memberships',
+            attributes: {
+              'created-at': certificationCenterMembership.createdAt,
+            },
+            relationships: {
+              'certification-center': {
+                data: {
+                  id: certificationCenter.id.toString(),
+                  type: 'certificationCenters',
+                },
+              },
+              user: {
+                data: {
+                  id: user.id.toString(),
+                  type: 'users',
+                },
+              },
+            },
+          },
+        ],
+        included: [
+          {
+            id: certificationCenter.id.toString(),
+            type: 'certificationCenters',
+            attributes: {
+              'external-id': certificationCenter.externalId,
+              name: certificationCenter.name,
+              type: certificationCenter.type,
+            },
+          },
+          {
+            id: user.id.toString(),
+            type: 'users',
+            attributes: {
+              'first-name': user.firstName,
+              'last-name': user.lastName,
+              email: user.email,
+            },
+          },
+        ],
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -41,6 +41,11 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             'email-confirmed-at': now,
           },
           relationships: {
+            'certification-center-memberships': {
+              links: {
+                related: '/api/admin/users/123/certification-center-memberships',
+              },
+            },
             'organization-learners': {
               data: [
                 {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer_test.js
@@ -34,7 +34,6 @@ describe('Unit | Serializer | JSONAPI | user-organization-for-admin-serializer',
         data: [
           {
             attributes: {
-              id: 42,
               'organization-external-id': '1234',
               'organization-id': 52,
               'organization-name': 'Organization 1',
@@ -47,7 +46,6 @@ describe('Unit | Serializer | JSONAPI | user-organization-for-admin-serializer',
           },
           {
             attributes: {
-              id: 43,
               'organization-external-id': '5678',
               'organization-id': 53,
               'organization-name': 'Organization 2',


### PR DESCRIPTION
## :unicorn: Problème

Dans pix-admin, sur la fiche d'un utilisateur, il est actuellement impossible de savoir à quels centres de certification est rattaché cet utilisateur. Et donc pour le savoir on est obligé d'aller sur les fiches de chaque centre de certification pour y chercher cet utilisateur.

## :robot: Solution

Ajouter un onglet « Centres de certification » sur la fiche de chaque utilisateur.

## :rainbow: Remarques

* Il n'y a pas de « Date dernière modification » à afficher pour l'instant.
* Dans 2 fichiers de tests pour la partie *admin*, c'est à dire Ember, il y a des `Why?` concernant du code que je n'ai pas réussi à faire fonctionner comme attendu ou pas réussi à faire fonctionner du tout.
* Après avoir fait un ajout ou une désactivation dans un centre de certification, il peut être nécessaire de recharger la page de l'utilisateur pour avoir l'information de rattachement au centre de certification à jour. C'est le cas comme pour d'autres relations de ce type dans pix-admin et donc on changera/corrigera ce comportement plutôt de manière globale dans le cadre d'une autre PR.
* Cette PR contient aussi, sur la page de chaque centre de certification, l'ajout de liens vers les pages de chaque utilisateur, auparavant on ne pouvait pas naviguer grâce des liens.

## :100: Pour tester

Information préliminaire pour les tests : les seeds contiennent déjà des utilisateurs rattachés à des centres de certification, par exemple l'utilisateur certif1@example.net est rattaché au centre de certification « Centre SCO Collège des Anne-Étoiles ».

1. Aller sur une fiche utilisateur n'appartenant à aucun centre de certification et vérifier qu'aucun centre de certification n'est présent dans l'onglet « Centres de certification »
3. Aller sur la fiche d'un centre de certification et ajouter cet utilisateur
4. Retourner sur la fiche de cet utilisateur et vérifier que ce centre de certification est maintenant présent dans l'onglet « Centres de certification »
6. Retourner sur la fiche du centre de certification et actionner le bouton `Désactiver` pour cet utilisateur
7. Retourner sur la fiche de cet utilisateur et vérifier que maintenant ce centre de certification n'est plus présent dans l'onglet « Centres de certification »
