### PR TITLE
[FEATURE] Ajout légende onglet Profil dans Pix Admin(PIX-5657).

### DIFF
--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -43,6 +43,7 @@
 @import 'components/certification-info-field';
 @import 'components/certification-issue-report';
 @import 'components/certification-issue-reports';
+@import 'components/profile';
 @import 'components/certified-profile';
 @import 'components/confirm-popup';
 @import 'components/member-item';

--- a/admin/app/styles/components/profile.scss
+++ b/admin/app/styles/components/profile.scss
@@ -1,0 +1,17 @@
+.profile {
+
+  &__header {
+    display: flex;
+    width: 100%;
+    padding: 32px;
+    justify-content: space-between;
+    border-radius: 5px;
+
+    .legend {
+      background-color: rgba(0, 0, 0, 0.03);
+      border-radius: 8px;
+      border: 1px solid $pix-neutral-22;
+      padding: 12px;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/certifications/certification/profile.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/profile.hbs
@@ -1,5 +1,20 @@
 {{page-title "Certif " @model.id " Profil | Pix Admin" replace=true}}
-<p>ID du compte Pix du candidat: {{@model.userId}}</p>
-<p>ID de la certification du candidat: {{@model.id}}</p>
+
+<section class="profile__header">
+  <div>
+    <p>ID du compte Pix du candidat: {{@model.userId}}</p>
+    <p>ID de la certification du candidat: {{@model.id}}</p>
+  </div>
+  <div class="legend">
+    <p>
+      <FaIcon @icon="check-double" class="skill-column--tested-in-certif" />
+      Acquis proposé en certification
+    </p>
+    <p>
+      <FaIcon @icon="check" class="skill-column--check" />
+      Acquis validé en direct ou par inférence en positionnement au moment du test de certification
+    </p>
+  </div>
+</section>
 
 <Certifications::CertifiedProfile @certifiedProfile={{@model}} />


### PR DESCRIPTION
## :unicorn: Problème
> _Décrivez ici le besoin ou l'intention couvert par cette Pull Request._

:coffee: Contexte : 
L’onglet “Profil” sur la page “Certifications” dans Pix Admin affiche le profil Pix du candidat. Depuis peu, les compétences des référentiels Pix+ sont également affichées (en plus de celles du référentiel coeur).

Il n’est pas indiqué si les acquis validés l'ont été en direct par le candidat ou bien inférés. Il n’est pas non plus précisé si l’affichage correspond au profil à la date du passage de sa certification ou bien s’il est à jour d'éventuels acquis supplémentaires validés depuis sa dernière certification.

Aucune légende ne permet de comprendre la coche verte affichée pour certaines des compétences ni la double coche orange indiquée pour d’autres.

:robot: Solution :
Ajouter une légende à la page de profil certifi"

## :100: Pour tester
- Passer/finaliser/publier une certification pix
- Aller voir le profil de la certification et constater la présence d'une magnifique légende :

![image](https://user-images.githubusercontent.com/37305474/191296099-407ea09c-7ed7-40a0-9225-3ff157cc7f54.png)

