### PR TITLE
[CLEANUP] Supprime la configuration des CSP

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -69,17 +69,6 @@ module.exports = function (environment) {
 
     googleFonts: ['Roboto:300,400,500,600'],
 
-    // Set or update content security policies
-    contentSecurityPolicy: {
-      'default-src': "'none'",
-      'script-src': "'self' www.google-analytics.com",
-      'font-src': "'self' fonts.gstatic.com",
-      'connect-src': "'self' www.google-analytics.com",
-      'img-src': "'self'",
-      'style-src': "'self' fonts.googleapis.com",
-      'media-src': "'self'",
-    },
-
     'ember-cli-notifications': {
       autoClear: true,
       includeFontAwesome: true,

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -70,17 +70,6 @@ module.exports = function (environment) {
       includeLocales: ['fr'],
     },
 
-    // Set or update content security policies
-    contentSecurityPolicy: {
-      'default-src': "'none'",
-      'script-src': "'self' www.google-analytics.com 'unsafe-inline' 'unsafe-eval' cdn.ravenjs.com",
-      'font-src': "'self' fonts.gstatic.com",
-      'connect-src': "'self' www.google-analytics.com app.getsentry.com",
-      'img-src': "'self' app.getsentry.com",
-      'style-src': "'self' fonts.googleapis.com",
-      'media-src': "'self'",
-    },
-
     matomo: {},
 
     formBuilderLinkUrl: 'https://form-eu.123formbuilder.com/41052/form',

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -117,17 +117,6 @@ module.exports = function (environment) {
       warnIfNoIconsIncluded: false,
     },
 
-    // Set or update content security policies
-    contentSecurityPolicy: {
-      'default-src': "'none'",
-      'script-src': "'self' www.google-analytics.com 'unsafe-inline' 'unsafe-eval' cdn.ravenjs.com",
-      'font-src': "'self' fonts.gstatic.com",
-      'connect-src': "'self' www.google-analytics.com",
-      'img-src': "'self'",
-      'style-src': "'self' fonts.googleapis.com",
-      'media-src': "'self'",
-    },
-
     showdown: {
       openLinksInNewWindow: true,
       strikethrough: true,

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -59,17 +59,6 @@ module.exports = function (environment) {
       includeLocales: ['fr'],
     },
 
-    // Set or update content security policies
-    contentSecurityPolicy: {
-      'default-src': "'none'",
-      'script-src': "'self' www.google-analytics.com 'unsafe-inline' 'unsafe-eval' cdn.ravenjs.com",
-      'font-src': "'self' fonts.gstatic.com",
-      'connect-src': "'self' www.google-analytics.com",
-      'img-src': "'self'",
-      'style-src': "'self' fonts.googleapis.com",
-      'media-src': "'self'",
-    },
-
     matomo: {},
 
     'ember-cli-notifications': {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons de la config dans les applications front pour les CSP, mais l'addon ember qui pourrait l'utiliser (https://github.com/rwjblue/ember-cli-content-security-policy/) n'a jamais été installé. Voir https://github.com/1024pix/pix/pull/1297#issuecomment-616410793

## :robot: Solution
Supprimer la config inutile et obsolète

## :100: Pour tester
:shrug: 
