### PR TITLE
[FEATURE] Envoyer un mail au(x) référent(s) d'un centre de certification à la publication d'une session avec au moins un candidat certifié CléA numérique (PIX-5770)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -190,6 +190,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SupervisorAccessNotAuthorizedError) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.SendingEmailToRefererError) {
+    return new HttpErrors.ServiceUnavailableError(error.message);
+  }
   if (error instanceof DomainErrors.SendingEmailToResultRecipientError) {
     return new HttpErrors.ServiceUnavailableError(error.message);
   }

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -101,6 +101,7 @@ module.exports = (function () {
           accountRecoveryTemplateId: process.env.SENDINBLUE_ACCOUNT_RECOVERY_TEMPLATE_ID,
           emailVerificationCodeTemplateId: process.env.SENDINBLUE_EMAIL_VERIFICATION_CODE_TEMPLATE_ID,
           cpfEmailTemplateId: process.env.SENDINBLUE_CPF_TEMPLATE_ID,
+          acquiredCleaResultTemplateId: process.env.SENDINBLUE_CLEA_ACQUIRED_RESULT_TEMPLATE_ID,
         },
       },
     },
@@ -337,6 +338,7 @@ module.exports = (function () {
     config.mailing.sendinblue.templates.accountRecoveryTemplateId = 'test-account-recovery-template-id';
     config.mailing.sendinblue.templates.emailVerificationCodeTemplateId = 'test-email-verification-code-template-id';
     config.mailing.sendinblue.templates.cpfEmailTemplateId = 'test-cpf-email-template-id';
+    config.mailing.sendinblue.templates.email = 'test-acquired-clea-result-template-id';
 
     config.bcryptNumberOfSaltRounds = 1;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -338,7 +338,7 @@ module.exports = (function () {
     config.mailing.sendinblue.templates.accountRecoveryTemplateId = 'test-account-recovery-template-id';
     config.mailing.sendinblue.templates.emailVerificationCodeTemplateId = 'test-email-verification-code-template-id';
     config.mailing.sendinblue.templates.cpfEmailTemplateId = 'test-cpf-email-template-id';
-    config.mailing.sendinblue.templates.email = 'test-acquired-clea-result-template-id';
+    config.mailing.sendinblue.templates.acquiredCleaResultTemplateId = 'test-acquired-clea-result-template-id';
 
     config.bcryptNumberOfSaltRounds = 1;
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -363,6 +363,14 @@ class DeprecatedCertificationIssueReportSubcategoryError extends DomainError {
   }
 }
 
+class SendingEmailToRefererError extends DomainError {
+  constructor(failedEmailReferers) {
+    super(
+      `Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : ${failedEmailReferers.join(', ')}`
+    );
+  }
+}
+
 class SendingEmailToResultRecipientError extends DomainError {
   constructor(failedEmailsRecipients) {
     super(`Échec lors de l'envoi des résultats au(x) destinataire(s) : ${failedEmailsRecipients.join(', ')}`);
@@ -1286,6 +1294,7 @@ module.exports = {
   OrganizationLearnerDisabledError,
   OrganizationLearnerNotFound,
   OrganizationLearnersCouldNotBeSavedError,
+  SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,

--- a/api/lib/domain/models/EmailingAttempt.js
+++ b/api/lib/domain/models/EmailingAttempt.js
@@ -1,6 +1,6 @@
 module.exports = class EmailingAttempt {
-  constructor(recipientEmail, status) {
-    this.recipientEmail = recipientEmail;
+  constructor(email, status) {
+    this.email = email;
     this.status = status;
   }
 
@@ -12,12 +12,12 @@ module.exports = class EmailingAttempt {
     return this.status === AttemptStatus.SUCCESS;
   }
 
-  static success(recipientEmail) {
-    return new EmailingAttempt(recipientEmail, AttemptStatus.SUCCESS);
+  static success(email) {
+    return new EmailingAttempt(email, AttemptStatus.SUCCESS);
   }
 
-  static failure(recipientEmail) {
-    return new EmailingAttempt(recipientEmail, AttemptStatus.FAILURE);
+  static failure(email) {
+    return new EmailingAttempt(email, AttemptStatus.FAILURE);
   }
 };
 

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
 
 const tokenService = require('./token-service');
 const mailer = require('../../infrastructure/mailers/mailer');
@@ -83,7 +83,7 @@ function sendCertificationResultEmail({
   daysBeforeExpiration,
 }) {
   const pixName = PIX_NAME_FR;
-  const formattedSessionDate = moment(sessionDate).locale('fr').format('L');
+  const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
   const token = tokenService.createCertificationResultsByRecipientEmailLinkToken({
     sessionId,
     resultRecipientEmail,
@@ -342,6 +342,20 @@ function sendCpfEmail({ email, generatedFiles }) {
   return mailer.sendEmail(options);
 }
 
+function sendNotificationToCertificationCenterRefererForCleaResults({ email, sessionId, sessionDate }) {
+  const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
+
+  const options = {
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME_FR,
+    to: email,
+    template: mailer.acquiredCleaResultTemplateId,
+    variables: { sessionId, sessionDate: formattedSessionDate },
+  };
+
+  return mailer.sendEmail(options);
+}
+
 module.exports = {
   sendAccountCreationEmail,
   sendAccountRecoveryEmail,
@@ -351,4 +365,5 @@ module.exports = {
   sendResetPasswordDemandEmail,
   sendVerificationCodeEmail,
   sendCpfEmail,
+  sendNotificationToCertificationCenterRefererForCleaResults,
 };

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -1,6 +1,7 @@
 module.exports = async function publishSession({
   sessionId,
   certificationRepository,
+  certificationCenterRepository,
   finalizedSessionRepository,
   sessionRepository,
   sessionPublicationService,
@@ -9,6 +10,7 @@ module.exports = async function publishSession({
   await sessionPublicationService.publishSession({
     sessionId,
     certificationRepository,
+    certificationCenterRepository,
     finalizedSessionRepository,
     sessionRepository,
     publishedAt,

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -3,6 +3,7 @@ const { SessionPublicationBatchResult } = require('../models/SessionPublicationB
 
 module.exports = async function publishSessionsInBatch({
   sessionIds,
+  certificationCenterRepository,
   certificationRepository,
   finalizedSessionRepository,
   sessionPublicationService,
@@ -16,6 +17,7 @@ module.exports = async function publishSessionsInBatch({
       await sessionPublicationService.publishSession({
         sessionId,
         certificationRepository,
+        certificationCenterRepository,
         finalizedSessionRepository,
         sessionRepository,
         publishedAt,

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -74,6 +74,10 @@ class Mailer {
   get cpfEmailTemplateId() {
     return mailing[this._providerName].templates.cpfEmailTemplateId;
   }
+
+  get acquiredCleaResultTemplateId() {
+    return mailing[this._providerName].templates.acquiredCleaResultTemplateId;
+  }
 }
 
 module.exports = new Mailer();

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const BookshelfCertificationCenter = require('../orm-models/CertificationCenter');
+const { knex } = require('../../../db/knex-database-connection');
 const CertificationCenter = require('../../domain/models/CertificationCenter');
 const ComplementaryCertification = require('../../domain/models/ComplementaryCertification');
 const { NotFoundError } = require('../../domain/errors');
@@ -149,5 +150,24 @@ module.exports = {
     });
 
     return certificationCenterBookshelf ? _toDomain(certificationCenterBookshelf) : null;
+  },
+
+  async getRefererEmails(certificationCenterId) {
+    const refererEmails = await knex('certification-centers')
+      .select('users.email')
+      .join(
+        'certification-center-memberships',
+        'certification-center-memberships.certificationCenterId',
+        'certification-centers.id'
+      )
+      .join('users', 'users.id', 'certification-center-memberships.userId')
+      .where('certification-centers.id', certificationCenterId)
+      .where('certification-center-memberships.isReferer', true);
+
+    if (!refererEmails.length) {
+      return null;
+    }
+
+    return refererEmails;
   },
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -211,6 +211,13 @@ PGBOSS_CONNECTION_POOL_MAX_SIZE=
 # default: none
 # SENDINBLUE_EMAIL_VERIFICATION_CODE_TEMPLATE_ID=
 
+# ID of the template used to notify the certification center referer to download clea results
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_CLEA_ACQUIRED_RESULT_TEMPLATE_ID=
+
 # String for links in emails redirect to a specific domain when user comes from french domain
 #
 # presence: optional

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -890,5 +890,16 @@ describe('Integration | API | Controller Error', function () {
         "Échec lors de l'envoi des résultats au(x) destinataire(s) : toto@pix.fr, titi@pix.fr"
       );
     });
+
+    it('responds ServiceUnavailable when a SendingEmailToRefererError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.SendingEmailToRefererError(['toto@pix.fr', 'titi@pix.fr']));
+
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(SERVICE_UNAVAILABLE_ERROR);
+      expect(responseDetail(response)).to.equal(
+        "Échec lors de l'envoi du mail au(x) référent(s) du centre de certification : toto@pix.fr, titi@pix.fr"
+      );
+    });
   });
 });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -648,4 +648,29 @@ describe('Unit | Service | MailService', function () {
       });
     });
   });
+
+  describe('#sendNotificationToCertificationCenterRefererForCleaResults', function () {
+    it(`should call sendEmail with the right options`, async function () {
+      // given
+      const email = 'user@example.net';
+      const sessionId = 123;
+      const sessionDate = new Date('2022-01-01');
+
+      // when
+      await mailService.sendNotificationToCertificationCenterRefererForCleaResults({
+        email,
+        sessionId,
+        sessionDate,
+      });
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWith({
+        from: 'ne-pas-repondre@pix.fr',
+        fromName: 'PIX - Ne pas répondre',
+        to: email,
+        template: mailer.acquiredCleaResultTemplateId,
+        variables: { sessionId, sessionDate: '01/01/2022' },
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/unit/domain/usecases/publish-session_test.js
@@ -20,10 +20,15 @@ describe('Unit | UseCase | publish-session', function () {
       publishSession: sinon.stub(),
     };
 
+    const certificationCenterRepository = {
+      getRefererEmails: sinon.stub(),
+    };
+
     // when
     const result = await publishSession({
       sessionId,
       certificationRepository,
+      certificationCenterRepository,
       finalizedSessionRepository,
       sessionRepository,
       sessionPublicationService,
@@ -34,6 +39,7 @@ describe('Unit | UseCase | publish-session', function () {
     expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
       sessionId,
       certificationRepository,
+      certificationCenterRepository,
       finalizedSessionRepository,
       sessionRepository,
       publishedAt,

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -7,11 +7,13 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
   let certificationRepository;
   let finalizedSessionRepository;
   let sessionRepository;
+  let certificationCenterRepository;
 
   beforeEach(function () {
     certificationRepository = Symbol('certificationRepository');
     finalizedSessionRepository = Symbol('finalizedSessionRepository');
     sessionRepository = Symbol('sessionRepository');
+    certificationCenterRepository = {};
 
     sessionPublicationService = {
       publishSession: sinon.stub(),
@@ -28,6 +30,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     await publishSessionsInBatch({
       sessionIds: [sessionId1, sessionId2],
       certificationRepository,
+      certificationCenterRepository,
       finalizedSessionRepository,
       sessionPublicationService,
       sessionRepository,
@@ -39,6 +42,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
       sessionId: sessionId1,
       certificationRepository,
+      certificationCenterRepository,
       finalizedSessionRepository,
       sessionRepository,
       publishedAt,
@@ -46,6 +50,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
       sessionId: sessionId2,
       certificationRepository,
+      certificationCenterRepository,
       finalizedSessionRepository,
       sessionRepository,
       publishedAt,
@@ -74,6 +79,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       await publishSessionsInBatch({
         sessionIds: [sessionId1, sessionId2],
         certificationRepository,
+        certificationCenterRepository,
         finalizedSessionRepository,
         sessionPublicationService,
         sessionRepository,
@@ -84,6 +90,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
         sessionId: sessionId2,
         certificationRepository,
+        certificationCenterRepository,
         finalizedSessionRepository,
         sessionRepository,
         publishedAt,


### PR DESCRIPTION
## :unicorn: Problème
Le référent Pix est le garant du bon déroulement de la certif Pix dans son centre. L’une des ces attributions consiste à s’assurer que les certificats CléA numérique des candidats certifiés CléA numérique by Pix soit générés sur la plateforme CléA. C’est dans ce but qu’un bouton a été ajouté sur la page de détail d’une session publiée avec au moins un certifié CléA numérique dedans, permettant de télécharger la liste des candidat certifiés à importer sur la plateforme.

A part si le référent est également prescripteur et donc reçoit le fichier csv des résultats, il n’a pas de moyen simple de savoir lorsqu’une session a été publiée, et donc qu’une liste de candidats certifiés CléA numérique est disponible.


## :robot: Solution
A la publication d’une session avec au moins un candidat CléA numérique, envoyer un mail au référent désigné du centre correspondant.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Créer une session avec une certification cléa
- Changer l'email du user du membre de l'espace pix-certif ( afin de tester la réception du mail)
- Changer son isRefer à true dans les membership
- Passer et finaliser la certification avec succès
- Publier la session et  constater la reception du mail