### PR TITLE
[BUGFIX] Permettre aux prescrits désactivés de participer à la campagne d'une orga passée en non isManagingStudents(Pix-5772)

### DIFF
--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -39,7 +39,7 @@ function organizationsSupBuilder({ databaseBuilder }) {
     id: SUP_UNIVERSITY_ID,
     type: 'SUP',
     name: 'Université du Lion',
-    isManagingStudents: true,
+    isManagingStudents: false,
     externalId: null,
     provinceCode: null,
     email: null,

--- a/api/lib/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participant-repository.js
@@ -35,6 +35,8 @@ async function _createNewOrganizationLearner(organizationLearner, queryBuilder) 
         firstName: organizationLearner.firstName,
         lastName: organizationLearner.lastName,
       })
+      .onConflict(['userId', 'organizationId'])
+      .merge({ isDisabled: false })
       .returning('id');
     return id;
   }

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -69,7 +69,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           isRestricted: orga.isManagingStudents,
         });
 
-        //then
+        // when
         await DomainTransaction.execute(async (domainTransaction) => {
           await campaignParticipantRepository.save(campaignParticipant, domainTransaction);
         });


### PR DESCRIPTION
## :unicorn: Problème
Des erreurs sont remontées en prod concernant des prescrits qui ne pouvaient pas participer à la campagne d'une orga. Après investigation, il s'avère que c'est une orga qui à été créée sans activer l'import (donc en `isManagingStudents = false`) donc les prescrits pouvaient y participer librement. Sauf qu'entre temps, l'orga a activé l'import  (`isManagingStudents = true`) et à importer des prescrits ce qui a désactivé les anciens prescrits donc ces derniers ne pouvaient plus participer aux campagne de l'orga. 
Pour contourner le problème, l'orga à de nouveau désactivé l'import (est repassée à `isManagingStudents = false`) mais les prescrits désactivés le sont restés et donc ne peuvent toujours pas participer aux campagnes de l'orga.
(D'un point de vu tech, comme le prescrit à une organizationLearner désactivée (donc elle ne ressort pas), on va chercher à lui en recréer une nouvelle, mais comme il en a une et qu'il y a une contrainte qui empêche à un user d'avoir plusieurs organizationLearners pour une même orga, ça casse)

## :robot: Solution
Lorsque qu'un user cherche à participer à une campagne d'une orga `isManagingStudents = false`  ET qu'il a une organizationLearner désactivée pour cette même orga alors on réactive son organizationLearner. 

## :rainbow: Remarques
On a ajouté des seeds pour tester le cas dans les RA. Mais ces seeds ne sont pas voués à être merger.

## :100: Pour tester
(- aller voir sur scalingo que l'organizationLearner du user studentsup.disabled est désactivée)
- Aller sur Mon-pix avec `studentsup.disabled@example.net` 
- aller participer à la campagne `SUPDROIT1` et voir qu'on peut y accéder.
(- aller voir sur scalingo que l'organizationLearner du user studentsup.disabled est activée)
