### PR TITLE
[FEATURE] Afficher un bouton pour télécharger les resultats clea dans pix-certif (PIX-5376)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -1,6 +1,7 @@
+const ComplementaryCertification = require('../../../lib/domain/models/ComplementaryCertification');
 const databaseBuffer = require('../database-buffer');
 
-module.exports = function buildComplementaryCertification({
+function buildComplementaryCertification({
   id = databaseBuffer.getNextId(),
   label = 'UneSuperCertifComplémentaire',
   key = 'SUPERCERTIF',
@@ -24,4 +25,19 @@ module.exports = function buildComplementaryCertification({
     tableName: 'complementary-certifications',
     values,
   });
+}
+
+buildComplementaryCertification.clea = function () {
+  return buildComplementaryCertification({
+    id: databaseBuffer.getNextId(),
+    label: 'CléA Numérique',
+    key: ComplementaryCertification.CLEA,
+    createdAt: new Date('2020-01-01'),
+    minimumReproducibilityRate: 50.0,
+    minimumEarnedPix: 70,
+    hasComplementaryReferential: false,
+    hasExternalJury: false,
+  });
 };
+
+module.exports = buildComplementaryCertification;

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -44,12 +44,8 @@ const {
 } = require('../badges-builder');
 
 function certificationCentersBuilder({ databaseBuilder }) {
-  databaseBuilder.factory.buildComplementaryCertification({
-    label: 'CléA Numérique',
-    key: 'CLEA',
+  databaseBuilder.factory.buildComplementaryCertification.clea({
     id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
-    minimumReproducibilityRate: 50.0,
-    minimumEarnedPix: 70,
   });
   databaseBuilder.factory.buildComplementaryCertificationBadge({
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V1,

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -45,7 +45,7 @@ module.exports = {
   async get(request) {
     const sessionId = request.params.id;
     const { session, hasSupervisorAccess } = await usecases.getSession({ sessionId });
-    return sessionSerializer.serialize(session, hasSupervisorAccess);
+    return sessionSerializer.serialize({ session, hasSupervisorAccess });
   },
 
   async save(request) {
@@ -54,7 +54,7 @@ module.exports = {
 
     const newSession = await usecases.createSession({ userId, session });
 
-    return sessionSerializer.serialize(newSession);
+    return sessionSerializer.serialize({ session: newSession });
   },
 
   async update(request) {
@@ -64,7 +64,7 @@ module.exports = {
 
     const updatedSession = await usecases.updateSession({ userId, session });
 
-    return sessionSerializer.serialize(updatedSession);
+    return sessionSerializer.serialize({ session: updatedSession });
   },
 
   async getAttendanceSheet(request, h) {
@@ -288,7 +288,7 @@ module.exports = {
 
     const session = await usecases.publishSession({ sessionId });
 
-    return sessionSerializer.serialize(session);
+    return sessionSerializer.serialize({ session });
   },
 
   async publishInBatch(request, h) {
@@ -308,13 +308,13 @@ module.exports = {
 
     const session = await usecases.unpublishSession({ sessionId });
 
-    return sessionSerializer.serialize(session);
+    return sessionSerializer.serialize({ session });
   },
 
   async flagResultsAsSentToPrescriber(request, h) {
     const sessionId = request.params.id;
     const { resultsFlaggedAsSent, session } = await usecases.flagSessionResultsAsSentToPrescriber({ sessionId });
-    const serializedSession = await sessionSerializer.serialize(session);
+    const serializedSession = await sessionSerializer.serialize({ session });
     return resultsFlaggedAsSent ? h.response(serializedSession).created() : serializedSession;
   },
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -44,8 +44,8 @@ module.exports = {
 
   async get(request) {
     const sessionId = request.params.id;
-    const { session, hasSupervisorAccess } = await usecases.getSession({ sessionId });
-    return sessionSerializer.serialize({ session, hasSupervisorAccess });
+    const { session, hasSupervisorAccess, hasSomeCleaAcquired } = await usecases.getSession({ sessionId });
+    return sessionSerializer.serialize({ session, hasSupervisorAccess, hasSomeCleaAcquired });
   },
 
   async save(request) {

--- a/api/lib/domain/usecases/get-session.js
+++ b/api/lib/domain/usecases/get-session.js
@@ -1,8 +1,10 @@
 module.exports = async function getSession({ sessionId, sessionRepository, supervisorAccessRepository }) {
   const session = await sessionRepository.get(sessionId);
+  const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(sessionId);
   const hasSupervisorAccess = await supervisorAccessRepository.sessionHasSupervisorAccess({ sessionId });
   return {
     session,
     hasSupervisorAccess,
+    hasSomeCleaAcquired,
   };
 };

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -7,6 +7,7 @@ const { NotFoundError } = require('../../../domain/errors');
 const Session = require('../../../domain/models/Session');
 const CertificationCenter = require('../../../domain/models/CertificationCenter');
 const CertificationCandidate = require('../../../domain/models/CertificationCandidate');
+const ComplementaryCertification = require('../../../domain/models/ComplementaryCertification');
 
 module.exports = {
   async save(sessionData) {
@@ -165,6 +166,34 @@ module.exports = {
     });
 
     return;
+  },
+
+  async hasSomeCleaAcquired(sessionId) {
+    const result = await knex
+      .select(1)
+      .from('sessions')
+      .innerJoin('certification-courses', 'certification-courses.sessionId', 'sessions.id')
+      .innerJoin(
+        'complementary-certification-courses',
+        'complementary-certification-courses.certificationCourseId',
+        'certification-courses.id'
+      )
+      .innerJoin(
+        'complementary-certifications',
+        'complementary-certifications.id',
+        'complementary-certification-courses.complementaryCertificationId'
+      )
+      .innerJoin(
+        'complementary-certification-course-results',
+        'complementary-certification-course-results.complementaryCertificationCourseId',
+        'complementary-certification-courses.id'
+      )
+      .where('sessions.id', sessionId)
+      .whereNotNull('sessions.publishedAt')
+      .where('complementary-certification-course-results.acquired', true)
+      .where('complementary-certifications.key', ComplementaryCertification.CLEA)
+      .first();
+    return Boolean(result);
   },
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -7,7 +7,7 @@ const { isValidDate } = require('../../utils/date-utils');
 const Session = require('../../../domain/models/Session');
 
 module.exports = {
-  serialize(sessions, hasSupervisorAccess) {
+  serialize({ session, hasSupervisorAccess, hasSomeCleaAcquired }) {
     const attributes = [
       'address',
       'room',
@@ -28,11 +28,15 @@ module.exports = {
       'certificationReports',
       'supervisorPassword',
       'hasSupervisorAccess',
+      'hasSomeCleaAcquired',
     ];
     return new Serializer('session', {
       transform(record) {
         if (hasSupervisorAccess !== undefined) {
           record.hasSupervisorAccess = hasSupervisorAccess;
+        }
+        if (hasSomeCleaAcquired !== undefined) {
+          record.hasSomeCleaAcquired = hasSomeCleaAcquired;
         }
         return record;
       },
@@ -56,7 +60,7 @@ module.exports = {
           },
         },
       },
-    }).serialize(sessions);
+    }).serialize(session);
   },
 
   deserialize(json) {

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -699,8 +699,8 @@ describe('Integration | Repository | Session', function () {
             sessionId,
             userId,
           }).id;
-          const badgeId = databaseBuilder.factory.buildBadge({}).id;
-          const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
+          const badgeId = databaseBuilder.factory.buildBadge().id;
+          const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
           const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
             badgeId,
             complementaryCertificationId,
@@ -738,11 +738,8 @@ describe('Integration | Repository | Session', function () {
           sessionId,
           userId,
         }).id;
-        const badgeId = databaseBuilder.factory.buildBadge({}).id;
-        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-          key: 'CLEA',
-          label: 'Cléa Numérique',
-        }).id;
+        const badgeId = databaseBuilder.factory.buildBadge().id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
         const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
           badgeId,
           complementaryCertificationId,
@@ -777,10 +774,8 @@ describe('Integration | Repository | Session', function () {
           sessionId,
           userId,
         }).id;
-        const badgeId = databaseBuilder.factory.buildBadge({}).id;
-        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-          key: 'CLEA',
-        }).id;
+        const badgeId = databaseBuilder.factory.buildBadge().id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
         const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
           badgeId,
           complementaryCertificationId,

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -684,4 +684,157 @@ describe('Integration | Repository | Session', function () {
       });
     });
   });
+
+  describe('#hasSomeCleaAcquired', function () {
+    context('when session is published', function () {
+      context('when at least one candidate has acquired Cléa', function () {
+        it('should return true', async function () {
+          // given
+          const sessionId = databaseBuilder.factory.buildSession({
+            publishedAt: '2022-01-01',
+          }).id;
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            sessionId,
+            userId,
+          }).id;
+          const badgeId = databaseBuilder.factory.buildBadge({}).id;
+          const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
+          const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+            badgeId,
+            complementaryCertificationId,
+          }).id;
+          const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
+            complementaryCertificationId,
+            complementaryCertificationBadgeId,
+            certificationCourseId,
+          }).id;
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId,
+            acquired: true,
+          });
+
+          await databaseBuilder.commit();
+
+          // when
+          const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(sessionId);
+
+          // then
+          expect(hasSomeCleaAcquired).to.be.true;
+        });
+      });
+    });
+
+    context('when session is not published', function () {
+      it('should return true', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession({
+          publishedAt: null,
+        }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId,
+        }).id;
+        const badgeId = databaseBuilder.factory.buildBadge({}).id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+          key: 'CLEA',
+          label: 'Cléa Numérique',
+        }).id;
+        const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId,
+          complementaryCertificationId,
+        }).id;
+        const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
+          complementaryCertificationId,
+          complementaryCertificationBadgeId,
+          certificationCourseId,
+        }).id;
+        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId,
+          acquired: true,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(sessionId);
+
+        // then
+        expect(hasSomeCleaAcquired).to.be.false;
+      });
+    });
+
+    context('when no candidate has acquired Cléa', function () {
+      it('should return false', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession().id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
+        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId,
+        }).id;
+        const badgeId = databaseBuilder.factory.buildBadge({}).id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+          key: 'CLEA',
+        }).id;
+        const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId,
+          complementaryCertificationId,
+        }).id;
+        const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
+          complementaryCertificationId,
+          complementaryCertificationBadgeId,
+          certificationCourseId,
+        }).id;
+        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+          complementaryCertificationCourseId,
+          acquired: false,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(sessionId);
+
+        // then
+        expect(hasSomeCleaAcquired).to.be.false;
+      });
+    });
+
+    context('when the session has no certification course', function () {
+      it('should return false', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession().id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(sessionId);
+
+        // then
+        expect(hasSomeCleaAcquired).to.be.false;
+      });
+    });
+
+    context('when the session has no candidate', function () {
+      it('should return false', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession().id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const hasSomeCleaAcquired = await sessionRepository.hasSomeCleaAcquired(sessionId);
+
+        // then
+        expect(hasSomeCleaAcquired).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -96,7 +96,7 @@ describe('Unit | Controller | sessionController', function () {
 
       // then
       expect(response).to.deep.equal(jsonApiSession);
-      expect(sessionSerializer.serialize).to.have.been.calledWith(savedSession);
+      expect(sessionSerializer.serialize).to.have.been.calledWith({ session: savedSession });
     });
   });
 
@@ -154,7 +154,9 @@ describe('Unit | Controller | sessionController', function () {
         const foundSession = Symbol('foundSession');
         const serializedSession = Symbol('serializedSession');
         usecases.getSession.withArgs({ sessionId }).resolves({ session: foundSession });
-        sessionSerializer.serialize.withArgs(foundSession).resolves(serializedSession);
+        sessionSerializer.serialize
+          .withArgs({ session: foundSession, hasSupervisorAccess: undefined })
+          .returns(serializedSession);
 
         // when
         const response = await sessionController.get(request, hFake);
@@ -193,7 +195,7 @@ describe('Unit | Controller | sessionController', function () {
     it('should return the updated session', async function () {
       // given
       usecases.updateSession.withArgs(updateSessionArgs).resolves(updatedSession);
-      sessionSerializer.serialize.withArgs(updatedSession).returns(updatedSession);
+      sessionSerializer.serialize.withArgs({ session: updatedSession }).returns(updatedSession);
 
       // when
       const response = await sessionController.update(request, hFake);
@@ -727,7 +729,7 @@ describe('Unit | Controller | sessionController', function () {
             sessionId,
           })
           .resolves(usecaseResult);
-        sinon.stub(sessionSerializer, 'serialize').withArgs(session).resolves(serializedSession);
+        sinon.stub(sessionSerializer, 'serialize').withArgs({ session: usecaseResult }).resolves(serializedSession);
       });
 
       it('should return the serialized session', async function () {
@@ -749,7 +751,7 @@ describe('Unit | Controller | sessionController', function () {
             sessionId,
           })
           .resolves(usecaseResult);
-        sinon.stub(sessionSerializer, 'serialize').withArgs(session).resolves(serializedSession);
+        sinon.stub(sessionSerializer, 'serialize').withArgs({ session }).resolves(serializedSession);
       });
 
       it('should return the serialized session', async function () {
@@ -886,7 +888,7 @@ describe('Unit | Controller | sessionController', function () {
       beforeEach(function () {
         const usecaseResult = { resultsFlaggedAsSent: false, session };
         sinon.stub(usecases, 'flagSessionResultsAsSentToPrescriber').withArgs({ sessionId }).resolves(usecaseResult);
-        sinon.stub(sessionSerializer, 'serialize').withArgs(session).resolves(serializedSession);
+        sinon.stub(sessionSerializer, 'serialize').withArgs({ session }).resolves(serializedSession);
       });
 
       it('should return the serialized session', async function () {
@@ -902,7 +904,7 @@ describe('Unit | Controller | sessionController', function () {
       beforeEach(function () {
         const usecaseResult = { resultsFlaggedAsSent: true, session };
         sinon.stub(usecases, 'flagSessionResultsAsSentToPrescriber').withArgs({ sessionId }).resolves(usecaseResult);
-        sinon.stub(sessionSerializer, 'serialize').withArgs(session).resolves(serializedSession);
+        sinon.stub(sessionSerializer, 'serialize').withArgs({ session }).resolves(serializedSession);
       });
 
       it('should return the serialized session with code 201', async function () {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -153,9 +153,9 @@ describe('Unit | Controller | sessionController', function () {
         // given
         const foundSession = Symbol('foundSession');
         const serializedSession = Symbol('serializedSession');
-        usecases.getSession.withArgs({ sessionId }).resolves({ session: foundSession });
+        usecases.getSession.withArgs({ sessionId }).resolves({ session: foundSession, hasSomeCleaAcquired: false });
         sessionSerializer.serialize
-          .withArgs({ session: foundSession, hasSupervisorAccess: undefined })
+          .withArgs({ session: foundSession, hasSupervisorAccess: undefined, hasSomeCleaAcquired: false })
           .returns(serializedSession);
 
         // when

--- a/api/tests/unit/domain/usecases/get-session_test.js
+++ b/api/tests/unit/domain/usecases/get-session_test.js
@@ -9,6 +9,7 @@ describe('Unit | UseCase | get-session', function () {
   beforeEach(function () {
     sessionRepository = {
       get: sinon.stub(),
+      hasSomeCleaAcquired: sinon.stub(),
     };
     supervisorAccessRepository = {
       sessionHasSupervisorAccess: sinon.stub(),
@@ -21,6 +22,7 @@ describe('Unit | UseCase | get-session', function () {
       const sessionId = 123;
       const sessionToFind = domainBuilder.buildSession({ id: sessionId });
       sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+      sessionRepository.hasSomeCleaAcquired.withArgs(sessionId).resolves(false);
       supervisorAccessRepository.sessionHasSupervisorAccess.resolves(true);
 
       // when
@@ -36,6 +38,7 @@ describe('Unit | UseCase | get-session', function () {
         const sessionId = 123;
         const sessionToFind = domainBuilder.buildSession({ id: sessionId });
         sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+        sessionRepository.hasSomeCleaAcquired.withArgs(sessionId).resolves(false);
         supervisorAccessRepository.sessionHasSupervisorAccess.resolves(true);
 
         // when
@@ -52,6 +55,7 @@ describe('Unit | UseCase | get-session', function () {
         const sessionId = 123;
         const sessionToFind = domainBuilder.buildSession({ id: sessionId });
         sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+        sessionRepository.hasSomeCleaAcquired.withArgs(sessionId).resolves(false);
         supervisorAccessRepository.sessionHasSupervisorAccess.resolves(false);
 
         // when
@@ -59,6 +63,48 @@ describe('Unit | UseCase | get-session', function () {
 
         // then
         expect(hasSupervisorAccess).to.be.false;
+      });
+    });
+
+    context('when the session does have any acquired clea result', function () {
+      it('should return hasSomeCleaAcquired to true', async function () {
+        // given
+        const sessionId = 123;
+        const sessionToFind = domainBuilder.buildSession({ id: sessionId });
+        sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+        sessionRepository.hasSomeCleaAcquired.withArgs(sessionId).resolves(true);
+        supervisorAccessRepository.sessionHasSupervisorAccess.resolves(true);
+
+        // when
+        const { hasSomeCleaAcquired } = await getSession({
+          sessionId,
+          sessionRepository,
+          supervisorAccessRepository,
+        });
+
+        // then
+        expect(hasSomeCleaAcquired).to.be.true;
+      });
+    });
+
+    context('when the session does not have acquired clea result', function () {
+      it('should return hasSomeCleaAcquired to true', async function () {
+        // given
+        const sessionId = 123;
+        const sessionToFind = domainBuilder.buildSession({ id: sessionId });
+        sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
+        sessionRepository.hasSomeCleaAcquired.withArgs(sessionId).resolves(false);
+        supervisorAccessRepository.sessionHasSupervisorAccess.resolves(true);
+
+        // when
+        const { hasSomeCleaAcquired } = await getSession({
+          sessionId,
+          sessionRepository,
+          supervisorAccessRepository,
+        });
+
+        // then
+        expect(hasSomeCleaAcquired).to.be.false;
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -6,7 +6,7 @@ const { statuses } = require('../../../../../lib/domain/models/Session');
 
 describe('Unit | Serializer | JSONAPI | session-serializer', function () {
   describe('#serialize()', function () {
-    let modelSession;
+    let session;
     let expectedJsonApi;
 
     beforeEach(function () {
@@ -46,7 +46,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
           },
         },
       };
-      modelSession = new Session({
+      session = new Session({
         id: 12,
         certificationCenterId: 123,
         address: 'Nice',
@@ -69,7 +69,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
     context('when session does not have a link to an existing certification center', function () {
       it('should convert a Session model object into JSON API data including supervisor password', function () {
         // when
-        const json = serializer.serialize(modelSession);
+        const json = serializer.serialize({ session });
 
         // then
         expect(json).to.deep.equal(expectedJsonApi);
@@ -85,10 +85,26 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function () {
         expectedJsonApiIncludingHasSupervisorAccess.data.attributes['has-supervisor-access'] = true;
 
         // when
-        const json = serializer.serialize(modelSession, true);
+        const json = serializer.serialize({ session, hasSupervisorAccess: true });
 
         // then
         expect(json).to.deep.equal(expectedJsonApiIncludingHasSupervisorAccess);
+      });
+    });
+
+    context('when hasSomeCleaAcquired is provided', function () {
+      it('should add hasSomeCleaAcquired to the serialized session', function () {
+        // given
+        const expectedJsonApiIncludingHasSomeCleaAcquired = {
+          ...expectedJsonApi,
+        };
+        expectedJsonApiIncludingHasSomeCleaAcquired.data.attributes['has-some-clea-acquired'] = true;
+
+        // when
+        const json = serializer.serialize({ session, hasSomeCleaAcquired: true });
+
+        // then
+        expect(json).to.deep.equal(expectedJsonApiIncludingHasSomeCleaAcquired);
       });
     });
   });

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -51,7 +51,6 @@ export class RadioButtonCategoryWithDescription extends RadioButtonCategory {
 }
 
 export class RadioButtonCategoryWithSubcategory extends RadioButtonCategory {
-  @service featureToggles;
   @tracked subcategory;
 
   constructor({ name, subcategory, isChecked }) {
@@ -106,7 +105,6 @@ export class RadioButtonCategoryWithSubcategoryAndQuestionNumber extends RadioBu
 
 export default class AddIssueReportModal extends Component {
   @service store;
-  @service featureToggles;
 
   @tracked signatureIssueCategory = new RadioButtonCategoryWithDescription({
     name: certificationIssueReportCategories.SIGNATURE_ISSUE,

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.js
@@ -1,6 +1,0 @@
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-
-export default class FraudCertificationIssueReportFields extends Component {
-  @service featureToggles;
-}

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import {
   certificationIssueReportSubcategories,
@@ -8,8 +7,6 @@ import {
 } from 'pix-certif/models/certification-issue-report';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
-  @service featureToggles;
-
   @action
   onChangeSubcategory(event) {
     this.args.inChallengeCategory.subcategory = event.target.value;

--- a/certif/app/components/session-clea-results-download.hbs
+++ b/certif/app/components/session-clea-results-download.hbs
@@ -1,0 +1,21 @@
+<div class="panel session-details__clea-results-download">
+  <div class="session-details__clea-results-download-grey">
+    <div class="session-details__clea-results-download-icon">
+      <FaIcon @icon="award" />
+    </div>
+    <div>
+      <h1 class="session-details__clea-results-download-title">
+        Des candidats ont obtenu le CléA numérique
+      </h1>
+      <p class="&__clea-results-download-description">
+        Pour générer les parchemin CléA numérique, téléchargez la liste des candidats puis importez la sur la
+        <a href="https://cleanumerique.org/" target="_blank" rel="noopener noreferrer">plateforme du CléA numérique.
+          <FaIcon @icon="link" /></a>
+      </p>
+
+      <PixButtonLink @href="#" class="session-details__clea-results-download-button">
+        Télécharger la liste des candidats
+      </PixButtonLink>
+    </div>
+  </div>
+</div>

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -10,7 +10,6 @@ export default class AuthenticatedController extends Controller {
   @tracked isBannerVisible = true;
   @service router;
   @service currentUser;
-  @service featureToggles;
 
   get showBanner() {
     const isOnFinalizationPage = this.router.currentRouteName === 'authenticated.sessions.finalize';

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -7,7 +7,6 @@ import { alias } from '@ember/object/computed';
 
 export default class SessionsDetailsController extends Controller {
   @service currentUser;
-  @service featureToggles;
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -8,7 +8,6 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class CertificationCandidatesController extends Controller {
-  @service featureToggles;
   @service currentUser;
 
   @alias('model.session') currentSession;

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -13,7 +13,6 @@ export default class SessionParametersController extends Controller {
   @tracked sessionNumberTooltipText = '';
   @tracked accessCodeTooltipText = '';
   @tracked supervisorPasswordTooltipText = '';
-  @service featureToggles;
   @service currentUser;
 
   @computed('certificationCandidates.@each.isLinked')

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -10,7 +10,6 @@ import trim from 'lodash/trim';
 
 export default class SessionsFinalizeController extends Controller {
   @service currentUser;
-  @service featureToggles;
   @service notifications;
 
   @alias('model') session;

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -1,5 +1,4 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
-import { inject as service } from '@ember/service';
 
 export const certificationIssueReportCategories = {
   CANDIDATE_INFORMATIONS_CHANGES: 'CANDIDATE_INFORMATIONS_CHANGES',
@@ -88,7 +87,6 @@ export const subcategoryToTextareaLabel = {
 };
 
 export default class CertificationIssueReport extends Model {
-  @service featureToggles;
   @attr('string') category;
   @attr('string') subcategory;
   @attr('string') description;

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,6 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isCertificationFreeFieldsDeletionEnabled;
   @attr('boolean') isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled;
 }

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -30,6 +30,7 @@ export default class Session extends Model {
   @attr('string') examinerGlobalComment;
   @attr('string') supervisorPassword;
   @attr('boolean') hasSupervisorAccess;
+  @attr('boolean') hasSomeCleaAcquired;
   @attr('boolean') hasIncident;
   @attr('boolean') hasJoiningIssue;
   @attr() certificationCenterId;
@@ -75,5 +76,12 @@ export default class Session extends Model {
 
   get uncompletedCertificationReports() {
     return this.certificationReports.filter((certificationReport) => !certificationReport.isCompleted);
+  }
+
+  get shouldDisplayCleaResultDownloadSection() {
+    return (
+      this.featureToggles.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled &&
+      this.hasSomeCleaAcquired
+    );
   }
 }

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -14,7 +14,6 @@
 }
 
 .session-details-header {
-
   &__title {
     display: flex;
     flex-direction: column;
@@ -132,6 +131,44 @@ $details-content-margin: 8px;
 }
 
 .session-details {
+  &__clea-results-download {
+    padding: 6px;
+  }
+
+  &__clea-results-download-grey {
+    padding: 16px;
+    background: $pix-neutral-5;
+    display: flex;
+  }
+
+  &__clea-results-download-title {
+    font-weight: 500;
+    font-size: 20px;
+    color: $pix-neutral-90;
+    margin: 0 0 4px 0;
+  }
+
+
+  &__clea-results-download-description {
+    color: $pix-neutral-50;
+  }
+
+  &__clea-results-download-icon {
+    width: 80px;
+    padding: 2px;
+    margin-right: 16px;
+    justify-content: center;
+    align-items: center;
+    display: flex;
+    svg {
+      font-size: 40px;
+      color: $pix-neutral-50;
+    }
+  }
+
+  &__clea-results-download-button {
+    width: 30%;
+  }
 
   &__controls {
     display: flex;

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -25,6 +25,10 @@
     </div>
   </div>
 
+  {{#if this.session.shouldDisplayCleaResultDownloadSection}}
+    <SessionCleaResultsDownload />
+  {{/if}}
+
   <div class="panel session-details__controls">
     <nav class="navbar session-details__controls-navbar-tabs">
       <LinkTo @route="authenticated.sessions.details.parameters" class="navbar-item">

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -179,6 +179,23 @@ module('Acceptance | Session Details', function (hooks) {
           assert.dom(screen.queryByRole('link', { name: 'Télécharger le kit surveillant' })).doesNotExist();
         });
       });
+
+      module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is enabled', function () {
+        module('when session has clea results and session is published', function () {
+          test('it should show the clea result download section', async function (assert) {
+            // given
+            session.update({ publishedAt: '2022-01-01', hasSomeCleaAcquired: true });
+            server.create('feature-toggle', { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true });
+
+            // when
+            const screen = await visit(`/sessions/${session.id}`);
+
+            // then
+            assert.dom(screen.getByText('Des candidats ont obtenu le CléA numérique')).exists();
+            assert.dom(screen.getByRole('link', { name: 'Télécharger la liste des candidats' })).exists();
+          });
+        });
+      });
     });
   });
 });

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
@@ -4,7 +4,6 @@ import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import { hbs } from 'ember-cli-htmlbars';
-import Service from '@ember/service';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import {
@@ -15,17 +14,6 @@ import {
 
 module('Integration | Component | add-issue-report-modal', function (hooks) {
   setupRenderingTest(hooks);
-
-  const featureToggles = {
-    isCertificationFreeFieldsDeletionEnabled: false,
-  };
-
-  hooks.beforeEach(function () {
-    class FeatureTogglesStub extends Service {
-      featureToggles = featureToggles;
-    }
-    this.owner.register('service:feature-toggles', FeatureTogglesStub);
-  });
 
   test('it show candidate informations in title', async function (assert) {
     // given

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -143,7 +143,7 @@ module('Unit | Model | session', function (hooks) {
             id: 123,
             status: CREATED,
             publishedAt: '2022-01-01',
-            hasAnyAcquiredCleaResult: true,
+            hasSomeCleaAcquired: true,
           });
 
           // when/then
@@ -163,7 +163,7 @@ module('Unit | Model | session', function (hooks) {
             id: 123,
             status: CREATED,
             publishedAt: '2022-01-01',
-            hasAnyAcquiredCleaResult: false,
+            hasSomeCleaAcquired: false,
           });
 
           // when/then
@@ -184,7 +184,7 @@ module('Unit | Model | session', function (hooks) {
           id: 123,
           status: CREATED,
           publishedAt: '2022-01-01',
-          hasAnyAcquiredCleaResult: true,
+          hasSomeCleaAcquired: true,
         });
 
         // when/then

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -128,6 +128,70 @@ module('Unit | Model | session', function (hooks) {
       assert.notPropEqual(model.completedCertificationReports[1].id, 3);
     });
   });
+
+  module('#shouldDisplayCleaResultDownloadSection', function () {
+    module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is enabled', function () {
+      module('when session has any acquired Clea result', function () {
+        test('it should return true', function (assert) {
+          // given
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const store = this.owner.lookup('service:store');
+          const model = store.createRecord('session', {
+            id: 123,
+            status: CREATED,
+            publishedAt: '2022-01-01',
+            hasAnyAcquiredCleaResult: true,
+          });
+
+          // when/then
+          assert.true(model.shouldDisplayCleaResultDownloadSection);
+        });
+      });
+
+      module('when session has no acquired Clea result', function () {
+        test('it should return false', function (assert) {
+          // given
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const store = this.owner.lookup('service:store');
+          const model = store.createRecord('session', {
+            id: 123,
+            status: CREATED,
+            publishedAt: '2022-01-01',
+            hasAnyAcquiredCleaResult: false,
+          });
+
+          // when/then
+          assert.false(model.shouldDisplayCleaResultDownloadSection);
+        });
+      });
+    });
+
+    module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is not enabled', function () {
+      test('it should return false', function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: false };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('session', {
+          id: 123,
+          status: CREATED,
+          publishedAt: '2022-01-01',
+          hasAnyAcquiredCleaResult: true,
+        });
+
+        // when/then
+        assert.false(model.shouldDisplayCleaResultDownloadSection);
+      });
+    });
+  });
 });
 
 function _createTwoCompleteAndOneUncompleteCertificationReports(store) {


### PR DESCRIPTION
## :unicorn: Problème
Les centres de certification habilités CléA numérique doivent importer les informations des candidats ayant obtenu leur “Cléa numérique by Pix” sur la plateforme mise à disposition par Certif Pro, notamment pour générer les parchemins (= certificat) de ces candidats. Pour le moment, nous leur avons indiqué dans le process, de se mettre en tant que “destinataire des résultats” pour chaque candidat Cléa, afin de recevoir le fichier csv des résultats à la publication de la session.

Il s’agit là d’une utilisation détournée du champ “E-mail du destinataire des résultats” qui a pour finalité de communiquer les résultats de certification des candidats au prescripteur de la certification, et non au centre de certification. De plus, le centre doit penser transmettre le fichier des résultats au prescripteur (vrai destinataire de ce fichier), ce qui n’est pas toujours fait en pratique.

## :robot: Solution
Permettre aux centres de certification habilités Cléa numérique de télécharger la liste des candidats à importer sur la plateforme Cléa depuis Pix Certif : 

Dès qu’une session avec au moins un candidat Cléa numérique est publiée, afficher sur la page de détails de la session la section suivante : 

- lien vers la plateforme CléaA numérique : https://cleanumerique.org/

## :rainbow: Remarques
:warning:  Le  téléchargement au clique du bouton sera géré dans une autre PR

TODO
- [x] Voir avec Quentin pour les icones de la maquette

## :100: Pour tester
- Activer le toggle FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
- Passer/finaliser/publier une certification Cléa
- Se rendre sur la page de la session dans pix-certif
- Constater la présence d'une section permettant le téléchargement des resutats cléa

![image](https://user-images.githubusercontent.com/37305474/191757666-f181b8e0-bddf-4cc5-8b21-79cb361a704e.png)

