### PR TITLE
[FEATURE] Rendre générique le script de création en masse des orgas (PIX-5705).

### DIFF
--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -1,8 +1,19 @@
 const Joi = require('joi');
 const { EntityValidationError } = require('../errors');
+const Organization = require('../models/Organization');
 const Membership = require('../models/Membership');
+const OidcIdentityProviders = require('../../../lib/domain/constants/oidc-identity-providers');
+
+const validProviders = Object.values(OidcIdentityProviders).map((provider) => provider.code);
 
 const schema = Joi.object({
+  type: Joi.string()
+    .valid(...Object.values(Organization.types))
+    .required()
+    .messages({
+      'string.empty': 'Le type n’est pas renseigné.',
+      'any.only': `Le type fourni doit avoir l'une des valeurs suivantes : ${Object.values(Organization.types)}`,
+    }),
   externalId: Joi.string().required().messages({
     'string.empty': "L'externalId n’est pas renseigné.",
   }),
@@ -19,11 +30,20 @@ const schema = Joi.object({
     'string.empty': "La locale n'est pas renseignée.",
     'any.only': "La locale doit avoir l'une des valeurs suivantes : fr-fr, fr ou en",
   }),
+  identityProviderForCampaigns: Joi.string()
+    .allow(null)
+    .valid('GAR', ...validProviders)
+    .messages({
+      'any.only': `L'organisme fourni doit avoir l'une des valeurs suivantes : GAR,${validProviders}`,
+    }),
   provinceCode: Joi.string().required().allow('', null),
   credit: Joi.number().required().messages({
     'number.base': 'Le crédit doit être un entier.',
   }),
-  email: Joi.string().email().messages({
+  emailInvitations: Joi.string().email().messages({
+    'string.email': "L'email fourni n'est pas valide.",
+  }),
+  emailForSCOActivation: Joi.string().email().allow('', null).messages({
     'string.email': "L'email fourni n'est pas valide.",
   }),
   organizationInvitationRole: Joi.string().valid(Membership.roles.ADMIN, Membership.roles.MEMBER).required().messages({

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -68,15 +68,16 @@ module.exports = {
       .then(([organization]) => _toDomain(organization));
   },
 
-  async batchCreateProOrganizations(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
+  async batchCreateOrganizations(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
     const organizationsRawData = organizations.map((organization) =>
       _.pick(organization, [
         'name',
         'type',
-        'logoUrl',
+        'email',
         'externalId',
         'provinceCode',
         'isManagingStudents',
+        'identityProviderForCampaigns',
         'credit',
         'createdBy',
         'documentationUrl',

--- a/api/scripts/helpers/csvHelpers.js
+++ b/api/scripts/helpers/csvHelpers.js
@@ -19,20 +19,34 @@ const optionsWithHeader = {
     if (typeof value === 'string') {
       value = value.trim();
     }
-    if (columnName === 'uai') {
-      value = value.toUpperCase();
+    if (columnName === 'isManagingStudents') {
+      value = Boolean(value);
     }
-    if (columnName === 'createdBy') {
-      value = !isEmpty(value) && parseInt(value, 10);
-    }
-    if (columnName === 'credit' && isEmpty(value)) {
-      value = 0;
-    }
-    if (columnName === 'locale' && isEmpty(value)) {
-      value = 'fr-fr';
-    }
-    if (columnName === 'email' && !isEmpty(value)) {
-      value = value.replaceAll(' ', '').toLowerCase();
+    if (!isEmpty(value)) {
+      if (
+        columnName === 'uai' ||
+        columnName === 'type' ||
+        columnName === 'organizationInvitationRole' ||
+        columnName === 'identityProviderForCampaigns'
+      ) {
+        value = value.toUpperCase();
+      }
+      if (columnName === 'createdBy') {
+        value = parseInt(value, 10);
+      }
+      if (columnName === 'emailInvitations' || columnName === 'emailForSCOActivation') {
+        value = value.replaceAll(' ', '').toLowerCase();
+      }
+    } else {
+      if (columnName === 'credit') {
+        value = 0;
+      }
+      if (columnName === 'identityProviderForCampaigns') {
+        value = null;
+      }
+      if (columnName === 'locale') {
+        value = 'fr-fr';
+      }
     }
     return value;
   },

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -15,10 +15,10 @@ const {
   ObjectValidationError,
   TargetProfileInvalidError,
 } = require('../../../../lib/domain/errors');
-const createProOrganizationsWithTagsAndTargetProfiles = require('../../../../lib/domain/usecases/create-pro-organizations-with-tags-and-target-profiles');
+const createOrganizationsWithTagsAndTargetProfiles = require('../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles');
 const Membership = require('../../../../lib/domain/models/Membership');
 
-describe('Integration | UseCases | create-pro-organizations-with-tags-and-target-profiles', function () {
+describe('Integration | UseCases | create-organizations-with-tags-and-target-profiles', function () {
   let userId;
 
   beforeEach(async function () {
@@ -68,7 +68,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: tooManyOccurencesOfTheSameOrganizationWithTags,
         organizationRepository,
@@ -88,7 +88,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       const organizations = [];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations,
         organizationRepository,
@@ -118,11 +118,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       const organizationsToCreate = [
         {
+          type: 'PRO',
           externalId: existingOrganization.externalId,
           name: existingOrganization.name,
           provinceCode: existingOrganization.provinceCode,
           credit: existingOrganization.credit,
-          email: existingOrganization.email,
+          emailInvitations: existingOrganization.email,
           locale: 'en',
           tags: 'Tag1',
           documentationUrl: 'http://www.pix.fr',
@@ -135,7 +136,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           name: anotherExistingOrganization.name,
           provinceCode: anotherExistingOrganization.provinceCode,
           credit: anotherExistingOrganization.credit,
-          email: anotherExistingOrganization.email,
+          emailInvitations: anotherExistingOrganization.email,
           type: anotherExistingOrganization.type,
           createdBy: userId,
           organizationInvitationRole: 'ADMIN',
@@ -145,11 +146,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           targetProfiles: '1_2_3',
         },
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           locale: 'fr-fr',
           tags: 'Tag1_Tag2',
           createdBy: userId,
@@ -160,7 +162,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: organizationsToCreate,
         organizationRepository,
@@ -181,6 +183,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       //given
       const organizationsWithEmptyValues = [
         {
+          type: '',
           externalId: '',
           name: '',
           provinceCode: '',
@@ -195,7 +198,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: organizationsWithEmptyValues,
         organizationRepository,
@@ -208,6 +211,14 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       // then
       expect(error).to.be.instanceOf(EntityValidationError);
       expect(error.invalidAttributes).to.eql([
+        {
+          attribute: 'type',
+          message: "Le type fourni doit avoir l'une des valeurs suivantes : SCO,SUP,PRO",
+        },
+        {
+          attribute: 'type',
+          message: 'Le type n’est pas renseigné.',
+        },
         {
           attribute: 'externalId',
           message: "L'externalId n’est pas renseigné.",
@@ -259,11 +270,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       //given
       const organizationsWithTagsWithOneMissingExternalId = [
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness',
+          emailInvitations: 'youness',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           createdBy: userId,
@@ -272,11 +284,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: '',
           name: 'Andreia & Co',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           createdBy: userId,
@@ -285,11 +298,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b201',
           name: 'Mathieu Bâtiment',
           provinceCode: '567',
           credit: 20,
-          email: 'mathieu@example.net',
+          emailInvitations: 'mathieu@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           createdBy: userId,
@@ -300,7 +314,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: organizationsWithTagsWithOneMissingExternalId,
         organizationRepository,
@@ -314,7 +328,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       expect(error).to.be.instanceOf(EntityValidationError);
       expect(error.invalidAttributes).to.eql([
         {
-          attribute: 'email',
+          attribute: 'emailInvitations',
           message: "L'email fourni n'est pas valide.",
         },
       ]);
@@ -324,11 +338,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       // given
       const organizationsWithTagsWithOneMissingName = [
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           createdBy: userId,
@@ -337,11 +352,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'MEMBER',
         },
         {
+          type: 'PRO',
           externalId: 'b201',
           name: '',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           createdBy: userId,
@@ -350,11 +366,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'MEMBER',
         },
         {
+          type: 'PRO',
           externalId: 'b202',
           name: 'Mathieu Bâtiment',
           provinceCode: '567',
           credit: 20,
-          email: 'mathieu@example.net',
+          emailInvitations: 'mathieu@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           createdBy: userId,
@@ -365,7 +382,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: organizationsWithTagsWithOneMissingName,
         organizationRepository,
@@ -394,11 +411,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       const organizationsWithTagsNotExists = [
         {
+          type: 'PRO',
           externalId: 'b400',
           name: 'Mathieu Bâtiment',
           provinceCode: '567',
           credit: 20,
-          email: 'mathieu@example.net',
+          emailInvitations: 'mathieu@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound_AnotherTagNotFound',
           targetProfiles: '123',
@@ -407,11 +425,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           locale: 'fr-fr',
           tags: 'TagNotFound',
           targetProfiles: '123',
@@ -420,11 +439,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'MEMBER',
         },
         {
+          type: 'PRO',
           externalId: 'b300',
           name: 'Andreia & Co',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           locale: 'fr-fr',
           tags: 'AnotherTagNotFound',
           targetProfiles: '123',
@@ -435,7 +455,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: organizationsWithTagsNotExists,
         organizationRepository,
@@ -466,11 +486,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       const organizationsWithTagsAlreadyExist = [
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           locale: 'fr-fr',
           tags: 'Tag1_Tag2',
           targetProfiles: '123',
@@ -479,11 +500,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b300',
           name: 'Andreia & Co',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           locale: 'fr-fr',
           tags: 'Tag2_Tag3',
           targetProfiles: '123',
@@ -492,11 +514,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b400',
           name: 'Mathieu Bâtiment',
           provinceCode: '567',
           credit: 20,
-          email: 'mathieu@example.net',
+          emailInvitations: 'mathieu@example.net',
           locale: 'fr-fr',
           tags: 'Tag1_Tag3',
           targetProfiles: '123',
@@ -507,7 +530,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      await createProOrganizationsWithTagsAndTargetProfiles({
+      await createOrganizationsWithTagsAndTargetProfiles({
         domainTransaction,
         organizations: organizationsWithTagsAlreadyExist,
         organizationRepository,
@@ -527,7 +550,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
         const organizationInDB = await knex('organizations')
           .first('id', 'externalId', 'name', 'provinceCode', 'credit')
           .where({ externalId: organization.externalId });
-        expect(omit(organizationInDB, 'id', 'email')).to.be.deep.equal(
+        expect(omit(organizationInDB, 'id', 'emailInvitations')).to.be.deep.equal(
           omit(
             organization,
             'locale',
@@ -536,7 +559,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
             'createdBy',
             'documentationUrl',
             'organizationInvitationRole',
-            'email',
+            'emailInvitations',
             'targetProfiles'
           )
         );
@@ -558,11 +581,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       const organizationsWithNonExistingTargetProfile = [
         {
+          type: 'PRO',
           externalId: 'b400',
           name: 'Mathieu Bâtiment',
           provinceCode: '567',
           credit: 20,
-          email: 'mathieu@example.net',
+          emailInvitations: 'mathieu@example.net',
           locale: 'fr-fr',
           tags: 'TAG1',
           targetProfiles: '1',
@@ -571,11 +595,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           locale: 'fr-fr',
           tags: 'TAG1',
           targetProfiles: '123',
@@ -584,11 +609,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'MEMBER',
         },
         {
+          type: 'PRO',
           externalId: 'b300',
           name: 'Andreia & Co',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           locale: 'fr-fr',
           tags: 'TAG1',
           targetProfiles: '123',
@@ -599,7 +625,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      const error = await catchErr(createProOrganizationsWithTagsAndTargetProfiles)({
+      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
         domainTransaction,
         organizations: organizationsWithNonExistingTargetProfile,
         organizationRepository,
@@ -630,11 +656,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       const organizationsWithExistingTargetProfiles = [
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           locale: 'fr-fr',
           tags: 'Tag1_Tag2',
           targetProfiles: '123',
@@ -643,11 +670,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b300',
           name: 'Andreia & Co',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           locale: 'fr-fr',
           tags: 'Tag2_Tag3',
           targetProfiles: '123',
@@ -656,11 +684,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           organizationInvitationRole: 'ADMIN',
         },
         {
+          type: 'PRO',
           externalId: 'b400',
           name: 'Mathieu Bâtiment',
           provinceCode: '567',
           credit: 20,
-          email: 'mathieu@example.net',
+          emailInvitations: 'mathieu@example.net',
           locale: 'fr-fr',
           tags: 'Tag1_Tag3',
           targetProfiles: '123',
@@ -671,7 +700,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      await createProOrganizationsWithTagsAndTargetProfiles({
+      await createOrganizationsWithTagsAndTargetProfiles({
         domainTransaction,
         organizations: organizationsWithExistingTargetProfiles,
         organizationRepository,
@@ -691,7 +720,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
         const organizationInDB = await knex('organizations')
           .first('id', 'externalId', 'name', 'provinceCode', 'credit')
           .where({ externalId: organization.externalId });
-        expect(omit(organizationInDB, 'id', 'email')).to.be.deep.equal(
+        expect(omit(organizationInDB, 'id', 'emailInvitations')).to.be.deep.equal(
           omit(
             organization,
             'locale',
@@ -700,7 +729,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
             'createdBy',
             'documentationUrl',
             'organizationInvitationRole',
-            'email',
+            'emailInvitations',
             'targetProfiles'
           )
         );
@@ -724,11 +753,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       const organizationsWithInvitationRole = [
         {
+          type: 'PRO',
           externalId: 'b200',
           name: 'Youness et Fils',
           provinceCode: '123',
           credit: 0,
-          email: 'youness@example.net',
+          emailInvitations: 'youness@example.net',
           organizationInvitationRole: Membership.roles.ADMIN,
           locale: 'fr-fr',
           tags: 'Tag1_Tag2',
@@ -737,11 +767,12 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
           documentationUrl: 'http://www.pix.fr',
         },
         {
+          type: 'PRO',
           externalId: 'b300',
           name: 'Andreia & Co',
           provinceCode: '345',
           credit: 10,
-          email: 'andreia@example.net',
+          emailInvitations: 'andreia@example.net',
           organizationInvitationRole: Membership.roles.MEMBER,
           locale: 'fr-fr',
           tags: 'Tag2_Tag3',
@@ -752,7 +783,7 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
       ];
 
       // when
-      await createProOrganizationsWithTagsAndTargetProfiles({
+      await createOrganizationsWithTagsAndTargetProfiles({
         domainTransaction,
         organizations: organizationsWithInvitationRole,
         organizationRepository,
@@ -764,11 +795,11 @@ describe('Integration | UseCases | create-pro-organizations-with-tags-and-target
 
       // then
       const firstOrganizationInvitation = await knex('organization-invitations')
-        .where({ email: organizationsWithInvitationRole[0].email })
+        .where({ email: organizationsWithInvitationRole[0].emailInvitations })
         .first();
       expect(firstOrganizationInvitation.role).to.be.equal(Membership.roles.ADMIN);
       const secondOrganizationInvitation = await knex('organization-invitations')
-        .where({ email: organizationsWithInvitationRole[1].email })
+        .where({ email: organizationsWithInvitationRole[1].emailInvitations })
         .first();
       expect(secondOrganizationInvitation.role).to.be.equal(Membership.roles.MEMBER);
     });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -957,7 +957,7 @@ describe('Integration | Repository | Organization', function () {
     });
   });
 
-  describe('#batchCreateProOrganizations', function () {
+  describe('#batchCreateOrganizations', function () {
     afterEach(async function () {
       await knex('organizations').delete();
     });
@@ -968,7 +968,7 @@ describe('Integration | Repository | Organization', function () {
       const organization2 = domainBuilder.buildOrganization();
 
       // when
-      await organizationRepository.batchCreateProOrganizations([organization1, organization2]);
+      await organizationRepository.batchCreateOrganizations([organization1, organization2]);
 
       // then
       const foundOrganizations = await knex('organizations').select();
@@ -991,7 +991,7 @@ describe('Integration | Repository | Organization', function () {
       });
 
       // when
-      await organizationRepository.batchCreateProOrganizations([organization]);
+      await organizationRepository.batchCreateOrganizations([organization]);
 
       // then
       const foundOrganizations = await knex('organizations').select();

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -14,7 +14,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
   const emptyFilePath = `${__dirname}/files/organizations-empty-file.csv`;
   const badExtensionFilePath = `${__dirname}/files/bad_extension.html`;
   const validFilePath = `${__dirname}/files/valid-organizations-test.csv`;
-  const organizationProWithTagsAndTargetProfilesFilePath = `${__dirname}/files/organizations-pro-with-tags-and-target-profiles-test.csv`;
+  const organizationWithTagsAndTargetProfilesFilePath = `${__dirname}/files/organizations-with-tags-and-target-profiles-test.csv`;
   const utf8FilePath = `${__dirname}/files/utf8_excel-test.csv`;
   const withHeaderFilePath = `${__dirname}/files/withHeader-test.csv`;
   const withValidHeaderFilePath = `${__dirname}/files/withValidHeaderFilePath.csv`;
@@ -98,17 +98,17 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
     context('when email column exists', function () {
       it('should remove spaces', async function () {
         // given & when
-        const data = await parseCsvWithHeader(organizationProWithTagsAndTargetProfilesFilePath);
+        const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
 
         // then
-        expect(data[0].email).to.equal('team-acces@example.net');
+        expect(data[0].emailInvitations).to.equal('team-acces@example.net');
       });
     });
 
     context('when credits column exists and the value is empty', function () {
       it('should return 0 by default', async function () {
         // given & when
-        const data = await parseCsvWithHeader(organizationProWithTagsAndTargetProfilesFilePath);
+        const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
 
         // then
         expect(data[0].credit).to.equal(0);
@@ -118,11 +118,43 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
     context('when locale column exists and the value is empty', function () {
       it('should return fr-fr by default', async function () {
         // given & when
-        const data = await parseCsvWithHeader(organizationProWithTagsAndTargetProfilesFilePath);
+        const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
 
         // then
         expect(data[0].locale).to.equal('fr-fr');
       });
+    });
+
+    it('should convert isManagingStudents to a boolean', async function () {
+      // given & when
+      const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
+
+      // then
+      expect(data[0].isManagingStudents).to.equal(false);
+    });
+
+    it('should convert identityProviderForCampaigns to uppercase', async function () {
+      // given & when
+      const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
+
+      // then
+      expect(data[0].identityProviderForCampaigns).to.equal('POLE_EMPLOI');
+    });
+
+    it('should convert organizationInvitationRole to uppercase', async function () {
+      // given & when
+      const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
+
+      // then
+      expect(data[0].organizationInvitationRole).to.equal('ADMIN');
+    });
+
+    it('should convert type to uppercase', async function () {
+      // given & when
+      const data = await parseCsvWithHeader(organizationWithTagsAndTargetProfilesFilePath);
+
+      // then
+      expect(data[0].type).to.equal('PRO');
     });
   });
 

--- a/api/tests/unit/scripts/helpers/files/organizations-pro-with-tags-and-target-profiles-test.csv
+++ b/api/tests/unit/scripts/helpers/files/organizations-pro-with-tags-and-target-profiles-test.csv
@@ -1,2 +1,0 @@
-externalId;name;provinceCode;credit;email;locale;tags;createdBy;documentationUrl;targetProfiles
-TUTU001;Team Accès;123;;   team-acces@e  x  ample.net   ;;PUBLIC_AGRICULTURE;100;https://pix.fr/;123456

--- a/api/tests/unit/scripts/helpers/files/organizations-with-tags-and-target-profiles-test.csv
+++ b/api/tests/unit/scripts/helpers/files/organizations-with-tags-and-target-profiles-test.csv
@@ -1,0 +1,2 @@
+type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns
+pro,TUTU001,Team Accès,123,,   team-acces@e  x  ample.net   ,superadmin@example.net,admin,,PUBLIC_AGRICULTURE,100,https://pix.fr/,123456,,pole_emploi


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il existe un script pour créer en masse des organisations PRO. On aimerait pouvoir utiliser le même script pour aussi créer en masse des orga SCO ou SUP.

## :robot: Solution
Rajouter les colonnes manquantes et renseigné le type dans le csv. 

## :rainbow: Remarques
Concernant les colonnes du fichier : 
- "emailForSCOActivation" : mis a null si le type est autre que SCO.

## :100: Pour tester
Créer un CSV `OGA.csv` avec le texte suivant et sauvegarder le dans un répertoire.

```
type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns
PRO,1,Test 1,,,sco.admin @  exa mplE.net,superadmin@example.net,ADMIN,fr-fr,CFA,1,http://test.com,4_5_7,,
PRO,2,Test 2,,,sco.admin@ExAmple.net,,ADMIN,,CFA,1,http://test.com,4_5_7,,
PRO,3,Test 3,,,sco.admin@example.net,,ADMIN,fr-fr,CFA,1,http://test.com,4_5_7,,POLE_EMPLOI
SCO,4,Test 4,,,sco.admin@example.net,superadmin@example.net,ADMIN,fr-fr,CFA,1,http://test.com,4_5_7,,GAR
PRO,5,Test 5,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,
SCO,6,Test 6,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,true,
PRO,7,Test 7,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,
PRO,8,Test 8,,,sco.admin@example.net,,MEMBER,,CFA,1,http://test.com,4_5_7,,CNAV
SUP,9,Test 9,,,sco.admin@example.net,superadmin@example.net,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,
PRO,10,Test 10,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,
PRO,11,Test 11,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,
PRO,12,Test 12,,0,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,
```

Lancer la commande `node scripts/create-organizations-with-tags-and-target-profiles.js /repertoire/OGA.csv`

Vérifier que l'email est seulement sauvegarder pour l'orga SCO Test 4
Vérifier que les identity providers sont bien renseigné
Remplacer des adresses emails de la colonne `emailInvitations` par le vôtre et activer l'envoi des mails pour vérifier que vous recevez bien l'invitation