### PR TITLE
[TECH] Attendre patiemment la cloture des clients redis

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -24,13 +24,13 @@ async function _exitOnSignal(signal) {
   logger.info('Closing connexions to database...');
   await disconnect();
   logger.info('Closing connexions to cache...');
-  cache.quit();
+  await cache.quit();
   logger.info('Closing connexions to temporary storage...');
-  temporaryStorage.quit();
+  await temporaryStorage.quit();
   logger.info('Closing connexions to redis monitor...');
-  redisMonitor.quit();
+  await redisMonitor.quit();
   logger.info('Closing connexions to redis rate limiter...');
-  redisRateLimiter.quit();
+  await redisRateLimiter.quit();
   logger.info('Exiting process...');
 }
 

--- a/api/lib/infrastructure/caches/DistributedCache.js
+++ b/api/lib/infrastructure/caches/DistributedCache.js
@@ -32,9 +32,11 @@ class DistributedCache extends Cache {
   }
 
   quit() {
-    this._underlyingCache.quit();
-    this._redisClientPublisher.quit();
-    this._redisClientSubscriber.quit();
+    return Promise.all([
+      this._underlyingCache.quit(),
+      this._redisClientPublisher.quit(),
+      this._redisClientSubscriber.quit(),
+    ]);
   }
 }
 

--- a/api/lib/infrastructure/caches/LayeredCache.js
+++ b/api/lib/infrastructure/caches/LayeredCache.js
@@ -25,8 +25,7 @@ class LayeredCache extends Cache {
   }
 
   quit() {
-    this._firstLevelCache.quit();
-    this._secondLevelCache.quit();
+    return Promise.all([this._firstLevelCache.quit(), this._secondLevelCache.quit()]);
   }
 }
 

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -65,8 +65,8 @@ class RedisCache extends Cache {
     return this._client.flushall();
   }
 
-  quit() {
-    this._client.quit();
+  async quit() {
+    await this._client.quit();
   }
 }
 

--- a/api/lib/infrastructure/caches/learning-content-cache.js
+++ b/api/lib/infrastructure/caches/learning-content-cache.js
@@ -38,9 +38,7 @@ class LearningContentCache extends Cache {
   }
 
   quit() {
-    this._underlyingCache.quit();
-    this.redisCache.quit();
-    this.distributedCache.quit();
+    return Promise.all([this._underlyingCache.quit(), this.redisCache.quit(), this.distributedCache.quit()]);
   }
 }
 

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -44,8 +44,8 @@ class RedisTemporaryStorage extends TemporaryStorage {
     await this._client.deleteByPrefix(prefix);
   }
 
-  quit() {
-    this._client.quit();
+  async quit() {
+    await this._client.quit();
   }
 }
 

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -57,8 +57,8 @@ module.exports = class RedisClient {
     this._client.on(event, callback);
   }
 
-  quit() {
-    this._client.quit();
+  async quit() {
+    await this._client.quit();
   }
 
   async deleteByPrefix(searchedPrefix) {

--- a/api/lib/infrastructure/utils/redis-monitor.js
+++ b/api/lib/infrastructure/utils/redis-monitor.js
@@ -15,8 +15,8 @@ class RedisMonitor {
     return this._client.ping();
   }
 
-  quit() {
-    this._client.quit();
+  async quit() {
+    await this._client.quit();
   }
 }
 

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -32,7 +32,7 @@ async function main() {
       process.exitCode = 1;
     } finally {
       await disconnect();
-      cache.quit();
+      await cache.quit();
     }
   }
 })();

--- a/api/scripts/compare-pix-with-latest-release.js
+++ b/api/scripts/compare-pix-with-latest-release.js
@@ -113,8 +113,8 @@ async function compareUserScoreWithLatestRelease(userId) {
 
 async function main(userId) {
   const result = await compareUserScoreWithLatestRelease(userId);
-  cache.quit();
-  disconnect();
+  await cache.quit();
+  await disconnect();
   console.log(result);
 }
 

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -428,7 +428,7 @@ async function _disconnect() {
   logger.info('Closing connexions to PG...');
   await disconnect();
   logger.info('Closing connexions to cache...');
-  cache.quit();
-  temporaryStorage.quit();
+  await cache.quit();
+  await temporaryStorage.quit();
   logger.info('Exiting process gracefully...');
 }

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -149,7 +149,7 @@ const isLaunchedFromCommandLine = require.main === module;
       process.exitCode = 1;
     } finally {
       await disconnect();
-      cache.quit();
+      await cache.quit();
     }
   }
 })();

--- a/api/scripts/prod/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/convert-target-profiles-into-new-format.js
@@ -21,7 +21,7 @@ async function main() {
     throw err;
   } finally {
     await disconnect();
-    cache.quit();
+    await cache.quit();
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les process node se termine on clot les connexions Redis, mais sans faire d'await, hors, client.quit() est asynchrone
https://github.com/redis/node-redis#disconnecting

## :robot: Solution
Await sur les deconnexions

## :rainbow: Remarques
[.QUIT()/.quit()](https://github.com/redis/node-redis/blob/c1fd86778a71072a805cbb0cf238bc38f387eea2/README.md)

## :100: Pour tester
Vérifier que l'arrêt de l'API affiche bien les messages (non test automatiquement)
```bash
npm start
(Ctrl-C)
[14:12:50] INFO: Stopping HAPI server...
[14:12:50] INFO: server stopped
    created: 1663769542878
    started: 0
    host: "OCTO-TOPI"
    port: 3000
    protocol: "http"
    id: "OCTO-TOPI:35392:l8bpfffi"
    uri: "http://OCTO-TOPI:3000"
    address: "0.0.0.0"
[14:12:50] INFO: Closing connexions to database...
[14:12:50] INFO: Closing connexions to cache...
[14:12:50] INFO: Closing connexions to temporary storage...
[14:12:50] INFO: Closing connexions to redis monitor...
[14:12:50] INFO: Closing connexions to redis rate limiter...
[14:12:50] INFO: Exiting process...
[14:12:50] INFO: Disconnected from server
    redisClient: "redis-monitor"
[14:12:50] INFO: Disconnected from server
    redisClient: "temporary-storage"
[14:12:50] INFO: Disconnected from server
    redisClient: "redis-cache-query-client"
[14:12:50] INFO: Disconnected from server
    redisClient: "distributed-cache-subscriber"
[14:12:50] INFO: Disconnected from server
    redisClient: "distributed-cache-publisher"

```
