### PR TITLE
[BUGFIX] Valider le userId lors de la récupération des méthodes d'authentification

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -871,6 +871,11 @@ exports.register = async function (server) {
       method: 'GET',
       path: '/api/users/{id}/authentication-methods',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         pre: [
           {
             method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -531,6 +531,25 @@ describe('Unit | Router | user-router', function () {
     });
   });
 
+  describe('GET /api/users/{id}/authentication-methods', function () {
+    const method = 'GET';
+
+    it('should return 400 when userId is not a number', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const userId = 'wrongId';
+      const url = `/api/users/${userId}/authentication-methods`;
+
+      // when
+      const result = await httpTestServer.request(method, url);
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+  });
+
   context('Routes /admin', function () {
     describe('GET /api/admin/users', function () {
       it('should return an HTTP status code 200', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Si un GET est fait sur ` /api/users/{id}/authentication-method` avec un userId invalide (pas un nombre), l'API retourne une erreur 500 car la requête échoue en BDD

```js
error: /* path: /api/users/{id}/authentication-methods */ select "id", "identityProvider", "authenticationComplement", "externalIdentifier", "userId", "createdAt", "updatedAt" from "authentication-methods" where "userId" = $1 order by "id" ASC - invalid input syntax for type integer: "<USER_ID>'+order+by+1--"
    at Parser.parseErrorMessage (/app/node_modules/pg-protocol/dist/parser.js:287:98)
    at Parser.handlePacket (/app/node_modules/pg-protocol/dist/parser.js:126:29)
    at Parser.parse (/app/node_modules/pg-protocol/dist/parser.js:39:38)
    at TLSSocket.<anonymous> (/app/node_modules/pg-protocol/dist/index.js:11:42)
    at TLSSocket.emit (node:events:520:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at TLSSocket.Readable.push (node:internal/streams/readable:228:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:190:23)
    at TLSWrap.callbackTrampoline (node:internal/async_hooks:130:17)
```

## :robot: Solution
Vérifier le format du `userId` en entrée (nombre)
Remonter une erreur  400 s'il est incorrect

## :rainbow: Remarques
Il y a d'autres routes, elles seront traitées dans une autre PR

## :100: Pour tester
Appeler la route en curl 
```
curl 'https://app.integration.pix.fr/api/users/104a/authentication-methods' -H 'Authorization: Bearer <TOKEN'
```