### PR TITLE
[FEATURE] Alignement du bouton de création de session dans certif (PIX-5737).

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -8,11 +8,14 @@
 
   &__header {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
     align-items: center;
-    align-content: center;
     height: 78px;
-    padding-right: 20px;
+    margin: 16px 0 20px;
+
+    & > h1 {
+      margin: 0;
+    }
   }
 
   &-content__update-button {

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -2,18 +2,14 @@
   {{#if this.displayNoSessionPanel}}
     <NoSessionPanel />
   {{else}}
-    <div>
-      <h1 class="page__title page-title">Sessions de certification</h1>
+    <div class="session-list__header">
+      <h1 class="page-title">Sessions de certification</h1>
+      <PixButtonLink @route="authenticated.sessions.new">
+        Créer une session
+        <FaIcon @icon="plus" class="new-session-icon" />
+      </PixButtonLink>
     </div>
 
-    <div class="panel">
-      <div class="session-list__header">
-        <PixButtonLink @route="authenticated.sessions.new">
-          Créer une session
-          <FaIcon @icon="plus" class="new-session-icon" />
-        </PixButtonLink>
-      </div>
-    </div>
     <SessionSummaryList @sessionSummaries={{@model}} @goToSessionDetails={{this.goToSessionDetails}} />
   {{/if}}
 </div>


### PR DESCRIPTION
## :unicorn: Problème

Sur l’onglet “Sessions” de Pix Certif, le bouton “Créer une session” n’est pas aligné avec le titre de la page “Sessions de certification”.

## :robot: Solution

Alignement du bouton avec le titre pour matcher avec pix-orga.

## :rainbow: Remarques
N/A

## :100: Pour tester

Sur la page de création de session, vérifier que le titre et le bouton de création sont alignés.
