### PR TITLE
[FEATURE] Changer la taille de police de la date et l'heure du détail d'une session (PIX-5789)

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -14,6 +14,7 @@
 }
 
 .session-details-header {
+
   &__title {
     display: flex;
     flex-direction: column;
@@ -35,6 +36,13 @@
     margin-right: 40px;
     border-right: 1px solid $pix-neutral-20;
   }
+
+  &__text {
+    font-size: 0.875rem;
+    font-weight: 400;
+    margin: 0;
+    padding: 8px 0;
+  }
 }
 
 .session-details-container {
@@ -44,8 +52,7 @@
 
 .session-details-row {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: wrap;
   padding: 0 8px;
 
   &__session-finalized-warning {
@@ -131,6 +138,7 @@ $details-content-margin: 8px;
 }
 
 .session-details {
+
   &__clea-results-download {
     padding: 6px;
   }
@@ -145,9 +153,8 @@ $details-content-margin: 8px;
     font-weight: 500;
     font-size: 20px;
     color: $pix-neutral-90;
-    margin: 0 0 4px 0;
+    margin: 0 0 4px;
   }
-
 
   &__clea-results-download-description {
     color: $pix-neutral-50;
@@ -160,6 +167,7 @@ $details-content-margin: 8px;
     justify-content: center;
     align-items: center;
     display: flex;
+
     svg {
       font-size: 40px;
       color: $pix-neutral-50;
@@ -176,7 +184,7 @@ $details-content-margin: 8px;
     margin: 1em 0;
     flex-direction: column;
 
-    @include device-is('desktop') {
+    @include device-is("desktop") {
       flex-direction: row;
     }
   }
@@ -202,7 +210,7 @@ $details-content-margin: 8px;
     margin-right: 24px;
     flex-wrap: wrap;
 
-    @include device-is('desktop') {
+    @include device-is("desktop") {
       flex-direction: row;
     }
   }

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -11,14 +11,14 @@
     <div class="session-details-header__datetime">
       <div class="session-details-header-datetime__date">
         <h4 class="label-text session-details-content__label">Date</h4>
-        <span class="content-text content-text--big session-details-content__text">
+        <span class="content-text content-text--big session-details-header-datetime__text">
           {{moment-format this.session.date "dddd DD MMM YYYY" allow-empty=true locale="fr"}}
         </span>
       </div>
 
       <div>
         <h4 class="label-text session-details-content__label">Heure de début (heure locale)</h4>
-        <span class="content-text content-text--big session-details-content__text">
+        <span class="content-text content-text--big session-details-header-datetime__text">
           {{moment-format this.session.time "HH:mm" "HH:mm:ss" allow-empty=true}}
         </span>
       </div>


### PR DESCRIPTION
## :unicorn: Problème
Dans le header de la page détails d’une session, on trouve le numéro de la session, puis la date et l’heure de début (heure locale). Dans le cadre de l’audit design Pix Certif, il a été remonté un problème de lisibilité au niveau de ce texte avec une petite font size en light.

## :robot: Solution
Changer la weight de la font pour 400 (regular).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix Certif
- Créer une session de certification
- Aller sur le détail de la session de certification et constater que la graisse de la police a été augmentée.