### PR TITLE
[FEATURE] Génération du fichier des résultats Cléa numérique (PIX-5375)

### DIFF
--- a/api/db/seeds/data/certification/certification-cpf-city-builder.js
+++ b/api/db/seeds/data/certification/certification-cpf-city-builder.js
@@ -1,5 +1,4 @@
 function certificationCpfCityBuilder({ databaseBuilder }) {
-
   databaseBuilder.factory.buildCertificationCpfCity({
     name: 'PARIS 1',
     postalCode: '75001',
@@ -58,6 +57,12 @@ function certificationCpfCityBuilder({ databaseBuilder }) {
     name: 'BUELLAS',
     postalCode: '01310',
     INSEECode: '01065',
+  });
+
+  databaseBuilder.factory.buildCertificationCpfCity({
+    name: 'LES ABYMES',
+    postalCode: '97139',
+    INSEECode: '97101',
   });
 }
 

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionForSupervisingController = require('./session-for-supervising-controller');
+const sessionWithCleaCertifiedCandidateController = require('./session-with-clea-certified-candidate-controller');
 const finalizedSessionController = require('./finalized-session-controller');
 const authorization = require('../preHandlers/authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
@@ -772,6 +773,29 @@ exports.register = async (server) => {
             '- Dans le cadre du SCO, inscrit un élève à une session de certification',
         ],
         tags: ['api', 'sessions', 'certification-candidates'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/sessions/{id}/certified-clea-candidate-data',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+          }),
+        },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: sessionWithCleaCertifiedCandidateController.getCleaCertifiedCandidateDataCsv,
+        tags: ['api', 'sessions', 'export-csv'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          "Elle retourne toutes les infos des candidats d'une session ayant obtenu la certification Clea, sous format CSV",
+        ],
       },
     },
   ]);

--- a/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
+++ b/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
@@ -1,0 +1,22 @@
+const usecases = require('../../domain/usecases');
+const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
+const dayjs = require('dayjs');
+
+module.exports = {
+  async getCleaCertifiedCandidateDataCsv(request, h) {
+    const sessionId = request.params.id;
+    const { session, cleaCertifiedCandidateData } = await usecases.getCleaCertifiedCandidateBySession({ sessionId });
+    const csvResult = await certificationResultUtils.getCleaCertifiedCandidateCsv(cleaCertifiedCandidateData);
+
+    const dateWithoutTime = dayjs(session.date).format('DD/MM/YYYY');
+    const dateWithTime = dayjs(dateWithoutTime + ' ' + session.time)
+      .locale('fr')
+      .format('YYYYMMDD_HHmm');
+    const fileName = `${dateWithTime}_candidats_certifies_clea_${sessionId}.csv`;
+
+    return h
+      .response(csvResult)
+      .header('Content-Type', 'text/csv;charset=utf-8')
+      .header('Content-Disposition', `attachment; filename=${fileName}`);
+  },
+};

--- a/api/lib/domain/read-models/CleaCertifiedCandidate.js
+++ b/api/lib/domain/read-models/CleaCertifiedCandidate.js
@@ -1,0 +1,53 @@
+class CleaCertifiedCandidate {
+  constructor({
+    firstName,
+    lastName,
+    email,
+    birthdate,
+    birthplace,
+    birthPostalCode,
+    birthINSEECode,
+    birthCountry,
+    sex,
+    createdAt,
+  } = {}) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.birthdate = birthdate;
+    this.birthplace = birthplace;
+    this.birthPostalCode = birthPostalCode;
+    this.birthINSEECode = birthINSEECode;
+    this.birthCountry = birthCountry;
+    this.sex = sex;
+    this.createdAt = createdAt;
+  }
+
+  get isBornInAForeignCountry() {
+    const INSEECodeForeignCountry = '99';
+
+    if (this.birthINSEECode.startsWith(INSEECodeForeignCountry)) {
+      return true;
+    }
+    return false;
+  }
+
+  get geographicAreaOfBirthCode() {
+    if (this.isBornInAForeignCountry) {
+      const index = this.birthINSEECode.charAt(2);
+      return `${index}00`;
+    }
+    return null;
+  }
+
+  get isBornInFrenchOutermostRegion() {
+    const INSEECodeFrenchOutermostRegion = ['97', '98'];
+
+    return (
+      this.birthINSEECode.startsWith(INSEECodeFrenchOutermostRegion[0]) ||
+      this.birthINSEECode.startsWith(INSEECodeFrenchOutermostRegion[1])
+    );
+  }
+}
+
+module.exports = CleaCertifiedCandidate;

