### PR TITLE
[FEATURE] Création de la nouvelle table pour identifier les DPOs (PIX-3501)

### DIFF
--- a/api/db/database-builder/factory/build-data-protection-officer.js
+++ b/api/db/database-builder/factory/build-data-protection-officer.js
@@ -1,0 +1,58 @@
+const databaseBuffer = require('../database-buffer');
+
+const TABLE_NAME = 'data-protection-officers';
+
+function buildCertificationCenterDataProtectionOfficer({
+  id = databaseBuffer.getNextId(),
+  firstName,
+  lastName,
+  email,
+  certificationCenterId,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+}) {
+  const values = {
+    id,
+    firstName,
+    lastName,
+    email,
+    certificationCenterId,
+    createdAt,
+    updatedAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: TABLE_NAME,
+    values,
+  });
+}
+
+function buildOrganizationDataProtectionOfficer({
+  id = databaseBuffer.getNextId(),
+  firstName,
+  lastName,
+  email,
+  organizationId,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+}) {
+  const values = {
+    id,
+    firstName,
+    lastName,
+    email,
+    organizationId,
+    createdAt,
+    updatedAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: TABLE_NAME,
+    values,
+  });
+}
+
+module.exports = {
+  withCertificationCenterId: buildCertificationCenterDataProtectionOfficer,
+  withOrganizationId: buildOrganizationDataProtectionOfficer,
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -38,6 +38,7 @@ module.exports = {
   buildComplementaryCertificationSubscription: require('./build-complementary-certification-subscription'),
   buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),
   buildCorrectAnswerAndKnowledgeElement: require('./build-correct-answer-and-knowledge-element'),
+  buildDataProtectionOfficer: require('./build-data-protection-officer'),
   buildFinalizedSession: require('./build-finalized-session'),
   buildFlashAssessmentResult: require('./build-flash-assessment-result'),
   buildKnowledgeElement: require('./build-knowledge-element'),

--- a/api/db/migrations/20220923141951_create-data-protection-officers-table.js
+++ b/api/db/migrations/20220923141951_create-data-protection-officers-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'data-protection-officers';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.bigIncrements().primary();
+    t.string('firstName').nullable();
+    t.string('lastName').nullable();
+    t.string('email').nullable();
+    t.bigInteger('organizationId').references('organizations.id').unique().nullable();
+    t.bigInteger('certificationCenterId').references('certification-centers.id').unique().nullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    t.check('(?? IS NOT NULL AND ?? IS NULL) OR (?? IS NULL AND ?? IS NOT NULL)', [
+      'organizationId',
+      'certificationCenterId',
+      'organizationId',
+      'certificationCenterId',
+    ]);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -201,11 +201,20 @@ function certificationCentersBuilder({ databaseBuilder }) {
     label: 'Pix+ Édu 2nd degré Expert',
   });
 
-  databaseBuilder.factory.buildCertificationCenter({
+  const now = new Date();
+  const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
     id: SCO_COLLEGE_CERTIF_CENTER_ID,
     name: SCO_COLLEGE_CERTIF_CENTER_NAME,
     externalId: SCO_COLLEGE_EXTERNAL_ID,
     type: 'SCO',
+  });
+  databaseBuilder.factory.buildDataProtectionOfficer.withCertificationCenterId({
+    firstName: 'Yukiko',
+    lastName: 'Tsubaki',
+    email: 'yukiko.tsubaki@example.net',
+    certificationCenterId: certificationCenter.id,
+    createdAt: now,
+    updatedAt: now,
   });
 
   databaseBuilder.factory.buildCertificationCenter({

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -41,7 +41,8 @@ function organizationsProBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildPixAdminRole({ userId: privateCompanyCreator.id, role: ROLES.SUPER_ADMIN });
 
-  databaseBuilder.factory.buildOrganization({
+  const now = new Date();
+  const organization = databaseBuilder.factory.buildOrganization({
     id: PRO_COMPANY_ID,
     type: 'PRO',
     name: 'Dragon & Co',
@@ -51,6 +52,14 @@ function organizationsProBuilder({ databaseBuilder }) {
     externalId: null,
     provinceCode: null,
     email: null,
+  });
+  databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+    firstName: 'Ayako',
+    lastName: 'Sora',
+    email: 'ayako.sora@example.net',
+    organizationId: organization.id,
+    createdAt: now,
+    updatedAt: now,
   });
 
   databaseBuilder.factory.buildMembership({


### PR DESCRIPTION
## :unicorn: Problème

Pour l'instant il n'y a aucun moyen d'identifier les Data Protection Officers (DPOs).

## :robot: Solution

Créer une nouvelle table `data-protection-officers`.

## :rainbow: Remarques

RAS

## :100: Pour tester

- En local, exécutez le script de migration `npm run db:migrate` dans le dossier `api` du projet
- Une fois la migration faite, vérifiez via votre outil favoris la présence de la nouvelle table avec toutes les contraintes nécessaires
- Tentez d'insérer des données qui doivent faire apparaître des messages d'erreurs liés aux contraintes
- Exécutez le script de rollback `npm run db:rollback:latest`, toujours dans le dossier `api` du projet
- Une fois le rollback fait, vérifiez via votre outil favoris que la nouvelle table n'est plus présente
