### PR TITLE
[BUGFIX] La page de détails d'un profil cible sur PixAdmin montre un référentiel non trié selon domaine/compétence/thématique/sujet (PIX-5786)

### DIFF
--- a/admin/app/controllers/authenticated/target-profiles/target-profile/details.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/details.js
@@ -2,21 +2,21 @@ import Controller from '@ember/controller';
 
 export default class TargetProfileDetailsController extends Controller {
   get areas() {
-    return this.model.newAreas.map((area) => this.buildAreaViewModel(area)).sortBy('code');
+    return this.model.newAreas.sortBy('frameworkId', 'code').map((area) => this.buildAreaViewModel(area));
   }
 
   buildAreaViewModel(area) {
     return {
       title: `${area.code} · ${area.title}`,
       color: area.color,
-      competences: area.competences.map((competence) => this.buildCompetenceViewModel(competence)).sortBy('index'),
+      competences: area.competences.sortBy('index').map((competence) => this.buildCompetenceViewModel(competence)),
     };
   }
 
   buildCompetenceViewModel(competence) {
     return {
       title: `${competence.index} ${competence.name}`,
-      thematics: competence.thematics.map((thematic) => this.buildThematicViewModel(thematic)).sortBy('index'),
+      thematics: competence.thematics.sortBy('index').map((thematic) => this.buildThematicViewModel(thematic)),
     };
   }
 
@@ -24,7 +24,7 @@ export default class TargetProfileDetailsController extends Controller {
     return {
       name: thematic.name,
       nbTubes: thematic.tubes.length,
-      tubes: thematic.tubes.map((tube) => this.buildTubeViewModel(tube)).sortBy('practicalTitle'),
+      tubes: thematic.tubes.sortBy('practicalTitle').map((tube) => this.buildTubeViewModel(tube)),
     };
   }
 

--- a/admin/app/models/new-area.js
+++ b/admin/app/models/new-area.js
@@ -4,6 +4,7 @@ export default class NewArea extends Model {
   @attr() title;
   @attr() code;
   @attr() color;
+  @attr() frameworkId;
 
   @hasMany('new-competence') competences;
 

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer.js
@@ -26,7 +26,7 @@ module.exports = {
       newAreas: {
         ref: 'id',
         included: true,
-        attributes: ['title', 'code', 'color', 'competences'],
+        attributes: ['title', 'code', 'color', 'frameworkId', 'competences'],
         competences: {
           ref: 'id',
           included: true,

--- a/api/tests/integration/application/target-profile/index_test.js
+++ b/api/tests/integration/application/target-profile/index_test.js
@@ -21,6 +21,7 @@ describe('Integration | Application | Route | target-profile-router', function (
         title: 'Super domaine',
         color: 'blue',
         code: 'lyoko',
+        frameworkId: 'recFrameworkCool1',
       });
       const targetProfileForAdminNewFormat = new TargetProfileForAdminNewFormat({
         id: 132,
@@ -169,6 +170,7 @@ describe('Integration | Application | Route | target-profile-router', function (
               title: 'Super domaine',
               color: 'blue',
               code: 'lyoko',
+              'framework-id': 'recFrameworkCool1',
             },
             relationships: {
               competences: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer_test.js
@@ -11,6 +11,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-new-format-seri
         title: 'Super domaine',
         color: 'blue',
         code: 'lyoko',
+        frameworkId: 'recFrameworkCool1',
       });
       const targetProfileForAdminNewFormat = new TargetProfileForAdminNewFormat({
         id: 132,
@@ -149,6 +150,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-new-format-seri
               title: 'Super domaine',
               color: 'blue',
               code: 'lyoko',
+              'framework-id': 'recFrameworkCool1',
             },
             relationships: {
               competences: {


### PR DESCRIPTION
## :unicorn: Problème
Le référentiel n'est pas bien trié sur la page de détails.

## :robot: Solution
Trier les domaines par : frameworkId puis index
les compétences par : index
les thématiques par : index
puis les tubes par : practicalTitle (index pas dispo depuis LCMS)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Créer un profil cible cross réf et vérifier que le contenu est bien trié sur la page de détails
