### PR TITLE
[FEATURE] Ajout d'une phrase de déconnexion écran FDT pour les certif à distance (PIX-5656)

### DIFF
--- a/mon-pix/app/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/components/certifications/certification-ender.hbs
@@ -31,6 +31,9 @@
       <div class="certification-ender__candidate-disconnect-tip">
         {{t "pages.certification-ender.candidate.disconnect-tip"}}
       </div>
+      <PixMessage @withIcon="true" class="certification-ender__remote-certification">
+        {{t "pages.certification-ender.candidate.remote-certification"}}
+      </PixMessage>
     </div>
   </div>
   <div class="certification-ender__results">

--- a/mon-pix/app/styles/components/certifications/certification-ender.scss
+++ b/mon-pix/app/styles/components/certifications/certification-ender.scss
@@ -49,6 +49,20 @@
     width: 272px;
   }
 
+  &__remote-certification {
+    margin-top: 16px;
+
+    .pix-message {
+
+      &__content {
+        margin-left: 16px;
+        font-size: 14px;
+        color: $pix-neutral-50;
+        line-height: 20px;
+      }
+    }
+  }
+
   .pix-button {
     display: inline-flex;
   }

--- a/mon-pix/tests/integration/components/certifications/certification-ender_test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender_test.js
@@ -50,6 +50,16 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
     expect(contains('Jim Halpert')).to.exist;
   });
 
+  it('should display the remote certification logout message', async function () {
+    // when
+    await render(hbs`
+      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
+    `);
+
+    // then
+    expect(contains(this.intl.t('pages.certification-ender.candidate.remote-certification'))).to.exist;
+  });
+
   context('when the assessment status is not ended by supervisor', function () {
     it('should not display the ended by supervisor text', async function () {
       // given

--- a/mon-pix/tests/integration/components/certifications/certification-ender_test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender_test.js
@@ -1,9 +1,8 @@
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { expect } from 'chai';
-import { contains } from '../../../helpers/contains';
 import Service from '@ember/service';
 
 describe('Integration | Component | Certifications | CertificationEnder', function () {
@@ -11,12 +10,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
 
   it('should display the translated labels', async function () {
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder />
     `);
 
     // then
-    expect(contains(this.intl.t('pages.certification-ender.candidate.title'))).to.exist;
+    expect(screen.getByText(this.intl.t('pages.certification-ender.candidate.title'))).to.exist;
   });
 
   it('should display the certification number', async function () {
@@ -24,12 +23,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
     this.certificationNumber = 1234;
 
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
     `);
 
     // then
-    expect(contains(1234)).to.exist;
+    expect(screen.getByText(1234)).to.exist;
   });
 
   it('should display the current user name', async function () {
@@ -42,22 +41,22 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
     this.owner.register('service:currentUser', currentUser);
 
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
     `);
 
     // then
-    expect(contains('Jim Halpert')).to.exist;
+    expect(screen.getByText('Jim Halpert')).to.exist;
   });
 
   it('should display the remote certification logout message', async function () {
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
     `);
 
     // then
-    expect(contains(this.intl.t('pages.certification-ender.candidate.remote-certification'))).to.exist;
+    expect(screen.getByText(this.intl.t('pages.certification-ender.candidate.remote-certification'))).to.exist;
   });
 
   context('when the assessment status is not ended by supervisor', function () {
@@ -71,12 +70,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
       this.owner.register('service:currentUser', currentUser);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedBySupervisor={{false}} />
     `);
 
       // then
-      expect(contains(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).not.to.exist;
+      expect(screen.queryByText(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).not.to.exist;
     });
   });
 
@@ -91,12 +90,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
       this.owner.register('service:currentUser', currentUser);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedBySupervisor={{true}} />
     `);
 
       // then
-      expect(contains(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).to.exist;
+      expect(screen.getByText(this.intl.t('pages.certification-ender.candidate.ended-by-supervisor'))).to.exist;
     });
   });
 
@@ -111,12 +110,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
       this.owner.register('service:currentUser', currentUser);
 
       // when
-      await render(hbs`
+      const screen = await renderScreen(hbs`
       <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @hasBeenEndedDueToFinalization={{true}} />
     `);
 
       // then
-      expect(contains(this.intl.t('pages.certification-ender.candidate.ended-due-to-finalization'))).to.exist;
+      expect(screen.getByText(this.intl.t('pages.certification-ender.candidate.ended-due-to-finalization'))).to.exist;
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -318,7 +318,8 @@
         "ended-by-supervisor": "Your invigilator has marked your certification test as completed. You cannot continue to answer questions.",
         "disconnect": "Log out of my account",
         "disconnect-tip": "If this is not your computer, please remember to log out.",
-        "ended-due-to-finalization": "Your certification centre has ended the session. You can no longer answer questions."
+        "ended-due-to-finalization": "Your certification centre has ended the session. You can no longer answer questions.",
+        "remote-certification": "If you're taking your Pix certificate remotely, please make sure you log out from the monitoring tool once your test is finished."
       },
       "results": {
         "disclaimer": "Your results, pending validation by the Pix team, will soon be available on your Pix account",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -318,7 +318,8 @@
         "ended-by-supervisor": "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.",
         "disconnect": "Déconnecter mon compte",
         "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.",
-        "ended-due-to-finalization": "La session a été finalisée par votre centre de certification. Vous ne pouvez plus continuer de répondre aux questions."
+        "ended-due-to-finalization": "La session a été finalisée par votre centre de certification. Vous ne pouvez plus continuer de répondre aux questions.",
+        "remote-certification": "Si vous passez votre certification Pix à distance, veillez à bien vous déconnecter de l’outil de surveillance une fois votre test terminé."
       },
       "results": {
         "disclaimer": "Vos résultats, en attente de validation par les équipes Pix, seront bientôt disponibles depuis votre compte Pix",


### PR DESCRIPTION
## :unicorn: Problème
Lors du passage d’une certification à distance sur Pix App et afin d’assurer sa mission, le surveillant a accès au micro, à la caméra et au partage d'écran du candidat.

Lorsque le candidat à la certification à distance a terminé son test, la surveillance à distance du candidat n’est pas coupée automatiquement sauf déconnexion du candidat ou du surveillant.

## :robot: Solution
Afficher un message sur la page de fin de test suivant : “Si vous passez votre certification Pix à distance, veillez à bien vous déconnecter de l’outil de surveillance une fois votre test terminé.” (visible de tous les candidats, mais uniquement à destination des candidats aux certifications à distance sur Pix App), pour les inciter à se déconnecter.

## :rainbow: Remarques
:warning: Ce ticket est "blocked" car en attente de traduction

## :100: Pour tester
- Passer un test de certification et constater le message suivant sur l'écran de fin de test : 
  - Si vous passez votre certification Pix à distance, veillez à bien vous déconnecter de l’outil de surveillance une fois votre test terminé.
  
  
![image](https://user-images.githubusercontent.com/37305474/192237629-026a9599-4fd6-45c7-b9b0-16bf1802ee3b.png)
