### PR TITLE
[FEATURE] Script de création de lien entre les formations et les profils cibles (PIX-5774)

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -1,0 +1,24 @@
+const databaseBuffer = require('../database-buffer');
+
+function buildTraining({
+  id = databaseBuffer.getNextId(),
+  title = 'title',
+  link = 'http://mon-link.com',
+  type = 'webinaire',
+  duration = '06:00:00',
+  locale = 'fr-fr',
+} = {}) {
+  const values = {
+    id,
+    title,
+    link,
+    type,
+    duration,
+    locale,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'trainings',
+    values,
+  });
+}
+module.exports = buildTraining;

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -61,6 +61,7 @@ module.exports = {
   buildTargetProfileSkill: require('./build-target-profile-skill'),
   buildTargetProfileShare: require('./build-target-profile-share'),
   buildTargetProfileTube: require('./build-target-profile-tube'),
+  buildTraining: require('./build-training'),
   buildTutorialEvaluation: require('./build-tutorial-evaluation'),
   buildUser: require('./build-user'),
   buildUserOrgaSettings: require('./build-user-orga-settings'),

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -1,5 +1,8 @@
 const trainingDatasource = require('../datasources/learning-content/training-datasource');
 const Training = require('../../domain/models/Training');
+const { knex } = require('../../../db/knex-database-connection');
+const { NotFoundError } = require('../../domain/errors');
+const TABLE_NAME = 'trainings';
 
 module.exports = {
   async findByTargetProfileIdAndLocale({ targetProfileId, locale = 'fr-fr' }) {
@@ -10,6 +13,14 @@ module.exports = {
       return hasTargetProfileId && hasLocale;
     });
     return trainings.map(_toDomain);
+  },
+
+  async get(id) {
+    const training = await knex(TABLE_NAME).where({ id }).first();
+    if (!training) {
+      throw new NotFoundError(`Not found training for ID ${id}`);
+    }
+    return _toDomain(training);
   },
 };
 

--- a/api/scripts/create-target-profile-trainings.js
+++ b/api/scripts/create-target-profile-trainings.js
@@ -1,0 +1,66 @@
+const { knex, disconnect } = require('../db/knex-database-connection');
+const trainingRepository = require('../lib/infrastructure/repositories/training-repository');
+const targetProfileRepository = require('../lib/infrastructure/repositories/target-profile-repository');
+const { NotFoundError } = require('../lib/domain/errors');
+
+async function checkTrainingExistence(trainingId) {
+  try {
+    await trainingRepository.get(trainingId);
+  } catch {
+    throw new NotFoundError(`Training ${trainingId} not found`);
+  }
+}
+
+async function checkTargetProfileExistence(targetProfileId) {
+  try {
+    await targetProfileRepository.get(targetProfileId);
+  } catch {
+    throw new NotFoundError(`Target profile ${targetProfileId} not found`);
+  }
+}
+
+async function createTargetProfileTraining(targetProfileTrainings) {
+  return knex.batchInsert('target-profile-trainings', targetProfileTrainings);
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  console.log('Starting creating target-profile-trainings.');
+
+  const filePath = process.argv[2];
+  console.log(filePath);
+
+  console.log('Reading json data file... ');
+  const jsonFile = require(filePath);
+  console.log('File exists. Browsing data...');
+
+  for (const { trainingId, targetProfileId } of jsonFile) {
+    await checkTrainingExistence(trainingId);
+    await checkTargetProfileExistence(targetProfileId);
+    console.log('Training & Target profile exist');
+  }
+
+  console.log('Insert target-profile-training in database...');
+  await createTargetProfileTraining(jsonFile);
+  console.log('\nDone.');
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = {
+  createTargetProfileTraining,
+  checkTrainingExistence,
+  checkTargetProfileExistence,
+};

--- a/api/tests/integration/scripts/create-target-profile-trainings_test.js
+++ b/api/tests/integration/scripts/create-target-profile-trainings_test.js
@@ -1,0 +1,53 @@
+const { expect, catchErr, databaseBuilder } = require('../../test-helper');
+const {
+  checkTrainingExistence,
+  checkTargetProfileExistence,
+} = require('../../../scripts/create-target-profile-trainings');
+
+describe('Unit | Scripts | create-target-profile-trainings.js', function () {
+  describe('#checkTrainingExistence', function () {
+    it(`should throw an error when training doesn't exist`, async function () {
+      // given
+      const trainingId = 1;
+
+      // when
+      const error = await catchErr(checkTrainingExistence)(trainingId);
+
+      // then
+      expect(error).to.be.an.instanceof(Error);
+      expect(error.message).to.be.equal(`Training ${trainingId} not found`);
+    });
+
+    it('should not throw an error if the training exists', async function () {
+      // given
+      const training = databaseBuilder.factory.buildTraining();
+      await databaseBuilder.commit();
+
+      // when
+      expect(await checkTrainingExistence(training.id)).not.to.throw;
+    });
+  });
+
+  describe('#checkTargetProfileExistence', function () {
+    it(`should throw an error when targetProfile doesn't exist`, async function () {
+      // given
+      const targetProfileId = 1;
+
+      // when
+      const error = await catchErr(checkTargetProfileExistence)(targetProfileId);
+
+      // then
+      expect(error).to.be.an.instanceof(Error);
+      expect(error.message).to.be.equal(`Target profile ${targetProfileId} not found`);
+    });
+
+    it('should not throw an error if the targetProfile exists', async function () {
+      // given
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      await databaseBuilder.commit();
+
+      // when
+      expect(await checkTargetProfileExistence(targetProfile.id)).not.to.throw;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin d'avoir un script pour ajouter un lien entre les formations et les profils cibles. 

## :robot: Solution
Création du script.

## :100: Pour tester
Pré-requis : Avoir des `targetProfile` et des `trainings` en db.
- Créer un fichier `data.json` :
```
[
    {
    "trainingId": 7, 
    "targetProfileId": 1
    },
    {
    "trainingId":7, 
    "targetProfileId": 2
    },
    {
    "trainingId": 9, 
    "targetProfileId": 1
    },
    {
    "trainingId": 8, 
    "targetProfileId": 2
    }
]
```

- Lancer la commande  : `node scripts/create-target-profile-trainings [full-path]/data.json `
- Vérifier dans la DB que le contenu se retrouve dans la table `target-profile-trainings`

Faites le même process, en ajoutant soit des `trainingId` non existants soit des `targetProfileId` non existants. Vérifiez alors les messages d'erreurs dans la console.
