### PR TITLE
[FEATURE] Script de création de formations (PIX-5774).

### DIFF
--- a/api/scripts/create-trainings.js
+++ b/api/scripts/create-trainings.js
@@ -1,0 +1,61 @@
+const { knex, disconnect } = require('../db/knex-database-connection');
+const { parseCsvWithHeaderAndRequiredFields } = require('./helpers/csvHelpers');
+const REQUIRED_FIELD_NAMES = ['title', 'link', 'type', 'duration', 'locale'];
+
+function prepareDataForInsert(rawTrainings) {
+  return rawTrainings.map(({ title, link, type, duration, locale }) => {
+    const trimmedType = type.trim();
+    if (['webinaire', 'autoformation'].includes(trimmedType)) {
+      return {
+        title: title.trim(),
+        link: link.trim(),
+        type: type.trim(),
+        duration: duration.trim(),
+        locale: locale.trim(),
+      };
+    }
+
+    throw new Error(`The type of training : "${title}" is invalid.`);
+  });
+}
+
+async function createTrainings(trainings) {
+  return knex.batchInsert('trainings', trainings);
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  console.log('Starting creating trainings.');
+
+  const filePath = process.argv[2];
+
+  console.log('Reading and parsing csv data file... ');
+  const csvData = await parseCsvWithHeaderAndRequiredFields({ filePath, requiredFieldNames: REQUIRED_FIELD_NAMES });
+
+  console.log('Preparing data... ');
+  const trainings = prepareDataForInsert(csvData);
+  console.log('ok');
+
+  console.log('Inserting trainings in database...');
+  await createTrainings(trainings);
+  console.log('\nDone.');
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = {
+  createTrainings,
+  prepareDataForInsert,
+};

--- a/api/scripts/helpers/csvHelpers.js
+++ b/api/scripts/helpers/csvHelpers.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const { readFile, access } = require('fs').promises;
 const path = require('path');
-const { difference, isEmpty, isNumber } = require('lodash');
+const { difference, isEmpty } = require('lodash');
 const papa = require('papaparse');
 
 const { NotFoundError, FileValidationError } = require('../../lib/domain/errors');
@@ -96,12 +96,12 @@ async function parseCsvWithHeaderAndRequiredFields({ filePath, requiredFieldName
   const csvData = [];
 
   const stepFunction = (results, parser) => {
-    requiredFieldNames.forEach((fieldName) => {
-      if (!isNumber(results.data[fieldName])) {
+    requiredFieldNames.forEach((requiredFieldName) => {
+      if (!results.data[requiredFieldName]) {
         parser.abort();
         throw new FileValidationError(
           ERRORS.MISSING_REQUIRED_FIELD_VALUES,
-          `Field values are required: ${requiredFieldNames}`
+          `Field values are required for ${requiredFieldName}`
         );
       }
     });

--- a/api/tests/integration/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/integration/scripts/helpers/csvHelpers_test.js
@@ -1,6 +1,6 @@
 const { expect, catchErr } = require('../../../test-helper');
 const { FileValidationError, NotFoundError } = require('../../../../lib/domain/errors');
-const { checkCsvHeader, parseCsvWithHeaderAndRequiredFields } = require('../../../../scripts/helpers/csvHelpers');
+const { checkCsvHeader } = require('../../../../scripts/helpers/csvHelpers');
 
 describe('Integration | Scripts | Helpers | csvHelpers.js', function () {
   const withValidHeaderFilePath = `${__dirname}/files/withValidHeader-test.csv`;
@@ -63,24 +63,6 @@ describe('Integration | Scripts | Helpers | csvHelpers.js', function () {
           requiredFieldNames,
         })
       ).to.not.throw;
-    });
-  });
-
-  describe('parseCsvWithHeaderAndRequiredFields', function () {
-    it('should throw FileValidationError if required field value is empty', async function () {
-      // given
-      const requiredFieldNames = ['createdBy', 'provinceCode'];
-
-      // when
-      const error = await catchErr(parseCsvWithHeaderAndRequiredFields)({
-        filePath: withValidHeaderFilePath,
-        requiredFieldNames,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(FileValidationError);
-      expect(error.code).to.equal('MISSING_REQUIRED_FIELD_VALUES');
-      expect(error.meta).to.equal('Field values are required: createdBy,provinceCode');
     });
   });
 });

--- a/api/tests/unit/scripts/create-trainings_test.js
+++ b/api/tests/unit/scripts/create-trainings_test.js
@@ -1,0 +1,77 @@
+const { expect, catchErr } = require('../../test-helper');
+
+const { prepareDataForInsert } = require('../../../scripts/create-trainings');
+
+describe('Unit | Scripts | create-trainings.js', function () {
+  describe('#prepareDataForInsert', function () {
+    it('should trim title, link, type, duration and locale', function () {
+      // given
+      const data = [
+        {
+          title: '   Travail de groupe et collaboration entre les personnels   ',
+          link: '   https://magistere.education.fr/ac-normandie/enrol/index.php?id=5924   ',
+          type: '   autoformation   ',
+          duration: '   06:00:00   ',
+          locale: '  fr-fr',
+        },
+        {
+          title: '   Moodle : Partager et échanger ses ressources',
+          link: '   https://tube-strasbourg.beta.education.fr/videos/watch/7df08eb6-603e-46a8-9be3-a34092fe7e68',
+          type: '   webinaire ',
+          duration: '01:00:00  ',
+          locale: 'fr-fr ',
+        },
+      ];
+
+      // when
+      const result = prepareDataForInsert(data);
+
+      // then
+      expect(result).to.deep.equal([
+        {
+          title: 'Travail de groupe et collaboration entre les personnels',
+          link: 'https://magistere.education.fr/ac-normandie/enrol/index.php?id=5924',
+          type: 'autoformation',
+          duration: '06:00:00',
+          locale: 'fr-fr',
+        },
+        {
+          title: 'Moodle : Partager et échanger ses ressources',
+          link: 'https://tube-strasbourg.beta.education.fr/videos/watch/7df08eb6-603e-46a8-9be3-a34092fe7e68',
+          type: 'webinaire',
+          duration: '01:00:00',
+          locale: 'fr-fr',
+        },
+      ]);
+    });
+
+    it('should throw an error when type is not valid', async function () {
+      // given
+      const data = [
+        {
+          title: 'Travail de groupe et collaboration entre les personnels   ',
+          link: 'https://magistere.education.fr/ac-normandie/enrol/index.php?id=5924   ',
+          type: 'autoformation',
+          duration: '06:00:00',
+          locale: 'fr-fr',
+        },
+        {
+          title: 'Moodle : Partager et échanger ses ressources',
+          link: 'https://tube-strasbourg.beta.education.fr/videos/watch/7df08eb6-603e-46a8-9be3-a34092fe7e68',
+          type: 'test',
+          duration: '01:00:00',
+          locale: 'fr-fr',
+        },
+      ];
+
+      // when
+      const result = await catchErr(prepareDataForInsert)(data);
+
+      // then
+      expect(result).to.be.instanceOf(Error);
+      expect(result.message).to.be.equal(
+        'The type of training : "Moodle : Partager et échanger ses ressources" is invalid.'
+      );
+    });
+  });
+});

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -6,6 +6,7 @@ const {
   readCsvFile,
   parseCsvWithHeader,
   checkCsvHeader,
+  parseCsvWithHeaderAndRequiredFields,
 } = require('../../../../scripts/helpers/csvHelpers');
 
 describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
@@ -16,6 +17,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
   const organizationProWithTagsAndTargetProfilesFilePath = `${__dirname}/files/organizations-pro-with-tags-and-target-profiles-test.csv`;
   const utf8FilePath = `${__dirname}/files/utf8_excel-test.csv`;
   const withHeaderFilePath = `${__dirname}/files/withHeader-test.csv`;
+  const withValidHeaderFilePath = `${__dirname}/files/withValidHeaderFilePath.csv`;
 
   describe('#readCsvFile', function () {
     it('should throw a NotFoundError when file does not exist', async function () {
@@ -159,6 +161,44 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       // then
       expect(error).to.be.instanceOf(FileValidationError);
       expect(error.meta).to.equal('File is empty');
+    });
+  });
+
+  describe('#parseCsvWithHeaderAndRequiredFields', function () {
+    it('should throw FileValidationError if required field value is empty', async function () {
+      // given
+      const requiredFieldNames = ['title', 'type'];
+
+      // when
+      const error = await catchErr(parseCsvWithHeaderAndRequiredFields)({
+        filePath: withValidHeaderFilePath,
+        requiredFieldNames,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(FileValidationError);
+      expect(error.code).to.equal('MISSING_REQUIRED_FIELD_VALUES');
+      expect(error.meta).to.equal('Field values are required for type');
+    });
+
+    it('should parse .csv with header and required fields', async function () {
+      // given
+      const requiredFieldNames = ['uai', 'name'];
+      const expectedItems = [
+        { uai: '0080017A', name: 'Collège Les Pixous' },
+        { uai: '0080018B', name: 'Lycée Pix' },
+        { uai: '0080040A', name: 'Lycée Tant Pix' },
+      ];
+
+      // when
+      const data = await parseCsvWithHeaderAndRequiredFields({
+        filePath: withHeaderFilePath,
+        requiredFieldNames,
+      });
+
+      // then
+      expect(data.length).to.equal(3);
+      expect(data).to.have.deep.members(expectedItems);
     });
   });
 });

--- a/api/tests/unit/scripts/helpers/files/withValidHeaderFilePath.csv
+++ b/api/tests/unit/scripts/helpers/files/withValidHeaderFilePath.csv
@@ -1,0 +1,3 @@
+title,type
+Titre1, Type1
+Titre2,


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin d'avoir un script pour ajouter des formations dans la base de données via un `.csv`

## :robot: Solution

- Création du script

## :rainbow: Remarques
La fonction `parseCsvWithHeaderAndRequiredFields` du helper csv a été modifié car il était à la fois plus utilisé et contenait des règles métier qui n'avait pas lieu d'être ici. Certains tests unitaires de `csvHelpers` ont du être modifiés ou déplacés suite aux différents changements dans le fichier.

## :100: Pour tester

**En locale :** 

- Créer un fichier `trainings.csv`  avec le contenu suivant : 
```
title,link,type,duration,locale
"Bulles de filtre, biais cognitifs",Médiacad (ac-besancon.fr),webinaire,1h,fr-fr
Travail de groupe et collaboration entre les personnels,https://magistere.education.fr/ac-normandie/enrol/index.php?id=5924,autoformation,6h,en
La veille informationnelle,M@gistère (education.fr),autoformation,4h,fr-fr
Conduire mes pratiques pédagogiques dans le cadre de la protection des données,M@gistère (education.fr),autoformation,6h,fr-fr
Comment favoriser et améliorer la mémorisation des élèves ?,Médiacad (ac-besancon.fr),webinaire,2h,fr-fr
Moodle : L'outil Devoir,"Semaine Moodle - Distribuer, récupérer et évaluer les travaux des élèves avec l'outil devoir - Mardi 05/05/20 - PeerTube de l'academie de Strasbourg (education.fr)",webinaire,1h,en-gb
```

- Lancer la commande  : `node scripts/create-trainings scripts/trainings.csv `
- Vérifier dans la DB que le contenu du `.csv` se trouve dans la table `trainings`
