### PR TITLE
[FEATURE] Retirer le 'mailto' sur l'adresse e-mail du dpo sur les pages 'épreuves' dans les signalements (PIX-5792)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -507,7 +507,7 @@
           }
         },
         "information": {
-          "data-usage": "'<p>'Pix processes the data from this area to manage and analyse the difficulty encountered and benefit from your feedback. You have rights over your data which can be exercised via '<a href=\"mailto:dpo@pix.fr\" class=\"link\">'dpo@pix.fr'</a>'.'</p><p><a href=\"https://pix.org/en-gb/personal-data-reporting-test\" target=\"_blank\" class=\"link\">'To find out more about protecting your data and your rights.'</a></p>'",
+          "data-usage": "'<p>'Pix processes the data from this area to manage and analyse the difficulty encountered and benefit from your feedback. You have rights over your data which can be exercised via: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.org/en-gb/personal-data-reporting-test\" target=\"_blank\" class=\"link\">'To find out more about protecting your data and your rights.'</a></p>'",
           "guidance": "'<p>'*Make sure you write in this zone: for your benefit and the benefit of others, please stay objective and keep to the facts.'</p><p>'Do not enter any information about yourself or third parties, or any information related to health; religion; political, or philosophical opinions; trade union affiliation; ethnic origins; or penalties and convictions.'</p>'"
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -507,7 +507,7 @@
           }
         },
         "information": {
-          "data-usage": "'<p>'Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de '<a href=\"mailto:dpo@pix.fr\" class=\"link\">'dpo@pix.fr'</a>'.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Pour en savoir plus sur la protection de vos données et sur vos droits.'</a></p>'",
+          "data-usage": "'<p>'Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de : <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Pour en savoir plus sur la protection de vos données et sur vos droits.'</a></p>'",
           "guidance": "'<p>'* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.'</p><p>'Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.'</p>'"
         }
       },


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la conformité applicative du GAR il ne faut pas inciter les élèves à utiliser des adresses email. 
Lors du signalement sur une épreuve Pix il est possible de cliquer sur `dpo@pix.fr` ce qui ouvre par défaut la boîte mail de l'utilisateur. Ce n'est donc pas souhaitable pour notre plus jeune publique.

## :robot: Solution
Retirer le fait que l'adresse email dpo soit un lien.

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer Pix App
Lancer une épreuve (cliquez sur reprendre sur n'importe quelle carte)
Cliquer sur "Signaler un problème" en bas de page
Cliquer sur le lien `dpo@pix.fr`
Constater que votre logiciel de boîte mail par défaut ne s'ouvre pas