--- a/api/lib/domain/usecases/get-clea-certified-candidate-by-session.js
+++ b/api/lib/domain/usecases/get-clea-certified-candidate-by-session.js
@@ -1,0 +1,10 @@
+module.exports = async function getCleaCertifiedCandidateBySession({
+  sessionId,
+  cleaCertifiedCandidateRepository,
+  sessionRepository,
+}) {
+  const cleaCertifiedCandidateData = await cleaCertifiedCandidateRepository.getBySessionId(sessionId);
+  const session = await sessionRepository.get(sessionId);
+
+  return { session, cleaCertifiedCandidateData };
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -59,6 +59,7 @@ const dependencies = {
   certificationResultRepository: require('../../infrastructure/repositories/certification-result-repository'),
   challengeRepository: require('../../infrastructure/repositories/challenge-repository'),
   challengeForPixAutoAnswerRepository: require('../../infrastructure/repositories/challenge-for-pix-auto-answer-repository'),
+  cleaCertifiedCandidateRepository: require('../../infrastructure/repositories/clea-certified-candidate-repository'),
   competenceEvaluationRepository: require('../../infrastructure/repositories/competence-evaluation-repository'),
   competenceMarkRepository: require('../../infrastructure/repositories/competence-mark-repository'),
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
@@ -314,6 +315,8 @@ module.exports = injectDependencies(
     getCertificationsResultsForLS: require('./certificate/get-certifications-results-for-ls'),
     getCertificationPointOfContact: require('./get-certification-point-of-contact'),
     getChallengeForPixAutoAnswer: require('./get-challenge-for-pix-auto-answer'),
+    getCleaCertifiedCandidateBySession: require('./get-clea-certified-candidate-by-session'),
+
     getCorrectionForAnswer: require('./get-correction-for-answer'),
     getCurrentUser: require('./get-current-user'),
     getExternalAuthenticationRedirectionUrl: require('./get-external-authentication-redirection-url'),

--- a/api/lib/infrastructure/repositories/clea-certified-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/clea-certified-candidate-repository.js
@@ -1,0 +1,45 @@
+const { knex } = require('../../../db/knex-database-connection');
+const { CLEA } = require('../../domain/models/ComplementaryCertification');
+const CleaCertifiedCandidate = require('../../domain/read-models/CleaCertifiedCandidate');
+
+module.exports = {
+  async getBySessionId(sessionId) {
+    const results = await knex
+      .from('certification-courses')
+      .select(
+        'certification-courses.firstName',
+        'certification-courses.lastName',
+        'users.email',
+        'certification-courses.birthdate',
+        'certification-courses.birthplace',
+        'certification-courses.birthPostalCode',
+        'certification-courses.birthINSEECode',
+        'certification-courses.birthCountry',
+        'certification-courses.sex',
+        'certification-courses.createdAt'
+      )
+      .innerJoin('users', 'certification-courses.userId', 'users.id')
+      .innerJoin(
+        'complementary-certification-courses',
+        'complementary-certification-courses.certificationCourseId',
+        'certification-courses.id'
+      )
+      .innerJoin(
+        'complementary-certifications',
+        'complementary-certifications.id',
+        'complementary-certification-courses.complementaryCertificationId'
+      )
+      .innerJoin(
+        'complementary-certification-course-results',
+        'complementary-certification-course-results.complementaryCertificationCourseId',
+        'complementary-certification-courses.id'
+      )
+      .where({
+        'certification-courses.sessionId': sessionId,
+        'certification-courses.isPublished': true,
+        'complementary-certifications.key': CLEA,
+        'complementary-certification-course-results.acquired': true,
+      });
+    return results.map((candidate) => new CleaCertifiedCandidate(candidate));
+  },
+};

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -19,6 +19,13 @@ async function getSessionCertificationResultsCsv({ session, certificationResults
   return getCsvContent({ data, fileHeaders });
 }
 
+async function getCleaCertifiedCandidateCsv(cleaCertifiedCandidates) {
+  const fileHeaders = _buildFileHeadersForCleaCandidates(cleaCertifiedCandidates);
+  const data = _buildFileDataForCleaCandidates(cleaCertifiedCandidates);
+
+  return getCsvContent({ data, fileHeaders });
+}
+
 function _buildFileDataWithoutCertificationCenterName({ certificationResults }) {
   return certificationResults.map(_getRowItemsFromResults);
 }
@@ -65,9 +72,73 @@ function _buildFileHeadersWithoutCertificationCenterName() {
   );
 }
 
+function _buildFileHeadersForCleaCandidates() {
+  return [
+    _headers.SIREN,
+    _headers.SIRET,
+    _headers.REGISTRATION_STATUS,
+    _headers.LEVEL,
+    _headers.ORIGIN,
+    _headers.FUNDER,
+    _headers.GENDER,
+    _headers.BIRTHNAME,
+    _headers.USUAL_NAME,
+    _headers.FIRSTNAME,
+    _headers.EMAIL,
+    _headers.PHONE,
+    _headers.ADDRESS,
+    _headers.ADDITIONAL_ADDRESS,
+    _headers.CITY,
+    _headers.POSTAL_CODE,
+    _headers.BIRTHDATE,
+    _headers.FOREIGN_BORN,
+    _headers.GEOGRAPHIC_AREA,
+    _headers.OUTERMOST_BORN,
+    _headers.BIRTH_CITY,
+    _headers.BIRTH_POSTAL_CODE,
+    _headers.PASSING_DATE,
+    _headers.CCPI,
+    _headers.STATUS,
+    _headers.FIRST_SHOT,
+  ];
+}
+
 function _buildFileData({ session, certificationResults }) {
   const sessionComplementaryCertificationsLabels = _getComplementaryCertificationResultsLabels(certificationResults);
   return certificationResults.map(_getRowItemsFromSessionAndResults(session, sessionComplementaryCertificationsLabels));
+}
+
+function _buildFileDataForCleaCandidates(cleaCertifiedCandidates) {
+  return cleaCertifiedCandidates.map((candidate) => {
+    return {
+      [_headers.SIREN]: null,
+      [_headers.SIRET]: null,
+      [_headers.REGISTRATION_STATUS]: null,
+      [_headers.LEVEL]: null,
+      [_headers.ORIGIN]: null,
+      [_headers.FUNDER]: null,
+      [_headers.GENDER]: _getGenderCandidate(candidate.sex),
+      [_headers.BIRTHNAME]: candidate.lastName,
+      [_headers.USUAL_NAME]: null,
+      [_headers.FIRSTNAME]: candidate.firstName,
+      [_headers.EMAIL]: candidate.email,
+      [_headers.PHONE]: null,
+      [_headers.ADDRESS]: null,
+      [_headers.ADDITIONAL_ADDRESS]: null,
+      [_headers.CITY]: null,
+      [_headers.POSTAL_CODE]: null,
+      [_headers.BIRTHDATE]: _formatDate(candidate.birthdate),
+      [_headers.FOREIGN_BORN]: _getValueForBoolean(candidate.isBornInAForeignCountry),
+      [_headers.GEOGRAPHIC_AREA]: candidate.geographicAreaOfBirthCode,
+      [_headers.OUTERMOST_BORN]: _getValueForBoolean(candidate.isBornInFrenchOutermostRegion),
+      [_headers.BIRTH_CITY]: candidate.birthplace,
+      [_headers.BIRTH_POSTAL_CODE]: candidate.birthPostalCode,
+      [_headers.PASSING_DATE]: _formatDate(candidate.createdAt),
+      [_headers.CCPI]: 'CléA Numérique by Pix',
+      [_headers.STATUS]: 'CERTIFIE',
+      [_headers.FIRST_SHOT]: null,
+    };
+  });
 }
 
 function _getComplementaryCertificationResultsHeaders(certificationResults) {
@@ -207,6 +278,14 @@ function _getCommentForOrganization(certificationResult) {
   return certificationResult.commentForOrganization;
 }
 
+function _getGenderCandidate(sex) {
+  return sex === 'F' ? 'MME' : 'M';
+}
+
+function _getValueForBoolean(value) {
+  return value ? 'OUI' : 'NON';
+}
+
 const _competenceIndexes = [
   '1.1',
   '1.2',
@@ -239,10 +318,34 @@ const _headers = {
   CERTIFICATION_CENTER: 'Centre de certification',
   CERTIFICATION_DATE: 'Date de passage de la certification',
   JURY_COMMENT_FOR_ORGANIZATION: 'Commentaire jury pour l’organisation',
+  SIREN: "SIREN de l'organisme",
+  SIRET: "Siret de l'établissement",
+  REGISTRATION_STATUS: "Statut à l'inscription",
+  LEVEL: "Niveau d'instruction",
+  ORIGIN: 'Origine de la démarche',
+  FUNDER: 'Financeur',
+  GENDER: 'Civilité',
+  BIRTHNAME: 'Nom de naissance',
+  USUAL_NAME: "Nom d'usage",
+  EMAIL: 'Email',
+  PHONE: 'Téléphone',
+  ADDRESS: 'Adresse',
+  ADDITIONAL_ADDRESS: "Complément d'adresse",
+  CITY: 'Ville',
+  POSTAL_CODE: 'Code postal',
+  FOREIGN_BORN: "Né à l'étranger",
+  GEOGRAPHIC_AREA: 'Zone géographique de naissance',
+  OUTERMOST_BORN: "Né en collectivité d'outre-mer",
+  BIRTH_CITY: 'Ville de naissance',
+  BIRTH_POSTAL_CODE: 'Code postal de naissance',
+  PASSING_DATE: 'Date de passage',
+  CCPI: 'CCPI',
+  FIRST_SHOT: 'Obtention après la première évaluation ?',
 };
 
 module.exports = {
   getSessionCertificationResultsCsv,
   getDivisionCertificationResultsCsv,
+  getCleaCertifiedCandidateCsv,
   REJECTED_AUTOMATICALLY_COMMENT,
 };

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1802,7 +1802,6 @@ describe('Acceptance | Application | organization-controller', function () {
   describe('GET /api/organizations/{id}/certification-results', function () {
     it('should return HTTP status 200', async function () {
       // given
-
       const user = databaseBuilder.factory.buildUser.withRawPassword();
 
       const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });

--- a/api/tests/acceptance/application/session/session-with-clea-certified-candidate-controller-get-clea-certified-candidate-data-csv.js
+++ b/api/tests/acceptance/application/session/session-with-clea-certified-candidate-controller-get-clea-certified-candidate-data-csv.js
@@ -1,0 +1,54 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+const { CLEA } = require('../../../../lib/domain/models/ComplementaryCertification');
+const { PIX_EMPLOI_CLEA_V3 } = require('../../../../lib/domain/models/Badge').keys;
+
+describe('Acceptance | Controller | session-with-clea-certified-candidate', function () {
+  describe('GET /api/sessions/{id}/certified-clea-candidate-data', function () {
+    it('should return 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const dbf = databaseBuilder.factory;
+
+      const user = dbf.buildUser();
+      databaseBuilder.factory.buildOrganization({ externalId: 'EXT1234' });
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ externalId: 'EXT1234' }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId: user.id, certificationCenterId });
+      const sessionId = dbf.buildSession({ certificationCenterId, date: '2020/01/01', time: '12:00' }).id;
+
+      const certificationCourse = dbf.buildCertificationCourse({ sessionId, userId: user.id });
+      dbf.buildComplementaryCertification({
+        id: 1,
+        key: CLEA,
+      });
+      const badgeClea = databaseBuilder.factory.buildBadge({ id: 1, isCertifiable: true, key: PIX_EMPLOI_CLEA_V3 });
+      const complementaryBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+        complementaryCertificationId: 1,
+        badgeId: badgeClea.id,
+      }).id;
+      const complementaryCertificationCourse = dbf.buildComplementaryCertificationCourse({
+        certificationCourseId: certificationCourse.id,
+        complementaryCertificationId: 1,
+        complementaryCertificationBadgeId: complementaryBadgeId,
+      });
+      dbf.buildComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId: complementaryCertificationCourse.id,
+        acquired: true,
+      });
+
+      const request = {
+        method: 'GET',
+        url: `/api/sessions/${sessionId}/certified-clea-candidate-data`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
@@ -1,0 +1,210 @@
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
+const cleaCertifiedCandidateRepository = require('../../../../lib/infrastructure/repositories/clea-certified-candidate-repository');
+const { PIX_EMPLOI_CLEA_V3 } = require('../../../../lib/domain/models/Badge').keys;
+
+describe('Integration | Repository | clea-certified-candidate-repository', function () {
+  describe('#getBySessionId', function () {
+    describe('when there are candidates for Clea certification in the session', function () {
+      it('returns the list of clea certified candidates', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession().id;
+        const userId = databaseBuilder.factory.buildUser({
+          email: 'jean-mi@coco.fr',
+        }).id;
+        const userId2 = databaseBuilder.factory.buildUser({
+          email: 'marie-mi@coco.fr',
+        }).id;
+        const candidateCleaSuccess = {
+          firstName: 'Jean-Mi',
+          lastName: 'Mi',
+          birthdate: '2001-02-07',
+          birthplace: 'Paris',
+          sex: 'M',
+          birthPostalCode: null,
+          birthINSEECode: '75115',
+          birthCountry: 'FRANCE',
+          createdAt: new Date('2020-02-01'),
+          userId,
+        };
+        const candidateCleaSuccess2 = {
+          firstName: 'Marie',
+          lastName: 'Ri',
+          birthdate: '2001-02-04',
+          birthplace: 'Orléans',
+          sex: 'F',
+          birthPostalCode: null,
+          birthINSEECode: '75115',
+          birthCountry: 'FRANCE',
+          createdAt: new Date('2020-02-01'),
+          userId: userId2,
+        };
+
+        databaseBuilder.factory.buildComplementaryCertification.clea({
+          id: 1,
+        });
+        const badgeClea = databaseBuilder.factory.buildBadge({ id: 1, isCertifiable: true, key: PIX_EMPLOI_CLEA_V3 });
+        const complementaryBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+          complementaryCertificationId: 1,
+          badgeId: badgeClea.id,
+        }).id;
+
+        databaseBuilder.factory.buildCertificationCourse({ id: 91, sessionId, ...candidateCleaSuccess });
+        databaseBuilder.factory.buildCertificationCourse({ id: 92, sessionId, ...candidateCleaSuccess2 });
+
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          id: 991,
+          certificationCourseId: 91,
+          complementaryCertificationId: 1,
+          complementaryCertificationBadgeId: complementaryBadgeId,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationCourse({
+          id: 992,
+          certificationCourseId: 92,
+          complementaryCertificationId: 1,
+          complementaryCertificationBadgeId: complementaryBadgeId,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId: 991,
+          acquired: true,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId: 992,
+          acquired: true,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const results = await cleaCertifiedCandidateRepository.getBySessionId(sessionId);
+
+        // then
+        expect(results).to.deepEqualArray([
+          domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Jean-Mi',
+            lastName: 'Mi',
+            email: 'jean-mi@coco.fr',
+            birthdate: '2001-02-07',
+            birthplace: 'Paris',
+            birthPostalCode: null,
+            birthINSEECode: '75115',
+            birthCountry: 'FRANCE',
+            sex: 'M',
+            createdAt: new Date('2020-02-01'),
+          }),
+          domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Marie',
+            lastName: 'Ri',
+            email: 'marie-mi@coco.fr',
+            birthdate: '2001-02-04',
+            birthplace: 'Orléans',
+            sex: 'F',
+            birthPostalCode: null,
+            birthINSEECode: '75115',
+            birthCountry: 'FRANCE',
+            createdAt: new Date('2020-02-01'),
+          }),
+        ]);
+      });
+
+      describe('when there is not certified candidates for Clea certification in the session', function () {
+        it('returns the list of clea certified candidates only', async function () {
+          // given
+          const sessionId = databaseBuilder.factory.buildSession().id;
+          const userId = databaseBuilder.factory.buildUser({
+            email: 'jean-mi@coco.fr',
+          }).id;
+          const candidateCleaSuccess = {
+            firstName: 'Jean-Mi',
+            lastName: 'Mi',
+            birthdate: '2001-02-07',
+            birthplace: 'Paris',
+            sex: 'M',
+            birthPostalCode: null,
+            birthINSEECode: '75115',
+            birthCountry: 'FRANCE',
+            createdAt: new Date('2020-02-01'),
+            userId,
+          };
+
+          const candidateCleaFail = {
+            firstName: 'Jean-Michou',
+            lastName: 'Chou',
+          };
+          databaseBuilder.factory.buildComplementaryCertification.clea({
+            id: 1,
+          });
+          const badgeClea = databaseBuilder.factory.buildBadge({ id: 1, isCertifiable: true, key: PIX_EMPLOI_CLEA_V3 });
+          const complementaryBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+            complementaryCertificationId: 1,
+            badgeId: badgeClea.id,
+          }).id;
+
+          databaseBuilder.factory.buildCertificationCourse({ id: 91, sessionId, ...candidateCleaSuccess });
+          databaseBuilder.factory.buildCertificationCourse({ id: 92, sessionId, ...candidateCleaFail });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 991,
+            certificationCourseId: 91,
+            complementaryCertificationId: 1,
+            complementaryCertificationBadgeId: complementaryBadgeId,
+          });
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 992,
+            certificationCourseId: 92,
+            complementaryCertificationId: 1,
+            complementaryCertificationBadgeId: complementaryBadgeId,
+          });
+
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 991,
+            acquired: true,
+          });
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 992,
+            acquired: false,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const results = await cleaCertifiedCandidateRepository.getBySessionId(sessionId);
+
+          // then
+          expect(results).to.deepEqualArray([
+            domainBuilder.buildCleaCertifiedCandidate({
+              firstName: 'Jean-Mi',
+              lastName: 'Mi',
+              email: 'jean-mi@coco.fr',
+              birthdate: '2001-02-07',
+              birthplace: 'Paris',
+              birthPostalCode: null,
+              birthINSEECode: '75115',
+              birthCountry: 'FRANCE',
+              sex: 'M',
+              createdAt: new Date('2020-02-01'),
+            }),
+          ]);
+        });
+      });
+    });
+
+    describe('when there is no candidates for clea certification in the session', function () {
+      it('returns an empty list', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession().id;
+
+        databaseBuilder.factory.buildCertificationCourse({ id: 91, sessionId });
+        databaseBuilder.factory.buildCertificationCourse({ id: 92, sessionId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const results = await cleaCertifiedCandidateRepository.getBySessionId(sessionId);
+
+        // then
+        expect(results).to.be.empty;
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -3,6 +3,7 @@ const {
   getSessionCertificationResultsCsv,
   getDivisionCertificationResultsCsv,
   REJECTED_AUTOMATICALLY_COMMENT,
+  getCleaCertifiedCandidateCsv,
 } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
 const {
   PIX_EMPLOI_CLEA_V3,
@@ -464,4 +465,119 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
       });
     });
   });
