### PR TITLE
[FEATURE] Ajouter une tooltip pour expliquer la certificabilité dans l'onglet Étudiants(Pix-5564)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -29,20 +29,10 @@
         <Table::Header @size="medium" @align="center">
           <div class="organization-participant-list-page__certificability-header">
             {{t "pages.organization-participants.table.column.is-certifiable.label"}}
-            <div class="organization-participant-list-page__certificability-header__tooltip">
-              <PixTooltip
-                @position="top-left"
-                @isWide={{true}}
-                aria-label={{t "pages.organization-participants.table.column.is-certifiable.tooltip"}}
-              >
-                <:triggerElement>
-                  <FaIcon @icon="circle-question" tabindex="0" />
-                </:triggerElement>
-                <:tooltip>
-                  {{t "pages.organization-participants.table.column.is-certifiable.tooltip"}}
-                </:tooltip>
-              </PixTooltip>
-            </div>
+            <Ui::CertificabilityTooltip
+              @aria-label={{t "pages.organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
+              @content={{t "pages.organization-participants.table.column.is-certifiable.tooltip.content"}}
+            />
           </div>
         </Table::Header>
       </tr>

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -86,20 +86,10 @@
         <Table::Header @size="medium" @align="center">
           <div class="sco-organization-participant-list-page__certificability-header">
             {{t "pages.sco-organization-participants.table.column.is-certifiable.label"}}
-            <div class="sco-organization-participant-list-page__certificability-header__tooltip">
-              <PixTooltip
-                @position="top-left"
-                @isWide={{true}}
-                aria-label={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip"}}
-              >
-                <:triggerElement>
-                  <FaIcon @icon="circle-question" tabindex="0" />
-                </:triggerElement>
-                <:tooltip>
-                  {{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip"}}
-                </:tooltip>
-              </PixTooltip>
-            </div>
+            <Ui::CertificabilityTooltip
+              @aria-label={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
+              @content={{t "pages.sco-organization-participants.table.column.is-certifiable.tooltip.content"}}
+            />
           </div>
         </Table::Header>
         <Table::Header @size="small" class="hide-on-mobile" />

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -58,7 +58,13 @@
           {{t "pages.sup-organization-participants.table.column.last-participation-date"}}
         </Table::Header>
         <Table::Header @size="medium" @align="center">
-          {{t "pages.sup-organization-participants.table.column.is-certifiable.label"}}
+          <div class="sup-organization-participant-list-page__certificability-header">
+            {{t "pages.sup-organization-participants.table.column.is-certifiable.label"}}
+            <Ui::CertificabilityTooltip
+              @aria-label={{t "pages.sup-organization-participants.table.column.is-certifiable.tooltip.aria-label"}}
+              @content={{t "pages.sup-organization-participants.table.column.is-certifiable.tooltip.content"}}
+            />
+          </div>
         </Table::Header>
         <Table::Header @size="medium" class="hide-on-mobile" />
       </tr>

--- a/orga/app/components/ui/certificability-tooltip.hbs
+++ b/orga/app/components/ui/certificability-tooltip.hbs
@@ -1,0 +1,15 @@
+<div class="certificability-tooltip">
+  <PixTooltip @id="column-is-certifiable-informations" @position="top-left" @isWide={{true}}>
+    <:triggerElement>
+      <FaIcon
+        @icon="circle-question"
+        tabindex="0"
+        aria-label={{@aria-label}}
+        aria-describedby="column-is-certifiable-informations"
+      />
+    </:triggerElement>
+    <:tooltip>
+      {{@content}}
+    </:tooltip>
+  </PixTooltip>
+</div>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -69,6 +69,7 @@
 @import 'pages/authenticated/campaigns/participant-profile';
 @import 'pages/authenticated/certifications';
 @import 'pages/authenticated/organization-participants';
+@import 'pages/authenticated/sup-organization-participants/list';
 @import 'pages/authenticated/sup-organization-participants/import';
 @import 'pages/authenticated/sco-organization-participants/list';
 @import 'pages/authenticated/preselect-target-profile';

--- a/orga/app/styles/components/ui/certificability-tooltip.scss
+++ b/orga/app/styles/components/ui/certificability-tooltip.scss
@@ -1,0 +1,10 @@
+.certificability-tooltip {
+	padding-left: 6px;
+	color: $pix-neutral-30;
+	margin-top: auto;
+	margin-bottom: auto;
+
+	[role="tooltip"] {
+		font-weight: $font-light;
+	}
+}

--- a/orga/app/styles/components/ui/index.scss
+++ b/orga/app/styles/components/ui/index.scss
@@ -1,3 +1,4 @@
 @import "cards";
 @import "chart";
 @import "placeholders";
+@import "certificability-tooltip";

--- a/orga/app/styles/pages/authenticated/organization-participants.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants.scss
@@ -15,15 +15,6 @@ $margin-right: 32px;
   &__certificability-header {
     display: flex;
     justify-content: center;
-
-    &__tooltip {
-      padding-left: 6px;
-      color: $pix-neutral-30;
-
-      [role="tooltip"] {
-        font-weight: $font-light;
-      }
-    }
   }
 
   &__certifiable-at {

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -7,15 +7,6 @@
   }
   &__certificability-header {
     display: flex;
-
-    &__tooltip {
-      padding-left: 6px;
-      color: $pix-neutral-30;
-
-      [role="tooltip"] {
-        font-weight: $font-light;
-      }
-    }
   }
 }
 

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/list.scss
@@ -1,0 +1,6 @@
+.sup-organization-participant-list-page {
+  &__certificability-header {
+    display: flex;
+  }
+}
+

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -203,4 +203,30 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // then
     assert.contains(this.intl.t('pages.organization-participants.table.empty'));
   });
+
+  test('it should display the certificability tooltip', async function (assert) {
+    // given
+    const participants = [
+      {
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        isCertifiable: true,
+      },
+    ];
+
+    this.set('participants', participants);
+    this.triggerFiltering = sinon.stub();
+
+    // when
+    const screen = await render(
+      hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{triggerFiltering}}/>`
+    );
+    assert
+      .dom(
+        screen.getByLabelText(
+          this.intl.t('pages.organization-participants.table.column.is-certifiable.tooltip.aria-label')
+        )
+      )
+      .exists();
+  });
 });

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -364,5 +364,26 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       // then
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
+
+    test('it should display the certificability tooltip', async function (assert) {
+      // given
+      this.set('students', [
+        store.createRecord('sco-organization-participant', {
+          isCertifiable: true,
+        }),
+      ]);
+
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+      // then
+      assert
+        .dom(
+          screen.getByLabelText(
+            this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.tooltip.aria-label')
+          )
+        )
+        .exists();
+    });
   });
 });

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -214,6 +214,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       ];
 
       this.set('students', students);
+
       this.triggerFiltering = sinon.spy();
       this.set('groups', []);
 

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -202,5 +202,34 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       sinon.assert.calledWithExactly(triggerFiltering, 'groups', ['L1']);
       assert.ok(true);
     });
+
+    test('it should display the certificability tooltip', async function (assert) {
+      // given
+      const students = [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          isCertifiable: true,
+        },
+      ];
+
+      this.set('students', students);
+      this.triggerFiltering = sinon.spy();
+      this.set('groups', []);
+
+      // when
+      const screen = await render(
+        hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{triggerFiltering}} @groups={{groups}}/>`
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByLabelText(
+            this.intl.t('pages.sup-organization-participants.table.column.is-certifiable.tooltip.aria-label')
+          )
+        )
+        .exists();
+    });
   });
 });

