### PR TITLE
[FEATURE] Ajout d'un tooltip sur l'en-tête de la colonne certificabilité dans le tableau sur la page des participants (PIX-5560)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -27,7 +27,23 @@
             "pages.organization-participants.table.column.lastest-participation"
           }}</Table::Header>
         <Table::Header @size="medium" @align="center">
-          {{t "pages.organization-participants.table.column.is-certifiable.label"}}
+          <div class="organization-participant-list-page__certificability-header">
+            {{t "pages.organization-participants.table.column.is-certifiable.label"}}
+            <div class="organization-participant-list-page__certificability-header__tooltip">
+              <PixTooltip
+                @position="top-left"
+                @isWide={{true}}
+                aria-label={{t "pages.organization-participants.table.column.is-certifiable.tooltip"}}
+              >
+                <:triggerElement>
+                  <FaIcon @icon="circle-question" tabindex="0" />
+                </:triggerElement>
+                <:tooltip>
+                  {{t "pages.organization-participants.table.column.is-certifiable.tooltip"}}
+                </:tooltip>
+              </PixTooltip>
+            </div>
+          </div>
         </Table::Header>
       </tr>
     </thead>

--- a/orga/app/styles/pages/authenticated/organization-participants.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants.scss
@@ -12,6 +12,20 @@ $margin-right: 32px;
     justify-content: center;
   }
 
+  &__certificability-header {
+    display: flex;
+    justify-content: center;
+
+    &__tooltip {
+      padding-left: 6px;
+      color: $pix-neutral-30;
+
+      [role="tooltip"] {
+        font-weight: $font-light;
+      }
+    }
+  }
+
   &__certifiable-at {
     display: block;
     margin-top: $spacing-xxs;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -679,7 +679,8 @@
           "lastest-participation": "Lastest participation",
           "participation-count": "Number of participations",
           "is-certifiable":{
-            "label": "Eligibility for certification"
+            "label": "Eligibility for certification",
+            "tooltip":"To know if a participant is eligible for certification, their Pix profile needs to be submitted through a profile collection campaign. If the participant has already submitted their profile, the date and status of the last submission are displayed."
           }
         },
         "empty": "No participants",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -679,7 +679,8 @@
           "lastest-participation": "Dernière participation",
           "participation-count": "Nombre de participations",
           "is-certifiable": {
-            "label": "Certificabilité"
+            "label": "Certificabilité",
+            "tooltip":"L’information de certificabilité remonte des campagnes de collecte de profil réalisées par le participant. Si le participant a déjà envoyé son profil, on affiche la date d’envoi ainsi que le statut du dernier envoi."
           }
         },
         "empty": "Aucun participant",


### PR DESCRIPTION
… table

## :unicorn: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.

## :robot: Solution
Ajout du tooltip dans l’entête de colonne pour expliquer comment cette colonne était calculée.

Texte a afficher en Français : “L’information de certificabilité remonte des campagnes de collecte de profil réalisées par le participant. Si le participant a déjà envoyé son profil, on affiche la date d’envoi ainsi que le statut du dernier envoi.”

Texte a afficher pour l’EN : “To know if a participant is eligible for certification, their Pix profile needs to be submitted through a profile collection campaign. If the participant has already submitted their profile, the date and status of the last submission are displayed.”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
se connecter à pix orga pour pro
aller sur la page Participants
observer l'icône fa-circle-interrogation
survoler ce dernier et observer le tooltip
tada 🎉
