### PR TITLE
[FEATURE] Créer la notion d'invitation à Pix Certif (PIX-5004)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center-invitation.js
+++ b/api/db/database-builder/factory/build-certification-center-invitation.js
@@ -1,0 +1,28 @@
+const databaseBuffer = require('../database-buffer');
+
+const TABLE_NAME = 'certification-center-invitations';
+
+module.exports = function buildCertificationCenterInvitation({
+  id = databaseBuffer.getNextId(),
+  certificationCenterId,
+  email = 'anemail@example.net',
+  status = 'pending',
+  code = 'ABCDEF123',
+  createdAt = new Date(),
+  updatedAt = new Date(),
+}) {
+  const values = {
+    id,
+    certificationCenterId,
+    email,
+    status,
+    code,
+    createdAt,
+    updatedAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: TABLE_NAME,
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -21,6 +21,7 @@ module.exports = {
   buildCertifiableUser: require('./build-certifiable-user'),
   buildCertificationCandidate: require('./build-certification-candidate'),
   buildCertificationCenter: require('./build-certification-center'),
+  buildCertificationCenterInvitation: require('./build-certification-center-invitation'),
   buildCertificationCenterMembership: require('./build-certification-center-membership'),
   buildCertificationChallenge: require('./build-certification-challenge'),
   buildComplementaryCertificationCourseResult: require('./build-complementary-certification-course-result'),

--- a/api/db/migrations/20220927130058_create-certification-center-invitations-table.js
+++ b/api/db/migrations/20220927130058_create-certification-center-invitations-table.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'certification-center-invitations';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.bigIncrements('id').primary();
+    table.bigInteger('certificationCenterId').references('certification-centers.id').index();
+    table.string('email').notNullable();
+    table.string('status').notNullable();
+    table.string('code').notNullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    table.check(`"status" IN ( 'pending', 'accepted', 'cancelled')`);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/certification/certification-center-invitations-builder.js
+++ b/api/db/seeds/data/certification/certification-center-invitations-builder.js
@@ -1,0 +1,33 @@
+const {
+  SUP_CERTIF_CENTER_ID,
+} = require('./certification-centers-builder');
+
+function certificationCenterInvitationsBuilder({ databaseBuilder }) {
+  databaseBuilder.factory.buildCertificationCenterInvitation({
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    email: 'alain.verse@example.net',
+    status: 'pending',
+  });
+
+  databaseBuilder.factory.buildCertificationCenterInvitation({
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    email: 'akim.embett@example.net',
+    status: 'pending',
+  });
+
+  databaseBuilder.factory.buildCertificationCenterInvitation({
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    email: 'alex.terrieur@example.net',
+    status: 'accepted',
+  });
+
+  databaseBuilder.factory.buildCertificationCenterInvitation({
+    certificationCenterId: SUP_CERTIF_CENTER_ID,
+    email: 'aline.eha@example.net',
+    status: 'cancelled',
+  });
+}
+
+module.exports = {
+  certificationCenterInvitationsBuilder,
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -13,6 +13,7 @@ const {
   complementaryCertificationCourseResultsBuilder,
 } = require('./data/certification/complementary-certification-course-results-builder');
 const { certificationCentersBuilder } = require('./data/certification/certification-centers-builder');
+const { certificationCenterInvitationsBuilder } = require('./data/certification/certification-center-invitations-builder');
 const { certificationCoursesBuilder } = require('./data/certification/certification-courses-builder');
 const certificationScoresBuilder = require('./data/certification/certification-scores-builder');
 const { certificationSessionsBuilder } = require('./data/certification/certification-sessions-builder');
@@ -63,6 +64,7 @@ exports.seed = async (knex) => {
 
   // Certifications
   certificationCentersBuilder({ databaseBuilder });
+  certificationCenterInvitationsBuilder({ databaseBuilder });
   certificationUsersBuilder({ databaseBuilder });
   certificationCenterMembershipsBuilder({ databaseBuilder });
   await certificationUserProfilesBuilder({ databaseBuilder });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement il n'existe aucune notion en BDD d'invitation à Pix Certif

## :robot: Solution
Créer la table certification-center-invitations 

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer une migration avec `npm run db:migrate`.
Vérifier que la nouvelle table `certification-center-invitations` existe.
Lancer les seeds `npm run db:seeds`
Vérifier qu'il y a quelques entrées dans la nouvelle table.
