### PR TITLE
[CLEANUP] Suppression de ember-cli-google-fonts de orga

### DIFF
--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -46,11 +46,6 @@ module.exports = function (environment) {
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
     },
 
-    googleFonts: [
-      'Roboto:300,400,500,700,900', // main font
-      'Open+Sans:300,400,600,700',
-    ],
-
     fontawesome: {
       warnIfNoIconsIncluded: false,
     },

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -32,7 +32,6 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-clipboard": "^0.16.0",
         "ember-cli-dependency-checker": "^3.3.1",
-        "ember-cli-google-fonts": "^2.16.2",
         "ember-cli-htmlbars": "^5.7.1",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-matomo-tag-manager": "^1.3.1",
@@ -12714,79 +12713,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz",
       "integrity": "sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=",
       "dev": true
-    },
-    "node_modules/ember-cli-google-fonts": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-google-fonts/-/ember-cli-google-fonts-2.16.2.tgz",
-      "integrity": "sha512-CwQwO+ry5LvcL5sQ8NCnmNQwCuGYgZIGm2jrXMaVHTKvgzWL7wO0XaBEbZKzMOLlR8DrtqivvImYxZ7T9elgeQ==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^6.6.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cli-google-fonts/node_modules/amd-name-resolver": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-      "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-      "dev": true,
-      "dependencies": {
-        "ensure-posix-path": "^1.0.1"
-      }
-    },
-    "node_modules/ember-cli-google-fonts/node_modules/babel-plugin-debug-macros": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-      "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-beta.42"
-      }
-    },
-    "node_modules/ember-cli-google-fonts/node_modules/ember-cli-babel": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-      "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-      "dev": true,
-      "dependencies": {
-        "amd-name-resolver": "1.2.0",
-        "babel-plugin-debug-macros": "^0.2.0-beta.6",
-        "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-        "babel-polyfill": "^6.26.0",
-        "babel-preset-env": "^1.7.0",
-        "broccoli-babel-transpiler": "^6.5.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.0",
-        "broccoli-source": "^1.1.0",
-        "clone": "^2.0.0",
-        "ember-cli-version-checker": "^2.1.2",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-cli-google-fonts/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/ember-cli-htmlbars": {
       "version": "5.7.1",
@@ -41888,66 +41814,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz",
       "integrity": "sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=",
       "dev": true
-    },
-    "ember-cli-google-fonts": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-google-fonts/-/ember-cli-google-fonts-2.16.2.tgz",
-      "integrity": "sha512-CwQwO+ry5LvcL5sQ8NCnmNQwCuGYgZIGm2jrXMaVHTKvgzWL7wO0XaBEbZKzMOLlR8DrtqivvImYxZ7T9elgeQ==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^6.6.0"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        }
-      }
     },
     "ember-cli-htmlbars": {
       "version": "5.7.1",

--- a/orga/package.json
+++ b/orga/package.json
@@ -60,7 +60,6 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-clipboard": "^0.16.0",
     "ember-cli-dependency-checker": "^3.3.1",
-    "ember-cli-google-fonts": "^2.16.2",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-matomo-tag-manager": "^1.3.1",


### PR DESCRIPTION
## :unicorn: Problème
Les fonts google étaient encore chargées sur pix orga alors que pix-ui les intégre désormais.

## :robot: Solution
Supprimer le chargement des google fonts sur pix orga

## :100: Pour tester
Sur la page de connexion de pix orga, vérifier qu'aucun appel a googleapis.com est fait.
