### PR TITLE
[FEATURE] Bloquer la finalisation d'une session sans certification (PIX-5727)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -322,6 +322,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SessionAlreadyFinalizedError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.SessionWithoutStartedCertificationError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
   if (error instanceof DomainErrors.SessionStartedDeletionError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -845,6 +845,14 @@ class SessionAlreadyFinalizedError extends DomainError {
   }
 }
 
+class SessionWithoutStartedCertificationError extends DomainError {
+  constructor(
+    message = "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."
+  ) {
+    super(message);
+  }
+}
+
 class SessionAlreadyPublishedError extends DomainError {
   constructor(message = 'La session est déjà publiée.') {
     super(message);
@@ -1283,6 +1291,7 @@ module.exports = {
   SessionAlreadyPublishedError,
   SessionNotAccessible,
   SessionStartedDeletionError,
+  SessionWithoutStartedCertificationError,
   SiecleXmlImportError,
   SupervisorAccessNotAuthorizedError,
   TargetProfileInvalidError,

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -1,4 +1,4 @@
-const { SessionAlreadyFinalizedError } = require('../errors');
+const { SessionAlreadyFinalizedError, SessionWithoutStartedCertificationError } = require('../errors');
 const SessionFinalized = require('../events/SessionFinalized');
 
 module.exports = async function finalizeSession({
@@ -12,8 +12,14 @@ module.exports = async function finalizeSession({
 }) {
   const isSessionAlreadyFinalized = await sessionRepository.isFinalized(sessionId);
 
+  const hasNoStartedCertification = await sessionRepository.hasNoStartedCertification(sessionId);
+
   if (isSessionAlreadyFinalized) {
     throw new SessionAlreadyFinalizedError('Cannot finalize session more than once');
+  }
+
+  if (hasNoStartedCertification) {
+    throw new SessionWithoutStartedCertificationError();
   }
 
   certificationReports.forEach((certifReport) => certifReport.validateForFinalization());

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -195,6 +195,11 @@ module.exports = {
       .first();
     return Boolean(result);
   },
+
+  async hasNoStartedCertification(sessionId) {
+    const result = await knex.select(1).from('certification-courses').where('sessionId', sessionId).first();
+    return !result;
+  },
 };
 
 function _toDomain(results) {

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -23,7 +23,7 @@ describe('Acceptance | Controller | sessions-controller', function () {
   beforeEach(async function () {
     server = await createServer();
     session = databaseBuilder.factory.buildSession();
-    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({}).id;
+    const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id }).id;
     const report1 = databaseBuilder.factory.buildCertificationReport({ sessionId: session.id, certificationCourseId });
     const report2 = databaseBuilder.factory.buildCertificationReport({ sessionId: session.id, certificationCourseId });
     databaseBuilder.factory.buildAssessment({ certificationCourseId });
@@ -100,24 +100,6 @@ describe('Acceptance | Controller | sessions-controller', function () {
         await knex('finalized-sessions').delete();
         await knex('competence-marks').delete();
         await knex('assessment-results').delete();
-      });
-
-      it('should respond OK', async function () {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          userId,
-          certificationCenterId: session.certificationCenterId,
-        });
-
-        await databaseBuilder.commit();
-        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
       });
 
       it('should update session', async function () {

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -555,6 +555,16 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('Erreur, tentatives de finalisation multiples de la session.');
     });
 
+    it('responds Bad Request when a SessionWithoutStartedCertificationError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.SessionWithoutStartedCertificationError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
+      expect(responseDetail(response)).to.equal(
+        "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."
+      );
+    });
+
     it('responds Bad Request when a SessionAlreadyPublishedError error occurs', async function () {
       routeHandler.throws(new DomainErrors.SessionAlreadyPublishedError());
       const response = await server.requestObject(request);

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -832,4 +832,42 @@ describe('Integration | Repository | Session', function () {
       });
     });
   });
+
+  describe('#hasNoStartedCertification', function () {
+    context('when session has at least one certification course', function () {
+      it('should return false', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession({}).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
+        databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const hasNoStartedCertification = await sessionRepository.hasNoStartedCertification(sessionId);
+
+        // then
+        expect(hasNoStartedCertification).to.be.false;
+      });
+    });
+
+    context('when session has no certification course', function () {
+      it('should return true', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession({}).id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const hasNoStartedCertification = await sessionRepository.hasNoStartedCertification(sessionId);
+
+        // then
+        expect(hasNoStartedCertification).to.be.true;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -138,6 +138,10 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.SessionAlreadyFinalizedError).to.exist;
   });
 
+  it('should export a SessionWithoutStartedCertificationError', function () {
+    expect(errors.SessionWithoutStartedCertificationError).to.exist;
+  });
+
   it('should export a TargetProfileInvalidError', function () {
     expect(errors.TargetProfileInvalidError).to.exist;
   });

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -69,9 +69,15 @@ export default class SessionsFinalizeController extends Controller {
       await this.session.save({ adapterOptions: { finalization: true } });
       this.showSuccessNotification('Les informations de la session ont été transmises avec succès.');
     } catch (err) {
-      err.errors && err.errors[0] && err.errors[0].status === '400'
-        ? this.showErrorNotification('Cette session a déjà été finalisée.')
-        : this.showErrorNotification('Erreur lors de la finalisation de session.');
+      if (_isSessionNotStartedError(err)) {
+        this.showErrorNotification(
+          "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."
+        );
+      } else {
+        err.errors && err.errors[0] && err.errors[0].status === '400'
+          ? this.showErrorNotification('Cette session a déjà été finalisée.')
+          : this.showErrorNotification('Erreur lors de la finalisation de session.');
+      }
     }
     this.showConfirmModal = false;
     this.transitionToRoute('authenticated.sessions.details', this.session.id);
@@ -151,4 +157,11 @@ export default class SessionsFinalizeController extends Controller {
 
     return invalidCertificationReports.length === 0;
   }
+}
+
+function _isSessionNotStartedError(err) {
+  return (
+    err.errors?.[0]?.detail ===
+    "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."
+  );
 }

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -399,5 +399,40 @@ module('Acceptance | Session Finalization', function (hooks) {
         });
       });
     });
