### PR TITLE
[FEATURE] Afficher la date de certificabilité dans la liste des élèves (PIX-5476)

### DIFF
--- a/api/lib/domain/read-models/OrganizationParticipant.js
+++ b/api/lib/domain/read-models/OrganizationParticipant.js
@@ -9,6 +9,7 @@ class OrganizationParticipant {
     campaignType,
     participationStatus,
     isCertifiable,
+    certifiableAt,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -19,6 +20,7 @@ class OrganizationParticipant {
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
     this.isCertifiable = isCertifiable;
+    this.certifiableAt = isCertifiable ? certifiableAt : null;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/organization-participant-repository.js
@@ -25,6 +25,7 @@ async function getParticipantsByOrganizationId({ organizationId, page, filters =
       'organization-learners.lastName',
       'organization-learners.firstName',
       'subquery.isCertifiable',
+      'subquery.certifiableAt',
       knex.raw(
         'COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER(PARTITION BY "organization-learners"."id") AS "participationCount"'
       ),
@@ -80,6 +81,9 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
       'organization-learners.id as organizationLearnerId',
       knex.raw(
         'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
+      ),
+      knex.raw(
+        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"'
       ),
     ])
     .from('organization-learners')

--- a/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/organization-participants-serializer.js
@@ -13,6 +13,7 @@ module.exports = {
         'campaignType',
         'participationStatus',
         'isCertifiable',
+        'certifiableAt',
       ],
       meta,
     }).serialize(organizationParticipants);

--- a/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -720,6 +720,64 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
         // then
         expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
       });
+
+      it('should return the date of the participation as certifiableAt property', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: true,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          organizationParticipants: [{ certifiableAt }],
+        } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+        });
+
+        //then
+        expect(certifiableAt).to.deep.equal(campaignParticipation.sharedAt);
+      });
+
+      it('should return null for certifiableAt property if the organization learner is not certifiable', async function () {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          status: CampaignParticipationStatuses.SHARED,
+          sharedAt: new Date('2021-01-01'),
+          isCertifiable: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          organizationParticipants: [{ certifiableAt }],
+        } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+          organizationId,
+        });
+
+        //then
+        expect(certifiableAt).to.equal(null);
+      });
     });
 
     context('#participantCount', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/organization-participants-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
           campaignType: 'ASSESSMENT',
           participationStatus: campaignParticipationsStatuses.TO_SHARE,
           isCertifiable: null,
+          certifiableAt: null,
         }),
         new OrganizationParticipant({
           id: 778,
@@ -28,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
           campaignType: 'PROFILES_COLLECTION',
           participationStatus: campaignParticipationsStatuses.SHARED,
           isCertifiable: true,
+          certifiableAt: '2021-03-04',
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -48,6 +50,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
               'campaign-type': organizationParticipants[0].campaignType,
               'participation-status': organizationParticipants[0].participationStatus,
               'is-certifiable': organizationParticipants[0].isCertifiable,
+              'certifiable-at': organizationParticipants[0].certifiableAt,
             },
           },
           {
@@ -62,6 +65,7 @@ describe('Unit | Serializer | JSONAPI | organization-participants-serializer', f
               'campaign-type': organizationParticipants[1].campaignType,
               'participation-status': organizationParticipants[1].participationStatus,
               'is-certifiable': organizationParticipants[1].isCertifiable,
+              'certifiable-at': organizationParticipants[1].certifiableAt,
             },
           },
         ],

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -68,6 +68,13 @@
             </td>
             <td class="table__column--center">
               <Ui::IsCertifiable @isCertifiable={{participant.isCertifiable}} />
+              {{#if participant.certifiableAt}}
+                <span class="organization-participant-list-page__certifiable-at">{{moment-format
+                    participant.certifiableAt
+                    "DD/MM/YYYY"
+                    allow-empty=true
+                  }}</span>
+              {{/if}}
             </td>
           </tr>
         {{/each}}

--- a/orga/app/models/organization-participant.js
+++ b/orga/app/models/organization-participant.js
@@ -9,4 +9,5 @@ export default class OrganizationParticipant extends Model {
   @attr('string') campaignType;
   @attr('string') participationStatus;
   @attr('boolean', { allowNull: true }) isCertifiable;
+  @attr('date') certifiableAt;
 }

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -142,7 +142,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
   });
 
-  test('it should display participant as eligible for certification when the participant is certifiable', async function (assert) {
+  test('it should display participant as eligible for certification when the participant is certifiable and the certifiableAt', async function (assert) {
     // given
     const participants = [
       {
@@ -151,6 +151,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
         id: 34,
         lastParticipationDate: new Date('2022-05-15'),
         isCertifiable: true,
+        certifiableAt: new Date('2022-01-02'),
       },
     ];
 
@@ -161,6 +162,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // then
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
+    assert.contains('02/01/2022');
   });
 
   test('it filters participant when the input is filled', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
L'information de la certificabilité d'un élève n'est pas suffisante en soit car les utilisateurs de Pix peuvent réinitialiser les compétences perdant de fait la certificabilité.

## :robot: Solution
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixOrga avec le compte admin Pro
- Aller dans l'onglet Participants
Constater la présence d'une date dans la colonne "Certificabilité" lorsque celle-ci est valorisé à "Certifiable"