### PR TITLE
[BUG] Corrige le filtre de certificabilité sur la page élèves (PIX-5817)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -775,7 +775,7 @@ exports.register = async (server) => {
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[connexionType]': Joi.string().empty(''),
             'filter[search]': Joi.string().empty(''),
-            'filter[certificability]': [Joi.string()],
+            'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),
         },
         handler: organizationController.findPaginatedFilteredScoParticipants,

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1081,6 +1081,36 @@ describe('Acceptance | Application | organization-controller', function () {
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.deep.equal(expectedResult.data);
       });
+
+      it('should filter certificability with one value', async function () {
+        // given
+        options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/sco-participants?filter[certificability][]=eligible`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should filter certificability with two values', async function () {
+        // given
+        options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/sco-participants?filter[certificability][]=eligible&filter[certificability][]=not-available`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
     });
 
     context('Resource access management', function () {


### PR DESCRIPTION
## :unicorn: Problème
Suite à du refactoring fait dans le cadre de PIX-5566 le filtre de certificabilité dans la page élèves ne fonctionne plus.

## :robot: Solution
Le problème est dû à une mauvaise configuration de la validation des query params sur le endpoint. Cette PR corrige la configuration et ajoute 2 tests.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter sur pix Orga avec le compte admin sco
- Aller sur la page élèves
- Tester toutes possibilités du filtre de certificabilité.
- Tada