### PR TITLE
[FEATURE] Ajouter la date de certification pour les étudiants certifiables (Pix-5565)

### DIFF
--- a/api/lib/domain/read-models/SupOrganizationParticipant.js
+++ b/api/lib/domain/read-models/SupOrganizationParticipant.js
@@ -12,6 +12,7 @@ class SupOrganizationParticipant {
     campaignType,
     participationStatus,
     isCertifiable,
+    certifiableAt,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -25,6 +26,7 @@ class SupOrganizationParticipant {
     this.campaignType = campaignType;
     this.participationStatus = participationStatus;
     this.isCertifiable = isCertifiable;
+    this.certifiableAt = isCertifiable ? certifiableAt : null;
   }
 }
 

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -30,6 +30,9 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
       knex.raw(
         'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
       ),
+      knex.raw(
+        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"'
+      ),
     ])
     .from('organization-learners')
     .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
@@ -63,6 +66,7 @@ module.exports = {
         'organization-learners.studentNumber',
         'organization-learners.organizationId',
         'subquery.isCertifiable',
+        'subquery.certifiableAt',
         knex.raw(
           'FIRST_VALUE("name") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."createdAt" DESC) AS "campaignName"'
         ),

--- a/api/lib/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer.js
@@ -16,6 +16,7 @@ module.exports = {
         'campaignType',
         'participationStatus',
         'isCertifiable',
+        'certifiableAt',
       ],
       meta,
     }).serialize(supOrganizationParticipants);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1176,7 +1176,7 @@ describe('Acceptance | Application | organization-controller', function () {
     });
 
     context('Expected output', function () {
-      let organizationLearner, campaign, participation;
+      let organizationLearner, campaign;
 
       beforeEach(async function () {
         campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
@@ -1184,7 +1184,7 @@ describe('Acceptance | Application | organization-controller', function () {
           organizationId: organization.id,
           userId: user.id,
         });
-        participation = databaseBuilder.factory.buildCampaignParticipation({
+        databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           organizationLearnerId: organizationLearner.id,
         });
@@ -1193,35 +1193,12 @@ describe('Acceptance | Application | organization-controller', function () {
       });
 
       it('should return the matching sup participants as JSON API', async function () {
-        // given
-        const expectedResult = {
-          data: [
-            {
-              attributes: {
-                'last-name': organizationLearner.lastName,
-                'first-name': organizationLearner.firstName,
-                birthdate: organizationLearner.birthdate,
-                'student-number': organizationLearner.studentNumber,
-                group: organizationLearner.group,
-                'participation-count': 1,
-                'last-participation-date': participation.createdAt,
-                'campaign-name': campaign.name,
-                'campaign-type': campaign.type,
-                'participation-status': participation.status,
-                'is-certifiable': participation.isCertifiable,
-              },
-              id: organizationLearner.id.toString(),
-              type: 'sup-organization-participants',
-            },
-          ],
-        };
-
         // when
         const response = await server.inject(options);
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data).to.deep.equal(expectedResult.data);
+        expect(response.result.data.length).to.equal(1);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -1004,6 +1004,66 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         // then
         expect(isCertifiable).to.equal(campaignParticipation.isCertifiable);
       });
+
+      context('#certifiableAt', function () {
+        it('should return the date of the participation as certifiableAt property', async function () {
+          // given
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({
+            organizationId,
+            type: CampaignTypes.PROFILES_COLLECTION,
+          }).id;
+          const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+          const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            organizationLearnerId,
+            status: CampaignParticipationStatuses.SHARED,
+            sharedAt: new Date('2021-01-01'),
+            isCertifiable: true,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const {
+            data: [{ certifiableAt }],
+          } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+            organizationId,
+          });
+
+          // then
+          expect(certifiableAt).to.deep.equal(campaignParticipation.sharedAt);
+        });
+
+        it('should return null for certifiableAt property if the organization learner is not certifiable', async function () {
+          // given
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({
+            organizationId,
+            type: CampaignTypes.PROFILES_COLLECTION,
+          }).id;
+          const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            organizationLearnerId,
+            status: CampaignParticipationStatuses.SHARED,
+            sharedAt: new Date('2021-01-01'),
+            isCertifiable: false,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const {
+            data: [{ certifiableAt }],
+          } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+            organizationId,
+          });
+
+          // then
+          expect(certifiableAt).to.equal(null);
+        });
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization/sup-organization-participants-serializer_test.js
@@ -21,6 +21,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
           campaignType: 'ASSESSMENT',
           participationStatus: campaignParticipationsStatuses.TO_SHARE,
           isCertifiable: true,
+          certifiableAt: new Date('2021-03-07'),
         }),
         new SupOrganizationParticipant({
           id: 778,
@@ -35,6 +36,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
           campaignType: 'PROFILES_COLLECTION',
           participationStatus: campaignParticipationsStatuses.SHARED,
           isCertifiable: false,
+          certifiableAt: null,
         }),
       ];
       const pagination = { page: { number: 1, pageSize: 2 } };
