### PR TITLE
[FEATURE] Afficher les compétences non Pix en premier dans le profil certifié (PIX 5655)

### DIFF
--- a/admin/app/components/certifications/certified-profile.js
+++ b/admin/app/components/certifications/certified-profile.js
@@ -1,12 +1,19 @@
 import Component from '@glimmer/component';
 import ENV from 'pix-admin/config/environment';
+import partition from 'lodash/partition';
 
 export default class CertifiedProfile extends Component {
   get certifiedCompetenceList() {
     const { certifiedAreas } = this.args.certifiedProfile;
-    return certifiedAreas
+
+    const competencesOfCertifiedAreas = certifiedAreas
       .toArray()
       .flatMap((certifiedArea) => this._buildCertifiedCompetencesOfCertifiedArea(certifiedArea));
+
+    const [pixCompetences, nonPixCompetences] = partition(competencesOfCertifiedAreas, { origin: 'Pix' });
+    const certifiedCompetencesGroupedByOriginWithNonPixCompetencesFirst = [...nonPixCompetences, ...pixCompetences];
+
+    return certifiedCompetencesGroupedByOriginWithNonPixCompetencesFirst;
   }
 
   get difficultyLevels() {
@@ -21,6 +28,7 @@ export default class CertifiedProfile extends Component {
         name: certifiedCompetence.name,
         certifiedArea,
         certifiedTubes: this._buildCertifiedTubeOfCertifiedCompetence(certifiedCompetence.id),
+        origin: certifiedCompetence.origin,
       }));
   }
 

--- a/admin/app/models/certified-competence.js
+++ b/admin/app/models/certified-competence.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class CertifiedCompetence extends Model {
   @attr('string') name;
   @attr('string') areaId;
+  @attr('string') origin;
 }

--- a/admin/tests/integration/components/certifications/certified-profile_test.js
+++ b/admin/tests/integration/components/certifications/certified-profile_test.js
@@ -135,5 +135,48 @@ module('Integration | Component | certifications/certified-profile', function (h
       assert.strictEqual(iconSkill1, 'check-double');
       assert.strictEqual(iconSkill2, 'check');
     });
+    test('it should display non Pix competences first', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const certifiedArea1 = store.createRecord('certified-area', {
+        id: 'idArea1',
+        name: 'area1',
+      });
+
+      const certifiedArea2 = store.createRecord('certified-area', {
+        id: 'idArea2',
+        name: 'area2',
+      });
+
+      const certifiedPixCompetenceCompetence = store.createRecord('certified-competence', {
+        name: 'competencePix',
+        areaId: 'idArea1',
+        origin: 'Pix',
+      });
+
+      const certifiedNonPixCompetence = store.createRecord('certified-competence', {
+        name: 'competenceNonPix',
+        areaId: 'idArea2',
+        origin: 'Autre',
+      });
+
+      const certifiedProfile = store.createRecord('certified-profile', {
+        certifiedAreas: [certifiedArea1, certifiedArea2],
+        certifiedCompetences: [certifiedPixCompetenceCompetence, certifiedNonPixCompetence],
+      });
+
+      this.set('certifiedProfile', certifiedProfile);
+
+      // when
+      const screen = await render(
+        hbs`<Certifications::CertifiedProfile @certifiedProfile={{this.certifiedProfile}} />`
+      );
+
+      // then
+      const [firstCompetenceTitle, secondCompetenceTitle] = screen.getAllByRole('heading');
+
+      assert.strictEqual(firstCompetenceTitle.innerText, 'competenceNonPix');
+      assert.strictEqual(secondCompetenceTitle.innerText, 'competencePix');
+    });
   });
 });

