### PR TITLE
[FEATURE] Optimiser les requête de récupération des certifications et améliorer le debugging (PIX-5804)

### DIFF
--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -7,9 +7,12 @@ module.exports = async function createAndUpload({
   cpfCertificationXmlExportService,
   cpfExternalStorage,
 }) {
-  const { certificationCourseIds } = data;
-  const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-    certificationCourseIds,
+  const { startDate, endDate, limit, offset } = data;
+  const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+    startDate,
+    endDate,
+    limit,
+    offset,
   });
 
   const writableStream = new PassThrough();
@@ -19,5 +22,6 @@ module.exports = async function createAndUpload({
   const filename = `pix-cpf-export-${now}.xml`;
   await cpfExternalStorage.upload({ filename, writableStream });
 
+  const certificationCourseIds = cpfCertificationResults.map(({ id }) => id);
   await cpfCertificationResultRepository.markCertificationCoursesAsExported({ certificationCourseIds, filename });
 };

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -14,10 +14,13 @@ module.exports = {
     return rowCount;
   },
 
-  async findByCertificationCourseIds({ certificationCourseIds }) {
+  async findByTimeRange({ startDate, endDate, offset, limit }) {
     const certificationCourses = await _selectCpfCertificationResults()
-      .whereIn('certification-courses.id', certificationCourseIds)
-      .orderBy(['sessions.publishedAt', 'certification-courses.lastName', 'certification-courses.firstName']);
+      .where('sessions.publishedAt', '>=', startDate)
+      .where('sessions.publishedAt', '<=', endDate)
+      .orderBy('certification-courses.id')
+      .offset(offset)
+      .limit(limit);
 
     return certificationCourses.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
   },

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -3,13 +3,15 @@ const CpfCertificationResult = require('../../domain/read-models/CpfCertificatio
 const AssessmentResult = require('../../domain/models/AssessmentResult');
 
 module.exports = {
-  async findByTimeRange({ startDate, endDate }) {
-    const certificationCourses = await _selectCpfCertificationResults()
+  async countByTimeRange({ startDate, endDate }) {
+    const queryBuilder = _selectCpfCertificationResults()
       .where('sessions.publishedAt', '>=', startDate)
       .where('sessions.publishedAt', '<=', endDate)
       .orderBy('certification-courses.id');
 
-    return certificationCourses.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
+    const clone = queryBuilder.clone();
+    const { rowCount } = await knex.count('*', { as: 'rowCount' }).from(clone.as('query_all_results')).first();
+    return rowCount;
   },
 
   async findByCertificationCourseIds({ certificationCourseIds }) {

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -3,8 +3,8 @@ const cpfCertificationResultRepository = require('../../../../lib/infrastructure
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 
 describe('Integration | Repository | CpfCertificationResult', function () {
-  describe('#findByTimeRange', function () {
-    it('should return an array of CpfCertificationResult ordered by certification course id', async function () {
+  describe('#countByTimeRange', function () {
+    it('should return the total number of certifications', async function () {
       // given
       const startDate = new Date('2022-01-01');
       const endDate = new Date('2022-01-10');
@@ -106,152 +106,17 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await databaseBuilder.commit();
 
       // when
-      const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+      const count = await cpfCertificationResultRepository.countByTimeRange({
         startDate,
         endDate,
       });
 
       // then
-      expect(cpfCertificationResults).to.deepEqualArray([
-        domainBuilder.buildCpfCertificationResult({
-          id: 245,
-          firstName: 'Ahmed',
-          lastName: 'Épan',
-          birthdate: '2004-06-12',
-          sex: 'M',
-          birthINSEECode: null,
-          birthPostalCode: '75008',
-          pixScore: 112,
-          publishedAt: new Date('2022-01-04'),
-          competenceMarks: [
-            {
-              competenceCode: '2.3',
-              areaCode: '2',
-              level: 4,
-            },
-            {
-              competenceCode: '3.1',
-              areaCode: '3',
-              level: 5,
-            },
-          ],
-        }),
-        domainBuilder.buildCpfCertificationResult({
-          id: 345,
-          firstName: 'Cécile',
-          lastName: 'En cieux',
-          birthdate: '2004-03-04',
-          sex: 'F',
-          birthINSEECode: '75114',
-          birthPostalCode: null,
-          pixScore: 268,
-          publishedAt: new Date('2022-01-10'),
-          competenceMarks: [
-            {
-              competenceCode: '2.1',
-              areaCode: '2',
-              level: 2,
-            },
-            {
-              competenceCode: '3.1',
-              areaCode: '3',
-              level: 4,
-            },
-          ],
-        }),
-        domainBuilder.buildCpfCertificationResult({
-          id: 545,
-          firstName: 'Barack',
-          lastName: 'Afritt',
-          birthdate: '2004-10-22',
-          sex: 'M',
-          birthINSEECode: '75116',
-          birthPostalCode: null,
-          pixScore: 132,
-          publishedAt: new Date('2022-01-04'),
-          competenceMarks: [
-            {
-              competenceCode: '1.2',
-              areaCode: '1',
-              level: 5,
-            },
-            {
-              competenceCode: '2.3',
-              areaCode: '2',
-              level: 5,
-            },
-          ],
-        }),
-      ]);
-    });
-
-    it('should only return competence marks with level greater than -1', async function () {
-      // given
-      const startDate = new Date('2022-01-01');
-      const endDate = new Date('2022-01-10');
-
-      const sessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
-      databaseBuilder.factory.buildCertificationCourse({
-        id: 545,
-        firstName: 'Barack',
-        lastName: 'Afritt',
-        birthdate: '2004-10-22',
-        sex: 'M',
-        birthINSEECode: '75116',
-        birthPostalCode: null,
-        isPublished: true,
-        sessionId,
-      });
-      databaseBuilder.factory.buildAssessmentResult({
-        id: 2244,
-        pixScore: 132,
-        assessmentId: databaseBuilder.factory.buildAssessment({
-          certificationCourseId: 545,
-        }).id,
-      });
-      databaseBuilder.factory.buildCompetenceMark({
-        assessmentResultId: 2244,
-        level: 5,
-        competence_code: '1.2',
-        area_code: '1',
-      });
-      databaseBuilder.factory.buildCompetenceMark({
-        assessmentResultId: 2244,
-        level: 0,
-        competence_code: '2.3',
-        area_code: '2',
-      });
-      databaseBuilder.factory.buildCompetenceMark({
-        assessmentResultId: 2244,
-        level: -1,
-        competence_code: '4.1',
-        area_code: '4',
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByTimeRange({
-        startDate,
-        endDate,
-      });
-
-      // then
-      expect(cpfCertificationResult.competenceMarks).to.deep.equal([
-        {
-          competenceCode: '1.2',
-          areaCode: '1',
-          level: 5,
-        },
-        {
-          competenceCode: '2.3',
-          areaCode: '2',
-          level: 0,
-        },
-      ]);
+      expect(count).to.equal(3);
     });
 
     context('when the certification course is not published', function () {
-      it('should return an empty array', async function () {
+      it('should return 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
@@ -260,18 +125,18 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        const count = await cpfCertificationResultRepository.countByTimeRange({
           startDate,
           endDate,
         });
 
         // then
-        expect(cpfCertificationResults).to.be.empty;
+        expect(count).equal(0);
       });
     });
 
     context('when the certification course is cancelled', function () {
-      it('should return an empty array', async function () {
+      it('should return 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
@@ -280,18 +145,18 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        const count = await cpfCertificationResultRepository.countByTimeRange({
           startDate,
           endDate,
         });
 
         // then
-        expect(cpfCertificationResults).to.be.empty;
+        expect(count).to.equal(0);
       });
     });
 
     context('when the latest assessment result is not validated', function () {
-      it('should return an empty array', async function () {
+      it('should return 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
@@ -303,18 +168,18 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        const count = await cpfCertificationResultRepository.countByTimeRange({
           startDate,
           endDate,
         });
 
         // then
-        expect(cpfCertificationResults).to.be.empty;
+        expect(count).to.equal(0);
       });
     });
 
     context('when the session date is ouf of bounds', function () {
-      it('should return an empty array', async function () {
+      it('should return 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
@@ -323,18 +188,18 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        const count = await cpfCertificationResultRepository.countByTimeRange({
           startDate,
           endDate,
         });
 
         // then
-        expect(cpfCertificationResults).to.be.empty;
+        expect(count).to.equal(0);
       });
     });
 
     context('when the certification course sex is not defined', function () {
-      it('should return an empty array', async function () {
+      it('should 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
@@ -343,18 +208,18 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        const count = await cpfCertificationResultRepository.countByTimeRange({
           startDate,
           endDate,
         });
 
         // then
-        expect(cpfCertificationResults).to.be.empty;
+        expect(count).to.equal(0);
       });
     });
 
     context('when the certification course has already been exported', function () {
-      it('should return an empty array', async function () {
+      it('should return 0', async function () {
         // given
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
@@ -363,13 +228,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        const count = await cpfCertificationResultRepository.countByTimeRange({
           startDate,
           endDate,
         });
 
         // then
-        expect(cpfCertificationResults).to.be.empty;
+        expect(count).to.equal(0);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -239,10 +239,13 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     });
   });
 
-  describe('#findByCertificationCourseIds', function () {
-    it('should return an array of CpfCertificationResult ordered by session publication date, last name and first name', async function () {
+  describe('#findByTimeRange', function () {
+    it('should return an array of CpfCertificationResult ordered by certification course id', async function () {
       // given
-      const certificationCourseIds = [245, 345, 545];
+      const startDate = new Date('2022-01-01');
+      const endDate = new Date('2022-01-10');
+      const offset = 0;
+      const limit = 5;
 
       const firstPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
       databaseBuilder.factory.buildCertificationCourse({
@@ -341,35 +344,15 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await databaseBuilder.commit();
 
       // when
-      const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-        certificationCourseIds,
+      const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        startDate,
+        endDate,
+        offset,
+        limit,
       });
 
       // then
       expect(cpfCertificationResults).to.deepEqualArray([
-        domainBuilder.buildCpfCertificationResult({
-          id: 545,
-          firstName: 'Barack',
-          lastName: 'Afritt',
-          birthdate: '2004-10-22',
-          sex: 'M',
-          birthINSEECode: '75116',
-          birthPostalCode: null,
-          pixScore: 132,
-          publishedAt: new Date('2022-01-04'),
-          competenceMarks: [
-            {
-              competenceCode: '1.2',
-              areaCode: '1',
-              level: 5,
-            },
-            {
-              competenceCode: '2.3',
-              areaCode: '2',
-              level: 5,
-            },
-          ],
-        }),
         domainBuilder.buildCpfCertificationResult({
           id: 245,
           firstName: 'Ahmed',
@@ -416,12 +399,177 @@ describe('Integration | Repository | CpfCertificationResult', function () {
             },
           ],
         }),
+        domainBuilder.buildCpfCertificationResult({
+          id: 545,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          pixScore: 132,
+          publishedAt: new Date('2022-01-04'),
+          competenceMarks: [
+            {
+              competenceCode: '1.2',
+              areaCode: '1',
+              level: 5,
+            },
+            {
+              competenceCode: '2.3',
+              areaCode: '2',
+              level: 5,
+            },
+          ],
+        }),
+      ]);
+    });
+
+    it('should only return CpfCertificationResults by offset and limit', async function () {
+      // given
+      const startDate = new Date('2022-01-01');
+      const endDate = new Date('2022-01-10');
+      const offset = 2;
+      const limit = 2;
+
+      const firstPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 545,
+        firstName: 'Barack',
+        lastName: 'Afritt',
+        birthdate: '2004-10-22',
+        sex: 'M',
+        birthINSEECode: '75116',
+        birthPostalCode: null,
+        isPublished: true,
+        sessionId: firstPublishedSessionId,
+      }).id;
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 2244,
+        pixScore: 132,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 545,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 5,
+        competence_code: '1.2',
+        area_code: '1',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 2244,
+        level: 5,
+        competence_code: '2.3',
+        area_code: '2',
+      });
+
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 245,
+        firstName: 'Ahmed',
+        lastName: 'Épan',
+        birthdate: '2004-06-12',
+        sex: 'M',
+        birthINSEECode: null,
+        birthPostalCode: '75008',
+        isPublished: true,
+        sessionId: firstPublishedSessionId,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 4466,
+        pixScore: 112,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 245,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4466,
+        level: 5,
+        competence_code: '3.1',
+        area_code: '3',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4466,
+        level: 4,
+        competence_code: '2.3',
+        area_code: '2',
+      });
+
+      const secondPublishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-10') }).id;
+      databaseBuilder.factory.buildCertificationCourse({
+        id: 345,
+        firstName: 'Cécile',
+        lastName: 'En cieux',
+        birthdate: '2004-03-04',
+        sex: 'F',
+        birthINSEECode: '75114',
+        birthPostalCode: null,
+        isPublished: true,
+        sessionId: secondPublishedSessionId,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        id: 4467,
+        pixScore: 268,
+        assessmentId: databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 345,
+        }).id,
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4467,
+        level: 2,
+        competence_code: '2.1',
+        area_code: '2',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        assessmentResultId: 4467,
+        level: 4,
+        competence_code: '3.1',
+        area_code: '3',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+        startDate,
+        endDate,
+        offset,
+        limit,
+      });
+
+      // then
+      expect(cpfCertificationResults).to.deepEqualArray([
+        domainBuilder.buildCpfCertificationResult({
+          id: 545,
+          firstName: 'Barack',
+          lastName: 'Afritt',
+          birthdate: '2004-10-22',
+          sex: 'M',
+          birthINSEECode: '75116',
+          birthPostalCode: null,
+          pixScore: 132,
+          publishedAt: new Date('2022-01-04'),
+          competenceMarks: [
+            {
+              competenceCode: '1.2',
+              areaCode: '1',
+              level: 5,
+            },
+            {
+              competenceCode: '2.3',
+              areaCode: '2',
+              level: 5,
+            },
+          ],
+        }),
       ]);
     });
 
     it('should only return competence marks with level greater than -1', async function () {
       // given
-      const certificationCourseIds = [545];
+      const startDate = new Date('2022-01-01');
+      const endDate = new Date('2022-01-10');
+      const offset = 0;
+      const limit = 5;
 
       const sessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date('2022-01-04') }).id;
       databaseBuilder.factory.buildCertificationCourse({
@@ -463,8 +611,11 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await databaseBuilder.commit();
 
       // when
-      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByCertificationCourseIds({
-        certificationCourseIds,
+      const [cpfCertificationResult] = await cpfCertificationResultRepository.findByTimeRange({
+        startDate,
+        endDate,
+        offset,
+        limit,
       });
 
       // then
@@ -482,20 +633,50 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       ]);
     });
 
+    context('when the session date is not between startDate and endDate', function () {
+      it('should return an empty array', async function () {
+        // given
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+        const offset = 0;
+        const limit = 1;
+
+        createCertificationCourseWithCompetenceMarks({ sessionDate: '2022-01-15' });
+        await databaseBuilder.commit();
+
+        // when
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+          offset,
+          limit,
+        });
+
+        // then
+        expect(cpfCertificationResults).to.be.empty;
+      });
+    });
+
     context('when the certification course is not published', function () {
       it('should return an empty array', async function () {
         // given
-        const certificationCourseIds = [101];
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+        const offset = 0;
+        const limit = 1;
 
         createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 101,
+          sessionDate: '2022-01-08',
           isPublished: false,
         });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-          certificationCourseIds,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+          offset,
+          limit,
         });
 
         // then
@@ -506,17 +687,23 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the certification course is cancelled', function () {
       it('should return an empty array', async function () {
         // given
-        const certificationCourseIds = [101];
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+        const offset = 0;
+        const limit = 1;
 
         createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 101,
+          sessionDate: '2022-01-08',
           certificationCourseCancelled: true,
         });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-          certificationCourseIds,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+          offset,
+          limit,
         });
 
         // then
@@ -527,35 +714,23 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the latest assessment result is not validated', function () {
       it('should return an empty array', async function () {
         // given
-        const certificationCourseIds = [101];
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+        const offset = 0;
+        const limit = 1;
 
         createCertificationCourseWithCompetenceMarks({
-          certificationCourseId: 101,
+          sessionDate: '2022-01-08',
           assessmentResultStatus: AssessmentResult.status.REJECTED,
         });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-          certificationCourseIds,
-        });
-
-        // then
-        expect(cpfCertificationResults).to.be.empty;
-      });
-    });
-
-    context('when the certification course id is not in the array', function () {
-      it('should return an empty array', async function () {
-        // given
-        const certificationCourseIds = [101];
-
-        createCertificationCourseWithCompetenceMarks({ certificationCourseId: 201 });
-        await databaseBuilder.commit();
-
-        // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-          certificationCourseIds,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+          offset,
+          limit,
         });
 
         // then
@@ -566,14 +741,20 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the certification course sex is not defined', function () {
       it('should return an empty array', async function () {
         // given
-        const certificationCourseIds = [101];
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+        const offset = 0;
+        const limit = 1;
 
-        createCertificationCourseWithCompetenceMarks({ certificationCourseId: 101, sex: null });
+        createCertificationCourseWithCompetenceMarks({ sessionDate: '2022-01-08', sex: null });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-          certificationCourseIds,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+          offset,
+          limit,
         });
 
         // then
@@ -584,14 +765,20 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     context('when the certification course has already been exported', function () {
       it('should return an empty array', async function () {
         // given
-        const certificationCourseIds = [101];
+        const startDate = new Date('2022-01-01');
+        const endDate = new Date('2022-01-10');
+        const offset = 0;
+        const limit = 1;
 
-        createCertificationCourseWithCompetenceMarks({ certificationCourseId: 101, cpfFilename: 'file.xml' });
+        createCertificationCourseWithCompetenceMarks({ sessionDate: '2022-01-08', cpfFilename: 'file.xml' });
         await databaseBuilder.commit();
 
         // when
-        const cpfCertificationResults = await cpfCertificationResultRepository.findByCertificationCourseIds({
-          certificationCourseIds,
+        const cpfCertificationResults = await cpfCertificationResultRepository.findByTimeRange({
+          startDate,
+          endDate,
+          offset,
+          limit,
         });
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le job de planification envoie une liste d'id de certifications au job de création et d'upload de fichiers. Cette liste est ensuite stockée en base de données par pg-boss. Cependant, cette information est difficilement lisible avec 50000 id. Par ailleurs, pour permettre de rejouer plus facilement la requête dans un contexte de debug, une liste d'id aussi longue n'est pas optimal.   

## :robot: Solution
- Utiliser un count afin de déterminer le nombre de certifications à envoyer dans le job de planification.
- Passer des paramètres plus compréhensibles au job de création et d'upload du fichier.

## :100: Pour tester
- Les jobs ont bien été lancés et le contenu de la colonne data sont correct
![Selection_085](https://user-images.githubusercontent.com/1216570/192821687-205880d3-c5a0-4b30-84aa-01d95a424942.png)

- Les fichiers ont bien été uploadé sur OVH
![Selection_084](https://user-images.githubusercontent.com/1216570/192821504-24427311-4224-4681-960f-f91f51b317f3.png)