+  context('#getCleaCertifiedCandidateCsv', function () {
+    context('when at least one candidate has passed a clea certification', function () {
+      it("returns a csv with candidate's information", async function () {
+        // given
+        const BOM = '\uFEFF';
+        const CleaCertifiedCandidate1 = domainBuilder.buildCleaCertifiedCandidate({
+          firstName: 'Léane',
+          lastName: 'Bern',
+          email: 'princesse-lele@gg.fr',
+          birthdate: '2001-05-10',
+          birthplace: 'Paris',
+          birthPostalCode: '75019',
+          birthINSEECode: '75119',
+          birthCountry: 'FRANCE',
+          sex: 'F',
+          createdAt: new Date('2020-02-01'),
+        });
+        const CleaCertifiedCandidate2 = domainBuilder.buildCleaCertifiedCandidate({
+          firstName: 'Jean-Mi',
+          lastName: 'Mi',
+          email: 'jean-mi@coco.fr',
+          birthdate: '2001-02-07',
+          birthplace: 'Paris',
+          birthPostalCode: '75015',
+          birthINSEECode: '75115',
+          birthCountry: 'FRANCE',
+          sex: 'M',
+          createdAt: new Date('2020-02-01'),
+        });
+
+        // when
+        const result = await getCleaCertifiedCandidateCsv([CleaCertifiedCandidate1, CleaCertifiedCandidate2]);
+
+        // then
+        const headers =
+          '"SIREN de l\'organisme";"Siret de l\'établissement";"Statut à l\'inscription";"Niveau d\'instruction";"Origine de la démarche";"Financeur";"Civilité";"Nom de naissance";"Nom d\'usage";"Prénom";"Email";"Téléphone";"Adresse";"Complément d\'adresse";"Ville";"Code postal";"Date de naissance";"Né à l\'étranger";"Zone géographique de naissance";"Né en collectivité d\'outre-mer";"Ville de naissance";"Code postal de naissance";"Date de passage";"CCPI";"Statut";"Obtention après la première évaluation ?"\n';
+        const CleaCertifiedCandidate1Data =
+          ';;;;;;"MME";"Bern";;"Léane";"princesse-lele@gg.fr";;;;;;"10/05/2001";"NON";;"NON";"Paris";"75019";"01/02/2020";"CléA Numérique by Pix";"CERTIFIE";\n';
+        const CleaCertifiedCandidate2Data =
+          ';;;;;;"M";"Mi";;"Jean-Mi";"jean-mi@coco.fr";;;;;;"07/02/2001";"NON";;"NON";"Paris";"75015";"01/02/2020";"CléA Numérique by Pix";"CERTIFIE";';
+
+        const expectedResult = BOM + headers + CleaCertifiedCandidate1Data + CleaCertifiedCandidate2Data;
+
+        expect(result).to.equal(expectedResult);
+      });
+      context('when clea certified candidates are born in french outermost region', function () {
+        it('should return csvContent with correct geographic area code and correct outermost born value', async function () {
+          // given
+          const CleaCertifiedCandidate = domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Léane',
+            lastName: 'Bern',
+            email: 'princesse-lele@gg.fr',
+            birthdate: '2001-05-10',
+            birthplace: 'STE MARIE',
+            birthPostalCode: '97418',
+            birthINSEECode: '97418',
+            birthCountry: 'FRANCE',
+            sex: 'F',
+            createdAt: new Date('2020-02-01'),
+          });
+
+          // when
+          const result = await getCleaCertifiedCandidateCsv([CleaCertifiedCandidate]);
+
+          // then
+          const expectedResult = [
+            { header: '"Né à l\'étranger"', value: '"NON"' },
+            { header: '"Zone géographique de naissance"', value: '' },
+            { header: '"Né en collectivité d\'outre-mer"', value: '"OUI"' },
+          ];
+          expectedResult.map(({ header, value }) => {
+            expect(_getValueFromHeader(header, result)).to.be.equal(value);
+          });
+        });
+      });
+      context('when clea certified candidates are born in foreign country', function () {
+        it('should return csvContent with correct foreign born value', async function () {
+          // given
+          const CleaCertifiedCandidate = domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Léane',
+            lastName: 'Bern',
+            email: 'princesse-lele@gg.fr',
+            birthdate: '2001-05-10',
+            birthplace: 'STE MARIE',
+            birthPostalCode: '99416',
+            birthINSEECode: '99416',
+            birthCountry: 'BRESIL',
+            sex: 'F',
+            createdAt: new Date('2020-02-01'),
+          });
+
+          // when
+          const result = await getCleaCertifiedCandidateCsv([CleaCertifiedCandidate]);
+
+          // then
+          const expectedResult = [
+            { header: '"Né à l\'étranger"', value: '"OUI"' },
+            { header: '"Zone géographique de naissance"', value: '"400"' },
+            { header: '"Né en collectivité d\'outre-mer"', value: '"NON"' },
+          ];
+          expectedResult.map(({ header, value }) => {
+            expect(_getValueFromHeader(header, result)).to.be.equal(value);
+          });
+        });
+      });
+    });
+  });
+
+  function _getValueFromHeader(nameHeader, result) {
+    const csv = result.split('\n');
+    const csvHeader = csv[0].split(';');
+    const csvData = csv[1].split(';');
+    const indexHeader = csvHeader.findIndex((header) => header === nameHeader);
+    return csvData[indexHeader];
+  }
 });

