### PR TITLE
[FEATURE] Modifier le wording du téléchargement de resultats CléA sur pix-certif (PIX-5768)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -27,16 +27,22 @@ function buildComplementaryCertification({
   });
 }
 
-buildComplementaryCertification.clea = function () {
+buildComplementaryCertification.clea = function ({
+  id = databaseBuffer.getNextId(),
+  minimumReproducibilityRate = 50.0,
+  minimumEarnedPix = 70,
+  hasComplementaryReferential = false,
+  hasExternalJury = false,
+}) {
   return buildComplementaryCertification({
-    id: databaseBuffer.getNextId(),
+    id,
     label: 'CléA Numérique',
     key: ComplementaryCertification.CLEA,
     createdAt: new Date('2020-01-01'),
-    minimumReproducibilityRate: 50.0,
-    minimumEarnedPix: 70,
-    hasComplementaryReferential: false,
-    hasExternalJury: false,
+    minimumReproducibilityRate,
+    minimumEarnedPix,
+    hasComplementaryReferential,
+    hasExternalJury,
   });
 };
 

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -700,7 +700,7 @@ describe('Integration | Repository | Session', function () {
             userId,
           }).id;
           const badgeId = databaseBuilder.factory.buildBadge().id;
-          const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
+          const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
           const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
             badgeId,
             complementaryCertificationId,
@@ -739,7 +739,7 @@ describe('Integration | Repository | Session', function () {
           userId,
         }).id;
         const badgeId = databaseBuilder.factory.buildBadge().id;
-        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
         const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
           badgeId,
           complementaryCertificationId,
@@ -775,7 +775,7 @@ describe('Integration | Repository | Session', function () {
           userId,
         }).id;
         const badgeId = databaseBuilder.factory.buildBadge().id;
-        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea().id;
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
         const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
           badgeId,
           complementaryCertificationId,

--- a/certif/app/components/session-clea-results-download.hbs
+++ b/certif/app/components/session-clea-results-download.hbs
@@ -5,10 +5,11 @@
     </div>
     <div>
       <h1 class="session-details__clea-results-download-title">
-        Des candidats ont obtenu le CléA numérique
+        Des candidats ont obtenu le certificat CléA numérique
       </h1>
       <p class="&__clea-results-download-description">
-        Pour générer les parchemin CléA numérique, téléchargez la liste des candidats puis importez la sur la
+        Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au
+        format .xlsx puis importez-la sur la
         <a href="https://cleanumerique.org/" target="_blank" rel="noopener noreferrer">plateforme du CléA numérique.
           <FaIcon @icon="link" /></a>
       </p>

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -191,7 +191,7 @@ module('Acceptance | Session Details', function (hooks) {
             const screen = await visit(`/sessions/${session.id}`);
 
             // then
-            assert.dom(screen.getByText('Des candidats ont obtenu le CléA numérique')).exists();
+            assert.dom(screen.getByText('Des candidats ont obtenu le certificat CléA numérique')).exists();
             assert.dom(screen.getByRole('link', { name: 'Télécharger la liste des candidats' })).exists();
           });
         });


### PR DESCRIPTION
## :unicorn: Problème
Le wording du téléchargement de resultats CléA a changé

## :robot: Solution
Modifier le wording


## :100: Pour tester
- Activer le toggle FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
- Passer/finaliser/publier une certification Cléa
- Se rendre sur la page de la session dans pix-certif
- Constater la présence d'une section permettant le téléchargement des resultats cléa avec le wording suivant : 

![image](https://user-images.githubusercontent.com/37305474/191775951-c669ae16-ebc4-4839-beea-888b69dcc64f.png)