--- a/orga/tests/integration/components/ui/certificability-tooltip_test.js
+++ b/orga/tests/integration/components/ui/certificability-tooltip_test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Ui::CertificabilityTooltip', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display the certificability tooltip', async function (assert) {
+    // given
+    this.label = 'Description';
+    this.content = 'Amazing content';
+
+    // when
+    await render(hbs`<Ui::CertificabilityTooltip @aria-label={{label}} @content={{content}}/>`);
+
+    // then
+    assert.contains('Amazing content');
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -680,7 +680,10 @@
           "participation-count": "Number of participations",
           "is-certifiable":{
             "label": "Eligibility for certification",
-            "tooltip":"To know if a participant is eligible for certification, their Pix profile needs to be submitted through a profile collection campaign. If the participant has already submitted their profile, the date and status of the last submission are displayed."
+            "tooltip": {
+              "aria-label": "How to know if a participant is eligible for certification and what does it mean?",
+              "content":"To know if a participant is eligible for certification (meaning they have reached the level 1 in at least 5 different competences), their Pix profile needs to be submitted through a profile collection campaign. If the participant has already submitted their profile, the date and status of the last submission are displayed."
+            }
           }
         },
         "empty": "No participants",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -863,7 +863,10 @@
             "label": "Eligibility for certification",
             "non-eligible": "Non-eligible",
             "not-available": "Not available",
