### PR TITLE
[FEATURE] Admin: Ajouter la possibilité de modifier les informations du DPO d'une organisation (PIX-4469)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -57,6 +57,59 @@
     </div>
 
     <div class="form-field">
+      <label for="dataProtectionOfficerFirstName" class="form-field__label">Prénom du DPO</label>
+      {{#if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")}}
+        <div class="form-field__error">
+          {{v-get this.form "dataProtectionOfficerFirstName" "message"}}
+        </div>
+      {{/if}}
+      <Input
+        id="dataProtectionOfficerFirstName"
+        @type="text"
+        class={{if
+          (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")
+          "form-control is-invalid"
+          "form-control"
+        }}
+        @value={{this.form.dataProtectionOfficerFirstName}}
+      />
+    </div>
+
+    <div class="form-field">
+      <label for="dataProtectionOfficerLastName" class="form-field__label">Nom du DPO</label>
+      {{#if (v-get this.form "dataProtectionOfficerLastName" "isInvalid")}}
+        <div class="form-field__error">
+          {{v-get this.form "dataProtectionOfficerLastName" "message"}}
+        </div>
+      {{/if}}
+      <Input
+        id="dataProtectionOfficerLastName"
+        @type="text"
+        class={{if
+          (v-get this.form "dataProtectionOfficerLastName" "isInvalid")
+          "form-control is-invalid"
+          "form-control"
+        }}
+        @value={{this.form.dataProtectionOfficerLastName}}
+      />
+    </div>
+
+    <div class="form-field">
+      <label for="dataProtectionOfficerEmail" class="form-field__label">Adresse e-mail du DPO</label>
+      {{#if (v-get this.form "dataProtectionOfficerEmail" "isInvalid")}}
+        <div class="form-field__error">
+          {{v-get this.form "dataProtectionOfficerEmail" "message"}}
+        </div>
+      {{/if}}
+      <Input
+        id="dataProtectionOfficerEmail"
+        @type="text"
+        class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
+        @value={{this.form.dataProtectionOfficerEmail}}
+      />
+    </div>
+
+    <div class="form-field">
       <label for="credits" class="form-field__label">Crédits</label>
       {{#if (v-get this.form "credit" "isInvalid")}}
         <div class="form-field__error">

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -38,6 +38,35 @@ const Validations = buildValidations({
       }),
     ],
   },
+  dataProtectionOfficerFirstName: {
+    validators: [
+      validator('length', {
+        max: 255,
+        message: 'La longueur du prénom ne doit pas excéder 255 caractères.',
+      }),
+    ],
+  },
+  dataProtectionOfficerLastName: {
+    validators: [
+      validator('length', {
+        max: 255,
+        message: 'La longueur du nom ne doit pas excéder 255 caractères.',
+      }),
+    ],
+  },
+  dataProtectionOfficerEmail: {
+    validators: [
+      validator('length', {
+        max: 255,
+        message: "La longueur de l'email ne doit pas excéder 255 caractères.",
+      }),
+      validator('format', {
+        allowBlank: true,
+        type: 'email',
+        message: "L'e-mail n'a pas le bon format.",
+      }),
+    ],
+  },
   email: {
     validators: [
       validator('length', {
@@ -89,6 +118,9 @@ class Form extends Object.extend(Validations) {
   @tracked name;
   @tracked externalId;
   @tracked provinceCode;
+  @tracked dataProtectionOfficerFirstName;
+  @tracked dataProtectionOfficerLastName;
+  @tracked dataProtectionOfficerEmail;
   @tracked email;
   @tracked credit;
   @tracked isManagingStudents;
@@ -155,6 +187,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('name', this.form.name);
     this.args.organization.set('externalId', this.form.externalId);
     this.args.organization.set('provinceCode', this.form.provinceCode);
+    this.args.organization.set('dataProtectionOfficerFirstName', this.form.dataProtectionOfficerFirstName);
+    this.args.organization.set('dataProtectionOfficerLastName', this.form.dataProtectionOfficerLastName);
+    this.args.organization.set('dataProtectionOfficerEmail', this.form.dataProtectionOfficerEmail);
     this.args.organization.set('email', this.form.email);
     this.args.organization.set('credit', this.form.credit);
     this.args.organization.set('isManagingStudents', this.form.isManagingStudents);
@@ -170,6 +205,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.form.name = this.args.organization.name;
     this.form.externalId = this.args.organization.externalId;
     this.form.provinceCode = this.args.organization.provinceCode;
+    this.form.dataProtectionOfficerFirstName = this.args.organization.dataProtectionOfficerFirstName;
+    this.form.dataProtectionOfficerLastName = this.args.organization.dataProtectionOfficerLastName;
+    this.form.dataProtectionOfficerEmail = this.args.organization.dataProtectionOfficerEmail;
     this.form.email = this.args.organization.email;
     this.form.credit = this.args.organization.credit;
     this.form.isManagingStudents = this.args.organization.isManagingStudents;

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -23,10 +23,15 @@ module('Acceptance | Organizations | Information management', function (hooks) {
 
       // when
       await fillByLabel('* Nom', 'newOrganizationName');
+      await fillByLabel('Prénom du DPO', 'Bru');
+      await fillByLabel('Nom du DPO', 'No');
+      await fillByLabel('Adresse e-mail du DPO', 'bru.no@example.net');
       await clickByName('Enregistrer', { exact: true });
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'newOrganizationName' })).exists();
+      assert.dom(screen.getByText('Nom du DPO : Bru No')).exists();
+      assert.dom(screen.getByText('Adresse e-mail du DPO : bru.no@example.net')).exists();
     });
   });
 

--- a/admin/tests/integration/components/organizations/information-section-edit_test.js
+++ b/admin/tests/integration/components/organizations/information-section-edit_test.js
@@ -76,6 +76,28 @@ module('Integration | Component | organizations/information-section-edit', funct
       assert.dom(screen.getByText('La longueur du département ne doit pas excéder 255 caractères')).exists();
     });
 
+    test("it should show error message if organization's data protection officer email is longer than 255 characters", async function (assert) {
+      // given
+      const screen = await render(hbs`<Organizations::InformationSectionEdit @organization={{this.organization}} />`);
+
+      // when
+      await fillByLabel('Adresse e-mail du DPO', 'a'.repeat(256));
+
+      // then
+      assert.dom(screen.getByText("La longueur de l'email ne doit pas excéder 255 caractères.")).exists();
+    });
+
+    test("it should show error message if organization's data protection officer email is not valid", async function (assert) {
+      // given
+      const screen = await render(hbs`<Organizations::InformationSectionEdit @organization={{this.organization}} />`);
+
+      // when
+      await fillByLabel('Adresse e-mail du DPO', 'not-valid-email-format');
+
+      // then
+      assert.dom(screen.getByText("L'e-mail n'a pas le bon format.")).exists();
+    });
+
     test("it should show error message if organization's email is longer than 255 characters", async function (assert) {
       // given
       const screen = await render(hbs`<Organizations::InformationSectionEdit @organization={{this.organization}} />`);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -70,6 +70,7 @@ const dependencies = {
   countryRepository: require('../../infrastructure/repositories/country-repository'),
   courseRepository: require('../../infrastructure/repositories/course-repository'),
   cpfCertificationResultRepository: require('../../infrastructure/repositories/cpf-certification-result-repository'),
+  dataProtectionOfficerRepository: require('../../infrastructure/repositories/data-protection-officer-repository'),
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
   endTestScreenRemovalService: require('../services/end-test-screen-removal-service'),

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -2,35 +2,6 @@ const bluebird = require('bluebird');
 const _ = require('lodash');
 const OrganizationTag = require('../models/OrganizationTag');
 
-module.exports = async function updateOrganizationInformation({
-  organization,
-  organizationForAdminRepository,
-  organizationTagRepository,
-  tagRepository,
-}) {
-  const existingOrganization = await organizationForAdminRepository.get(organization.id);
-  await _updateOrganizationTags({
-    organization,
-    existingOrganization,
-    organizationTagRepository,
-    tagRepository,
-  });
-
-  if (organization.name) existingOrganization.name = organization.name;
-  if (organization.type) existingOrganization.type = organization.type;
-  if (organization.logoUrl) existingOrganization.logoUrl = organization.logoUrl;
-  existingOrganization.email = organization.email;
-  existingOrganization.credit = organization.credit;
-  existingOrganization.externalId = organization.externalId;
-  existingOrganization.provinceCode = organization.provinceCode;
-  existingOrganization.isManagingStudents = organization.isManagingStudents;
-  existingOrganization.documentationUrl = organization.documentationUrl;
-  existingOrganization.showSkills = organization.showSkills;
-  existingOrganization.identityProviderForCampaigns = organization.identityProviderForCampaigns;
-
-  return organizationForAdminRepository.update(existingOrganization);
-};
-
 async function _updateOrganizationTags({
   organization,
   existingOrganization,
@@ -62,3 +33,32 @@ async function _updateOrganizationTags({
     });
   }
 }
+
+module.exports = async function updateOrganizationInformation({
+  organization,
+  organizationForAdminRepository,
+  organizationTagRepository,
+  tagRepository,
+}) {
+  const existingOrganization = await organizationForAdminRepository.get(organization.id);
+  await _updateOrganizationTags({
+    organization,
+    existingOrganization,
+    organizationTagRepository,
+    tagRepository,
+  });
+
+  if (organization.name) existingOrganization.name = organization.name;
+  if (organization.type) existingOrganization.type = organization.type;
+  if (organization.logoUrl) existingOrganization.logoUrl = organization.logoUrl;
+  existingOrganization.email = organization.email;
+  existingOrganization.credit = organization.credit;
+  existingOrganization.externalId = organization.externalId;
+  existingOrganization.provinceCode = organization.provinceCode;
+  existingOrganization.isManagingStudents = organization.isManagingStudents;
+  existingOrganization.documentationUrl = organization.documentationUrl;
+  existingOrganization.showSkills = organization.showSkills;
+  existingOrganization.identityProviderForCampaigns = organization.identityProviderForCampaigns;
+
+  return organizationForAdminRepository.update(existingOrganization);
+};

--- a/api/lib/infrastructure/repositories/data-protection-officer-repository.js
+++ b/api/lib/infrastructure/repositories/data-protection-officer-repository.js
@@ -1,4 +1,5 @@
 const { knex } = require('../../../db/knex-database-connection');
+const DataProtectionOfficer = require('../../domain/models/DataProtectionOfficer');
 const DomainTransaction = require('../DomainTransaction');
 
 const DATA_PROTECTION_OFFICERS_TABLE_NAME = 'data-protection-officers';
@@ -12,6 +13,55 @@ async function batchAddDataProtectionOfficerToOrganization(
     .transacting(domainTransaction.knexTransaction);
 }
 
+async function get({ organizationId = null, certificationCenterId = null }) {
+  const [dataProtectionOfficerRow] = await knex(DATA_PROTECTION_OFFICERS_TABLE_NAME)
+    .where({ organizationId, certificationCenterId })
+    .returning('*');
+
+  if (!dataProtectionOfficerRow) return;
+
+  return new DataProtectionOfficer(dataProtectionOfficerRow);
+}
+
+async function create(dataProtectionOfficer, { knexTransaction } = DomainTransaction.emptyTransaction()) {
+  const { firstName, lastName, email, organizationId, certificationCenterId } = dataProtectionOfficer;
+  const query = knex(DATA_PROTECTION_OFFICERS_TABLE_NAME).insert({
+    firstName,
+    lastName,
+    email,
+    organizationId,
+    certificationCenterId,
+  });
+
+  if (knexTransaction) query.transacting(knexTransaction);
+
+  const [dataProtectionOfficerRow] = await query.returning('*');
+
+  return new DataProtectionOfficer(dataProtectionOfficerRow);
+}
+
+async function update(dataProtectionOfficer) {
+  const { firstName, lastName, email, organizationId, certificationCenterId } = dataProtectionOfficer;
+  const updatedAt = new Date();
+
+  const query = knex(DATA_PROTECTION_OFFICERS_TABLE_NAME).update({
+    firstName,
+    lastName,
+    email,
+    updatedAt,
+  });
+
+  if (organizationId) query.where({ organizationId });
+  else query.where({ certificationCenterId });
+
+  const [dataProtectionOfficerRow] = await query.returning('*');
+
+  return new DataProtectionOfficer(dataProtectionOfficerRow);
+}
+
 module.exports = {
   batchAddDataProtectionOfficerToOrganization,
+  create,
+  get,
+  update,
 };

--- a/api/lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-for-admin-serializer.js
@@ -83,6 +83,9 @@ module.exports = {
       documentationUrl: attributes['documentation-url'],
       showSkills: attributes['show-skills'],
       identityProviderForCampaigns: attributes['identity-provider-for-campaigns'],
+      dataProtectionOfficerFirstName: attributes['data-protection-officer-first-name'],
+      dataProtectionOfficerLastName: attributes['data-protection-officer-last-name'],
+      dataProtectionOfficerEmail: attributes['data-protection-officer-email'],
       tags,
     });
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -154,6 +154,7 @@ describe('Acceptance | Application | organization-controller', function () {
   describe('PATCH /api/admin/organizations/{id}', function () {
     afterEach(async function () {
       await knex('organization-tags').delete();
+      await knex('data-protection-officers').delete();
     });
 
     it('should return the updated organization and status code 200', async function () {

--- a/api/tests/integration/infrastructure/repositories/data-protection-officer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/data-protection-officer-repository_test.js
@@ -1,12 +1,15 @@
-const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { databaseBuilder, expect, knex } = require('../../../test-helper');
+const DataProtectionOfficer = require('../../../../lib/domain/models/DataProtectionOfficer');
 const dataProtectionOfficerRepository = require('../../../../lib/infrastructure/repositories/data-protection-officer-repository');
 
 describe('Integration | Repository | data-protection-officer', function () {
-  describe('#batchAddDataProtectionOfficerToOrganization', function () {
-    afterEach(function () {
-      return knex('data-protection-officers').delete();
-    });
+  const now = new Date('2022-09-27T16:30:00Z');
 
+  afterEach(async function () {
+    await knex('data-protection-officers').delete();
+  });
+
+  describe('#batchAddDataProtectionOfficerToOrganization', function () {
     it('should add rows in the table "data-protection-officers"', async function () {
       // given
       const firstOrganization = databaseBuilder.factory.buildOrganization();
@@ -43,6 +46,137 @@ describe('Integration | Repository | data-protection-officer', function () {
       expect(foundDataProtectionOfficers[1]).to.contain({
         ...dataProtectionOfficerB,
         organizationId: secondOrganization.id,
+      });
+    });
+  });
+
+  describe('#create', function () {
+    context('on success', function () {
+      it('should return a DPO domain object', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const organization = databaseBuilder.factory.buildOrganization({
+          name: 'InYak',
+          createdBy: user.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const dataProtectionOfficer = new DataProtectionOfficer({
+          firstName: 'Justin',
+          lastName: 'Ptipeu',
+          email: 'justin.ptipeu@example.net',
+          organizationId: organization.id,
+        });
+        const dataProtectionOfficerSaved = await dataProtectionOfficerRepository.create(dataProtectionOfficer);
+
+        // then
+        expect(dataProtectionOfficerSaved).to.be.an.instanceof(DataProtectionOfficer);
+        expect(dataProtectionOfficerSaved).to.deep.equal({
+          id: dataProtectionOfficerSaved.id,
+          firstName: 'Justin',
+          lastName: 'Ptipeu',
+          email: 'justin.ptipeu@example.net',
+          organizationId: organization.id,
+          certificationCenterId: null,
+          createdAt: dataProtectionOfficerSaved.createdAt,
+          updatedAt: dataProtectionOfficerSaved.updatedAt,
+        });
+      });
+    });
+  });
+
+  describe('#get', function () {
+    context('on success', function () {
+      context('when DPO exists', function () {
+        it('should return a DPO domain object', async function () {
+          // given
+          const user = databaseBuilder.factory.buildUser();
+          const organization = databaseBuilder.factory.buildOrganization({
+            name: 'InYak',
+            createdBy: user.id,
+          });
+          const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+            firstName: 'Justin',
+            lastName: 'Ptipeu',
+            email: 'justin.ptipeu@example.net',
+            organizationId: organization.id,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const dataProtectionOfficerFound = await dataProtectionOfficerRepository.get({
+            organizationId: organization.id,
+          });
+
+          // then
+          expect(dataProtectionOfficerFound).to.be.an.instanceof(DataProtectionOfficer);
+          expect(dataProtectionOfficerFound).to.deep.equal({
+            id: dataProtectionOfficer.id,
+            firstName: 'Justin',
+            lastName: 'Ptipeu',
+            email: 'justin.ptipeu@example.net',
+            organizationId: organization.id,
+            certificationCenterId: null,
+            createdAt: dataProtectionOfficer.createdAt,
+            updatedAt: dataProtectionOfficer.updatedAt,
+          });
+        });
+      });
+
+      context('when DPO does not exist', function () {
+        it('should return undefined', async function () {
+          // given & when
+          const dataProtectionOfficerFound = await dataProtectionOfficerRepository.get({ organizationId: 1234 });
+
+          // then
+          expect(dataProtectionOfficerFound).to.be.undefined;
+        });
+      });
+    });
+  });
+
+  describe('#update', function () {
+    context('on success', function () {
+      it('should return a DPO domain object', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const organization = databaseBuilder.factory.buildOrganization({
+          name: 'UruYak',
+          createdBy: user.id,
+        });
+        const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+          firstName: 'Justin',
+          lastName: 'Ptipeu',
+          email: 'justin.ptipeu@example.net',
+          organizationId: organization.id,
+          createdAt: now,
+          updatedAt: now,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const dataProtectionOfficerToUpdate = new DataProtectionOfficer({
+          id: dataProtectionOfficer.id,
+          firstName: '',
+          lastName: '',
+          email: '',
+          organizationId: organization.id,
+        });
+        const dataProtectionOfficerSaved = await dataProtectionOfficerRepository.update(dataProtectionOfficerToUpdate);
+
+        // then
+        expect(dataProtectionOfficerSaved).to.be.an.instanceof(DataProtectionOfficer);
+        expect(dataProtectionOfficerSaved).to.deep.equal({
+          id: dataProtectionOfficerSaved.id,
+          firstName: '',
+          lastName: '',
+          email: '',
+          organizationId: organization.id,
+          certificationCenterId: null,
+          createdAt: now,
+          updatedAt: dataProtectionOfficerSaved.updatedAt,
+        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -7,11 +7,17 @@ const OrganizationForAdmin = require('../../../../lib/domain/models/Organization
 const OidcIdentityProviders = require('../../../../lib/domain/constants/oidc-identity-providers');
 
 describe('Unit | UseCase | update-organization-information', function () {
+  let dataProtectionOfficerRepository;
   let organizationForAdminRepository;
   let organizationTagRepository;
   let tagRepository;
 
   beforeEach(function () {
+    dataProtectionOfficerRepository = {
+      create: sinon.stub(),
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
     organizationForAdminRepository = {
       get: sinon.stub(),
       update: sinon.stub(),
@@ -39,9 +45,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -62,9 +75,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -84,9 +104,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -106,9 +133,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -128,9 +162,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -150,9 +191,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -172,9 +220,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -193,9 +248,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
         ...originalOrganization,
         isManagingStudents: false,
@@ -213,9 +275,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -235,9 +304,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -257,9 +333,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -279,9 +362,16 @@ describe('Unit | UseCase | update-organization-information', function () {
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
       organizationForAdminRepository.get.resolves(originalOrganization);
+      organizationForAdminRepository.update.resolves({});
+      dataProtectionOfficerRepository.get.resolves({});
+      dataProtectionOfficerRepository.update.resolves({});
 
       // when
-      await updateOrganizationInformation({ organization: givenOrganization, organizationForAdminRepository });
+      await updateOrganizationInformation({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        dataProtectionOfficerRepository,
+      });
 
       // then
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
@@ -306,6 +396,9 @@ describe('Unit | UseCase | update-organization-information', function () {
 
         organizationForAdminRepository.get.withArgs(organizationId).resolves(originalOrganization);
         tagRepository.get.withArgs(tagToAdd.id).resolves(originalTag);
+        organizationForAdminRepository.update.resolves({});
+        dataProtectionOfficerRepository.get.resolves({});
+        dataProtectionOfficerRepository.update.resolves({});
 
         // when
         await updateOrganizationInformation({
@@ -313,6 +406,7 @@ describe('Unit | UseCase | update-organization-information', function () {
           organizationForAdminRepository,
           organizationTagRepository,
           tagRepository,
+          dataProtectionOfficerRepository,
         });
 
         // given
@@ -344,6 +438,9 @@ describe('Unit | UseCase | update-organization-information', function () {
         organizationTagRepository.findOneByOrganizationIdAndTagId
           .withArgs({ organizationId: originalOrganization.id, tagId: originalTag.id })
           .resolves(organizationTagToRemove);
+        organizationForAdminRepository.update.resolves({});
+        dataProtectionOfficerRepository.get.resolves({});
+        dataProtectionOfficerRepository.update.resolves({});
 
         // when
         await updateOrganizationInformation({
@@ -351,6 +448,7 @@ describe('Unit | UseCase | update-organization-information', function () {
           organizationForAdminRepository,
           organizationTagRepository,
           tagRepository,
+          dataProtectionOfficerRepository,
         });
 
         // given
@@ -358,6 +456,79 @@ describe('Unit | UseCase | update-organization-information', function () {
           organizationTagId: organizationTagToRemove.id,
         });
         expect(organizationTagRepository.create).to.have.not.been.called;
+      });
+    });
+
+    context('when a data protection officer is linked to this organization', function () {
+      it('should allow to update the data protection officer information', async function () {
+        // given
+        const givenOrganization = {
+          id: 7,
+          dataProtectionOfficerFirstName: 'Infinite',
+          dataProtectionOfficerLastName: 'Blossom',
+          dataProtectionOfficerEmail: 'karasu.nogymx@example.net',
+        };
+
+        organizationForAdminRepository.get.resolves({ id: 7 });
+        organizationForAdminRepository.update.resolves({ id: 7 });
+        dataProtectionOfficerRepository.get.resolves({ id: 1 });
+        dataProtectionOfficerRepository.update.resolves({
+          id: 1,
+          firstName: 'Infinite',
+          lastName: 'Blossom',
+          email: 'karasu.nogymx@example.net',
+          organizationId: 7,
+        });
+
+        // when
+        await updateOrganizationInformation({
+          organization: givenOrganization,
+          organizationForAdminRepository,
+          dataProtectionOfficerRepository,
+        });
+
+        // then
+        expect(dataProtectionOfficerRepository.update).to.have.been.calledWithMatch({
+          firstName: 'Infinite',
+          lastName: 'Blossom',
+          email: 'karasu.nogymx@example.net',
+        });
+      });
+    });
+
+    context('when a data protection officer is not linked to this organization', function () {
+      it('should allow to create a data protection officer', async function () {
+        // given
+        const givenOrganization = {
+          id: 7,
+          dataProtectionOfficerFirstName: 'Infinite',
+          dataProtectionOfficerLastName: 'Blossom',
+          dataProtectionOfficerEmail: 'karasu.nogymx@example.net',
+        };
+
+        organizationForAdminRepository.get.resolves({ id: 7 });
+        organizationForAdminRepository.update.resolves({ id: 7 });
+        dataProtectionOfficerRepository.get.resolves(null);
+        dataProtectionOfficerRepository.create.resolves({
+          id: 1,
+          firstName: 'Infinite',
+          lastName: 'Blossom',
+          email: 'karasu.nogymx@example.net',
+        });
+
+        // when
+        await updateOrganizationInformation({
+          organization: givenOrganization,
+          organizationForAdminRepository,
+          dataProtectionOfficerRepository,
+        });
+
+        // then
+        expect(dataProtectionOfficerRepository.create).to.have.been.calledWithMatch({
+          firstName: 'Infinite',
+          lastName: 'Blossom',
+          email: 'karasu.nogymx@example.net',
+        });
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -124,6 +124,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         documentationUrl: 'https://pix.fr/',
         showSkills: false,
         identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+        dataProtectionOfficerFirstName: 'Justin',
+        dataProtectionOfficerLastName: 'Ptipeu',
+        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
       };
 
       // when
@@ -144,6 +147,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'documentation-url': organizationAttributes.documentationUrl,
             'show-skills': organizationAttributes.showSkills,
             'identity-provider-for-campaigns': organizationAttributes.identityProviderForCampaigns,
+            'data-protection-officer-first-name': organizationAttributes.dataProtectionOfficerFirstName,
+            'data-protection-officer-last-name': organizationAttributes.dataProtectionOfficerLastName,
+            'data-protection-officer-email': organizationAttributes.dataProtectionOfficerEmail,
           },
         },
       });
@@ -163,6 +169,9 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         documentationUrl: organizationAttributes.documentationUrl,
         showSkills: organizationAttributes.showSkills,
         identityProviderForCampaigns: organizationAttributes.identityProviderForCampaigns,
+        dataProtectionOfficerFirstName: organizationAttributes.dataProtectionOfficerFirstName,
+        dataProtectionOfficerLastName: organizationAttributes.dataProtectionOfficerLastName,
+        dataProtectionOfficerEmail: organizationAttributes.dataProtectionOfficerEmail,
       });
       expect(organization).to.be.instanceOf(OrganizationForAdmin);
       expect(organization).to.deep.equal(expectedOrganization);


### PR DESCRIPTION
## :unicorn: Problème

Actuellement sur Pix Admin, nous avons la possibilité de voir les informations d'un data protection office (DPO) attaché à une organisation sans pouvoir modifier ces informations.

## :robot: Solution

Modifier le formulaire d'édition d'information d'une organisation en y ajoutant 3 nouveaux champs qui seront le prénom, nom et adresse e-mail du DPO.

## :rainbow: Remarques

RAS

## :100: Pour tester

#### Rôle SUPERADMIN, SUPPORT, METIER

- Se connecter à Pix Admin avec un utilisateur ayant le rôle SUPERADMIN, SUPPORT ou METIER
- Ouvrir la page des détails d'une organisation
- Editez les informations de l'organisation en fournissant ou non les informations du DPO
- Validez les modifications
- Constatez l'affichage d'une notification de succès
- Constatez que les nouvelles informations sont visibles

#### Rôle CERTIF

- Se connecter à Pix Admin avec un utilisateur ayant le rôle CERTIF
- Ouvrir la page des détails d'une organisation
- Constatez que l'édition des informations d'une organisation n'est pas possible.
