### PR TITLE
[TECH] Ajout d'une ligne de séparation entre les thématiques lors de la création d'un profil cible (PIX-5786).

### DIFF
--- a/admin/app/styles/components/target-profiles/tubes-selection.scss
+++ b/admin/app/styles/components/target-profiles/tubes-selection.scss
@@ -85,6 +85,10 @@
   thead {
     background: $pix-neutral-10;
   }
+
+  tr:not(:first-child) {
+    border-top: solid 1px $pix-neutral-20;
+  }
 }
 
 .area-border-container {


### PR DESCRIPTION
## :unicorn: Problème
La ligne de séparation entre les thématiques n'était pas présente lors de la selection des sujets a la création d'un profil cible.

## :robot: Solution
Ajouter une bordure aux thématiques (sauf la premiere de chaque compétence)

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Se rendre sur la page de création d'un profil cible > sélectionner des sujets et constater la présence de la ligne de séparation.
