### PR TITLE
[FEATURE] Prendre le dernier RT obtenu de plus haut niveau pour une certif complémentaire (PIX-5783)

### DIFF
--- a/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -39,7 +39,13 @@ module.exports = {
         'badges.isCertifiable': true,
       })
       .whereRaw(
-        '"complementary-certification-badges".level = (select max(level) from "complementary-certification-badges" ccb join "badges" b on ccb."badgeId" = b.id join "badge-acquisitions" ba on ba."badgeId" = b.id where "complementary-certification-badges"."complementaryCertificationId" = ccb."complementaryCertificationId" and ba."userId" = ? and b."isCertifiable" = true)',
+        `"badge-acquisitions"."createdAt" = 
+            (select max(ba."createdAt") from "complementary-certification-badges" ccb 
+            join "badges" b on ccb."badgeId" = b.id 
+            join "badge-acquisitions" ba on ba."badgeId" = b.id 
+            where "complementary-certification-badges"."complementaryCertificationId" = ccb."complementaryCertificationId" 
+            and ba."userId" = ? and b."isCertifiable" = true)
+        `,
         userId
       );
 

--- a/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -6,6 +6,7 @@ const ComplementaryCertificationBadge = require('../../domain/models/Complementa
 const { knex } = require('../../../db/knex-database-connection');
 const DomainTransaction = require('../DomainTransaction');
 const ComplementaryCertification = require('../../domain/models/ComplementaryCertification');
+const _ = require('lodash');
 
 const BADGE_ACQUISITIONS_TABLE = 'badge-acquisitions';
 
@@ -25,7 +26,6 @@ module.exports = {
         'complementary-certifications.key as complementaryCertificationKey',
         'campaign-participations.campaignId'
       )
-      .distinctOn('complementary-certifications.id')
       .join('badges', 'badges.id', 'badge-acquisitions.badgeId')
       .join('complementary-certification-badges', 'badges.id', 'complementary-certification-badges.badgeId')
       .join(
@@ -39,17 +39,26 @@ module.exports = {
         'badges.isCertifiable': true,
       })
       .whereRaw(
-        `"badge-acquisitions"."createdAt" = 
-            (select max(ba."createdAt") from "complementary-certification-badges" ccb 
-            join "badges" b on ccb."badgeId" = b.id 
-            join "badge-acquisitions" ba on ba."badgeId" = b.id 
-            where "complementary-certification-badges"."complementaryCertificationId" = ccb."complementaryCertificationId" 
+        `"badge-acquisitions"."createdAt" =
+            (select max(ba."createdAt") from "complementary-certification-badges" ccb
+            join "badges" b on ccb."badgeId" = b.id
+            join "badge-acquisitions" ba on ba."badgeId" = b.id
+            where "complementary-certification-badges"."complementaryCertificationId" = ccb."complementaryCertificationId"
             and ba."userId" = ? and b."isCertifiable" = true)
         `,
         userId
       );
 
-    const certifiableBadgeAcquisitionBadgeIds = certifiableBadgeAcquisitions.map(
+    const highestCertifiableBadgeAcquisitionByComplementaryCertificationId = _(certifiableBadgeAcquisitions)
+      .groupBy('complementaryCertificationId')
+      .values()
+      .map((certifiableBadgeAcquisitionByComplementaryCertifications) =>
+        _.maxBy(certifiableBadgeAcquisitionByComplementaryCertifications, 'complementaryCertificationBadgeLevel')
+      )
+      .flatten()
+      .value();
+
+    const certifiableBadgeAcquisitionBadgeIds = highestCertifiableBadgeAcquisitionByComplementaryCertificationId.map(
       (certifiableBadgeAcquisition) => certifiableBadgeAcquisition.badgeId
     );
 
@@ -61,7 +70,7 @@ module.exports = {
 
     const skillSets = await knexConn('skill-sets').whereIn('id', uniqueSkillSetIds);
 
-    return _toDomain(certifiableBadgeAcquisitions, badgeCriteria, skillSets);
+    return _toDomain(highestCertifiableBadgeAcquisitionByComplementaryCertificationId, badgeCriteria, skillSets);
   },
 };
 

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -281,89 +281,80 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
       });
     });
 
-    describe('when the user has several acquired badges acquired at the same time', function () {
-      it('should return the highest level certifiable badge acquired for each complementary certification', async function () {
+    describe('when the user has several acquired badges', function () {
+      it('should return the highest level and latest certifiable badge acquired for each complementary certification', async function () {
         //given
-        const user = databaseBuilder.factory.buildUser();
-        const badgeLevel1 = databaseBuilder.factory.buildBadge.certifiable({
-          key: 'level-1',
-        });
-        const badgeLevel2 = databaseBuilder.factory.buildBadge.certifiable({
-          key: 'level-2',
-          imageUrl: 'badge-url-2.fr',
-        });
-        const badgeLevel3 = databaseBuilder.factory.buildBadge.certifiable({
-          key: 'level-3',
-        });
+        const userId = databaseBuilder.factory.buildUser().id;
 
-        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
-
+        const firstComplementaryBadges = buildComplementaryCertificationWithMultipleCertifiableBadges({
+          userId,
+          keys: [1, 2],
+          level: [1, 2],
+        });
+        const sameDateCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
         databaseBuilder.factory.buildBadgeAcquisition({
-          badgeId: badgeLevel1.id,
-          userId: user.id,
-          campaignParticipationId,
+          badgeId: firstComplementaryBadges[0].id,
+          userId,
+          sameDateCampaignParticipationId,
+          createdAt: new Date('2022-09-29'),
         });
         databaseBuilder.factory.buildBadgeAcquisition({
-          badgeId: badgeLevel2.id,
-          userId: user.id,
-          campaignParticipationId,
+          badgeId: firstComplementaryBadges[1].id,
+          userId,
+          sameDateCampaignParticipationId,
+          createdAt: new Date('2022-09-29'),
         });
 
-        const { id: complementaryCertificationId } = databaseBuilder.factory.buildComplementaryCertification();
-        databaseBuilder.factory.buildComplementaryCertificationBadge({
-          badgeId: badgeLevel2.id,
-          complementaryCertificationId,
-          level: 2,
-          imageUrl: 'complementary-certification-badge-url-2.fr',
+        const secondComplementaryBadges = buildComplementaryCertificationWithMultipleCertifiableBadges({
+          userId,
+          keys: [3, 4],
+          level: [3, 4],
+        });
+        const oldestCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+        databaseBuilder.factory.buildBadgeAcquisition({
+          badgeId: secondComplementaryBadges[0].id,
+          userId,
+          oldestCampaignParticipationId,
+          createdAt: new Date('2020-01-01'),
+        });
+        databaseBuilder.factory.buildBadgeAcquisition({
+          badgeId: secondComplementaryBadges[1].id,
+          userId,
+          oldestCampaignParticipationId,
+          createdAt: new Date('2020-01-01'),
+        });
+        const latestCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+        databaseBuilder.factory.buildBadgeAcquisition({
+          badgeId: secondComplementaryBadges[0].id,
+          userId,
+          latestCampaignParticipationId,
+          createdAt: new Date('2022-01-01'),
         });
 
-        databaseBuilder.factory.buildComplementaryCertificationBadge({
-          badgeId: badgeLevel1.id,
-          complementaryCertificationId,
-          level: 1,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationBadge({
-          badgeId: badgeLevel3.id,
-          complementaryCertificationId,
-          level: 3,
-        });
-
-        const badgeLevel1skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeLevel1.id });
-        const badgeLevel2skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeLevel2.id });
-        const badgeLevel3SkillSet = databaseBuilder.factory.buildSkillSet({
-          badgeId: badgeLevel3.id,
-        });
-
-        databaseBuilder.factory.buildBadgeCriterion({
-          badgeId: badgeLevel1.id,
-          skillSetIds: [badgeLevel1skillSet.id],
-        });
-        databaseBuilder.factory.buildBadgeCriterion({
-          badgeId: badgeLevel2.id,
-          skillSetIds: [badgeLevel2skillSet.id],
-        });
-        databaseBuilder.factory.buildBadgeCriterion({
-          badgeId: badgeLevel3.id,
-          skillSetIds: [badgeLevel3SkillSet.id],
-        });
         await databaseBuilder.commit();
 
         // when
         const certifiableBadgesAcquiredByUser = await DomainTransaction.execute(async (domainTransaction) => {
           return certifiableBadgeAcquisitionRepository.findHighestCertifiable({
-            userId: user.id,
+            userId,
             domainTransaction,
           });
         });
 
         // then
-        expect(certifiableBadgesAcquiredByUser.length).to.equal(1);
-        expect(certifiableBadgesAcquiredByUser.map(({ badge }) => ({ imageUrl: badge.imageUrl }))).to.deep.equal([
-          { imageUrl: badgeLevel2.imageUrl },
+        expect(certifiableBadgesAcquiredByUser.length).to.equal(2);
+        expect(
+          certifiableBadgesAcquiredByUser.map(({ badge }) => ({
+            key: badge.key,
+            complementaryCertificationBadgeLevel: badge.complementaryCertificationBadge.level,
+          }))
+        ).to.deep.equal([
+          { key: 'level-2', complementaryCertificationBadgeLevel: 2 },
+          { key: 'level-3', complementaryCertificationBadgeLevel: 3 },
         ]);
       });
     });
+
     describe('when the user has no certifiable acquired badge', function () {
       it('should return an empty array', async function () {
         // given
@@ -392,3 +383,40 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
     });
   });
 });
+
+function buildComplementaryCertificationWithMultipleCertifiableBadges({ keys, level }) {
+  const badgeLevel1 = databaseBuilder.factory.buildBadge.certifiable({
+    key: `level-${keys[0]}`,
+  });
+  const badgeLevel2 = databaseBuilder.factory.buildBadge.certifiable({
+    key: `level-${keys[1]}`,
+  });
+
+  const { id: complementaryCertificationId } = databaseBuilder.factory.buildComplementaryCertification();
+  databaseBuilder.factory.buildComplementaryCertificationBadge({
+    badgeId: badgeLevel1.id,
+    complementaryCertificationId,
+    level: level[0],
+    imageUrl: 'complementary-certification-badge-url-2.fr',
+  });
+
+  databaseBuilder.factory.buildComplementaryCertificationBadge({
+    badgeId: badgeLevel2.id,
+    complementaryCertificationId,
+    level: level[1],
+  });
+
+  const badgeLevel1skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeLevel1.id });
+  const badgeLevel2skillSet = databaseBuilder.factory.buildSkillSet({ badgeId: badgeLevel2.id });
+
+  databaseBuilder.factory.buildBadgeCriterion({
+    badgeId: badgeLevel1.id,
+    skillSetIds: [badgeLevel1skillSet.id],
+  });
+  databaseBuilder.factory.buildBadgeCriterion({
+    badgeId: badgeLevel2.id,
+    skillSetIds: [badgeLevel2skillSet.id],
+  });
+
+  return [badgeLevel1, badgeLevel2];
+}

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -6,7 +6,7 @@ const Badge = require('../../../../lib/domain/models/Badge');
 describe('Integration | Repository | Certifiable Badge Acquisition', function () {
   describe('#findHighestCertifiable', function () {
     describe('when the user has a certifiable acquired badge', function () {
-      it('should return the highest level certifiable acquired badge', async function () {
+      it('should return the certifiable acquired badge', async function () {
         //given
         const user = databaseBuilder.factory.buildUser();
         const acquiredBadge = databaseBuilder.factory.buildBadge.certifiable({
@@ -181,25 +181,29 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
     });
 
     describe('when the user has the same certifiable acquired badge twice', function () {
-      it('should return the highest level certifiable acquired badge only once', async function () {
+      it('should return the latest certifiable acquired badge', async function () {
         //given
         const user = databaseBuilder.factory.buildUser();
         const acquiredBadge = databaseBuilder.factory.buildBadge.certifiable({
           key: 'PIX_DROIT_MAITRE_CERTIF',
         });
 
-        const { id: campaignParticipationId, campaignId } = databaseBuilder.factory.buildCampaignParticipation();
+        const { id: latestCampaignParticipationId, campaignId: latestCampaignId } =
+          databaseBuilder.factory.buildCampaignParticipation();
+        const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
 
         databaseBuilder.factory.buildBadgeAcquisition({
           badgeId: acquiredBadge.id,
           userId: user.id,
           campaignParticipationId,
+          createdAt: new Date('2022-01-01'),
         });
 
         databaseBuilder.factory.buildBadgeAcquisition({
           badgeId: acquiredBadge.id,
           userId: user.id,
-          campaignParticipationId,
+          campaignParticipationId: latestCampaignParticipationId,
+          createdAt: new Date('2022-01-02'),
         });
 
         databaseBuilder.factory.buildComplementaryCertification({
@@ -264,7 +268,7 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             badgeCriteria: expectedBadgeCriteria,
           }),
           userId: user.id,
-          campaignId,
+          campaignId: latestCampaignId,
           complementaryCertification: domainBuilder.buildComplementaryCertification({
             id: 123,
             label: 'Label Certif Complémentaire',
@@ -277,7 +281,7 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
       });
     });
 
-    describe('when the user has several acquired badges', function () {
+    describe('when the user has several acquired badges acquired at the same time', function () {
       it('should return the highest level certifiable badge acquired for each complementary certification', async function () {
         //given
         const user = databaseBuilder.factory.buildUser();


### PR DESCRIPTION
## :unicorn: Problème

La team Contenus est en train de travailler actuellement sur la pérennité des profils cibles (PC). L’idée est de sortir du fonctionnement un PC = une liste d’acquis figée, mais d’avoir un PC = une liste de sujets cappés (ou non) en terme de niveau. Cela permet d’avoir toujours un PC à jour et qui suit les évolutions du référentiel à chaque création de campagne, basée sur un PC donné.
Les RT seront également mis à jour automatiquement en terme d’acquis liés, et donc il y a un risque qu’un utilisateur ayant obtenu son RT via une campagne A avec une certaine liste d’acquis, voit son éligibilité remise en question si le PC lié a été mis à jour entre temps. 

## :robot: Solution

Lors de la vérification faite sur l'éligibilité à une certif complémentaire au clic sur le menu “Certification” sur app, prendre en compte la liste d’acquis liée au dernier RT acquis par le candidat.

## :rainbow: Remarques

## :100: Pour tester
Non regression pour le moment, la team contenu gerera la possibilité d'avoir plusieurs RT pour un même badge, le test fonctionnel n'est pas encore possible pour le moment