### PR TITLE
[BUGFIX] Corriger le total du nb de participant dans l'onglet Participants(PIX-5723)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
@@ -1,7 +1,7 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize({ organizationParticipants, pagination }) {
+  serialize({ organizationParticipants, meta }) {
     return new Serializer('organization-participants', {
       id: 'id',
       attributes: [
@@ -14,7 +14,7 @@ module.exports = {
         'participationStatus',
         'isCertifiable',
       ],
-      meta: pagination,
+      meta,
     }).serialize(organizationParticipants);
   },
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
@@ -31,6 +31,8 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
+      const participantCount = 10;
+      const meta = { ...pagination, participantCount };
 
       const expectedJSON = {
         data: [
@@ -63,11 +65,11 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
             },
           },
         ],
-        meta: pagination,
+        meta,
       };
 
       // when
-      const json = serializer.serialize({ organizationParticipants, pagination });
+      const json = serializer.serialize({ organizationParticipants, meta });
 
       // then
       expect(json).to.deep.equal(expectedJSON);

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "pages.organization-participants.page-title")}}
 
 <div class="organization-participant-list-page">
-  <OrganizationParticipant::Header @participantCount={{this.currentUser.prescriber.participantCount}} />
+  <OrganizationParticipant::Header @participantCount={{@model.meta.participantCount}} />
   {{#if this.currentUser.prescriber.hasParticipants}}
     <OrganizationParticipant::List
       @participants={{@model}}

--- a/orga/tests/integration/components/organization-participant/header_test.js
+++ b/orga/tests/integration/components/organization-participant/header_test.js
@@ -1,19 +1,32 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@1024pix/ember-testing-library';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | OrganizationParticipant::header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display the header labels', async function (assert) {
-    // given
-    this.set('participantCount', 5);
+  module('Title', () => {
+    test('it should show only title when participant count = 0', async function (assert) {
+      //given
+      this.set('participantCount', 0);
 
-    // when
-    await render(hbs`<OrganizationParticipant::Header @participantCount={{participantCount}}/>`);
+      // when
+      const screen = await renderScreen(hbs`<OrganizationParticipant::Header @participantCount={{participantCount}}/>`);
 
-    // then
-    assert.contains(this.intl.t('pages.organization-participants.title', { count: 5 }));
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.organization-participants.title', { count: 0 }))).exists();
+    });
+
+    test('it should show title with participant count when count > 0', async function (assert) {
+      //given
+      this.set('participantCount', 5);
+
+      // when
+      const screen = await renderScreen(hbs`<OrganizationParticipant::Header @participantCount={{participantCount}}/>`);
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.organization-participants.title', { count: 5 }))).exists();
+    });
   });
 });

--- a/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/header-actions_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
@@ -7,15 +8,32 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | ScoOrganizationParticipant::HeaderActions', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should show title with participant count', async function (assert) {
-    //given
-    this.set('participantCount', 10);
+  module('Title', () => {
+    test('it should show only title when participant count = 0', async function (assert) {
+      //given
+      this.set('participantCount', 0);
 
-    // when
-    await render(hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`);
+      // when
+      const screen = await renderScreen(
+        hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`
+      );
 
-    // then
-    assert.contains(this.intl.t('pages.sco-organization-participants.title', { count: 10 }));
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.sco-organization-participants.title', { count: 0 }))).exists();
+    });
+
+    test('it should show title with participant count when count > 0', async function (assert) {
+      //given
+      this.set('participantCount', 5);
+
+      // when
+      const screen = await renderScreen(
+        hbs`<ScoOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.sco-organization-participants.title', { count: 5 }))).exists();
+    });
   });
 
   module('user rights', () => {

--- a/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/header-actions_test.js
@@ -1,29 +1,39 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | SupOrganizationParticipant::HeaderActions', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should show title', async function (assert) {
-    // when
-    await render(hbs`<SupOrganizationParticipant::HeaderActions/>`);
+  module('Title', () => {
+    test('it should show only title when participant count = 0', async function (assert) {
+      //given
+      this.set('participantCount', 0);
 
-    // then
-    assert.contains('Étudiants');
-  });
+      // when
+      const screen = await renderScreen(
+        hbs`<SupOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`
+      );
 
-  test('it should show title with participant count', async function (assert) {
-    //given
-    this.set('participantCount', 10);
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.sup-organization-participants.title', { count: 0 }))).exists();
+    });
 
-    // when
-    await render(hbs`<SupOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`);
+    test('it should show title with participant count when count > 0', async function (assert) {
+      //given
+      this.set('participantCount', 5);
 
-    // then
-    assert.contains('Étudiants (10)');
+      // when
+      const screen = await renderScreen(
+        hbs`<SupOrganizationParticipant::HeaderActions @participantCount={{participantCount}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.sup-organization-participants.title', { count: 5 }))).exists();
+    });
   });
 
   module('when user is admin', function (hooks) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -687,7 +687,7 @@
         "row-title": "Participant"
       },
       "page-title": "Participants",
-      "title": "{count, plural, =0 {Participants} =1 {Participant} other {Participants ({count})}}"
+      "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },
     "participants-list": {
       "latest-participation-information-tooltip": {
@@ -762,7 +762,7 @@
     },
     "sco-organization-participants": {
       "page-title": "Students",
-      "title": "{count, plural, =0 {Students} =1 {Student} other {Students ({count})}}",
+      "title": "{count, plural, =0 {Students} =1 {Student ({count})} other {Students ({count})}}",
       "actions": {
         "import-file": {
           "file-type-separator": " or ",
@@ -872,7 +872,7 @@
       }
     },
     "sup-organization-participants": {
-      "title": "{count, plural, =0 {Students} =1 {Student} other {Students ({count})}}",
+      "title": "{count, plural, =0 {Students} =1 {Student ({count})} other {Students ({count})}}",
       "page-title": "Students",
       "actions": {
         "download-template": "Download the template",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -687,7 +687,7 @@
         "row-title": "Participant"
       },
       "page-title": "Participants",
-      "title": "{count, plural, =0 {Participants} =1 {Participant} other {Participants ({count})}}"
+      "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },
     "participants-list": {
       "latest-participation-information-tooltip": {
@@ -762,7 +762,7 @@
     },
     "sco-organization-participants": {
       "page-title": "Élèves",
-      "title": "{count, plural, =0 {Élèves} =1 {Élève} other {Élèves ({count})}}",
+      "title": "{count, plural, =0 {Élèves} =1 {Élève ({count})} other {Élèves ({count})}}",
       "actions": {
         "import-file": {
           "file-type-separator": " ou ",
@@ -872,7 +872,7 @@
       }
     },
     "sup-organization-participants": {
-      "title": "{count, plural, =0 {Étudiants} =1 {Étudiant} other {Étudiants ({count})}}",
+      "title": "{count, plural, =0 {Étudiants} =1 {Étudiant ({count})} other {Étudiants ({count})}}",
       "page-title": "Étudiants",
       "actions": {
         "download-template": "Télécharger le modèle",
@@ -928,7 +928,7 @@
             "aria-label": "Entrer un numéro étudiant",
             "label": "Rechercher par numéro étudiant"
           },
-          "students-count": "{count, plural, =0 {0 élève} =1 {1 élève} other {{count} élèves}}",
+          "students-count": "{count, plural, =0 {0 étudiant} =1 {1 étudiant} other {{count} étudiants}}",
           "title": "Filtres"
         },
         "row-title": "Étudiant"


### PR DESCRIPTION
## :unicorn: Problème
Dans [ce ticket](https://1024pix.atlassian.net/browse/PIX-5568?atlOrigin=eyJpIjoiMmI4NjdlNDFkMWQ4NDc5ZjkxNDQzYTBkYzZiYTQ2YmIiLCJwIjoiaiJ9), on a ajouté le nombre de participants/étudiants/élèves dans le titre de la page.

Le calcule de nombre de participants pour une organisation  non-managing students était pas bon, donc le nombre affiché dans la page de participants est erroné.

## :robot: Solution
Corriger le calcul du total des participants dans la page de participants en fonction des participations actives et supprimées.
## :rainbow: Remarques
> _RAS_

## :100: Pour tester
Se connecter avec un compte qui gère une orga non-managing students puis aller sur la page des participants, constater que le nombre affiché à côté du titre correspondant au nombre des participants affiché dans la liste plus bas.
