### PR TITLE
[BUGFIX] Le endpoint  /admin/organizations/1/target-profile-summaries renvoie des doublons (PIX-5734)

### DIFF
--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -22,14 +22,18 @@ module.exports = {
         name: 'target-profiles.name',
         outdated: 'target-profiles.outdated',
       })
-      .leftJoin('target-profile-shares', 'target-profile-shares.targetProfileId', 'target-profiles.id')
+      .leftJoin('target-profile-shares', function () {
+        this.on('target-profile-shares.targetProfileId', 'target-profiles.id').on(
+          'target-profile-shares.organizationId',
+          organizationId
+        );
+      })
       .where({ outdated: false })
       .where((qb) => {
         qb.orWhere({ isPublic: true });
         qb.orWhere({ ownerOrganizationId: organizationId });
         qb.orWhere((subQb) => {
           subQb.whereNotNull('target-profile-shares.id');
-          subQb.where('target-profile-shares.organizationId', organizationId);
         });
       })
       .orderBy('id', 'ASC');

--- a/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -256,6 +256,35 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
           ];
           expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
         });
+
+        it('should return once if target profile is owned and shared', async function () {
+          // given
+          databaseBuilder.factory.buildOrganization({ id: 1 });
+          databaseBuilder.factory.buildTargetProfile({
+            id: 11,
+            name: 'A_tp',
+            ownerOrganizationId: 1,
+            outdated: false,
+            isPublic: false,
+          });
+          databaseBuilder.factory.buildOrganization({ id: 2 });
+          databaseBuilder.factory.buildOrganization({ id: 3 });
+          databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: 11, organizationId: 2 });
+          databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: 11, organizationId: 3 });
+          await databaseBuilder.commit();
+
+          // when
+          const actualTargetProfileSummaries = await targetProfileSummaryForAdminRepository.findByOrganization({
+            organizationId: 1,
+          });
+
+          // then
+          const expectedTargetProfileSummaries = [
+            domainBuilder.buildTargetProfileSummaryForAdmin({ id: 11, name: 'A_tp', outdated: false }),
+          ];
+          expect(actualTargetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);
+        });
+
         it('should return summaries for attached target profiles', async function () {
           // given
           databaseBuilder.factory.buildOrganization({ id: 1 });


### PR DESCRIPTION
## :unicorn: Problème
Si une organisation a partagé son profil cible avec N organisations, lorsqu'elle consulte ses profils cibles, elle le voit apparaître N fois. Les données sont correctement affichées par le front-end une seule fois, mais la si l'organisation a partagé des profils à nombre d'organisations, la cardinalité peut être très grande et causer un crash par pénurie de mémoire.

![image](https://user-images.githubusercontent.com/56302715/191313937-f229d62c-42fb-4b27-8889-49310f7ee748.png)


## :robot: Solution
Ne remonter qu'un seul enregistrement

![image](https://user-images.githubusercontent.com/56302715/191314001-58b6f4af-689b-44a4-9beb-b815d1ff15bf.png)


## :rainbow: Remarques
L'organisation 1 en production est probablement sujette à ce comportement.

## :100: Pour tester
Sur une organisation, créer:
- un profil public;
- un profil non partagé;
- un profil partagé avec 2 organisations.

Sur cette organisation, vérifier que le retour du endpoint comporte une seule fois chacun des profils cibles.

