### PR TITLE
[FEATURE] Repositionnement du header de page de détails d'une session (PIX-5748).

### DIFF
--- a/certif/app/styles/globals/pages.scss
+++ b/certif/app/styles/globals/pages.scss
@@ -1,5 +1,5 @@
 .page {
-  padding: 58px 35px;
+  padding: 48px 35px;
   flex-grow: 1;
 
   &__title {

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -10,7 +10,7 @@
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  margin: 1em 0;
+  margin-bottom: 16px;
 }
 
 .session-details-header {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l’audit design Pix Certif, une anomalie a été remontée sur la page détail d’une session.
Il y a une marge trop importante entre le haut de la page et le header.

## :robot: Solution

Plutôt que d’avoir 74px entre le haut de la page et le header, nous réduisons à 48px.
De même, nous passons la marge à 32 px entre le header et la section suivante.

## :rainbow: Remarques
N/A

## :100: Pour tester
Vérifier qu'il y a 48px entre le haut de page et le header sur la page de détails d'une session.
Idem vérifier qu'il y a 32px entre le header et la section suivante sur la même page.