--- a/api/tests/tooling/domain-builder/factory/build-clea-certified-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certified-candidate.js
@@ -1,0 +1,27 @@
+const CleaCertifiedCandidate = require('../../../../lib/domain/read-models/CleaCertifiedCandidate');
+
+module.exports = function buildCleaCertifiedCandidate({
+  firstName = 'Gandhi',
+  lastName = 'Matmatah',
+  email = 'matmatahGdu75@dhi.fr',
+  birthplace = 'Perpignan',
+  birthdate = '1985-01-20',
+  sex = 'F',
+  birthPostalCode = '75005',
+  birthINSEECode = '75112',
+  birthCountry = 'FRANCE',
+  createdAt = new Date('2020-02-01'),
+} = {}) {
+  return new CleaCertifiedCandidate({
+    firstName,
+    lastName,
+    email,
+    birthdate,
+    birthplace,
+    birthPostalCode,
+    birthINSEECode,
+    birthCountry,
+    sex,
+    createdAt,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -58,6 +58,7 @@ module.exports = {
   buildCertifiedTube: require('./build-certified-tube'),
   buildChallenge: require('./build-challenge'),
   buildChallengeLearningContentDataObject: require('./build-challenge-learning-content-data-object'),
+  buildCleaCertifiedCandidate: require('./build-clea-certified-candidate'),
   buildCompetence: require('./build-competence'),
   buildCompetenceEvaluation: require('./build-competence-evaluation'),
   buildCompetenceMark: require('./build-competence-mark'),

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -9,6 +9,7 @@ const { expect, HttpTestServer, sinon } = require('../../../test-helper');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const sessionController = require('../../../../lib/application/sessions/session-controller');
 const sessionForSupervisingController = require('../../../../lib/application/sessions/session-for-supervising-controller');
+const sessionWithCleaCertifiedCandidateController = require('../../../../lib/application/sessions/session-with-clea-certified-candidate-controller');
 const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
 const authorization = require('../../../../lib/application/preHandlers/authorization');
 const moduleUnderTest = require('../../../../lib/application/sessions');
@@ -352,6 +353,14 @@ describe('Unit | Application | Sessions | Routes', function () {
       {
         condition: 'session ID params is out of range for database integer (> 2147483647)',
         request: { method: 'PATCH', url: '/api/admin/sessions/9999999999/certification-officer-assignment' },
+      },
+      {
+        condition: 'session ID params is not a number',
+        request: { method: 'GET', url: '/api/sessions/hello/certified-clea-candidate-data' },
+      },
+      {
+        condition: 'session ID params is out of range for database integer (> 2147483647)',
+        request: { method: 'GET', url: '/api/sessions/9999999999/certified-clea-candidate-data' },
       },
     ].forEach(({ condition, request }) => {
       it(`should return 400 when ${condition}`, async function () {
@@ -1015,6 +1024,22 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       // then
       expect(response.statusCode).to.equal(404);
+    });
+  });
+
+  describe('GET /api/sessions/{id}/certified-clea-candidate-data', function () {
+    it('should exist', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').returns(null);
+      sinon.stub(sessionWithCleaCertifiedCandidateController, 'getCleaCertifiedCandidateDataCsv').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/sessions/3/certified-clea-candidate-data');
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/application/session/session-with-clea-certified-candidate-controller_test.js
+++ b/api/tests/unit/application/session/session-with-clea-certified-candidate-controller_test.js
@@ -1,0 +1,57 @@
+const { domainBuilder, sinon, hFake, expect } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const certificationResultUtils = require('../../../../lib/infrastructure/utils/csv/certification-results');
+const sessionWithCleaCertifiedCandidateController = require('../../../../lib/application/sessions/session-with-clea-certified-candidate-controller');
+
+describe('Unit | Controller | session-with-clea-certified-candidate', function () {
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(new Date('2021-01-01T14:30:00Z'));
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#getCleaCertifiedCandidateDataCsv', function () {
+    it('should return a response with CSV results', async function () {
+      // given
+      const request = {
+        params: {
+          id: 1,
+        },
+      };
+      const session = domainBuilder.buildSession({ id: 1, date: new Date('2021-01-01'), time: '14:30' });
+      const cleaCertifiedCandidates = [
+        domainBuilder.buildCleaCertifiedCandidate({ createdAt: new Date('2021-01-01') }),
+      ];
+
+      // sinon.stub(momentProto, 'format');
+      // momentProto.format.withArgs('YYYYMMDD_HHmm').returns('20210101_1430');
+
+      sinon
+        .stub(usecases, 'getCleaCertifiedCandidateBySession')
+        .withArgs({ sessionId: 1 })
+        .resolves({ session, cleaCertifiedCandidateData: cleaCertifiedCandidates });
+
+      sinon
+        .stub(certificationResultUtils, 'getCleaCertifiedCandidateCsv')
+        .withArgs(cleaCertifiedCandidates)
+        .resolves('csv-string');
+
+      // when
+      const response = await sessionWithCleaCertifiedCandidateController.getCleaCertifiedCandidateDataCsv(
+        request,
+        hFake
+      );
+
+      // then
+      expect(response.source).to.equal('csv-string');
+      expect(response.headers['Content-Type']).to.equal('text/csv;charset=utf-8');
+      expect(response.headers['Content-Disposition']).to.equal(
+        'attachment; filename=20210101_1430_candidats_certifies_clea_1.csv'
+      );
+    });
+  });
+});

--- a/api/tests/unit/domain/read-models/CleaCertifiedCandidate_test.js
+++ b/api/tests/unit/domain/read-models/CleaCertifiedCandidate_test.js
@@ -1,0 +1,110 @@
+const { expect } = require('../../../test-helper');
+const CleaCertifiedCandidate = require('../../../../lib/domain/read-models/CleaCertifiedCandidate');
+
+describe('Unit | Domain | Models | CleaCertifiedCandidate', function () {
+  describe('#isBornInAForeignCountry', function () {
+    describe('when the candidate is born in a foreign country', function () {
+      it('should return true', function () {
+        // given
+        const cleaCertifiedCandidate = new CleaCertifiedCandidate({ birthINSEECode: '99100' });
+
+        // when
+        const bornInAForeignCountry = cleaCertifiedCandidate.isBornInAForeignCountry;
+
+        // then
+        expect(bornInAForeignCountry).to.be.true;
+      });
+    });
+    describe('when the candidate is born in France', function () {
+      it('should return false', function () {
+        // given
+        const cleaCertifiedCandidate = new CleaCertifiedCandidate({ birthINSEECode: '94700' });
+
+        // when
+        const bornInAForeignCountry = cleaCertifiedCandidate.isBornInAForeignCountry;
+
+        // then
+        expect(bornInAForeignCountry).to.be.false;
+      });
+    });
+  });
+
+  describe('#geographicAreaOfBirthCode', function () {
+    describe('when the candidate is born in a foreign country', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        {
+          code: '100',
+          INSEECode: '99102',
+        },
+        {
+          code: '200',
+          INSEECode: '99201',
+        },
+        {
+          code: '300',
+          INSEECode: '99302',
+        },
+        {
+          code: '400',
+          INSEECode: '99402',
+        },
+        {
+          code: '500',
+          INSEECode: '99502',
+        },
+      ].forEach(({ code, INSEECode }) => {
+        it(`should return ${code}`, function () {
+          // given
+          const cleaCertifiedCandidate = new CleaCertifiedCandidate({ birthINSEECode: INSEECode });
+
+          // when
+          const geographicAreaOfBirthCode = cleaCertifiedCandidate.geographicAreaOfBirthCode;
+
+          // then
+          expect(geographicAreaOfBirthCode).to.equal(code);
+        });
+      });
+    });
+    describe('when the candidate is born in France', function () {
+      it('should return null', function () {
+        // given
+        const cleaCertifiedCandidate = new CleaCertifiedCandidate({ birthINSEECode: '94700' });
+
+        // when
+        const geographicAreaOfBirthCode = cleaCertifiedCandidate.geographicAreaOfBirthCode;
+
+        // then
+        expect(geographicAreaOfBirthCode).to.be.null;
+      });
+    });
+  });
+
+  describe('#isBornInFrenchOutermostRegion', function () {
+    describe('when the candidate is born in outermost region', function () {
+      it('should return true', function () {
+        // given
+        const cleaCertifiedCandidate = new CleaCertifiedCandidate({ birthINSEECode: '97302' });
+
+        // when
+        const bornInFrenchOutermostRegion = cleaCertifiedCandidate.isBornInFrenchOutermostRegion;
+
+        // then
+        expect(bornInFrenchOutermostRegion).to.be.true;
+      });
+    });
+
+    describe('when the candidate is not born in outermost region', function () {
+      it('should return false', function () {
+        // given
+        const cleaCertifiedCandidate = new CleaCertifiedCandidate({ birthINSEECode: '37300' });
+
+        // when
+        const bornInFrenchOutermostRegion = cleaCertifiedCandidate.isBornInFrenchOutermostRegion;
+
+        // then
+        expect(bornInFrenchOutermostRegion).to.be.false;
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-clea-certified-candidate-by-session_test.js
+++ b/api/tests/unit/domain/usecases/get-clea-certified-candidate-by-session_test.js
@@ -1,0 +1,98 @@
+const { sinon, domainBuilder, expect } = require('../../../test-helper');
+const getCleaCertifiedCandidateBySession = require('../../../../lib/domain/usecases/get-clea-certified-candidate-by-session');
+
+describe('Unit | UseCase | getCleaCertifiedCandidateBySession', function () {
+  let cleaCertifiedCandidateRepository;
+  let sessionRepository;
+
+  beforeEach(function () {
+    sessionRepository = { get: sinon.stub() };
+    cleaCertifiedCandidateRepository = { getBySessionId: sinon.stub() };
+  });
+
+  it('should return session', async function () {
+    // given
+    const expectedSession = domainBuilder.buildSession();
+    sessionRepository.get.withArgs(123).resolves(expectedSession);
+    cleaCertifiedCandidateRepository.getBySessionId.withArgs(123).resolves([]);
+
+    // when
+    const { session } = await getCleaCertifiedCandidateBySession({
+      sessionId: 123,
+      sessionRepository,
+      cleaCertifiedCandidateRepository,
+    });
+
+    // then
+    expect(session).to.deepEqualInstance(expectedSession);
+  });
+
+  describe('when the session is publish', function () {
+    describe('when there is clea certified candidates in the session', function () {
+      it('should return data of certified candidates', async function () {
+        // given
+        cleaCertifiedCandidateRepository.getBySessionId.withArgs(1).resolves([
+          domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Jean-Mi',
+            lastName: 'Mi',
+            email: 'jean-mi@coco.fr',
+            birthdate: '2001-02-07',
+            birthplace: 'Paris',
+            birthPostalCode: '75015',
+            birthINSEECode: '75115',
+            birthCountry: 'FRANCE',
+            sex: 'M',
+            createdAt: new Date('2020-02-01'),
+          }),
+          domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Léane',
+            lastName: 'Bern',
+            email: 'princesse-lele@gg.fr',
+            birthdate: '2001-05-10',
+            birthplace: 'Paris',
+            birthPostalCode: '75019',
+            birthINSEECode: '75119',
+            birthCountry: 'FRANCE',
+            sex: 'F',
+            createdAt: new Date('2020-02-01'),
+          }),
+        ]);
+
+        // when
+        const { cleaCertifiedCandidateData } = await getCleaCertifiedCandidateBySession({
+          sessionId: 1,
+          cleaCertifiedCandidateRepository,
+          sessionRepository,
+        });
+
+        // then
+        expect(cleaCertifiedCandidateData).to.deepEqualArray([
+          domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Jean-Mi',
+            lastName: 'Mi',
+            email: 'jean-mi@coco.fr',
+            birthdate: '2001-02-07',
+            birthplace: 'Paris',
+            birthPostalCode: '75015',
+            birthINSEECode: '75115',
+            birthCountry: 'FRANCE',
+            sex: 'M',
+            createdAt: new Date('2020-02-01'),
+          }),
+          domainBuilder.buildCleaCertifiedCandidate({
+            firstName: 'Léane',
+            lastName: 'Bern',
+            email: 'princesse-lele@gg.fr',
+            birthdate: '2001-05-10',
+            birthplace: 'Paris',
+            birthPostalCode: '75019',
+            birthINSEECode: '75119',
+            birthCountry: 'FRANCE',
+            sex: 'F',
+            createdAt: new Date('2020-02-01'),
+          }),
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les centres de certification habilités CléA numérique doivent importer les informations des candidats ayant obtenu leur “Cléa numérique by Pix” sur la plateforme mise à disposition par Certif Pro, notamment pour générer les parchemins (= certificat) de ces candidats. Pour le moment, nous leur avons indiqué dans le process, de se mettre en tant que “destinataire des résultats” pour chaque candidat Cléa, afin de recevoir le fichier csv des résultats à la publication de la session.

## :robot: Solution
Permettre un export au format csv des informations des candidats ayant obtenu leur certif Cléa numérique pour import sur la plateforme Cléa pour une session donnée.

## :100: Pour tester

1. Se connecter avec le compte certif-pro qui a la session avec du Clea Numérique: **Numéro 106132**
2. Télécharger le csv avec la commande suivante : ```curl -H "Authorization: Bearer votretoken" "https://api-pr4957.review.pix.fr/api/sessions/106132/certified-clea-candidate-data" --output candidats_certifies_clea_106132.csv```
3. Constater le format suivant :

- Civilité : doit contenir "M" pour une homme et "MME" pour une femme
- Nom de naissance
- Prénom
- Email : si renseigné lors de l’inscription du candidat, sinon laisser vide
- Date de naissance
- Né à l'étranger : à remplir si le candidat est né à l'étranger, il doit contenir la valeur OUI ou NON, s'il est vide la valeur sera NON
- Zone géographique de naissance : à remplir si le candidat est né à l'étranger, il peut contenir les valeurs suivantes :
    - 100 pour les candidats nés en Europe
    - 200 pour les candidats nés en Asie
    - 300 pour les candidats nés en Afrique
    - 400 pour les candidats nés en Amérique
    - 500 pour les candidats nés en Océanie
- Né en collectivité d'outre-mer : à remplir si le candidat est né dans une collectivité d'outre-mer, il doit contenir la valeur OUI ou NON, s'il est vide la valeur sera NON
- Ville de naissance
- Code postal de naissance : il est obligatoire pour les candidats nés en France et doit contenir un nombre de 5 chiffres
- Date de passage : date de passage de la certif (et non date de publi !)
- CCPI : "CléA Numérique by Pix"
- Statut : "CERTIFIE"

Les autres champs doivent etre vides

























