+
+    module('When certificationPointOfContact tries to finalize a session that has not started yet', function () {
+      test('it should redirect to session details and show an error', async function (assert) {
+        // given
+        this.server.put(
+          `/sessions/${session.id}/finalization`,
+          () => ({
+            errors: [
+              {
+                detail:
+                  "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer.",
+              },
+            ],
+          }),
+          400
+        );
+        // when
+        const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
+
+        await click(screen.getByText('Finaliser'));
+        await click(screen.getByText('Confirmer la finalisation'));
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."
+            )
+          )
+          .exists();
+        assert.dom(screen.getByText('Numéro de session')).exists();
+        assert.dom(screen.getByText("Code d'accès")).exists();
+        assert.dom(screen.getByText('Nom du site')).exists();
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il n’est pas possible de finaliser une session qui n’a pas été rejoint par au moins un candidat. En effet, le bouton “Finaliser la session” n’apparaît QUE lorsque au moins un candidat a rejoint la session.

Il est aujourd’hui possible d’ajouter “/finalisation” à la fin de l’URL de la page de détail d’une session sans candidat l’ayant rejoint pour la finaliser malgré tout.


## :robot: Solution
Ne plus permettre de finaliser une session sans candidat l’ayant rejoint : lorsqu’un utilisateur Pix Certif cliquer sur le bouton “Finaliser la session” depuis la page de finalisation d’une session, vérifier si cette session a été rejointe par au moins un candidat : 

- si la session a été rejointe par au moins un candidat : la session peut être finalisée

- si la session n’a jamais été rejointe : 

  - rediriger l’utilisateur vers la page de détail de la session

  - afficher un message d’erreur : “Cette session n’a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer.”


## :100: Pour tester
- Créer une session sans candidat
- Acceder à la finalisation de session via l'url ```/sessions/{ID_DE_SESSION}/finalisation```
- Tenter de finaliser la session
- Constater la redirection vers la page de détail et la présence du bon message d'erreur


![image](https://user-images.githubusercontent.com/37305474/192285386-43b7b86a-bf36-4ae1-aae2-2352334f4a24.png)
