### PR TITLE
[FEATURE] Changement du wording de la bannière de session non finalisée (PIX-5797).

### DIFF
--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -2,10 +2,13 @@
 
   <table>
     <caption>
-      <div class="session-finalization-reports-information-step__title-uncompleted">
-        <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon" />
+      <PixMessage
+        @type="warning"
+        @withIcon={{true}}
+        class="session-finalization-reports-information-step__title-uncompleted"
+      >
         Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test
-      </div>
+      </PixMessage>
       <span class="sr-only">
         {{t "pages.sessions.finalize.unfinished-test-list-description"}}
       </span>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -4,7 +4,7 @@
     <caption>
       <div class="session-finalization-reports-information-step__title-uncompleted">
         <FaIcon @icon="exclamation-triangle" class="session-finalization-reports-information-step__icon" />
-        Ces candidats n'ont pas fini leur test de certification
+        Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test
       </div>
       <span class="sr-only">
         {{t "pages.sessions.finalize.unfinished-test-list-description"}}

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -23,11 +23,6 @@
     padding: 20px 0 20px 24px;
   }
 
-  &__icon {
-    margin-right: 12px;
-    font-size: 1rem;
-  }
-
   table {
     table-layout: initial;
 

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -280,7 +280,13 @@ module('Acceptance | Session Finalization', function (hooks) {
           const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
 
           // then
-          assert.dom(screen.queryByText("Ces candidats n'ont pas fini leur test de certification")).doesNotExist();
+          assert
+            .dom(
+              screen.queryByText(
+                "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test"
+              )
+            )
+            .doesNotExist();
         });
       });
 
@@ -355,7 +361,13 @@ module('Acceptance | Session Finalization', function (hooks) {
           const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
 
           // then
-          assert.dom(screen.getByText("Ces candidats n'ont pas fini leur test de certification")).exists();
+          assert
+            .dom(
+              screen.getByText(
+                "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test"
+              )
+            )
+            .exists();
         });
 
         module('without any selected reason', function () {

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -41,7 +41,13 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
       `);
 
     // then
-    assert.dom(screen.getByText("Ces candidats n'ont pas fini leur test de certification")).exists();
+    assert
+      .dom(
+        screen.getByText(
+          "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test"
+        )
+      )
+      .exists();
     assert.dom(screen.getByText('1 signalement')).exists();
   });
 
@@ -79,7 +85,13 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
       `);
 
     // then
-    assert.dom(screen.getByText("Ces candidats n'ont pas fini leur test de certification")).exists();
+    assert
+      .dom(
+        screen.getByText(
+          "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test"
+        )
+      )
+      .exists();
     assert.dom(screen.getByText('2 signalements')).exists();
   });
 
@@ -208,7 +220,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
     assert
       .dom(
         screen.getByRole('table', {
-          name: `Ces candidats n'ont pas fini leur test de certification ${this.intl.t(
+          name: `Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test ${this.intl.t(
             'pages.sessions.finalize.unfinished-test-list-description'
           )}`,
         })


### PR DESCRIPTION
## :unicorn: Problème

Sur la page de finalisation d’une session, si au moins un candidat n’a pas répondu à la dernière question de son test, un tableau s’affiche avec pour titre actuel “Ces candidats n'ont pas fini leur test de certification“. Aussi, une raison de l’abandon est demandée afin de savoir quel traitement appliquer aux questions non répondues par le candidat.

![image](https://user-images.githubusercontent.com/36371437/192749531-ac2c101d-bd27-4c23-bb19-1dcdc157c678.png)

Ce tableau prend donc en compte les candidats n’ayant pas répondu à la dernière question et dont le statut est resté “en cours”, mais aussi ceux pour lesquels le test a été terminé par le surveillant depuis l’ES. Ce qui n’est pas explicite dans le titre actuel du tableau et qui entraine de l’incompréhension par nos utilisateurs.

## :robot: Solution

MAJ le nom du tableau comme suit : “Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test”

## :rainbow: Remarques

Le remplacement de la `div` contenant le message par PixMessage a modifié l'icône associée au texte.

## :100: Pour tester

Aller sur la page de finalisation de la session `test` sur certif.
Vérifier que le wording de la bannière a changé.
