### PR TITLE
[FEATURE] Créer la table `trainings` (PIX-5763)

### DIFF
--- a/api/db/migrations/20220926084112_create_trainings_table.js
+++ b/api/db/migrations/20220926084112_create_trainings_table.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'trainings';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.string('title').notNullable();
+    t.string('link').notNullable();
+    t.string('type').notNullable();
+    t.specificType('duration', 'interval').notNullable();
+    t.string('locale').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de persister une nouvelle entité `trainings` pour donner accès à des contenus de formations sur Pix.

## :robot: Solution
Créer une nouvelle table `trainings`.

## :100: Pour tester
- En local, lancez le script `npm run db:migrate`dans `api`. 
- Vérifiez que la nouvelle table est présente dans le DB.
- Lancer le script de rollback `npm run db:rollback:latest` et vérifier que la table n'est plus présente.