### PR TITLE
[BUGFIX] Corriger la migration ajoutant la colonne stickerUrl dans la table complementary-certification-badges (PIX-5793)

### DIFF
--- a/api/db/migrations/20220927073844_add-column-sticker-url-to-table-complementary-certification-badges.js
+++ b/api/db/migrations/20220927073844_add-column-sticker-url-to-table-complementary-certification-badges.js
@@ -4,6 +4,7 @@ const STICKERS_URL_BY_BADGE_KEY = {
   PIX_EMPLOI_CLEA: 'https://images.pix.fr/stickers/macaron_clea.pdf',
   PIX_EMPLOI_CLEA_V2: 'https://images.pix.fr/stickers/macaron_clea.pdf',
   PIX_EMPLOI_CLEA_V3: 'https://images.pix.fr/stickers/macaron_clea.pdf',
+  PIX_EMPLOI_CLEA_V4: 'https://images.pix.fr/stickers/macaron_clea.pdf',
   PIX_DROIT_MAITRE_CERTIF: 'https://images.pix.fr/stickers/macaron_droit_maitre.pdf',
   PIX_DROIT_EXPERT_CERTIF: 'https://images.pix.fr/stickers/macaron_droit_expert.pdf',
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE: 'https://images.pix.fr/stickers/macaron_edu_2nd_initie.pdf',
@@ -30,9 +31,11 @@ exports.up = async function (knex) {
   const certifiableBadges = await knex('badges').select('id', 'key').where({ isCertifiable: true });
 
   await bluebird.each(certifiableBadges, async ({ id: badgeId, key }) => {
-    await knex('complementary-certification-badges')
-      .update({ stickerUrl: STICKERS_URL_BY_BADGE_KEY[key] })
-      .where({ badgeId });
+    if (STICKERS_URL_BY_BADGE_KEY[key]) {
+      await knex('complementary-certification-badges')
+        .update({ stickerUrl: STICKERS_URL_BY_BADGE_KEY[key] })
+        .where({ badgeId });
+    }
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il existe en recette des badges certifiables qui n'étaient pas connu de la team certification. Le script permettant de créer la colonne `stickerUrl` et de la remplir a donc échoué. Par ailleurs, cela nous a permis de nous rendre compte de l'existence d'un badge `PIX_EMPLOI_CLEA_V4` en production.

## :robot: Solution
- Ajouter le badge `PIX_EMPLOI_CLEA_V4` dans le script
- Faire en sorte que le script n'échoue pas si un bagde certifiable non connu existe