### PR TITLE
[BUGFIX] Corrige l'affichage du lien "Mes parcours" dans la navbar mobile (PIX-5682)

### DIFF
--- a/mon-pix/app/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/components/navbar-burger-menu.hbs
@@ -38,7 +38,7 @@
       <ul class="navbar-burger-menu__footer">
         {{#if this.showMyTestsLink}}
           <li class="navbar-burger-menu-list__item">
-            <LinkTo @route="authenticated.user-tests" class="navbar-burger-menu-footer-list-item__link">
+            <LinkTo @route="authenticated.user-tests" class="navbar-burger-menu-footer-item__link">
               {{t "navigation.user.tests"}}
             </LinkTo>
           </li>


### PR DESCRIPTION
## :unicorn: Problème
Le lien vers "Mes parcours" dans la navbar mobile n'a pas le même style que les autres liens.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5855339/191963943-e4c0220b-e924-43a3-a646-cf8e56994435.png">

## :robot: Solution
Appliquer le même style que les autres liens.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA le style des liens de la navbar mobile après avoir débuté un parcours.
