### PR TITLE
[FEATURE] Créer la table `target-profile-trainings` (PIX-5773)

### DIFF
--- a/api/db/migrations/20220926091617_create_target_profile_trainings_table.js
+++ b/api/db/migrations/20220926091617_create_target_profile_trainings_table.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'target-profile-trainings';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('targetProfileId').references('target-profiles.id').notNullable();
+    t.integer('trainingId').references('trainings.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};


### PR DESCRIPTION
## :robot: Solution
Nous avons besoin de persister une nouvelle entité `target-profile-trainings` reliée à la table `trainings` pour donner accès à des contenus de formations sur Pix.

## :rainbow: Remarques
Créer une nouvelle table `target-profile-trainings`.

## :100: Pour tester
- En local, lancez le script `npm run db:migrate`dans `api`. 
- Vérifiez que la nouvelle table est présente dans le DB.
- Lancer le script de rollback `npm run db:rollback:latest` et vérifier que la table n'est plus présente.
