### PR TITLE
[BUGFIX] Orga: permettre l'inscription d'une adresse e-mail en majuscules (PIX-5733)

### DIFF
--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -9,7 +9,8 @@ const { extractLocaleFromRequest } = require('../../infrastructure/utils/request
 module.exports = {
   async acceptOrganizationInvitation(request) {
     const organizationInvitationId = request.params.id;
-    const { code, email } = request.payload.data.attributes;
+    const { code, email: rawEmail } = request.payload.data.attributes;
+    const email = rawEmail?.trim().toLowerCase();
 
     const membership = await usecases.acceptOrganizationInvitation({ organizationInvitationId, code, email });
     await usecases.createCertificationCenterMembershipForScoOrganizationMember({ membership });

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Application | organization-invitation-controller', functi
               type: 'organization-invitation-responses',
               attributes: {
                 code,
-                email: userToInviteEmail,
+                email: userToInviteEmail.toUpperCase(),
               },
             },
           },

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -40,7 +40,7 @@ describe('Integration | Application | Organization-invitations | organization-in
         type: 'organization-invitation-responses',
         attributes: {
           code: 'DZWMP7L5UM',
-          email: 'user@example.net',
+          email: 'USER@example.net',
         },
       },
     };

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -17,7 +17,7 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
         payload: {
           data: {
             type: 'organization-invitations',
-            attributes: { code, email },
+            attributes: { code, email: email.toUpperCase() },
           },
         },
       };

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -87,7 +87,7 @@ export default class RegisterForm extends Component {
   @action
   validateEmail(event) {
     this.emailValidationMessage = null;
-    this.email = event.target.value?.trim();
+    this.email = event.target.value?.trim().toLowerCase();
     const isInvalidInput = !isEmailValid(this.email);
 
     if (isInvalidInput) {

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -110,7 +110,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
       await renderScreen(hbs`<Auth::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
       await fillByLabel(firstNameInputLabel, 'pix');
       await fillByLabel(lastNameInputLabel, 'pix');
-      await fillByLabel(emailInputLabel, 'shi@fu.me');
+      await fillByLabel(emailInputLabel, 'SHI@fu.me');
       await fillByLabel(passwordInputLabel, 'Mypassword1');
       await clickByName(cguAriaLabel);
 


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'une personne accepte une invitation à rejoindre une organisation, si cette personne fourni une adresse e-mail contenant une ou plusieurs majuscules, cette dernière recevra un message d'erreur car l'inscription n'a pas été finalisée.

Le compte de l'utilisateur sera créé mais lorsque l'action de faire le lien entre cet utilisateur et l'organisation est exécutée, l'e-mail n'est pas le même (majuscules vs minuscules)

## :robot: Solution

Transformer toutes les majuscules en minuscules au niveau de l'application Pix Orga pour l'email et le faire également au niveau de l'api.

## :rainbow: Remarques

- Se pencher sur la solution de Joi au niveau de l'api pour appliquer la méthode `lowercase` sur une propriété de type email.
- Vérifier si dans toutes les applications la méthode `toLowerCase()` est appliquée sur les e-mails.
- Faire une seule requête et gérer les actions via une transaction pour quelles soient réversibles.

## :100: Pour tester

##### Pix Admin

- Se connecter à Pix Admin
- Ouvrir les détails d'une organisation
- Allez sur l'onglet `Invitations`
- Invitez vous

##### Pix Orga

- Cliquez sur le lien d'invitation que vous avez reçu dans votre boîte courriels
- Une fois sur Pix Orga, fournir toutes les informations demandées pour l'inscription
- Fournir une adresse e-mail contenant des majuscules
- Validez votre inscription
- Constatez que la page d'acceptation des CGUs est visible