-            "tooltip": "To know if a student is eligible for certification, their Pix profile needs to be submitted through a profile collection campaign. If the student has already submitted their profile, the date and status of the last submission are displayed."
+            "tooltip": {
+              "aria-label": "How to know if a student is eligible for certification and what does it mean?",
+              "content":"To know if a student is eligible for certification (meaning they have reached the level 1 in at least 5 different competences), their Pix profile needs to be submitted through a profile collection campaign. If the student has already submitted their profile, the date and status of the last submission are displayed."
+            }
           },
           "last-name": "Last name",
           "last-participation-date": "Latest participation",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -908,7 +908,11 @@
           "participation-count": "Number of participations",
           "student-number": "Student number",
           "is-certifiable": {
-            "label": "Certificabilité"
+            "label": "Certificabilité",
+            "tooltip": {
+              "aria-label": "How to know if a student is eligible for certification and what does it mean?",
+              "content":"To know if a student is eligible for certification (meaning they have reached the level 1 in at least 5 different competences), their Pix profile needs to be submitted through a profile collection campaign. If the student has already submitted their profile, the date and status of the last submission are displayed."
+            }
           }
         },
         "empty": "No students.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -863,7 +863,11 @@
             "label": "Certificabilité",
             "non-eligible": "Non Certifiable",
             "not-available": "Non communiqué",
-            "tooltip": "L’information de certificabilité remonte des campagnes de collecte de profils réalisées par l'élève. Si l'élève a déjà envoyé son profil, on affiche la date d’envoi ainsi que le statut du dernier envoi."
+
+            "tooltip": {
+              "aria-label": "Explication sur la certificabilité",
+              "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. L'information provient des campagnes de collecte de profil réalisées par ce dernier. Si l'élève a déjà envoyé son profil, on affiche la date ainsi que le statut du dernier envoi."
+            }
           },
           "last-name": "Nom",
           "last-participation-date": "Dernière participation",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -680,7 +680,10 @@
           "participation-count": "Nombre de participations",
           "is-certifiable": {
             "label": "Certificabilité",
-            "tooltip":"L’information de certificabilité remonte des campagnes de collecte de profil réalisées par le participant. Si le participant a déjà envoyé son profil, on affiche la date d’envoi ainsi que le statut du dernier envoi."
+            "tooltip": {
+              "aria-label": "Explication sur la certificabilité",
+              "content": "La certificabilité signifie que le participant a atteint le niveau 1 dans au moins 5 compétences différentes. L'information provient des campagnes de collecte de profil réalisées par ce dernier. Si le participant a déjà envoyé son profil, on affiche la date ainsi que le statut du dernier envoi."
+            }
           }
         },
         "empty": "Aucun participant",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -863,7 +863,6 @@
             "label": "Certificabilité",
             "non-eligible": "Non Certifiable",
             "not-available": "Non communiqué",
-
             "tooltip": {
               "aria-label": "Explication sur la certificabilité",
               "content": "La certificabilité signifie que l'élève a atteint le niveau 1 dans au moins 5 compétences différentes. L'information provient des campagnes de collecte de profil réalisées par ce dernier. Si l'élève a déjà envoyé son profil, on affiche la date ainsi que le statut du dernier envoi."
@@ -909,7 +908,11 @@
           "participation-count": "Nombre de participations",
           "student-number": "Numéro étudiant",
           "is-certifiable": {
-            "label": "Certificabilité"
+            "label": "Certificabilité",
+            "tooltip": {
+              "aria-label": "Explication sur la certificabilité",
+              "content": "La certificabilité signifie que l'étudiant a atteint le niveau 1 dans au moins 5 compétences différentes. L'information provient des campagnes de collecte de profil réalisées par ce dernier. Si l'étudiant a déjà envoyé son profil, on affiche la date ainsi que le statut du dernier envoi."
+            }
           }
         },
         "empty": "Aucun étudiant.",


### PR DESCRIPTION
## :unicorn: Problème
Dans la suite de l'épix 'calcul de la certificabilité', nous affichons la certificabilité. Cependant, cette notion peut être abstraite. Nous avons décidé de donner plus de détails sur ce qu'est la certificabilité grâce à une tooltip.

## :robot: Solution
Afficher une tooltip pour donner plus de détails sur ce qu'est la certificabilité.

## :rainbow: Remarques
Création d'un composant tooltip qui est appelé pour les 3 tableaux.

## :100: Pour tester
- se connecter à pix orga pour sup
- aller sur la page Étudiants
- observer l'icône fa-circle-interrogation
- survoler ce dernier et observer le tooltip
tada 🎉
