### PR TITLE
[BUGFIX] Admin: Ne pas afficher NULL lorsque les champs du DPO ne sont fournis (PIX-5814)

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -56,7 +56,12 @@ export default class Organization extends Model {
   }
 
   get dataProtectionOfficerFullName() {
-    return `${this.dataProtectionOfficerFirstName} ${this.dataProtectionOfficerLastName}`;
+    const fullName = [];
+
+    if (this.dataProtectionOfficerFirstName) fullName.push(this.dataProtectionOfficerFirstName);
+    if (this.dataProtectionOfficerLastName) fullName.push(this.dataProtectionOfficerLastName);
+
+    return fullName.join(' ');
   }
 
   attachTargetProfiles = memberAction({

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -54,6 +54,98 @@ module('Integration | Component | organizations/information-section-view', funct
       assert.dom(screen.getByText('SSO : super-sso')).exists();
     });
 
+    module('data protection officer information', function () {
+      test('it renders complete DPO information', async function (assert) {
+        // given
+        class OidcIdentityProvidersStub extends Service {
+          list = [{ organizationName: 'super-sso', code: 'IDP' }];
+        }
+        this.owner.register('service:oidc-identity-providers', OidcIdentityProvidersStub);
+
+        this.set('organization', {
+          type: 'SUP',
+          isManagingStudents: false,
+          name: 'SUPer Orga',
+          credit: 350,
+          documentationUrl: 'https://pix.fr',
+          showSkills: true,
+          createdBy: 1,
+          createdAtFormattedDate: '02/09/2022',
+          creatorFullName: 'Gilles Parbal',
+          identityProviderForCampaigns: 'IDP',
+          dataProtectionOfficerFullName: 'Justin Ptipeu',
+          dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        });
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.getByText('Nom du DPO : Justin Ptipeu')).exists();
+        assert.dom(screen.getByText('Adresse e-mail du DPO : justin.ptipeu@example.net')).exists();
+      });
+
+      test('it renders partial DPO information', async function (assert) {
+        // given
+        class OidcIdentityProvidersStub extends Service {
+          list = [{ organizationName: 'super-sso', code: 'IDP' }];
+        }
+        this.owner.register('service:oidc-identity-providers', OidcIdentityProvidersStub);
+
+        this.set('organization', {
+          type: 'SUP',
+          isManagingStudents: false,
+          name: 'SUPer Orga',
+          credit: 350,
+          documentationUrl: 'https://pix.fr',
+          showSkills: true,
+          createdBy: 1,
+          createdAtFormattedDate: '02/09/2022',
+          creatorFullName: 'Gilles Parbal',
+          identityProviderForCampaigns: 'IDP',
+          dataProtectionOfficerFullName: 'Ptipeu',
+          dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        });
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.getByText('Nom du DPO : Ptipeu')).exists();
+        assert.dom(screen.getByText('Adresse e-mail du DPO : justin.ptipeu@example.net')).exists();
+      });
+
+      test('it renders without DPO information', async function (assert) {
+        // given
+        class OidcIdentityProvidersStub extends Service {
+          list = [{ organizationName: 'super-sso', code: 'IDP' }];
+        }
+        this.owner.register('service:oidc-identity-providers', OidcIdentityProvidersStub);
+
+        this.set('organization', {
+          type: 'SUP',
+          isManagingStudents: false,
+          name: 'SUPer Orga',
+          credit: 350,
+          documentationUrl: 'https://pix.fr',
+          showSkills: true,
+          createdBy: 1,
+          createdAtFormattedDate: '02/09/2022',
+          creatorFullName: 'Gilles Parbal',
+          identityProviderForCampaigns: 'IDP',
+          dataProtectionOfficerFullName: '',
+          dataProtectionOfficerEmail: '',
+        });
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.getByText('Nom du DPO :')).exists();
+        assert.dom(screen.getByText('Adresse e-mail du DPO :')).exists();
+      });
+    });
+
     test('it renders edit and archive button', async function (assert) {
       // given
       this.organization = EmberObject.create({ type: 'SUP', isManagingStudents: false, name: 'SUPer Orga' });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement sur Pix Admin, si une organisation n'a pas encore de data protection officer (DPO), lors de l'affichage des détails de cette organisation, on peut voir pour le nom du DPO `Nom du DPO : null null`.

## :robot: Solution

Retourner une chaîne de caractère vide si les champs sont vides.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter sur Pix Admin
- Ouvrir les détails d'une organisation n'ayant pas d'information concernant un DPO
- Constatez que `Nom du DPO : null null` ne s'affiche plus mais plutôt `Nom du DPO :`.