--- a/admin/tests/integration/components/certifications/certified-profile_test.js
+++ b/admin/tests/integration/components/certifications/certified-profile_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
-import { run } from '@ember/runloop';
+
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | certifications/certified-profile', function (hooks) {
@@ -11,11 +11,9 @@ module('Integration | Component | certifications/certified-profile', function (h
     // given
     const store = this.owner.lookup('service:store');
     const certifiedAreas = [];
-    const certifiedProfile = run(() =>
-      store.createRecord('certified-profile', {
-        certifiedAreas,
-      })
-    );
+    const certifiedProfile = store.createRecord('certified-profile', {
+      certifiedAreas,
+    });
     this.set('certifiedProfile', certifiedProfile);
 
     // when
@@ -29,24 +27,18 @@ module('Integration | Component | certifications/certified-profile', function (h
     test('it should display one column per difficulty levels within a competence', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const certifiedArea = run(() =>
-        store.createRecord('certified-area', {
-          id: 'idArea1',
-          name: 'area1',
-        })
-      );
-      const certifiedCompetence = run(() =>
-        store.createRecord('certified-competence', {
-          name: 'competence1',
-          areaId: 'idArea1',
-        })
-      );
-      const certifiedProfile = run(() =>
-        store.createRecord('certified-profile', {
-          certifiedAreas: [certifiedArea],
-          certifiedCompetences: [certifiedCompetence],
-        })
-      );
+      const certifiedArea = store.createRecord('certified-area', {
+        id: 'idArea1',
+        name: 'area1',
+      });
+      const certifiedCompetence = store.createRecord('certified-competence', {
+        name: 'competence1',
+        areaId: 'idArea1',
+      });
+      const certifiedProfile = store.createRecord('certified-profile', {
+        certifiedAreas: [certifiedArea],
+        certifiedCompetences: [certifiedCompetence],
+      });
       this.set('certifiedProfile', certifiedProfile);
 
       // when
@@ -68,24 +60,18 @@ module('Integration | Component | certifications/certified-profile', function (h
     test('it should display data about area and competence', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const certifiedArea = run(() =>
-        store.createRecord('certified-area', {
-          id: 'idArea1',
-          name: 'area1',
-        })
-      );
-      const certifiedCompetence = run(() =>
-        store.createRecord('certified-competence', {
-          name: 'competence1',
-          areaId: 'idArea1',
-        })
-      );
-      const certifiedProfile = run(() =>
-        store.createRecord('certified-profile', {
-          certifiedAreas: [certifiedArea],
-          certifiedCompetences: [certifiedCompetence],
-        })
-      );
+      const certifiedArea = store.createRecord('certified-area', {
+        id: 'idArea1',
+        name: 'area1',
+      });
+      const certifiedCompetence = store.createRecord('certified-competence', {
+        name: 'competence1',
+        areaId: 'idArea1',
+      });
+      const certifiedProfile = store.createRecord('certified-profile', {
+        certifiedAreas: [certifiedArea],
+        certifiedCompetences: [certifiedCompetence],
+      });
       this.set('certifiedProfile', certifiedProfile);
 
       // when
@@ -101,52 +87,40 @@ module('Integration | Component | certifications/certified-profile', function (h
     test('it should display the expected iconography depending on the state of the skill in a tube', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const certifiedArea = run(() =>
-        store.createRecord('certified-area', {
-          id: 'idArea1',
-          name: 'area1',
-        })
-      );
-      const certifiedCompetence = run(() =>
-        store.createRecord('certified-competence', {
-          id: 'idCompetence1',
-          name: 'competence1',
-          areaId: 'idArea1',
-        })
-      );
-      const certifiedTube = run(() =>
-        store.createRecord('certified-tube', {
-          id: 'idTube1',
-          name: 'tube1',
-          competenceId: 'idCompetence1',
-        })
-      );
-      const certifiedSkillInCertificationTest = run(() =>
-        store.createRecord('certified-skill', {
-          id: 'idSkill1',
-          name: 'skill1',
-          tubeId: 'idTube1',
-          hasBeenAskedInCertif: true,
-          difficulty: 1,
-        })
-      );
-      const certifiedSkillNotInCertificationTest = run(() =>
-        store.createRecord('certified-skill', {
-          id: 'idSkill2',
-          name: 'skill2',
-          tubeId: 'idTube1',
-          hasBeenAskedInCertif: false,
-          difficulty: 2,
-        })
-      );
-      const certifiedProfile = run(() =>
-        store.createRecord('certified-profile', {
-          certifiedAreas: [certifiedArea],
-          certifiedCompetences: [certifiedCompetence],
-          certifiedTubes: [certifiedTube],
-          certifiedSkills: [certifiedSkillInCertificationTest, certifiedSkillNotInCertificationTest],
-        })
-      );
+      const certifiedArea = store.createRecord('certified-area', {
+        id: 'idArea1',
+        name: 'area1',
+      });
+      const certifiedCompetence = store.createRecord('certified-competence', {
+        id: 'idCompetence1',
+        name: 'competence1',
+        areaId: 'idArea1',
+      });
+      const certifiedTube = store.createRecord('certified-tube', {
+        id: 'idTube1',
+        name: 'tube1',
+        competenceId: 'idCompetence1',
+      });
+      const certifiedSkillInCertificationTest = store.createRecord('certified-skill', {
+        id: 'idSkill1',
+        name: 'skill1',
+        tubeId: 'idTube1',
+        hasBeenAskedInCertif: true,
+        difficulty: 1,
+      });
+      const certifiedSkillNotInCertificationTest = store.createRecord('certified-skill', {
+        id: 'idSkill2',
+        name: 'skill2',
+        tubeId: 'idTube1',
+        hasBeenAskedInCertif: false,
+        difficulty: 2,
+      });
+      const certifiedProfile = store.createRecord('certified-profile', {
+        certifiedAreas: [certifiedArea],
+        certifiedCompetences: [certifiedCompetence],
+        certifiedTubes: [certifiedTube],
+        certifiedSkills: [certifiedSkillInCertificationTest, certifiedSkillNotInCertificationTest],
+      });
       this.set('certifiedProfile', certifiedProfile);
 
       // when
@@ -158,12 +132,8 @@ module('Integration | Component | certifications/certified-profile', function (h
       assert.dom(screen.getByText('tube1')).exists();
       const iconSkill1 = screen.getByLabelText('skill1').getAttribute('data-icon');
       const iconSkill2 = screen.getByLabelText('skill2').getAttribute('data-icon');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(iconSkill1, 'check-double');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(iconSkill2, 'check');
+      assert.strictEqual(iconSkill1, 'check-double');
+      assert.strictEqual(iconSkill2, 'check');
     });
   });
 });

--- a/api/lib/domain/read-models/CertifiedProfile.js
+++ b/api/lib/domain/read-models/CertifiedProfile.js
@@ -17,10 +17,11 @@ class CertifiedTube {
 }
 
 class CertifiedCompetence {
-  constructor({ id, name, areaId }) {
+  constructor({ id, name, areaId, origin }) {
     this.id = id;
     this.name = name;
     this.areaId = areaId;
+    this.origin = origin;
   }
 }
 

--- a/api/lib/infrastructure/repositories/certified-profile-repository.js
+++ b/api/lib/infrastructure/repositories/certified-profile-repository.js
@@ -96,6 +96,7 @@ async function _createCertifiedCompetences(certifiedTubes) {
       id: learningContentCompetence.id,
       name,
       areaId: learningContentCompetence.areaId,
+      origin: learningContentCompetence.origin,
     });
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/certified-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certified-profile-serializer.js
@@ -23,7 +23,7 @@ module.exports = {
       certifiedCompetences: {
         ref: 'id',
         included: true,
-        attributes: ['name', 'areaId'],
+        attributes: ['name', 'areaId', 'origin'],
       },
       certifiedAreas: {
         ref: 'id',

--- a/api/tests/integration/infrastructure/repositories/certified-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certified-profile-repository_test.js
@@ -93,6 +93,7 @@ describe('Integration | Repository | Certified Profile', function () {
         id: 'recArea1_Competence1',
         name: 'competence1_1_name',
         areaId: 'recArea1',
+        origin: 'Pix',
       });
       const area1 = domainBuilder.buildCertifiedArea({
         id: 'recArea1',
@@ -115,6 +116,7 @@ describe('Integration | Repository | Certified Profile', function () {
         id: 'recArea1_Competence2',
         name: 'competence1_2_name',
         areaId: 'recArea1',
+        origin: 'Edu',
       });
 
       const userId = databaseBuilder.factory.buildUser({ id: 123 }).id;

--- a/api/tests/tooling/domain-builder/factory/build-certified-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-certified-competence.js
@@ -4,11 +4,13 @@ const buildCertifiedCompetence = function buildCertifiedCompetence({
   id = 'someCompetenceId',
   name = 'someName',
   areaId = 'someAreaId',
+  origin = 'Pix',
 } = {}) {
   return new CertifiedCompetence({
     id,
     name,
     areaId,
+    origin,
   });
 };
 

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -390,6 +390,7 @@ describe('Unit | Controller | certification-course-controller', function () {
         id: 'recCompetence1',
         name: 'competence_1',
         areaId: 'recArea1',
+        origin: 'Pix',
       });
       const area1 = domainBuilder.buildCertifiedArea({
         id: 'recArea1',
@@ -494,6 +495,7 @@ describe('Unit | Controller | certification-course-controller', function () {
             attributes: {
               name: 'competence_1',
               'area-id': 'recArea1',
+              origin: 'Pix',
             },
           },
           {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certified-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certified-profile-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | certified-profile-serializer', function 
         id: 'recCompetence1',
         name: 'competence_1',
         areaId: 'recArea1',
+        origin: 'Pix',
       });
       const area1 = domainBuilder.buildCertifiedArea({
         id: 'recArea1',
@@ -124,6 +125,7 @@ describe('Unit | Serializer | JSONAPI | certified-profile-serializer', function 
             attributes: {
               name: 'competence_1',
               'area-id': 'recArea1',
+              origin: 'Pix',
             },
           },
           {


### PR DESCRIPTION
## :unicorn: Problème
Les compétences Pix+ ont été ajoutées sur l’onglet “Profil” sur la page de détails d’une certification dans Pix Admin.

Les compétences Pix+ vs. celles du référentiel coeur ne sont pas triées (donc mélangées), ce qui rend plus compliqué la lecture de cette page / la détection en cas de bug.

## :robot: Solution
Afficher en haut de page les compétences Pix+


## :100: Pour tester
- Passer/finaliser/publier une certification complémentaire
-  Sur pix-admin, constater que les compétences non Pix sont affichées en début de profil

![image](https://user-images.githubusercontent.com/37305474/191266596-a49c4066-669f-42b9-be73-2998fa82f7d3.png)