@@ -58,6 +60,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
               'campaign-type': supOrganizationParticipants[0].campaignType,
               'participation-status': supOrganizationParticipants[0].participationStatus,
               'is-certifiable': supOrganizationParticipants[0].isCertifiable,
+              'certifiable-at': supOrganizationParticipants[0].certifiableAt,
             },
           },
           {
@@ -75,6 +78,7 @@ describe('Unit | Serializer | JSONAPI | sup-organization-participants-serializer
               'campaign-type': supOrganizationParticipants[1].campaignType,
               'participation-status': supOrganizationParticipants[1].participationStatus,
               'is-certifiable': supOrganizationParticipants[1].isCertifiable,
+              'certifiable-at': supOrganizationParticipants[1].certifiableAt,
             },
           },
         ],

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -95,6 +95,13 @@
             </td>
             <td class="table__column--center">
               <Ui::IsCertifiable @isCertifiable={{student.isCertifiable}} />
+              {{#if student.certifiableAt}}
+                <span class="organization-participant-list-page__certifiable-at">{{moment-format
+                    student.certifiableAt
+                    "DD/MM/YYYY"
+                    allow-empty=true
+                  }}</span>
+              {{/if}}
             </td>
             <td class="organization-participant-list-page__actions hide-on-mobile">
               {{#if this.currentUser.isAdminInOrganization}}

--- a/orga/app/models/sup-organization-participant.js
+++ b/orga/app/models/sup-organization-participant.js
@@ -13,4 +13,5 @@ export default class SupOrganizationParticipant extends Model {
   @attr('string') participationStatus;
   @belongsTo('organization') organization;
   @attr('boolean', { allowNull: true }) isCertifiable;
+  @attr('string') certifiableAt;
 }

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -125,6 +125,28 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
   });
 
+  test('it should display since when the sup participant is certifiable', async function (assert) {
+    // given
+    const students = [
+      {
+        lastParticipationDate: new Date('2022-01-03'),
+        campaignName: 'SUP - Campagne de collecte de profils',
+        campaignType: 'PROFILES_COLLECTION',
+        participationStatus: 'SHARED',
+        isCertifiable: true,
+        certifiableAt: new Date('2022-01-03'),
+      },
+    ];
+
+    this.set('students', students);
+
+    // when
+    await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+    // then
+    assert.contains('03/01/2022');
+  });
+
   module('when user is filtering some users', function () {
     test('it should trigger filtering with lastname', async function (assert) {
       const triggerFiltering = sinon.spy();


### PR DESCRIPTION
## :unicorn: Problème
Dans la suite de l'épix 'calcul de la certificabilité', nous affichons la certificabilité. Mais on ne sait pas de quand date cette certification. 

## :robot: Solution
Afficher la date de certificabilité quand le prescrit est certifiable.

## :rainbow: Remarques


## :100: Pour tester
- se connecter à pix orga pour sup
- aller sur la page Étudiants
- lorsque que le prescrit est certifiable voir la date de certificabilité
